### PR TITLE
Fix/draw cursor allow window change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
         copy "Release_G1A_AVX2\ddraw.dll" "${{env.RELEASE_DIR}}\GD3D11\Bin\g1a_avx2.dll"
         copy "Release_G1A_AVX\ddraw.dll" "${{env.RELEASE_DIR}}\GD3D11\Bin\g1a_avx.dll"
         copy "Release_G1A_SSE2\ddraw.dll" "${{env.RELEASE_DIR}}\GD3D11\Bin\g1a.dll"
+        copy "Launcher\ddraw.dll" "${{env.RELEASE_DIR}}\"
         cd "${{env.RELEASE_DIR}}"
         7z a -tzip "..\${{env.RELEASE_DIR}}.zip" -r
 

--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -206,4 +206,6 @@ public:
     virtual void DrawString( const std::string& str, float x, float y, const zFont* font, zColor& fontColor ) {};
 
     virtual XRESULT UpdateRenderStates() { return XR_SUCCESS; };
+
+    virtual void SetWindowMode( WindowModes mode ) { };
 };

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -319,6 +319,7 @@ public:
     void EnsureTempVertexBufferSize( std::unique_ptr<D3D11VertexBuffer>& buffer, UINT size );
 
     float UpdateCustomFontMultiplierFontRendering( float multiplier );
+    void SetWindowMode( WindowModes mode ) override;
 
 protected:
     std::unique_ptr<FpsLimiter> m_FrameLimiter;
@@ -425,4 +426,5 @@ protected:
     int m_previousFpsLimit;
     bool m_isWindowActive;
     float unionCurrentCustomFontMultiplier;
+    bool m_recreateSwapChain;
 };

--- a/D3D11Engine/D3D11GraphicsEngineBase.h
+++ b/D3D11Engine/D3D11GraphicsEngineBase.h
@@ -128,6 +128,7 @@ public:
     //virtual int MeasureString(std::string str, zFont* zFont);
 
     void ResetPresentPending() { PresentPending = false; }
+    void SetWindowMode( WindowModes mode ) override { }
 
 protected:
     /** Updates the transformsCB with new values from the GAPI */
@@ -204,4 +205,5 @@ protected:
 
     /** If true, we are still waiting for a present to happen. Don't draw everything twice! */
     bool PresentPending;
+    WindowModes m_currentWindowMode;
 };

--- a/D3D11Engine/Types.h
+++ b/D3D11Engine/Types.h
@@ -42,6 +42,9 @@ struct INT2 {
         return std::to_string( x ) + "x" + std::to_string( y );
     }
 
+    bool operator==( const INT2& rhs ) { return x == rhs.x && y == rhs.y; }
+    bool operator!=( const INT2& rhs ) { return !(x == rhs.x && y == rhs.y); }
+
     int x;
     int y;
 };


### PR DESCRIPTION
- Allow changing from Fullscreen Borderless to Fullscreen Low Latency / Windowed at runtime
- Draw own Cursor when borderless fullscreen is stretched (for now, should really fix the inconsistency here)
- fix release.yml not copying the launcher `ddraw.dll`
- Fix Adapter-Enumeration code so that D3D11 DEBUG (graphics debugging in Visual Studio) is possible again