### PR TITLE
Improve GMP detection

### DIFF
--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -6,6 +6,7 @@ struct GothicMemoryLocations {
         static const unsigned int Alg_Rotation3DNRad = 0x00517E90;
         static const unsigned int vidGetFPSRate = 0x004FDCD0;
         static const unsigned int HandledWinMain = 0x00502ED0;
+        static const unsigned int WinMain = 0x00502D70;
         //static const unsigned int ExitGameFunc = 0x00425F30;
         static const unsigned int zCExceptionHandler_UnhandledExceptionFilter = 0x004C88C0;
     };

--- a/D3D11Engine/HookedFunctions.cpp
+++ b/D3D11Engine/HookedFunctions.cpp
@@ -81,12 +81,6 @@ void HookedFunctionInfo::InitHooks() {
     original_Alg_Rotation3DNRad = (Alg_Rotation3DNRad)GothicMemoryLocations::Functions::Alg_Rotation3DNRad;
 
 #ifdef BUILD_GOTHIC_2_6_fix
-    // Remove automatic volume change of sounds regarding whether the camera is indoor or outdoor
-    // TODO: Implement!
-    if ( !GMPModeActive ) {
-        XHook( GothicMemoryLocations::zCActiveSnd::AutoCalcObstruction, HookedFunctionInfo::hooked_zCActiveSndAutoCalcObstruction );
-    }
-
     zQuat::Hook();
     zMat4::Hook();
 


### PR DESCRIPTION
Implements #57.
Changes the file check into a check if the gmp.dll is loaded.
Since DLLMain is generally a critical area, this check is postponed. The main reason is that it is not guaranteed that the gmp.dll is loaded. Also this is in line with the [microsoft best pratices for dlls](https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-best-practices#general-best-practices).

Note that ms recommends not to use functions like LoadLibrary and CoInitializeEx inside the DLLMain. GD3D11 violates these recommandations, but fixing this issue is out of scope for this PR. But you could probably use the hooked WinMain for it.

This also means that the hook for GothicMemoryLocations::zCActiveSnd::AutoCalcObstruction has to be postponed because it uses the GMPModeActive variable.

To make sure all dlls are loaded the WinMain from Gothic is hooked. This is probably the best solution as it still comes before any Gothic code is executed.

Since the gmp only supports Gothic 2, the changes are only related to g2. 