### PR TITLE
introduce constexpr vertexIndexDxgiFormat, increase `zTexCacheOutTimeMSec` again, as 1 second of texture cache is too low, make more helpers debug-build friendly

### DIFF
--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -119,7 +119,7 @@ void MaterialInfo::UpdateConstantbuffer() {
 
 namespace
 {
-    float GetPrivateProfileFloatA(
+    OPT_DBG_NOINLINE float GetPrivateProfileFloatA(
         const LPCSTR lpAppName,
         const LPCSTR lpKeyName,
         const float nDefault,
@@ -263,7 +263,7 @@ namespace
     }
 
     template<typename T>
-    void WritePrivateProfileArray(
+    OPT_DBG_NOINLINE void WritePrivateProfileArray(
         const LPCSTR lpAppName,
         const LPCSTR lpKeyName, 
         T* values,
@@ -282,7 +282,7 @@ namespace
         WritePrivateProfileStringA(lpAppName, lpKeyName, ss.str().c_str(), lpFileName.c_str());
     }
 
-    void WritePrivateProfileRGB(
+    OPT_DBG_NOINLINE void WritePrivateProfileRGB(
         const LPCSTR lpAppName,
         const LPCSTR lpKeyName, 
         float3 values,
@@ -296,7 +296,7 @@ namespace
         WritePrivateProfileArray(lpAppName, lpKeyName, color, 3, lpFileName.c_str());
     }
 
-    std::string GetPrivateProfileStringA(
+    OPT_DBG_NOINLINE std::string GetPrivateProfileStringA(
         const LPCSTR lpAppName,
         const LPCSTR lpKeyName,
         const std::string& lpcstrDefault,
@@ -306,7 +306,7 @@ namespace
         return std::string( buffer, count );
     }
 
-    bool GetPrivateProfileBoolA(
+    OPT_DBG_NOINLINE bool GetPrivateProfileBoolA(
         const LPCSTR lpAppName,
         const LPCSTR lpKeyName,
         const bool nDefault,

--- a/D3D11Engine/zCOption.h
+++ b/D3D11Engine/zCOption.h
@@ -116,10 +116,10 @@ public:
             LogInfo() << "Forcing zVidResFullscreenY";
             LogInfo() << "Forcing zVidResFullscreenBPP = 32";
             LogInfo() << "Forcing zTexMaxSize = 16384";
-            LogInfo() << "Forcing zTexCacheOutTimeMSec = 1024";
-            LogInfo() << "Forcing zTexCacheSizeMaxBytes = 2147483648";
-            LogInfo() << "Forcing zSndCacheOutTimeMSec = 1024";
-            LogInfo() << "Forcing zSndCacheSizeMaxBytes = 536870912";
+            LogInfo() << "Forcing zTexCacheOutTimeMSec = 9120000"; // G2A Engine default: 240000
+            LogInfo() << "Forcing zTexCacheSizeMaxBytes = 2147483648"; // G2A Engine default: 32 MB (not MiB)
+            LogInfo() << "Forcing zSndCacheOutTimeMSec = 10000"; // G2A Engine default: 10000
+            LogInfo() << "Forcing zSndCacheSizeMaxBytes = 536870912"; // G2A Engine default: 20 MB (not MiB)
         }
 
         if ( _stricmp( var, "zVidResFullscreenX" ) == 0 ) {
@@ -134,13 +134,12 @@ public:
             return 32;
         } else if ( _stricmp( var, "zTexMaxSize" ) == 0 ) {
             return Engine::GAPI->GetRendererState().RendererSettings.textureMaxSize;
-        } else if ( _stricmp( var, "zTexCacheOutTimeMSec" ) == 0 ) // Previous values were taken outta fucking ass
-        {
-            return 1024;
+        } else if ( _stricmp( var, "zTexCacheOutTimeMSec" ) == 0 ) { // Following values are from Marcellos L'Hiver config
+            return 9120000;
         } else if ( _stricmp( var, "zTexCacheSizeMaxBytes" ) == 0 ) {
             return 2147483648;
         } else if ( _stricmp( var, "zSndCacheOutTimeMSec" ) == 0 ) {
-            return 1024;
+            return 10000;
         } else if ( _stricmp( var, "zSndCacheSizeMaxBytes" ) == 0 ) {
             return 536870912;
         } else if ( _stricmp( var, "zVidDevice" ) == 0 ) {
@@ -156,13 +155,13 @@ public:
         // TODO: Make Option checkable
         // LogInfo() << "Reading Gothic-Config: " << var;
 
-        if ( _stricmp( var, "zTexCacheOutTimeMSec" ) == 0 ) // Previous values were taken from fucking ass
+        if ( _stricmp( var, "zTexCacheOutTimeMSec" ) == 0 ) // Following values are from Marcellos L'Hiver config
         {
-            return 1024;
+            return 9120000;
         } else if ( _stricmp( var, "zTexCacheSizeMaxBytes" ) == 0 ) {
             return 2147483648;
         } else if ( _stricmp( var, "zSndCacheOutTimeMSec" ) == 0 ) {
-            return 1024;
+            return 10000;
         } else if ( _stricmp( var, "zSndCacheSizeMaxBytes" ) == 0 ) {
             return 536870912;
         }


### PR DESCRIPTION
introduce constexpr vertexIndexDxgiFormat, increase `zTexCacheOutTimeMSec` again, as 1 second of texture cache is too low, make more helpers debug-build friendly