### PR TITLE
Fix tiled shading, shim span-like as `std::span` instead of `Span`

### DIFF
--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -150,7 +150,7 @@ public:
     virtual XRESULT DrawDynamicVertexBufferIndexed( std::vector<ExVertexStruct>& vertices, D3D11VertexBuffer* ib, unsigned int numIndices, unsigned int indexOffset = 0 ) { return XR_SUCCESS; };
 
     /** Draws a skeletal mesh */
-    virtual XRESULT DrawSkeletalMesh( SkeletalVobInfo* vi, const Span<XMFLOAT4X4> transforms, float4 color, const XMFLOAT4X4& world, float fatness = 1.0f ) { return XR_SUCCESS; };
+    virtual XRESULT DrawSkeletalMesh( SkeletalVobInfo* vi, const std::span<XMFLOAT4X4> transforms, float4 color, const XMFLOAT4X4& world, float fatness = 1.0f ) { return XR_SUCCESS; };
 
     /** Draws a vertexarray, non-indexed */
     virtual XRESULT DrawIndexedVertexArray( ExVertexStruct* vertices, unsigned int numVertices, D3D11VertexBuffer* ib, unsigned int numIndices, unsigned int stride = sizeof( ExVertexStruct ) ) { return XR_SUCCESS; };

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4473,6 +4473,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
     Engine::GAPI->GetRendererState().DepthState.DepthBufferCompareFunc = GothicDepthBufferStateInfo::ECompareFunc::CF_COMPARISON_LESS_EQUAL;
     Engine::GAPI->GetRendererState().DepthState.SetDirty();
 
+    Context->PSSetShaderResources( 0, 6, s_nullSRVs );
+
     bool linearDepth =
         (Engine::GAPI->GetRendererState().GraphicsState.FF_GSwitches &
             GSWITCH_LINEAR_DEPTH) != 0;
@@ -4656,6 +4658,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
         }
 
         // At this point either renderedVobs or rndVob is filled with something
+        D3D11Texture* lastBoundTexture = nullptr;
         std::list<VobInfo*>& rl = renderedVobs != nullptr ? *renderedVobs : rndVob;
         for ( auto const& vobInfo : rl ) {
             // Bind per-instance buffer
@@ -4668,10 +4671,14 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                         materialMesh.first->GetAlphaFunc() !=
                         zMAT_ALPHA_FUNC_MAT_DEFAULT ) {
                         if ( materialMesh.first->GetTexture()->CacheIn( 0.6f ) == zRES_CACHED_IN ) {
-                            materialMesh.first->GetTexture()->Bind( 0 );
+                            materialMesh.first->GetTexture()->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
+                            lastBoundTexture = materialMesh.first->GetTexture()->GetSurface()->GetEngineTexture();
                         }
                     } else {
+                        if (lastBoundTexture != DistortionTexture.get()) {
                             DistortionTexture->BindToPixelShader( 0 );
+                            lastBoundTexture = DistortionTexture.get();
+                        }
                     }
                 }
                 for ( auto const& meshInfo : materialMesh.second ) {
@@ -4780,6 +4787,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
     Engine::GAPI->GetRendererState().DepthState.SetDefault();
     Engine::GAPI->GetRendererState().DepthState.DepthBufferCompareFunc = GothicDepthBufferStateInfo::ECompareFunc::CF_COMPARISON_LESS_EQUAL;
     Engine::GAPI->GetRendererState().DepthState.SetDirty();
+
+    Context->PSSetShaderResources( 0, 6, s_nullSRVs );
 
     bool linearDepth =
         (Engine::GAPI->GetRendererState().GraphicsState.FF_GSwitches &
@@ -4964,21 +4973,28 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
 
         // At this point either renderedVobs or rndVob is filled with something
         std::list<VobInfo*>& rl = renderedVobs != nullptr ? *renderedVobs : rndVob;
+        auto _ = Engine::GraphicsEngine->RecordGraphicsEvent(L"Draw vobs (layered)");
+
+        D3D11Texture* lastBoundTexture = nullptr;
         for ( auto const& vobInfo : rl ) {
             // Bind per-instance buffer
             vobInfo->VobConstantBuffer->BindToVertexShader( 1 );
 
-            // Draw the vob
+            // Draw the vob1
             for ( auto const& materialMesh : vobInfo->VisualInfo->Meshes ) {
                 if ( materialMesh.first && materialMesh.first->GetTexture() ) {
                     if ( materialMesh.first->GetAlphaFunc() != zMAT_ALPHA_FUNC_NONE ||
                         materialMesh.first->GetAlphaFunc() !=
                         zMAT_ALPHA_FUNC_MAT_DEFAULT ) {
                         if ( materialMesh.first->GetTexture()->CacheIn( 0.6f ) == zRES_CACHED_IN ) {
-                            materialMesh.first->GetTexture()->Bind( 0 );
+                            materialMesh.first->GetTexture()->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
+                            lastBoundTexture = materialMesh.first->GetTexture()->GetSurface()->GetEngineTexture();
                         }
                     } else {
+                        if (lastBoundTexture != DistortionTexture.get()) {
                             DistortionTexture->BindToPixelShader( 0 );
+                            lastBoundTexture = DistortionTexture.get();
+                        }
                     }
                 }
                 for ( auto const& meshInfo : materialMesh.second ) {
@@ -5034,6 +5050,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
 
         // At this point eiter renderedMobs or rndVob is filled with something
         std::list<SkeletalVobInfo*>& rl = renderedMobs != nullptr ? *renderedMobs : rndVob;
+        auto _ = Engine::GraphicsEngine->RecordGraphicsEvent(L"Draw static skeletal meshes (layered)");
         for ( auto it : rl ) {
             Engine::GAPI->DrawSkeletalMeshVob_Layered( it, FLT_MAX );
         }
@@ -5042,6 +5059,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
     if ( Engine::GAPI->GetRendererState().RendererSettings.DrawSkeletalMeshes ) {
         // Draw animated skeletal meshes if wanted
         if ( renderNPCs ) {
+            auto _ = Engine::GraphicsEngine->RecordGraphicsEvent(L"Draw animated skeletal meshes (layered)");
             for ( auto const& skeletalMeshVob : Engine::GAPI->GetAnimatedSkeletalMeshVobs() ) {
                 if ( !skeletalMeshVob->VisualInfo ) {
                     // Seems to happen in Gothic 1

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2126,7 +2126,7 @@ bool D3D11GraphicsEngine::BindTextureNRFX( zCTexture* tex, bool bindShader ) {
 
 XRESULT  D3D11GraphicsEngine::DrawSkeletalVertexNormals( SkeletalVobInfo* vi,
     const XMFLOAT4X4& world,
-    const Span<XMFLOAT4X4> transforms, float4 color, float fatness ) {
+    const std::span<XMFLOAT4X4> transforms, float4 color, float fatness ) {
     std::shared_ptr<D3D11GShader> gshader = ShaderManager->GetGShader( GShaderID::GS_VertexNormals );
     gshader->Apply();
 
@@ -2185,7 +2185,7 @@ XRESULT  D3D11GraphicsEngine::DrawSkeletalVertexNormals( SkeletalVobInfo* vi,
 
 /** Draws a skeletal mesh */
 XRESULT D3D11GraphicsEngine::DrawSkeletalMesh( SkeletalVobInfo* vi,
-    const Span<XMFLOAT4X4> transforms, float4 color, const XMFLOAT4X4& world, float fatness ) {
+    const std::span<XMFLOAT4X4> transforms, float4 color, const XMFLOAT4X4& world, float fatness ) {
     if ( GetRenderingStage() == DES_SHADOWMAP_CUBE ) {
         SetActiveVertexShader( VShaderID::VS_ExSkeletalCube );
     } else {
@@ -2214,8 +2214,8 @@ XRESULT D3D11GraphicsEngine::DrawSkeletalMesh( SkeletalVobInfo* vi,
         // Don't bind previous, as we don't use them here yet.
     }
     else if ( GetRenderingStage() != DES_SHADOWMAP ) {
-        const Span<XMFLOAT4X4> prevTransforms = (vi->HasValidPrevTransforms && !vi->PrevBoneTransforms.empty())
-            ? make_span(vi->PrevBoneTransforms) 
+        const std::span<XMFLOAT4X4> prevTransforms = (vi->HasValidPrevTransforms && !vi->PrevBoneTransforms.empty())
+            ? std::span(vi->PrevBoneTransforms)
             : transforms;
         
         ActiveVS->GetBuffer("PrevBoneTransforms").Update( &prevTransforms[0], sizeof( XMFLOAT4X4 ) * std::min<UINT>( prevTransforms.size(), NUM_MAX_BONES ) ).Bind();
@@ -2287,7 +2287,7 @@ XRESULT D3D11GraphicsEngine::DrawSkeletalMesh( SkeletalVobInfo* vi,
 }
 
 XRESULT D3D11GraphicsEngine::DrawSkeletalMesh_Layered( SkeletalVobInfo* vi,
-    const Span<XMFLOAT4X4> transforms, float4 color, XMFLOAT4X4& world, float fatness ) {
+    const std::span<XMFLOAT4X4> transforms, float4 color, XMFLOAT4X4& world, float fatness ) {
     SetActiveVertexShader( VShaderID::VS_ExSkeletalLayered );
 
     SetupVS_ExMeshDrawCall();
@@ -2551,7 +2551,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 #else
             if ( !model->GetDrawHandVisualsOnly() ) {
 #endif
-                const auto transforms = make_span( &BoneTransformCache[boneIdx], numBones );
+                const auto transforms = std::span( &BoneTransformCache[boneIdx], numBones );
                 const auto color = modelColor;
 
                 VS_ExConstantBuffer_PerInstanceSkeletal cb2;
@@ -2570,8 +2570,8 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                     // Don't bind previous, as we don't use them here yet.
                 }
                 else if ( GetRenderingStage() != DES_SHADOWMAP ) {
-                    const Span<XMFLOAT4X4> prevTransforms = (vi->HasValidPrevTransforms && !vi->PrevBoneTransforms.empty())
-                        ? make_span(vi->PrevBoneTransforms) 
+                    const std::span<XMFLOAT4X4> prevTransforms = (vi->HasValidPrevTransforms && !vi->PrevBoneTransforms.empty())
+                        ? std::span(vi->PrevBoneTransforms)
                         : transforms;
                     
                     prevBoneTransformsCb.Update( &prevTransforms[0], sizeof( XMFLOAT4X4 ) * std::min<UINT>( prevTransforms.size(), NUM_MAX_BONES ) );
@@ -2653,7 +2653,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         auto vi = data.VobInfo;
         auto model = data.Model;
         auto modelColor = data.ModelColor;
-        auto transforms = make_span( &BoneTransformCache[data.BoneIdx], data.NumBones );
+        auto transforms = std::span( &BoneTransformCache[data.BoneIdx], data.NumBones );
         auto fatness = data.Fatness;
         auto& world = data.World;
 
@@ -4671,7 +4671,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                             materialMesh.first->GetTexture()->Bind( 0 );
                         }
                     } else {
-                        DistortionTexture->BindToPixelShader( 0 );
+                            DistortionTexture->BindToPixelShader( 0 );
                     }
                 }
                 for ( auto const& meshInfo : materialMesh.second ) {
@@ -4978,7 +4978,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
                             materialMesh.first->GetTexture()->Bind( 0 );
                         }
                     } else {
-                        DistortionTexture->BindToPixelShader( 0 );
+                            DistortionTexture->BindToPixelShader( 0 );
                     }
                 }
                 for ( auto const& meshInfo : materialMesh.second ) {

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -142,10 +142,10 @@ public:
     bool BindTextureNRFX( zCTexture* tex, bool bindShader );
 
     /** Draws a skeletal mesh */
-    XRESULT DrawSkeletalVertexNormals(SkeletalVobInfo* vi, const XMFLOAT4X4& world, const Span<XMFLOAT4X4> transforms, float4 color, float fatness =
+    XRESULT DrawSkeletalVertexNormals(SkeletalVobInfo* vi, const XMFLOAT4X4& world, const std::span<XMFLOAT4X4> transforms, float4 color, float fatness =
                                           1.0f);
-    XRESULT DrawSkeletalMesh( SkeletalVobInfo* vi, const Span<XMFLOAT4X4> transforms, float4 color, const XMFLOAT4X4& world, float fatness = 1.0f ) override;
-    XRESULT DrawSkeletalMesh_Layered(SkeletalVobInfo* vi, const Span<XMFLOAT4X4> transforms, float4 color, XMFLOAT4X4& world, float fatness = 1.0f);
+    XRESULT DrawSkeletalMesh( SkeletalVobInfo* vi, const std::span<XMFLOAT4X4> transforms, float4 color, const XMFLOAT4X4& world, float fatness = 1.0f ) override;
+    XRESULT DrawSkeletalMesh_Layered(SkeletalVobInfo* vi, const std::span<XMFLOAT4X4> transforms, float4 color, XMFLOAT4X4& world, float fatness = 1.0f);
 
     /** Draws a batch of skeletal mesh vobs */
     void DrawSkeletalMeshVobs( const std::vector<SkeletalVobInfo*>& vis, float distance, bool updateState, bool drawAttachments );

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -249,7 +249,7 @@ void D3D11PointLight::RenderFullCubemap() {
     // Don't use the cache if we have moved
     if ( WorldCacheInvalid )
         wc = nullptr;
-    auto _ = engine->RecordGraphicsEvent( L"RenderFullCubemap->RenderShadowCube" );
+    auto _ = engine->RecordGraphicsEvent( L"RenderFullCubemap->RenderFullCubemap" );
     RenderToDepthStencilBuffer& target = m_TiledDepthTarget ? *m_TiledDepthTarget : *m_DepthCubemap;
     engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), range, target, nullptr, nullptr, false, LightInfo->IsIndoorVob, noNPCs, &VobCache, &SkeletalVobCache, wc );
 
@@ -283,7 +283,7 @@ void D3D11PointLight::RenderCubemapFace( const XMFLOAT4X4& view, const XMFLOAT4X
 
     // Draw cubemap face
     Microsoft::WRL::ComPtr<ID3D11RenderTargetView> debugRTV = engine->GetDummyCubeRT() != nullptr ? engine->GetDummyCubeRT()->GetRTVCubemapFace( faceIdx ) : nullptr;
-    auto _ = engine->RecordGraphicsEvent( L"RenderFullCubemap->RenderShadowCube" );
+    auto _ = engine->RecordGraphicsEvent( L"RenderFullCubemap->RenderCubemapFace" );
     engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), range, *m_DepthCubemap, m_DepthCubemap->GetDSVCubemapFace( faceIdx ).Get(), debugRTV.Get(), false );
 
     //Engine::GAPI->GetRendererState().RendererSettings.DrawSkeletalMeshes = oldDrawSkel;

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -19,16 +19,9 @@ D3D11PointLight::D3D11PointLight( VobLightInfo* info, bool dynamicLight ) {
     XMStoreFloat3( &LastUpdatePosition, LightInfo->Vob->GetPositionWorldXM() );
 
     m_DepthCubemap = nullptr;
+    WorldCacheInvalid = true;
 
-    if ( !dynamicLight ) {
-        InitDone = false;
-
-        // Add to queue
-        Engine::WorkerThreadPool->enqueue( [this] { InitResources(); } );
-
-    } else {
-        InitResources();
-    }
+    StartReInit();
 
     DrawnOnce = false;
 }
@@ -66,18 +59,22 @@ void D3D11PointLight::AcquireShadowMap( DepthStencilPool* pool, int resolution )
 
     // don't reset DrawnOnce here, or NPCs won't show up in the first frame a shadow gets a different LOD
     // DrawnOnce = false;
+    StartReInit();
 }
 
 void D3D11PointLight::ReleaseShadowMap() {
     // This calls the custom deleter, returning the texture to the pool
     m_DepthCubemap.reset();
     m_CurrentResolution = 0;
+
 }
 
 void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner ) {
     m_TiledSlotIndex = slot;
     m_TiledDepthTarget = target;
     m_TiledOwner = owner;
+
+    StartReInit();
 }
 
 void D3D11PointLight::ClearTiledSlot() {
@@ -87,6 +84,7 @@ void D3D11PointLight::ClearTiledSlot() {
     m_TiledSlotIndex = -1;
     m_TiledDepthTarget = nullptr;
     m_TiledOwner = nullptr;
+
 }
 
 /** Returns true if this is the first time that light is being rendered */
@@ -254,6 +252,29 @@ void D3D11PointLight::RenderFullCubemap() {
     engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), range, target, nullptr, nullptr, false, LightInfo->IsIndoorVob, noNPCs, &VobCache, &SkeletalVobCache, wc );
 
     //Engine::GAPI->GetRendererState().RendererSettings.DrawSkeletalMeshes = oldDrawSkel;
+}
+
+void D3D11PointLight::Invalidate() {
+    DrawnOnce = false;
+    VobCache.clear();
+    SkeletalVobCache.clear();
+    WorldCacheInvalid = true;
+}
+
+void D3D11PointLight::StartReInit() {
+    if ( !WorldCacheInvalid ) {
+        return;
+    }
+
+    if ( !DynamicLight ) {
+        InitDone = false;
+
+        // Add to queue
+        Engine::WorkerThreadPool->enqueue( [this] { InitResources(); } );
+
+    } else {
+        InitResources();
+    }
 }
 
 /** Renders the scene with the given view-proj-matrices */

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -58,6 +58,9 @@ public:
     void SetCurrentResolution( int r ) { m_CurrentResolution = r; }
 
 protected:
+    void Invalidate();
+    void StartReInit();
+
     /** Renders the scene with the given view-proj-matrices */
     void RenderCubemapFace( const XMFLOAT4X4& view, const XMFLOAT4X4& proj, UINT faceIdx );
 

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -760,6 +760,18 @@ std::vector<float> D3D11ShadowMap::ComputeCascadeSplits( float nearPlane, float 
 
 XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& lights ) {
     auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+
+    // Release any resources of not visible lights
+    for ( auto& it : Engine::GAPI->VobLightMap ) {
+        if ( it.second->LightShadowBuffers
+            && (!it.second->Vob->IsEnabled() || !it.second->VisibleInFrame) ) {
+            if ( D3D11PointLight* pl = static_cast<D3D11PointLight*>(it.second->LightShadowBuffers.get()) ) {
+                pl->ClearTiledSlot();
+                pl->ReleaseShadowMap();
+            }
+        }
+    }
+
     if (settings.EnablePointlightShadows <= 0) {
         return XR_SUCCESS;
     }
@@ -787,17 +799,6 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
     std::list<VobLightInfo*> importantUpdates;
 
     DepthStencilPool* dsPool = graphicsEngine->GetPfxRenderer()->GetDepthStencilPool();
-
-    // Release any resources of not visible lights
-    for (auto& it : Engine::GAPI->VobLightMap) {
-        if (it.second->LightShadowBuffers
-            && (!it.second->Vob->IsEnabled() || !it.second->VisibleInFrame)) {
-            if ( D3D11PointLight* pl = static_cast<D3D11PointLight*>(it.second->LightShadowBuffers.get())) {
-                pl->ClearTiledSlot();
-                pl->ReleaseShadowMap();
-            }
-        }
-    }
     
     for ( auto const& light : lights ) {
         if ( !light->Vob->IsEnabled() || !light->VisibleInFrame ) {
@@ -823,6 +824,11 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
 
             // pick shadow resolution based on distance.
             int desiredResolution = SHADOW_CUBE_SIZE; // Fallback / far distance
+            if ( d < distVeryCloseSq ) {
+                light->UpdateShadows = true;
+                // for now, keep all lights/shadows the same size, otherwise they change their "volume"
+                // desiredResolution = 256; // High res for close lights
+            }
 
             bool inShadowRange = d < distMaxShadowSq;
             if ( inShadowRange ) {
@@ -847,10 +853,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
                     light->UpdateShadows = true; // Force an immediate render this frame
                 }
 
-                // TODO: prioritize updates based on distance, as player will notice updates more on close lights.
-                // TODO: actually only render lights visible in the frustum.
-
-                bool needsUpdate = pl->NeedsUpdate() || desiredResolution == 256;
+                bool needsUpdate = pl->NeedsUpdate();
                 bool isInited = pl->IsInited();
 
                 // Sort into Important vs Background Queue

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -822,10 +822,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
             float distMaxShadowSq = (range * 9.0f) * (range * 9.0f); // Fade out entirely after this
 
             // pick shadow resolution based on distance.
-            int desiredResolution = 64; // Fallback / far distance
-            if ( d < distVeryCloseSq ) {
-                desiredResolution = 256; // High res for close lights
-            }
+            int desiredResolution = SHADOW_CUBE_SIZE; // Fallback / far distance
 
             bool inShadowRange = d < distMaxShadowSq;
             if ( inShadowRange ) {

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -109,7 +109,7 @@ void D3D11TiledDeferredShading::EnsureShadowArray() {
     desc.Format = DXGI_FORMAT_R16_TYPELESS;
     desc.SampleDesc.Count = 1;
     desc.Usage = D3D11_USAGE_DEFAULT;
-    desc.BindFlags = D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE;
+    desc.BindFlags = D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE; 
     desc.MiscFlags = D3D11_RESOURCE_MISC_TEXTURECUBE;
 
     m_device->CreateTexture2D( &desc, nullptr, m_ShadowCubeArray.ReleaseAndGetAddressOf() );
@@ -381,7 +381,7 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
             }
             shadeCB.LimitLightIntensity = settings.LimitLightIntesity ? 1 : 0;
             shadeCB.NumTilesX = numTilesX;
-            XMStoreFloat4x4( &shadeCB.InvView, XMMatrixInverse( nullptr, view ) );
+            XMStoreFloat4x4( &shadeCB.InvView, XMMatrixInverse( nullptr, viewRaw ) );
 
             csTiledShading->GetBuffer( "TiledShadingConstantBuffer" ).Update( &shadeCB ).Bind();
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -2477,7 +2477,7 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
 #else
         if ( !model->GetDrawHandVisualsOnly() ) {
 #endif
-            Engine::GraphicsEngine->DrawSkeletalMesh( vi, make_span( transforms ), modelColor, world, fatness);
+            Engine::GraphicsEngine->DrawSkeletalMesh( vi, std::span( transforms ), modelColor, world, fatness );
         }
     } else {
         if ( model->GetMeshSoftSkinList()->NumInArray > 0 ) {
@@ -2505,16 +2505,16 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
     const std::vector<XMFLOAT4X4>& prevBoneTransforms = (vi->HasValidPrevTransforms && !vi->PrevBoneTransforms.empty())
         ? vi->PrevBoneTransforms
         : transforms;
-    const XMMATRIX prevWorldMatrix = vi->HasValidPrevTransforms 
-        ? XMLoadFloat4x4(&vi->PrevWorldMatrix) 
+    const XMMATRIX prevWorldMatrix = vi->HasValidPrevTransforms
+        ? XMLoadFloat4x4( &vi->PrevWorldMatrix )
         : XMLoadFloat4x4( &world );
-    
+
     phmap::flat_hash_map<int, std::vector<MeshVisualInfo*>>& nodeAttachments = vi->NodeAttachments;
     auto vsBufMPI = g->GetActiveVS()->GetBuffer( "Matrices_PerInstances" );
     vsBufMPI.Bind();
     for ( unsigned int i = 0; i < transforms.size(); i++ ) {
         // Check for new visual
-        zCModel* mvis = static_cast<zCModel*>(vi->Vob->GetVisual());
+        zCModel* mvis = static_cast<zCModel*>( vi->Vob->GetVisual() );
         zCModelNodeInst* node = mvis->GetNodeList()->Array[i];
 
         if ( !node->NodeVisual )
@@ -2559,11 +2559,11 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
             for ( MeshVisualInfo* mvi : nodeAttachment->second ) {
                 XMMATRIX curTransform = XMLoadFloat4x4( &transforms[i] );
                 XMFLOAT4X4 finalWorld;
-                XMStoreFloat4x4(&finalWorld, xmWorld * curTransform);
+                XMStoreFloat4x4( &finalWorld, xmWorld * curTransform );
 
                 XMMATRIX prevTransform = XMLoadFloat4x4( &prevBoneTransforms[i] );
-                auto prevWorldNode = prevWorldMatrix * prevTransform; 
-                
+                auto prevWorldNode = prevWorldMatrix * prevTransform;
+
                 if ( !mvi->Visual ) {
                     LogWarn() << "Attachment without visual on model: " << model->GetVisualName();
                     continue;
@@ -2577,7 +2577,7 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
                 }
 
                 // Update animated textures
-                bool isMMS = strcmp( mvi->Visual->GetFileExtension( 0 ), ".MMS") == 0;
+                bool isMMS = strcmp( mvi->Visual->GetFileExtension( 0 ), ".MMS" ) == 0;
                 if ( updateState ) {
                     node->TexAniState.UpdateTexList();
                     if ( isMMS ) {
@@ -2598,12 +2598,12 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
 
                 auto& VShader = g->GetActiveVS();
                 if ( distance < 1000 && isMMS ) {
-                    zCMorphMesh* mm = reinterpret_cast<zCMorphMesh*>(mvi->Visual);
+                    zCMorphMesh* mm = reinterpret_cast<zCMorphMesh*>( mvi->Visual );
                     // Only draw this as a morphmesh when rendering the main scene or when rendering as ghost
                     if ( g->GetRenderingStage() == DES_MAIN || g->GetRenderingStage() == DES_GHOST ) {
                         // Update constantbuffer
                         instanceInfo.World = finalWorld;
-                        XMStoreFloat4x4(&instanceInfo.PrevWorld, prevWorldNode);
+                        XMStoreFloat4x4( &instanceInfo.PrevWorld, prevWorldNode );
                         vsBufMPI.Update( &instanceInfo );
 
                         if ( updateState ) {
@@ -2616,12 +2616,12 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
                 }
 
                 instanceInfo.World = finalWorld;
-                XMStoreFloat4x4(&instanceInfo.PrevWorld, prevWorldNode);
+                XMStoreFloat4x4( &instanceInfo.PrevWorld, prevWorldNode );
                 vsBufMPI.Update( &instanceInfo );
 
                 // Go through all materials registered here
 
-                if ( g->GetRenderingStage() == DES_SHADOWMAP 
+                if ( g->GetRenderingStage() == DES_SHADOWMAP
                     || g->GetRenderingStage() == DES_SHADOWMAP_CUBE ) {
                     for ( auto const& itm : mvi->Meshes ) {
                         // no texture binding for shadowmap
@@ -2652,7 +2652,7 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
     RendererState.RendererInfo.FrameDrawnVobs++;
 }
 
-void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo* vi, float distance, bool updateState ) {
+void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distance, bool updateState ) {
     // TODO: Put this into the renderer!!
     D3D11GraphicsEngine* g = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
 
@@ -2693,7 +2693,7 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo* vi, float distance
     XMMATRIX scale = XMMatrixScalingFromVector( model->GetModelScaleXM() );
 
     XMMATRIX xmWorld = vi->Vob->GetWorldMatrixXM() * scale;
-    XMFLOAT4X4 world; XMStoreFloat4x4(&world, xmWorld);
+    XMFLOAT4X4 world; XMStoreFloat4x4( &world, xmWorld );
 
     float fatness = model->GetModelFatness();
 
@@ -2714,7 +2714,7 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo* vi, float distance
 #else
         if ( !model->GetDrawHandVisualsOnly() ) {
 #endif
-            g->DrawSkeletalMesh_Layered( vi, make_span( transforms ), modelColor, world, fatness );
+            g->DrawSkeletalMesh_Layered( vi, std::span( transforms ), modelColor, world, fatness );
         }
     } else {
         if ( model->GetMeshSoftSkinList()->NumInArray > 0 ) {
@@ -2740,7 +2740,7 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo* vi, float distance
     vsBufMPI.Bind();
     for ( unsigned int i = 0; i < transforms.size(); i++ ) {
         // Check for new visual
-        zCModel* mvis = static_cast<zCModel*>(vi->Vob->GetVisual());
+        zCModel* mvis = static_cast<zCModel*>( vi->Vob->GetVisual() );
         zCModelNodeInst* node = mvis->GetNodeList()->Array[i];
 
         if ( !node->NodeVisual )
@@ -2785,7 +2785,7 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo* vi, float distance
             for ( MeshVisualInfo* mvi : nodeAttachment->second ) {
                 XMMATRIX curTransform = XMLoadFloat4x4( &transforms[i] );
                 XMFLOAT4X4 finalWorld;
-                XMStoreFloat4x4(&finalWorld, xmWorld * curTransform);
+                XMStoreFloat4x4( &finalWorld, xmWorld * curTransform );
 
                 if ( !mvi->Visual ) {
                     LogWarn() << "Attachment without visual on model: " << model->GetVisualName();
@@ -2821,7 +2821,7 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo* vi, float distance
 
                 auto& VShader = g->GetActiveVS();
                 if ( distance < 1000 && isMMS ) {
-                    zCMorphMesh* mm = reinterpret_cast<zCMorphMesh*>(mvi->Visual);
+                    zCMorphMesh* mm = reinterpret_cast<zCMorphMesh*>( mvi->Visual );
                     // Only draw this as a morphmesh when rendering the main scene or when rendering as ghost
                     if ( g->GetRenderingStage() == DES_MAIN || g->GetRenderingStage() == DES_GHOST ) {
                         // Update constantbuffer
@@ -2969,7 +2969,7 @@ void GothicAPI::DrawSkeletalVN() {
             XMMATRIX scale = XMMatrixScalingFromVector( model->GetModelScaleXM() );
 
             XMMATRIX xmWorld = vi->Vob->GetWorldMatrixXM() * scale;
-            XMFLOAT4X4 world; XMStoreFloat4x4(&world, xmWorld);
+            XMFLOAT4X4 world; XMStoreFloat4x4( &world, xmWorld );
 
             float fatness = model->GetModelFatness();
 
@@ -2979,7 +2979,7 @@ void GothicAPI::DrawSkeletalVN() {
             model->GetBoneTransforms( &transforms );
 
             if ( !static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->SkeletalMeshes.empty() ) {
-                g->DrawSkeletalVertexNormals( vi, world, make_span( transforms ), 0xFFFFFF, fatness);
+                g->DrawSkeletalVertexNormals( vi, world, std::span( transforms ), 0xFFFFFF, fatness);
             }
         }
 

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -48,31 +48,46 @@ float CalcBlinnPhongLighting( float3 N, float3 H ) {
     return saturate( dot( N, H ) );
 }
 
-// 8-tap PCF shadow sampling matching PS_DS_PointLightDynShadow.hlsl
+// 8-tap PCF for 64×64 cubemap faces.
+// Two-ring unit-disk layout: inner ring (r=0.5) + outer ring (r=1.0, rotated 22.5°).
+// All magnitudes ≤ 1.0 so fixedBlurScale directly controls the texel spread.
 static const int SHADOW_BLUR_COUNT = 8;
-static const float3 SHADOW_BLUR_OFFSETS[SHADOW_BLUR_COUNT] = {
-    float3( 0.054426466605825*2-1, 0.057144871008184*2-1, 0.57025665350736*2-1 ),
-    float3( 0.32904030165125*2-1, 0.22406590786952*2-1, 0.76940122329136*2-1 ),
-    float3( 0.90462177475198*2-1, 0.091382070021416*2-1, 0.0065345494107038*2-1 ),
-    float3( 0.93540243382352*2-1, 0.61764284391778*2-1, 0.103979589466*2-1 ),
-    float3( 0.44626536287659*2-1, 0.19266830440269*2-1, 0.73062449308607*2-1 ),
-    float3( 0.0084832706528172*2-1, 0.83200742948428*2-1, 0.43927977813374*2-1 ),
-    float3( 0.28579624476181*2-1, 0.57096250149001*2-1, 0.0095401159532089*2-1 ),
-    float3( 0.55814247604373*2-1, 0.59385285228205*2-1, 0.44374119743879*2-1 )
+static const float2 SHADOW_BLUR_OFFSETS[SHADOW_BLUR_COUNT] = {
+    // Inner ring – r = 0.5, every 90°
+    float2(  0.500f,  0.000f ),
+    float2(  0.000f,  0.500f ),
+    float2( -0.500f,  0.000f ),
+    float2(  0.000f, -0.500f ),
+    // Outer ring – r = 1.0, offset 22.5° from inner so rings don't align
+    float2(  0.924f,  0.383f ),
+    float2( -0.383f,  0.924f ),
+    float2( -0.924f, -0.383f ),
+    float2(  0.383f, -0.924f ),
 };
 
 float SampleShadowCube( float3 wsPosition, float3 lightPosWorld, float lightRange, int cubeIndex ) {
-    float3 dir = normalize( wsPosition - lightPosWorld );
-    float distance = length( wsPosition - lightPosWorld );
+    float3 toPixel = wsPosition - lightPosWorld;
+    float3 dir = normalize( toPixel );
+    float distance = length( toPixel );
     float zFar = lightRange * 2.0f;
     distance = distance / zFar;
 
-    float fixedBias = 0.005f;
-    float fixedBlurScale = 0.010f;
+    float fixedBias = 0.006f;
+    // One texel on a 64×64 cubemap face ≈ 0.031 in direction-space.
+    // 0.034 puts outer-ring taps just over 1 texel away – enough to blur stripe
+    // boundaries without reaching into unrelated geometry at the light's range edge.
+    float fixedBlurScale = 0.034f;
+
+    // Stable tangent frame: displace perpendicular to the lookup direction so
+    // all perturbed directions remain close to the original cubemap face.
+    float3 up = abs( dir.y ) < 0.999f ? float3( 0, 1, 0 ) : float3( 1, 0, 0 );
+    float3 right = normalize( cross( up, dir ) );
+    up = cross( dir, right );
 
     float shd = 0;
     [unroll] for ( int i = 0; i < SHADOW_BLUR_COUNT; i++ ) {
-        float4 sampleCoord = float4( dir + SHADOW_BLUR_OFFSETS[i] * fixedBlurScale, (float)cubeIndex );
+        float3 perturbedDir = dir + (right * SHADOW_BLUR_OFFSETS[i].x + up * SHADOW_BLUR_OFFSETS[i].y) * fixedBlurScale;
+        float4 sampleCoord = float4( perturbedDir, (float)cubeIndex );
         shd += TX_ShadowCubeArray.SampleCmpLevelZero( SS_Comp, sampleCoord, distance - fixedBias );
     }
     shd /= SHADOW_BLUR_COUNT;

--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -84,32 +84,27 @@ extern ZUnquantizeHalfFloat_X4 UnquantizeHalfFloat_X8;
 
 
 /* Thin span-like data structure to allow re-using parts of a big std::vector for example */
-template<typename T>
-struct Span {
-private:
-    T* _data = nullptr;
-    size_t _size = 0;
+namespace std {
+    template<typename T>
+    struct span {
+    private:
+        T* _data = nullptr;
+        size_t _size = 0;
 
-public:
-    T& operator[]( size_t i ) { return _data[i]; }
-    const T& operator[]( size_t i ) const { return _data[i]; }
-    T* begin() { return _data; }
-    T* end() { return _data + _size; }
-    const size_t size() const { return _size; }
-    const T* data() { return _data; }
+    public:
+        span() = delete;
+        span(const span&) = default;
+        span(span&&) = default;
 
-    Span() = delete;
-    Span( T* data, size_t size )
-        : _data( data ), _size( size )
-    { }
-};
+        constexpr span( T* data, size_t size ) : _data( data ), _size( size ) {}
+        constexpr span( std::vector<T>& data ) : _data( data.data() ), _size( data.size() ) {}
 
-template<typename T>
-static Span<T> make_span( T* data, size_t size ) {
-    return Span( data, size );
-}
+        T& operator[]( size_t i ) { return _data[i]; }
+        const T& operator[]( size_t i ) const { return _data[i]; }
+        T* begin() { return _data; }
+        T* end() { return _data + _size; }
+        const size_t size() const { return _size; }
+        const T* data() { return _data; }
 
-template<typename T>
-static Span<T> make_span( std::vector<T>& vec ) {
-    return Span( vec.data(), vec.size() );
+    };
 }


### PR DESCRIPTION
- Fixes Tiled Shading
  - Wrong inverse caused flickering shadows
  - replaced previous blur with a more appropriate blur for 64x64 shadows
- rename `Span` with `std::span`, to ease future c++20 upgrade
- reduce texture bindings in `DrawWorldAround_Layered`