### PR TITLE
Merge latest changes from @SaiyansKing

### DIFF
--- a/D3D11Engine/D2DSettingsDialog.cpp
+++ b/D3D11Engine/D2DSettingsDialog.cpp
@@ -265,7 +265,23 @@ XRESULT D2DSettingsDialog::InitControls() {
 		if ( i <= 25 ) {
 			fpsValues.emplace_back( "off" );
 		} else {
-			fpsValues.emplace_back( std::move( std::to_string( i ) ) );
+            if ( i >= 28 && i <= 32 ) {
+                fpsValues.emplace_back( "30" );
+            } else if ( i >= 58 && i <= 62 ) {
+                fpsValues.emplace_back( "60" );
+            } else if ( i >= 73 && i <= 77 ) {
+                fpsValues.emplace_back( "75" );
+            } else if ( i >= 88 && i <= 92 ) {
+                fpsValues.emplace_back( "90" );
+            } else if ( i >= 98 && i <= 102 ) {
+                fpsValues.emplace_back( "100" );
+            } else if ( i >= 118 && i <= 122 ) {
+                fpsValues.emplace_back( "120" );
+            } else if ( i >= 142 && i <= 146 ) {
+                fpsValues.emplace_back( "144" );
+            } else {
+                fpsValues.emplace_back( std::move( std::to_string( i ) ) );
+            }
 		}
 	}
 	fpsLimitSlider->SetDisplayValues( fpsValues );
@@ -570,7 +586,24 @@ XRESULT D2DSettingsDialog::InitControls() {
 
 void D2DSettingsDialog::FpsLimitSliderChanged( SV_Slider* sender, void* userdata ) {
 	int newValue = static_cast<int>(sender->GetValue());
-	Engine::GAPI->GetRendererState().RendererSettings.FpsLimit = newValue <= 25 ? 0 : newValue;
+    if ( newValue <= 25 ) {
+        newValue = 0;
+    } else if ( newValue >= 28 && newValue <= 32 ) {
+        newValue = 30;
+    } else if ( newValue >= 58 && newValue <= 62 ) {
+        newValue = 60;
+    } else if ( newValue >= 73 && newValue <= 77 ) {
+        newValue = 75;
+    } else if ( newValue >= 88 && newValue <= 92 ) {
+        newValue = 90;
+    } else if ( newValue >= 98 && newValue <= 102 ) {
+        newValue = 100;
+    } else if ( newValue >= 118 && newValue <= 122 ) {
+        newValue = 120;
+    } else if ( newValue >= 142 && newValue <= 146 ) {
+        newValue = 144;
+    }
+	Engine::GAPI->GetRendererState().RendererSettings.FpsLimit = newValue;
 }
 
 void D2DSettingsDialog::FovOverrideCheckedChanged( SV_Checkbox* sender, void* userdata ) {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3380,7 +3380,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                 if ( meshInfoByKey->first.Material && meshInfoByKey->first.Material->GetTexture() ) {
                     // Check surface type
 
-                    if ( meshInfoByKey->first.Info->MaterialType == MaterialInfo::MT_Water ) {
+                    if ( meshInfoByKey->first.Info->MaterialType != MaterialInfo::MT_None ) {
                         continue;
                     }
 
@@ -3422,7 +3422,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                             for ( auto&& meshInfoByKey = section.WorldMeshes.begin();
                                 meshInfoByKey != section.WorldMeshes.end(); ++meshInfoByKey ) {
                                 // Check surface type
-                                if ( meshInfoByKey->first.Info->MaterialType == MaterialInfo::MT_Water ) {
+                                if ( meshInfoByKey->first.Info->MaterialType != MaterialInfo::MT_None ) {
                                     continue;
                                 }
 
@@ -3712,7 +3712,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround( FXMVECTOR position,
                     } else {
                         for ( const auto& it : section.WorldMeshes ) {
                             // Check surface type
-                            if ( it.first.Info->MaterialType == MaterialInfo::MT_Water ) {
+                            if ( it.first.Info->MaterialType != MaterialInfo::MT_None ) {
                                 continue;
                             }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2759,16 +2759,18 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                     key.Texture = aniTex;
                 }
 
+                if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_Portal ) {
+                    FrameTransparencyMeshesPortal.push_back( worldMesh );
+                    continue;
+                } else if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_WaterfallFoam ) {
+                    FrameTransparencyMeshesWaterfall.push_back( worldMesh );
+                    continue;
+                }
+
                 // Check for alphablending
                 if ( worldMesh.first.Material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
                     worldMesh.first.Material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST ) {
-                    if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_Portal ) {
-                        FrameTransparencyMeshesPortal.push_back( worldMesh );
-                    } else if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_WaterfallFoam ) {
-                        FrameTransparencyMeshesWaterfall.push_back( worldMesh );
-                    } else {
-                        FrameTransparencyMeshes.push_back( worldMesh );
-                    }
+                    FrameTransparencyMeshes.push_back( worldMesh );
                 } else {
                     // Create a new pair using the animated texture
                     meshList.emplace_back( key, worldMesh.second );

--- a/D3D11Engine/D3D7/MyDirect3DDevice7.h
+++ b/D3D11Engine/D3D7/MyDirect3DDevice7.h
@@ -482,10 +482,6 @@ public:
 
 	HRESULT STDMETHODCALLTYPE DrawPrimitive( D3DPRIMITIVETYPE dptPrimitiveType, DWORD dwVertexTypeDesc, LPVOID lpvVertices, DWORD dwVertexCount, DWORD dwFlags ) {
 		DebugWrite( "MyDirect3DDevice7::DrawPrimitive" );
-		if ( dptPrimitiveType != D3DPT_TRIANGLEFAN )
-		{
-			return S_OK;
-		}
 
 		// Convert them into ExVertices
 		static std::vector<ExVertexStruct> exv;

--- a/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
+++ b/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
@@ -333,7 +333,6 @@ HRESULT MyDirectDrawSurface7::Lock( LPRECT lpDestRect, LPDDSURFACEDESC2 lpDDSurf
         lpDDSurfaceDesc->ddpfPixelFormat.dwBBitMask = 0x000000FF;
         lpDDSurfaceDesc->ddpfPixelFormat.dwRGBAlphaBitMask = 0x00000000;
 
-        // Gothic transforms this into a 256x256 texture anyways
         lpDDSurfaceDesc->lPitch = buffersize.x * pixelSize;
         lpDDSurfaceDesc->dwWidth = buffersize.x;
         lpDDSurfaceDesc->dwHeight = buffersize.y;

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -352,16 +352,19 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
             continue;
         }
 
-        //Flag portals so that we can apply a different PS shader later
-        if ( poly->GetPolyFlags()->PortalPoly && poly->GetMaterial()->GetTexture() ) {
-            std::string textureName = poly->GetMaterial()->GetTexture()->GetNameWithoutExt();
-            if ( textureName == "OWODFLWOODGROUND" ) {
-                continue; //this is a ground texture that is sometimes re-used for visual tricks to darken tunnels, etc. We don't want to treat this as a portal.
-            } else {
-                MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom( poly->GetMaterial()->GetTexture() );
-                if ( info ) {
+        // Flag portals so that we can apply a different PS shader later
+        if ( poly->GetPolyFlags()->PortalPoly ) {
+            zCMaterial* polymat = poly->GetMaterial();
+            if ( zCTexture* tex = polymat->GetTextureSingle() ) {
+                std::string textureName = tex->GetNameWithoutExt();
+                if ( textureName == "OWODFLWOODGROUND" ) {
+                    continue; // this is a ground texture that is sometimes re-used for visual tricks to darken tunnels, etc. We don't want to treat this as a portal.
+                } else {
+                    MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom( tex );
                     info->MaterialType = MaterialInfo::MT_Portal;
                 }
+            } else {
+                continue;
             }
         }
 

--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -33,7 +33,7 @@ using namespace DirectX;
 #define ENABLE_TESSELATION 0
 
 #ifndef VERSION_NUMBER
-#define VERSION_NUMBER "17.8-dev14"
+#define VERSION_NUMBER "17.8-dev15"
 #endif
 
 __declspec(selectany) const char* VERSION_NUMBER_STR = VERSION_NUMBER;

--- a/D3D11Engine/zBinkPlayer.cpp
+++ b/D3D11Engine/zBinkPlayer.cpp
@@ -269,6 +269,14 @@ int __fastcall BinkPlayerPlayFrame(DWORD BinkPlayer)
                     video->textureU->Init(INT2(vidWidth / 2, vidHeight / 2), D3D11Texture::ETextureFormat::TF_R8, 1, nullptr, "Video Texture U");
                     video->textureV->Init(INT2(vidWidth / 2, vidHeight / 2), D3D11Texture::ETextureFormat::TF_R8, 1, nullptr, "Video Texture V");
                     video->textureData = new unsigned char[(vidWidth * vidHeight) + ((vidWidth / 2) * (vidHeight / 2)) * 2];
+
+                    // Init textureData as black pixel yuv data
+                    unsigned char* dataY = video->textureData;
+                    memset( dataY, 16, vidWidth * vidHeight );
+                    unsigned char* dataV = dataY + (vidWidth * vidHeight);
+                    memset( dataV, 128, (vidWidth / 2) * (vidHeight / 2) );
+                    unsigned char* dataU = dataV + ((vidWidth / 2) * (vidHeight / 2));
+                    memset( dataU, 128, (vidWidth / 2) * (vidHeight / 2) );
                 }
                 reinterpret_cast<void( __stdcall* )(void*, void*, int, DWORD, DWORD, DWORD, DWORD)>(BinkCopyToBuffer)
                     (video->vid, video->textureData, vidWidth, vidHeight, 0, 0, 0x70000000L | 15);

--- a/D3D11Engine/zCMaterial.h
+++ b/D3D11Engine/zCMaterial.h
@@ -165,7 +165,7 @@ public:
     }
 
     bool HasTexAniMap() {
-        return *reinterpret_cast<unsigned char*>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_AlphaFunc )) & GothicMemoryLocations::zCMaterial::Mask_FlagTexAniMap;
+        return *reinterpret_cast<unsigned char*>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_Flags )) & GothicMemoryLocations::zCMaterial::Mask_FlagTexAniMap;
     }
 
     XMFLOAT2 GetTexAniMapDelta() {


### PR DESCRIPTION
This includes

- A fix to rendering "portals" (e.g. Dark Forest in G1, enabled via CTRL+F11) (095ebcb568d68dddff369479e83404c38f33d013)
- Video-Data is preinitialized with black pixels (2400a1f5259eebc68f1f561789dfcbd7c678d009)
- Clamping of FPS values, so that it's easier to target common values (30, 60, 75, 90, 100, 120, 144) (bbd084770ad9f4f941d68c2bec05392b6dfee7a8)