### PR TITLE
Actions: build-action now creates downloadable artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 defaults:
   run:
@@ -32,3 +33,53 @@ jobs:
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: msbuild /p:Configuration=${{matrix.configuration}} .
+      
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.configuration }}
+        path: ${{ matrix.configuration }}/ddraw.dll
+        retention-days: 2
+
+  artifacts:
+    needs: build
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set tag and directory name env
+      run: |
+        $tagName = $Env:GITHUB_SHA.Substring(0, 9)
+        $dirName = "GD3D11-git-$tagName"
+        echo "Tag: ${tagName}"
+        echo "Directory: ${dirName}"
+        echo "RELEASE_VERSION=${tagName}" >> $Env:GITHUB_ENV
+        echo "RELEASE_DIR=${dirName}" >> $Env:GITHUB_ENV
+
+    - uses: actions/download-artifact@v3
+    
+    - name: Display structure of downloaded files
+      run: ls -R
+    
+    - name: Create distribution zip
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        mkdir "${{env.RELEASE_DIR}}\GD3D11\shaders\CSFFT"
+        mkdir "${{env.RELEASE_DIR}}\GD3D11\Bin"
+        Xcopy "D3D11Engine\Shaders\*" "${{env.RELEASE_DIR}}\GD3D11\shaders" /s
+        copy "D3D11Engine\CSFFT\*.hlsl" "${{env.RELEASE_DIR}}\GD3D11\shaders\CSFFT"
+        Xcopy "blobs\Meshes" "${{env.RELEASE_DIR}}\GD3D11\Meshes\" /s
+        Xcopy "blobs\Textures" "${{env.RELEASE_DIR}}\GD3D11\Textures\" /s
+        Xcopy "blobs\libs\*" "${{env.RELEASE_DIR}}\" /s
+        copy "Release_AVX\ddraw.dll" "${{env.RELEASE_DIR}}\GD3D11\Bin\g2a_avx2.dll"
+        copy "Release\ddraw.dll" "${{env.RELEASE_DIR}}\GD3D11\Bin\g2a.dll"
+        copy "Release_G1_AVX\ddraw.dll" "${{env.RELEASE_DIR}}\GD3D11\Bin\g1_avx.dll"
+        copy "Release_G1\ddraw.dll" "${{env.RELEASE_DIR}}\GD3D11\Bin\g1.dll"
+        copy "Launcher\ddraw.dll" "${{env.RELEASE_DIR}}\"
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.RELEASE_DIR }}
+        path: ${{ env.RELEASE_DIR }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         configuration: [Release_AVX, Release_G1_AVX, Release, Release_G1, Spacer_NET, Launcher]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,7 @@ jobs:
 
     - name: Build Launcher
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: |
-        msbuild /p:Configuration=Launcher .
+      run: msbuild /p:Configuration=Launcher .
 
     - name: Create distribution zip
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set tag and directory name env
       run: |

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Launcher|Win32">
+      <Configuration>Launcher</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release_AVX|Win32">
       <Configuration>Release_AVX</Configuration>
       <Platform>Win32</Platform>
@@ -62,7 +66,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_AVX|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -107,6 +111,9 @@
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Launcher|Win32'">
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/Direct3D7Wrapper.sln
+++ b/Direct3D7Wrapper.sln
@@ -26,8 +26,7 @@ Global
 		Spacer_NET|Win32 = Spacer_NET|Win32
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Launcher|Win32.ActiveCfg = Release|Win32
-		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Launcher|Win32.Build.0 = Release|Win32
+		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Launcher|Win32.ActiveCfg = Launcher|Win32
 		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Release_AVX|Win32.ActiveCfg = Release_AVX|Win32
 		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Release_AVX|Win32.Build.0 = Release_AVX|Win32
 		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Release_G1_12f|Win32.ActiveCfg = Release_G1_12f|Win32
@@ -47,22 +46,15 @@ Global
 		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Spacer_NET|Win32.ActiveCfg = Spacer_NET|Win32
 		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Spacer_NET|Win32.Build.0 = Spacer_NET|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Launcher|Win32.ActiveCfg = Launcher|Win32
+		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Launcher|Win32.Build.0 = Launcher|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_AVX|Win32.ActiveCfg = Launcher|Win32
-		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_AVX|Win32.Build.0 = Launcher|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_G1_12f|Win32.ActiveCfg = Launcher|Win32
-		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_G1_12f|Win32.Build.0 = Launcher|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_G1_AVX|Win32.ActiveCfg = Launcher|Win32
-		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_G1_AVX|Win32.Build.0 = Launcher|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_G1|Win32.ActiveCfg = Launcher|Win32
-		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_G1|Win32.Build.0 = Launcher|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_NoOpt_G1|Win32.ActiveCfg = Launcher|Win32
-		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_NoOpt_G1|Win32.Build.0 = Launcher|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_NoOpt_Spacer|Win32.ActiveCfg = Launcher|Win32
-		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_NoOpt_Spacer|Win32.Build.0 = Launcher|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_NoOpt|Win32.ActiveCfg = Launcher|Win32
-		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_NoOpt|Win32.Build.0 = Launcher|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release|Win32.ActiveCfg = Launcher|Win32
-		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release|Win32.Build.0 = Launcher|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Spacer_NET|Win32.ActiveCfg = Launcher|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution


### PR DESCRIPTION
artifacts for every push can now be downloaded for about 90 days (maximum retention time by github)
This allows to more quickly test new features and provide new builds to interested users.