### PR TITLE
Allow ForceFOV to work in G2, change ForceFOV default for G2 to keep …

### DIFF
--- a/D3D11Engine/BaseAntTweakBar.cpp
+++ b/D3D11Engine/BaseAntTweakBar.cpp
@@ -233,6 +233,7 @@ XRESULT BaseAntTweakBar::Init() {
 	TwDefine( " General/GothicUIScale  step=0.01" );
 	TwAddVarRW( Bar_General, "FOVHoriz", TW_TYPE_FLOAT, &Engine::GAPI->GetRendererState()->RendererSettings.FOVHoriz, nullptr );
 	TwAddVarRW( Bar_General, "FOVVert", TW_TYPE_FLOAT, &Engine::GAPI->GetRendererState()->RendererSettings.FOVVert, nullptr );
+	TwAddVarRW( Bar_General, "ForceFOV", TW_TYPE_BOOLCPP, &Engine::GAPI->GetRendererState()->RendererSettings.ForceFOV, nullptr );
 	//TwAddVarRW(Bar_General, "Max Num Indices", TW_TYPE_INT32, &Engine::GAPI->GetRendererState()->RendererSettings.MaxNumFaces, nullptr);
 
 	Bar_Info = TwNewBar( "FrameStats" );

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -3569,7 +3569,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
 	TCHAR NPath[MAX_PATH];
 	// Returns Gothic directory.
 	int len = GetCurrentDirectory( MAX_PATH, NPath );
-	// Get path to UserSettings.Ini
+	// Get path to Gothic.Ini
 	auto ini = std::string( NPath, len ).append( "\\" + file );
 
 	LogInfo() << "Saving menu settings to " << ini;
@@ -3642,7 +3642,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
 	TCHAR NPath[MAX_PATH];
 	// Returns Gothic directory.
 	int len = GetCurrentDirectory( MAX_PATH, NPath );
-	// Get path to UserSettings.Ini
+	// Get path to Gothic.Ini
 	auto ini = std::string( NPath, len ).append( "\\" + file );
 
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -764,23 +764,25 @@ void GothicAPI::DrawWorldMeshNaive() {
 		CurrentCamera = zCCamera::GetCamera();
 }
 #else
-	float fovH = 90.0f, fovV = 90.0f;
-	if ( zCCamera::GetCamera() )
-		zCCamera::GetCamera()->GetFOV( fovH, fovV );
+	if ( RendererState.RendererSettings.ForceFOV ) {
+		float fovH = 90.0f, fovV = 90.0f;
+		if ( zCCamera::GetCamera() )
+			zCCamera::GetCamera()->GetFOV( fovH, fovV );
 
-	// TODO: FOV is being reset after a dialog!
-	if ( zCCamera::GetCamera() && (zCCamera::GetCamera() != CurrentCamera
-		|| setfovH != RendererState.RendererSettings.FOVHoriz
-		|| setfovV != RendererState.RendererSettings.FOVVert
-		|| (fovH == 90.0f && fovV == 90.0f)) ) // FIXME: This is being reset after a dialog!
-	{
-		setfovH = RendererState.RendererSettings.FOVHoriz;
-		setfovV = RendererState.RendererSettings.FOVVert;
+		// TODO: FOV is being reset after a dialog!
+		if ( zCCamera::GetCamera() && (zCCamera::GetCamera() != CurrentCamera
+			|| setfovH != RendererState.RendererSettings.FOVHoriz
+			|| setfovV != RendererState.RendererSettings.FOVVert
+			|| (fovH == 90.0f && fovV == 90.0f)) ) // FIXME: This is being reset after a dialog!
+		{
+			setfovH = RendererState.RendererSettings.FOVHoriz;
+			setfovV = RendererState.RendererSettings.FOVVert;
 
-		// Fix camera FOV-Bug
-		zCCamera::GetCamera()->SetFOV( RendererState.RendererSettings.FOVHoriz, (Engine::GraphicsEngine->GetResolution().y / (float)Engine::GraphicsEngine->GetResolution().x) * RendererState.RendererSettings.FOVVert );
+			// Fix camera FOV-Bug
+			zCCamera::GetCamera()->SetFOV( RendererState.RendererSettings.FOVHoriz, (Engine::GraphicsEngine->GetResolution().y / (float)Engine::GraphicsEngine->GetResolution().x) * RendererState.RendererSettings.FOVVert );
 
-		CurrentCamera = zCCamera::GetCamera();
+			CurrentCamera = zCCamera::GetCamera();
+		}
 	}
 #endif
 
@@ -3567,7 +3569,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
 	TCHAR NPath[MAX_PATH];
 	// Returns Gothic directory.
 	int len = GetCurrentDirectory( MAX_PATH, NPath );
-	// Get path to Gothic.Ini
+	// Get path to UserSettings.Ini
 	auto ini = std::string( NPath, len ).append( "\\" + file );
 
 	LogInfo() << "Saving menu settings to " << ini;
@@ -3640,7 +3642,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
 	TCHAR NPath[MAX_PATH];
 	// Returns Gothic directory.
 	int len = GetCurrentDirectory( MAX_PATH, NPath );
-	// Get path to Gothic.Ini
+	// Get path to UserSettings.Ini
 	auto ini = std::string( NPath, len ).append( "\\" + file );
 
 

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -559,7 +559,13 @@ struct GothicRendererSettings {
 		EnableCustomFontRendering = false;
 		FontFileDefault = "Gothic_14.spritefont";
 		FontFileMenu = "Gothic_14.spritefont";
+
+#ifdef BUILD_GOTHIC_1_08k
 		ForceFOV = false;
+#else
+		ForceFOV = true;
+#endif
+
 		StretchWindow = false;
 	}
 


### PR DESCRIPTION
…current behaviour

As discussed in the WoP thread. Allows fixing FOV issues on 21:9 res (by manually setting ForceFOV=0 for G2).