### PR TITLE
Fixed UI textures uv clamping

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2389,7 +2389,7 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_NONE;
     Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
     UpdateRenderStates();
-    GetContext()->PSSetSamplers( 0, 1, ClampSamplerState.GetAddressOf() );
+    GetContext()->PSSetSamplers( 0, 1, CubeSamplerState.GetAddressOf() );
 
     // Save screenshot if wanted
     if ( SaveScreenshotNextFrame ) {


### PR DESCRIPTION
In ZenGin it's possible to render a texture on screen in a mosaic-like way by manipulating its UV. 

Unfortunately, the renderer is trying to clamp UV values higher than 1.0 for UI textures, which makes this feature broken.

**More context**
This was discovered by playing with G2O modification. In G2O you can render a texture with a specific size on screen and manipulate its UV. Sample code:
```js
local tex = null
addEventHandler("onInit", function() {
  tex = Texture(0, 0, 0, 0, "STARTSCREEN.TGA")
  tex.setPositionPx(200, 200)
  tex.setSizePx(512, 350)
  tex.setUV(0.0, 0.0, 4.0, 4.0) // this should repeat the texture four times on x and y axis
  tex.visible = true
})
```

**How it looks without renderer (on vanilla Gothic II)**
![image](https://github.com/user-attachments/assets/9987ef84-841c-40ca-9652-1c25e0a352a3)

**How it looks with renderer**
![image](https://github.com/user-attachments/assets/3b407c12-1c1a-41b4-ad2a-d768dacd6c05)

In order to fix this, we just need to use `CubeSamplerState` (which is set to WRAP mode) instead of `ClampSamplerState` (which is set to CLAMP) while rendering UI textures.