### PR TITLE
Render fog zones in Gothic 1

### DIFF
--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -2720,6 +2720,12 @@ GInventory* GothicAPI::GetInventory() {
     return Inventory.get();
 }
 
+/** Returns the far Z */
+float GothicAPI::GetFarZ() {
+    zCSkyController_Outdoor* sc = oCGame::GetGame()->_zCSession_world->GetSkyControllerOutdoor();
+    return sc->GetFarZ();
+}
+
 /** Returns the fog-color */
 FXMVECTOR GothicAPI::GetFogColor() {
     zCSkyController_Outdoor* sc = oCGame::GetGame()->_zCSession_world->GetSkyControllerOutdoor();

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -403,6 +403,9 @@ public:
     /** Returns the GSky-Object */
     GSky* GetSky() const;
 
+    /** Returns the far Z */
+    float GetFarZ();
+
     /** Returns the fog-color */
     FXMVECTOR GetFogColor();
 

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -123,8 +123,8 @@ struct GothicMemoryLocations {
         static const unsigned int Init = 0x005E6A00;*/
 
         static const unsigned int GetUnderwaterFX = 0x5baaa0;
-        static const unsigned int Offset_OverrideColor = 0x558;
-        static const unsigned int Offset_OverrideFlag = 0x564;
+        static const unsigned int Offset_FarZ = 0x56C;
+        static const unsigned int Offset_Color = 0x580;
 
         static const unsigned int SetCameraLocationHint = 0x005BC7D0;
 

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -191,6 +191,8 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_SkyLayerState1 = 0x124;
         static const unsigned int Offset_OverrideColor = 0x558;
         static const unsigned int Offset_OverrideFlag = 0x564;
+        static const unsigned int Offset_FarZ = 0x580;
+        static const unsigned int Offset_Color = 0x594;
         static const unsigned int Interpolate = 0x005E8C20;
         static const unsigned int Offset_InitDone = 0x7C;
         static const unsigned int Init = 0x005E6A00;

--- a/D3D11Engine/zCSkyController_Outdoor.h
+++ b/D3D11Engine/zCSkyController_Outdoor.h
@@ -208,13 +208,22 @@ public:
 #ifndef BUILD_GOTHIC_1_08k
         return *reinterpret_cast<XMFLOAT3*>(THISPTR_OFFSET( GothicMemoryLocations::zCSkyController_Outdoor::Offset_OverrideColor ));
 #else
-        return XMFLOAT3( 0, 0, 0 );
+        zColor color = *reinterpret_cast<zColor*>THISPTR_OFFSET( GothicMemoryLocations::zCSkyController_Outdoor::Offset_Color );
+        return XMFLOAT3( color.bgra.r / 255.0f, color.bgra.g / 255.0f, color.bgra.b / 255.0f );
 #endif
     }
 
     bool GetOverrideFlag() {
 #ifndef BUILD_GOTHIC_1_08k
         return *reinterpret_cast<int*>(THISPTR_OFFSET( GothicMemoryLocations::zCSkyController_Outdoor::Offset_OverrideFlag )) != 0;
+#else
+        return 1;
+#endif
+    }
+
+    float GetFarZ() {
+#if defined(BUILD_GOTHIC_1_08k) || defined(BUILD_GOTHIC_2_6_fix)
+        return *reinterpret_cast<float*>THISPTR_OFFSET( GothicMemoryLocations::zCSkyController_Outdoor::Offset_FarZ );
 #else
         return 0;
 #endif


### PR DESCRIPTION
This PR will modulate the fog density in Gothic 1 based on the far Z value. The behaviour of the renderer with Gothic 2 is not changed.

The fog in Gothic 1 is not that complex. There is no override flag or -color, compared to Gothic 2. Only the far Z value is changed, limiting the maximum view distance and leaving the rest to D3D. That version of zEngine does not even calculate the color but I wrote a Union plugin to fix that.

I did not module HF_WeightZNear and HF_WeightZFar as it was not beneficial to the graphics, the default values are fine.

The change was tested on Gothic 1 inside and outside of a fog zone, with and without rain as well as with and without my additional plugin. Everything looked fine.