### PR TITLE
Implement Tiled-Deferred Shading for FL11+

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -353,4 +353,22 @@ struct VelocityDebugConstantBuffer {
     float AbsoluteMode;     // 0 = signed (-1 to 1), 1 = absolute values
     float Padding;
 };
+
+struct LightCullingConstantBuffer {
+    XMFLOAT4X4 Proj;
+    uint32_t ScreenWidth;
+    uint32_t ScreenHeight;
+    uint32_t TotalLights;
+    uint32_t Pad;
+};
+
+struct TiledShadingConstantBuffer {
+    float2 ViewportSize;
+    float2 Pad0;
+    float4 ProjParams; // x = 1/P._11, y = 1/P._22, z = P._43, w = P._33
+    uint32_t LimitLightIntensity;
+    uint32_t NumTilesX;
+    float2 Pad1;
+    XMFLOAT4X4 InvView; // For world-space reconstruction (shadow sampling)
+};
 #pragma pack (pop)

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -842,6 +842,8 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="D3D11RenderQueue.h" />
     <ClInclude Include="D3D11ShaderManager.h" />
     <ClInclude Include="D3D11ShadowMap.h" />
+    <ClInclude Include="D3D11TiledDeferredShading.h" />
+    <ClInclude Include="D3D11LegacyDeferredShading.h" />
     <ClInclude Include="D3D11Texture.h" />
     <ClInclude Include="D3D11VertexBuffer.h" />
     <ClInclude Include="D3D11VShader.h" />
@@ -1092,6 +1094,8 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="D3D11RenderQueue.cpp" />
     <ClCompile Include="D3D11ShaderManager.cpp" />
     <ClCompile Include="D3D11ShadowMap.cpp" />
+    <ClCompile Include="D3D11TiledDeferredShading.cpp" />
+    <ClCompile Include="D3D11LegacyDeferredShading.cpp" />
     <ClCompile Include="D3D11Texture.cpp" />
     <ClCompile Include="D3D11VertexBuffer.cpp" />
     <ClCompile Include="D3D11VShader.cpp" />

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -810,6 +810,12 @@
     <ClInclude Include="D3D11ShadowMap.h">
       <Filter>Engine\D3D11</Filter>
     </ClInclude>
+    <ClInclude Include="D3D11TiledDeferredShading.h">
+      <Filter>Engine\D3D11</Filter>
+    </ClInclude>
+    <ClInclude Include="D3D11LegacyDeferredShading.h">
+      <Filter>Engine\D3D11</Filter>
+    </ClInclude>
     <ClInclude Include="D3D11PipelineStates.h">
       <Filter>Engine\D3D11</Filter>
     </ClInclude>
@@ -1095,6 +1101,12 @@
       <Filter>Engine\D3D11\PFX\Effects</Filter>
     </ClCompile>
     <ClCompile Include="D3D11ShadowMap.cpp">
+      <Filter>Engine\D3D11</Filter>
+    </ClCompile>
+    <ClCompile Include="D3D11TiledDeferredShading.cpp">
+      <Filter>Engine\D3D11</Filter>
+    </ClCompile>
+    <ClCompile Include="D3D11LegacyDeferredShading.cpp">
       <Filter>Engine\D3D11</Filter>
     </ClCompile>
     <ClCompile Include="D3D11RenderQueue.cpp">

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -870,7 +870,8 @@ XRESULT D3D11GraphicsEngine::SetWindow( HWND hWnd ) {
 /** Reset BackBuffer */
 void D3D11GraphicsEngine::OnResetBackBuffer() {
     auto res = GetResolution();
-    HDRBackBuffer = std::make_unique<RenderToTextureBuffer>( GetDevice().Get(), res.x, res.y, GetBackBufferFormat());
+    HDRBackBuffer = std::make_unique<RenderToTextureBuffer>( GetDevice().Get(), res.x, res.y, GetBackBufferFormat(), nullptr, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, 1, 1,
+        D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE | (Device->GetFeatureLevel() >= D3D_FEATURE_LEVEL_11_0 ? D3D11_BIND_UNORDERED_ACCESS : 0));
     SetDebugName( HDRBackBuffer->GetShaderResView().Get(), "Backbuffer->ShaderResourceView" );
     SetDebugName( HDRBackBuffer->GetRenderTargetView().Get(), "Backbuffer->RenderTargetView" );
 }

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -349,6 +349,8 @@ public:
     auto GetClampSamplerState() -> auto { return ClampSamplerState.Get(); }
     auto GetCubeSamplerState() -> auto { return CubeSamplerState.Get(); }
     auto GetLinearSamplerState() -> auto { return LinearSamplerState.Get(); }
+
+    D3D11ShadowMap* GetShadowMaps() const { return ShadowMaps.get(); }
 protected:
 
     void StoreVobPreviousTransforms();

--- a/D3D11Engine/D3D11GraphicsEngineBase.h
+++ b/D3D11Engine/D3D11GraphicsEngineBase.h
@@ -127,6 +127,7 @@ public:
     void ResetPresentPending() { PresentPending = false; }
 
     auto GetOutputWindow() -> auto { return OutputWindow; }
+    ID3D11SamplerState* GetDefaultSamplerState() const { return DefaultSamplerState.Get(); }
 
     std::unique_ptr<GraphicsEventRecord> RecordGraphicsEvent( LPCWSTR region ) override {
         return std::make_unique<D3DGraphicsEventRecord>( m_UserDefinedAnnotation.Get(), region );

--- a/D3D11Engine/D3D11LegacyDeferredShading.cpp
+++ b/D3D11Engine/D3D11LegacyDeferredShading.cpp
@@ -1,0 +1,159 @@
+#include "pch.h"
+#include "D3D11LegacyDeferredShading.h"
+
+#include "D3D11GraphicsEngine.h"
+#include "D3D11PointLight.h"
+#include "Engine.h"
+#include "GothicAPI.h"
+#include "ConstantBufferStructs.h"
+#include "D3D11_Helpers.h"
+#include "zCVobLight.h"
+#include "GMesh.h"
+
+XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
+    std::vector<VobLightInfo*>& lights,
+    RenderToTextureBuffer& color,
+    RenderToTextureBuffer& normals,
+    RenderToTextureBuffer& specular,
+    RenderToTextureBuffer& depthCopy ) {
+    auto graphicsEngine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    auto _ = graphicsEngine->RecordGraphicsEvent( L"LegacyPointlightLights" );
+    auto& context = graphicsEngine->GetContext();
+    auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+
+    XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
+    Engine::GAPI->SetViewTransformXM( view );
+    view = XMMatrixTranspose( view );
+
+    graphicsEngine->SetActiveVertexShader( "VS_ExPointLight" );
+    graphicsEngine->SetActivePixelShader( "PS_DS_PointLight" );
+
+    auto psPointLight = graphicsEngine->GetShaderManager().GetPShader( "PS_DS_PointLight" );
+    auto psPointLightDynShadow = graphicsEngine->GetShaderManager().GetPShader( "PS_DS_PointLightDynShadow" );
+
+    Engine::GAPI->GetRendererState().BlendState.SetAdditiveBlending();
+    if ( settings.LimitLightIntesity ) {
+        Engine::GAPI->GetRendererState().BlendState.BlendOp = GothicBlendStateInfo::BO_BLEND_OP_MAX;
+    }
+    Engine::GAPI->GetRendererState().BlendState.SetDirty();
+
+    Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled = false;
+    Engine::GAPI->GetRendererState().DepthState.SetDirty();
+
+    Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
+    Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+
+    graphicsEngine->SetupVS_ExMeshDrawCall();
+    graphicsEngine->SetupVS_ExConstantBuffer();
+
+    graphicsEngine->CopyDepthStencil();
+
+    context->OMSetRenderTargets( 1, graphicsEngine->GetHDRBackBuffer().GetRenderTargetView().GetAddressOf(), graphicsEngine->GetDepthBuffer()->GetDepthStencilView().Get() );
+
+    DS_PointLightConstantBuffer plcb = {};
+
+    {
+        auto& proj = Engine::GAPI->GetProjectionMatrix();
+        plcb.PL_ProjParams = float4( 1.0f / proj._11, 1.0f / proj._22, proj._43, proj._33 );
+    }
+    XMStoreFloat4x4( &plcb.PL_InvView, XMMatrixInverse( nullptr, XMLoadFloat4x4( &Engine::GAPI->GetRendererState().TransformState.TransformView ) ) );
+
+    plcb.PL_ViewportSize = Engine::GraphicsEngine->GetResolution();
+
+    color.BindToPixelShader( context.Get(), 0 );
+    normals.BindToPixelShader( context.Get(), 1 );
+    specular.BindToPixelShader( context.Get(), 7 );
+    depthCopy.BindToPixelShader( context.Get(), 2 );
+
+    for ( auto const& light : lights ) {
+        zCVobLight* vob = light->Vob;
+
+        light->VisibleInRenderPass = false;
+
+        if ( !vob->IsEnabled() ) continue;
+
+        if ( settings.EnablePointlightShadows > 0 ) {
+            D3D11PointLight* pl = light->LightShadowBuffers ? static_cast<D3D11PointLight*>(light->LightShadowBuffers) : nullptr;
+
+            if ( pl && pl->IsInited() && pl->HasShadowMap() ) {
+                if ( graphicsEngine->GetActivePS() != psPointLightDynShadow ) {
+                    graphicsEngine->SetActivePS( psPointLightDynShadow )->Apply();
+                }
+            } else if ( graphicsEngine->GetActivePS() != psPointLight ) {
+                graphicsEngine->SetActivePS( psPointLight )->Apply();
+            }
+        }
+
+        vob->DoAnimation();
+
+        plcb.PL_Color = float4( vob->GetLightColor() );
+        plcb.PL_Range = vob->GetLightRange();
+        plcb.Pl_PositionWorld = vob->GetPositionWorld();
+        plcb.PL_Outdoor = light->IsIndoorVob ? 0.0f : 1.0f;
+
+        float dist;
+        XMStoreFloat( &dist, XMVector3Length( XMLoadFloat3( plcb.Pl_PositionWorld.toXMFLOAT3() ) - Engine::GAPI->GetCameraPositionXM() ) );
+
+        if ( dist + plcb.PL_Range <
+            settings.VisualFXDrawRadius ) {
+            float fadeEnd =
+                settings.VisualFXDrawRadius;
+
+            float fadeFactor = std::min(
+                1.0f,
+                std::max( 0.0f, ((fadeEnd - (dist + plcb.PL_Range)) / plcb.PL_Range) ) );
+            plcb.PL_Color.x *= fadeFactor;
+            plcb.PL_Color.y *= fadeFactor;
+            plcb.PL_Color.z *= fadeFactor;
+        }
+
+        float lightFactor = 1.2f;
+
+        plcb.PL_Color.x *= lightFactor;
+        plcb.PL_Color.y *= lightFactor;
+        plcb.PL_Color.z *= lightFactor;
+
+        FXMVECTOR Pl_PositionWorld = XMLoadFloat3( plcb.Pl_PositionWorld.toXMFLOAT3() );
+        XMStoreFloat3( plcb.Pl_PositionView.toXMFLOAT3(),
+            XMVector3TransformCoord( Pl_PositionWorld, view ) );
+
+        XMStoreFloat3( plcb.PL_LightScreenPos.toXMFLOAT3(),
+            XMVector3TransformCoord( Pl_PositionWorld, XMLoadFloat4x4( &Engine::GAPI->GetProjectionMatrix() ) ) );
+
+        if ( dist < plcb.PL_Range ) {
+            if ( Engine::GAPI->GetRendererState().DepthState.DepthBufferEnabled ) {
+                Engine::GAPI->GetRendererState().DepthState.DepthBufferEnabled = false;
+                Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_FRONT;
+                Engine::GAPI->GetRendererState().DepthState.SetDirty();
+                Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+                graphicsEngine->UpdateRenderStates();
+            }
+        } else {
+            if ( !Engine::GAPI->GetRendererState().DepthState.DepthBufferEnabled ) {
+                Engine::GAPI->GetRendererState().DepthState.DepthBufferEnabled = true;
+                Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
+                Engine::GAPI->GetRendererState().DepthState.SetDirty();
+                Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+                graphicsEngine->UpdateRenderStates();
+            }
+        }
+
+        plcb.PL_LightScreenPos.x = plcb.PL_LightScreenPos.x / 2.0f + 0.5f;
+        plcb.PL_LightScreenPos.y = plcb.PL_LightScreenPos.y / -2.0f + 0.5f;
+
+        graphicsEngine->GetActivePS()->GetConstantBuffer()[0]->UpdateBuffer( &plcb );
+        graphicsEngine->GetActivePS()->GetConstantBuffer()[0]->BindToPixelShader( 0 );
+        graphicsEngine->GetActivePS()->GetConstantBuffer()[0]->BindToVertexShader( 1 );
+
+        if ( settings.EnablePointlightShadows > 0 ) {
+            if ( light->LightShadowBuffers )
+                static_cast<D3D11PointLight*>(light->LightShadowBuffers)->OnRenderLight();
+        }
+
+        graphicsEngine->InverseUnitSphereMesh->DrawMesh();
+
+        Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnLights++;
+    }
+
+    return XR_SUCCESS;
+}

--- a/D3D11Engine/D3D11LegacyDeferredShading.h
+++ b/D3D11Engine/D3D11LegacyDeferredShading.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "pch.h"
+#include <vector>
+#include "WorldObjects.h"
+
+struct RenderToTextureBuffer;
+
+class D3D11LegacyDeferredShading {
+public:
+    XRESULT DrawPointlightLights(
+        std::vector<VobLightInfo*>& lights,
+        RenderToTextureBuffer& color,
+        RenderToTextureBuffer& normals,
+        RenderToTextureBuffer& specular,
+        RenderToTextureBuffer& depthCopy );
+};

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "D3D11PointLight.h"
+#include "D3D11TiledDeferredShading.h"
 #include "RenderToTextureBuffer.h"
 #include "D3D11GraphicsEngineBase.h"
 #include "D3D11GraphicsEngine.h" // TODO: Remove and use newer system!
@@ -36,6 +37,7 @@ D3D11PointLight::~D3D11PointLight() {
     // Make sure we are out of the init-queue
     while ( !InitDone );
 
+    ClearTiledSlot();
     ReleaseShadowMap();
 
     for ( auto& [k, mesh] : WorldMeshCache ) {
@@ -70,6 +72,21 @@ void D3D11PointLight::ReleaseShadowMap() {
     // This calls the custom deleter, returning the texture to the pool
     m_DepthCubemap.reset();
     m_CurrentResolution = 0;
+}
+
+void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner ) {
+    m_TiledSlotIndex = slot;
+    m_TiledDepthTarget = target;
+    m_TiledOwner = owner;
+}
+
+void D3D11PointLight::ClearTiledSlot() {
+    if ( m_TiledSlotIndex >= 0 && m_TiledOwner ) {
+        m_TiledOwner->FreeSlot( m_TiledSlotIndex );
+    }
+    m_TiledSlotIndex = -1;
+    m_TiledDepthTarget = nullptr;
+    m_TiledOwner = nullptr;
 }
 
 /** Returns true if this is the first time that light is being rendered */
@@ -120,7 +137,7 @@ bool D3D11PointLight::WantsUpdate() {
 
 /** Draws the surrounding scene into the cubemap */
 void D3D11PointLight::RenderCubemap( bool forceUpdate, D3D11ConstantBuffer* ViewMatricesCB ) {
-    if ( !InitDone || !ViewMatricesCB || !m_DepthCubemap )
+    if ( !InitDone || !ViewMatricesCB || (!m_DepthCubemap && !m_TiledDepthTarget) )
         return;
 
     //if (!GetAsyncKeyState('X'))
@@ -233,7 +250,8 @@ void D3D11PointLight::RenderFullCubemap() {
     if ( WorldCacheInvalid )
         wc = nullptr;
     auto _ = engine->RecordGraphicsEvent( L"RenderFullCubemap->RenderShadowCube" );
-    engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), range, *m_DepthCubemap, nullptr, nullptr, false, LightInfo->IsIndoorVob, noNPCs, &VobCache, &SkeletalVobCache, wc );
+    RenderToDepthStencilBuffer& target = m_TiledDepthTarget ? *m_TiledDepthTarget : *m_DepthCubemap;
+    engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), range, target, nullptr, nullptr, false, LightInfo->IsIndoorVob, noNPCs, &VobCache, &SkeletalVobCache, wc );
 
     //Engine::GAPI->GetRendererState().RendererSettings.DrawSkeletalMeshes = oldDrawSkel;
 }

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -7,6 +7,7 @@
 #include "TexturePool.h"
 
 class D3D11PointLight;
+class D3D11TiledDeferredShading;
 
 struct VobLightInfo;
 struct RenderToDepthStencilBuffer;
@@ -43,11 +44,18 @@ public:
     /** Called when a vob got removed from the world */
     virtual void OnVobRemovedFromWorld( BaseVobInfo* vob );
 
-    bool HasShadowMap() const { return m_DepthCubemap != nullptr; }
+    bool HasShadowMap() const { return m_DepthCubemap != nullptr || m_TiledDepthTarget != nullptr; }
     int GetShadowMapResolution() const { return m_CurrentResolution; }
+    ID3D11Texture2D* GetShadowCubeTexture() const { return m_DepthCubemap ? m_DepthCubemap->GetTexture().Get() : nullptr; }
 
     void AcquireShadowMap( DepthStencilPool* pool, int resolution );
     void ReleaseShadowMap();
+
+    // Tiled deferred slot management (renders directly into shared TextureCubeArray)
+    void SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner );
+    void ClearTiledSlot();
+    int GetTiledSlot() const { return m_TiledSlotIndex; }
+    void SetCurrentResolution( int r ) { m_CurrentResolution = r; }
 
 protected:
     /** Renders the scene with the given view-proj-matrices */
@@ -70,5 +78,9 @@ protected:
     bool DynamicLight;
     std::atomic<bool> InitDone;
     bool DrawnOnce;
-};
 
+    // Tiled deferred slot (non-owning, owned by D3D11TiledDeferredShading)
+    int m_TiledSlotIndex = -1;
+    RenderToDepthStencilBuffer* m_TiledDepthTarget = nullptr;
+    D3D11TiledDeferredShading* m_TiledOwner = nullptr;
+};

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -626,6 +626,12 @@ XRESULT D3D11ShaderManager::Init() {
 
         Shaders.push_back( ShaderInfo( "CS_AdvanceRain", "CS_AdvanceRain.hlsl", "c" ) );
         Shaders.back().cBufferSizes.push_back( sizeof( AdvanceRainConstantBuffer ) );
+
+        Shaders.push_back( ShaderInfo( "CS_LightCulling", "CS_LightCulling.hlsl", "c" ) );
+        Shaders.back().cBufferSizes.push_back( sizeof( LightCullingConstantBuffer ) );
+
+        Shaders.push_back( ShaderInfo( "CS_TiledShading", "CS_TiledShading.hlsl", "c" ) );
+        Shaders.back().cBufferSizes.push_back( sizeof( TiledShadingConstantBuffer ) );
     }
 
     return XR_SUCCESS;

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -329,6 +329,11 @@ void D3D11ShadowMap::Init( Microsoft::WRL::ComPtr<ID3D11Device1>& device, Micros
     m_PointLightCB.reset( cb );
 
     Resize( s );
+
+    if ( !FeatureLevel10Compatibility ) {
+        m_TiledDeferred = std::make_unique<D3D11TiledDeferredShading>();
+        m_TiledDeferred->Init( device, context );
+    }
 }
 
 void D3D11ShadowMap::Resize( int size ) {
@@ -369,6 +374,10 @@ void D3D11ShadowMap::BindToPixelShader( ID3D11DeviceContext1* context, UINT slot
 
 void D3D11ShadowMap::BindSampler( ID3D11DeviceContext1* context, UINT slot ) {
     if ( m_shadowmapSampler ) context->PSSetSamplers( slot, 1, m_shadowmapSampler.GetAddressOf() );
+}
+
+void D3D11ShadowMap::BindSamplerToCS( ID3D11DeviceContext1* context, UINT slot ) {
+    if ( m_shadowmapSampler ) context->CSSetSamplers( slot, 1, m_shadowmapSampler.GetAddressOf() );
 }
 
 XRESULT D3D11ShadowMap::PrepareRender()
@@ -762,6 +771,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
         if (it.second->LightShadowBuffers
             && (!it.second->Vob->IsEnabled() || !it.second->VisibleInFrame)) {
             if ( D3D11PointLight* pl = static_cast<D3D11PointLight*>(it.second->LightShadowBuffers)) {
+                pl->ClearTiledSlot();
                 pl->ReleaseShadowMap();
             }
         }
@@ -795,9 +805,24 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
 
             bool inShadowRange = d < distMaxShadowSq;
             if ( inShadowRange ) {
-                // Acquire memory if it doesn't have it
+                // Acquire memory if it doesn't have it (or resolution changed)
                 if ( !pl->HasShadowMap() || pl->GetShadowMapResolution() != desiredResolution ) {
-                    pl->AcquireShadowMap( dsPool, desiredResolution );
+                    pl->ClearTiledSlot();
+                    pl->ReleaseShadowMap();
+
+                    // Try tiled slot for small (64×64) lights when tiled lighting is active
+                    if ( desiredResolution == SHADOW_CUBE_SIZE && m_TiledDeferred && settings.EnableTiledLighting ) {
+                        int slot = m_TiledDeferred->AllocateSlot();
+                        if ( slot >= 0 ) {
+                            pl->SetTiledSlot( slot, m_TiledDeferred->GetSlotTarget( slot ), m_TiledDeferred.get() );
+                            pl->SetCurrentResolution( desiredResolution );
+                        } else {
+                            pl->AcquireShadowMap( dsPool, desiredResolution );
+                        }
+                    } else {
+                        pl->AcquireShadowMap( dsPool, desiredResolution );
+                    }
+
                     light->UpdateShadows = true; // Force an immediate render this frame
                 }
 
@@ -827,8 +852,9 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
                     // TODO: actually fix memory leakage, as many lights can spawn without ever releasing their shadowmaps
                     // because if they suddenly go out of range (Frustum or VisualFX distance),
                     // we never "collect" them and thus never get to call ReleasShadowMap().
-                    // we could in theory keep a "last seen" list of lights and every frame look up which ones are gone, 
+                    // we could in theory keep a "last seen" list of lights and every frame look up which ones are gone,
                     // to then release theirs resources BEFORE anything else acquires new ones.
+                    pl->ClearTiledSlot();
                     pl->ReleaseShadowMap();
 
                     // Erase from the update queue if it happens to be pending
@@ -955,167 +981,16 @@ XRESULT D3D11ShadowMap::DrawPointlightLights(
     std::vector<VobLightInfo*>& lights,
     RenderToTextureBuffer& color,
     RenderToTextureBuffer& normals,
-    RenderToTextureBuffer& specular,    
-    RenderToTextureBuffer& depthCopy    
+    RenderToTextureBuffer& specular,
+    RenderToTextureBuffer& depthCopy
     ) {
-    auto graphicsEngine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
-    auto _ = graphicsEngine->RecordGraphicsEvent( L"DrawPointlightLights" );
     auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
 
-    XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
-    Engine::GAPI->SetViewTransformXM( view );
-    view = XMMatrixTranspose( view );
-
-    graphicsEngine->SetActiveVertexShader( "VS_ExPointLight" );
-    graphicsEngine->SetActivePixelShader( "PS_DS_PointLight" );
-
-    auto psPointLight = graphicsEngine->GetShaderManager().GetPShader( "PS_DS_PointLight" );
-    auto psPointLightDynShadow = graphicsEngine->GetShaderManager().GetPShader( "PS_DS_PointLightDynShadow" );
-
-    Engine::GAPI->GetRendererState().BlendState.SetAdditiveBlending();
-    if ( settings.LimitLightIntesity ) {
-        Engine::GAPI->GetRendererState().BlendState.BlendOp = GothicBlendStateInfo::BO_BLEND_OP_MAX;
+    if ( m_TiledDeferred && settings.EnableTiledLighting ) {
+        return m_TiledDeferred->DrawPointlightLights( lights, color, normals, specular, depthCopy );
     }
-    Engine::GAPI->GetRendererState().BlendState.SetDirty();
 
-    Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled = false;
-    Engine::GAPI->GetRendererState().DepthState.SetDirty();
-
-    Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
-    Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
-
-    graphicsEngine->SetupVS_ExMeshDrawCall();
-    graphicsEngine->SetupVS_ExConstantBuffer();
-
-    // Copy this, so we can access depth in the pixelshader and still use the buffer for culling
-    graphicsEngine->CopyDepthStencil();
-
-    // Set the main rendertarget
-    m_context->OMSetRenderTargets( 1, graphicsEngine->GetHDRBackBuffer().GetRenderTargetView().GetAddressOf(), graphicsEngine->GetDepthBuffer()->GetDepthStencilView().Get() );
-    
-    DS_PointLightConstantBuffer plcb = {};
-
-    {
-        auto& proj = Engine::GAPI->GetProjectionMatrix();
-        plcb.PL_ProjParams = float4( 1.0f / proj._11, 1.0f / proj._22, proj._43, proj._33 );
-    }
-    XMStoreFloat4x4( &plcb.PL_InvView, XMMatrixInverse( nullptr, XMLoadFloat4x4( &Engine::GAPI->GetRendererState().TransformState.TransformView ) ) );
-
-    plcb.PL_ViewportSize = Engine::GraphicsEngine->GetResolution();
-
-    color.BindToPixelShader( m_context.Get(), 0 );
-    normals.BindToPixelShader( m_context.Get(), 1 );
-    specular.BindToPixelShader( m_context.Get(), 7 );
-    depthCopy.BindToPixelShader( m_context.Get(), 2 );
-
-    // Draw all lights
-    for ( auto const& light : lights ) {
-        zCVobLight* vob = light->Vob;
-
-        // Reset state from CollectVisibleVobs
-        light->VisibleInRenderPass = false;
-
-        if ( !vob->IsEnabled() ) continue;
-
-        // Set right shader
-        if ( settings.EnablePointlightShadows > 0 ) {
-            D3D11PointLight* pl = light->LightShadowBuffers ? static_cast<D3D11PointLight*>(light->LightShadowBuffers) : nullptr;
-
-            // Only use the DynamicShadow shader if the light actually HAS a pooled shadow map assigned!
-            if ( pl && pl->IsInited() && pl->HasShadowMap() ) {
-                if ( graphicsEngine->GetActivePS() != psPointLightDynShadow ) {
-                    graphicsEngine->SetActivePS( psPointLightDynShadow )->Apply();
-                }
-            } else if ( graphicsEngine->GetActivePS() != psPointLight ) {
-                // Need to update shader for usual pointlight
-                graphicsEngine->SetActivePS( psPointLight )->Apply();
-            }
-        }
-
-        // Animate the light
-        vob->DoAnimation();
-
-        plcb.PL_Color = float4( vob->GetLightColor() );
-        plcb.PL_Range = vob->GetLightRange();
-        plcb.Pl_PositionWorld = vob->GetPositionWorld();
-        plcb.PL_Outdoor = light->IsIndoorVob ? 0.0f : 1.0f;
-
-        float dist;
-        XMStoreFloat( &dist, XMVector3Length( XMLoadFloat3( plcb.Pl_PositionWorld.toXMFLOAT3() ) - Engine::GAPI->GetCameraPositionXM() ) );
-
-        // Gradually fade in the lights
-        if ( dist + plcb.PL_Range <
-            settings.VisualFXDrawRadius ) {
-            // float fadeStart =
-            // settings.VisualFXDrawRadius -
-            // plcb.PL_Range;
-            float fadeEnd =
-                settings.VisualFXDrawRadius;
-
-            float fadeFactor = std::min(
-                1.0f,
-                std::max( 0.0f, ((fadeEnd - (dist + plcb.PL_Range)) / plcb.PL_Range) ) );
-            plcb.PL_Color.x *= fadeFactor;
-            plcb.PL_Color.y *= fadeFactor;
-            plcb.PL_Color.z *= fadeFactor;
-            // plcb.PL_Color.w *= fadeFactor;
-        }
-
-        // Make the lights a little bit brighter
-        float lightFactor = 1.2f;
-
-        plcb.PL_Color.x *= lightFactor;
-        plcb.PL_Color.y *= lightFactor;
-        plcb.PL_Color.z *= lightFactor;
-
-        // Need that in view space
-        FXMVECTOR Pl_PositionWorld = XMLoadFloat3( plcb.Pl_PositionWorld.toXMFLOAT3() );
-        XMStoreFloat3( plcb.Pl_PositionView.toXMFLOAT3(),
-            XMVector3TransformCoord( Pl_PositionWorld, view ) );
-
-        XMStoreFloat3( plcb.PL_LightScreenPos.toXMFLOAT3(),
-            XMVector3TransformCoord( Pl_PositionWorld, XMLoadFloat4x4( &Engine::GAPI->GetProjectionMatrix() ) ) );
-
-        if ( dist < plcb.PL_Range ) {
-            if ( Engine::GAPI->GetRendererState().DepthState.DepthBufferEnabled ) {
-                Engine::GAPI->GetRendererState().DepthState.DepthBufferEnabled = false;
-                Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_FRONT;
-                Engine::GAPI->GetRendererState().DepthState.SetDirty();
-                Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
-                graphicsEngine->UpdateRenderStates();
-            }
-        } else {
-            if ( !Engine::GAPI->GetRendererState().DepthState.DepthBufferEnabled ) {
-                Engine::GAPI->GetRendererState().DepthState.DepthBufferEnabled = true;
-                Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
-                Engine::GAPI->GetRendererState().DepthState.SetDirty();
-                Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
-                graphicsEngine->UpdateRenderStates();
-            }
-        }
-
-        plcb.PL_LightScreenPos.x = plcb.PL_LightScreenPos.x / 2.0f + 0.5f;
-        plcb.PL_LightScreenPos.y = plcb.PL_LightScreenPos.y / -2.0f + 0.5f;
-
-        // Apply the constantbuffer to vs and PS
-        graphicsEngine->GetActivePS()->GetConstantBuffer()[0]->UpdateBuffer( &plcb );
-        graphicsEngine->GetActivePS()->GetConstantBuffer()[0]->BindToPixelShader( 0 );
-        graphicsEngine->GetActivePS()->GetConstantBuffer()[0]->BindToVertexShader(
-            1 );  // Bind this instead of the usual per-instance buffer
-
-        if ( settings.EnablePointlightShadows > 0 ) {
-            // Bind shadowmap, if possible
-            if ( light->LightShadowBuffers )
-                static_cast<D3D11PointLight*>(light->LightShadowBuffers)->OnRenderLight();
-        }
-
-        // Draw the mesh
-        graphicsEngine->InverseUnitSphereMesh->DrawMesh();
-
-        Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnLights++;
-    }
-    
-    return XR_SUCCESS;
+    return m_LegacyDeferred.DrawPointlightLights( lights, color, normals, specular, depthCopy );
 }
 
 XRESULT D3D11ShadowMap::DrawLighting( 
@@ -1139,8 +1014,21 @@ XRESULT D3D11ShadowMap::DrawLighting(
     DrawRainShadowmap();
 
     Engine::GAPI->SetFarPlane(static_cast<float>(settings.SectionDrawRadius) * WORLD_SECTION_SIZE );
-    
+
     DrawPointlightLights(lights, color, normals, specular, depthCopy);
+
+    m_context->OMSetRenderTargets( 1, graphicsEngine->GetHDRBackBuffer().GetRenderTargetView().GetAddressOf(),
+        nullptr );
+
+    ID3D11ShaderResourceView* srvs[3] = {
+        color.GetShaderResView().Get(),
+        normals.GetShaderResView().Get(),
+        depthCopy.GetShaderResView().Get(),
+    };
+    m_context->PSSetShaderResources( 0, 3, srvs );
+
+    srvs[0] = specular.GetShaderResView().Get();
+    m_context->PSSetShaderResources( 7, 1, srvs );
 
     DrawWorldLights();
 
@@ -1264,7 +1152,7 @@ XRESULT D3D11ShadowMap::DrawWorldLights()
     auto _ = graphicsEngine->RecordGraphicsEvent( L"DrawWorldLights" );
     auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
 
-    Engine::GAPI->GetRendererState().BlendState.BlendOp = GothicBlendStateInfo::BO_BLEND_OP_ADD;
+    Engine::GAPI->GetRendererState().BlendState.SetAdditiveBlending();
     Engine::GAPI->GetRendererState().BlendState.SetDirty();
 
     Engine::GAPI->GetRendererState().DepthState.DepthBufferCompareFunc = GothicDepthBufferStateInfo::CF_COMPARISON_ALWAYS;

--- a/D3D11Engine/D3D11ShadowMap.h
+++ b/D3D11Engine/D3D11ShadowMap.h
@@ -17,6 +17,8 @@
 #include "GSky.h"
 #include "Frustum.h"
 #include "D3D11RenderQueue.h"
+#include "D3D11TiledDeferredShading.h"
+#include "D3D11LegacyDeferredShading.h"
 
 struct RenderToDepthStencilBuffer;
 struct RenderToTextureBuffer;
@@ -121,6 +123,7 @@ public:
 
     // Bind the shadowmap sampler to the given slot
     void BindSampler( ID3D11DeviceContext1* context, UINT slot );
+    void BindSamplerToCS( ID3D11DeviceContext1* context, UINT slot );
 
     XRESULT PrepareRender();
 
@@ -191,4 +194,7 @@ private:
     std::vector<float> m_CascadeSplits;
     std::array<bool, MAX_CSM_CASCADES> m_ShouldUpdateCascade;
     XMFLOAT3 m_WorldShadowPos;
+
+    std::unique_ptr<D3D11TiledDeferredShading> m_TiledDeferred;
+    D3D11LegacyDeferredShading m_LegacyDeferred;
 };

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -1,0 +1,435 @@
+#include "pch.h"
+#include "D3D11TiledDeferredShading.h"
+
+#include "D3D11GraphicsEngine.h"
+#include "D3D11LegacyDeferredShading.h"
+#include "D3D11PointLight.h"
+#include "Engine.h"
+#include "GothicAPI.h"
+#include "ConstantBufferStructs.h"
+#include "D3D11PfxRenderer.h"
+#include "D3D11_Helpers.h"
+#include "RenderToTextureBuffer.h"
+#include "zCVobLight.h"
+
+using namespace DirectX;
+using Microsoft::WRL::ComPtr;
+
+void D3D11TiledDeferredShading::Init(
+    const ComPtr<ID3D11Device1>& device,
+    const ComPtr<ID3D11DeviceContext1>& context ) {
+    m_device = device;
+    m_context = context;
+
+    // Light buffer: dynamic structured buffer for uploading per-frame light data
+    {
+        D3D11_BUFFER_DESC desc = {};
+        desc.ByteWidth = MAX_TILED_LIGHTS * sizeof( TiledPointLight );
+        desc.Usage = D3D11_USAGE_DYNAMIC;
+        desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+        desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+        desc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+        desc.StructureByteStride = sizeof( TiledPointLight );
+
+        m_device->CreateBuffer( &desc, nullptr, m_LightBuffer.ReleaseAndGetAddressOf() );
+        SetDebugName( m_LightBuffer.Get(), "TiledDeferred_LightBuffer" );
+
+        D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+        srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+        srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
+        srvDesc.Buffer.ElementWidth = MAX_TILED_LIGHTS;
+
+        m_device->CreateShaderResourceView( m_LightBuffer.Get(), &srvDesc, m_LightBufferSRV.ReleaseAndGetAddressOf() );
+        SetDebugName( m_LightBufferSRV.Get(), "TiledDeferred_LightBuffer_SRV" );
+    }
+
+    // Index counter: single uint for atomic allocation
+    {
+        D3D11_BUFFER_DESC desc = {};
+        desc.ByteWidth = sizeof( uint32_t ) * 4; // Pad to 16 bytes
+        desc.Usage = D3D11_USAGE_DEFAULT;
+        desc.BindFlags = D3D11_BIND_UNORDERED_ACCESS;
+        desc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+        desc.StructureByteStride = sizeof( uint32_t );
+
+        m_device->CreateBuffer( &desc, nullptr, m_IndexCounter.ReleaseAndGetAddressOf() );
+        SetDebugName( m_IndexCounter.Get(), "TiledDeferred_IndexCounter" );
+
+        D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+        uavDesc.Format = DXGI_FORMAT_UNKNOWN;
+        uavDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
+        uavDesc.Buffer.NumElements = 4;
+
+        m_device->CreateUnorderedAccessView( m_IndexCounter.Get(), &uavDesc, m_IndexCounterUAV.ReleaseAndGetAddressOf() );
+        SetDebugName( m_IndexCounterUAV.Get(), "TiledDeferred_IndexCounter_UAV" );
+    }
+
+    // Light index list: global flat array of light indices
+    {
+        D3D11_BUFFER_DESC desc = {};
+        desc.ByteWidth = MAX_LIGHT_INDEX_ENTRIES * sizeof( uint32_t );
+        desc.Usage = D3D11_USAGE_DEFAULT;
+        desc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+        desc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+        desc.StructureByteStride = sizeof( uint32_t );
+
+        m_device->CreateBuffer( &desc, nullptr, m_LightIndexList.ReleaseAndGetAddressOf() );
+        SetDebugName( m_LightIndexList.Get(), "TiledDeferred_LightIndexList" );
+
+        D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+        srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+        srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
+        srvDesc.Buffer.ElementWidth = MAX_LIGHT_INDEX_ENTRIES;
+
+        m_device->CreateShaderResourceView( m_LightIndexList.Get(), &srvDesc, m_LightIndexListSRV.ReleaseAndGetAddressOf() );
+        SetDebugName( m_LightIndexListSRV.Get(), "TiledDeferred_LightIndexList_SRV" );
+
+        D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+        uavDesc.Format = DXGI_FORMAT_UNKNOWN;
+        uavDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
+        uavDesc.Buffer.NumElements = MAX_LIGHT_INDEX_ENTRIES;
+
+        m_device->CreateUnorderedAccessView( m_LightIndexList.Get(), &uavDesc, m_LightIndexListUAV.ReleaseAndGetAddressOf() );
+        SetDebugName( m_LightIndexListUAV.Get(), "TiledDeferred_LightIndexList_UAV" );
+    }
+
+    // Shadow cube array is lazy-created on first AllocateSlot() to save memory when shadows are off
+}
+
+void D3D11TiledDeferredShading::EnsureShadowArray() {
+    if ( m_ShadowArrayCreated ) return;
+    m_ShadowArrayCreated = true;
+
+    // TextureCubeArray as depth render target + shader resource (no copies needed)
+    D3D11_TEXTURE2D_DESC desc = {};
+    desc.Width = SHADOW_CUBE_SIZE;
+    desc.Height = SHADOW_CUBE_SIZE;
+    desc.MipLevels = 1;
+    desc.ArraySize = MAX_SHADOW_CUBEMAPS * 6;
+    desc.Format = DXGI_FORMAT_R16_TYPELESS;
+    desc.SampleDesc.Count = 1;
+    desc.Usage = D3D11_USAGE_DEFAULT;
+    desc.BindFlags = D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE;
+    desc.MiscFlags = D3D11_RESOURCE_MISC_TEXTURECUBE;
+
+    m_device->CreateTexture2D( &desc, nullptr, m_ShadowCubeArray.ReleaseAndGetAddressOf() );
+    SetDebugName( m_ShadowCubeArray.Get(), "TiledDeferred_ShadowCubeArray" );
+
+    // SRV for sampling in the tiled shading CS
+    D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+    srvDesc.Format = DXGI_FORMAT_R16_UNORM;
+    srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBEARRAY;
+    srvDesc.TextureCubeArray.MostDetailedMip = 0;
+    srvDesc.TextureCubeArray.MipLevels = 1;
+    srvDesc.TextureCubeArray.First2DArrayFace = 0;
+    srvDesc.TextureCubeArray.NumCubes = MAX_SHADOW_CUBEMAPS;
+
+    m_device->CreateShaderResourceView( m_ShadowCubeArray.Get(), &srvDesc, m_ShadowCubeArraySRV.ReleaseAndGetAddressOf() );
+    SetDebugName( m_ShadowCubeArraySRV.Get(), "TiledDeferred_ShadowCubeArray_SRV" );
+
+    // Per-slot DSVs (6 faces each) and RenderToDepthStencilBuffer view wrappers
+    for ( uint32_t slot = 0; slot < MAX_SHADOW_CUBEMAPS; slot++ ) {
+        D3D11_DEPTH_STENCIL_VIEW_DESC dsvDesc = {};
+        dsvDesc.Format = DXGI_FORMAT_D16_UNORM;
+        dsvDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
+        dsvDesc.Texture2DArray.FirstArraySlice = slot * 6;
+        dsvDesc.Texture2DArray.ArraySize = 6;
+        dsvDesc.Texture2DArray.MipSlice = 0;
+
+        m_device->CreateDepthStencilView( m_ShadowCubeArray.Get(), &dsvDesc, m_SlotDSVs[slot].ReleaseAndGetAddressOf() );
+
+        // View wrapper for RenderShadowCube() interface (uses GetSizeX() and GetDepthStencilView())
+        m_SlotViews[slot] = std::make_unique<RenderToDepthStencilBuffer>(
+            m_ShadowCubeArray, m_SlotDSVs[slot], nullptr,
+            SHADOW_CUBE_SIZE, SHADOW_CUBE_SIZE );
+    }
+}
+
+int D3D11TiledDeferredShading::AllocateSlot() {
+    EnsureShadowArray();
+    for ( uint32_t i = 0; i < MAX_SHADOW_CUBEMAPS; i++ ) {
+        if ( !m_SlotInUse[i] ) {
+            m_SlotInUse[i] = true;
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+void D3D11TiledDeferredShading::FreeSlot( int slot ) {
+    if ( slot >= 0 && static_cast<uint32_t>(slot) < MAX_SHADOW_CUBEMAPS )
+        m_SlotInUse[slot] = false;
+}
+
+RenderToDepthStencilBuffer* D3D11TiledDeferredShading::GetSlotTarget( int slot ) {
+    if ( slot >= 0 && static_cast<uint32_t>(slot) < MAX_SHADOW_CUBEMAPS && m_ShadowArrayCreated )
+        return m_SlotViews[slot].get();
+    return nullptr;
+}
+
+void D3D11TiledDeferredShading::EnsureBuffers( uint32_t numTilesX, uint32_t numTilesY ) {
+    uint32_t totalTiles = numTilesX * numTilesY;
+
+    if ( numTilesX == m_lastNumTilesX && numTilesY == m_lastNumTilesY )
+        return;
+
+    m_lastNumTilesX = numTilesX;
+    m_lastNumTilesY = numTilesY;
+
+    // Recreate light grid buffer for new tile count
+    D3D11_BUFFER_DESC desc = {};
+    desc.ByteWidth = totalTiles * sizeof( LightGrid );
+    desc.Usage = D3D11_USAGE_DEFAULT;
+    desc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+    desc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+    desc.StructureByteStride = sizeof( LightGrid );
+
+    m_device->CreateBuffer( &desc, nullptr, m_LightGrid.ReleaseAndGetAddressOf() );
+    SetDebugName( m_LightGrid.Get(), "TiledDeferred_LightGrid" );
+
+    D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+    srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+    srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
+    srvDesc.Buffer.ElementWidth = totalTiles;
+
+    m_device->CreateShaderResourceView( m_LightGrid.Get(), &srvDesc, m_LightGridSRV.ReleaseAndGetAddressOf() );
+    SetDebugName( m_LightGridSRV.Get(), "TiledDeferred_LightGrid_SRV" );
+
+    D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+    uavDesc.Format = DXGI_FORMAT_UNKNOWN;
+    uavDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
+    uavDesc.Buffer.NumElements = totalTiles;
+
+    m_device->CreateUnorderedAccessView( m_LightGrid.Get(), &uavDesc, m_LightGridUAV.ReleaseAndGetAddressOf() );
+    SetDebugName( m_LightGridUAV.Get(), "TiledDeferred_LightGrid_UAV" );
+}
+
+XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
+    std::vector<VobLightInfo*>& lights,
+    RenderToTextureBuffer& color,
+    RenderToTextureBuffer& normals,
+    RenderToTextureBuffer& specular,
+    RenderToTextureBuffer& depthCopy ) {
+
+    auto graphicsEngine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    auto _ = graphicsEngine->RecordGraphicsEvent( L"TiledPointlightLights" );
+    auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+    auto& context = graphicsEngine->GetContext();
+
+    XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
+    Engine::GAPI->SetViewTransformXM( view );
+    view = XMMatrixTranspose( view );
+
+    INT2 resolution = Engine::GraphicsEngine->GetResolution();
+    uint32_t numTilesX = (resolution.x + TILE_SIZE - 1) / TILE_SIZE;
+    uint32_t numTilesY = (resolution.y + TILE_SIZE - 1) / TILE_SIZE;
+
+    EnsureBuffers( numTilesX, numTilesY );
+
+    // Partition lights: all lights go tiled where possible.
+    // Shadowed lights with a tiled slot render directly into the shared array (no copies).
+    // Shadowed lights without a tiled slot (256×256 or overflow) fall back to legacy.
+    std::vector<VobLightInfo*> legacyLights;
+    uint32_t tiledLightCount = 0;
+    bool hasShadowedTiledLights = false;
+
+    // Map light buffer
+    D3D11_MAPPED_SUBRESOURCE mapped;
+    context->Map( m_LightBuffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped );
+    TiledPointLight* lightData = reinterpret_cast<TiledPointLight*>(mapped.pData);
+
+    for ( auto const& light : lights ) {
+        zCVobLight* vob = light->Vob;
+
+        light->VisibleInRenderPass = false;
+
+        if ( !vob->IsEnabled() ) continue;
+
+        // Check if this light has shadows
+        D3D11PointLight* pl = nullptr;
+        bool hasShadow = false;
+        if ( settings.EnablePointlightShadows > 0 ) {
+            pl = light->LightShadowBuffers ? static_cast<D3D11PointLight*>(light->LightShadowBuffers) : nullptr;
+            if ( pl && pl->IsInited() && pl->HasShadowMap() ) {
+                hasShadow = true;
+            }
+        }
+
+        // Shadowed lights need a tiled slot (assigned earlier in DrawPointlightShadows).
+        // If they don't have one (256×256 or slot overflow), fall back to legacy.
+        if ( hasShadow && pl->GetTiledSlot() < 0 ) {
+            legacyLights.push_back( light );
+            continue;
+        }
+
+        if ( tiledLightCount >= MAX_TILED_LIGHTS )
+            continue;
+
+        vob->DoAnimation();
+
+        float4 lightColor = float4( vob->GetLightColor() );
+        float lightRange = vob->GetLightRange();
+        float3 posWorld = vob->GetPositionWorld();
+
+        // Distance fade
+        float dist;
+        XMStoreFloat( &dist, XMVector3Length( XMLoadFloat3( posWorld.toXMFLOAT3() ) - Engine::GAPI->GetCameraPositionXM() ) );
+
+        if ( dist + lightRange < settings.VisualFXDrawRadius ) {
+            float fadeEnd = settings.VisualFXDrawRadius;
+            float fadeFactor = std::min( 1.0f, std::max( 0.0f, ((fadeEnd - (dist + lightRange)) / lightRange) ) );
+            lightColor.x *= fadeFactor;
+            lightColor.y *= fadeFactor;
+            lightColor.z *= fadeFactor;
+        }
+
+        // Brightness multiplier
+        float lightFactor = 1.2f;
+        lightColor.x *= lightFactor;
+        lightColor.y *= lightFactor;
+        lightColor.z *= lightFactor;
+
+        // Skip completely dark lights
+        if ( lightColor.x <= 0.0f && lightColor.y <= 0.0f && lightColor.z <= 0.0f )
+            continue;
+
+        // View-space position
+        FXMVECTOR posWorldVec = XMLoadFloat3( posWorld.toXMFLOAT3() );
+        XMFLOAT3 posView;
+        XMStoreFloat3( &posView, XMVector3TransformCoord( posWorldVec, view ) );
+
+        TiledPointLight& tl = lightData[tiledLightCount];
+        tl.PositionView = posView;
+        tl.Range = lightRange;
+        tl.Color = XMFLOAT4( lightColor.x, lightColor.y, lightColor.z, lightColor.w );
+        tl.PositionWorld = XMFLOAT3( posWorld.x, posWorld.y, posWorld.z );
+
+        if ( hasShadow ) {
+            tl.ShadowCubeIndex = pl->GetTiledSlot();
+            hasShadowedTiledLights = true;
+        } else {
+            tl.ShadowCubeIndex = -1;
+        }
+
+        tiledLightCount++;
+        Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnLights++;
+    }
+
+    context->Unmap( m_LightBuffer.Get(), 0 );
+
+    // No copies needed — shadowed lights rendered directly into the TextureCubeArray slots
+
+    // Only run tiled path if we have lights
+    if ( tiledLightCount > 0 ) {
+        graphicsEngine->CopyDepthStencil();
+
+        // ---- Pass 1: Light Culling ----
+        {
+            auto csLightCull = graphicsEngine->GetShaderManager().GetCShader( "CS_LightCulling" );
+            csLightCull->Apply();
+
+            // Fill and bind culling constant buffer
+            LightCullingConstantBuffer cullCB = {};
+            cullCB.Proj = Engine::GAPI->GetProjectionMatrix();
+            cullCB.ScreenWidth = static_cast<uint32_t>(resolution.x);
+            cullCB.ScreenHeight = static_cast<uint32_t>(resolution.y);
+            cullCB.TotalLights = tiledLightCount;
+            cullCB.Pad = 0;
+
+            csLightCull->GetConstantBuffer()[0]->UpdateBuffer( &cullCB );
+            csLightCull->GetConstantBuffer()[0]->BindToComputeShader( 0 );
+
+            // Bind depth copy as SRV to CS slot t0
+            context->CSSetShaderResources( 0, 1, depthCopy.GetShaderResView().GetAddressOf() );
+            // Bind light buffer as SRV to CS slot t1
+            context->CSSetShaderResources( 1, 1, m_LightBufferSRV.GetAddressOf() );
+
+            // Clear atomic counter
+            UINT clearVal[4] = { 0, 0, 0, 0 };
+            context->ClearUnorderedAccessViewUint( m_IndexCounterUAV.Get(), clearVal );
+
+            // Bind UAVs
+            ID3D11UnorderedAccessView* uavs[3] = { m_LightGridUAV.Get(), m_LightIndexListUAV.Get(), m_IndexCounterUAV.Get() };
+            context->CSSetUnorderedAccessViews( 0, 3, uavs, nullptr );
+
+            context->Dispatch( numTilesX, numTilesY, 1 );
+
+            // Unbind
+            ID3D11UnorderedAccessView* nullUAVs[3] = { nullptr, nullptr, nullptr };
+            context->CSSetUnorderedAccessViews( 0, 3, nullUAVs, nullptr );
+            ID3D11ShaderResourceView* nullSRVs[2] = { nullptr, nullptr };
+            context->CSSetShaderResources( 0, 2, nullSRVs );
+            context->CSSetShader( nullptr, nullptr, 0 );
+        }
+
+        // ---- Pass 2: Tiled Shading ----
+        {
+            // Unbind HDR as RTV before binding as UAV
+            ID3D11RenderTargetView* nullRTV = nullptr;
+            context->OMSetRenderTargets( 1, &nullRTV, nullptr );
+
+            auto csTiledShading = graphicsEngine->GetShaderManager().GetCShader( "CS_TiledShading" );
+            csTiledShading->Apply();
+
+            // Fill and bind shading constant buffer
+            TiledShadingConstantBuffer shadeCB = {};
+            shadeCB.ViewportSize = float2( static_cast<float>(resolution.x), static_cast<float>(resolution.y) );
+            {
+                auto& proj = Engine::GAPI->GetProjectionMatrix();
+                shadeCB.ProjParams = float4( 1.0f / proj._11, 1.0f / proj._22, proj._43, proj._33 );
+            }
+            shadeCB.LimitLightIntensity = settings.LimitLightIntesity ? 1 : 0;
+            shadeCB.NumTilesX = numTilesX;
+            XMStoreFloat4x4( &shadeCB.InvView, XMMatrixInverse( nullptr, XMLoadFloat4x4( &Engine::GAPI->GetRendererState().TransformState.TransformView ) ) );
+
+            csTiledShading->GetConstantBuffer()[0]->UpdateBuffer( &shadeCB );
+            csTiledShading->GetConstantBuffer()[0]->BindToComputeShader( 0 );
+
+            // Bind GBuffer SRVs to CS
+            context->CSSetShaderResources( 0, 1, color.GetShaderResView().GetAddressOf() );
+            context->CSSetShaderResources( 1, 1, normals.GetShaderResView().GetAddressOf() );
+            context->CSSetShaderResources( 2, 1, depthCopy.GetShaderResView().GetAddressOf() );
+            context->CSSetShaderResources( 7, 1, specular.GetShaderResView().GetAddressOf() );
+
+            // Bind linear sampler to CS slot 0 (required for GBuffer SampleLevel calls)
+            ID3D11SamplerState* linearSampler = graphicsEngine->GetDefaultSamplerState();
+            context->CSSetSamplers( 0, 1, &linearSampler );
+
+            // Bind tiled data SRVs
+            context->CSSetShaderResources( 8, 1, m_LightBufferSRV.GetAddressOf() );
+            context->CSSetShaderResources( 9, 1, m_LightGridSRV.GetAddressOf() );
+            context->CSSetShaderResources( 10, 1, m_LightIndexListSRV.GetAddressOf() );
+
+            // Bind shadow cubemap array and comparison sampler
+            if ( hasShadowedTiledLights && m_ShadowArrayCreated ) {
+                context->CSSetShaderResources( 11, 1, m_ShadowCubeArraySRV.GetAddressOf() );
+                graphicsEngine->GetShadowMaps()->BindSamplerToCS( context.Get(), 2 );
+            }
+
+            // Bind HDR UAV
+            auto& hdrUAV = graphicsEngine->GetHDRBackBuffer().GetUnorderedAccessView();
+            context->CSSetUnorderedAccessViews( 0, 1, hdrUAV.GetAddressOf(), nullptr );
+
+            context->Dispatch( numTilesX, numTilesY, 1 );
+
+            // Unbind everything
+            ID3D11UnorderedAccessView* nullUAV = nullptr;
+            context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+            ID3D11ShaderResourceView* nullSRVs[12] = {};
+            context->CSSetShaderResources( 0, 12, nullSRVs );
+            context->CSSetShader( nullptr, nullptr, 0 );
+
+            // Restore HDR as RTV
+            context->OMSetRenderTargets( 1, graphicsEngine->GetHDRBackBuffer().GetRenderTargetView().GetAddressOf(),
+                graphicsEngine->GetDepthBuffer()->GetDepthStencilView().Get() );
+        }
+    }
+
+    // Draw lights that couldn't go through the tiled path (mismatched shadow cube size, overflow)
+    if ( !legacyLights.empty() ) {
+        D3D11LegacyDeferredShading legacy;
+        legacy.DrawPointlightLights( legacyLights, color, normals, specular, depthCopy );
+    }
+
+    return XR_SUCCESS;
+}

--- a/D3D11Engine/D3D11TiledDeferredShading.h
+++ b/D3D11Engine/D3D11TiledDeferredShading.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "pch.h"
+#include <wrl/client.h>
+#include <vector>
+#include <bitset>
+#include <array>
+#include <DirectXMath.h>
+#include "WorldObjects.h"
+
+struct RenderToTextureBuffer;
+struct RenderToDepthStencilBuffer;
+
+constexpr uint32_t MAX_TILED_LIGHTS = 1024;
+constexpr uint32_t TILE_SIZE = 16;
+constexpr uint32_t MAX_LIGHTS_PER_TILE = 256;
+constexpr uint32_t MAX_LIGHT_INDEX_ENTRIES = 256 * 1024;
+
+constexpr uint32_t MAX_SHADOW_CUBEMAPS = 128;
+constexpr uint32_t SHADOW_CUBE_SIZE = 64; // Must match POINTLIGHT_SHADOWMAP_SIZE
+
+struct TiledPointLight {
+    DirectX::XMFLOAT3 PositionView;
+    float Range;
+    DirectX::XMFLOAT4 Color;
+    DirectX::XMFLOAT3 PositionWorld;
+    int32_t ShadowCubeIndex; // -1 = no shadow, else index into TextureCubeArray
+};
+
+struct LightGrid {
+    uint32_t Offset;
+    uint32_t Count;
+};
+
+class D3D11TiledDeferredShading {
+public:
+    void Init( const Microsoft::WRL::ComPtr<ID3D11Device1>& device, const Microsoft::WRL::ComPtr<ID3D11DeviceContext1>& context );
+
+    XRESULT DrawPointlightLights(
+        std::vector<VobLightInfo*>& lights,
+        RenderToTextureBuffer& color,
+        RenderToTextureBuffer& normals,
+        RenderToTextureBuffer& specular,
+        RenderToTextureBuffer& depthCopy );
+
+    // Shadow cubemap array slot management
+    int AllocateSlot();
+    void FreeSlot( int slot );
+    RenderToDepthStencilBuffer* GetSlotTarget( int slot );
+
+private:
+    void EnsureBuffers( uint32_t numTilesX, uint32_t numTilesY );
+    void EnsureShadowArray();
+
+    Microsoft::WRL::ComPtr<ID3D11Device1> m_device;
+    Microsoft::WRL::ComPtr<ID3D11DeviceContext1> m_context;
+
+    // Light data buffer (dynamic structured buffer)
+    Microsoft::WRL::ComPtr<ID3D11Buffer> m_LightBuffer;
+    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_LightBufferSRV;
+
+    // Per-tile light grid (offset + count)
+    Microsoft::WRL::ComPtr<ID3D11Buffer> m_LightGrid;
+    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_LightGridSRV;
+    Microsoft::WRL::ComPtr<ID3D11UnorderedAccessView> m_LightGridUAV;
+
+    // Global light index list
+    Microsoft::WRL::ComPtr<ID3D11Buffer> m_LightIndexList;
+    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_LightIndexListSRV;
+    Microsoft::WRL::ComPtr<ID3D11UnorderedAccessView> m_LightIndexListUAV;
+
+    // Atomic counter for index list allocation
+    Microsoft::WRL::ComPtr<ID3D11Buffer> m_IndexCounter;
+    Microsoft::WRL::ComPtr<ID3D11UnorderedAccessView> m_IndexCounterUAV;
+
+    // Shadow cubemap array for tiled shadowed lights (lazy-created)
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> m_ShadowCubeArray;
+    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_ShadowCubeArraySRV;
+    std::bitset<MAX_SHADOW_CUBEMAPS> m_SlotInUse;
+    std::array<Microsoft::WRL::ComPtr<ID3D11DepthStencilView>, MAX_SHADOW_CUBEMAPS> m_SlotDSVs;
+    std::array<std::unique_ptr<RenderToDepthStencilBuffer>, MAX_SHADOW_CUBEMAPS> m_SlotViews;
+    bool m_ShadowArrayCreated = false;
+
+    uint32_t m_lastNumTilesX = 0;
+    uint32_t m_lastNumTilesY = 0;
+};

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4992,6 +4992,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "Display", "Rain", std::to_string( s.EnableRain ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "RainEffects", std::to_string( s.EnableRainEffects ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "LimitLightIntesity", std::to_string( s.LimitLightIntesity ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "TiledLighting", std::to_string( s.EnableTiledLighting ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "WindQuality", std::to_string( s.WindQuality ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "WindStrength", std::to_string( s.GlobalWindStrength ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "WaterWaveAnimation", std::to_string( s.EnableWaterAnimation ? TRUE : FALSE ).c_str(), ini.c_str() );
@@ -5132,6 +5133,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.EnableRain = GetPrivateProfileBoolA( "Display", "Rain", true, ini );
         s.EnableRainEffects = GetPrivateProfileBoolA( "Display", "RainEffects", true, ini );
         s.LimitLightIntesity = GetPrivateProfileBoolA( "Display", "LimitLightIntesity", false, ini );
+        s.EnableTiledLighting = GetPrivateProfileBoolA( "Display", "TiledLighting", true, ini );
         s.WindQuality = GetPrivateProfileIntA( "Display", "WindQuality", 0, ini.c_str() );
         s.GlobalWindStrength = GetPrivateProfileFloatA( "Display", "WindStrength", 1.0f, ini );
         s.EnableWaterAnimation = GetPrivateProfileBoolA( "Display", "WaterWaveAnimation", true, ini );

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -688,6 +688,7 @@ struct GothicRendererSettings {
         EnablePointlightShadows = PLS_UPDATE_DYNAMIC;
         MinLightShadowUpdateRange = 300.0f;
         PartialDynamicShadowUpdates = true;
+        EnableTiledLighting = true;
         DrawSectionIntersections = true;
 
         EnableGodRays = true;
@@ -839,6 +840,7 @@ struct GothicRendererSettings {
     EPointLightShadowMode EnablePointlightShadows;
     float MinLightShadowUpdateRange;
     bool PartialDynamicShadowUpdates;
+    bool EnableTiledLighting;
     bool DrawSectionIntersections;
 
     int MaxNumFaces;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1334,8 +1334,14 @@ void RenderAdvancedColumn2( GothicRendererSettings& settings, GothicAPI* gapi ) 
             }
             
             if (ImGui::BeginTabItem("Featureset", nullptr, ImGuiTabItemFlags_::ImGuiTabItemFlags_NoReorder)) {
-                ImGui::Checkbox("Use MDI", &settings.DebugSettings.FeatureSet.UseMDI );
-                ImGui::Checkbox("Use Layered Drawing", &settings.DebugSettings.FeatureSet.UseLayeredRendering );
+                if (!FeatureLevel10Compatibility){
+                    ImGui::Checkbox("Use MDI", &settings.DebugSettings.FeatureSet.UseMDI );
+                    ImGui::SetItemTooltip("Support for MultiDrawInstancedIndirect via Driver Extensions (AMD, Nvidia, Intel).");
+
+                    ImGui::Checkbox("Use Layered Drawing", &settings.DebugSettings.FeatureSet.UseLayeredRendering );
+                    ImGui::Checkbox("Use Tiled Lighting", &settings.EnableTiledLighting );
+                    ImGui::SetItemTooltip( "Uses compute shader light culling for point lights. Reduces draw calls and overdraw." );
+                }
                 if ( ImGui::Checkbox( "Use Shadow Atlas", &settings.DebugSettings.FeatureSet.UseShadowAtlas ) ) {
                     ApplyFeatureLevel10Downgrades( settings );
                 }

--- a/D3D11Engine/RenderToTextureBuffer.h
+++ b/D3D11Engine/RenderToTextureBuffer.h
@@ -181,6 +181,16 @@ struct RenderToDepthStencilBuffer {
     ~RenderToDepthStencilBuffer() {
     }
 
+    /** Wraps pre-existing resources without allocating — used for views into a shared TextureCubeArray */
+    RenderToDepthStencilBuffer(
+        Microsoft::WRL::ComPtr<ID3D11Texture2D> texture,
+        Microsoft::WRL::ComPtr<ID3D11DepthStencilView> dsv,
+        Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> srv,
+        UINT SizeX, UINT SizeY )
+        : Texture( std::move( texture ) ), DepthStencilView( std::move( dsv ) ),
+          ShaderResView( std::move( srv ) ), SizeX( SizeX ), SizeY( SizeY ) {
+    }
+
     /** Creates the render-to-texture buffers */
     RenderToDepthStencilBuffer( ID3D11Device* device, UINT SizeX, UINT SizeY, DXGI_FORMAT Format, HRESULT* Result = nullptr, DXGI_FORMAT DSVFormat = DXGI_FORMAT_UNKNOWN, DXGI_FORMAT SRVFormat = DXGI_FORMAT_UNKNOWN, UINT arraySize = 1 )
         :SizeX(SizeX),

--- a/D3D11Engine/Shaders/CS_LightCulling.hlsl
+++ b/D3D11Engine/Shaders/CS_LightCulling.hlsl
@@ -1,0 +1,148 @@
+#define TILE_SIZE 16
+#define MAX_LIGHTS_PER_TILE 256
+
+struct TiledPointLight {
+    float3 PositionView;
+    float Range;
+    float4 Color;
+    float3 PositionWorld;
+    int ShadowCubeIndex;
+};
+
+struct LightGrid {
+    uint Offset;
+    uint Count;
+};
+
+Texture2D<float> TX_Depth : register( t0 );
+StructuredBuffer<TiledPointLight> SB_Lights : register( t1 );
+
+cbuffer LightCullingConstantBuffer : register( b0 ) {
+    matrix Proj;
+    uint2 ScreenDimensions;
+    uint TotalLights;
+    uint Pad;
+};
+
+RWStructuredBuffer<LightGrid> RW_LightGrid : register( u0 );
+RWStructuredBuffer<uint> RW_LightIndexList : register( u1 );
+RWStructuredBuffer<uint> RW_IndexCounter : register( u2 );
+
+groupshared uint gs_MinDepthInt;
+groupshared uint gs_MaxDepthInt;
+groupshared uint gs_TileLightCount;
+groupshared uint gs_TileLightIndices[MAX_LIGHTS_PER_TILE];
+
+float3 ScreenToView( float2 screenCoord, float depth ) {
+    float2 ndc;
+    ndc.x = screenCoord.x / (float)ScreenDimensions.x * 2.0f - 1.0f;
+    ndc.y = -(screenCoord.y / (float)ScreenDimensions.y * 2.0f - 1.0f);
+
+    float4 clipPos = float4( ndc, depth, 1.0f );
+
+    // Invert projection: viewPos = invProj * clipPos
+    // For a standard perspective projection we can do this analytically:
+    //   x_view = ndc.x / Proj[0][0]  *  z_view
+    //   y_view = ndc.y / Proj[1][1]  *  z_view
+    //   z_view = Proj[3][2] / (depth - Proj[2][2])
+    float z_view = Proj[3][2] / (depth - Proj[2][2]);
+    float x_view = ndc.x / Proj[0][0] * z_view;
+    float y_view = ndc.y / Proj[1][1] * z_view;
+
+    return float3( x_view, y_view, z_view );
+}
+
+bool SphereInsideAABB( float3 center, float radius, float3 aabbMin, float3 aabbMax ) {
+    float3 closest = clamp( center, aabbMin, aabbMax );
+    float3 delta = closest - center;
+    float distSq = dot( delta, delta );
+    return distSq <= (radius * radius);
+}
+
+[numthreads( TILE_SIZE, TILE_SIZE, 1 )]
+void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint3 dispatchThreadID : SV_DispatchThreadID ) {
+    uint threadIndex = threadID.y * TILE_SIZE + threadID.x;
+
+    // Initialize shared memory
+    if ( threadIndex == 0 ) {
+        gs_MinDepthInt = 0x7F7FFFFF;
+        gs_MaxDepthInt = 0;
+        gs_TileLightCount = 0;
+    }
+    GroupMemoryBarrierWithGroupSync();
+
+    // Calculate min/max depth for this tile
+    if ( dispatchThreadID.x < ScreenDimensions.x && dispatchThreadID.y < ScreenDimensions.y ) {
+        float depth = TX_Depth.Load( uint3( dispatchThreadID.xy, 0 ) ).r;
+        uint depthInt = asuint( depth );
+
+        if ( depth > 0.0f && depth < 1.0f ) {
+            InterlockedMin( gs_MinDepthInt, depthInt );
+            InterlockedMax( gs_MaxDepthInt, depthInt );
+        }
+    }
+    GroupMemoryBarrierWithGroupSync();
+
+    // Build tile AABB in view space
+    float minDepth = asfloat( gs_MinDepthInt );
+    float maxDepth = asfloat( gs_MaxDepthInt );
+
+    // Handle empty tiles (no geometry)
+    if ( gs_MinDepthInt == 0x7F7FFFFF ) {
+        minDepth = 1.0f;
+        maxDepth = 1.0f;
+    }
+
+    float2 tileMin = float2( groupID.xy ) * TILE_SIZE;
+    float2 tileMax = float2( groupID.xy + 1 ) * TILE_SIZE;
+
+    // Reconstruct all 8 view-space corners of the tile frustum
+    float3 corners[8];
+    corners[0] = ScreenToView( float2( tileMin.x, tileMin.y ), minDepth );
+    corners[1] = ScreenToView( float2( tileMax.x, tileMin.y ), minDepth );
+    corners[2] = ScreenToView( float2( tileMin.x, tileMax.y ), minDepth );
+    corners[3] = ScreenToView( float2( tileMax.x, tileMax.y ), minDepth );
+    corners[4] = ScreenToView( float2( tileMin.x, tileMin.y ), maxDepth );
+    corners[5] = ScreenToView( float2( tileMax.x, tileMin.y ), maxDepth );
+    corners[6] = ScreenToView( float2( tileMin.x, tileMax.y ), maxDepth );
+    corners[7] = ScreenToView( float2( tileMax.x, tileMax.y ), maxDepth );
+
+    float3 aabbMin = corners[0];
+    float3 aabbMax = corners[0];
+    [unroll]
+    for ( uint c = 1; c < 8; c++ ) {
+        aabbMin = min( aabbMin, corners[c] );
+        aabbMax = max( aabbMax, corners[c] );
+    }
+
+    // Cull lights: distribute across threads in the group
+    uint numThreads = TILE_SIZE * TILE_SIZE;
+    for ( uint i = threadIndex; i < TotalLights; i += numThreads ) {
+        TiledPointLight light = SB_Lights[i];
+
+        if ( SphereInsideAABB( light.PositionView, light.Range, aabbMin, aabbMax ) ) {
+            uint index;
+            InterlockedAdd( gs_TileLightCount, 1, index );
+            if ( index < MAX_LIGHTS_PER_TILE ) {
+                gs_TileLightIndices[index] = i;
+            }
+        }
+    }
+    GroupMemoryBarrierWithGroupSync();
+
+    // Write results to global memory (thread 0 only)
+    if ( threadIndex == 0 ) {
+        uint count = min( gs_TileLightCount, MAX_LIGHTS_PER_TILE );
+        uint offset;
+        InterlockedAdd( RW_IndexCounter[0], count, offset );
+
+        uint numTilesX = (ScreenDimensions.x + TILE_SIZE - 1) / TILE_SIZE;
+        uint tileIndex = groupID.y * numTilesX + groupID.x;
+        RW_LightGrid[tileIndex].Offset = offset;
+        RW_LightGrid[tileIndex].Count = count;
+
+        for ( uint j = 0; j < count; j++ ) {
+            RW_LightIndexList[offset + j] = gs_TileLightIndices[j];
+        }
+    }
+}

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -1,0 +1,165 @@
+#define TILE_SIZE 16
+
+struct TiledPointLight {
+    float3 PositionView;
+    float Range;
+    float4 Color;
+    float3 PositionWorld;
+    int ShadowCubeIndex; // -1 = no shadow, else index into TextureCubeArray
+};
+
+struct LightGrid {
+    uint Offset;
+    uint Count;
+};
+
+cbuffer TiledShadingConstantBuffer : register( b0 ) {
+    float2 ViewportSize;
+    float2 Pad0;
+    float4 ProjParams; // x = 1/P._11, y = 1/P._22, z = P._43, w = P._33
+    uint LimitLightIntensity;
+    uint NumTilesX;
+    float2 Pad1;
+    matrix InvView; // For world-space reconstruction (shadow sampling)
+};
+
+SamplerState SS_Linear : register( s0 );
+SamplerComparisonState SS_Comp : register( s2 );
+Texture2D TX_Diffuse : register( t0 );
+Texture2D TX_Nrm : register( t1 );
+Texture2D TX_Depth : register( t2 );
+Texture2D TX_SI_SP : register( t7 );
+
+StructuredBuffer<TiledPointLight> SB_Lights : register( t8 );
+StructuredBuffer<LightGrid> SB_LightGrid : register( t9 );
+StructuredBuffer<uint> SB_LightIndexList : register( t10 );
+
+TextureCubeArray TX_ShadowCubeArray : register( t11 );
+
+RWTexture2D<float4> RW_HDR : register( u0 );
+
+float3 VSPositionFromDepth( float depth, float2 texCoord ) {
+    float2 ndc = texCoord * float2( 2.0f, -2.0f ) + float2( -1.0f, 1.0f );
+    float linearZ = ProjParams.z / (depth - ProjParams.w);
+    return float3( ndc * ProjParams.xy * linearZ, linearZ );
+}
+
+float CalcBlinnPhongLighting( float3 N, float3 H ) {
+    return saturate( dot( N, H ) );
+}
+
+// 8-tap PCF shadow sampling matching PS_DS_PointLightDynShadow.hlsl
+static const int SHADOW_BLUR_COUNT = 8;
+static const float3 SHADOW_BLUR_OFFSETS[SHADOW_BLUR_COUNT] = {
+    float3( 0.054426466605825*2-1, 0.057144871008184*2-1, 0.57025665350736*2-1 ),
+    float3( 0.32904030165125*2-1, 0.22406590786952*2-1, 0.76940122329136*2-1 ),
+    float3( 0.90462177475198*2-1, 0.091382070021416*2-1, 0.0065345494107038*2-1 ),
+    float3( 0.93540243382352*2-1, 0.61764284391778*2-1, 0.103979589466*2-1 ),
+    float3( 0.44626536287659*2-1, 0.19266830440269*2-1, 0.73062449308607*2-1 ),
+    float3( 0.0084832706528172*2-1, 0.83200742948428*2-1, 0.43927977813374*2-1 ),
+    float3( 0.28579624476181*2-1, 0.57096250149001*2-1, 0.0095401159532089*2-1 ),
+    float3( 0.55814247604373*2-1, 0.59385285228205*2-1, 0.44374119743879*2-1 )
+};
+
+float SampleShadowCube( float3 wsPosition, float3 lightPosWorld, float lightRange, int cubeIndex ) {
+    float3 dir = normalize( wsPosition - lightPosWorld );
+    float distance = length( wsPosition - lightPosWorld );
+    float zFar = lightRange * 2.0f;
+    distance = distance / zFar;
+
+    float fixedBias = 0.005f;
+    float fixedBlurScale = 0.010f;
+
+    float shd = 0;
+    [unroll] for ( int i = 0; i < SHADOW_BLUR_COUNT; i++ ) {
+        float4 sampleCoord = float4( dir + SHADOW_BLUR_OFFSETS[i] * fixedBlurScale, (float)cubeIndex );
+        shd += TX_ShadowCubeArray.SampleCmpLevelZero( SS_Comp, sampleCoord, distance - fixedBias );
+    }
+    shd /= SHADOW_BLUR_COUNT;
+    return shd;
+}
+
+[numthreads( TILE_SIZE, TILE_SIZE, 1 )]
+void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint3 dispatchThreadID : SV_DispatchThreadID ) {
+    uint2 pixelCoord = dispatchThreadID.xy;
+
+    if ( pixelCoord.x >= (uint)ViewportSize.x || pixelCoord.y >= (uint)ViewportSize.y )
+        return;
+
+    float2 uv = (float2( pixelCoord ) + 0.5f) / ViewportSize;
+
+    // Read GBuffer
+    float4 diffuse = TX_Diffuse.SampleLevel( SS_Linear, uv, 0 );
+    float4 gb2 = TX_Nrm.SampleLevel( SS_Linear, uv, 0 );
+    float3 normal = normalize( gb2.xyz );
+    float4 gb3 = TX_SI_SP.SampleLevel( SS_Linear, uv, 0 );
+    float specIntensity = gb3.x;
+    float specPower = gb3.y;
+
+    float expDepth = TX_Depth.SampleLevel( SS_Linear, uv, 0 ).r;
+    float3 vsPosition = VSPositionFromDepth( expDepth, uv );
+
+    // World-space position for shadow sampling (computed once, shared by all shadowed lights)
+    float3 wsPosition = mul( float4( vsPosition, 1 ), InvView ).xyz;
+
+    // Compute tile index
+    uint tileX = pixelCoord.x / TILE_SIZE;
+    uint tileY = pixelCoord.y / TILE_SIZE;
+    uint tileIndex = tileY * NumTilesX + tileX;
+
+    LightGrid grid = SB_LightGrid[tileIndex];
+
+    float3 totalLighting = float3( 0, 0, 0 );
+    float3 maxLighting = float3( 0, 0, 0 );
+
+    for ( uint i = 0; i < grid.Count; i++ ) {
+        uint lightIdx = SB_LightIndexList[grid.Offset + i];
+        TiledPointLight light = SB_Lights[lightIdx];
+
+        float3 lightDir = light.PositionView - vsPosition;
+        float distance = length( lightDir );
+
+        if ( distance >= light.Range )
+            continue;
+
+        lightDir /= distance;
+
+        float ndl = max( 0, dot( lightDir, normal ) );
+        float falloff = pow( saturate( 1.0f - (distance / light.Range) ), 1.2f );
+
+        // Match legacy PS_DS_PointLight: V is computed from the light's view position,
+        // not the pixel's. This is per-light, matching the legacy per-draw-call behavior.
+        float3 V = normalize( -light.PositionView );
+        float3 H = normalize( lightDir + V );
+        float spec = CalcBlinnPhongLighting( normal, H );
+        float specMod = pow( dot( float3( 0.333f, 0.333f, 0.333f ), diffuse.rgb ), 2 );
+        float3 specBare = pow( spec, specPower ) * specIntensity * light.Color.rgb * falloff;
+        float3 specColored = lerp( specBare, specBare * diffuse.rgb, specMod );
+
+        float3 color = saturate( falloff * ndl * light.Color.rgb );
+        float3 lighting = color * diffuse.rgb + specColored;
+
+        // Apply shadow if this light has a shadow cubemap
+        if ( light.ShadowCubeIndex >= 0 ) {
+            float shadow = SampleShadowCube( wsPosition, light.PositionWorld, light.Range, light.ShadowCubeIndex );
+            lighting *= shadow;
+        }
+
+        lighting = saturate( lighting );
+
+        totalLighting += lighting;
+        maxLighting = max( maxLighting, lighting );
+    }
+
+    float3 activeLighting = LimitLightIntensity ? maxLighting : totalLighting;
+    if ( any( activeLighting > 0 ) ) {
+        float4 existing = RW_HDR[pixelCoord];
+        if ( LimitLightIntensity ) {
+            // Match legacy MAX blend: each light uses max(light, existing) individually.
+            // Since we see all lights at once, take the per-light max.
+            RW_HDR[pixelCoord] = float4( max( existing.rgb, maxLighting ), existing.a );
+        } else {
+            RW_HDR[pixelCoord] = float4( existing.rgb + totalLighting, existing.a );
+        }
+    }
+}


### PR DESCRIPTION
Tiled deferred shading reduces amount of draw calls and over-draw for lights, also reduces "empty" drawing by clustering lights so only "visible" lights produce light.

This is another attempt at reducing bandwidth and memory usage to improve performance on embedded GPUs with slow system memory backed VRAM.

Following up will be an optional Forward+ only draw pass as an alternative to the curent deferred shading. Which also SHOULD reduce VRAM and memory bandwidth requirements for those players who need it.

----

This might seem like a huge commit, but was squashed from a lot of tiny attempts until I was happy with how everything worked so far.