### PR TITLE
Add `WINVER` and `_WIN32_WINNT` to explicitly support Windows 7

### DIFF
--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -2,6 +2,7 @@
 
 #define WINVER 0x0601 // Windows 7
 #define _WIN32_WINNT 0x0601 // Windows 7
+#define NTDDI_VERSION 0x06010000 // Windows 7
 
 #pragma warning(disable: 4731) // Change of ebp from inline assembly
 #pragma warning(disable: 4244) // Loss of data during conversion

--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#define WINVER 0x0601 // Windows 7
+#define _WIN32_WINNT 0x0601 // Windows 7
+
 #pragma warning(disable: 4731) // Change of ebp from inline assembly
 #pragma warning(disable: 4244) // Loss of data during conversion
 #include <Windows.h>


### PR DESCRIPTION
Add `WINVER` and `_WIN32_WINNT` to explicitly support Windows 7 with any target platform

https://docs.microsoft.com/de-de/cpp/porting/modifying-winver-and-win32-winnt?view=vs-2019