### PR TITLE
Cleaning up the shader for the 'forest portals'

### DIFF
--- a/D3D11Engine/Shaders/PS_PortalDiffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_PortalDiffuse.hlsl
@@ -1,5 +1,5 @@
 //--------------------------------------------------------------------------------------
-// World/VOB-Pixelshader for G2D3D11 by SaulMyers
+// World/VOB-Pixelshader for Gothic 1 D3D11 by SaulMyers
 //--------------------------------------------------------------------------------------
 #include <DS_Defines.h>
 #include <AtmosphericScattering.h>
@@ -8,11 +8,7 @@
 // Textures and Samplers
 //--------------------------------------------------------------------------------------
 SamplerState SS_Linear : register(s0);
-SamplerState SS_samMirror : register(s1);
 Texture2D	TX_Texture0 : register(t0);
-Texture2D	TX_Texture1 : register(t1);
-Texture2D	TX_Texture2 : register(t2);
-TextureCube	TX_ReflectionCube : register(t4);
 
 //--------------------------------------------------------------------------------------
 // Input / Output structures
@@ -20,7 +16,6 @@ TextureCube	TX_ReflectionCube : register(t4);
 struct PS_INPUT
 {
 	float2 vTexcoord		: TEXCOORD0;
-	float2 vTexcoord2		: TEXCOORD1;
 	float4 vDiffuse			: TEXCOORD2;
 	float3 vNormalVS		: TEXCOORD4;
 	float3 vViewPosition	: TEXCOORD5;
@@ -34,29 +29,28 @@ DEFERRED_PS_OUTPUT PSMain(PS_INPUT Input) : SV_TARGET
 {
 	//how far is the nameless hero from the object?
 	float distFromCamera = distance(Input.vViewPosition, Input.vPosition);
-	
-	//start / end distances for fading
-	float startFade = 6000.0f;
-	float completeFade = 5000.0f;
 
-	//how much to fade the object by
-	float percentageFade = (distFromCamera - completeFade) / (startFade - completeFade);
-		
-	//keep the fade in bounds
-	if (percentageFade < 0) {percentageFade = 0.0f;}
-	if (percentageFade > 1)	{percentageFade = 1.0f;}
+//correct issue with transparency of forest portals for certain camera angles
+if (Input.vViewPosition.x > 0) { distFromCamera = distFromCamera + (Input.vViewPosition.x * clamp(Input.vViewPosition.x / 9000, 0, 1)); }
 
-	//darken the portals depending on where the sun is in the sky
-	float darknessFactor = 2.0f;
-	if (AC_LightPos.y <= 0.05f) { darknessFactor += (1 - AC_LightPos.y) * 6; }
-	else if (AC_LightPos.y > 0.05f) { darknessFactor = 7.5f - (1 + AC_LightPos.y) * 3; }
+//start / end distances for fading
+float startFade = 6500.0f;
+float completeFade = 5500.0f;
 
-	//sample the texture we want to fade out and apply relevant darkness factor for day / night cycle
-	float4 color = TX_Texture0.Sample(SS_Linear, Input.vTexcoord) / darknessFactor;
-	
-	//apply fade
-	DEFERRED_PS_OUTPUT output;
-	output.vDiffuse = float4(color.rgb, percentageFade);	
+//how much to fade the object by
+float percentageFade = clamp((distFromCamera - completeFade) / (startFade - completeFade), 0, 1);
 
-	return output;
+//darken the portals depending on where the sun is in the sky
+float darknessFactor = 4.0f;
+if (AC_LightPos.y <= 0.05f) { darknessFactor += (1 - AC_LightPos.y) * 6; }
+else if (AC_LightPos.y > 0.05f) { darknessFactor = 7.5f - (1 + AC_LightPos.y) * 3; }
+
+//sample the texture we want to fade out and apply relevant darkness factor for day / night cycle
+float4 color = TX_Texture0.Sample(SS_Linear, Input.vTexcoord) / darknessFactor;
+
+//apply fade
+DEFERRED_PS_OUTPUT output;
+output.vDiffuse = float4(color.rgb, percentageFade);
+
+return output;
 }


### PR DESCRIPTION
Cleaning up the shader for the 'forest portals', which is responsible for fading out the textures drawn around forests as the hero approaches. Fixed an issue with diffusing from certain angles, and changed the fade distance to make the effect less obtrusive.