### PR TITLE
Fixed foam of waterfalls

### DIFF
--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -448,10 +448,10 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
             && !mat->HasAlphaTest() ) // Fix foam on waterfalls
         {
 #ifdef BUILD_GOTHIC_1_08k
-            if ( key.Texture && key.Texture->HasAlphaChannel() && AdditionalCheckWaterFall( key.Texture ) ) { // Fix foam on waterfalls
-                // Give it alpha test since it contains alpha channel and most like is the foam
+            if ( key.Texture && AdditionalCheckWaterFall( key.Texture ) ) { // Fix foam on waterfalls
+                // Give it alpha blend since it contains alpha channel and most like is the foam
                 // Normal water surfaces shouldn't have alpha channel
-                mat->SetAlphaFunc( zMAT_ALPHA_FUNC_TEST );
+                mat->SetAlphaFunc( zMAT_ALPHA_FUNC_BLEND );
             } else {
                 // Give water surfaces a water-shader
                 MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom( key.Texture );


### PR DESCRIPTION
For some reason, key.Texture->HasAlphaChannel() returns false the first time it encounters OWODWFALL_HITSURFACE_A0 or OWODWFALL_STONE_A0 and true after that. I removed this check as AdditionalCheckWaterFall() is more restrictive anyway. Of course comparing strings takes longer than a bool but the parent function is called once a level is loaded, therefore this shouldn't have any noticable performance impact. Finally I changed zMAT_ALPHA_FUNC_TEST to zMAT_ALPHA_FUNC_BLEND, which looks better.

![grafik](https://user-images.githubusercontent.com/4657476/193424536-f72da128-3d89-4456-b28f-ed821eaa4687.png)