### PR TITLE
- Water shader will now darken / lighten with day / night cycle

### DIFF
--- a/D3D11Engine/BaseAntTweakBar.cpp
+++ b/D3D11Engine/BaseAntTweakBar.cpp
@@ -250,6 +250,10 @@ XRESULT BaseAntTweakBar::Init() {
     TwAddVarRW( Bar_General, "ForceFOV", TW_TYPE_BOOLCPP, &Engine::GAPI->GetRendererState().RendererSettings.ForceFOV, nullptr );
     //TwAddVarRW(Bar_General, "Max Num Indices", TW_TYPE_INT32, &Engine::GAPI->GetRendererState().RendererSettings.MaxNumFaces, nullptr);
 
+#ifdef BUILD_GOTHIC_1_08k
+    TwAddVarRW( Bar_General, "DrawForestPortals", TW_TYPE_BOOLCPP, &Engine::GAPI->GetRendererState().RendererSettings.DrawG1ForestPortals, nullptr );
+#endif
+
     Bar_Info = TwNewBar( "FrameStats" );
     TwDefine( " FrameStats refresh=0.3" );
     TwDefine( " FrameStats position='800 0'" );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -258,6 +258,10 @@ XRESULT D3D11GraphicsEngine::Init() {
     PS_DiffuseNormalmappedAlphatest = ShaderManager->GetPShader( "PS_DiffuseNormalmappedAlphaTest" );
     PS_DiffuseAlphatest = ShaderManager->GetPShader( "PS_DiffuseAlphaTest" );
 
+    PS_PortalDiffuse = ShaderManager->GetPShader( "PS_PortalDiffuse" );
+
+    PS_WaterfallFoam = ShaderManager->GetPShader( "PS_WaterfallFoam" );
+
     TempVertexBuffer = std::make_unique<D3D11VertexBuffer>();
     TempVertexBuffer->Init(
         nullptr, DRAWVERTEXARRAY_BUFFER_SIZE, D3D11VertexBuffer::B_VERTEXBUFFER,
@@ -2213,6 +2217,8 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     RenderedVobs.clear();
     FrameWaterSurfaces.clear();
     FrameTransparencyMeshes.clear();
+    FrameTransparencyMeshesPortal.clear();
+    FrameTransparencyMeshesWaterfall.clear();
 
     // TODO: TODO: Hack for texture caching!
     zCTextureCacheHack::NumNotCachedTexturesInFrame = 0;
@@ -2258,6 +2264,14 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
 
     // Draw light-shafts
     DrawMeshInfoListAlphablended( FrameTransparencyMeshes );
+
+    //draw forest / door portals
+    if ( Engine::GAPI->GetRendererState().RendererSettings.DrawG1ForestPortals ) {
+        DrawMeshInfoListAlphablended( FrameTransparencyMeshesPortal );
+    }
+
+    //draw waterfall foam
+    DrawMeshInfoListAlphablended( FrameTransparencyMeshesWaterfall );
 
     // Draw ghosts
     D3D11ENGINE_RENDER_STAGE oldStage = RenderingStage;
@@ -2613,9 +2627,10 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
             // Bind both
             GetContext()->PSSetShaderResources( 0, 3, srv );
 
-            // Get the right shader for it
             int alphaFunc = it.first.Material->GetAlphaFunc();
-            BindShaderForTexture( texture, false, alphaFunc );
+
+            //Get the right shader for it
+            BindShaderForTexture( texture, false, alphaFunc, it.first.Info->MaterialType );
 
             // Check for alphablending on world mesh
             if ( lastAlphaFunc != alphaFunc ) {
@@ -2645,6 +2660,7 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
             // Draw the section-part
             DrawVertexBufferIndexedUINT( nullptr, nullptr, it.second->Indices.size(),
                 it.second->BaseIndexLocation );
+
         }
     }
 
@@ -2739,9 +2755,15 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                 }
 
                 // Check for alphablending
-                if (worldMesh.first.Material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
-                    worldMesh.first.Material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST) {
-                    FrameTransparencyMeshes.push_back(worldMesh);
+                if ( worldMesh.first.Material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
+                    worldMesh.first.Material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST ) {
+                    if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_Portal ) {
+                        FrameTransparencyMeshesPortal.push_back( worldMesh );
+                    } else if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_WaterfallFoam ) {
+                        FrameTransparencyMeshesWaterfall.push_back( worldMesh );
+                    } else {
+                        FrameTransparencyMeshes.push_back( worldMesh );
+                    }
                 } else {
                     // Create a new pair using the animated texture
                     meshList.emplace_back( key, worldMesh.second );
@@ -3270,7 +3292,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
     bool noNPCs, std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
     std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache ) {
-
+        
     // Setup renderstates
     Engine::GAPI->GetRendererState().RasterizerState.SetDefault();
     Engine::GAPI->GetRendererState().RasterizerState.CullMode =
@@ -3351,6 +3373,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                 // Bind texture
                 if ( meshInfoByKey->first.Material && meshInfoByKey->first.Material->GetTexture() ) {
                     // Check surface type
+
                     if ( meshInfoByKey->first.Info->MaterialType == MaterialInfo::MT_Water ) {
                         continue;
                     }
@@ -3376,7 +3399,6 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                 DrawVertexBufferIndexedUINT( nullptr, nullptr,
                     meshInfoByKey->second->Indices.size(), meshInfoByKey->second->BaseIndexLocation );
             }
-
         } else {
             for ( auto&& itx : Engine::GAPI->GetWorldSections() ) {
                 for ( auto&& ity : itx.second ) {
@@ -5541,10 +5563,11 @@ void D3D11GraphicsEngine::GetBackbufferData( byte** data, int& pixelsize ) {
     *data = d;
 }
 
-/** Binds the right shader for the given texture */
+/* Binds the right shader for the given texture */ 
 void D3D11GraphicsEngine::BindShaderForTexture( zCTexture* texture,
     bool forceAlphaTest,
-    int zMatAlphaFunc ) {
+    int zMatAlphaFunc,
+    MaterialInfo::EMaterialType materialInfo ) {
     auto active = ActivePS;
     auto newShader = ActivePS;
 
@@ -5552,7 +5575,11 @@ void D3D11GraphicsEngine::BindShaderForTexture( zCTexture* texture,
     bool blendBlend = zMatAlphaFunc == zMAT_ALPHA_FUNC_BLEND;
     bool linZ = (Engine::GAPI->GetRendererState().GraphicsState.FF_GSwitches & GSWITCH_LINEAR_DEPTH) != 0;
 
-    if ( linZ ) {
+    if ( materialInfo == MaterialInfo::MT_Portal ) {
+        newShader = PS_PortalDiffuse;
+    } else if ( materialInfo == MaterialInfo::MT_WaterfallFoam ) {
+        newShader = PS_WaterfallFoam;
+    } else if ( linZ ) {
         newShader = PS_LinDepth;
     } else if ( blendAdd || blendBlend ) {
         newShader = PS_Simple;

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "D3D11GraphicsEngineBase.h"
 #include "fpslimiter.h"
+#include "GothicAPI.h"
 
 struct RenderToDepthStencilBuffer;
 
@@ -313,7 +314,7 @@ public:
     void DrawUnderwaterEffects();
 
     /** Binds the right shader for the given texture */
-    void BindShaderForTexture( zCTexture* texture, bool forceAlphaTest = false, int zMatAlphaFunc = 0 );
+    void BindShaderForTexture( zCTexture* texture, bool forceAlphaTest = false, int zMatAlphaFunc = 0, MaterialInfo::EMaterialType materialInfo = MaterialInfo::MT_None );
 
     /** Copies the depth stencil buffer to DepthStencilBufferCopy */
     void CopyDepthStencil();
@@ -398,6 +399,12 @@ protected:
 
     /** List of worldmeshes we have to render using alphablending */
     std::vector<std::pair<MeshKey, MeshInfo*>> FrameTransparencyMeshes;
+
+    /** List of portal worldmeshes we have to render using alphablending */
+    std::vector<std::pair<MeshKey, MeshInfo*>> FrameTransparencyMeshesPortal;
+
+    /** List of waterfall worldmeshes we have to render using alphablending */
+    std::vector<std::pair<MeshKey, MeshInfo*>> FrameTransparencyMeshesWaterfall;
 
     /** Reflection */
     Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> ReflectionCube;

--- a/D3D11Engine/D3D11GraphicsEngineBase.h
+++ b/D3D11Engine/D3D11GraphicsEngineBase.h
@@ -189,6 +189,9 @@ protected:
     std::shared_ptr<D3D11VShader> VS_ExRemapInstancedObj;
     std::shared_ptr<D3D11VShader> VS_ExSkeletal;
     std::shared_ptr<D3D11GShader> GS_Billboard;
+    
+    std::shared_ptr<D3D11PShader> PS_PortalDiffuse;
+    std::shared_ptr<D3D11PShader> PS_WaterfallFoam;
 
     std::shared_ptr<D3D11VShader> ActiveVS;
     std::shared_ptr<D3D11PShader> ActivePS;

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -275,7 +275,7 @@ XRESULT D3D11ShaderManager::Init() {
     Shaders.push_back( ShaderInfo( "PS_PFX_LumConvert", "PS_PFX_LumConvert.hlsl", "p" ) );
     Shaders.push_back( ShaderInfo( "PS_PFX_LumAdapt", "PS_PFX_LumAdapt.hlsl", "p" ) );
     Shaders.back().cBufferSizes.push_back( sizeof( LumAdaptConstantBuffer ) );
-
+        
     D3D_SHADER_MACRO m;
     std::vector<D3D_SHADER_MACRO> makros;
 
@@ -355,12 +355,15 @@ XRESULT D3D11ShaderManager::Init() {
     m.Name = "ALPHATEST";
     m.Definition = "0";
     makros.push_back( m );
-
+    
     Shaders.push_back( ShaderInfo( "PS_Diffuse", "PS_Diffuse.hlsl", "p", makros ) );
     Shaders.back().cBufferSizes.push_back( sizeof( GothicGraphicsState ) );
     Shaders.back().cBufferSizes.push_back( sizeof( AtmosphereConstantBuffer ) );
     Shaders.back().cBufferSizes.push_back( sizeof( MaterialInfo::Buffer ) );
     Shaders.back().cBufferSizes.push_back( sizeof( PerObjectState ) );
+
+    Shaders.push_back( ShaderInfo( "PS_PortalDiffuse", "PS_PortalDiffuse.hlsl", "p" ) ); //forest portals, doors, etc.
+    Shaders.push_back( ShaderInfo( "PS_WaterfallFoam", "PS_WaterfallFoam.hlsl", "p" ) );     //foam on at the base of waterfalls
 
     makros.clear();
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -3914,6 +3914,8 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "General", "CompressBackBuffer", std::to_string( s.CompressBackBuffer ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "AnimateStaticVobs", std::to_string( s.AnimateStaticVobs ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "DrawWorldSectionIntersections", std::to_string( s.DrawSectionIntersections ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "SunLightStrength", std::to_string( s.SunLightStrength ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "DrawG1ForestPortals", std::to_string( s.DrawG1ForestPortals ? TRUE : FALSE ).c_str(), ini.c_str() );
 
     /*
     * Draw-distance is saved on a per World basis using SaveRendererWorldSettings
@@ -3949,6 +3951,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "Shadows", "PointlightShadows", std::to_string( s.EnablePointlightShadows ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "EnableDynamicLighting", std::to_string( s.EnableDynamicLighting ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "SmoothCameraUpdate", std::to_string( s.SmoothShadowCameraUpdate ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "ShadowStrength", std::to_string( s.ShadowStrength ).c_str(), ini.c_str() );
 
     WritePrivateProfileStringA( "SMAA", "Enabled", std::to_string( s.EnableSMAA ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "SMAA", "SharpenFactor", std::to_string( s.SharpenFactor ).c_str(), ini.c_str() );
@@ -4009,6 +4012,8 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
     s.CompressBackBuffer = GetPrivateProfileBoolA( "General", "CompressBackBuffer", defaultRendererSettings.CompressBackBuffer, ini );
     s.AnimateStaticVobs = GetPrivateProfileBoolA( "General", "AnimateStaticVobs", defaultRendererSettings.AnimateStaticVobs, ini );
     s.DrawSectionIntersections = GetPrivateProfileBoolA( "General", "DrawWorldSectionIntersections", defaultRendererSettings.DrawSectionIntersections, ini );
+    s.SunLightStrength = GetPrivateProfileFloatA( "General", "SunLightStrength", defaultRendererSettings.SunLightStrength, ini );
+    s.DrawG1ForestPortals = GetPrivateProfileBoolA( "General", "DrawG1ForestPortals", defaultRendererSettings.DrawG1ForestPortals, ini );
 
     /*
     * Draw-distance is Loaded on a per World basis using LoadRendererWorldSettings
@@ -4034,6 +4039,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
     s.WorldShadowRangeScale = GetPrivateProfileFloatA( "Shadows", "WorldShadowRangeScale", 1.0f, ini );
     s.EnableDynamicLighting = GetPrivateProfileBoolA( "Shadows", "EnableDynamicLighting", defaultRendererSettings.EnableDynamicLighting, ini );
     s.SmoothShadowCameraUpdate = GetPrivateProfileBoolA( "Shadows", "SmoothCameraUpdate", defaultRendererSettings.SmoothShadowCameraUpdate, ini );
+    s.ShadowStrength = GetPrivateProfileFloatA( "Shadows", "ShadowStrength", defaultRendererSettings.ShadowStrength, ini );
 
     INT2 res = {};
     RECT desktopRect;

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -84,7 +84,9 @@ struct MaterialInfo {
     enum EMaterialType {
         MT_None,
         MT_Water,
-        MT_Ocean
+        MT_Ocean,
+        MT_Portal,
+        MT_WaterfallFoam
     };
 
     MaterialInfo() {

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -538,6 +538,9 @@ struct GothicRendererSettings {
         ShowSkeletalVertexNormals = false;
         EnableDynamicLighting = true;
 
+        DrawG1ForestPortals = false;    //enables the textures around forests and some doors to darken them
+                                        //these are only applicable to G1, they don't appear to have been used in G2
+
         FastShadows = false;
         MaxNumFaces = 0;
         IndoorVobDrawRadius = 5000.0f;
@@ -709,6 +712,7 @@ struct GothicRendererSettings {
     bool DrawParticleEffects;
     bool DrawSky;
     bool DrawFog;
+    bool DrawG1ForestPortals;
     bool EnableHDR;
     E_HDRToneMap HDRToneMap;
     bool EnableVSync;

--- a/D3D11Engine/Shaders/PS_PFX_Heightfog.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_Heightfog.hlsl
@@ -94,15 +94,14 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	position.y -= HF_FogHeight;
 	
 	float fog = 1.0f - ComputeVolumetricFog(position, posOriginal);
-	
-	
-	
+		
 	float3 color = ApplyAtmosphericScatteringGround(position, HF_FogColorMod, true);
-	
-	return float4(saturate(color), saturate(fog));
-	
-	//float zView = HF_ProjAB.y / (expDepth - HF_ProjAB.x);
-	
-	//return float4(HF_CameraPosition + Input.vEyeRay * zView, 1);// fog);
+
+	//darken / lighten fog based on the day / night cycle
+	float darknessFactor = 2.0f;
+	if (AC_LightPos.y < 0.0f) { darknessFactor -= AC_LightPos.y * 3.0f; }
+	else if (AC_LightPos.y > 0.0f) { darknessFactor -= AC_LightPos.y; }
+
+	return float4(saturate(color / darknessFactor), saturate(fog));
 }
 

--- a/D3D11Engine/Shaders/PS_PortalDiffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_PortalDiffuse.hlsl
@@ -1,0 +1,62 @@
+//--------------------------------------------------------------------------------------
+// World/VOB-Pixelshader for G2D3D11 by SaulMyers
+//--------------------------------------------------------------------------------------
+#include <DS_Defines.h>
+#include <AtmosphericScattering.h>
+
+//--------------------------------------------------------------------------------------
+// Textures and Samplers
+//--------------------------------------------------------------------------------------
+SamplerState SS_Linear : register(s0);
+SamplerState SS_samMirror : register(s1);
+Texture2D	TX_Texture0 : register(t0);
+Texture2D	TX_Texture1 : register(t1);
+Texture2D	TX_Texture2 : register(t2);
+TextureCube	TX_ReflectionCube : register(t4);
+
+//--------------------------------------------------------------------------------------
+// Input / Output structures
+//--------------------------------------------------------------------------------------
+struct PS_INPUT
+{
+	float2 vTexcoord		: TEXCOORD0;
+	float2 vTexcoord2		: TEXCOORD1;
+	float4 vDiffuse			: TEXCOORD2;
+	float3 vNormalVS		: TEXCOORD4;
+	float3 vViewPosition	: TEXCOORD5;
+	float4 vPosition		: SV_POSITION;
+};
+
+//--------------------------------------------------------------------------------------
+// Pixel Shader
+//--------------------------------------------------------------------------------------
+DEFERRED_PS_OUTPUT PSMain(PS_INPUT Input) : SV_TARGET
+{
+	//how far is the nameless hero from the object?
+	float distFromCamera = distance(Input.vViewPosition, Input.vPosition);
+	
+	//start / end distances for fading
+	float startFade = 8000.0f;
+	float completeFade = 6000.0f;
+
+	//how much to fade the object by
+	float percentageFade = (distFromCamera - completeFade) / (startFade - completeFade);
+		
+	//keep the fade in bounds
+	if (percentageFade < 0) { percentageFade = 0.0f; clip(-1); }
+	if (percentageFade > 1)	{percentageFade = 1.0f;}
+
+	//darken the portals depending on where the sun is in the sky
+	float darknessFactor = 2.0f;
+	if (AC_LightPos.y <= 0.05f) { darknessFactor += (1 - AC_LightPos.y) * 6; }
+	else if (AC_LightPos.y > 0.05f) { darknessFactor = 7.5f - (1 + AC_LightPos.y) * 3; }
+
+	//sample the texture we want to fade out and apply relevant darkness factor for day / night cycle
+	float4 color = TX_Texture0.Sample(SS_Linear, Input.vTexcoord) / darknessFactor;
+	
+	//apply fade
+	DEFERRED_PS_OUTPUT output;
+	output.vDiffuse = float4(color.rgb, percentageFade);	
+
+	return output;
+}

--- a/D3D11Engine/Shaders/PS_Water.hlsl
+++ b/D3D11Engine/Shaders/PS_Water.hlsl
@@ -106,15 +106,11 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float fresnel = min(0.5f, saturate(pow(1.0f - saturate(dot(-viewDirection, wavesFres)), 10.0f)));
 	
 	// Reflection
-	float3 reflect_vec = reflect(-viewDirection, wavesFres);
-	
+	float3 reflect_vec = reflect(-viewDirection, wavesFres);	
 	
 	// sample reflection cube
 	float3 reflection = TX_ReflectionCube.Sample(SS_Linear, reflect_vec).xyz;
 	
-	//scene *= float4(0,0,1,1);
-	
-
 	// Darken the scene, to make a wet surface
 	float f = 1-saturate(pow(1-shallowDepth, 8.0f) + clamp(pow(distortionSmall.y, 2), 0.5f, 1.0f));
 
@@ -138,6 +134,11 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float cos_spec = clamp(dot(reflect_vecSmall, -AC_LightPos.xyz * float3(1,1,1)), 0, 1);
 	float sun_spot = pow(cos_spec, 500.0f) * 0.5f;
 	color.rgb += lerp(sunColor * sun_spot, float3(0.0f, 0.0f, 0.0f), step(step(0.0f, AC_LightPos.y) * Input.vDiffuse.y, 0.5f));
-	
-	return float4(color, 1);
+
+	//darken / lighten water based on the day / night cycle
+	float darknessFactor = 2.0f;
+	if (AC_LightPos.y < 0.0f) { darknessFactor -= AC_LightPos.y; }
+	else if (AC_LightPos.y > 0.0f) { darknessFactor -= AC_LightPos.y; }
+
+	return float4(color / darknessFactor, 1);
 }

--- a/D3D11Engine/Shaders/PS_WaterfallFoam.hlsl
+++ b/D3D11Engine/Shaders/PS_WaterfallFoam.hlsl
@@ -1,0 +1,38 @@
+#include <AtmosphericScattering.h>
+
+//--------------------------------------------------------------------------------------
+// Textures and Samplers
+//--------------------------------------------------------------------------------------
+SamplerState SS_Linear : register(s0);
+SamplerState SS_samMirror : register(s1);
+Texture2D	TX_Texture0 : register(t0);
+
+//--------------------------------------------------------------------------------------
+// Input / Output structures
+//--------------------------------------------------------------------------------------
+struct PS_INPUT
+{
+	float2 vTexcoord		: TEXCOORD0;
+	float3 vEyeRay			: TEXCOORD1;
+	float4 vPosition		: SV_POSITION;
+};
+
+//--------------------------------------------------------------------------------------
+// Pixel Shader
+//--------------------------------------------------------------------------------------
+float4 PSMain(PS_INPUT Input) : SV_TARGET
+{
+	float4 colour = TX_Texture0.Sample(SS_Linear, Input.vTexcoord);
+
+	//darken / lighten foam based on the day / night cycle
+	float colourRGB = clamp(AC_LightPos.y+0.2f, 0.1f, 0.6f);
+	float opaqueLevel = 1 - clamp(AC_LightPos.y + 0.2f, 0.33f, 0.66f);
+	if (AC_LightPos.y <= 0.08f) {
+		colour *= float4(colourRGB, colourRGB, colourRGB+0.1f, 0.66f); //add blue tint at night
+	}
+	else if (AC_LightPos.y > 0.08f) {
+		colour *= float4(colourRGB, colourRGB, colourRGB, opaqueLevel); //adjust opaque level according to sun height
+	}	
+
+	return colour;
+}

--- a/D3D11Engine/Shaders/PS_WaterfallFoam.hlsl
+++ b/D3D11Engine/Shaders/PS_WaterfallFoam.hlsl
@@ -26,12 +26,11 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 
 	//darken / lighten foam based on the day / night cycle
 	float colourRGB = clamp(AC_LightPos.y+0.2f, 0.1f, 0.6f);
-	float opaqueLevel = 1 - clamp(AC_LightPos.y + 0.2f, 0.33f, 0.66f);
 	if (AC_LightPos.y <= 0.08f) {
-		colour *= float4(colourRGB, colourRGB, colourRGB+0.1f, 0.66f); //add blue tint at night
+		colour *= float4(colourRGB, colourRGB, colourRGB+0.1f, 0.80f); //add blue tint at night
 	}
 	else if (AC_LightPos.y > 0.08f) {
-		colour *= float4(colourRGB, colourRGB, colourRGB, opaqueLevel); //adjust opaque level according to sun height
+		colour *= float4(colourRGB, colourRGB, colourRGB, 0.80f);
 	}	
 
 	return colour;

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -348,12 +348,22 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
         zCPolygon* poly = polys[i];
 
         // Check if we even need this polygon
-        if ( poly->GetPolyFlags()->GhostOccluder || poly->GetPolyFlags()->PortalPoly ) {
+        if ( poly->GetPolyFlags()->GhostOccluder ) {
             continue;
         }
 
-        //if (polygons[i]->GetNumPolyVertices() != 3)
-        //	continue;
+        //Flag portals so that we can apply a different PS shader later
+        if ( poly->GetPolyFlags()->PortalPoly && poly->GetMaterial()->GetTexture() ) {
+            std::string textureName = poly->GetMaterial()->GetTexture()->GetNameWithoutExt();
+            if ( textureName == "OWODFLWOODGROUND" ) {
+                continue; //this is a ground texture that is sometimes re-used for visual tricks to darken tunnels, etc. We don't want to treat this as a portal.
+            } else {
+                MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom( poly->GetMaterial()->GetTexture() );
+                if ( info ) {
+                    info->MaterialType = MaterialInfo::MT_Portal;
+                }
+            }
+        }
 
         // Calculate midpoint of this triange to get the section
         XMFLOAT3 avgPos;
@@ -362,11 +372,6 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
         INT2 section = GetSectionOfPos( avgPos );
         WorldMeshSectionInfo& sectionInfo = (*outSections)[section.x][section.y];
         sectionInfo.WorldCoordinates = section;
-
-        //if ( poly->GetMaterial() && poly->GetMaterial()->GetMatGroup() == zMAT_GROUP_WATER ) {
-            //sectionInfo.OceanPoints.push_back(*poly->getVertices()[0]->Position.toXMFLOAT3());
-            //continue;
-        //}
 
         XMFLOAT3& bbmin = sectionInfo.BoundingBox.Min;
         XMFLOAT3& bbmax = sectionInfo.BoundingBox.Max;
@@ -433,31 +438,29 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
         key.Texture = mat != nullptr ? mat->GetTextureSingle() : nullptr;
         key.Material = mat;
 
-        //key.Lightmap = poly->GetLightmap();
-
         if ( sectionInfo.WorldMeshes.count( key ) == 0 ) {
             key.Info = Engine::GAPI->GetMaterialInfoFrom( key.Texture );
             sectionInfo.WorldMeshes[key] = new WorldMeshInfo;
         }
         TriangleFanToList( &polyVertices[0], polyVertices.size(), &sectionInfo.WorldMeshes[key]->Vertices );
 
-        //if (mat && mat->GetTexture())
-        //	LogInfo() << "Got texture name: " << mat->GetTexture()->GetName();
-
         if ( mat && mat->GetMatGroup() == zMAT_GROUP_WATER // Check for water
-            && !mat->HasAlphaTest() ) // Fix foam on waterfalls
+            && !mat->HasAlphaTest() ) 
         {
 #ifdef BUILD_GOTHIC_1_08k
-            if ( key.Texture && AdditionalCheckWaterFall( key.Texture ) ) { // Fix foam on waterfalls
-                // Give it alpha blend since it contains alpha channel and most like is the foam
-                // Normal water surfaces shouldn't have alpha channel
-                mat->SetAlphaFunc( zMAT_ALPHA_FUNC_BLEND );
-            } else {
+            MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom( key.Texture );
+            if ( !(AdditionalCheckWaterFall( key.Texture )) ) { 
                 // Give water surfaces a water-shader
-                MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom( key.Texture );
                 if ( info ) {
                     info->PixelShader = "PS_Water";
                     info->MaterialType = MaterialInfo::MT_Water;
+                }
+            }
+            else {
+                //apply alpha blend to waterfall foam and flag it as water fall foam to apply shader later
+                if ( info ) {
+                    poly->GetMaterial()->SetAlphaFunc( zMAT_ALPHA_FUNC_BLEND );
+                    info->MaterialType = MaterialInfo::MT_WaterfallFoam;
                 }
             }
 #else


### PR DESCRIPTION
- Water shader will now darken / lighten with day / night cycle
- Fog shader will now darken / lighten with day / night cycle
- Optional 'enable forest portal' option for G1 which displays the textures around forests and some doors to darken them from a distance (disabled by default)
- Fixed waterfall foam texture display to not display them as a water material, allow blending, and darken them with day / night cycle