### PR TITLE
Make caves in Gothic 1 less dark (but dark enough)

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4623,7 +4623,10 @@ XRESULT D3D11GraphicsEngine::DrawLighting( std::vector<VobLightInfo*>& lights ) 
             // TODO: fix caves in Gothic 1 being way too dark. Remove this workaround.
     #if BUILD_GOTHIC_1_08k
             // Kirides: Nah, just make it dark enough.
-            scb.SQ_ShadowStrength = 0.333f;
+            if ( Engine::GAPI->GetLoadedWorldInfo()->WorldName == "ORCTEMPEL" )
+                scb.SQ_ShadowStrength = 0.15f;
+            else
+                scb.SQ_ShadowStrength = 0.3f;
     #else
             // Turn off shadows
             scb.SQ_ShadowStrength = 0.0f;


### PR DESCRIPTION
G1 Original
![Mine_G1](https://github.com/user-attachments/assets/16f7cac2-3ff5-47a8-802e-3cf34eb19ac8)

Before change
![Mine_Before](https://github.com/user-attachments/assets/e1614de8-85b2-4a52-b958-9fb695bed99f)

After change
![Mine_After](https://github.com/user-attachments/assets/50a5b6b2-9e80-4340-a785-8a8a3932ff4c)

It is still darker than the original but that was too bright anyway. I spent some minutes testing various settings and this one looked best to me.