### PR TITLE
Revert fix for uv clamping

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2674,7 +2674,7 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_NONE;
     Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
     UpdateRenderStates();
-    GetContext()->PSSetSamplers( 0, 1, CubeSamplerState.GetAddressOf() );
+    GetContext()->PSSetSamplers( 0, 1, ClampSamplerState.GetAddressOf() );
 
     // Save screenshot if wanted
     if ( SaveScreenshotNextFrame ) {


### PR DESCRIPTION
This is a revert for https://github.com/kirides/GD3D11/pull/196

Unfortunately this causes some artifacts for transparent textures (such as books) and it should be reverted till better solution

![image](https://github.com/user-attachments/assets/b13cd231-4463-4341-b756-619ee82f2e82)
