### PR TITLE
automatically version based on git tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set tag and directory name env
       run: |
         $shortHash = $Env:GITHUB_SHA.Substring(0, 9)
-        echo (-join("CL=/DVERSION_NUMBER#",'\"',"unstable-${shortHash}",'\"')) >> $Env:GITHUB_ENV
+        echo (-join("CL=/DVERSION_NUMBER#",'\"',"-git-${shortHash}",'\"')) >> $Env:GITHUB_ENV
 
     - name: Restore NuGet packages
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,11 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1
 
+    - name: Set tag and directory name env
+      run: |
+        $shortHash = $Env:GITHUB_SHA.Substring(0, 9)
+        echo (-join("CL=/DVERSION_NUMBER#",'\"',"unstable-${shortHash}",'\"')) >> $Env:GITHUB_ENV
+
     - name: Restore NuGet packages
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: nuget restore .
@@ -56,7 +61,6 @@ jobs:
         echo "Directory: ${dirName}"
         echo "RELEASE_VERSION=${tagName}" >> $Env:GITHUB_ENV
         echo "RELEASE_DIR=${dirName}" >> $Env:GITHUB_ENV
-        echo (-join("CL=/DVERSION_NUMBER#",'\"',"unstable-${shortHash}",'\"')) >> $Env:GITHUB_ENV
 
     - uses: actions/download-artifact@v3
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
         echo "Directory: ${dirName}"
         echo "RELEASE_VERSION=${tagName}" >> $Env:GITHUB_ENV
         echo "RELEASE_DIR=${dirName}" >> $Env:GITHUB_ENV
+        echo "CL=/DVERSION_NUMBER#\\\"dev-${shortHash}\\\"" >> $Env:GITHUB_ENV
 
     - uses: actions/download-artifact@v3
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         echo "Directory: ${dirName}"
         echo "RELEASE_VERSION=${tagName}" >> $Env:GITHUB_ENV
         echo "RELEASE_DIR=${dirName}" >> $Env:GITHUB_ENV
-        echo "CL=/DVERSION_NUMBER#\\\"dev-${shortHash}\\\"" >> $Env:GITHUB_ENV
+        echo (-join("CL=/DVERSION_NUMBER#",'\"',"unstable-${shortHash}",'\"')) >> $Env:GITHUB_ENV
 
     - uses: actions/download-artifact@v3
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,12 @@ jobs:
       run: |
         $tagName = $Env:GITHUB_REF -replace 'refs/tags/', ''
         $dirName = "GD3D11-${tagName}"
+        $shortHash = $Env:GITHUB_SHA.Substring(0, 9)
         echo "Tag: ${tagName}"
         echo "Directory: ${dirName}"
         echo "RELEASE_VERSION=${tagName}" >> $Env:GITHUB_ENV
         echo "RELEASE_DIR=${dirName}" >> $Env:GITHUB_ENV
+        echo "CL=/DVERSION_NUMBER#\\\"${tagName}-${shortHash}\\\"" >> $Env:GITHUB_ENV
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         echo "Directory: ${dirName}"
         echo "RELEASE_VERSION=${tagName}" >> $Env:GITHUB_ENV
         echo "RELEASE_DIR=${dirName}" >> $Env:GITHUB_ENV
-        echo "CL=/DVERSION_NUMBER#\\\"${tagName}-${shortHash}\\\"" >> $Env:GITHUB_ENV
+        echo (-join("CL=/DVERSION_NUMBER#",'\"',"${tagName}-${shortHash}",'\"')) >> $Env:GITHUB_ENV
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1

--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -32,7 +32,10 @@ using namespace DirectX;
 
 #define ENABLE_TESSELATION 0
 
+#ifndef VERSION_NUMBER
 #define VERSION_NUMBER "17.8-dev9"
+#endif
+
 __declspec(selectany) const char* VERSION_NUMBER_STR = VERSION_NUMBER;
 
 extern bool FeatureLevel10Compatibility;


### PR DESCRIPTION
This PR sets the displayed version information in-game through CI, such that we technically no longer have to modify pch.h for newer versions