### PR TITLE
Added CHECKSUM_G1_1_08k_4GB to version check

### DIFF
--- a/D3D11Engine/VersionCheck.cpp
+++ b/D3D11Engine/VersionCheck.cpp
@@ -15,6 +15,7 @@ namespace VersionCheck {
 	static const int CHECKSUM_G2_2_6_FIX = 0x008a3e89;
 	static const int CHECKSUM_G2_2_6_FIX_4GB = 0x008a3ea9;
 	static const int CHECKSUM_G1_1_08k = 0x0000eb3d;
+	static const int CHECKSUM_G1_1_08k_4GB = 0x08608228;
 	static const int CHECKSUM_G1_1_12f = 0x00862362;
 
 	/** Returns whether the given file exists */
@@ -77,7 +78,7 @@ namespace VersionCheck {
                 "\nYour checksum was: " << headersum;
         }
 #else
-		if ( headersum != CHECKSUM_G1_1_08k ) {
+		if ( headersum != CHECKSUM_G1_1_08k && headersum != CHECKSUM_G1_1_08k_4GB ) {
 			LogWarnBox() << "Your Gothic-Executable does not match the checksum for this version of GD3D11!\n"
 				"This DLL only works for Gothic 1 - Version 1.08k_mod or the System-Pack.\n\n"
 				"You can continue and try anyways but the game will most likely crash.\n"


### PR DESCRIPTION
TLDR; This change is required to run the Gothic Reloaded Mod.

D3D11 failed to allocate memory for a vertex buffer (D3D11ConstantBuffer.cpp, line 24 returned E_OUTOFMEMORY) and then the renderer crashed to a black screen. The Gothic process was around 600-700 MB RAM, far from the 2GB limit, while my system has 32 GB of CPU memory and 8 GB of GPU memory, both being about 80% free. My assumption was that the vertex buffer to be created, which is around 800 MB for some reason, is to be allocated in the process memory because D3D11_USAGE_DYNAMIC is specified and this fails as the memory is fragmented and there is not enough _sequential_ free memory. As a workaround I used the large address aware hack from NicoDE, which seems to have solved the problem. Unfortunately this caused the renderer to complain about the checksum.