### PR TITLE
Warnings and fixes

### DIFF
--- a/D3D11Engine/D2DSettingsDialog.cpp
+++ b/D3D11Engine/D2DSettingsDialog.cpp
@@ -189,7 +189,7 @@ XRESULT D2DSettingsDialog::InitControls() {
 	fpsLimitSlider->SetDisplayValues( fpsValues );
 
 	// Fix the fps value
-	fpsLimitSlider->SetValue( Engine::GAPI->GetRendererState().RendererSettings.FpsLimit );
+	fpsLimitSlider->SetValue( (float)Engine::GAPI->GetRendererState().RendererSettings.FpsLimit );
 
 	// Next column
 	SV_Label* outdoorVobsDDLabel = new SV_Label( MainView, MainPanel );
@@ -355,7 +355,7 @@ XRESULT D2DSettingsDialog::InitControls() {
 }
 
 void D2DSettingsDialog::FpsLimitSliderChanged( SV_Slider* sender, void* userdata ) {
-	int newValue = sender->GetValue();
+	int newValue = (int)sender->GetValue();
 	Engine::GAPI->GetRendererState().RendererSettings.FpsLimit = newValue <= 25 ? 0 : newValue;
 }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2738,7 +2738,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
         } else {
             for ( auto&& itx : Engine::GAPI->GetWorldSections() ) {
                 for ( auto&& ity : itx.second ) {
-                    float vLen; XMStoreFloat( &vLen, XMVector3Length( XMVectorSet( itx.first - s.x, ity.first - s.y, 0, 0 ) ) );
+                    float vLen; XMStoreFloat( &vLen, XMVector3Length( XMVectorSet( float(itx.first - s.x), float(ity.first - s.y), 0, 0 ) ) );
 
                     if ( vLen < 2 ) {
                         WorldMeshSectionInfo& section = ity.second;
@@ -3040,7 +3040,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround( FXMVECTOR position,
             for ( const auto& ity : itx.second ) {
 
                 float len;
-                XMStoreFloat( &len, XMVector2Length( XMVectorSet( itx.first - s.x, ity.first - s.y, 0, 0 ) ) );
+                XMStoreFloat( &len, XMVector2Length( XMVectorSet( float(itx.first - s.x), float(ity.first - s.y), 0, 0 ) ) );
                 if ( len < sectionRange ) {
                     const WorldMeshSectionInfo& section = ity.second;
 

--- a/D3D11Engine/GMesh.cpp
+++ b/D3D11Engine/GMesh.cpp
@@ -161,8 +161,7 @@ XRESULT GMesh::LoadCached( const std::string& file ) {
         // Read texture name
         unsigned char numTxNameChars;
         fread( &numTxNameChars, sizeof( numTxNameChars ), 1, f );
-        char tx[255];
-        memset( tx, 0, 255 );
+        char tx[256] = { '\0' };
         fread( tx, numTxNameChars, 1, f );
 
         // Read num submeshes

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -653,12 +653,10 @@ void GothicAPI::LoadRendererWorldSettings( GothicRendererSettings& s ) {
         GetPrivateProfileIntA( "Atmoshpere", "FogColorModB", (int)(s.FogColorMod.z * 255.0f), ini.c_str() )
     );
 
-    if ( !GMPModeActive ) {
-        s.VisualFXDrawRadius = GetPrivateProfileFloatA( "General", "VisualFXDrawRadius", s.VisualFXDrawRadius, ini.c_str() );
-        s.OutdoorVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorVobDrawRadius", s.OutdoorVobDrawRadius, ini.c_str() );
-        s.OutdoorSmallVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorSmallVobDrawRadius", s.OutdoorSmallVobDrawRadius, ini.c_str() );
-        s.SectionDrawRadius = GetPrivateProfileFloatA( "General", "SectionDrawRadius", s.SectionDrawRadius, ini.c_str() );
-    }
+    s.VisualFXDrawRadius = GetPrivateProfileFloatA( "General", "VisualFXDrawRadius", s.VisualFXDrawRadius, ini.c_str() );
+    s.OutdoorVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorVobDrawRadius", s.OutdoorVobDrawRadius, ini.c_str() );
+    s.OutdoorSmallVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorSmallVobDrawRadius", s.OutdoorSmallVobDrawRadius, ini.c_str() );
+    s.SectionDrawRadius = GetPrivateProfileFloatA( "General", "SectionDrawRadius", s.SectionDrawRadius, ini.c_str() );
 
     s.ReplaceSunDirection = GetPrivateProfileBoolA( "Atmoshpere", "ReplaceSunDirection", s.ReplaceSunDirection, ini );
 
@@ -2481,7 +2479,7 @@ LRESULT GothicAPI::OnWindowMessage( HWND hWnd, UINT msg, WPARAM wParam, LPARAM l
         Engine::GraphicsEngine->OnKeyDown( wParam );
         switch ( wParam ) {
         case VK_F11:
-            if ( GetAsyncKeyState( VK_CONTROL ) && !GMPModeActive ) {
+            if ( GetAsyncKeyState( VK_CONTROL ) & 0x8000 && !GMPModeActive ) {
                 Engine::AntTweakBar->SetActive( !Engine::AntTweakBar->GetActive() );
                 SetEnableGothicInput( !Engine::AntTweakBar->GetActive() );
             } else {

--- a/D3D11Engine/GothicMemoryLocations.h
+++ b/D3D11Engine/GothicMemoryLocations.h
@@ -27,11 +27,12 @@ static void PatchAddr( unsigned int adr, const T( &v )[n] ) {
 }
 
 // -- call macro from GothicX (thx, Zerxes!)
-#define XCALL(uAddr)                    \
-        __asm { mov esp, ebp    }       \
-        __asm { pop ebp                 }       \
-        __asm { mov eax, uAddr  }       \
-        __asm { jmp eax                 }
+#define XCALL(address)      \
+{                           \
+    __asm leave             \
+    __asm mov eax, address  \
+    __asm jmp eax           \
+}
 
 #define INST_NOP 0x90
 #define REPLACE_OP(addr, op) {unsigned char* a = (unsigned char*)addr; *a = op;}

--- a/D3D11Engine/StackWalker.cpp
+++ b/D3D11Engine/StackWalker.cpp
@@ -1428,7 +1428,7 @@ void StackWalker::OnLoadModule(LPCSTR    img,
   maxLen = _TRUNCATE;
 #endif
   if (fileVersion == 0)
-    _snprintf_s(buffer, maxLen, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s'",
+    _snprintf_s(buffer, maxLen, "%s:%s (%p), size: %lu (result: %lu), SymType: '%s', PDB: '%s'",
                 img, mod, (LPVOID)baseAddr, size, result, symType, pdbName);
   else
   {
@@ -1438,7 +1438,7 @@ void StackWalker::OnLoadModule(LPCSTR    img,
     DWORD v1 = (DWORD)((fileVersion >> 48) & 0xFFFF);
     _snprintf_s(
         buffer, maxLen,
-        "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s', fileVersion: %d.%d.%d.%d",
+        "%s:%s (%p), size: %lu (result: %lu), SymType: '%s', PDB: '%s', fileVersion: %lu.%lu.%lu.%lu",
         img, mod, (LPVOID)baseAddr, size, result, symType, pdbName, v1, v2, v3, v4);
   }
   buffer[STACKWALK_MAX_NAMELEN - 1] = 0; // be sure it is NULL terminated
@@ -1469,7 +1469,7 @@ void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry& ent
                   entry.lineFileName, entry.name);
     }
     else
-      _snprintf_s(buffer, maxLen, "%s (%d): %s", entry.lineFileName, entry.lineNumber,
+      _snprintf_s(buffer, maxLen, "%s (%lu): %s", entry.lineFileName, entry.lineNumber,
                   entry.name);
     buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
     OnOutput(buffer);
@@ -1483,7 +1483,7 @@ void StackWalker::OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr)
 #if _MSC_VER >= 1400
   maxLen = _TRUNCATE;
 #endif
-  _snprintf_s(buffer, maxLen, "ERROR: %s, GetLastError: %d (Address: %p)", szFuncName, gle,
+  _snprintf_s(buffer, maxLen, "ERROR: %s, GetLastError: %lu (Address: %p)", szFuncName, gle,
               (LPVOID)addr);
   buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
   OnOutput(buffer);
@@ -1496,7 +1496,7 @@ void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUser
 #if _MSC_VER >= 1400
   maxLen = _TRUNCATE;
 #endif
-  _snprintf_s(buffer, maxLen, "SymInit: Symbol-SearchPath: '%s', symOptions: %d, UserName: '%s'",
+  _snprintf_s(buffer, maxLen, "SymInit: Symbol-SearchPath: '%s', symOptions: %lu, UserName: '%s'",
               szSearchPath, symOptions, szUserName);
   buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
   OnOutput(buffer);
@@ -1507,7 +1507,7 @@ void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUser
   ver.dwOSVersionInfoSize = sizeof(ver);
   if (GetVersionExA(&ver) != FALSE)
   {
-    _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s)", ver.dwMajorVersion,
+    _snprintf_s(buffer, maxLen, "OS-Version: %lu.%lu.%lu (%s)", ver.dwMajorVersion,
                 ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion);
     buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
     OnOutput(buffer);
@@ -1522,7 +1522,7 @@ void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUser
 #endif
   if (GetVersionExA((OSVERSIONINFOA*)&ver) != FALSE)
   {
-    _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s) 0x%x-0x%x", ver.dwMajorVersion,
+    _snprintf_s(buffer, maxLen, "OS-Version: %lu.%lu.%lu (%s) 0x%hx-0x%hx", ver.dwMajorVersion,
                 ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion, ver.wSuiteMask,
                 ver.wProductType);
     buffer[STACKWALK_MAX_NAMELEN - 1] = 0;

--- a/D3D11Engine/XUnzip.cpp
+++ b/D3D11Engine/XUnzip.cpp
@@ -4137,12 +4137,13 @@ ZRESULT TUnzip::Unzip(int index,void *dst,unsigned int len,DWORD flags)
 		return ZR_NOFILE;
 	
 	unzOpenCurrentFile(uf);
-	BYTE buf[16384];  
+    const unsigned bufsize = 16384;
+    BYTE *buf = new BYTE[bufsize];
 	bool haderr=false;
 	
 	for (;;)
 	{ 
-		int res = unzReadCurrentFile(uf,buf, 16384);
+		int res = unzReadCurrentFile(uf,buf, bufsize);
 		if (res<0) 
 		{
 			haderr=true; 
@@ -4158,6 +4159,7 @@ ZRESULT TUnzip::Unzip(int index,void *dst,unsigned int len,DWORD flags)
 			break;
 		}
 	}
+    delete[] buf;
 	bool settime=false;
 	DWORD type = GetFileType(h); 
 	if (type==FILE_TYPE_DISK && !haderr) 

--- a/D3D11Engine/zCView.h
+++ b/D3D11Engine/zCView.h
@@ -96,7 +96,7 @@ public:
             || (thisptr == GetScreen()) ) {
             Engine::GraphicsEngine->DrawString(
                 s.ToChar(),
-                thisptr->pposx + thisptr->nax( x ), thisptr->pposy + thisptr->nay( y ),
+                float(thisptr->pposx + thisptr->nax( x )), float(thisptr->pposy + thisptr->nay( y )),
                 thisptr->font, thisptr->fontColor );
         } else {
             // create a textview for later blitting
@@ -128,9 +128,9 @@ public:
             if ( text->colored ) { fontColor = text->color; }
             //else                 { fontColor = thisptr->fontColor;}
 
-            x = thisptr->pposx + thisptr->nax( text->posx );
+            x = float(thisptr->pposx + thisptr->nax( text->posx ));
             // TODO: Remove additional addition if we get the correct char positioning
-            y = thisptr->pposy + thisptr->nay( text->posy );
+            y = float(thisptr->pposy + thisptr->nay( text->posy ));
 
             if ( !thisptr->font ) continue;
 


### PR DESCRIPTION
Hi,

I fixed a few warnings and a bug in opening the F11 menu. If the player pressed Ctrl at any point in time before pressing F11, the advanced menu would open, but I think it should only open if the player presses F11 while holding the Ctrl button. Also I activated saving of the sight range settings when in GMP mode, because I can't see the reason it was disabled - you could change the values anyway, they just weren't adopted in the next session.