### PR TITLE
SettingsDialog improvements

### DIFF
--- a/D3D11Engine/D2DSettingsDialog.cpp
+++ b/D3D11Engine/D2DSettingsDialog.cpp
@@ -10,7 +10,7 @@
 #include "SV_Slider.h"
 
 D2DSettingsDialog::D2DSettingsDialog( D2DView* view, D2DSubView* parent ) : D2DDialog( view, parent ) {
-	SetPositionCentered( D2D1::Point2F( view->GetRenderTarget()->GetSize().width / 2, view->GetRenderTarget()->GetSize().height / 2 ), D2D1::SizeF( 500, 300 ) );
+	SetPositionCentered( D2D1::Point2F( view->GetRenderTarget()->GetSize().width / 2, view->GetRenderTarget()->GetSize().height / 2 ), D2D1::SizeF( 500, 340 ) );
 	Header->SetCaption( "Settings" );
 
 	// Get display modes
@@ -43,7 +43,7 @@ XRESULT D2DSettingsDialog::InitControls() {
 
 	SV_Label* resolutionLabel = new SV_Label( MainView, MainPanel );
 	resolutionLabel->SetPositionAndSize( D2D1::Point2F( 10, 10 ), D2D1::SizeF( 150, 12 ) );
-	resolutionLabel->AlignUnder( Header, 10 );
+	resolutionLabel->AlignUnder( Header, 5 );
 	resolutionLabel->SetCaption( "Resolution [*]:" );
 	resolutionLabel->SetPosition( D2D1::Point2F( 5, resolutionLabel->GetPosition().y ) );
 
@@ -67,7 +67,7 @@ XRESULT D2DSettingsDialog::InitControls() {
 	normalmapsCheckbox->SetSize( D2D1::SizeF( 160, 20 ) );
 	normalmapsCheckbox->SetCaption( "Enable Normalmaps" );
 	normalmapsCheckbox->SetDataToUpdate( &Engine::GAPI->GetRendererState().RendererSettings.AllowNormalmaps );
-	normalmapsCheckbox->AlignUnder( normalmapsCheckbox, 5 );
+	normalmapsCheckbox->AlignUnder( resolutionSlider, 10 );
 	normalmapsCheckbox->SetPosition( D2D1::Point2F( 5, normalmapsCheckbox->GetPosition().y ) );
 	normalmapsCheckbox->SetChecked( Engine::GAPI->GetRendererState().RendererSettings.AllowNormalmaps );
 
@@ -75,7 +75,7 @@ XRESULT D2DSettingsDialog::InitControls() {
 	numpadCheckbox->SetSize( D2D1::SizeF( 160, 20 ) );
 	numpadCheckbox->SetCaption( "Enable Numpad Keys" );
 	numpadCheckbox->SetDataToUpdate( &Engine::GAPI->GetRendererState().RendererSettings.AllowNumpadKeys );
-	numpadCheckbox->AlignUnder( resolutionSlider, 10 );
+	numpadCheckbox->AlignUnder( normalmapsCheckbox, 5 );
 	numpadCheckbox->SetPosition( D2D1::Point2F( 5, numpadCheckbox->GetPosition().y ) );
 	numpadCheckbox->SetChecked( Engine::GAPI->GetRendererState().RendererSettings.AllowNumpadKeys );
 
@@ -118,11 +118,22 @@ XRESULT D2DSettingsDialog::InitControls() {
 	tesselationCheckbox->SetPosition(D2D1::Point2F(5, tesselationCheckbox->GetPosition().y));
 	tesselationCheckbox->SetChecked(Engine::GAPI->GetRendererState().RendererSettings.EnableTesselation);*/
 
+	SV_Checkbox* hdrCheckbox = new SV_Checkbox(MainView, MainPanel);
+	hdrCheckbox->SetSize(D2D1::SizeF(160, 20));
+	hdrCheckbox->SetCaption("Enable HDR");
+	hdrCheckbox->SetDataToUpdate(&Engine::GAPI->GetRendererState().RendererSettings.EnableHDR);
+	hdrCheckbox->AlignUnder( smaaCheckbox, 5 );
+	hdrCheckbox->SetPosition(D2D1::Point2F(5, hdrCheckbox->GetPosition().y));
+	hdrCheckbox->SetChecked(Engine::GAPI->GetRendererState().RendererSettings.EnableHDR);
+	if (GMPModeActive) {
+		hdrCheckbox->SetHidden(true);
+	}
+
 	SV_Checkbox* shadowsCheckbox = new SV_Checkbox( MainView, MainPanel );
 	shadowsCheckbox->SetSize( D2D1::SizeF( 160, 20 ) );
 	shadowsCheckbox->SetCaption( "Enable Shadows[*]" );
 	shadowsCheckbox->SetDataToUpdate( &Engine::GAPI->GetRendererState().RendererSettings.EnableShadows );
-	shadowsCheckbox->AlignUnder( smaaCheckbox, 5 );
+	shadowsCheckbox->AlignUnder( hdrCheckbox, 5 );
 	shadowsCheckbox->SetPosition( D2D1::Point2F( 5, shadowsCheckbox->GetPosition().y ) );
 	shadowsCheckbox->SetChecked( Engine::GAPI->GetRendererState().RendererSettings.EnableShadows );
 
@@ -184,20 +195,9 @@ XRESULT D2DSettingsDialog::InitControls() {
 	fpsLimitSlider->SetValue( Engine::GAPI->GetRendererState().RendererSettings.FpsLimit );
 
 	// Next column
-	SV_Checkbox* hdrCheckbox = new SV_Checkbox( MainView, MainPanel );
-	hdrCheckbox->SetSize( D2D1::SizeF( 160, 20 ) );
-	hdrCheckbox->SetCaption( "Enable HDR" );
-	hdrCheckbox->SetDataToUpdate( &Engine::GAPI->GetRendererState().RendererSettings.EnableHDR );
-	hdrCheckbox->AlignUnder( Header, 5 );
-	hdrCheckbox->SetPosition( D2D1::Point2F( 170, hdrCheckbox->GetPosition().y ) );
-	hdrCheckbox->SetChecked( Engine::GAPI->GetRendererState().RendererSettings.EnableHDR );
-	if ( GMPModeActive ) {
-		hdrCheckbox->SetHidden( true );
-	}
-
 	SV_Label* outdoorVobsDDLabel = new SV_Label( MainView, MainPanel );
 	outdoorVobsDDLabel->SetPositionAndSize( D2D1::Point2F( 10, 10 ), D2D1::SizeF( 150, 12 ) );
-	outdoorVobsDDLabel->AlignUnder( hdrCheckbox, 5 );
+	outdoorVobsDDLabel->AlignUnder( Header, 5 );
 	outdoorVobsDDLabel->SetPosition( D2D1::Point2F( 170, outdoorVobsDDLabel->GetPosition().y ) );
 	outdoorVobsDDLabel->SetCaption( "Object draw distance:" );
 
@@ -284,13 +284,12 @@ XRESULT D2DSettingsDialog::InitControls() {
 	fovOverrideCheckbox->AlignUnder( Header, 5 );
 	fovOverrideCheckbox->SetCaption( "Enable FOV Override" );
 	fovOverrideCheckbox->SetDataToUpdate( &Engine::GAPI->GetRendererState().RendererSettings.ForceFOV );
-	//fovOverrideCheckbox->AlignUnder( ______, 5 );
 	fovOverrideCheckbox->SetChecked( Engine::GAPI->GetRendererState().RendererSettings.ForceFOV );
 	fovOverrideCheckbox->SetPosition( D2D1::Point2F( 170 + 160 + 10, fovOverrideCheckbox->GetPosition().y ) );
 
 	SV_Label* horizFOVLabel = new SV_Label( MainView, MainPanel );
 	horizFOVLabel->SetPositionAndSize( D2D1::Point2F( 10, 10 ), D2D1::SizeF( 150, 12 ) );
-	horizFOVLabel->AlignUnder(fovOverrideCheckbox, 5);
+	horizFOVLabel->AlignUnder( fovOverrideCheckbox, 8 );
 	horizFOVLabel->SetCaption( "Horizontal FOV:" );
 	horizFOVLabel->SetPosition( D2D1::Point2F( 170 + 160 + 10, horizFOVLabel->GetPosition().y ) );
 
@@ -328,7 +327,7 @@ XRESULT D2DSettingsDialog::InitControls() {
 
 	SV_Label* brightnessLabel = new SV_Label( MainView, MainPanel );
 	brightnessLabel->SetPositionAndSize( D2D1::Point2F( 10, 10 ), D2D1::SizeF( 150, 12 ) );
-	brightnessLabel->AlignUnder( vertFOVSlider, 8 );
+	brightnessLabel->AlignUnder( vertFOVSlider, 16 );
 	brightnessLabel->SetCaption( "Brightness:" );
 
 	SV_Slider* brightnessSlider = new SV_Slider( MainView, MainPanel );

--- a/D3D11Engine/D2DSubView.cpp
+++ b/D3D11Engine/D2DSubView.cpp
@@ -209,16 +209,17 @@ void D2DSubView::SetHidden( bool hidden ) {
 	Hidden = hidden;
 }
 
-
 /** Returns if this control is hidden */
 bool D2DSubView::IsHidden() const {
 	return Hidden;
 }
 
+/** Sets if this control is disabled */
 void D2DSubView::SetDisabled( bool disabled ) {
 	Disabled = disabled;
 }
-/** Returns if this control is hidden */
+
+/** Returns if this control is disabled */
 bool D2DSubView::IsDisabled() const {
 	return Disabled;
 }

--- a/D3D11Engine/D2DView.h
+++ b/D3D11Engine/D2DView.h
@@ -8,7 +8,7 @@
 #include "D2DMessageBox.h"
 
 const D2D1_COLOR_F SV_DEF_INNER_LINE_COLOR = D2D1::ColorF( 0.3f, 0.3f, 0.6f, 1.0f );
-const D2D1_COLOR_F SV_DEF_DISABLED_COLOR = D2D1::ColorF( 0.8f, 0.8f, 0.8f, 1.0f );
+const D2D1_COLOR_F SV_DEF_DISABLED_COLOR = D2D1::ColorF( 0.3f, 0.3f, 0.6f, 0.3f );
 const float SV_DEF_SHADOW_RANGE = 19.0f;
 
 class D2DDialog;

--- a/D3D11Engine/SV_Checkbox.h
+++ b/D3D11Engine/SV_Checkbox.h
@@ -29,7 +29,7 @@ public:
 	/** Sets the data location to update with this checkbox */
 	void SetDataToUpdate( bool* data );
 
-	/** Sets the data location to update with this checkbox */
+	/** Sets the callback */
 	void SetCheckedChangedCallback( SV_CheckboxCheckedChangedCallback cb, void* userdata);
 
 	/** Processes a window-message. Return false to stop the message from going to children */

--- a/D3D11Engine/SV_Label.cpp
+++ b/D3D11Engine/SV_Label.cpp
@@ -19,6 +19,8 @@ SV_Label::~SV_Label() {
 
 /** Draws this sub-view */
 void SV_Label::Draw( const D2D1_RECT_F& clientRectAbs, float deltaTime ) {
+
+	D2D1_COLOR_F LabelTextColor = D2D1::ColorF(TextColor.r, TextColor.g, TextColor.b, TextColor.a * (IsDisabled() ? 0.3f : 1.0f));
 	//Set up the layer for this control
 	MainView->GetRenderTarget()->SetTransform( D2D1::Matrix3x2F::Translation( clientRectAbs.left, clientRectAbs.top ) );
 
@@ -34,7 +36,7 @@ void SV_Label::Draw( const D2D1_RECT_F& clientRectAbs, float deltaTime ) {
 			}
 		}
 
-		MainView->GetBrush()->SetColor( TextColor );
+		MainView->GetBrush()->SetColor( LabelTextColor );
 		MainView->GetRenderTarget()->DrawTextLayout( D2D1::Point2F( ViewRect.left, ViewRect.top ), CaptionLayout, MainView->GetBrush() );
 	}
 

--- a/D3D11Engine/SV_Slider.cpp
+++ b/D3D11Engine/SV_Slider.cpp
@@ -123,14 +123,8 @@ void SV_Slider::RenderSlider() {
 	D2D1_RECT_F sc = ViewRect;
 	D2D1_RECT_F bc = ViewRect;
 
-	D2D1_COLOR_F BarBackgroundColor = D2D1::ColorF( 0.2f, 0.2f, 0.2f, 1.0f );
-	D2D1_COLOR_F LineColor = SV_DEF_INNER_LINE_COLOR;
+	D2D1_COLOR_F BarBackgroundColor = D2D1::ColorF( 0.2f, 0.2f, 0.2f, IsDisabled() ? 0.3f : 1.0f );
 	float BarInnerShadowStrength = 0.8f;
-	
-	if ( IsDisabled() ) {
-		BarBackgroundColor = SV_DEF_DISABLED_COLOR;
-		LineColor = SV_DEF_DISABLED_COLOR;
-	}
 
 	MainView->GetBrush()->SetColor( BarBackgroundColor );
 	MainView->GetRenderTarget()->FillRectangle( sc, MainView->GetBrush() );
@@ -141,7 +135,7 @@ void SV_Slider::RenderSlider() {
 	MainView->GetLinearReflectBrushHigh()->SetEndPoint( D2D1::Point2F( ViewRect.right, ViewRect.bottom ) );
 	MainView->GetRenderTarget()->DrawRectangle( sc, MainView->GetLinearReflectBrushHigh() );
 
-	MainView->GetBrush()->SetColor( LineColor );
+	MainView->GetBrush()->SetColor(IsDisabled() ? SV_DEF_DISABLED_COLOR : SV_DEF_INNER_LINE_COLOR );
 	D2DView::ShrinkRect( &sc, 1 );
 
 	MainView->GetRenderTarget()->DrawRectangle( sc, MainView->GetBrush() );
@@ -177,6 +171,7 @@ void SV_Slider::RenderSlider() {
 		ValueLabel->SetSize( D2D1::SizeF( (BarPosition - 2 - SV_SLIDERCONTROL_SLIDER_SIZEX), GetSize().height ) );
 		ValueLabel->SetHorizAlignment( DWRITE_TEXT_ALIGNMENT_TRAILING );
 	}
+	ValueLabel->SetDisabled( IsDisabled() );
 
 	// Only change when needed
 	if ( (DraggingSlider && (!DataToUpdate)) || (DataToUpdate && *DataToUpdate != Value) || !ValueLabel ) {


### PR DESCRIPTION
I added some improvements to the settings dialog. The disabled state is now visualized by 0.6f alpha and the checkboxes ("Enable Normalmaps" e.g.) no longer overlap the slider.

![Gothic2 2020-11-10 20-50-15-05](https://user-images.githubusercontent.com/1990806/98726282-9530c500-2396-11eb-8a75-7c789f45b089.png)
