### PR TITLE
- Exclude forest portals when doing second depthbuffer draw of world …

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2679,7 +2679,7 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
     // Draw again, but only to depthbuffer this time to make them work with
     // fogging
     for ( auto const& [meshKey, meshInfo] : list ) {
-        if ( meshKey.Material->GetAniTexture() != nullptr ) {
+        if ( meshKey.Material->GetAniTexture() != nullptr && meshKey.Info->MaterialType != MaterialInfo::MT_Portal ) {
             // Draw the section-part
             DrawVertexBufferIndexedUINT( nullptr, nullptr, meshInfo->Indices.size(),
                 meshInfo->BaseIndexLocation );

--- a/D3D11Engine/Shaders/PS_PortalDiffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_PortalDiffuse.hlsl
@@ -36,14 +36,14 @@ DEFERRED_PS_OUTPUT PSMain(PS_INPUT Input) : SV_TARGET
 	float distFromCamera = distance(Input.vViewPosition, Input.vPosition);
 	
 	//start / end distances for fading
-	float startFade = 8000.0f;
-	float completeFade = 6000.0f;
+	float startFade = 6000.0f;
+	float completeFade = 5000.0f;
 
 	//how much to fade the object by
 	float percentageFade = (distFromCamera - completeFade) / (startFade - completeFade);
 		
 	//keep the fade in bounds
-	if (percentageFade < 0) { percentageFade = 0.0f; clip(-1); }
+	if (percentageFade < 0) {percentageFade = 0.0f;}
 	if (percentageFade > 1)	{percentageFade = 1.0f;}
 
 	//darken the portals depending on where the sun is in the sky


### PR DESCRIPTION
…objects - this caused an ugly effect after the texture had been defused to 100%, but before the depthbuffer pixels had been clipped.

- Removed the clip from the portal shader - not required now.