### PR TITLE
reduce SMAA SharpenFactor

### DIFF
--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -516,7 +516,7 @@ struct GothicRendererSettings {
 		FOVHoriz = 90.0f;
 		FOVVert = 90.0f;
 
-		SharpenFactor = 0.8f;
+		SharpenFactor = 0.2f;
 
 		RainRadiusRange = 5000.0f;
 		RainHeightRange = 1000.0f;


### PR DESCRIPTION
0.8 is oversharping, 0.2 looks more natural