### PR TITLE
apply Gamma/Brightness to final image, including inventory. split Gam…

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -37,10 +37,13 @@ struct SkyConstantBuffer {
 struct GammaCorrectConstantBuffer {
     float G_Gamma;
     float G_Brightness;
-    float2 G_TextureSize;
+    float2 G_pad;
+};
 
+struct PfxSharpenConstantBuffer {
+    float2 G_TextureSize;
     float G_SharpenStrength;
-    float3 G_pad1;
+    float G_pad;
 };
 
 struct BlurConstantBuffer {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -1524,7 +1524,20 @@ XRESULT D3D11GraphicsEngine::Present() {
     UpdateRenderStates();
     {
         auto _ = RecordGraphicsEvent( L"Blit onto Swapchain" );
-        PfxRenderer->CopyTextureToRTV( Backbuffer->GetShaderResView(), BackbufferRTV );
+
+        SetActivePixelShader( "PS_PFX_GammaCorrectInv" );
+
+        ActivePS->Apply();
+
+        // apply gamma and brightness at the end of processing the image
+        GammaCorrectConstantBuffer gcb;
+        gcb.G_Gamma = Engine::GAPI->GetGammaValue();
+        gcb.G_Brightness = Engine::GAPI->GetBrightnessValue();
+
+        ActivePS->GetConstantBuffer()[0]->UpdateBuffer( &gcb );
+        ActivePS->GetConstantBuffer()[0]->BindToPixelShader( 0 );
+
+        PfxRenderer->CopyTextureToRTV( Backbuffer->GetShaderResView(), BackbufferRTV, {}, true );
         GetContext()->OMSetRenderTargets( 1, BackbufferRTV.GetAddressOf(), nullptr );
     }
 
@@ -2847,32 +2860,15 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
 
         SetDefaultStates();
 
-        SetActivePixelShader( "PS_PFX_GammaCorrectInv" );
-
-        ActivePS->Apply();
-
-        GammaCorrectConstantBuffer gcb;
-        gcb.G_Gamma = Engine::GAPI->GetGammaValue();
-        gcb.G_Brightness = Engine::GAPI->GetBrightnessValue();
-        gcb.G_TextureSize = GetResolution();
-        gcb.G_SharpenStrength = Engine::GAPI->GetRendererState().RendererSettings.SharpenFactor;
-
-        ActivePS->GetConstantBuffer()[0]->UpdateBuffer( &gcb );
-        ActivePS->GetConstantBuffer()[0]->BindToPixelShader( 0 );
-
         if ( Engine::GAPI->GetRendererState().RendererSettings.ResolutionScalePercent < 100 
             && Engine::GAPI->GetRendererState().RendererSettings.Upscaler == GothicRendererSettings::E_Upscaler::UPSCALER_FSR_1 ) {
             
             auto _ = RecordGraphicsEvent( L"FSR 1" );
-            auto temp = PfxRenderer->GetTempBuffer();
-
-            // Get the gamma corrected scene into a temp buffer
-            PfxRenderer->CopyTextureToRTV( HDRBackBuffer->GetShaderResView(), temp->GetRenderTargetView(), INT2(0, 0), true);
 
             // Now upscale it to backbuffer with sharpening
             auto sharpenFactor = Engine::GAPI->GetRendererState().RendererSettings.SharpenFactor;
             PfxRenderer->GetFSR1()->Apply(
-                temp->GetShaderResView(),
+                HDRBackBuffer->GetShaderResView(),
                 Backbuffer->GetRenderTargetView(),
                 GetResolution(),
                 GetBackbufferResolution(),
@@ -2882,18 +2878,17 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
 
             if ( Engine::GAPI->GetRendererState().RendererSettings.SharpeningMode
                 && Engine::GAPI->GetRendererState().RendererSettings.SharpenFactor > 0.0f) {
-                auto tempNativeBuffer = GetPfxRenderer()->GetBackbufferTempBuffer();
 
                 {
-                    auto _ = RecordGraphicsEvent( L"Tonemap into SDR buffer" );
-                    PfxRenderer->CopyTextureToRTV( HDRBackBuffer->GetShaderResView(), tempNativeBuffer->GetRenderTargetView(), GetBackbufferResolution(), true);
+                    auto _ = RecordGraphicsEvent( L"Copy into native-size backbuffer" );
+                    PfxRenderer->CopyTextureToRTV( HDRBackBuffer->GetShaderResView(), Backbuffer->GetRenderTargetView(), GetBackbufferResolution() );
                 }
 
                 switch ( Engine::GAPI->GetRendererState().RendererSettings.SharpeningMode ) {
                 case GothicRendererSettings::SHARPEN_SIMPLE:
                     if ( !FeatureLevel10Compatibility ) {
                         auto _ = RecordGraphicsEvent( L"ApplySimpleSharpen" );
-                        PfxRenderer->RenderSimpleSharpen( tempNativeBuffer->GetShaderResView(), GetBackbufferResolution(), tempNativeBuffer->GetRenderTargetView(), GetBackbufferResolution(), *GetPfxRenderer()->GetBackbufferTempBuffer());
+                        PfxRenderer->RenderSimpleSharpen( Backbuffer->GetShaderResView(), GetBackbufferResolution(), Backbuffer->GetRenderTargetView(), GetBackbufferResolution(), *GetPfxRenderer()->GetBackbufferTempBuffer());
                         GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
                     }
                     break;
@@ -2901,19 +2896,16 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
                 case GothicRendererSettings::SHARPEN_CAS:
                     if ( !FeatureLevel10Compatibility ) {
                         auto _ = RecordGraphicsEvent( L"ApplyCAS" );
-                        PfxRenderer->RenderCAS( tempNativeBuffer->GetShaderResView(), GetBackbufferResolution(), tempNativeBuffer->GetRenderTargetView(), GetBackbufferResolution(), *GetPfxRenderer()->GetBackbufferTempBuffer());
+                        PfxRenderer->RenderCAS( Backbuffer->GetShaderResView(), GetBackbufferResolution(), Backbuffer->GetRenderTargetView(), GetBackbufferResolution(), *GetPfxRenderer()->GetBackbufferTempBuffer());
                         GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
                     }
                     break;
                 }
 
-                auto _ = RecordGraphicsEvent( L"Blit onto native-size backbuffer" );
-                PfxRenderer->CopyTextureToRTV( tempNativeBuffer->GetShaderResView(), Backbuffer->GetRenderTargetView(), GetBackbufferResolution() );
             } else {
-                auto _ = RecordGraphicsEvent( L"Tonemap into native-size backbuffer" );
-                PfxRenderer->CopyTextureToRTV( HDRBackBuffer->GetShaderResView(), Backbuffer->GetRenderTargetView(), GetBackbufferResolution(), true );
+                auto _ = RecordGraphicsEvent( L"Copy into native-size backbuffer" );
+                PfxRenderer->CopyTextureToRTV( HDRBackBuffer->GetShaderResView(), Backbuffer->GetRenderTargetView(), GetBackbufferResolution() );
             }
-
         }
 
         // Below this, we assume UI/HUD rendering
@@ -5725,8 +5717,6 @@ void D3D11GraphicsEngine::GetBackbufferData( bool thumbnail, byte** data, INT2& 
     GammaCorrectConstantBuffer gcb;
     gcb.G_Gamma = Engine::GAPI->GetGammaValue();
     gcb.G_Brightness = Engine::GAPI->GetBrightnessValue();
-    gcb.G_TextureSize = buffersize;
-    gcb.G_SharpenStrength = Engine::GAPI->GetRendererState().RendererSettings.SharpenFactor;
 
     ActivePS->GetConstantBuffer()[0]->UpdateBuffer( &gcb );
     ActivePS->GetConstantBuffer()[0]->BindToPixelShader( 0 );

--- a/D3D11Engine/D3D11PFX_SimpleSharpen.cpp
+++ b/D3D11Engine/D3D11PFX_SimpleSharpen.cpp
@@ -38,9 +38,7 @@ XRESULT D3D11PFX_SimpleSharpen::Apply( const Microsoft::WRL::ComPtr<ID3D11Shader
     auto sharpenPS = engine->GetShaderManager().GetPShader( "PS_PFX_Sharpen" );
     sharpenPS->Apply();
 
-    GammaCorrectConstantBuffer gcb;
-    gcb.G_Gamma = Engine::GAPI->GetGammaValue();
-    gcb.G_Brightness = Engine::GAPI->GetBrightnessValue();
+    PfxSharpenConstantBuffer gcb;
     gcb.G_TextureSize = inputSize;
     gcb.G_SharpenStrength = Engine::GAPI->GetRendererState().RendererSettings.SharpenFactor;
 

--- a/D3D11Engine/Shaders/PS_PFX_GammaCorrectInv.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_GammaCorrectInv.hlsl
@@ -6,18 +6,13 @@
 // Textures and Samplers
 //--------------------------------------------------------------------------------------
 SamplerState SS_Linear : register( s0 );
-SamplerState SS_samMirror : register( s1 );
 Texture2D	TX_Texture0 : register( t0 );
-Texture2D	TX_Depth : register( t1 );
 
 cbuffer GammaCorrectConstantBuffer : register( b0 )
 {
 	float G_Gamma;
 	float G_Brightness;
-	float2 G_TextureSize;
-	
-	float G_SharpenStrength;
-	float3 G_pad1;
+	float2 G_Pad;
 }
 
 //--------------------------------------------------------------------------------------
@@ -29,32 +24,6 @@ struct PS_INPUT
 	float3 vEyeRay			: TEXCOORD1;
 	float4 vPosition		: SV_POSITION;
 };
-
-float4 SharpenSample(Texture2D tx, float2 uv, float strength = 0.8f)
-{
-	/** it's a rather easy effect. what you basicly do is blur the image, subtract the blurred from the original to get the difference and then add it to the original again.
-		(Source: http://www.polycount.com/forum/archive/index.php/t-78153.html) **/
-	
-	// run linear blur
-	float3 mask = 0.0f;
-	float4 sample = tx.Sample(SS_Linear, uv);
-	
-	const int N = 3;
-	for(int y=0;y<N;y++)
-	{
-		for(int x=0;x<N;x++)
-		{
-			float2 offset = float2(x - N/2, y - N/2) * (1.0f / G_TextureSize);
-			mask += tx.Sample(SS_Linear, uv + offset).rgb;
-		}
-	}
-	
-	mask /= N*N;
-	
-	mask = max(0, sample.rgb - mask);
-	
-	return sample + float4(mask * strength, 0);
-}
 
 //--------------------------------------------------------------------------------------
 // Pixel Shader

--- a/D3D11Engine/Shaders/PS_PFX_Sharpen.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_Sharpen.hlsl
@@ -10,14 +10,11 @@ SamplerState SS_samMirror : register( s1 );
 Texture2D	TX_Texture0 : register( t0 );
 Texture2D	TX_Depth : register( t1 );
 
-cbuffer GammaCorrectConstantBuffer : register( b0 )
+cbuffer PfxSharpenConstantBuffer : register( b0 )
 {
-	float G_Gamma;
-	float G_Brightness;
 	float2 G_TextureSize;
-	
 	float G_SharpenStrength;
-	float3 G_pad1;
+	float G_pad1;
 }
 
 //--------------------------------------------------------------------------------------


### PR DESCRIPTION
- apply Gamma/Brightness to final image, including any text and inventory drawings.
- split GammaCorrectConstantBuffer for GammaCorrectInv.hlsl and Sharpen.hlsl
  - before it was a single buffer shared for gamma/brightness control and simple sharpening PFX.