### PR TITLE
OBSOLETE: feat: Compute shader based effects

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -12,8 +12,15 @@ struct VobInstanceInfo {
     DWORD color;
     float windStrenth;
     float canBeAffectedByPlayer;
-    // General purpose slot
+    // General purpose slot. Used by instanced VOB rendering to store an index
+    // into optional per-visual metadata buffers.
     DWORD GP_Slot;
+};
+
+struct VobWindMetadata {
+    float MinHeight;
+    float MaxHeight;
+    float2 Padding;
 };
 
 /** Per-instance data for instanced node attachment rendering */

--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -116,6 +116,25 @@ struct DepthOfFieldConstantBuffer {
     float DoF_Pad2;
 };
 
+struct SAOConstantBuffer {
+    float4 SAO_ProjParams;    // x = 1/P._11, y = 1/P._22, z = P._34, w = P._33
+    float  SAO_Radius;        // World-space AO radius
+    float  SAO_Bias;          // Normal bias to reduce self-occlusion
+    float  SAO_Intensity;     // Darkening strength
+    int    SAO_NumSamples;    // Spiral sample count (16-48)
+    float2 SAO_InvResolution; // 1/width, 1/height
+    float  SAO_BlurSharpness; // Bilateral blur edge preservation
+    float  SAO_Pad;
+};
+
+struct SAOBlurConstantBuffer {
+    float2 SAO_Blur_InvResolution;
+    float2 SAO_Blur_Direction;
+    float  SAO_Blur_Sharpness;
+    float3 SAO_Blur_Pad;
+    float4 SAO_Blur_ProjParams;
+};
+
 struct HDRSettingsConstantBuffer {
     float HDR_MiddleGray;
     float HDR_LumWhite;

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -878,6 +878,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="BaseWidget.h" />
     <ClInclude Include="BasicTimer.h" />
     <ClInclude Include="D3D11CascadedShadowMapBuffer.h" />
+    <ClInclude Include="D3D11FileRelativeInclude.h" />
     <ClInclude Include="D3D11GraphicsShader.h" />
     <ClInclude Include="D3D11PFX_ASSAO.h" />
     <ClInclude Include="D3D11ShadowAtlas.h" />
@@ -1144,6 +1145,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="BaseLineRenderer.cpp" />
     <ClCompile Include="BaseWidget.cpp" />
     <ClCompile Include="D3D11CascadedShadowMapBuffer.cpp" />
+    <ClCompile Include="D3D11FileRelativeInclude.cpp" />
     <ClCompile Include="D3D11GraphicsShader.cpp" />
     <ClCompile Include="D3D11PFX_ASSAO.cpp" />
     <ClCompile Include="D3D11ShadowAtlas.cpp" />

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -907,6 +907,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="D3D11PFX_FSR3.h" />
     <ClInclude Include="D3D11PFX_GodRays.h" />
     <ClInclude Include="D3D11PFX_DepthOfField.h" />
+    <ClInclude Include="D3D11PFX_SAO.h" />
     <ClInclude Include="D3D11PFX_HDR.h" />
     <ClInclude Include="D3D11PFX_HeightFog.h" />
     <ClInclude Include="D3D11PFX_SimpleSharpen.h" />
@@ -1168,6 +1169,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="D3D11PFX_FSR3.cpp" />
     <ClCompile Include="D3D11PFX_GodRays.cpp" />
     <ClCompile Include="D3D11PFX_DepthOfField.cpp" />
+    <ClCompile Include="D3D11PFX_SAO.cpp" />
     <ClCompile Include="D3D11PFX_HDR.cpp" />
     <ClCompile Include="D3D11PFX_HeightFog.cpp" />
     <ClCompile Include="D3D11PFX_SimpleSharpen.cpp" />

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -879,6 +879,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="BasicTimer.h" />
     <ClInclude Include="D3D11CascadedShadowMapBuffer.h" />
     <ClInclude Include="D3D11GraphicsShader.h" />
+    <ClInclude Include="D3D11PFX_ASSAO.h" />
     <ClInclude Include="D3D11ShadowAtlas.h" />
     <ClInclude Include="CGameManager.h" />
     <ClInclude Include="D3D11AGS.h" />
@@ -1144,6 +1145,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="BaseWidget.cpp" />
     <ClCompile Include="D3D11CascadedShadowMapBuffer.cpp" />
     <ClCompile Include="D3D11GraphicsShader.cpp" />
+    <ClCompile Include="D3D11PFX_ASSAO.cpp" />
     <ClCompile Include="D3D11ShadowAtlas.cpp" />
     <ClCompile Include="D3D11AGS.cpp" />
     <ClCompile Include="D3D11ConstantBuffer.cpp" />

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -845,6 +845,10 @@
     <ClInclude Include="D3D11Upscaling.h">
       <Filter>Engine\D3D11</Filter>
     </ClInclude>
+    <ClInclude Include="D3D11PFX_SAO.h" />
+    <ClInclude Include="D3D11PFX_ASSAO.h">
+      <Filter>Engine\D3D11\PFX\Effects</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -1149,6 +1153,10 @@
     </ClCompile>
     <ClCompile Include="D3D11Upscaling.cpp">
       <Filter>Engine\D3D11</Filter>
+    </ClCompile>
+    <ClCompile Include="D3D11PFX_SAO.cpp" />
+    <ClCompile Include="D3D11PFX_ASSAO.cpp">
+      <Filter>Engine\D3D11\PFX\Effects</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -849,6 +849,7 @@
     <ClInclude Include="D3D11PFX_ASSAO.h">
       <Filter>Engine\D3D11\PFX\Effects</Filter>
     </ClInclude>
+    <ClInclude Include="D3D11FileRelativeInclude.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -1158,6 +1159,7 @@
     <ClCompile Include="D3D11PFX_ASSAO.cpp">
       <Filter>Engine\D3D11\PFX\Effects</Filter>
     </ClCompile>
+    <ClCompile Include="D3D11FileRelativeInclude.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ddraw.def">

--- a/D3D11Engine/D3D11FileRelativeInclude.cpp
+++ b/D3D11Engine/D3D11FileRelativeInclude.cpp
@@ -1,0 +1,57 @@
+#include "D3D11FileRelativeInclude.h"
+
+HRESULT __stdcall D3D11FileRelativeInclude::Open( D3D_INCLUDE_TYPE includeType, LPCSTR pFileName, LPCVOID pParentData, LPCVOID* ppData, UINT* pBytes )
+{
+    if ( ppData == nullptr || pBytes == nullptr || pFileName == nullptr )
+        return E_INVALIDARG;
+
+    std::filesystem::path baseDir = RootDir;
+
+    // If pParentData is an include we previously returned, use its directory as base.
+    if ( pParentData != nullptr ) {
+        auto it = ParentDirByData.find( pParentData );
+        if ( it != ParentDirByData.end() )
+            baseDir = it->second;
+    }
+
+    std::filesystem::path requested = std::filesystem::path( pFileName );
+
+    // Resolve strategy:
+    // 1) If requested is absolute -> use it
+    // 2) else -> resolve relative to includer's directory (baseDir)
+    // 3) If not found, optionally fall back to RootDir (useful for global include roots)
+    std::filesystem::path fullPath = requested.is_absolute() ? requested : (baseDir / requested);
+    fullPath = fullPath.lexically_normal();
+
+    if ( !std::filesystem::exists( fullPath ) && !requested.is_absolute() ) {
+        std::filesystem::path fallback = (RootDir / requested).lexically_normal();
+        if ( std::filesystem::exists( fallback ) )
+            fullPath = fallback;
+    }
+
+    std::ifstream file( fullPath, std::ios::binary );
+    if ( !file )
+        return HRESULT_FROM_WIN32( ERROR_FILE_NOT_FOUND );
+
+    file.seekg( 0, std::ios::end );
+    const std::streamoff size = file.tellg();
+    file.seekg( 0, std::ios::beg );
+
+    if ( size <= 0 )
+        return HRESULT_FROM_WIN32( ERROR_INVALID_DATA );
+
+    auto buffer = std::make_unique<uint8_t[]>( static_cast<size_t>(size) );
+    file.read( reinterpret_cast<char*>(buffer.get()), size );
+    if ( !file )
+        return HRESULT_FROM_WIN32( ERROR_READ_FAULT );
+
+    const void* dataPtr = buffer.get();
+    *ppData = dataPtr;
+    *pBytes = static_cast<UINT>(size);
+
+    // Track the directory of THIS include, so nested includes resolve against it.
+    ParentDirByData.emplace( dataPtr, fullPath.parent_path() );
+
+    OwnedBuffers.emplace_back( std::move( buffer ) );
+    return S_OK;
+}

--- a/D3D11Engine/D3D11FileRelativeInclude.h
+++ b/D3D11Engine/D3D11FileRelativeInclude.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <d3d11.h>
+#include <filesystem>
+#include <fstream>
+#include <unordered_map>
+#include <vector>
+#include <memory>
+
+// Include handler that resolves includes relative to the including file
+// and also files relative to any relative included file (i.e. nested includes).
+class D3D11FileRelativeInclude final : public ID3DInclude
+{
+public:
+    explicit D3D11FileRelativeInclude( std::filesystem::path rootDir )
+        : RootDir( std::move( rootDir ) )
+    {
+    }
+
+    HRESULT __stdcall Open( D3D_INCLUDE_TYPE includeType, LPCSTR pFileName, LPCVOID pParentData, LPCVOID* ppData, UINT* pBytes ) override;
+
+    HRESULT __stdcall Close( LPCVOID pData ) override
+    {
+        if ( pData == nullptr )
+            return E_INVALIDARG;
+
+        ParentDirByData.erase( pData );
+
+        // Owned buffer lifetime is tied to this include handler; we can keep it until the compile ends.
+        // (D3DCompile will call Close, but we keep buffers to avoid pointer invalidation for ParentDirByData lookups.)
+        return S_OK;
+    }
+
+private:
+    std::filesystem::path RootDir;
+
+    // key: pointer handed to compiler (ppData), value: directory of that include
+    std::unordered_map<const void*, std::filesystem::path> ParentDirByData;
+
+    // keep memory alive for duration of compilation
+    std::vector<std::unique_ptr<uint8_t[]>> OwnedBuffers;
+};

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -5865,6 +5865,11 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
             }
         }
 
+        // Apply instancing shader early so metadata indexing can be prepared before instance upload.
+        SetActiveVertexShader( VShaderID::VS_ExInstancedObj );
+        ActiveVS->Apply();
+        const bool useWindMetadata = PrepareAndBindWindMetadata( activeVisuals );
+
         byte* data;
         UINT size;
         if ( SUCCEEDED( DynamicInstancingBuffer->Map( D3D11VertexBuffer::M_WRITE_DISCARD,
@@ -5881,11 +5886,6 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
             LogError() << "Failed to map dynamic instancing buffer for vobs.";
         }
 
-        // Apply instancing shader
-        SetActiveVertexShader( VShaderID::VS_ExInstancedObj );
-        // SetActivePixelShader("PS_DiffuseAlphaTest");
-        ActiveVS->Apply();
-
         if ( !linearDepth )  // Only unbind when not rendering linear depth
         {
             // Unbind PS
@@ -5901,6 +5901,9 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
 
         XMFLOAT3 vPlayerPosition = Engine::GAPI->GetPlayerVob() ? Engine::GAPI->GetPlayerVob()->GetPositionWorld() : XMFLOAT3( 0, 0, 0 );
         g_windBuffer.playerPos = float3( vPlayerPosition.x, vPlayerPosition.y, vPlayerPosition.z );
+        if ( windBuffer.GetRawBuffer() ) {
+            windBuffer.Update( &g_windBuffer );
+        }
 
         UINT dynOffset[] = { 0 };
         UINT dynuStride[] = { sizeof( VobInstanceInfo ) };
@@ -5958,12 +5961,11 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
         zCTexture* previousTx = nullptr;
         ID3D11ShaderResourceView* lastNrmTex = nullptr;
         ID3D11ShaderResourceView* lastFxTex = nullptr;
+        MeshVisualInfo* lastWindVisual = nullptr;
 
         for ( auto const& [staticMeshVisual, meshKey, meshInfo] : instancedMeshesToDraw ) {
-            // Shadow wind buffer state
-            if ( std::abs( g_windBuffer.minHeight - staticMeshVisual->BBox.Min.y ) > 0.1f ||
-                std::abs( g_windBuffer.maxHeight - staticMeshVisual->BBox.Max.y ) > 0.1f ) {
-
+            if ( !useWindMetadata && windBuffer.GetRawBuffer() && lastWindVisual != staticMeshVisual ) {
+                lastWindVisual = staticMeshVisual;
                 g_windBuffer.minHeight = staticMeshVisual->BBox.Min.y;
                 g_windBuffer.maxHeight = staticMeshVisual->BBox.Max.y;
                 windBuffer.Update( &g_windBuffer );
@@ -6039,6 +6041,10 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
             Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnVobs++;
         }
 
+        if ( useWindMetadata ) {
+            UnbindWindMetadata();
+        }
+
         for ( auto [_, sm] : Engine::GAPI->GetStaticMeshVisuals() ) {
             sm->Instances.clear();
         }
@@ -6111,6 +6117,72 @@ namespace {
             if ( staticMeshVisual->Instances.empty() ) continue;
             WorldConverter::UpdateMorphMeshVisual( staticMeshVisual->MorphMeshVisual, staticMeshVisual );
         }
+    }
+}
+
+bool D3D11GraphicsEngine::PrepareAndBindWindMetadata( const std::vector<MeshVisualInfo*>& activeVisuals ) {
+    if ( !ActiveVS || activeVisuals.empty() ) {
+        return false;
+    }
+
+    if ( ActiveVS->GetInputIndex( "WindMetaData" ) == -1 ) {
+        return false;
+    }
+
+    m_WindMetadataStaging.clear();
+    m_WindMetadataStaging.reserve( activeVisuals.size() );
+
+    for ( MeshVisualInfo* visual : activeVisuals ) {
+        if ( !visual ) {
+            continue;
+        }
+
+        const DWORD metadataIndex = static_cast<DWORD>(m_WindMetadataStaging.size());
+        VobWindMetadata metadata = {};
+        metadata.MinHeight = visual->BBox.Min.y;
+        metadata.MaxHeight = visual->BBox.Max.y;
+        m_WindMetadataStaging.push_back( metadata );
+
+        for ( auto& instance : visual->Instances ) {
+            instance.GP_Slot = metadataIndex;
+        }
+    }
+
+    if ( m_WindMetadataStaging.empty() ) {
+        return false;
+    }
+
+    const UINT requiredSize = static_cast<UINT>(m_WindMetadataStaging.size() * sizeof( VobWindMetadata ));
+
+    if ( !WindMetadataBuffer || WindMetadataBuffer->GetSizeInBytes() < requiredSize ) {
+        WindMetadataBuffer = std::make_unique<D3D11VertexBuffer>();
+        if ( XR_SUCCESS != WindMetadataBuffer->Init(
+            nullptr,
+            requiredSize,
+            D3D11VertexBuffer::B_SHADER_RESOURCE,
+            D3D11VertexBuffer::U_DYNAMIC,
+            D3D11VertexBuffer::CA_WRITE,
+            "WindMetadataBuffer",
+            sizeof( VobWindMetadata ) ) ) {
+            WindMetadataBuffer.reset();
+            return false;
+        }
+
+        SetDebugName( WindMetadataBuffer->GetShaderResourceView().Get(), "WindMetadataBuffer->ShaderResourceView" );
+        SetDebugName( WindMetadataBuffer->GetVertexBuffer().Get(), "WindMetadataBuffer->Buffer" );
+    }
+
+    if ( XR_SUCCESS != WindMetadataBuffer->UpdateBuffer( m_WindMetadataStaging.data(), requiredSize ) ) {
+        return false;
+    }
+
+    ActiveVS->BindResource( "WindMetaData", WindMetadataBuffer->GetShaderResourceView().Get() );
+    return true;
+}
+
+void D3D11GraphicsEngine::UnbindWindMetadata() {
+    if ( ActiveVS ) {
+        ActiveVS->BindResource( "WindMetaData", nullptr );
     }
 }
 
@@ -6258,6 +6330,8 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                 UpdateMorphMeshVisuals( activeVisuals );
             }
 
+            const bool useWindMetadata = PrepareAndBindWindMetadata( activeVisuals );
+
             // Create instancebuffer for this frame
             size_t ByteWidth = DynamicInstancingBuffer->GetSizeInBytes();
 
@@ -6300,6 +6374,9 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
 
             XMFLOAT3 vPlayerPosition = Engine::GAPI->GetPlayerVob() ? Engine::GAPI->GetPlayerVob()->GetPositionWorld() : XMFLOAT3( 0, 0, 0 );
             g_windBuffer.playerPos = float3( vPlayerPosition.x, vPlayerPosition.y, vPlayerPosition.z );
+            if ( windBuffer.GetRawBuffer() ) {
+                windBuffer.Update( &g_windBuffer );
+            }
 
             float cachedSmallVobRadius = -1.0f;
             float cachedVobRadius = -1.0f;
@@ -6360,6 +6437,7 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
             zCTexture* lastTex = nullptr;
             ID3D11ShaderResourceView* lastNrmTex = nullptr;
             ID3D11ShaderResourceView* lastFxTex = nullptr;
+            MeshVisualInfo* lastWindVisual = nullptr;
 
             for ( auto const& [staticMeshVisual, meshKey, meshInfo] : instancedMeshesToDraw ) {
                 float expectedSmallRadius = renderSettings.OutdoorSmallVobDrawRadius - staticMeshVisual->MeshSize;
@@ -6383,10 +6461,8 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                     }
                 }
 
-                // Shadow wind buffer state
-                if ( std::abs( g_windBuffer.minHeight - staticMeshVisual->BBox.Min.y ) > 0.1f ||
-                    std::abs( g_windBuffer.maxHeight - staticMeshVisual->BBox.Max.y ) > 0.1f ) {
-
+                if ( !useWindMetadata && windBuffer.GetRawBuffer() && lastWindVisual != staticMeshVisual ) {
+                    lastWindVisual = staticMeshVisual;
                     g_windBuffer.minHeight = staticMeshVisual->BBox.Min.y;
                     g_windBuffer.maxHeight = staticMeshVisual->BBox.Max.y;
                     windBuffer.Update( &g_windBuffer );
@@ -6494,6 +6570,11 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                     sizeof( VobInstanceInfo ), staticMeshVisual->Instances.size(),
                     sizeof( ExVertexStruct ), staticMeshVisual->StartInstanceNum );
             }
+
+            if ( useWindMetadata ) {
+                UnbindWindMetadata();
+            }
+
             for ( auto sm : activeVisuals ) {
                 bool clear = true;
                 for ( auto& [meshKey, _] : sm->MeshesByTexture ) {
@@ -6564,6 +6645,61 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
 
     GetContext()->OMSetRenderTargets( 1, HDRBackBuffer->GetRenderTargetView().GetAddressOf(),
         DepthStencilBuffer->GetDepthStencilView().Get() );
+
+    bool useWindMetadata = false;
+    if ( ActiveVS && ActiveVS->GetInputIndex( "WindMetaData" ) != -1 && !m_AlphaMeshes.empty() ) {
+        std::unordered_map<MeshVisualInfo*, DWORD> metadataByVisual;
+        metadataByVisual.reserve( m_AlphaMeshes.size() );
+
+        m_WindMetadataStaging.clear();
+        m_WindMetadataStaging.reserve( m_AlphaMeshes.size() );
+
+        for ( auto& alphaData : m_AlphaMeshes ) {
+            MeshVisualInfo* visual = alphaData.vi;
+            if ( !visual ) {
+                continue;
+            }
+
+            auto [it, inserted] = metadataByVisual.try_emplace( visual, static_cast<DWORD>(m_WindMetadataStaging.size()) );
+            if ( inserted ) {
+                VobWindMetadata metadata = {};
+                metadata.MinHeight = visual->BBox.Min.y;
+                metadata.MaxHeight = visual->BBox.Max.y;
+                m_WindMetadataStaging.push_back( metadata );
+            }
+
+            for ( auto& instance : alphaData.instances ) {
+                instance.GP_Slot = it->second;
+            }
+        }
+
+        if ( !m_WindMetadataStaging.empty() ) {
+            const UINT requiredSize = static_cast<UINT>(m_WindMetadataStaging.size() * sizeof( VobWindMetadata ));
+
+            if ( !WindMetadataBuffer || WindMetadataBuffer->GetSizeInBytes() < requiredSize ) {
+                WindMetadataBuffer = std::make_unique<D3D11VertexBuffer>();
+                if ( XR_SUCCESS == WindMetadataBuffer->Init(
+                    nullptr,
+                    requiredSize,
+                    D3D11VertexBuffer::B_SHADER_RESOURCE,
+                    D3D11VertexBuffer::U_DYNAMIC,
+                    D3D11VertexBuffer::CA_WRITE,
+                    "WindMetadataBuffer",
+                    sizeof( VobWindMetadata ) ) ) {
+                    SetDebugName( WindMetadataBuffer->GetShaderResourceView().Get(), "WindMetadataBuffer->ShaderResourceView" );
+                    SetDebugName( WindMetadataBuffer->GetVertexBuffer().Get(), "WindMetadataBuffer->Buffer" );
+                } else {
+                    WindMetadataBuffer.reset();
+                }
+            }
+
+            if ( WindMetadataBuffer
+                && XR_SUCCESS == WindMetadataBuffer->UpdateBuffer( m_WindMetadataStaging.data(), requiredSize ) ) {
+                ActiveVS->BindResource( "WindMetaData", WindMetadataBuffer->GetShaderResourceView().Get() );
+                useWindMetadata = true;
+            }
+        }
+    }
     
     // re-setup dynamic instancing buffer with correct instances and values
     // shadow pass breaks the "global" state of this.
@@ -6589,6 +6725,7 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
         (Engine::GAPI->GetRendererState().RendererSettings.WindQuality > 0 || Engine::GAPI->GetRendererState().RendererSettings.HeroAffectsObjects) ) {
         windBuffer = ActiveVS->GetBuffer( "WindParams" );
         windBuffer.Bind();
+        windBuffer.Update( &g_windBuffer );
     }
 
     for ( auto const& alphaMesh : m_AlphaMeshes ) {
@@ -6639,7 +6776,9 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
             MaterialInfo* info = mk.Info;
             if ( !info->Constantbuffer ) info->UpdateConstantbuffer();
 
-            windBuffer.Update( &g_windBuffer );
+            if ( !useWindMetadata && windBuffer.GetRawBuffer() ) {
+                windBuffer.Update( &g_windBuffer );
+            }
 
             // Draw batch
             DrawInstanced( mi->MeshVertexBuffer, mi->MeshIndexBuffer, mi->Indices.size(),
@@ -6654,7 +6793,9 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
         g_windBuffer.minHeight = vi->BBox.Min.y;
         g_windBuffer.maxHeight = vi->BBox.Max.y;
 
-        windBuffer.Update( &g_windBuffer );
+        if ( !useWindMetadata && windBuffer.GetRawBuffer() ) {
+            windBuffer.Update( &g_windBuffer );
+        }
 
         // Draw batch
         DrawInstanced( mi->MeshVertexBuffer, mi->MeshIndexBuffer, mi->Indices.size(),
@@ -6665,6 +6806,11 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
         // Reset visual
         vi->StartNewFrame();
     }
+
+    if ( useWindMetadata ) {
+        UnbindWindMetadata();
+    }
+
     m_AlphaMeshes.clear();
     
     return XR_SUCCESS;

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3436,6 +3436,14 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     );    
 
     // Draw Ambient Occlusion
+    // Shared state for PostFX composition pass
+    ID3D11ShaderResourceView* compositionGodRaysSRV = nullptr;
+    bool isOutdoor = Engine::GAPI->GetLoadedWorldInfo()->BspTree->GetBspTreeMode() == zBSP_MODE_OUTDOOR;
+    bool compositionSAO = (rendererState.RendererSettings.AoMode == AOMode::AO_SAO);
+    bool compositionGodRays = (rendererState.RendererSettings.EnableGodRays && isOutdoor);
+    bool compositionHeightFog = (rendererState.RendererSettings.DrawFog && isOutdoor);
+    bool compositionActive = compositionSAO || compositionGodRays || compositionHeightFog;
+
     if ( rendererState.RendererSettings.AoMode == AOMode::AO_HBAO ) {
         graph.AddPass( L"HBAO+", [&]( RGBuilder& builder, RenderPass& pass ) {
             builder.Read( normalsResource );
@@ -3451,19 +3459,17 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
                 GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
             };
         });
-    } else if ( rendererState.RendererSettings.AoMode == AOMode::AO_SAO ) {
-        graph.AddPass( L"SAO", [&]( RGBuilder& builder, RenderPass& pass ) {
+    } else if ( compositionSAO ) {
+        // SAO compute-only pass — skips the final modulate blit (composition handles it)
+        graph.AddPass( L"SAO Compute", [&]( RGBuilder& builder, RenderPass& pass ) {
             builder.Read( normalsResource );
-            builder.Write( backBufferHandle );
 
-            pass.m_executeCallback = [this, normalsResource, backBufferHandle](const RenderGraph& graph) {
+            pass.m_executeCallback = [this, normalsResource](const RenderGraph& graph) {
                 auto normalsTexture = graph.GetPhysicalTexture(normalsResource);
-                auto backBuffer = graph.GetPhysicalTexture(backBufferHandle);
 
-                PfxRenderer->RenderSAO(
+                PfxRenderer->RenderSAOCompute(
                     GetDepthBuffer()->GetShaderResView().Get(),
-                    normalsTexture->GetShaderResView().Get(),
-                    backBuffer->GetRenderTargetView().Get());
+                    normalsTexture->GetShaderResView().Get());
                 GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
             };
         });
@@ -3527,7 +3533,9 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     
     if (rendererState.RendererSettings.DrawFog &&
                 Engine::GAPI->GetLoadedWorldInfo()->BspTree->GetBspTreeMode() ==
-                zBSP_MODE_OUTDOOR) {
+                zBSP_MODE_OUTDOOR && !compositionActive) {
+        // Standalone heightfog pass — only used when composition is not active (shouldn't happen
+        // when DrawFog is on, but kept as fallback for FL10 or edge cases)
         graph.AddPass( L"Draw Heightfog", [&]( RGBuilder& builder, RenderPass& pass ) {
             builder.Read( backBufferHandle );
             builder.Write( backBufferHandle );
@@ -3598,22 +3606,73 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     if (rendererState.RendererSettings.EnableGodRays &&
         Engine::GAPI->GetLoadedWorldInfo()->BspTree->GetBspTreeMode() ==
         zBSP_MODE_OUTDOOR) {
-        graph.AddPass( L"Draw Godrays", [&]( RGBuilder& builder, RenderPass& pass ) {
-            builder.Read( normalsResource );
+        if ( compositionActive ) {
+            // GodRays compute-only pass — writes to pool texture, skips the final additive blit
+            graph.AddPass( L"GodRays Compute", [&]( RGBuilder& builder, RenderPass& pass ) {
+                builder.Read( normalsResource );
+                builder.Read( backBufferHandle );
+
+                pass.m_executeCallback = [this, backBufferHandle, normalsResource, &compositionGodRaysSRV](const RenderGraph& graph) {
+                    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> srv;
+                    GetContext()->PSSetShaderResources( 5, 1, srv.GetAddressOf() );
+
+                    auto backbufferResource = graph.GetPhysicalTexture(backBufferHandle);
+                    auto normalsTexture = graph.GetPhysicalTexture(normalsResource);
+
+                    PfxRenderer->RenderGodRaysToTexture(
+                        backbufferResource->GetShaderResView().Get(),
+                        normalsTexture->GetShaderResView().Get(),
+                        &compositionGodRaysSRV);
+                    GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
+                };
+            });
+        } else {
+            // Standalone GodRays pass (fallback when composition is not active)
+            graph.AddPass( L"Draw Godrays", [&]( RGBuilder& builder, RenderPass& pass ) {
+                builder.Read( normalsResource );
+                builder.Read( backBufferHandle );
+                builder.Write( backBufferHandle );
+
+                pass.m_executeCallback = [this, backBufferHandle, normalsResource](const RenderGraph& graph) {
+                    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> srv;
+                    GetContext()->PSSetShaderResources( 5, 1, srv.GetAddressOf() );
+
+                    auto backbufferResource = graph.GetPhysicalTexture(backBufferHandle);
+                    auto normalsTexture = graph.GetPhysicalTexture(normalsResource);
+
+                    PfxRenderer->RenderGodRays(backbufferResource->GetShaderResView().Get(), normalsTexture->GetShaderResView().Get());
+                    GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
+                };
+            });
+        }
+    }
+
+    // PostFX Composition pass — merges SAO, HeightFog, and GodRays in a single full-screen blit
+    if ( compositionActive ) {
+        graph.AddPass( L"PostFX Composition", [&]( RGBuilder& builder, RenderPass& pass ) {
             builder.Read( backBufferHandle );
             builder.Write( backBufferHandle );
 
-            pass.m_executeCallback = [this, backBufferHandle, normalsResource](const RenderGraph& graph) {
-                // Unbind temporary backbuffer copy
-                Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> srv;
-                GetContext()->PSSetShaderResources( 5, 1, srv.GetAddressOf() );
-                
-                auto backbufferResource = graph.GetPhysicalTexture(backBufferHandle);
-                auto normalsTexture = graph.GetPhysicalTexture(normalsResource);
-                
-                PfxRenderer->RenderGodRays(backbufferResource->GetShaderResView().Get(), normalsTexture->GetShaderResView().Get());
-                // Godrays bind a different sampler
-                GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );                
+            pass.m_executeCallback = [this, backBufferHandle, compositionSAO, compositionHeightFog,
+                                      &compositionGodRaysSRV](const RenderGraph& graph) {
+                auto backBuffer = graph.GetPhysicalTexture(backBufferHandle);
+
+                // Copy backbuffer to a temp texture — we need to read it as SRV while writing to RTV
+                auto tempBuffer = PfxRenderer->GetTempBuffer();
+                GetContext()->CopyResource( tempBuffer->GetTexture().Get(), backBuffer->GetTexture().Get() );
+
+                // Gather SRVs for composition
+                ID3D11ShaderResourceView* saoSRV = compositionSAO ? PfxRenderer->GetSAOResultSRV() : nullptr;
+                ID3D11ShaderResourceView* depthSRV = compositionHeightFog ? GetDepthBuffer()->GetShaderResView().Get() : nullptr;
+
+                PfxRenderer->RenderPostFXComposition(
+                    backBuffer->GetRenderTargetView().Get(),
+                    tempBuffer->GetShaderResView().Get(),
+                    saoSRV,
+                    compositionGodRaysSRV,
+                    depthSRV );
+
+                GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
             };
         });
     }

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3230,6 +3230,7 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     if ( FeatureLevel10Compatibility ) {
         // Disable here what we can't draw in feature level 10 compatibility
         rendererState.RendererSettings.HbaoSettings.Enabled = false;
+        rendererState.RendererSettings.AoMode = AOMode::AO_NONE;
         rendererState.RendererSettings.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_NONE;
     }
 
@@ -3434,8 +3435,8 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         }
     );    
 
-    // Draw HBAO
-    if ( rendererState.RendererSettings.HbaoSettings.Enabled ) {
+    // Draw Ambient Occlusion
+    if ( rendererState.RendererSettings.AoMode == AOMode::AO_HBAO ) {
         graph.AddPass( L"HBAO+", [&]( RGBuilder& builder, RenderPass& pass ) {
             builder.Read( normalsResource );
             builder.Write( backBufferHandle );
@@ -3447,6 +3448,22 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
                 PfxRenderer->DrawHBAO( backBuffer->GetRenderTargetView(),
                     GetDepthBuffer()->GetShaderResView(), 
                     normalsTexture->GetShaderResView());
+                GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
+            };
+        });
+    } else if ( rendererState.RendererSettings.AoMode == AOMode::AO_SAO ) {
+        graph.AddPass( L"SAO", [&]( RGBuilder& builder, RenderPass& pass ) {
+            builder.Read( normalsResource );
+            builder.Write( backBufferHandle );
+
+            pass.m_executeCallback = [this, normalsResource, backBufferHandle](const RenderGraph& graph) {
+                auto normalsTexture = graph.GetPhysicalTexture(normalsResource);
+                auto backBuffer = graph.GetPhysicalTexture(backBufferHandle);
+
+                PfxRenderer->RenderSAO(
+                    GetDepthBuffer()->GetShaderResView().Get(),
+                    normalsTexture->GetShaderResView().Get(),
+                    backBuffer->GetRenderTargetView().Get());
                 GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
             };
         });

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2878,8 +2878,12 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
                 for ( auto const& itm : mvi->Meshes ) {
                     zCTexture* texture = nullptr;
-                    if ( !isShadowPass && itm.first ) {
+                    if ( itm.first ) {
                         texture = itm.first->GetAniTexture();
+                        if ( !texture || texture->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
+                            // need to cache in in order to know its alpha/material state
+                            continue;
+                        }
                     }
 
                     for ( unsigned int m = 0; m < itm.second.size(); m++ ) {
@@ -2900,21 +2904,14 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
     // By sorting ->HasAlphaChannel() first, we ensure minimum shader changes
     // then sorting by texture pointer groups nulls together for shadow passes, and also minimizes texture changes for main/ghost
     
-    if (wantShader) {
-        std::sort( instancedDrawItems.begin(), instancedDrawItems.end(),
-          []( const NodeAttachmentDrawItem& a, const NodeAttachmentDrawItem& b ) {
-              if ( a.needAlpha != b.needAlpha )
-                  return a.needAlpha < b.needAlpha; // non-alpha firstes
-              if ( a.texture != b.texture )
-                  return a.texture < b.texture; // sort by texture pointer
-              return a.mesh->meshId < b.mesh->meshId;
-          } );
-    } else {
-        std::sort( instancedDrawItems.begin(), instancedDrawItems.end(),
-          []( const NodeAttachmentDrawItem& a, const NodeAttachmentDrawItem& b ) {
-              return a.mesh->meshId < b.mesh->meshId;
-          } );
-    }
+    std::sort( instancedDrawItems.begin(), instancedDrawItems.end(),
+        []( const NodeAttachmentDrawItem& a, const NodeAttachmentDrawItem& b ) {
+            if ( a.needAlpha != b.needAlpha )
+                return a.needAlpha < b.needAlpha; // non-alpha firstes
+            if ( a.texture != b.texture )
+                return a.texture < b.texture; // sort by texture pointer
+            return a.mesh->meshId < b.mesh->meshId;
+        } );
 
     // Ensure instance buffer is large enough
     const size_t neededBytes = instancedDrawItems.size() * sizeof( NodeAttachmentInstanceData );
@@ -2936,6 +2933,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         zCMaterial* material;
         unsigned int startInstance;
         unsigned int instanceCount;
+        bool needAlpha;
     };
 
     static std::vector<InstanceBatch> batches;
@@ -2960,10 +2958,14 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         zCTexture* batchTex = instancedDrawItems[i].texture;
         zCMaterial* batchMat = instancedDrawItems[i].material;
 
+        bool needAlpha = false;
         while ( i < instancedDrawItems.size()
                 && meshId > 0 // assume meshId 0 means "not batch-able"
                 && instancedDrawItems[i].mesh->meshId == meshId
                 && instancedDrawItems[i].texture == batchTex ) {
+            // Some of them have needAlpha false, even though they share the same texture!
+            // thus we now just walk all batch items and assume if one needs alpha, all do.
+            needAlpha |= instancedDrawItems[i].needAlpha;
             destData[currentIdx] = instancedDrawItems[i].instanceData;
             ++currentIdx;
             ++i;
@@ -2971,7 +2973,8 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
         batches.push_back( { batchMesh, batchTex, batchMat,
             batchStart,
-            (i - batchStart) } );
+            (i - batchStart),
+            needAlpha } );
     }
 
     NodeAttachmentInstancingBuffer->Unmap();
@@ -3016,19 +3019,51 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
     MaterialInfo* lastMaterialInfo = nullptr;
 
-    void* lastTex = nullptr;
+    void* lastBatchTex = nullptr;
     auto lastSwitches = graphicsState.FF_GSwitches;
+    void* lastPs = nullptr;
+
+    // otherwise shadows of streetlamps are not accurate
+    const bool needsAlphaTesting = isShadowPass;
+
     for ( const auto& batch : batches ) {
         MeshInfo* mi = batch.mesh;
 
+        MaterialInfo* info = nullptr;
+        if ( batch.texture ) {
+            info = Engine::GAPI->GetMaterialInfoFrom( batch.texture );
+            if ( needsAlphaTesting && info->MaterialType == MaterialInfo::MT_FullAlpha ) {
+                continue;
+            }
+        }
+
         // Bind texture for non-shadow passes
-        if ( wantShader && batch.texture && batch.texture != lastTex) {
-            MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom( batch.texture );
+        if ( needsAlphaTesting ) {
+            if ( batch.needAlpha ) {
+                if ( !batch.texture || batch.texture->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
+                    // can't do alpha without a texture
+                    continue;
+                }
+                if ( lastBatchTex != batch.texture ) {
+                    batch.texture->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
+                    lastBatchTex = batch.texture;
+                }
+                SetActivePixelShader( PShaderID::PS_DiffuseAlphaTestShadows );
+                if ( ActivePS.get() != lastPs ) {
+                    ActivePS->Apply();
+                    lastPs = ActivePS.get();
+                }
+            } else if ( lastPs != nullptr ) {
+                ActivePS = nullptr;
+                lastPs = nullptr;
+                GetContext()->PSSetShader( nullptr, nullptr, 0 );
+            }
+        } else if ( wantShader && batch.texture && batch.texture != lastBatchTex ) {
             if ( !BindTextureNRFX( batch.texture, isMainOrGhost, info != lastMaterialInfo ) ) {
                 continue;
             }
             lastMaterialInfo = info;
-            lastTex = batch.texture;
+            lastBatchTex = batch.texture;
         }
 
         // Set up alpha test state from material

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3410,9 +3410,9 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
             if ( Engine::GAPI->GetRendererState().RendererSettings.EnableShadows ) {
                 // Cascades only get rendered if this is enabled. 
                 ShadowMaps->PrepareRender();
-                // Lights need a working depth stencil copy!
-                CopyDepthStencil();
             }
+            // Lights need a working depth stencil copy, so do other effects!
+            CopyDepthStencil();
 
             ShadowMaps->DrawLighting(m_FrameLights, 
                 *colorTexture, 
@@ -3454,12 +3454,29 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
                 auto backBuffer = graph.GetPhysicalTexture(backBufferHandle);
 
                 PfxRenderer->DrawHBAO( backBuffer->GetRenderTargetView(),
-                    GetDepthBuffer()->GetShaderResView(), 
+                    GetDepthBufferCopy()->GetShaderResView(),
                     normalsTexture->GetShaderResView());
                 GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
             };
         });
-    } else if ( compositionSAO ) {
+    }
+    else if ( rendererState.RendererSettings.AoMode == AOMode::AO_ASSAO ) {
+        graph.AddPass( L"ASSAO", [&]( RGBuilder& builder, RenderPass& pass ) {
+            builder.Read( normalsResource );
+            builder.Write( backBufferHandle );
+
+            pass.m_executeCallback = [this, normalsResource, backBufferHandle]( const RenderGraph& graph ) {
+                auto normalsTexture = graph.GetPhysicalTexture( normalsResource );
+                auto backBuffer = graph.GetPhysicalTexture( backBufferHandle );
+
+                PfxRenderer->RenderASSAO( backBuffer->GetRenderTargetView().Get(),
+                    GetDepthBufferCopy()->GetShaderResView().Get(),
+                    normalsTexture->GetShaderResView().Get() );
+                GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
+            };
+        } );
+    }
+    else if ( compositionSAO ) {
         // SAO compute-only pass — skips the final modulate blit (composition handles it)
         graph.AddPass( L"SAO Compute", [&]( RGBuilder& builder, RenderPass& pass ) {
             builder.Read( normalsResource );
@@ -3468,7 +3485,7 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
                 auto normalsTexture = graph.GetPhysicalTexture(normalsResource);
 
                 PfxRenderer->RenderSAOCompute(
-                    GetDepthBuffer()->GetShaderResView().Get(),
+                    GetDepthBufferCopy()->GetShaderResView().Get(),
                     normalsTexture->GetShaderResView().Get());
                 GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
             };

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3317,7 +3317,7 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     graph.AddPass( L"G-Buffer Pass", [&]( RGBuilder& builder, RenderPass& pass ) {
         // Setup / Declare
         auto size = GetResolution();
-        normalsResource = builder.CreateTexture({ static_cast<uint32_t>(size.x), static_cast<uint32_t>(size.y), DXGI_FORMAT_R8G8B8A8_SNORM, L"GBufferNormals" });
+        normalsResource = builder.CreateTexture({ static_cast<uint32_t>(size.x), static_cast<uint32_t>(size.y), DXGI_FORMAT_R16G16_SNORM, L"GBufferNormals" });
         specularResource = builder.CreateTexture({ static_cast<uint32_t>(size.x), static_cast<uint32_t>(size.y), DXGI_FORMAT_R16G16_FLOAT, L"GBufferSpecular" });
         reactiveMaskResource = builder.CreateTexture({ static_cast<uint32_t>(size.x), static_cast<uint32_t>(size.y), DXGI_FORMAT_R8_UNORM, L"ReactiveMask" });
 
@@ -3621,7 +3621,7 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
 
                     PfxRenderer->RenderGodRaysToTexture(
                         backbufferResource->GetShaderResView().Get(),
-                        normalsTexture->GetShaderResView().Get(),
+                        GetDepthBuffer()->GetShaderResView().Get(),
                         &compositionGodRaysSRV);
                     GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
                 };

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4628,12 +4628,6 @@ void D3D11GraphicsEngine::DrawWaterSurfaces() {
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
     Engine::GAPI->SetViewTransformXM( view );  // Update view transform
 
-    // Setup render states for z-prepass
-    Engine::GAPI->GetRendererState().BlendState.ColorWritesEnabled =
-        false; // Rasterization is faster without writes
-    Engine::GAPI->GetRendererState().BlendState.SetDirty();
-    UpdateRenderStates();
-
     // Bind vertex water shader
     ActivePS = nullptr;
     SetActiveVertexShader( VShaderID::VS_ExWater );
@@ -4643,8 +4637,6 @@ void D3D11GraphicsEngine::DrawWaterSurfaces() {
     float totalTime = Engine::GAPI->GetTotalTime();
     ActiveVS->GetBuffer( "Matrices_PerInstances" ).Update( &totalTime, 4 ).Bind();
 
-    // Do Z-prepass on the water to make sure only the visible pixels will get drawn instead of multiple layers of water
-    GetContext()->PSSetShader( nullptr, nullptr, 0 );
     GetContext()->OMSetRenderTargets( 1, HDRBackBuffer->GetRenderTargetView().GetAddressOf(),
         DepthStencilBuffer->GetDepthStencilView().Get() );
 
@@ -4652,19 +4644,80 @@ void D3D11GraphicsEngine::DrawWaterSurfaces() {
     DrawVertexBufferIndexedUINT(
         Engine::GAPI->GetWrappedWorldMesh()->MeshVertexBuffer,
         Engine::GAPI->GetWrappedWorldMesh()->MeshIndexBuffer, 0, 0 );
+
+    // Build per-texture batch descriptors and flat indirect draw args
+    struct WaterTextureBatch {
+        zCTexture* texture;
+        unsigned int argsOffset; // index into waterDrawArgs
+        unsigned int drawCount;
+    };
+
+    static std::vector<D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGS> waterDrawArgs;
+    static std::vector<WaterTextureBatch> waterBatches;
+    waterDrawArgs.clear();
+    waterBatches.clear();
+
     for ( const auto& [texture, meshes] : FrameWaterSurfaces ) {
-        // Draw surfaces
+        WaterTextureBatch batch;
+        batch.texture = texture;
+        batch.argsOffset = static_cast<unsigned int>( waterDrawArgs.size() );
+        batch.drawCount = 0;
+
         for ( const auto& mesh : meshes ) {
+            D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGS args;
+            args.IndexCountPerInstance = static_cast<UINT>( mesh->Indices.size() );
+            args.InstanceCount = 1;
+            args.StartIndexLocation = mesh->BaseIndexLocation;
+            args.BaseVertexLocation = 0;
+            args.StartInstanceLocation = 0;
+            waterDrawArgs.push_back( args );
+            batch.drawCount++;
+        }
+
+        waterBatches.push_back( batch );
+    }
+
+    constexpr unsigned int argStride = sizeof( D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGS );
+
+    // === Z-Prepass ===
+    // Disable color writes for depth-only rendering
+    Engine::GAPI->GetRendererState().BlendState.ColorWritesEnabled = false;
+    Engine::GAPI->GetRendererState().BlendState.SetDirty();
+    UpdateRenderStates();
+
+    GetContext()->PSSetShader( nullptr, nullptr, 0 );
+
+    if ( !FeatureLevel10Compatibility ) {
+        // MDI path: upload all draw args and dispatch in one call
+        const size_t requiredSize = waterDrawArgs.size() * argStride;
+
+        if ( !WaterIndirectBuffer || WaterIndirectBuffer->GetSizeInBytes() < requiredSize ) {
+            WaterIndirectBuffer = std::make_unique<D3D11IndirectBuffer>();
+            WaterIndirectBuffer->Init(
+                waterDrawArgs.data(), static_cast<unsigned int>( requiredSize ),
+                D3D11IndirectBuffer::B_INDEXBUFFER, D3D11IndirectBuffer::U_DYNAMIC,
+                D3D11IndirectBuffer::CA_WRITE );
+        } else {
+            WaterIndirectBuffer->UpdateBuffer( waterDrawArgs.data(), static_cast<unsigned int>( requiredSize ) );
+        }
+
+        DrawMultiIndexedInstancedIndirect( Context.Get(),
+            static_cast<unsigned int>( waterDrawArgs.size() ),
+            WaterIndirectBuffer->GetIndirectBuffer().Get(),
+            0, argStride );
+    } else {
+        // FL10 fallback: direct DrawIndexed per mesh
+        for ( const auto& args : waterDrawArgs ) {
             DrawVertexBufferIndexedUINT( nullptr, nullptr,
-                mesh->Indices.size(), mesh->BaseIndexLocation );
+                args.IndexCountPerInstance, args.StartIndexLocation );
         }
     }
 
-    // Disable depth writes after z-prepass
+    // === Refraction Pass ===
+    // Enable color writes, disable depth writes
     Engine::GAPI->GetRendererState().BlendState.ColorWritesEnabled = true;
     Engine::GAPI->GetRendererState().BlendState.SetDirty();
-    Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled =
-        false; // Rasterization is faster without writes
+    Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled = false;
     Engine::GAPI->GetRendererState().DepthState.SetDirty();
     UpdateRenderStates();
 
@@ -4693,20 +4746,33 @@ void D3D11GraphicsEngine::DrawWaterSurfaces() {
     ricb.RI_Time = Engine::GAPI->GetTimeSeconds();
     ricb.RI_CameraPosition = float3( Engine::GAPI->GetCameraPosition() );
 
-    ActivePS->GetBuffer("RefractionInfo").Update(&ricb).Bind();
+    ActivePS->GetBuffer( "RefractionInfo" ).Update( &ricb ).Bind();
 
     // Bind reflection cube
     GetContext()->PSSetShaderResources( 3, 1, ReflectionCube.GetAddressOf() );
-    for ( const auto& [texture, meshes] : FrameWaterSurfaces ) {
-        // Bind diffuse
-        texture->CacheIn( -1 );    // Force immediate cache in, because water
-                                   // is important!
-        texture->Bind( 0 );
 
-        // Draw surfaces
-        for ( const auto& mesh : meshes ) {
-            DrawVertexBufferIndexedUINT( nullptr, nullptr,
-                mesh->Indices.size(), mesh->BaseIndexLocation );
+    if ( !FeatureLevel10Compatibility ) {
+        // MDI path: one MDI call per texture batch
+        for ( const auto& batch : waterBatches ) {
+            batch.texture->CacheIn( -1 );
+            batch.texture->Bind( 0 );
+
+            DrawMultiIndexedInstancedIndirect( Context.Get(),
+                batch.drawCount,
+                WaterIndirectBuffer->GetIndirectBuffer().Get(),
+                batch.argsOffset * argStride, argStride );
+        }
+    } else {
+        // FL10 fallback: per-texture loop with direct DrawIndexed
+        for ( const auto& batch : waterBatches ) {
+            batch.texture->CacheIn( -1 );
+            batch.texture->Bind( 0 );
+
+            for ( unsigned int i = 0; i < batch.drawCount; i++ ) {
+                const auto& args = waterDrawArgs[batch.argsOffset + i];
+                DrawVertexBufferIndexedUINT( nullptr, nullptr,
+                    args.IndexCountPerInstance, args.StartIndexLocation );
+            }
         }
     }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4213,10 +4213,10 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh_Indirect( bool noTextures ) {
 
     std::unordered_map<zCTexture*, MDI_DrawArgs> mdiDrawArgs;
     static std::vector<D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGS> drawIndirectArgs; drawIndirectArgs.clear();
-    static std::vector<std::tuple<zCTexture*, WorldMeshInfo*, MaterialInfo*>> meshList; meshList.clear();
-    static std::vector<std::tuple<zCTexture*, WorldMeshInfo*, MaterialInfo*>> meshListAlpha; meshListAlpha.clear();
+    static std::vector<std::tuple<zCTexture*, MeshInfo*, MaterialInfo*>> meshList; meshList.clear();
+    static std::vector<std::tuple<zCTexture*, MeshInfo*, MaterialInfo*>> meshListAlpha; meshListAlpha.clear();
     if ( meshList.capacity() == 0 ) { meshList.reserve( 4096 ); meshListAlpha.reserve( 512 ); drawIndirectArgs.reserve( 4096 ); }
-    auto CompareMesh = []( std::tuple<zCTexture*, WorldMeshInfo*, MaterialInfo*>& a, std::tuple<zCTexture*, WorldMeshInfo*, MaterialInfo*>& b )
+    auto CompareMesh = []( std::tuple<zCTexture*, MeshInfo*, MaterialInfo*>& a, std::tuple<zCTexture*, MeshInfo*, MaterialInfo*>& b )
         -> bool { return std::get<0>( a ) < std::get<0>( b ); };
 
     for ( auto const& renderItem : renderList ) {
@@ -4475,7 +4475,7 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
         //zCLightmap* Lightmap;
     };
 
-    static std::vector<std::pair<WorldMeshKey, WorldMeshInfo*>> meshList;
+    static std::vector<std::pair<WorldMeshKey, MeshInfo*>> meshList;
     meshList.clear();
     if ( meshList.capacity() == 0 ) meshList.reserve( 4096 );
 
@@ -4534,7 +4534,7 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
             }
         }
     }
-    auto CompareMesh = []( std::pair<WorldMeshKey, WorldMeshInfo*>& a, std::pair<WorldMeshKey, WorldMeshInfo*>& b ) -> bool {
+    auto CompareMesh = []( std::pair<WorldMeshKey, MeshInfo*>& a, std::pair<WorldMeshKey, MeshInfo*>& b ) -> bool {
         if ( a.first.AlphaLevel != b.first.AlphaLevel )
             return a.first.AlphaLevel < b.first.AlphaLevel;
         return a.first.Texture < b.first.Texture;
@@ -4804,7 +4804,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
     FXMVECTOR position, float range, bool cullFront, bool indoor,
     bool noNPCs, std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache,
+    std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache,
     unsigned int casterMask ) {
 
     // Setup renderstates
@@ -5127,7 +5127,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
     FXMVECTOR position, float range, bool cullFront, bool indoor,
     bool noNPCs, std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache,
+    std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache,
     unsigned int casterMask ) {
 
     // Setup renderstates
@@ -5475,7 +5475,7 @@ void D3D11GraphicsEngine::ShadowPass_DrawWorldMesh_Indirect(const std::vector<Wo
         }
     // Collect all meshes first, then batch by alpha requirement
     static thread_local std::vector<D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGS> opaqueDrawArgs;
-    static thread_local std::vector<std::pair<zCTexture*, WorldMeshInfo*>> alphaMeshes;
+    static thread_local std::vector<std::pair<zCTexture*, MeshInfo*>> alphaMeshes;
     opaqueDrawArgs.clear();
     alphaMeshes.clear();
     if ( opaqueDrawArgs.capacity() == 0 ) { opaqueDrawArgs.reserve( 4096 ); alphaMeshes.reserve( 512 ); }
@@ -5568,8 +5568,8 @@ void D3D11GraphicsEngine::ShadowPass_DrawWorldMesh(const std::vector<WorldMeshSe
     bool linearDepth = (Engine::GAPI->GetRendererState().GraphicsState.FF_GSwitches &
                 GSWITCH_LINEAR_DEPTH) != 0;
     
-    static thread_local std::vector<WorldMeshInfo*> opaqueMeshes;
-    static thread_local std::vector<std::pair<zCTexture*, WorldMeshInfo*>> alphaMeshes;
+    static thread_local std::vector<MeshInfo*> opaqueMeshes;
+    static thread_local std::vector<std::pair<zCTexture*, MeshInfo*>> alphaMeshes;
     opaqueMeshes.clear();
     alphaMeshes.clear();
 
@@ -5600,7 +5600,7 @@ void D3D11GraphicsEngine::ShadowPass_DrawWorldMesh(const std::vector<WorldMeshSe
             Context->PSSetShader( nullptr, nullptr, 0 );
         }
 
-        for ( WorldMeshInfo* mesh : opaqueMeshes ) {
+        for ( MeshInfo* mesh : opaqueMeshes ) {
             DrawVertexBufferIndexedUINT( nullptr, nullptr,
                 mesh->Indices.size(), mesh->BaseIndexLocation );
         }
@@ -6930,7 +6930,7 @@ void XM_CALLCONV D3D11GraphicsEngine::RenderShadowCube(
     Microsoft::WRL::ComPtr<ID3D11RenderTargetView> debugRTV, bool cullFront, bool indoor, bool noNPCs,
     std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache,
+    std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache,
     bool clearDepth,
     unsigned int casterMask ) {
     

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -433,8 +433,15 @@ public:
     Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> ReflectionCube;
     Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> ReflectionCube2;
 private:
+    bool PrepareAndBindWindMetadata( const std::vector<MeshVisualInfo*>& activeVisuals );
+    void UnbindWindMetadata();
+
     std::vector<AlphaMeshData> m_AlphaMeshes;
     std::vector<VobLightInfo*> m_FrameLights;
+    std::vector<VobWindMetadata> m_WindMetadataStaging;
+
+    /** Optional per-visual wind metadata for FL11+ instanced VOB rendering. */
+    std::unique_ptr<D3D11VertexBuffer> WindMetadataBuffer;
     
     /** World-Mesh indirect buffer */
     std::unique_ptr<D3D11IndirectBuffer> WorldMeshIndirectBuffer;

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -239,14 +239,14 @@ public:
         bool cullFront = true,
         bool indoor = false,
         bool noNPCs = false,
-        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache = nullptr,
+        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache = nullptr,
         unsigned int casterMask = SHADOW_CASTER_ALL );
     void XM_CALLCONV DrawWorldAround_Layered( FXMVECTOR position,
         float range,
         bool cullFront = true,
         bool indoor = false,
         bool noNPCs = false,
-        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache = nullptr,
+        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache = nullptr,
         unsigned int casterMask = SHADOW_CASTER_ALL );
 
     /** Update morph mesh visual */
@@ -277,7 +277,7 @@ public:
         bool cullFront = true,
         bool indoor = false,
         bool noNPCs = false,
-        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache = nullptr,
+        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache = nullptr,
         bool clearDepth = true,
         unsigned int casterMask = SHADOW_CASTER_ALL );
 
@@ -413,7 +413,7 @@ protected:
     D3D11ENGINE_RENDER_STAGE RenderingStage;
 
     /** List of water surfaces for this frame */
-    std::unordered_map<zCTexture*, std::vector<WorldMeshInfo*>> FrameWaterSurfaces;
+    std::unordered_map<zCTexture*, std::vector<MeshInfo*>> FrameWaterSurfaces;
 
     /** List of worldmeshes we have to render using alphablending */
     std::vector<std::pair<MeshKey, MeshInfo*>> FrameTransparencyMeshes;

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -439,6 +439,9 @@ private:
     /** World-Mesh indirect buffer */
     std::unique_ptr<D3D11IndirectBuffer> WorldMeshIndirectBuffer;
 
+    /** Water surface indirect buffer */
+    std::unique_ptr<D3D11IndirectBuffer> WaterIndirectBuffer;
+
     /** Buffer for previous bone transforms */
     std::unique_ptr<D3D11ConstantBuffer> PrevBoneTransformsBuffer;
 

--- a/D3D11Engine/D3D11NVHBAO.cpp
+++ b/D3D11Engine/D3D11NVHBAO.cpp
@@ -58,7 +58,7 @@ XRESULT D3D11NVHBAO::Render(
     Input.DepthData.ProjectionMatrix.Layout = GFSDK_SSAO_COLUMN_MAJOR_ORDER;
     Input.DepthData.MetersToViewSpaceUnits = settings.MetersToViewSpaceUnits;
 
-    Input.NormalData.Enable = true;
+    Input.NormalData.Enable = false;
     Input.NormalData.pFullResNormalTextureSRV = pFullResNormalTexSRV.Get();
     auto identity = XMMatrixIdentity();
     Input.NormalData.WorldToViewMatrix.Data = GFSDK_SSAO_Float4x4( reinterpret_cast<float*>(&identity) ); // We already have them in view-space

--- a/D3D11Engine/D3D11PFX_ASSAO.cpp
+++ b/D3D11Engine/D3D11PFX_ASSAO.cpp
@@ -1,0 +1,63 @@
+#include "D3D11PFX_ASSAO.h"
+#include "Engine.h"
+#include "GothicAPI.h"
+#include "BaseGraphicsEngine.h"
+
+#include <iostream>
+#include <fstream>
+
+#undef SAFE_RELEASE
+#include <ASSAO/ASSAODX11.cpp>
+
+void D3D11PFX_ASSAO::Init()
+{
+    std::string fileName = Engine::GAPI->GetStartDirectory() + "\\system\\GD3D11\\shaders\\ASSAO\\ASSAO.hlsl";
+    
+    auto shaderDataSize = std::filesystem::file_size( fileName );
+    std::vector<char> shaderData( shaderDataSize );
+
+    std::ifstream in( fileName.c_str(),
+      std::ios_base::in | std::ios_base::binary );
+
+    size_t offset = 0;
+    do {
+        in.read( &shaderData[offset], shaderDataSize - offset );
+        offset += in.gcount();                                          
+    } while ( in.gcount() > 0 );
+
+    auto desc = ASSAO_CreateDescDX11(m_Device.Get(), shaderData.data(), shaderDataSize);
+    auto assaoX11 = ASSAODX11::CreateInstance( &desc );
+    m_assaoEffect.reset( assaoX11 );
+}
+
+void D3D11PFX_ASSAO::Render( 
+    ID3D11ShaderResourceView* depthCopy,
+    ID3D11ShaderResourceView* normals,
+    ID3D11RenderTargetView* renderTarget )
+{
+    ASSAO_Settings settingsCopy = Engine::GAPI->GetRendererState().RendererSettings.AssaoSettings;
+    // scale to gothic world scale (centimeters)
+    settingsCopy.Radius *= 100;
+    settingsCopy.FadeOutFrom *= 100;
+    settingsCopy.FadeOutTo *= 100;
+
+    ASSAO_InputsDX11 inputs = {};
+    inputs.DepthSRV = depthCopy;
+    inputs.DeviceContext = m_Context.Get();
+    inputs.OverrideOutputRTV = renderTarget;
+    inputs.NormalSRV = normals;
+    inputs.ProjectionMatrix = ASSAO_Float4x4((float*) &Engine::GAPI->GetProjectionMatrix()._11);
+    inputs.MatricesRowMajorOrder = false;
+
+    auto res = Engine::GraphicsEngine->GetResolution();
+    inputs.ViewportWidth = res.x;
+    inputs.ViewportHeight = res.y;
+
+
+    m_assaoEffect->Draw( settingsCopy, &inputs );
+}
+
+void DestroyAssaoEffect( ASSAO_Effect* effect )
+{
+    ASSAODX11::DestroyInstance( effect );
+}

--- a/D3D11Engine/D3D11PFX_ASSAO.h
+++ b/D3D11Engine/D3D11PFX_ASSAO.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "pch.h"
+#include <ASSAO/ASSAO.h>
+
+
+void DestroyAssaoEffect( ASSAO_Effect* effect );
+
+class D3D11PFX_ASSAO
+{
+public:
+    D3D11PFX_ASSAO( ID3D11Device* device,
+        ID3D11DeviceContext* context )
+        : 
+        m_Device( device ),
+        m_Context( context ),
+        m_assaoEffect( nullptr, DestroyAssaoEffect )
+    {}
+
+    void Init();
+    void Render( ID3D11ShaderResourceView* depthCopy,
+    ID3D11ShaderResourceView* normals,
+    ID3D11RenderTargetView* renderTarget );
+
+private:
+    Microsoft::WRL::ComPtr<ID3D11Device> m_Device;
+    Microsoft::WRL::ComPtr<ID3D11DeviceContext> m_Context;
+    std::unique_ptr<ASSAO_Effect, void(*)(ASSAO_Effect*)> m_assaoEffect;
+};
+

--- a/D3D11Engine/D3D11PFX_DepthOfField.cpp
+++ b/D3D11Engine/D3D11PFX_DepthOfField.cpp
@@ -7,10 +7,13 @@
 #include "D3D11ShaderManager.h"
 #include "D3D11VShader.h"
 #include "D3D11PShader.h"
+#include "D3D11CShader.h"
 #include "D3D11ConstantBuffer.h"
 #include "ConstantBufferStructs.h"
 #include "GothicAPI.h"
 #include "TexturePool.h"
+
+extern bool FeatureLevel10Compatibility;
 
 D3D11PFX_DepthOfField::D3D11PFX_DepthOfField( D3D11PfxRenderer* rnd ) : D3D11PFX_Effect( rnd ), m_FocusIndex( 0 ) {
     auto* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
@@ -23,16 +26,21 @@ D3D11PFX_DepthOfField::D3D11PFX_DepthOfField( D3D11PfxRenderer* rnd ) : D3D11PFX
     texDesc.Format = DXGI_FORMAT_R32_FLOAT;
     texDesc.SampleDesc.Count = 1;
     texDesc.Usage = D3D11_USAGE_DEFAULT;
-    texDesc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+    texDesc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE 
+        | (FeatureLevel10Compatibility ? 0 : D3D11_BIND_UNORDERED_ACCESS);
 
     for ( int i = 0; i < 2; i++ ) {
         engine->GetDevice()->CreateTexture2D( &texDesc, nullptr, m_FocusTexture[i].GetAddressOf() );
         engine->GetDevice()->CreateShaderResourceView( m_FocusTexture[i].Get(), nullptr, m_FocusSRV[i].GetAddressOf() );
         engine->GetDevice()->CreateRenderTargetView( m_FocusTexture[i].Get(), nullptr, m_FocusRTV[i].GetAddressOf() );
+
+        D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+        uavDesc.Format = DXGI_FORMAT_R32_FLOAT;
+        uavDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D;
+        uavDesc.Texture2D.MipSlice = 0;
+        engine->GetDevice()->CreateUnorderedAccessView( m_FocusTexture[i].Get(), &uavDesc, m_FocusUAV[i].GetAddressOf() );
     }
 }
-
-D3D11PFX_DepthOfField::~D3D11PFX_DepthOfField() {}
 
 XRESULT D3D11PFX_DepthOfField::Render( ID3D11ShaderResourceView* backbuffer ) {
     D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
@@ -43,6 +51,12 @@ XRESULT D3D11PFX_DepthOfField::Render( ID3D11ShaderResourceView* backbuffer ) {
     Microsoft::WRL::ComPtr<ID3D11DepthStencilView> oldDSV;
     engine->GetContext()->OMGetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.GetAddressOf() );
     auto& rendererSettings = Engine::GAPI->GetRendererState().RendererSettings;
+
+    if ( !FeatureLevel10Compatibility ) {
+        auto res = RenderCS( backbuffer );
+        engine->GetContext()->OMSetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.Get() );
+        return res;
+    }
 
     auto vs = engine->GetShaderManager().GetVShader( VShaderID::VS_PFX );
     auto focusPS = engine->GetShaderManager().GetPShader( PShaderID::PS_PFX_DoF_FocusResolve );
@@ -133,6 +147,125 @@ XRESULT D3D11PFX_DepthOfField::Render( ID3D11ShaderResourceView* backbuffer ) {
     FxRenderer->DrawFullScreenQuad();
 
     engine->GetContext()->PSSetShaderResources( 0, 4, nullSRVs );
+
+    // Blit composite result to backbuffer
+    FxRenderer->CopyTextureToRTV( compositeBuffer->GetShaderResView(), oldRTV, res );
+
+    engine->GetContext()->OMSetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.Get() );
+
+    return XR_SUCCESS;
+}
+
+/** Compute shader path for FL11+ */
+XRESULT D3D11PFX_DepthOfField::RenderCS( ID3D11ShaderResourceView* backbuffer ) {
+    D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    auto& context = engine->GetContext();
+
+    engine->SetDefaultStates();
+
+    Microsoft::WRL::ComPtr<ID3D11RenderTargetView> oldRTV;
+    Microsoft::WRL::ComPtr<ID3D11DepthStencilView> oldDSV;
+    context->OMGetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.GetAddressOf() );
+
+    ID3D11RenderTargetView* nullRtv = nullptr;
+    engine->GetContext()->OMSetRenderTargets( 1, &nullRtv, nullptr );
+
+    auto& rendererSettings = Engine::GAPI->GetRendererState().RendererSettings;
+
+    DepthOfFieldConstantBuffer cb = {};
+    cb.DoF_FocusRange = rendererSettings.DoFFocusRange;
+    cb.DoF_BokehRadius = rendererSettings.DoFBokehRadius;
+    cb.DoF_MaxBlur = rendererSettings.DoFMaxBlur;
+
+    auto& proj = Engine::GAPI->GetProjectionMatrix();
+    cb.DoF_ProjParams = float4( 1.0f / proj._11, 1.0f / proj._22, proj._34, proj._33 );
+    cb.DoF_NearPlane = Engine::GAPI->GetRendererState().RendererInfo.NearPlane;
+    cb.DoF_FarPlane = Engine::GAPI->GetRendererState().RendererInfo.FarPlane;
+
+    auto defaultSampler = engine->GetDefaultSamplerState();
+    ID3D11UnorderedAccessView* nullUAV = nullptr;
+    ID3D11ShaderResourceView* nullSRVs[4] = { nullptr, nullptr, nullptr, nullptr };
+
+    // --- Pass 0: Focus Resolve (1x1 compute) ---
+    int prevIdx = m_FocusIndex;
+    int curIdx = 1 - m_FocusIndex;
+
+    auto focusCS = engine->GetShaderManager().GetCShader( CShaderID::CS_PFX_DoF_FocusResolve );
+    focusCS->Apply();
+    focusCS->GetBuffer( "DepthOfFieldConstantBuffer" ).Update( &cb ).Bind();
+
+    context->CSSetSamplers( 0, 1, &defaultSampler );
+
+    ID3D11ShaderResourceView* focusSRVs[2] = {
+        engine->GetDepthBuffer()->GetShaderResView().Get(),
+        m_FocusSRV[prevIdx].Get()
+    };
+    context->CSSetShaderResources( 0, 2, focusSRVs );
+    context->CSSetUnorderedAccessViews( 0, 1, m_FocusUAV[curIdx].GetAddressOf(), nullptr );
+
+    context->Dispatch( 1, 1, 1 );
+
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    context->CSSetShaderResources( 0, 2, nullSRVs );
+
+    m_FocusIndex = curIdx;
+
+    // --- Pass 1: Half-res bokeh blur ---
+    auto res = engine->GetResolution();
+    DXGI_FORMAT bbufferFormat = engine->GetBackBufferFormat();
+    auto halfBuffer = FxRenderer->GetTexturePool()->Acquire(
+        TexturePool::Description{ res.x / 2, res.y / 2, bbufferFormat,
+            D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE } );
+
+    auto blurCS = engine->GetShaderManager().GetCShader(
+        rendererSettings.DoFGaussBlur
+            ? CShaderID::CS_PFX_DoF_Gauss
+            : CShaderID::CS_PFX_DoF );
+    blurCS->Apply();
+    blurCS->GetBuffer( "DepthOfFieldConstantBuffer" ).Update( &cb ).Bind();
+
+    context->CSSetSamplers( 0, 1, &defaultSampler );
+
+    // t0 = full-res scene, t1 = full-res depth, t2 = focus (1x1)
+    ID3D11ShaderResourceView* blurSRVs[3] = {
+        backbuffer,
+        engine->GetDepthBuffer()->GetShaderResView().Get(),
+        m_FocusSRV[m_FocusIndex].Get()
+    };
+    context->CSSetShaderResources( 0, 3, blurSRVs );
+    context->CSSetUnorderedAccessViews( 0, 1, halfBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
+
+    context->Dispatch( (res.x / 2 + 7) / 8, (res.y / 2 + 7) / 8, 1 );
+
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    context->CSSetShaderResources( 0, 3, nullSRVs );
+
+    // --- Pass 2: Full-res composite ---
+    auto compositeBuffer = FxRenderer->GetTexturePool()->Acquire(
+        TexturePool::Description{ res.x, res.y, bbufferFormat,
+            D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE } );
+
+    auto compositeCS = engine->GetShaderManager().GetCShader( CShaderID::CS_PFX_DoF_Composite );
+    compositeCS->Apply();
+    compositeCS->GetBuffer( "DepthOfFieldConstantBuffer" ).Update( &cb ).Bind();
+
+    context->CSSetSamplers( 0, 1, &defaultSampler );
+
+    // t0 = full-res scene, t1 = half-res blur, t2 = full-res depth, t3 = focus (1x1)
+    ID3D11ShaderResourceView* compositeSRVs[4] = {
+        backbuffer,
+        halfBuffer->GetShaderResView().Get(),
+        engine->GetDepthBuffer()->GetShaderResView().Get(),
+        m_FocusSRV[m_FocusIndex].Get()
+    };
+    context->CSSetShaderResources( 0, 4, compositeSRVs );
+    context->CSSetUnorderedAccessViews( 0, 1, compositeBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
+
+    context->Dispatch( (res.x + 7) / 8, (res.y + 7) / 8, 1 );
+
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    context->CSSetShaderResources( 0, 4, nullSRVs );
+    context->CSSetShader( nullptr, nullptr, 0 );
 
     // Blit composite result to backbuffer
     FxRenderer->CopyTextureToRTV( compositeBuffer->GetShaderResView(), oldRTV, res );

--- a/D3D11Engine/D3D11PFX_DepthOfField.h
+++ b/D3D11Engine/D3D11PFX_DepthOfField.h
@@ -5,21 +5,26 @@
 struct ID3D11Texture2D;
 struct ID3D11ShaderResourceView;
 struct ID3D11RenderTargetView;
+struct ID3D11UnorderedAccessView;
 
 class D3D11PFX_DepthOfField :
     public D3D11PFX_Effect {
 public:
     D3D11PFX_DepthOfField( D3D11PfxRenderer* rnd );
-    ~D3D11PFX_DepthOfField();
+    ~D3D11PFX_DepthOfField() override = default;
 
     /** Draws this effect to the given buffer */
     XRESULT Render( RenderToTextureBuffer* fxbuffer ) override { return XR_FAILED; }
     XRESULT Render( ID3D11ShaderResourceView* backbuffer );
 
 private:
+    /** Compute shader path for FL11+ */
+    XRESULT RenderCS( ID3D11ShaderResourceView* backbuffer );
+
     // Ping-pong 1x1 R32_FLOAT textures for temporal focus smoothing
     Microsoft::WRL::ComPtr<ID3D11Texture2D> m_FocusTexture[2];
     Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_FocusSRV[2];
     Microsoft::WRL::ComPtr<ID3D11RenderTargetView> m_FocusRTV[2];
+    Microsoft::WRL::ComPtr<ID3D11UnorderedAccessView> m_FocusUAV[2];
     int m_FocusIndex;
 };

--- a/D3D11Engine/D3D11PFX_GodRays.cpp
+++ b/D3D11Engine/D3D11PFX_GodRays.cpp
@@ -244,3 +244,182 @@ XRESULT D3D11PFX_GodRays::RenderCS(
 
     return XR_SUCCESS;
 }
+
+/** Public entry point: renders godrays to a pool texture, skipping the final additive blit */
+XRESULT D3D11PFX_GodRays::RenderToTexture(
+    ID3D11ShaderResourceView* backbuffer,
+    ID3D11ShaderResourceView* normals,
+    ID3D11ShaderResourceView** outGodRaysSRV ) {
+
+    *outGodRaysSRV = nullptr;
+
+    if ( Engine::GAPI->GetSky()->GetAtmoshpereSettings().LightDirection.y <= 0 )
+        return XR_SUCCESS;
+
+    D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    engine->SetDefaultStates();
+
+    if ( !FeatureLevel10Compatibility ) {
+        return RenderToTextureCS( backbuffer, normals, outGodRaysSRV );
+    }
+
+    // FL10 pixel shader path: mask → zoom → write to pool texture (no additive blit)
+    XMVECTOR xmSunPosition = XMLoadFloat3( Engine::GAPI->GetSky()->GetAtmosphereCB().AC_LightPos.toXMFLOAT3() );
+    float outerRadius = Engine::GAPI->GetSky()->GetAtmosphereCB().AC_OuterRadius;
+    xmSunPosition *= outerRadius;
+    xmSunPosition += Engine::GAPI->GetCameraPositionXM();
+
+    XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
+    XMMATRIX proj = XMLoadFloat4x4( &Engine::GAPI->GetProjectionMatrix() );
+    XMMATRIX viewProj = XMMatrixTranspose( XMMatrixMultiply( proj, view ) );
+    view = XMMatrixTranspose( view );
+
+    XMFLOAT3 sunViewPosition; XMStoreFloat3( &sunViewPosition, XMVector3TransformCoord( xmSunPosition, view ) );
+    XMFLOAT3 sunPosition; XMStoreFloat3( &sunPosition, XMVector3TransformCoord( xmSunPosition, viewProj ) );
+
+    if ( sunViewPosition.z < 0.0f )
+        return XR_SUCCESS;
+
+    GodRayZoomConstantBuffer gcb = {};
+    gcb.GR_Weight = 1.0f;
+    gcb.GR_Decay = Engine::GAPI->GetRendererState().RendererSettings.GodRayDecay;
+    gcb.GR_Weight = Engine::GAPI->GetRendererState().RendererSettings.GodRayWeight;
+    gcb.GR_Density = Engine::GAPI->GetRendererState().RendererSettings.GodRayDensity;
+    gcb.GR_Center.x = sunPosition.x / 2.0f + 0.5f;
+    gcb.GR_Center.y = sunPosition.y / -2.0f + 0.5f;
+    gcb.GR_ColorMod = Engine::GAPI->GetRendererState().RendererSettings.GodRayColorMod;
+
+    if ( abs( gcb.GR_Center.x - 0.5f ) > 0.5f )
+        gcb.GR_Weight *= std::max( 0.0f, 1.0f - (abs( gcb.GR_Center.x - 0.5f ) - 0.5f) / 0.5f );
+    if ( abs( gcb.GR_Center.y - 0.5f ) > 0.5f )
+        gcb.GR_Weight *= std::max( 0.0f, 1.0f - (abs( gcb.GR_Center.y - 0.5f ) - 0.5f) / 0.5f );
+
+    auto vs = engine->GetShaderManager().GetVShader( VShaderID::VS_PFX );
+    auto maskPS = engine->GetShaderManager().GetPShader( PShaderID::PS_PFX_GodRayMask );
+    auto zoomPS = engine->GetShaderManager().GetPShader( PShaderID::PS_PFX_GodRayZoom );
+
+    maskPS->Apply();
+    vs->Apply();
+
+    auto tempBuffer = FxRenderer->GetTempBufferDS4();
+    auto tempBuffer2 = FxRenderer->GetTempBufferDS4();
+
+    engine->GetContext()->OMSetRenderTargets( 1, tempBuffer->GetRenderTargetView().GetAddressOf(), nullptr );
+
+    ID3D11ShaderResourceView* srvs[2] { backbuffer, normals };
+    engine->GetContext()->PSSetShaderResources( 0, 2, srvs );
+    engine->SetViewport({ 0, 0, INT2(tempBuffer->GetSizeX(), tempBuffer->GetSizeY()) });
+    FxRenderer->DrawFullScreenQuad();
+
+    zoomPS->Apply();
+    zoomPS->GetBuffer( "GodRayZoomConstantBuffer" ).Update( &gcb ).Bind();
+
+    auto clampSampler = engine->GetClampSamplerState();
+    engine->GetContext()->PSSetSamplers( 0, 1, &clampSampler );
+
+    FxRenderer->CopyTextureToRTV( tempBuffer->GetShaderResView(), tempBuffer2->GetRenderTargetView(), INT2( 0, 0 ), true );
+
+    // Keep the result texture alive until next frame by storing the handle as a member
+    m_GodRaysResult = std::move( tempBuffer2 );
+    *outGodRaysSRV = m_GodRaysResult->GetShaderResView().Get();
+
+    ID3D11ShaderResourceView* nullSRVs[2] { nullptr, nullptr };
+    engine->GetContext()->PSSetShaderResources( 0, 2, nullSRVs );
+
+    auto defaultSampler2 = engine->GetDefaultSamplerState();
+    engine->GetContext()->PSSetSamplers( 0, 1, &defaultSampler2 );
+
+    return XR_SUCCESS;
+}
+
+/** CS path: mask+zoom to pool texture, no final blit */
+XRESULT D3D11PFX_GodRays::RenderToTextureCS(
+    ID3D11ShaderResourceView* backbuffer,
+    ID3D11ShaderResourceView* normals,
+    ID3D11ShaderResourceView** outGodRaysSRV ) {
+
+    D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    auto& context = engine->GetContext();
+
+    XMVECTOR xmSunPosition = XMLoadFloat3( Engine::GAPI->GetSky()->GetAtmosphereCB().AC_LightPos.toXMFLOAT3() );
+    float outerRadius = Engine::GAPI->GetSky()->GetAtmosphereCB().AC_OuterRadius;
+    xmSunPosition *= outerRadius;
+    xmSunPosition += Engine::GAPI->GetCameraPositionXM();
+
+    XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
+    XMMATRIX proj = XMLoadFloat4x4( &Engine::GAPI->GetProjectionMatrix() );
+    XMMATRIX viewProj = XMMatrixTranspose( XMMatrixMultiply( proj, view ) );
+    view = XMMatrixTranspose( view );
+
+    XMFLOAT3 sunViewPosition; XMStoreFloat3( &sunViewPosition, XMVector3TransformCoord( xmSunPosition, view ) );
+    XMFLOAT3 sunPosition; XMStoreFloat3( &sunPosition, XMVector3TransformCoord( xmSunPosition, viewProj ) );
+
+    if ( sunViewPosition.z < 0.0f )
+        return XR_SUCCESS;
+
+    GodRayZoomConstantBuffer gcb = {};
+    gcb.GR_Weight = 1.0f;
+    gcb.GR_Decay = Engine::GAPI->GetRendererState().RendererSettings.GodRayDecay;
+    gcb.GR_Weight = Engine::GAPI->GetRendererState().RendererSettings.GodRayWeight;
+    gcb.GR_Density = Engine::GAPI->GetRendererState().RendererSettings.GodRayDensity;
+    gcb.GR_Center.x = sunPosition.x / 2.0f + 0.5f;
+    gcb.GR_Center.y = sunPosition.y / -2.0f + 0.5f;
+    gcb.GR_ColorMod = Engine::GAPI->GetRendererState().RendererSettings.GodRayColorMod;
+
+    if ( abs( gcb.GR_Center.x - 0.5f ) > 0.5f )
+        gcb.GR_Weight *= std::max( 0.0f, 1.0f - (abs( gcb.GR_Center.x - 0.5f ) - 0.5f) / 0.5f );
+    if ( abs( gcb.GR_Center.y - 0.5f ) > 0.5f )
+        gcb.GR_Weight *= std::max( 0.0f, 1.0f - (abs( gcb.GR_Center.y - 0.5f ) - 0.5f) / 0.5f );
+
+    ID3D11RenderTargetView* nullRtv = nullptr;
+    context->OMSetRenderTargets( 1, &nullRtv, nullptr );
+
+    auto res = engine->GetResolution();
+    INT2 ds4Size = { res.x / 4, res.y / 4 };
+
+    auto maskBuffer = FxRenderer->GetTexturePool()->Acquire(
+        TexturePool::Description{ ds4Size.x, ds4Size.y, engine->GetBackBufferFormat(),
+            D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE } );
+    auto zoomBuffer = FxRenderer->GetTexturePool()->Acquire(
+        TexturePool::Description{ ds4Size.x, ds4Size.y, engine->GetBackBufferFormat(),
+            D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE } );
+
+    auto clampSampler = engine->GetClampSamplerState();
+
+    // --- Pass 1: CS Mask ---
+    auto maskCS = engine->GetShaderManager().GetCShader( CShaderID::CS_PFX_GodRayMask );
+    maskCS->Apply();
+    context->CSSetSamplers( 0, 1, &clampSampler );
+
+    ID3D11ShaderResourceView* maskSRVs[2] = { backbuffer, normals };
+    context->CSSetShaderResources( 0, 2, maskSRVs );
+    context->CSSetUnorderedAccessViews( 0, 1, maskBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
+    context->Dispatch( (ds4Size.x + 7) / 8, (ds4Size.y + 7) / 8, 1 );
+
+    ID3D11UnorderedAccessView* nullUAV = nullptr;
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    ID3D11ShaderResourceView* nullSRVs[2] = { nullptr, nullptr };
+    context->CSSetShaderResources( 0, 2, nullSRVs );
+
+    // --- Pass 2: CS Zoom ---
+    auto zoomCS = engine->GetShaderManager().GetCShader( CShaderID::CS_PFX_GodRayZoom );
+    zoomCS->Apply();
+    zoomCS->GetBuffer( "GodRayZoomConstantBuffer" ).Update( &gcb ).Bind();
+    context->CSSetSamplers( 0, 1, &clampSampler );
+
+    ID3D11ShaderResourceView* zoomSRV = maskBuffer->GetShaderResView().Get();
+    context->CSSetShaderResources( 0, 1, &zoomSRV );
+    context->CSSetUnorderedAccessViews( 0, 1, zoomBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
+    context->Dispatch( (ds4Size.x + 7) / 8, (ds4Size.y + 7) / 8, 1 );
+
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    ID3D11ShaderResourceView* nullSRV1 = nullptr;
+    context->CSSetShaderResources( 0, 1, &nullSRV1 );
+    context->CSSetShader( nullptr, nullptr, 0 );
+
+    // Keep the result texture alive until next frame by storing the handle as a member
+    m_GodRaysResult = std::move( zoomBuffer );
+    *outGodRaysSRV = m_GodRaysResult->GetShaderResView().Get();
+
+    return XR_SUCCESS;
+}

--- a/D3D11Engine/D3D11PFX_GodRays.cpp
+++ b/D3D11Engine/D3D11PFX_GodRays.cpp
@@ -21,7 +21,7 @@ D3D11PFX_GodRays::D3D11PFX_GodRays( D3D11PfxRenderer* rnd ) : D3D11PFX_Effect( r
 /** Draws this effect to the given buffer */
 XRESULT D3D11PFX_GodRays::Render( 
     ID3D11ShaderResourceView* backbuffer, 
-    ID3D11ShaderResourceView* normals ) {
+    ID3D11ShaderResourceView* depth ) {
     if ( Engine::GAPI->GetSky()->GetAtmoshpereSettings().LightDirection.y <= 0 )
         return XR_SUCCESS; // Don't render the godrays in the night-time
 
@@ -34,7 +34,7 @@ XRESULT D3D11PFX_GodRays::Render(
     engine->GetContext()->OMGetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.GetAddressOf() );
 
     if ( !FeatureLevel10Compatibility ) {
-        auto res = RenderCS( backbuffer, normals );
+        auto res = RenderCS( backbuffer, depth );
         engine->GetContext()->OMSetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.Get() );
         return res;
     }
@@ -89,7 +89,7 @@ XRESULT D3D11PFX_GodRays::Render(
 
     ID3D11ShaderResourceView* srvs[2] {
         backbuffer,
-        normals,
+        depth,
     };
     engine->GetContext()->PSSetShaderResources( 0, 2, srvs );
 
@@ -129,7 +129,7 @@ XRESULT D3D11PFX_GodRays::Render(
 /** Compute shader path for FL11+ */
 XRESULT D3D11PFX_GodRays::RenderCS(
     ID3D11ShaderResourceView* backbuffer,
-    ID3D11ShaderResourceView* normals ) {
+    ID3D11ShaderResourceView* depthCopy ) {
 
     D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
     auto& context = engine->GetContext();
@@ -198,7 +198,7 @@ XRESULT D3D11PFX_GodRays::RenderCS(
 
     context->CSSetSamplers( 0, 1, &clampSampler );
 
-    ID3D11ShaderResourceView* maskSRVs[2] = { backbuffer, normals };
+    ID3D11ShaderResourceView* maskSRVs[2] = { backbuffer, depthCopy };
     context->CSSetShaderResources( 0, 2, maskSRVs );
     context->CSSetUnorderedAccessViews( 0, 1, maskBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
 
@@ -248,7 +248,7 @@ XRESULT D3D11PFX_GodRays::RenderCS(
 /** Public entry point: renders godrays to a pool texture, skipping the final additive blit */
 XRESULT D3D11PFX_GodRays::RenderToTexture(
     ID3D11ShaderResourceView* backbuffer,
-    ID3D11ShaderResourceView* normals,
+    ID3D11ShaderResourceView* depthCopy,
     ID3D11ShaderResourceView** outGodRaysSRV ) {
 
     *outGodRaysSRV = nullptr;
@@ -260,7 +260,7 @@ XRESULT D3D11PFX_GodRays::RenderToTexture(
     engine->SetDefaultStates();
 
     if ( !FeatureLevel10Compatibility ) {
-        return RenderToTextureCS( backbuffer, normals, outGodRaysSRV );
+        return RenderToTextureCS( backbuffer, depthCopy, outGodRaysSRV );
     }
 
     // FL10 pixel shader path: mask → zoom → write to pool texture (no additive blit)
@@ -306,7 +306,7 @@ XRESULT D3D11PFX_GodRays::RenderToTexture(
 
     engine->GetContext()->OMSetRenderTargets( 1, tempBuffer->GetRenderTargetView().GetAddressOf(), nullptr );
 
-    ID3D11ShaderResourceView* srvs[2] { backbuffer, normals };
+    ID3D11ShaderResourceView* srvs[2] { backbuffer, depthCopy };
     engine->GetContext()->PSSetShaderResources( 0, 2, srvs );
     engine->SetViewport({ 0, 0, INT2(tempBuffer->GetSizeX(), tempBuffer->GetSizeY()) });
     FxRenderer->DrawFullScreenQuad();

--- a/D3D11Engine/D3D11PFX_GodRays.cpp
+++ b/D3D11Engine/D3D11PFX_GodRays.cpp
@@ -7,14 +7,16 @@
 #include "D3D11ShaderManager.h"
 #include "D3D11VShader.h"
 #include "D3D11PShader.h"
+#include "D3D11CShader.h"
 #include "D3D11ConstantBuffer.h"
 #include "ConstantBufferStructs.h"
 #include "GothicAPI.h"
 #include "GSky.h"
+#include "TexturePool.h"
+
+extern bool FeatureLevel10Compatibility;
 
 D3D11PFX_GodRays::D3D11PFX_GodRays( D3D11PfxRenderer* rnd ) : D3D11PFX_Effect( rnd ) {}
-
-D3D11PFX_GodRays::~D3D11PFX_GodRays() {}
 
 /** Draws this effect to the given buffer */
 XRESULT D3D11PFX_GodRays::Render( 
@@ -26,6 +28,16 @@ XRESULT D3D11PFX_GodRays::Render(
 	D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
 
 	engine->SetDefaultStates();
+
+    Microsoft::WRL::ComPtr<ID3D11RenderTargetView> oldRTV;
+    Microsoft::WRL::ComPtr<ID3D11DepthStencilView> oldDSV;
+    engine->GetContext()->OMGetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.GetAddressOf() );
+
+    if ( !FeatureLevel10Compatibility ) {
+        auto res = RenderCS( backbuffer, normals );
+        engine->GetContext()->OMSetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.Get() );
+        return res;
+    }
 
 	XMVECTOR xmSunPosition = XMLoadFloat3( Engine::GAPI->GetSky()->GetAtmosphereCB().AC_LightPos.toXMFLOAT3() );
 
@@ -42,7 +54,7 @@ XRESULT D3D11PFX_GodRays::Render(
 	XMFLOAT3 sunViewPosition; XMStoreFloat3( &sunViewPosition, XMVector3TransformCoord( xmSunPosition, view ) ); // This is for checking if the light is behind the camera
 	XMFLOAT3 sunPosition; XMStoreFloat3( &sunPosition, XMVector3TransformCoord( xmSunPosition, viewProj ) );
 
-	if ( sunViewPosition.z < 0.0f )
+	if ( sunViewPosition.z < 0.0f ) 
 		return XR_SUCCESS; // Don't render the godrays when the sun is behind the camera
 
 	GodRayZoomConstantBuffer gcb = {};
@@ -61,11 +73,6 @@ XRESULT D3D11PFX_GodRays::Render(
 
 	if ( abs( gcb.GR_Center.y - 0.5f ) > 0.5f )
 		gcb.GR_Weight *= std::max( 0.0f, 1.0f - (abs( gcb.GR_Center.y - 0.5f ) - 0.5f) / 0.5f );
-
-	Microsoft::WRL::ComPtr<ID3D11RenderTargetView> oldRTV;
-	Microsoft::WRL::ComPtr<ID3D11DepthStencilView> oldDSV;
-
-	engine->GetContext()->OMGetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.GetAddressOf() );
 
 	auto vs = engine->GetShaderManager().GetVShader( VShaderID::VS_PFX );
 	auto maskPS = engine->GetShaderManager().GetPShader( PShaderID::PS_PFX_GodRayMask );
@@ -117,4 +124,123 @@ XRESULT D3D11PFX_GodRays::Render(
 	engine->GetContext()->OMSetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.Get() );
 
 	return XR_SUCCESS;
+}
+
+/** Compute shader path for FL11+ */
+XRESULT D3D11PFX_GodRays::RenderCS(
+    ID3D11ShaderResourceView* backbuffer,
+    ID3D11ShaderResourceView* normals ) {
+
+    D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    auto& context = engine->GetContext();
+
+    engine->SetDefaultStates();
+
+    XMVECTOR xmSunPosition = XMLoadFloat3( Engine::GAPI->GetSky()->GetAtmosphereCB().AC_LightPos.toXMFLOAT3() );
+
+    float outerRadius = Engine::GAPI->GetSky()->GetAtmosphereCB().AC_OuterRadius;
+    xmSunPosition *= outerRadius;
+    xmSunPosition += Engine::GAPI->GetCameraPositionXM();
+
+    XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
+    XMMATRIX proj = XMLoadFloat4x4( &Engine::GAPI->GetProjectionMatrix() );
+
+    XMMATRIX viewProj = XMMatrixTranspose( XMMatrixMultiply( proj, view ) );
+    view = XMMatrixTranspose( view );
+
+    XMFLOAT3 sunViewPosition; XMStoreFloat3( &sunViewPosition, XMVector3TransformCoord( xmSunPosition, view ) );
+    XMFLOAT3 sunPosition; XMStoreFloat3( &sunPosition, XMVector3TransformCoord( xmSunPosition, viewProj ) );
+
+    if ( sunViewPosition.z < 0.0f )
+        return XR_SUCCESS;
+
+    GodRayZoomConstantBuffer gcb = {};
+    gcb.GR_Weight = 1.0f;
+    gcb.GR_Decay = Engine::GAPI->GetRendererState().RendererSettings.GodRayDecay;
+    gcb.GR_Weight = Engine::GAPI->GetRendererState().RendererSettings.GodRayWeight;
+    gcb.GR_Density = Engine::GAPI->GetRendererState().RendererSettings.GodRayDensity;
+
+    gcb.GR_Center.x = sunPosition.x / 2.0f + 0.5f;
+    gcb.GR_Center.y = sunPosition.y / -2.0f + 0.5f;
+
+    gcb.GR_ColorMod = Engine::GAPI->GetRendererState().RendererSettings.GodRayColorMod;
+
+    if ( abs( gcb.GR_Center.x - 0.5f ) > 0.5f )
+        gcb.GR_Weight *= std::max( 0.0f, 1.0f - (abs( gcb.GR_Center.x - 0.5f ) - 0.5f) / 0.5f );
+
+    if ( abs( gcb.GR_Center.y - 0.5f ) > 0.5f )
+        gcb.GR_Weight *= std::max( 0.0f, 1.0f - (abs( gcb.GR_Center.y - 0.5f ) - 0.5f) / 0.5f );
+
+    // Save old render targets
+    Microsoft::WRL::ComPtr<ID3D11RenderTargetView> oldRTV;
+    Microsoft::WRL::ComPtr<ID3D11DepthStencilView> oldDSV;
+    context->OMGetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.GetAddressOf() );
+
+    ID3D11RenderTargetView* nullRtv = nullptr;
+    engine->GetContext()->OMSetRenderTargets( 1, &nullRtv, nullptr );
+
+    auto res = engine->GetResolution();
+    INT2 ds4Size = { res.x / 4, res.y / 4 };
+
+    // Acquire DS4 UAV-capable textures from the pool
+    auto maskBuffer = FxRenderer->GetTexturePool()->Acquire(
+        TexturePool::Description{ ds4Size.x, ds4Size.y, engine->GetBackBufferFormat(),
+            D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE } );
+    auto zoomBuffer = FxRenderer->GetTexturePool()->Acquire(
+        TexturePool::Description{ ds4Size.x, ds4Size.y, engine->GetBackBufferFormat(),
+            D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE } );
+
+    auto clampSampler = engine->GetClampSamplerState();
+
+    // --- Pass 1: Compute Shader Mask ---
+    auto maskCS = engine->GetShaderManager().GetCShader( CShaderID::CS_PFX_GodRayMask );
+    maskCS->Apply();
+
+    context->CSSetSamplers( 0, 1, &clampSampler );
+
+    ID3D11ShaderResourceView* maskSRVs[2] = { backbuffer, normals };
+    context->CSSetShaderResources( 0, 2, maskSRVs );
+    context->CSSetUnorderedAccessViews( 0, 1, maskBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
+
+    context->Dispatch( (ds4Size.x + 7) / 8, (ds4Size.y + 7) / 8, 1 );
+
+    // Unbind UAV and SRVs
+    ID3D11UnorderedAccessView* nullUAV = nullptr;
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    ID3D11ShaderResourceView* nullSRVs[2] = { nullptr, nullptr };
+    context->CSSetShaderResources( 0, 2, nullSRVs );
+
+    // --- Pass 2: Compute Shader Zoom ---
+    auto zoomCS = engine->GetShaderManager().GetCShader( CShaderID::CS_PFX_GodRayZoom );
+    zoomCS->Apply();
+
+    zoomCS->GetBuffer( "GodRayZoomConstantBuffer" ).Update( &gcb ).Bind();
+
+    context->CSSetSamplers( 0, 1, &clampSampler );
+
+    ID3D11ShaderResourceView* zoomSRV = maskBuffer->GetShaderResView().Get();
+    context->CSSetShaderResources( 0, 1, &zoomSRV );
+    context->CSSetUnorderedAccessViews( 0, 1, zoomBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
+
+    context->Dispatch( (ds4Size.x + 7) / 8, (ds4Size.y + 7) / 8, 1 );
+
+    // Unbind
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    ID3D11ShaderResourceView* nullSRV1 = nullptr;
+    context->CSSetShaderResources( 0, 1, &nullSRV1 );
+    context->CSSetShader( nullptr, nullptr, 0 );
+
+    // --- Pass 3: Upscale and additive blend via pixel shader (reuse existing path) ---
+    Engine::GAPI->GetRendererState().BlendState.SetAdditiveBlending();
+    Engine::GAPI->GetRendererState().BlendState.SetDirty();
+
+    FxRenderer->CopyTextureToRTV( zoomBuffer->GetShaderResView(), oldRTV, res );
+
+    engine->SetViewport( { 0, 0, res } );
+
+    engine->GetContext()->OMSetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.Get() );
+    auto defaultSampler = engine->GetDefaultSamplerState();
+    engine->GetContext()->PSSetSamplers( 0, 1, &defaultSampler );
+
+    return XR_SUCCESS;
 }

--- a/D3D11Engine/D3D11PFX_GodRays.h
+++ b/D3D11Engine/D3D11PFX_GodRays.h
@@ -5,10 +5,14 @@ class D3D11PFX_GodRays :
     public D3D11PFX_Effect {
 public:
     D3D11PFX_GodRays( D3D11PfxRenderer* rnd );
-    ~D3D11PFX_GodRays();
+    ~D3D11PFX_GodRays() override = default;
 
     /** Draws this effect to the given buffer */
     XRESULT Render( RenderToTextureBuffer* fxbuffer ) override { return XR_FAILED; }
     XRESULT Render( ID3D11ShaderResourceView* backbuffer, ID3D11ShaderResourceView* normals );
+
+private:
+    /** Compute shader path for FL11+ */
+    XRESULT RenderCS( ID3D11ShaderResourceView* backbuffer, ID3D11ShaderResourceView* normals );
 };
 

--- a/D3D11Engine/D3D11PFX_GodRays.h
+++ b/D3D11Engine/D3D11PFX_GodRays.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "d3d11pfx_effect.h"
+#include "TexturePool.h"
 
 class D3D11PFX_GodRays :
     public D3D11PFX_Effect {
@@ -11,8 +12,22 @@ public:
     XRESULT Render( RenderToTextureBuffer* fxbuffer ) override { return XR_FAILED; }
     XRESULT Render( ID3D11ShaderResourceView* backbuffer, ID3D11ShaderResourceView* normals );
 
+    /** Renders godrays mask+zoom to a ¼-res pool texture, skipping the final additive blit.
+        Returns the pool texture SRV via outGodRaysSRV. Returns XR_SUCCESS if godrays were produced. */
+    XRESULT RenderToTexture( ID3D11ShaderResourceView* backbuffer,
+                             ID3D11ShaderResourceView* normals,
+                             ID3D11ShaderResourceView** outGodRaysSRV );
+
 private:
     /** Compute shader path for FL11+ */
     XRESULT RenderCS( ID3D11ShaderResourceView* backbuffer, ID3D11ShaderResourceView* normals );
+
+    /** Compute shader path that writes to pool texture without final blit */
+    XRESULT RenderToTextureCS( ID3D11ShaderResourceView* backbuffer,
+                               ID3D11ShaderResourceView* normals,
+                               ID3D11ShaderResourceView** outGodRaysSRV );
+
+    /** Keeps the godrays result texture alive until the next frame replaces it */
+    TextureHandle m_GodRaysResult;
 };
 

--- a/D3D11Engine/D3D11PFX_GodRays.h
+++ b/D3D11Engine/D3D11PFX_GodRays.h
@@ -10,21 +10,21 @@ public:
 
     /** Draws this effect to the given buffer */
     XRESULT Render( RenderToTextureBuffer* fxbuffer ) override { return XR_FAILED; }
-    XRESULT Render( ID3D11ShaderResourceView* backbuffer, ID3D11ShaderResourceView* normals );
+    XRESULT Render( ID3D11ShaderResourceView* backbuffer, ID3D11ShaderResourceView* depthCopy );
 
     /** Renders godrays mask+zoom to a ¼-res pool texture, skipping the final additive blit.
         Returns the pool texture SRV via outGodRaysSRV. Returns XR_SUCCESS if godrays were produced. */
     XRESULT RenderToTexture( ID3D11ShaderResourceView* backbuffer,
-                             ID3D11ShaderResourceView* normals,
+                             ID3D11ShaderResourceView* depthCopy,
                              ID3D11ShaderResourceView** outGodRaysSRV );
 
 private:
     /** Compute shader path for FL11+ */
-    XRESULT RenderCS( ID3D11ShaderResourceView* backbuffer, ID3D11ShaderResourceView* normals );
+    XRESULT RenderCS( ID3D11ShaderResourceView* backbuffer, ID3D11ShaderResourceView* depthCopy );
 
     /** Compute shader path that writes to pool texture without final blit */
     XRESULT RenderToTextureCS( ID3D11ShaderResourceView* backbuffer,
-                               ID3D11ShaderResourceView* normals,
+                               ID3D11ShaderResourceView* depthCopy,
                                ID3D11ShaderResourceView** outGodRaysSRV );
 
     /** Keeps the godrays result texture alive until the next frame replaces it */

--- a/D3D11Engine/D3D11PFX_SAO.cpp
+++ b/D3D11Engine/D3D11PFX_SAO.cpp
@@ -1,0 +1,178 @@
+#include "pch.h"
+#include "D3D11PFX_SAO.h"
+#include "Engine.h"
+#include "D3D11GraphicsEngine.h"
+#include "D3D11PfxRenderer.h"
+#include "RenderToTextureBuffer.h"
+#include "D3D11ShaderManager.h"
+#include "D3D11CShader.h"
+#include "D3D11PShader.h"
+#include "D3D11VShader.h"
+#include "D3D11ConstantBuffer.h"
+#include "ConstantBufferStructs.h"
+#include "GothicAPI.h"
+
+D3D11PFX_SAO::D3D11PFX_SAO( D3D11PfxRenderer* rnd ) : D3D11PFX_Effect( rnd ) {
+    auto* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    auto res = engine->GetResolution();
+
+    m_AOBuffer = std::make_unique<RenderToTextureBuffer>(
+        engine->GetDevice().Get(), res.x, res.y, DXGI_FORMAT_R8_UNORM,
+        nullptr, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, 1, 1,
+        D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE );
+
+    m_BlurTempBuffer = std::make_unique<RenderToTextureBuffer>(
+        engine->GetDevice().Get(), res.x, res.y, DXGI_FORMAT_R8_UNORM,
+        nullptr, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, 1, 1,
+        D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE );
+}
+
+XRESULT D3D11PFX_SAO::Render(
+    ID3D11ShaderResourceView* depthSRV,
+    ID3D11ShaderResourceView* normalsSRV,
+    ID3D11RenderTargetView* outputRTV ) {
+
+    D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    auto& context = engine->GetContext();
+    auto res = engine->GetResolution();
+
+    // Unbind RTVs for compute shader passes
+    ID3D11RenderTargetView* nullRtv = nullptr;
+    context->OMSetRenderTargets( 1, &nullRtv, nullptr );
+
+    // Recreate buffers if resolution changed
+    if ( m_AOBuffer->GetSizeX() != static_cast<UINT>(res.x) ||
+         m_AOBuffer->GetSizeY() != static_cast<UINT>(res.y) ) {
+        m_AOBuffer = std::make_unique<RenderToTextureBuffer>(
+            engine->GetDevice().Get(), res.x, res.y, DXGI_FORMAT_R8_UNORM,
+            nullptr, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, 1, 1,
+            D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE );
+        m_BlurTempBuffer = std::make_unique<RenderToTextureBuffer>(
+            engine->GetDevice().Get(), res.x, res.y, DXGI_FORMAT_R8_UNORM,
+            nullptr, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, 1, 1,
+            D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE );
+    }
+
+    auto& saoSettings = Engine::GAPI->GetRendererState().RendererSettings.SaoSettings;
+    auto& projMatrix = Engine::GAPI->GetProjectionMatrix();
+
+    auto defaultSampler = engine->GetDefaultSamplerState();
+    ID3D11UnorderedAccessView* nullUAV = nullptr;
+    ID3D11ShaderResourceView* nullSRVs[2] = { nullptr, nullptr };
+
+    // --- Pass 1: SAO Main ---
+    SAOConstantBuffer saoCB = {};
+    saoCB.SAO_ProjParams = float4( 1.0f / projMatrix._11, 1.0f / projMatrix._22, projMatrix._34, projMatrix._33 );
+    saoCB.SAO_Radius = saoSettings.Radius * 100.0f; // Scale to match engine units
+    saoCB.SAO_Bias = saoSettings.Bias;
+    saoCB.SAO_Intensity = saoSettings.Intensity;
+    saoCB.SAO_NumSamples = saoSettings.NumSamples;
+    saoCB.SAO_InvResolution = float2( 1.0f / res.x, 1.0f / res.y );
+    saoCB.SAO_BlurSharpness = saoSettings.BlurSharpness;
+
+    auto saoCS = engine->GetShaderManager().GetCShader( CShaderID::CS_PFX_SAO );
+    saoCS->Apply();
+    saoCS->GetBuffer( "SAOConstantBuffer" ).Update( &saoCB ).Bind();
+
+    context->CSSetSamplers( 0, 1, &defaultSampler );
+
+    ID3D11ShaderResourceView* saoSRVs[2] = { depthSRV, normalsSRV };
+    context->CSSetShaderResources( 0, 2, saoSRVs );
+    context->CSSetUnorderedAccessViews( 0, 1, m_AOBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
+
+    context->Dispatch( (res.x + 7) / 8, (res.y + 7) / 8, 1 );
+
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    context->CSSetShaderResources( 0, 2, nullSRVs );
+
+    // --- Pass 2: Bilateral Blur (horizontal) ---
+    SAOBlurConstantBuffer blurCB = {};
+    blurCB.SAO_Blur_InvResolution = float2( 1.0f / res.x, 1.0f / res.y );
+    blurCB.SAO_Blur_Sharpness = saoSettings.BlurSharpness;
+    blurCB.SAO_Blur_ProjParams = saoCB.SAO_ProjParams;
+
+    auto blurCS = engine->GetShaderManager().GetCShader( CShaderID::CS_PFX_SAO_Blur );
+
+    // Horizontal pass: AO -> BlurTemp
+    blurCB.SAO_Blur_Direction = float2( 1.0f, 0.0f );
+    blurCS->Apply();
+    blurCS->GetBuffer( "SAOBlurConstantBuffer" ).Update( &blurCB ).Bind();
+
+    context->CSSetSamplers( 0, 1, &defaultSampler );
+
+    ID3D11ShaderResourceView* blurHSRVs[2] = { m_AOBuffer->GetShaderResView().Get(), depthSRV };
+    context->CSSetShaderResources( 0, 2, blurHSRVs );
+    context->CSSetUnorderedAccessViews( 0, 1, m_BlurTempBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
+
+    context->Dispatch( (res.x + 7) / 8, (res.y + 7) / 8, 1 );
+
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    context->CSSetShaderResources( 0, 2, nullSRVs );
+
+    // --- Pass 3: Bilateral Blur (vertical) ---
+    // Vertical pass: BlurTemp -> AO
+    blurCB.SAO_Blur_Direction = float2( 0.0f, 1.0f );
+    blurCS->Apply();
+    blurCS->GetBuffer( "SAOBlurConstantBuffer" ).Update( &blurCB ).Bind();
+
+    context->CSSetSamplers( 0, 1, &defaultSampler );
+
+    ID3D11ShaderResourceView* blurVSRVs[2] = { m_BlurTempBuffer->GetShaderResView().Get(), depthSRV };
+    context->CSSetShaderResources( 0, 2, blurVSRVs );
+    context->CSSetUnorderedAccessViews( 0, 1, m_AOBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
+
+    context->Dispatch( (res.x + 7) / 8, (res.y + 7) / 8, 1 );
+
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    context->CSSetShaderResources( 0, 2, nullSRVs );
+    context->CSSetShader( nullptr, nullptr, 0 );
+
+    // --- Pass 4: Multiply-blend AO onto the scene ---
+    // Follow the same pattern as DrawScreenFade()'s modulate blend path:
+    // Set blend, depth, shaders, RTV, then DrawFullScreenQuad (which calls UpdateRenderStates)
+
+    Engine::GAPI->GetRendererState().BlendState.SetModulateBlending();
+    Engine::GAPI->GetRendererState().BlendState.SetDirty();
+
+    Engine::GAPI->GetRendererState().DepthState.DepthBufferCompareFunc =
+        GothicDepthBufferStateInfo::CF_COMPARISON_ALWAYS;
+    Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled = false;
+    Engine::GAPI->GetRendererState().DepthState.SetDirty();
+
+    // Apply VS_PFX + PS_PFX_Simple_R8
+    engine->GetShaderManager().GetVShader( VShaderID::VS_PFX )->Apply();
+    engine->GetShaderManager().GetPShader( PShaderID::PS_PFX_Simple_R8 )->Apply();
+
+    // Set viewport to full resolution
+    D3D11_VIEWPORT vp = {};
+    vp.Width = static_cast<float>(res.x);
+    vp.Height = static_cast<float>(res.y);
+    vp.MinDepth = 0.0f;
+    vp.MaxDepth = 1.0f;
+    context->RSSetViewports( 1, &vp );
+
+    // Bind the explicit outputRTV (from render graph), DSV = nullptr
+    context->OMSetRenderTargets( 1, &outputRTV, nullptr );
+
+    // Unbind slot 0, then bind AO buffer
+    ID3D11ShaderResourceView* nullSRV1 = nullptr;
+    context->PSSetShaderResources( 0, 1, &nullSRV1 );
+    auto aoSRV = m_AOBuffer->GetShaderResView();
+    context->PSSetShaderResources( 0, 1, aoSRV.GetAddressOf() );
+
+    // Draw fullscreen triangle (calls UpdateRenderStates internally)
+    FxRenderer->DrawFullScreenQuad();
+
+    // Cleanup: unbind SRV
+    context->PSSetShaderResources( 0, 1, &nullSRV1 );
+
+    // Restore default states
+    Engine::GAPI->GetRendererState().BlendState.SetDefault();
+    Engine::GAPI->GetRendererState().BlendState.SetDirty();
+    Engine::GAPI->GetRendererState().DepthState.DepthBufferCompareFunc =
+        GothicDepthBufferStateInfo::DEFAULT_DEPTH_COMP_STATE;
+    Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled = true;
+    Engine::GAPI->GetRendererState().DepthState.SetDirty();
+
+    return XR_SUCCESS;
+}

--- a/D3D11Engine/D3D11PFX_SAO.cpp
+++ b/D3D11Engine/D3D11PFX_SAO.cpp
@@ -176,3 +176,107 @@ XRESULT D3D11PFX_SAO::Render(
 
     return XR_SUCCESS;
 }
+
+XRESULT D3D11PFX_SAO::RenderAO(
+    ID3D11ShaderResourceView* depthSRV,
+    ID3D11ShaderResourceView* normalsSRV ) {
+
+    D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    auto& context = engine->GetContext();
+    auto res = engine->GetResolution();
+
+    // Unbind RTVs for compute shader passes
+    ID3D11RenderTargetView* nullRtv = nullptr;
+    context->OMSetRenderTargets( 1, &nullRtv, nullptr );
+
+    // Recreate buffers if resolution changed
+    if ( m_AOBuffer->GetSizeX() != static_cast<UINT>(res.x) ||
+         m_AOBuffer->GetSizeY() != static_cast<UINT>(res.y) ) {
+        m_AOBuffer = std::make_unique<RenderToTextureBuffer>(
+            engine->GetDevice().Get(), res.x, res.y, DXGI_FORMAT_R8_UNORM,
+            nullptr, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, 1, 1,
+            D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE );
+        m_BlurTempBuffer = std::make_unique<RenderToTextureBuffer>(
+            engine->GetDevice().Get(), res.x, res.y, DXGI_FORMAT_R8_UNORM,
+            nullptr, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, 1, 1,
+            D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE );
+    }
+
+    auto& saoSettings = Engine::GAPI->GetRendererState().RendererSettings.SaoSettings;
+    auto& projMatrix = Engine::GAPI->GetProjectionMatrix();
+
+    auto defaultSampler = engine->GetDefaultSamplerState();
+    ID3D11UnorderedAccessView* nullUAV = nullptr;
+    ID3D11ShaderResourceView* nullSRVs[2] = { nullptr, nullptr };
+
+    // --- Pass 1: SAO Main ---
+    SAOConstantBuffer saoCB = {};
+    saoCB.SAO_ProjParams = float4( 1.0f / projMatrix._11, 1.0f / projMatrix._22, projMatrix._34, projMatrix._33 );
+    saoCB.SAO_Radius = saoSettings.Radius * 100.0f;
+    saoCB.SAO_Bias = saoSettings.Bias;
+    saoCB.SAO_Intensity = saoSettings.Intensity;
+    saoCB.SAO_NumSamples = saoSettings.NumSamples;
+    saoCB.SAO_InvResolution = float2( 1.0f / res.x, 1.0f / res.y );
+    saoCB.SAO_BlurSharpness = saoSettings.BlurSharpness;
+
+    auto saoCS = engine->GetShaderManager().GetCShader( CShaderID::CS_PFX_SAO );
+    saoCS->Apply();
+    saoCS->GetBuffer( "SAOConstantBuffer" ).Update( &saoCB ).Bind();
+
+    context->CSSetSamplers( 0, 1, &defaultSampler );
+
+    ID3D11ShaderResourceView* saoSRVs[2] = { depthSRV, normalsSRV };
+    context->CSSetShaderResources( 0, 2, saoSRVs );
+    context->CSSetUnorderedAccessViews( 0, 1, m_AOBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
+
+    context->Dispatch( (res.x + 7) / 8, (res.y + 7) / 8, 1 );
+
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    context->CSSetShaderResources( 0, 2, nullSRVs );
+
+    // --- Pass 2: Bilateral Blur (horizontal) ---
+    SAOBlurConstantBuffer blurCB = {};
+    blurCB.SAO_Blur_InvResolution = float2( 1.0f / res.x, 1.0f / res.y );
+    blurCB.SAO_Blur_Sharpness = saoSettings.BlurSharpness;
+    blurCB.SAO_Blur_ProjParams = saoCB.SAO_ProjParams;
+
+    auto blurCS = engine->GetShaderManager().GetCShader( CShaderID::CS_PFX_SAO_Blur );
+
+    blurCB.SAO_Blur_Direction = float2( 1.0f, 0.0f );
+    blurCS->Apply();
+    blurCS->GetBuffer( "SAOBlurConstantBuffer" ).Update( &blurCB ).Bind();
+
+    context->CSSetSamplers( 0, 1, &defaultSampler );
+
+    ID3D11ShaderResourceView* blurHSRVs[2] = { m_AOBuffer->GetShaderResView().Get(), depthSRV };
+    context->CSSetShaderResources( 0, 2, blurHSRVs );
+    context->CSSetUnorderedAccessViews( 0, 1, m_BlurTempBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
+
+    context->Dispatch( (res.x + 7) / 8, (res.y + 7) / 8, 1 );
+
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    context->CSSetShaderResources( 0, 2, nullSRVs );
+
+    // --- Pass 3: Bilateral Blur (vertical) ---
+    blurCB.SAO_Blur_Direction = float2( 0.0f, 1.0f );
+    blurCS->Apply();
+    blurCS->GetBuffer( "SAOBlurConstantBuffer" ).Update( &blurCB ).Bind();
+
+    context->CSSetSamplers( 0, 1, &defaultSampler );
+
+    ID3D11ShaderResourceView* blurVSRVs[2] = { m_BlurTempBuffer->GetShaderResView().Get(), depthSRV };
+    context->CSSetShaderResources( 0, 2, blurVSRVs );
+    context->CSSetUnorderedAccessViews( 0, 1, m_AOBuffer->GetUnorderedAccessView().GetAddressOf(), nullptr );
+
+    context->Dispatch( (res.x + 7) / 8, (res.y + 7) / 8, 1 );
+
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    context->CSSetShaderResources( 0, 2, nullSRVs );
+    context->CSSetShader( nullptr, nullptr, 0 );
+
+    return XR_SUCCESS;
+}
+
+ID3D11ShaderResourceView* D3D11PFX_SAO::GetAOResultSRV() const {
+    return m_AOBuffer ? m_AOBuffer->GetShaderResView().Get() : nullptr;
+}

--- a/D3D11Engine/D3D11PFX_SAO.h
+++ b/D3D11Engine/D3D11PFX_SAO.h
@@ -17,6 +17,13 @@ public:
                     ID3D11ShaderResourceView* normalsSRV,
                     ID3D11RenderTargetView* outputRTV );
 
+    /** Computes AO into m_AOBuffer but skips the final modulate blit */
+    XRESULT RenderAO( ID3D11ShaderResourceView* depthSRV,
+                      ID3D11ShaderResourceView* normalsSRV );
+
+    /** Returns the SRV of the computed AO buffer (R8_UNORM) for composition */
+    ID3D11ShaderResourceView* GetAOResultSRV() const;
+
 private:
     std::unique_ptr<RenderToTextureBuffer> m_AOBuffer;      // Full-res R8_UNORM with UAV
     std::unique_ptr<RenderToTextureBuffer> m_BlurTempBuffer; // Full-res R8_UNORM with UAV for blur ping-pong

--- a/D3D11Engine/D3D11PFX_SAO.h
+++ b/D3D11Engine/D3D11PFX_SAO.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "d3d11pfx_effect.h"
+#include <wrl/client.h>
+
+struct RenderToTextureBuffer;
+
+class D3D11PFX_SAO : public D3D11PFX_Effect {
+public:
+    D3D11PFX_SAO( D3D11PfxRenderer* rnd );
+    ~D3D11PFX_SAO() override = default;
+
+    /** Not used */
+    XRESULT Render( RenderToTextureBuffer* fxbuffer ) override { return XR_FAILED; }
+
+    /** Renders SAO into the given render target */
+    XRESULT Render( ID3D11ShaderResourceView* depthSRV,
+                    ID3D11ShaderResourceView* normalsSRV,
+                    ID3D11RenderTargetView* outputRTV );
+
+private:
+    std::unique_ptr<RenderToTextureBuffer> m_AOBuffer;      // Full-res R8_UNORM with UAV
+    std::unique_ptr<RenderToTextureBuffer> m_BlurTempBuffer; // Full-res R8_UNORM with UAV for blur ping-pong
+};

--- a/D3D11Engine/D3D11PShader.cpp
+++ b/D3D11Engine/D3D11PShader.cpp
@@ -49,12 +49,16 @@ XRESULT D3D11PShader::Apply() {
 
 void D3D11PShader::BindResource(StringID name, ID3D11ShaderResourceView* srv)
 {
-    reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine)->GetContext()->PSSetShaderResources( GetInputIndex(name), 1, &srv );
+    const int inputIndex = GetInputIndex(name);
+    if (inputIndex != -1)
+        reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine)->GetContext()->PSSetShaderResources( inputIndex, 1, &srv );
 }
 
 void D3D11PShader::BindSampler(StringID name, ID3D11SamplerState* sampler)
 {
-    reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine)->GetContext()->PSSetSamplers( GetInputIndex(name), 1, &sampler );
+    const int inputIndex = GetInputIndex(name);
+    if (inputIndex != -1)
+        reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine)->GetContext()->PSSetSamplers( inputIndex, 1, &sampler );
 }
 
 void D3D11PShader::BindBuffer(StringID name, D3D11ConstantBuffer* buffer) {

--- a/D3D11Engine/D3D11PfxRenderer.cpp
+++ b/D3D11Engine/D3D11PfxRenderer.cpp
@@ -20,6 +20,7 @@
 #include "D3D11PFX_FSR1.h"
 #include "D3D11PFX_FSR2.h"
 #include "D3D11PFX_FSR3.h"
+#include "D3D11PFX_SAO.h"
 
 D3D11PfxRenderer::D3D11PfxRenderer() {
 
@@ -37,6 +38,7 @@ D3D11PfxRenderer::D3D11PfxRenderer() {
         FX_SMAA = std::make_unique<D3D11PFX_SMAA>( this );
         FX_TAA = std::make_unique<D3D11PFX_TAA>( this );
         NvHBAO = std::make_unique<D3D11NVHBAO>();
+        FX_SAO = std::make_unique<D3D11PFX_SAO>( this );
         PFX_FSR1 = std::make_unique<D3D11PFX_FSR1>( this );
         PFX_FSR2 = std::make_unique<D3D11PFX_FSR2>( this );
         PFX_FSR3 = std::make_unique<D3D11PFX_FSR3>( this );
@@ -238,6 +240,15 @@ XRESULT D3D11PfxRenderer::DrawHBAO(
     return NvHBAO->Render( rtv.Get(), pFullResDepthTexSRV, pFullResNormalTexSRV);
 }
 
+/** Renders the SAO effect */
+XRESULT D3D11PfxRenderer::RenderSAO(
+    ID3D11ShaderResourceView* depthSRV,
+    ID3D11ShaderResourceView* normalsSRV,
+    ID3D11RenderTargetView* outputRTV ) {
+    if ( !FX_SAO ) return XR_FAILED;
+    return FX_SAO->Render( depthSRV, normalsSRV, outputRTV );
+}
+
 TextureHandle D3D11PfxRenderer::GetTempBuffer()
 {
     D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
@@ -288,7 +299,7 @@ void D3D11PfxRenderer::FreeResources()
     }
 
     if ( this->NvHBAO 
-        && !settings.HbaoSettings.Enabled ) {
+        && settings.AoMode != AOMode::AO_HBAO ) {
         this->NvHBAO->ReleaseResources();
     }
 }

--- a/D3D11Engine/D3D11PfxRenderer.cpp
+++ b/D3D11Engine/D3D11PfxRenderer.cpp
@@ -21,6 +21,10 @@
 #include "D3D11PFX_FSR2.h"
 #include "D3D11PFX_FSR3.h"
 #include "D3D11PFX_SAO.h"
+#include "D3D11ConstantBuffer.h"
+#include "ConstantBufferStructs.h"
+#include "GothicAPI.h"
+#include "GSky.h"
 
 D3D11PfxRenderer::D3D11PfxRenderer() {
 
@@ -247,6 +251,142 @@ XRESULT D3D11PfxRenderer::RenderSAO(
     ID3D11RenderTargetView* outputRTV ) {
     if ( !FX_SAO ) return XR_FAILED;
     return FX_SAO->Render( depthSRV, normalsSRV, outputRTV );
+}
+
+XRESULT D3D11PfxRenderer::RenderSAOCompute(
+    ID3D11ShaderResourceView* depthSRV,
+    ID3D11ShaderResourceView* normalsSRV ) {
+    if ( !FX_SAO ) return XR_FAILED;
+    return FX_SAO->RenderAO( depthSRV, normalsSRV );
+}
+
+ID3D11ShaderResourceView* D3D11PfxRenderer::GetSAOResultSRV() const {
+    return FX_SAO ? FX_SAO->GetAOResultSRV() : nullptr;
+}
+
+XRESULT D3D11PfxRenderer::RenderGodRaysToTexture(
+    ID3D11ShaderResourceView* backbuffer,
+    ID3D11ShaderResourceView* normals,
+    ID3D11ShaderResourceView** outGodRaysSRV ) {
+    return FX_GodRays->RenderToTexture( backbuffer, normals, outGodRaysSRV );
+}
+
+XRESULT D3D11PfxRenderer::RenderPostFXComposition(
+    ID3D11RenderTargetView* outputRTV,
+    ID3D11ShaderResourceView* backbufferSRV,
+    ID3D11ShaderResourceView* saoSRV,
+    ID3D11ShaderResourceView* godraysSRV,
+    ID3D11ShaderResourceView* depthSRV ) {
+
+    D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    auto& context = engine->GetContext();
+    auto res = engine->GetResolution();
+
+    // Set up shaders
+    engine->GetShaderManager().GetVShader( VShaderID::VS_PFX )->Apply();
+    auto compositionPS = engine->GetShaderManager().GetPShader( PShaderID::PS_PFX_Composition );
+    compositionPS->Apply();
+
+    // Update constant buffers for inline heightfog if active
+    auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+    if ( settings.DrawFog ) {
+        HeightfogConstantBuffer cb;
+        {
+            auto& proj = Engine::GAPI->GetProjectionMatrix();
+            cb.HF_ProjParams = float4( 1.0f / proj._11, 1.0f / proj._22, proj._43, proj._33 );
+        }
+        XMStoreFloat4x4( &cb.InvView, XMMatrixInverse( nullptr, Engine::GAPI->GetViewMatrixXM() ) );
+        cb.CameraPosition = Engine::GAPI->GetCameraPosition();
+        cb.HF_GlobalDensity = settings.FogGlobalDensity;
+        cb.HF_HeightFalloff = settings.FogHeightFalloff;
+
+        float height = settings.FogHeight;
+        XMVECTOR color = XMLoadFloat3( settings.FogColorMod.toXMFLOAT3() );
+
+        float fnear = 15000.0f;
+        float ffar = 60000.0f;
+        float secScale = std::min<float>( settings.SectionDrawRadius, settings.FogRange );
+
+        cb.HF_WeightZNear = std::max( 0.0f, WORLD_SECTION_SIZE * ((secScale - 0.5f) * 0.7f) - (ffar - fnear) );
+        cb.HF_WeightZFar = WORLD_SECTION_SIZE * ((secScale - 0.5f) * 0.8f);
+
+        float atmoMax = 83200.0f;
+        float atmoMin = 27799.9922f;
+        cb.HF_WeightZFar = std::min( cb.HF_WeightZFar, atmoMax );
+        cb.HF_WeightZNear = std::min( cb.HF_WeightZNear, atmoMin );
+
+#if !defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+        float fogDensityFactor = 2;
+        float fogDensityFactorRain = (1.0f - Engine::GAPI->GetFogOverride());
+#else
+        float fogDensityFactor = pow( 15000.0f / Engine::GAPI->GetFarZ(), 4.0f );
+        float fogDensityFactorRain = 1.0f;
+#endif
+
+        if ( Engine::GAPI->GetFogOverride() > 0.0f ) {
+            height = Toolbox::lerp( height, Engine::GAPI->GetCameraPosition().y + 10000, Engine::GAPI->GetFogOverride() );
+            color = Engine::GAPI->GetFogColor();
+#if !defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+            cb.HF_HeightFalloff = Toolbox::lerp( cb.HF_HeightFalloff, 0.000001f, Engine::GAPI->GetFogOverride() );
+#endif
+            cb.HF_GlobalDensity = Toolbox::lerp( cb.HF_GlobalDensity, cb.HF_GlobalDensity * fogDensityFactor, Engine::GAPI->GetFogOverride() );
+#if !defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+            cb.HF_WeightZNear = Toolbox::lerp( cb.HF_WeightZNear, WORLD_SECTION_SIZE * 0.09f, Engine::GAPI->GetFogOverride() );
+            cb.HF_WeightZFar = Toolbox::lerp( cb.HF_WeightZFar, WORLD_SECTION_SIZE * 0.8, Engine::GAPI->GetFogOverride() );
+#endif
+        }
+
+        cb.HF_FogHeight = height;
+        cb.HF_ProjAB = float2( Engine::GAPI->GetProjectionMatrix()._33, Engine::GAPI->GetProjectionMatrix()._34 );
+
+        float rain = Engine::GAPI->GetRainFXWeight();
+        XMFLOAT3 FogColorMod;
+        XMStoreFloat3( &FogColorMod, XMVectorLerpV( color, XMLoadFloat3( &settings.RainFogColor ), XMVectorSet( std::min( 1.0f, rain * 2.0f ), std::min( 1.0f, rain * 2.0f ), std::min( 1.0f, rain * 2.0f ), 0 ) ) );
+        cb.HF_FogColorMod = FogColorMod;
+        cb.HF_GlobalDensity = Toolbox::lerp( cb.HF_GlobalDensity, settings.RainFogDensity, rain * fogDensityFactorRain );
+
+        compositionPS->GetBuffer( "PFXBuffer" ).Update( &cb ).Bind();
+
+        GSky* sky = Engine::GAPI->GetSky();
+        compositionPS->GetBuffer( "Atmosphere" ).Update( &sky->GetAtmosphereCB() ).Bind();
+    }
+
+    // Set viewport
+    D3D11_VIEWPORT vp = {};
+    vp.Width = static_cast<float>(res.x);
+    vp.Height = static_cast<float>(res.y);
+    vp.MinDepth = 0.0f;
+    vp.MaxDepth = 1.0f;
+    context->RSSetViewports( 1, &vp );
+
+    // Bind output RTV (no depth)
+    context->OMSetRenderTargets( 1, &outputRTV, nullptr );
+
+    // Bind SRVs: t0=backbuffer, t1=SAO, t2=GodRays, t3=Depth
+    ID3D11ShaderResourceView* srvs[4] = { backbufferSRV, saoSRV, godraysSRV, depthSRV };
+    context->PSSetShaderResources( 0, 4, srvs );
+
+    // No blending — direct overwrite
+    Engine::GAPI->GetRendererState().BlendState.SetDefault();
+    Engine::GAPI->GetRendererState().BlendState.SetDirty();
+    Engine::GAPI->GetRendererState().DepthState.DepthBufferCompareFunc =
+        GothicDepthBufferStateInfo::CF_COMPARISON_ALWAYS;
+    Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled = false;
+    Engine::GAPI->GetRendererState().DepthState.SetDirty();
+
+    DrawFullScreenQuad();
+
+    // Unbind SRVs
+    ID3D11ShaderResourceView* nullSRVs[4] = { nullptr, nullptr, nullptr, nullptr };
+    context->PSSetShaderResources( 0, 4, nullSRVs );
+
+    // Restore default states
+    Engine::GAPI->GetRendererState().DepthState.DepthBufferCompareFunc =
+        GothicDepthBufferStateInfo::DEFAULT_DEPTH_COMP_STATE;
+    Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled = true;
+    Engine::GAPI->GetRendererState().DepthState.SetDirty();
+
+    return XR_SUCCESS;
 }
 
 TextureHandle D3D11PfxRenderer::GetTempBuffer()

--- a/D3D11Engine/D3D11PfxRenderer.cpp
+++ b/D3D11Engine/D3D11PfxRenderer.cpp
@@ -74,8 +74,8 @@ XRESULT D3D11PfxRenderer::RenderHeightfog() {
 }
 
 /** Renders the godrays-Effect */
-XRESULT D3D11PfxRenderer::RenderGodRays(ID3D11ShaderResourceView* backbuffer, ID3D11ShaderResourceView* normals) {
-    return FX_GodRays->Render( backbuffer , normals );
+XRESULT D3D11PfxRenderer::RenderGodRays(ID3D11ShaderResourceView* backbuffer, ID3D11ShaderResourceView* depth) {
+    return FX_GodRays->Render( backbuffer , depth );
 }
 
 /** Renders the depth-of-field effect */
@@ -266,9 +266,9 @@ ID3D11ShaderResourceView* D3D11PfxRenderer::GetSAOResultSRV() const {
 
 XRESULT D3D11PfxRenderer::RenderGodRaysToTexture(
     ID3D11ShaderResourceView* backbuffer,
-    ID3D11ShaderResourceView* normals,
+    ID3D11ShaderResourceView* depthCopy,
     ID3D11ShaderResourceView** outGodRaysSRV ) {
-    return FX_GodRays->RenderToTexture( backbuffer, normals, outGodRaysSRV );
+    return FX_GodRays->RenderToTexture( backbuffer, depthCopy, outGodRaysSRV );
 }
 
 XRESULT D3D11PfxRenderer::RenderPostFXComposition(

--- a/D3D11Engine/D3D11PfxRenderer.cpp
+++ b/D3D11Engine/D3D11PfxRenderer.cpp
@@ -21,6 +21,7 @@
 #include "D3D11PFX_FSR2.h"
 #include "D3D11PFX_FSR3.h"
 #include "D3D11PFX_SAO.h"
+#include "D3D11PFX_ASSAO.h"
 #include "D3D11ConstantBuffer.h"
 #include "ConstantBufferStructs.h"
 #include "GothicAPI.h"
@@ -28,8 +29,9 @@
 
 D3D11PfxRenderer::D3D11PfxRenderer() {
 
-    m_texturePool = std::make_unique<TexturePool>( reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine)->GetDevice().Get() );
-    m_depthStencilPool = std::make_unique<DepthStencilPool>( reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine)->GetDevice().Get() );
+    auto engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    m_texturePool = std::make_unique<TexturePool>( engine->GetDevice().Get() );
+    m_depthStencilPool = std::make_unique<DepthStencilPool>( engine->GetDevice().Get() );
 
     FX_Blur = std::make_unique<D3D11PFX_Blur>( this );
     FX_HeightFog = std::make_unique<D3D11PFX_HeightFog>( this );
@@ -46,6 +48,11 @@ D3D11PfxRenderer::D3D11PfxRenderer() {
         PFX_FSR1 = std::make_unique<D3D11PFX_FSR1>( this );
         PFX_FSR2 = std::make_unique<D3D11PFX_FSR2>( this );
         PFX_FSR3 = std::make_unique<D3D11PFX_FSR3>( this );
+        PFX_ASSAO = std::make_unique<D3D11PFX_ASSAO>(
+            engine->GetDevice().Get(),
+            engine->GetContext().Get() );
+
+        PFX_ASSAO->Init();
     }
 
     PFX_CAS = std::make_unique<D3D11PFX_CAS>( this );
@@ -386,6 +393,16 @@ XRESULT D3D11PfxRenderer::RenderPostFXComposition(
     Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled = true;
     Engine::GAPI->GetRendererState().DepthState.SetDirty();
 
+    return XR_SUCCESS;
+}
+
+XRESULT D3D11PfxRenderer::RenderASSAO( ID3D11RenderTargetView* outputRTV, ID3D11ShaderResourceView* depthCopy, ID3D11ShaderResourceView* normals )
+{
+    if ( !PFX_ASSAO ) {
+        return XR_FAILED;
+    }
+
+    PFX_ASSAO->Render( depthCopy, normals, outputRTV );
     return XR_SUCCESS;
 }
 

--- a/D3D11Engine/D3D11PfxRenderer.h
+++ b/D3D11Engine/D3D11PfxRenderer.h
@@ -17,6 +17,7 @@ class D3D11PFX_SMAA;
 class D3D11PFX_GodRays;
 class D3D11PFX_DepthOfField;
 class D3D11NVHBAO;
+class D3D11PFX_SAO;
 class D3D11PFX_SimpleSharpen;
 
 class D3D11PfxRenderer {
@@ -65,6 +66,11 @@ public:
     XRESULT DrawHBAO(const ComPtr<ID3D11RenderTargetView>& rtv, const ComPtr<ID3D11ShaderResourceView>& pFullResDepthTexSRV, const ComPtr<
                      ID3D11ShaderResourceView>& pFullResNormalTexSRV);
 
+    /** Renders the SAO effect */
+    XRESULT RenderSAO( ID3D11ShaderResourceView* depthSRV,
+                       ID3D11ShaderResourceView* normalsSRV,
+                       ID3D11RenderTargetView* outputRTV );
+
     /** Accessors */
     TextureHandle GetTempBuffer();
     TextureHandle GetBackbufferTempBuffer();
@@ -96,6 +102,9 @@ private:
     std::unique_ptr<D3D11PFX_SMAA> FX_SMAA;
     std::unique_ptr<D3D11PFX_GodRays> FX_GodRays;
     std::unique_ptr<D3D11PFX_DepthOfField> FX_DepthOfField;
+
+    /** SAO effect (FL11+ only) */
+    std::unique_ptr<D3D11PFX_SAO> FX_SAO;
 
     /** Nivida HBAO+ */
     std::unique_ptr<D3D11NVHBAO> NvHBAO;

--- a/D3D11Engine/D3D11PfxRenderer.h
+++ b/D3D11Engine/D3D11PfxRenderer.h
@@ -48,7 +48,7 @@ public:
     XRESULT RenderSimpleSharpen( const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& input, INT2 inputSize, const Microsoft::WRL::ComPtr<ID3D11RenderTargetView>& output, INT2 outputSize, RenderToTextureBuffer& intermediateBuffer );
 
     /** Renders the godrays-Effect */
-    XRESULT RenderGodRays(ID3D11ShaderResourceView* backbuffer, ID3D11ShaderResourceView* normals);
+    XRESULT RenderGodRays(ID3D11ShaderResourceView* backbuffer, ID3D11ShaderResourceView* depth);
 
     /** Renders the depth-of-field effect */
     XRESULT RenderDepthOfField(ID3D11ShaderResourceView* backbuffer);

--- a/D3D11Engine/D3D11PfxRenderer.h
+++ b/D3D11Engine/D3D11PfxRenderer.h
@@ -71,6 +71,25 @@ public:
                        ID3D11ShaderResourceView* normalsSRV,
                        ID3D11RenderTargetView* outputRTV );
 
+    /** Computes SAO into internal buffer, skipping the final modulate blit */
+    XRESULT RenderSAOCompute( ID3D11ShaderResourceView* depthSRV,
+                              ID3D11ShaderResourceView* normalsSRV );
+
+    /** Returns the SRV of the last computed SAO result (R8_UNORM) */
+    ID3D11ShaderResourceView* GetSAOResultSRV() const;
+
+    /** Renders godrays mask+zoom to a pool texture, skipping the final additive blit */
+    XRESULT RenderGodRaysToTexture( ID3D11ShaderResourceView* backbuffer,
+                                    ID3D11ShaderResourceView* normals,
+                                    ID3D11ShaderResourceView** outGodRaysSRV );
+
+    /** Renders the PostFX composition uber pass (SAO + HeightFog + GodRays) */
+    XRESULT RenderPostFXComposition( ID3D11RenderTargetView* outputRTV,
+                                     ID3D11ShaderResourceView* backbufferSRV,
+                                     ID3D11ShaderResourceView* saoSRV,
+                                     ID3D11ShaderResourceView* godraysSRV,
+                                     ID3D11ShaderResourceView* depthSRV );
+
     /** Accessors */
     TextureHandle GetTempBuffer();
     TextureHandle GetBackbufferTempBuffer();

--- a/D3D11Engine/D3D11PfxRenderer.h
+++ b/D3D11Engine/D3D11PfxRenderer.h
@@ -19,6 +19,7 @@ class D3D11PFX_DepthOfField;
 class D3D11NVHBAO;
 class D3D11PFX_SAO;
 class D3D11PFX_SimpleSharpen;
+class D3D11PFX_ASSAO;
 
 class D3D11PfxRenderer {
 public:
@@ -90,6 +91,10 @@ public:
                                      ID3D11ShaderResourceView* godraysSRV,
                                      ID3D11ShaderResourceView* depthSRV );
 
+    XRESULT RenderASSAO( ID3D11RenderTargetView* outputRTV,
+                            ID3D11ShaderResourceView* depthCopy,
+                            ID3D11ShaderResourceView* normals );
+
     /** Accessors */
     TextureHandle GetTempBuffer();
     TextureHandle GetBackbufferTempBuffer();
@@ -135,6 +140,7 @@ private:
     std::unique_ptr<D3D11PFX_FSR1> PFX_FSR1;
     std::unique_ptr<D3D11PFX_FSR2> PFX_FSR2;
     std::unique_ptr<D3D11PFX_FSR3> PFX_FSR3;
+    std::unique_ptr<D3D11PFX_ASSAO> PFX_ASSAO;
     std::unique_ptr<TexturePool> m_texturePool;
     std::unique_ptr<DepthStencilPool> m_depthStencilPool;
 };

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -192,7 +192,7 @@ void D3D11PointLight::RenderStaticShadowPass( RenderToDepthStencilBuffer& target
     D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
     const float range = LightInfo->Vob->GetLightRange() * 1.1f;
 
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* wc = &WorldMeshCache;
+    std::map<MeshKey, MeshInfo*, cmpMeshKey>* wc = &WorldMeshCache;
     if ( WorldCacheInvalid ) {
         wc = nullptr;
     }
@@ -435,7 +435,7 @@ void D3D11PointLight::RenderFullCubemap() {
         return;
     }
 
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* wc = &WorldMeshCache;
+    std::map<MeshKey, MeshInfo*, cmpMeshKey>* wc = &WorldMeshCache;
     if ( WorldCacheInvalid ) {
         wc = nullptr;
     }

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -91,7 +91,7 @@ protected:
 
     std::list<VobInfo*> VobCache;
     std::list<SkeletalVobInfo*> SkeletalVobCache;
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey> WorldMeshCache;
+    std::map<MeshKey, MeshInfo*, cmpMeshKey> WorldMeshCache;
     bool WorldCacheInvalid;
 
     VobLightInfo* LightInfo;

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -308,6 +308,7 @@ XRESULT D3D11ShaderManager::Init() {
     Shaders.push_back( ShaderInfo::make<VShaderID::VS_CinemaScope>( "VS_CinemaScope.hlsl" )  );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_Simple>( "PS_PFX_Simple.hlsl" ) );
+    Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_Simple_R8>( "PS_PFX_Simple_R8.hlsl" ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_VelocityDebug>( "PS_PFX_VelocityDebug.hlsl" )  );
 
@@ -524,6 +525,10 @@ XRESULT D3D11ShaderManager::Init() {
             .with_macros( {{ "DOF_GAUSS_BLUR", "1" }} ) );
 
         Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_DoF_Composite>( "CS_PFX_DoF_Composite.hlsl" ));
+
+        Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_SAO>( "CS_PFX_SAO.hlsl" ));
+
+        Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_SAO_Blur>( "CS_PFX_SAO_Blur.hlsl" ));
     }
 
     return XR_SUCCESS;

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -165,12 +165,15 @@ XRESULT D3D11ShaderManager::Init() {
 #ifdef BUILD_GOTHIC_2_6_fix
             list.push_back( {"SHD_WIND",      s.WindQuality == GothicRendererSettings::EWindQuality::WIND_QUALITY_ADVANCED ? "1" : "0"} );
             list.push_back( {"SHD_INFLUENCE", s.HeroAffectsObjects ? "1" : "0"} );
+            list.push_back( {"WIND_META_SRV", (!FeatureLevel10Compatibility && (s.WindQuality == GothicRendererSettings::EWindQuality::WIND_QUALITY_ADVANCED || s.HeroAffectsObjects)) ? "1" : "0"} );
 #elif defined(BUILD_1_12F)
             list.push_back( {"SHD_WIND",      "0"} );
             list.push_back( {"SHD_INFLUENCE", "0"} );
+            list.push_back( {"WIND_META_SRV", "0"} );
 #else
             list.push_back( {"SHD_WIND",      (haveWindAnimations && s.WindQuality == GothicRendererSettings::EWindQuality::WIND_QUALITY_ADVANCED) ? "1" : "0"} );
             list.push_back( {"SHD_INFLUENCE", (haveWindAnimations && s.HeroAffectsObjects) ? "1" : "0"} );
+            list.push_back( {"WIND_META_SRV", (!FeatureLevel10Compatibility && haveWindAnimations && (s.WindQuality == GothicRendererSettings::EWindQuality::WIND_QUALITY_ADVANCED || s.HeroAffectsObjects)) ? "1" : "0"} );
 #endif
         }) );
 

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -15,6 +15,7 @@
 #include "D3D11GraphicsEngineBase.h"
 #include <d3dcompiler.h>
 #include "D3D11PFX_TAA.h"
+#include "D3D11FileRelativeInclude.h"
 
 #pragma comment(lib, "d3d11.lib")
 #pragma comment(lib, "d3dcompiler.lib")
@@ -27,97 +28,6 @@
 
 #include <fstream>
 #include <unordered_map>
-
-namespace
-{
-    // Include handler that resolves includes relative to the including file
-    // and also files relative to any relative included file (i.e. nested includes).
-    class D3D11FileRelativeInclude final : public ID3DInclude
-    {
-    public:
-        explicit D3D11FileRelativeInclude( std::filesystem::path rootDir )
-            : RootDir( std::move( rootDir ) )
-        {
-        }
-
-        HRESULT __stdcall Open( D3D_INCLUDE_TYPE includeType, LPCSTR pFileName, LPCVOID pParentData, LPCVOID* ppData, UINT* pBytes ) override
-        {
-            if ( ppData == nullptr || pBytes == nullptr || pFileName == nullptr )
-                return E_INVALIDARG;
-
-            std::filesystem::path baseDir = RootDir;
-
-            // If pParentData is an include we previously returned, use its directory as base.
-            if ( pParentData != nullptr ) {
-                auto it = ParentDirByData.find( pParentData );
-                if ( it != ParentDirByData.end() )
-                    baseDir = it->second;
-            }
-
-            std::filesystem::path requested = std::filesystem::path( pFileName );
-
-            // Resolve strategy:
-            // 1) If requested is absolute -> use it
-            // 2) else -> resolve relative to includer's directory (baseDir)
-            // 3) If not found, optionally fall back to RootDir (useful for global include roots)
-            std::filesystem::path fullPath = requested.is_absolute() ? requested : (baseDir / requested);
-            fullPath = fullPath.lexically_normal();
-
-            if ( !std::filesystem::exists( fullPath ) && !requested.is_absolute() ) {
-                std::filesystem::path fallback = (RootDir / requested).lexically_normal();
-                if ( std::filesystem::exists( fallback ) )
-                    fullPath = fallback;
-            }
-
-            std::ifstream file( fullPath, std::ios::binary );
-            if ( !file )
-                return HRESULT_FROM_WIN32( ERROR_FILE_NOT_FOUND );
-
-            file.seekg( 0, std::ios::end );
-            const std::streamoff size = file.tellg();
-            file.seekg( 0, std::ios::beg );
-
-            if ( size <= 0 )
-                return HRESULT_FROM_WIN32( ERROR_INVALID_DATA );
-
-            auto buffer = std::make_unique<uint8_t[]>( static_cast<size_t>(size) );
-            file.read( reinterpret_cast<char*>(buffer.get()), size );
-            if ( !file )
-                return HRESULT_FROM_WIN32( ERROR_READ_FAULT );
-
-            const void* dataPtr = buffer.get();
-            *ppData = dataPtr;
-            *pBytes = static_cast<UINT>(size);
-
-            // Track the directory of THIS include, so nested includes resolve against it.
-            ParentDirByData.emplace( dataPtr, fullPath.parent_path() );
-
-            OwnedBuffers.emplace_back( std::move( buffer ) );
-            return S_OK;
-        }
-
-        HRESULT __stdcall Close( LPCVOID pData ) override
-        {
-            if ( pData == nullptr )
-                return E_INVALIDARG;
-
-            ParentDirByData.erase( pData );
-
-            // Owned buffer lifetime is tied to this include handler; we can keep it until the compile ends.
-            // (D3DCompile will call Close, but we keep buffers to avoid pointer invalidation for ParentDirByData lookups.)
-            return S_OK;
-        }
-
-    private:
-        std::filesystem::path RootDir;
-
-        // key: pointer handed to compiler (ppData), value: directory of that include
-        std::unordered_map<const void*, std::filesystem::path> ParentDirByData;
-
-        // keep memory alive for duration of compilation
-        std::vector<std::unique_ptr<uint8_t[]>> OwnedBuffers;
-    };
-}
 
 const int NUM_MAX_BONES = 96;
 

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -515,6 +515,15 @@ XRESULT D3D11ShaderManager::Init() {
         Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_GodRayMask>( "CS_PFX_GodRayMask.hlsl" ));
 
         Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_GodRayZoom>( "CS_PFX_GodRayZoom.hlsl" ));
+
+        Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_DoF_FocusResolve>( "CS_PFX_DoF_FocusResolve.hlsl" ));
+
+        Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_DoF>( "CS_PFX_DoF.hlsl" ));
+
+        Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_DoF_Gauss>( "CS_PFX_DoF.hlsl" )
+            .with_macros( {{ "DOF_GAUSS_BLUR", "1" }} ) );
+
+        Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_DoF_Composite>( "CS_PFX_DoF_Composite.hlsl" ));
     }
 
     return XR_SUCCESS;

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -246,11 +246,10 @@ XRESULT D3D11ShaderManager::Init() {
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_GodRayMask>( "PS_PFX_GodRayMask.hlsl" ) );
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_GodRayZoom>( "PS_PFX_GodRayZoom.hlsl" ) );
 
-    // PostFX Composition uber shader — macros come from ConstructShaderMakroList()
+    // PostFX Composition uber shader
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_Composition>( "PS_PFX_Composition.hlsl" )
-        .with_macros( []( std::vector<D3D_SHADER_MACRO>& list ) {
+        .with_macros( [](std::vector<D3D_SHADER_MACRO>& list) {
             const auto& s = Engine::GAPI->GetRendererState().RendererSettings;
-
             list.push_back( { "COMPOSE_SAO", (s.AoMode == AOMode::AO_SAO) ? "1" : "0" } );
             list.push_back( { "COMPOSE_GODRAYS", s.EnableGodRays ? "1" : "0" } );
             list.push_back( { "COMPOSE_HEIGHTFOG", s.DrawFog ? "1" : "0" } );

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -336,6 +336,16 @@ XRESULT D3D11ShaderManager::Init() {
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_GodRayMask>( "PS_PFX_GodRayMask.hlsl" ) );
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_GodRayZoom>( "PS_PFX_GodRayZoom.hlsl" ) );
 
+    // PostFX Composition uber shader — macros come from ConstructShaderMakroList()
+    Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_Composition>( "PS_PFX_Composition.hlsl" )
+        .with_macros( []( std::vector<D3D_SHADER_MACRO>& list ) {
+            const auto& s = Engine::GAPI->GetRendererState().RendererSettings;
+
+            list.push_back( { "COMPOSE_SAO", (s.AoMode == AOMode::AO_SAO) ? "1" : "0" } );
+            list.push_back( { "COMPOSE_GODRAYS", s.EnableGodRays ? "1" : "0" } );
+            list.push_back( { "COMPOSE_HEIGHTFOG", s.DrawFog ? "1" : "0" } );
+        } ) );
+
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_Tonemap>( "PS_PFX_Tonemap.hlsl" )
         .with_category(ShaderCategory::Tonemapping)
         .with_macros( []( std::vector<D3D_SHADER_MACRO>& list ) {

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -511,6 +511,10 @@ XRESULT D3D11ShaderManager::Init() {
         }));
 
         Shaders.push_back( ShaderInfo::make<CShaderID::CS_TiledShading>( "CS_TiledShading.hlsl" ));
+
+        Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_GodRayMask>( "CS_PFX_GodRayMask.hlsl" ));
+
+        Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_GodRayZoom>( "CS_PFX_GodRayZoom.hlsl" ));
     }
 
     return XR_SUCCESS;

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1343,7 +1343,7 @@ void XM_CALLCONV D3D11ShadowMap::RenderShadowCube(
     Microsoft::WRL::ComPtr<ID3D11RenderTargetView> debugRTV, bool cullFront, bool indoor, bool noNPCs,
     std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache,
+    std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache,
     bool clearDepth,
     unsigned int casterMask ) {
 

--- a/D3D11Engine/D3D11ShadowMap.h
+++ b/D3D11Engine/D3D11ShadowMap.h
@@ -157,7 +157,7 @@ public:
         std::list<VobInfo*>* renderedVobs = nullptr, 
         std::list<SkeletalVobInfo*>* renderedMobs = nullptr,
         std::map<MeshKey,
-        WorldMeshInfo*,
+        MeshInfo*,
         cmpMeshKey>* worldMeshCache = nullptr,
         bool clearDepth = true,
         unsigned int casterMask = 0xFFFFFFFFu );

--- a/D3D11Engine/D3D11VShader.cpp
+++ b/D3D11Engine/D3D11VShader.cpp
@@ -144,6 +144,7 @@ XRESULT D3D11VShader::LoadShader( const ShaderInfo& si, const std::vector<D3D_SH
         { "INSTANCE_PREV_WORLD_MATRIX", 3, DXGI_FORMAT_R32G32B32A32_FLOAT, 1, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_INSTANCE_DATA, 1 },
         { "INSTANCE_COLOR", 0, DXGI_FORMAT_R8G8B8A8_UNORM, 1, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_INSTANCE_DATA, 1 },
         { "INSTANCE_WINDFLUENCE", 0, DXGI_FORMAT_R32G32_FLOAT, 1, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_INSTANCE_DATA, 1 },
+        { "INSTANCE_WIND_META_INDEX", 0, DXGI_FORMAT_R32_UINT, 1, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_INSTANCE_DATA, 1 },
     };
 
     const D3D11_INPUT_ELEMENT_DESC layout11[] =
@@ -279,11 +280,15 @@ XRESULT D3D11VShader::Apply() {
 }
 
 void D3D11VShader::BindResource(StringID name, ID3D11ShaderResourceView* srv) {
-    reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine)->GetContext()->VSSetShaderResources( GetInputIndex(name), 1, &srv );
+    const int inputIndex = GetInputIndex(name);
+    if (inputIndex != -1)
+        reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine)->GetContext()->VSSetShaderResources( inputIndex, 1, &srv );
 }
 
 void D3D11VShader::BindSampler(StringID name, ID3D11SamplerState* sampler) {
-    reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine)->GetContext()->VSSetSamplers( GetInputIndex(name), 1, &sampler );
+    const int inputIndex = GetInputIndex(name);
+    if (inputIndex != -1)
+        reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine)->GetContext()->VSSetSamplers( inputIndex, 1, &sampler );
 }
 
 void D3D11VShader::BindBuffer(StringID name, D3D11ConstantBuffer* buffer) {

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4887,6 +4887,13 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "HBAO", "SsaoBlurRadius", std::to_string( s.HbaoSettings.SsaoBlurRadius ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "HBAO", "SsaoStepCount", std::to_string( s.HbaoSettings.SsaoStepCount ).c_str(), ini.c_str() );
 
+    WritePrivateProfileStringA( "AO", "Mode", std::to_string( static_cast<int>(s.AoMode) ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "SAO", "Radius", std::to_string( s.SaoSettings.Radius ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "SAO", "Bias", std::to_string( s.SaoSettings.Bias ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "SAO", "Intensity", std::to_string( s.SaoSettings.Intensity ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "SAO", "NumSamples", std::to_string( s.SaoSettings.NumSamples ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "SAO", "BlurSharpness", std::to_string( s.SaoSettings.BlurSharpness ).c_str(), ini.c_str() );
+
     WritePrivateProfileStringA( "FontRendering", "Enable", std::to_string( s.EnableCustomFontRendering ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Debug", "UseShadowAtlas", std::to_string( s.DebugSettings.FeatureSet.UseShadowAtlas ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Debug", "ForceFeatureLevel10", std::to_string( s.DebugSettings.FeatureSet.ForceFeatureLevel10 ? TRUE : FALSE ).c_str(), ini.c_str() );
@@ -5015,6 +5022,17 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.HbaoSettings.EnableBlur = GetPrivateProfileBoolA( "HBAO", "EnableBlur", defaultHBAOSettings.EnableBlur, ini );
         s.HbaoSettings.SsaoBlurRadius = GetPrivateProfileIntA( "HBAO", "SsaoBlurRadius", defaultHBAOSettings.SsaoBlurRadius, ini.c_str() );
         s.HbaoSettings.SsaoStepCount = GetPrivateProfileIntA( "HBAO", "SsaoStepCount", defaultHBAOSettings.SsaoStepCount, ini.c_str() );
+
+        // Migrate legacy HBAO Enabled setting to AoMode
+        int defaultAoMode = static_cast<int>(s.HbaoSettings.Enabled ? AOMode::AO_HBAO : AOMode::AO_NONE);
+        s.AoMode = static_cast<AOMode>(GetPrivateProfileIntA( "AO", "Mode", defaultAoMode, ini.c_str() ));
+
+        SAOSettings defaultSAOSettings;
+        s.SaoSettings.Radius = GetPrivateProfileFloatA( "SAO", "Radius", defaultSAOSettings.Radius, ini );
+        s.SaoSettings.Bias = GetPrivateProfileFloatA( "SAO", "Bias", defaultSAOSettings.Bias, ini );
+        s.SaoSettings.Intensity = GetPrivateProfileFloatA( "SAO", "Intensity", defaultSAOSettings.Intensity, ini );
+        s.SaoSettings.NumSamples = GetPrivateProfileIntA( "SAO", "NumSamples", defaultSAOSettings.NumSamples, ini.c_str() );
+        s.SaoSettings.BlurSharpness = GetPrivateProfileFloatA( "SAO", "BlurSharpness", defaultSAOSettings.BlurSharpness, ini );
 
         s.EnableCustomFontRendering = GetPrivateProfileBoolA( "FontRendering", "Enable", defaultRendererSettings.EnableCustomFontRendering, ini );
         s.DebugSettings.FeatureSet.UseShadowAtlas = GetPrivateProfileBoolA( "Debug", "UseShadowAtlas", defaultRendererSettings.DebugSettings.FeatureSet.UseShadowAtlas, ini );

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -3437,7 +3437,7 @@ bool GothicAPI::TraceWorldMesh( const XMFLOAT3& origin, const XMFLOAT3& dir, XMF
 
     int numProcessed = 0;
     for ( auto const& bit : hitSections ) {
-        for ( std::map<MeshKey, WorldMeshInfo*>::iterator it = bit.first->WorldMeshes.begin(); it != bit.first->WorldMeshes.end(); ++it ) {
+        for ( std::map<MeshKey, MeshInfo*>::iterator it = bit.first->WorldMeshes.begin(); it != bit.first->WorldMeshes.end(); ++it ) {
             float u, v, t;
 
             for ( unsigned int i = 0; i < it->second->Indices.size(); i += 3 ) {
@@ -4592,7 +4592,7 @@ void GothicAPI::ApplySuppressedSectionTextures() {
         WorldMeshSectionInfo* section = it.first;
 
         // Look into each mesh of this section and find the texture
-        for ( std::map<MeshKey, WorldMeshInfo*>::iterator mit = section->WorldMeshes.begin(); mit != section->WorldMeshes.end(); mit++ ) {
+        for ( std::map<MeshKey, MeshInfo*>::iterator mit = section->WorldMeshes.begin(); mit != section->WorldMeshes.end(); mit++ ) {
             for ( unsigned int i = 0; i < it.second.size(); i++ ) {
                 // Is this the texture we are looking for?
                 if ( (*mit).first.Material && (*mit).first.Material->GetTexture() && (*mit).first.Material->GetTexture()->GetNameWithoutExt() == it.second[i] ) {

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -614,7 +614,7 @@ struct GothicRendererSettings {
 
         DrawSky = true;
         DrawFog = true;
-        FogRange = 1.0f;
+        FogRange = SWITCH_ENGINE(1.0f, 1.0f, 3.0f, 3.0f);
         EnableHDR = false;
         HDRToneMap = E_HDRToneMap::ToneMap_Simple;
         ReplaceSunDirection = false;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -5,6 +5,7 @@
 #include "pch.h"
 #include "BasicTimer.h"
 #include "BasePipelineStates.h"
+#include <ASSAO/ASSAO.h>
 
 /** Struct handling all the graphical states set by the game. Can be used as Constantbuffer */
 const int GSWITCH_FOG = 1;
@@ -512,6 +513,7 @@ enum class AOMode : int {
     AO_NONE = 0,
     AO_HBAO = 1,
     AO_SAO = 2,
+    AO_ASSAO = 3,
 };
 
 struct SAOSettings {
@@ -786,8 +788,46 @@ struct GothicRendererSettings {
         EnableWaterAnimation = false;
 
         GraphicsPreset = E_GraphicsPreset::GRAPHICS_CUSTOM;
+        ApplyAssaoPreset(1);
 
         ResetDebugSettings();
+    }
+
+    void ApplyAssaoPreset( int preset ) {
+        AssaoSettings = ASSAO_Settings();
+        // personal taste.
+        AssaoSettings.ShadowPower = 1.0f; // i feel defaults are too dark
+        AssaoSettings.HorizonAngleThreshold = 0.2f; // way too harsh shadowing otherwise
+
+        if ( preset <= 0 ) {
+            // default
+        } else if ( preset == 1 ) {
+            // higher quality but still default look
+            AssaoSettings.QualityLevel = 3;
+            AssaoSettings.AdaptiveQualityLimit = 0.6f;
+        } else if ( preset == 2 ) {
+            // Fake HBAO+ look, dark punchy shadowing
+            AssaoSettings.Radius = 1.0f;
+            AssaoSettings.ShadowMultiplier = 1.3f;
+            AssaoSettings.ShadowPower = 1.5f;
+            AssaoSettings.ShadowClamp = 1.0f;
+            AssaoSettings.HorizonAngleThreshold = 0.200f;
+            AssaoSettings.QualityLevel = 3;
+            AssaoSettings.AdaptiveQualityLimit = 0.6f;
+
+            AssaoSettings.BlurPassCount = 4;
+            AssaoSettings.Sharpness = 1.0f;
+            AssaoSettings.DetailShadowStrength = 0.5f;
+        } else if ( preset >= 3 ) {
+            // Fake GTAO look, broader radius, more details
+            AssaoSettings.Radius = 1.6f;
+            AssaoSettings.ShadowPower = 1.3f;
+            AssaoSettings.ShadowClamp = 0.95f;
+            AssaoSettings.HorizonAngleThreshold = 0.150f;
+            AssaoSettings.QualityLevel = 3;
+            AssaoSettings.AdaptiveQualityLimit = 0.6f;
+            AssaoSettings.DetailShadowStrength = 2.5f;
+        }
     }
     
     void ResetDebugSettings() {
@@ -928,6 +968,7 @@ struct GothicRendererSettings {
 
     HBAOSettings HbaoSettings;
     SAOSettings SaoSettings;
+    ASSAO_Settings AssaoSettings;
     AOMode AoMode;
 
     bool FixViewFrustum;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -508,6 +508,28 @@ struct HBAOSettings {
     int SsaoStepCount;
 };
 
+enum class AOMode : int {
+    AO_NONE = 0,
+    AO_HBAO = 1,
+    AO_SAO = 2,
+};
+
+struct SAOSettings {
+    SAOSettings() {
+        Radius = 1.5f;
+        Bias = 0.02f;
+        Intensity = 3.0f;
+        NumSamples = 16;
+        BlurSharpness = 1.0f;
+    }
+
+    float Radius;
+    float Bias;
+    float Intensity;
+    int NumSamples;
+    float BlurSharpness;
+};
+
 struct GothicRendererSettings {
     enum EPointLightShadowMode {
         PLS_DISABLED = 0,
@@ -725,6 +747,8 @@ struct GothicRendererSettings {
         DoFBokehRadius = 8.0f;
         DoFMaxBlur = 12.0f;
 
+        AoMode = AOMode::AO_HBAO;
+
         RECT desktopRect;
         GetClientRect( GetDesktopWindow(), &desktopRect );
 
@@ -903,6 +927,8 @@ struct GothicRendererSettings {
     float DoFMaxBlur;
 
     HBAOSettings HbaoSettings;
+    SAOSettings SaoSettings;
+    AOMode AoMode;
 
     bool FixViewFrustum;
 

--- a/D3D11Engine/ImGuiEditorView.cpp
+++ b/D3D11Engine/ImGuiEditorView.cpp
@@ -908,19 +908,6 @@ bool ImGuiEditorView::OnWindowMessage(HWND hWnd, unsigned int msg, WPARAM wParam
         }
         if (wParam == VK_DELETE) {
             OnDelete();
-        } else if (wParam == VK_SPACE) {
-            if (Selection.SelectedMesh) {
-                SmoothMesh((WorldMeshInfo*)Selection.SelectedMesh, true);
-
-                if (Selection.SelectedMaterial && Selection.SelectedMaterial->GetTexture()) {
-                    MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom(Selection.SelectedMaterial->GetTexture());
-
-                    if (info) {
-                        // Overwrite shader
-                        // info->TesselationShaderPair = "PNAEN_Tesselation";
-                    }
-                }
-            }
         }
         break;
 
@@ -1089,15 +1076,6 @@ GVegetationBox* ImGuiEditorView::TraceVegetationBoxes(const XMFLOAT3& wPos, cons
     }
 
     return b;
-}
-
-void ImGuiEditorView::SmoothMesh(WorldMeshInfo* mesh, bool tesselate) {
-    // Copy old vertices so we can directly write to the vectors again
-    std::vector<ExVertexStruct> vxOld = mesh->Vertices;
-    std::vector<unsigned short> ixOld = mesh->Indices;
-
-    // Mark dirty
-    mesh->SaveInfo = true;
 }
 
 XRESULT ImGuiEditorView::OnVobRemovedFromWorld(zCVob* vob) {

--- a/D3D11Engine/ImGuiEditorView.h
+++ b/D3D11Engine/ImGuiEditorView.h
@@ -8,7 +8,6 @@
 
 class GVegetationBox;
 struct MeshInfo;
-struct WorldMeshInfo;
 struct VobInfo;
 struct SkeletalVobInfo;
 class zCMaterial;
@@ -108,9 +107,6 @@ protected:
 
     /** Handles vegetation removing */
     void DoVegetationRemove();
-
-    /** Smoothes a mesh */
-    void SmoothMesh(WorldMeshInfo* mesh, bool tesselate = false);
 
     /** Called on VK_DELETE */
     void OnDelete();

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -434,7 +434,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.EnableDynamicLighting = false;
         s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_DISABLED;
 
-        s.HbaoSettings.Enabled = false;
+        s.AoMode = AOMode::AO_NONE;
 
         s.textureMaxSize = static_cast<int>(TX_QUALITY::Medium);
 
@@ -467,7 +467,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.EnableDynamicLighting = true;
         s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY;
 
-        s.HbaoSettings.Enabled = false;
+        s.AoMode = AOMode::AO_NONE;
 
         s.textureMaxSize = static_cast<int>(TX_QUALITY::Medium);
 
@@ -500,7 +500,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.EnableDynamicLighting = true;
         s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_UPDATE_DYNAMIC;
 
-        s.HbaoSettings.Enabled = true;
+        s.AoMode = AOMode::AO_HBAO;
         s.HbaoSettings.SsaoStepCount = 4;
         s.HbaoSettings.SsaoBlurRadius = 4;
 
@@ -535,7 +535,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.EnableDynamicLighting = true;
         s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_FULL;
 
-        s.HbaoSettings.Enabled = true;
+        s.AoMode = AOMode::AO_HBAO;
         s.HbaoSettings.SsaoStepCount = 8;
         s.HbaoSettings.SsaoBlurRadius = 4;
 
@@ -642,8 +642,15 @@ void ImGuiShim::RenderSettingsWindow()
                 Engine::GAPI->UpdateTextureMaxSize();
             }
 
-            ImGui::Checkbox( "HBAO+", &settings.HbaoSettings.Enabled );
-            ImGui::SetItemTooltip( "Enable Screen-Space ambient occlusion." );
+            static std::vector<std::pair<const char*, AOMode>> aoModes = {
+                {"Off", AOMode::AO_NONE},
+                {"HBAO+", AOMode::AO_HBAO},
+                {"SAO", AOMode::AO_SAO},
+            };
+            if ( ImComboBox( "Ambient Occlusion", aoModes, &settings.AoMode ) ) {
+                ImGui::EndCombo();
+            }
+            ImGui::SetItemTooltip( "Screen-Space ambient occlusion mode." );
 
             ImGui::Checkbox( "Godrays", &settings.EnableGodRays );
             ImGui::Checkbox( "Depth of Field", &settings.EnableDoF );
@@ -1497,33 +1504,51 @@ void RenderAdvancedColumn3( GothicRendererSettings& settings, GothicAPI* gapi ) 
 
 void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) {
     if ( ImGui::Begin( "Post Processing Effects", nullptr, ImGuiWindowFlags_NoCollapse ) ) {
-            ImGui::SeparatorText( "HBAO+ Settings" );
+            ImGui::SeparatorText( "Ambient Occlusion" );
             {
-                ImGui::PushID( "HBAOSettings" );
-                ImGui::Checkbox( "Enable HBAO+", &settings.HbaoSettings.Enabled );
-                ImGui::DragFloat( "Radius", &settings.HbaoSettings.Radius, 0.01f );
-                ImGui::DragFloat( "MetersToViewSpaceUnits", &settings.HbaoSettings.MetersToViewSpaceUnits, 0.01f );
-                if ( ImGui::DragFloat( "PowerExponent", &settings.HbaoSettings.PowerExponent, 0.01f ) ) {
-                    settings.HbaoSettings.PowerExponent = std::clamp( settings.HbaoSettings.PowerExponent, 1.0f, 4.0f );
-                }
-                if ( ImGui::DragFloat( "Bias", &settings.HbaoSettings.Bias, 0.01f ) ) {
-                    settings.HbaoSettings.Bias = std::clamp( settings.HbaoSettings.Bias, 0.0f, 0.5f );
-                }
-
-                ImGui::Checkbox( "Enable Blur", &settings.HbaoSettings.EnableBlur );
-                static std::vector<std::pair<const char*, int>> ssaoRadi = { {"2", 0}, {"4", 1} };
-                if ( ImComboBox( "SSAO radius", ssaoRadi, &settings.HbaoSettings.SsaoBlurRadius ) ) {
-                    ImGui::EndCombo();
-                }
-                ImGui::DragFloat( "BlurSharpness", &settings.HbaoSettings.BlurSharpness, 0.01f );
-                static std::vector<std::pair<const char*, int>> blendMode = { {"Replace", 0}, {"Multiply", 1} };
-                if ( ImComboBox( "BlendMode", blendMode, &settings.HbaoSettings.BlendMode ) ) {
+                ImGui::PushID( "AOSettings" );
+                static std::vector<std::pair<const char*, AOMode>> aoModes = {
+                    {"Disabled", AOMode::AO_NONE},
+                    {"HBAO+", AOMode::AO_HBAO},
+                    {"SAO", AOMode::AO_SAO},
+                };
+                if ( ImComboBox( "AO Mode", aoModes, &settings.AoMode ) ) {
                     ImGui::EndCombo();
                 }
 
-                static std::vector<std::pair<const char*, int>> stepCount = { {"4", 0}, {"8", 1} };
-                if ( ImComboBox( "SSAO steps", stepCount, &settings.HbaoSettings.SsaoStepCount ) ) {
-                    ImGui::EndCombo();
+                if ( settings.AoMode == AOMode::AO_HBAO ) {
+                    ImGui::SeparatorText( "HBAO+ Settings" );
+                    ImGui::DragFloat( "Radius", &settings.HbaoSettings.Radius, 0.01f );
+                    ImGui::DragFloat( "MetersToViewSpaceUnits", &settings.HbaoSettings.MetersToViewSpaceUnits, 0.01f );
+                    if ( ImGui::DragFloat( "PowerExponent", &settings.HbaoSettings.PowerExponent, 0.01f ) ) {
+                        settings.HbaoSettings.PowerExponent = std::clamp( settings.HbaoSettings.PowerExponent, 1.0f, 4.0f );
+                    }
+                    if ( ImGui::DragFloat( "Bias", &settings.HbaoSettings.Bias, 0.01f ) ) {
+                        settings.HbaoSettings.Bias = std::clamp( settings.HbaoSettings.Bias, 0.0f, 0.5f );
+                    }
+
+                    ImGui::Checkbox( "Enable Blur", &settings.HbaoSettings.EnableBlur );
+                    static std::vector<std::pair<const char*, int>> ssaoRadi = { {"2", 0}, {"4", 1} };
+                    if ( ImComboBox( "SSAO radius", ssaoRadi, &settings.HbaoSettings.SsaoBlurRadius ) ) {
+                        ImGui::EndCombo();
+                    }
+                    ImGui::DragFloat( "BlurSharpness", &settings.HbaoSettings.BlurSharpness, 0.01f );
+                    static std::vector<std::pair<const char*, int>> blendMode = { {"Replace", 0}, {"Multiply", 1} };
+                    if ( ImComboBox( "BlendMode", blendMode, &settings.HbaoSettings.BlendMode ) ) {
+                        ImGui::EndCombo();
+                    }
+
+                    static std::vector<std::pair<const char*, int>> stepCount = { {"4", 0}, {"8", 1} };
+                    if ( ImComboBox( "SSAO steps", stepCount, &settings.HbaoSettings.SsaoStepCount ) ) {
+                        ImGui::EndCombo();
+                    }
+                } else if ( settings.AoMode == AOMode::AO_SAO ) {
+                    ImGui::SeparatorText( "SAO Settings" );
+                    ImGui::DragFloat( "Radius", &settings.SaoSettings.Radius, 0.01f, 0.1f, 10.0f );
+                    ImGui::DragFloat( "Bias", &settings.SaoSettings.Bias, 0.001f, 0.0f, 0.1f );
+                    ImGui::DragFloat( "Intensity", &settings.SaoSettings.Intensity, 0.01f, 0.0f, 10.0f );
+                    ImGui::SliderInt( "Samples", &settings.SaoSettings.NumSamples, 4, 64 );
+                    ImGui::DragFloat( "Blur Sharpness", &settings.SaoSettings.BlurSharpness, 0.01f, 0.0f, 16.0f );
                 }
                 ImGui::PopID();
             }

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -422,6 +422,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
     {
         s.ChangeWindowPreset = WINDOW_MODE_FULLSCREEN_BORDERLESS;
 
+        s.CompressBackBuffer = true;
         s.WorldShadowRangeScale = 1.0f;
         s.NumShadowCascades = 2;
         s.ShadowMapSize = 1024;
@@ -455,6 +456,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
     {
         s.ChangeWindowPreset = WINDOW_MODE_FULLSCREEN_BORDERLESS;
 
+        s.CompressBackBuffer = true;
         s.WorldShadowRangeScale = 1.0f;
         s.NumShadowCascades = 3;
         s.ShadowMapSize = 2048;
@@ -488,6 +490,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
     {
         s.ChangeWindowPreset = WINDOW_MODE_FULLSCREEN_BORDERLESS;
 
+        s.CompressBackBuffer = false;
         s.WorldShadowRangeScale = 1.0f;
         s.NumShadowCascades = 3;
         s.ShadowMapSize = 4096;
@@ -523,6 +526,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
     {
         s.ChangeWindowPreset = WINDOW_MODE_FULLSCREEN_BORDERLESS;
 
+        s.CompressBackBuffer = false;
         s.WorldShadowRangeScale = 1.0f;
         s.NumShadowCascades = 4;
         s.ShadowMapSize = 4096;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -642,14 +642,15 @@ void ImGuiShim::RenderSettingsWindow()
                 Engine::GAPI->UpdateTextureMaxSize();
             }
 
-            static std::vector<std::pair<const char*, AOMode>> aoModes = {
-                {"Off", AOMode::AO_NONE},
-                {"HBAO+", AOMode::AO_HBAO},
-                {"SAO", AOMode::AO_SAO},
+            static std::vector<std::tuple<const char*, AOMode, const char*>> aoModes = {
+                    {"Disabled", AOMode::AO_NONE, nullptr},
+                    {"HBAO+", AOMode::AO_HBAO, "NVIDIA HBAO+ (Horizon-Based Ambient Occlusion Plus)"},
+                    {"SAO", AOMode::AO_SAO, nullptr},
+                    {"ASSAO", AOMode::AO_ASSAO, "Intel ASSAO (Adaptive Screen Space Ambient Occlusion)"},
             };
-            if ( ImComboBoxC( "Ambient Occlusion", aoModes, &settings.AoMode , [] {
-                    Engine::GraphicsEngine->ReloadShaders( ShaderCategory::Other );
-                } )) {
+            if ( ImComboBoxCT( "AO Mode", aoModes, &settings.AoMode, [] {
+                Engine::GraphicsEngine->ReloadShaders( ShaderCategory::Other );
+                } ) ) {
                 ImGui::EndCombo();
             }
             ImGui::SetItemTooltip( "Screen-Space ambient occlusion mode.\nChanging this will reload shaders." );
@@ -1524,12 +1525,13 @@ void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) 
             ImGui::SeparatorText( "Ambient Occlusion" );
             {
                 ImGui::PushID( "AOSettings" );
-                static std::vector<std::pair<const char*, AOMode>> aoModes = {
-                    {"Disabled", AOMode::AO_NONE},
-                    {"HBAO+", AOMode::AO_HBAO},
-                    {"SAO", AOMode::AO_SAO},
+                static std::vector<std::tuple<const char*, AOMode, const char*>> aoModes = {
+                    {"Disabled", AOMode::AO_NONE, nullptr},
+                    {"HBAO+", AOMode::AO_HBAO, "NVIDIA HBAO+ (Horizon-Based Ambient Occlusion Plus)"},
+                    {"SAO", AOMode::AO_SAO, nullptr},
+                    {"ASSAO", AOMode::AO_ASSAO, "Intel ASSAO (Adaptive Screen Space Ambient Occlusion)"},
                 };
-                if ( ImComboBoxC( "AO Mode", aoModes, &settings.AoMode, [] {
+                if ( ImComboBoxCT( "AO Mode", aoModes, &settings.AoMode, [] {
                         Engine::GraphicsEngine->ReloadShaders( ShaderCategory::Other );
                     } ) ) {
                     ImGui::EndCombo();
@@ -1569,6 +1571,61 @@ void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) 
                     ImGui::DragFloat( "Intensity", &settings.SaoSettings.Intensity, 0.01f, 0.0f, 10.0f );
                     ImGui::SliderInt( "Samples", &settings.SaoSettings.NumSamples, 4, 64 );
                     ImGui::DragFloat( "Blur Sharpness", &settings.SaoSettings.BlurSharpness, 0.01f, 0.0f, 16.0f );
+                } else if ( settings.AoMode == AOMode::AO_ASSAO ) {
+                    ImGui::SeparatorText( "ASSAO Settings" );
+
+                    ImGui::TextUnformatted( "Preset" ); ImGui::SameLine();
+                    if ( ImGui::Button( "Low" ) ) {
+                        settings.ApplyAssaoPreset(0);
+                    }
+                    ImGui::SameLine();
+                    if ( ImGui::Button( "High" ) ) {
+                        settings.ApplyAssaoPreset( 1 );
+                    }
+                    ImGui::SameLine();
+
+                    if ( ImGui::Button( "Dark" ) ) {
+                        settings.ApplyAssaoPreset( 2 );
+                    }
+                    ImGui::SetItemTooltip( "Mimics HBAO+" );
+                    ImGui::SameLine();
+
+                    if ( ImGui::Button( "Soft" ) ) {
+                        settings.ApplyAssaoPreset( 3 );
+                    }
+                    ImGui::SetItemTooltip("Mimics GTAO");
+
+                    ImGui::DragFloat( "Radius", &settings.AssaoSettings.Radius, 0.01f, 0.0f, 0.0f, "%.2f" );
+                    ImGui::SetItemTooltip( "[0.0, ~] World (view) space size of the occlusion sphere." );
+                    ImGui::DragFloat( "Shadow Multiplier", &settings.AssaoSettings.ShadowMultiplier, 0.01f, 0.0f, 5.0f, "%.2f", ImGuiSliderFlags_ClampOnInput );
+                    ImGui::SetItemTooltip( "[0.0, 5.0] Effect strength linear multiplier." );
+                    ImGui::DragFloat( "Shadow Power", &settings.AssaoSettings.ShadowPower, 0.01f, 0.5f, 5.0f, "%.2f", ImGuiSliderFlags_ClampOnInput );
+                    ImGui::SetItemTooltip( "[0.5, 5.0] Effect strength pow modifier." );
+                    ImGui::DragFloat( "Shadow Clamp", &settings.AssaoSettings.ShadowClamp, 0.01f, 0.0f, 1.0f, "%.2f", ImGuiSliderFlags_ClampOnInput );
+                    ImGui::SetItemTooltip( "[0.0, 1.0] Effect max limit." );
+                    ImGui::DragFloat( "Horizon Angle Threshold", &settings.AssaoSettings.HorizonAngleThreshold, 0.001f, 0.0f, 0.2f, "%.3f", ImGuiSliderFlags_ClampOnInput );
+                    ImGui::SetItemTooltip( "[0.0, 0.2] Limits self-shadowing." );
+                    ImGui::DragFloat( "Fade Out From", &settings.AssaoSettings.FadeOutFrom, 1.0f, 0.0f, 0.0f, "%.0f" );
+                    ImGui::SetItemTooltip( "[0.0, ~] Distance to start fading out the effect." );
+                    ImGui::DragFloat( "Fade Out To", &settings.AssaoSettings.FadeOutTo, 1.0f, 0.0f, 0.0f, "%.0f" );
+                    ImGui::SetItemTooltip( "[0.0, ~] Distance at which the effect is fully faded out." );
+                    static std::vector<std::pair<const char*, int>> assaoQuality = {
+                        {"Lowest (-1)", -1}, {"Low (0)", 0}, {"Medium (1)", 1}, {"High (2)", 2}, {"Very High/Adaptive (3)", 3}
+                    };
+                    if ( ImComboBox( "Quality Level", assaoQuality, &settings.AssaoSettings.QualityLevel ) ) {
+                        ImGui::EndCombo();
+                    }
+                    ImGui::SetItemTooltip( "[-1, 3] Effect quality. Each level is ~2x more costly than the previous." );
+                    ImGui::BeginDisabled( settings.AssaoSettings.QualityLevel != 3 );
+                    ImGui::DragFloat( "Adaptive Quality Limit", &settings.AssaoSettings.AdaptiveQualityLimit, 0.01f, 0.0f, 1.0f, "%.2f", ImGuiSliderFlags_ClampOnInput );
+                    ImGui::SetItemTooltip( "[0.0, 1.0] Only for Quality Level 3." );
+                    ImGui::EndDisabled();
+                    ImGui::SliderInt( "Blur Pass Count", &settings.AssaoSettings.BlurPassCount, 0, 6 );
+                    ImGui::SetItemTooltip( "[0, 6] Number of edge-sensitive smart blur passes." );
+                    ImGui::DragFloat( "Sharpness", &settings.AssaoSettings.Sharpness, 0.01f, 0.0f, 1.0f, "%.2f", ImGuiSliderFlags_ClampOnInput );
+                    ImGui::SetItemTooltip( "[0.0, 1.0] How much to bleed over edges." );
+                    ImGui::DragFloat( "Detail Shadow Strength", &settings.AssaoSettings.DetailShadowStrength, 0.01f, 0.0f, 5.0f, "%.2f", ImGuiSliderFlags_ClampOnInput );
+                    ImGui::SetItemTooltip( "[0.0, 5.0] High-res detail AO; adds detail but reduces temporal stability." );
                 }
                 ImGui::PopID();
             }

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -647,12 +647,18 @@ void ImGuiShim::RenderSettingsWindow()
                 {"HBAO+", AOMode::AO_HBAO},
                 {"SAO", AOMode::AO_SAO},
             };
-            if ( ImComboBox( "Ambient Occlusion", aoModes, &settings.AoMode ) ) {
+            if ( ImComboBoxC( "Ambient Occlusion", aoModes, &settings.AoMode , [] {
+                    Engine::GraphicsEngine->ReloadShaders( ShaderCategory::Other );
+                } )) {
                 ImGui::EndCombo();
             }
-            ImGui::SetItemTooltip( "Screen-Space ambient occlusion mode." );
+            ImGui::SetItemTooltip( "Screen-Space ambient occlusion mode.\nChanging this will reload shaders." );
 
-            ImGui::Checkbox( "Godrays", &settings.EnableGodRays );
+            if ( ImGui::Checkbox( "Godrays", &settings.EnableGodRays ) ) {
+                Engine::GraphicsEngine->ReloadShaders( ShaderCategory::Other );
+            }
+            ImGui::SetItemTooltip( "Changing this will reload shaders." );
+
             ImGui::Checkbox( "Depth of Field", &settings.EnableDoF );
             ImGui::SetItemTooltip( "Enable Depth of Field with bokeh blur." );
             static std::vector<std::tuple<const char*, GothicRendererSettings::E_AntiAliasingMode, const char*>> antiAliasing = {
@@ -1015,7 +1021,10 @@ void RenderAdvancedColumn1( GothicRendererSettings& settings, GothicAPI* gapi ) 
         ImGui::SeparatorText( "GodRays" );
         {
             ImGui::PushID( "GodRaysSettings" );
-            ImGui::Checkbox( "GodRays", &settings.EnableGodRays );
+            if ( ImGui::Checkbox( "GodRays", &settings.EnableGodRays ) ) {
+                Engine::GraphicsEngine->ReloadShaders( ShaderCategory::Other );
+            }
+            ImGui::SetItemTooltip( "Changing this will reload shaders." );
             ImGui::DragFloat( "GodRayDecay", &settings.GodRayDecay, 0.01f );
             ImGui::DragFloat( "GodRayWeight", &settings.GodRayWeight, 0.01f );
             ImGui::ColorEdit3( "GodRayColorMod", &settings.GodRayColorMod.x );
@@ -1138,7 +1147,11 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         ImGui::EndDisabled();
 
         // ImGui::Checkbox( "Draw Sky", &settings.DrawSky );
-        ImGui::Checkbox( "Draw Fog", &settings.DrawFog );
+        if ( ImGui::Checkbox( "Draw Fog", &settings.DrawFog ) ) {
+            Engine::GraphicsEngine->ReloadShaders( ShaderCategory::Other );
+        }
+        ImGui::SetItemTooltip( "Changing this will reload shaders." );
+
         ImGui::BeginDisabled( !settings.DrawFog );
         {
             // caution, FogRange is reduced by 0.5f (secScale - 0.5f) in D3D11PFX_HeightFog
@@ -1223,6 +1236,8 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
             if ( ImComboBoxC( "ShadowmapSize", shadowMapSizes, (int*)(&settings.ShadowMapSize), []() { Engine::GraphicsEngine->ReloadShaders( ShaderCategory::LightsAndShadows ); } ) ) {
                 ImGui::EndCombo();
             }
+            ImGui::SetItemTooltip( "Changing this will reload shaders." );
+
             ImGui::DragFloat( "Shadow Distance", &settings.WorldShadowRangeScale, 0.01f, 0.00f, 10.0f, "%.2f" );
             ImGui::SetItemTooltip( "Larger values produce less detailed shadows\nEffective Distance: %.0f", 12000 * settings.WorldShadowRangeScale );
 
@@ -1240,6 +1255,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 ApplyFeatureLevel10Downgrades(settings);
                 Engine::GraphicsEngine->ReloadShaders( ShaderCategory::LightsAndShadows );
             }
+            ImGui::SetItemTooltip( "Changing this will reload shaders." );
 
             ImGui::BeginDisabled( settings.NumShadowCascades <= 1 );
             {
@@ -1266,13 +1282,14 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                     } ) ) {
                     ImGui::EndCombo();
                 }
+                ImGui::SetItemTooltip( "Changing this will reload shaders." );
             }
             settings.ShadowCascadePCFLimit = std::clamp( settings.ShadowCascadePCFLimit, 1, settings.NumShadowCascades );
             if ( ImGui::SliderInt( "Soft shadow limit", &settings.ShadowCascadePCFLimit, 1, settings.NumShadowCascades, "%d", ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput ) ) {
                 settings.ShadowCascadePCFLimit = std::clamp( settings.ShadowCascadePCFLimit, 1, settings.NumShadowCascades );
                 Engine::GraphicsEngine->ReloadShaders( ShaderCategory::LightsAndShadows );
             }
-            ImGui::SetItemTooltip( "Which shadow cascades should be filtered using '16xPCF'" );
+            ImGui::SetItemTooltip( "Which shadow cascades should be filtered using '16xPCF'.\nChanging this will reload shaders." );
             
             ImGui::DragFloat( "ShadowStrength", &settings.ShadowStrength, 0.01f, 0.01f, 5.0f, "%.2f" );
             ImGui::DragFloat( "ShadowSoftness", &settings.ShadowSoftness, 0.05f, 0.2f, 8.0f, "%.2f" );
@@ -1512,9 +1529,12 @@ void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) 
                     {"HBAO+", AOMode::AO_HBAO},
                     {"SAO", AOMode::AO_SAO},
                 };
-                if ( ImComboBox( "AO Mode", aoModes, &settings.AoMode ) ) {
+                if ( ImComboBoxC( "AO Mode", aoModes, &settings.AoMode, [] {
+                        Engine::GraphicsEngine->ReloadShaders( ShaderCategory::Other );
+                    } ) ) {
                     ImGui::EndCombo();
                 }
+                ImGui::SetItemTooltip( "Changing this will reload shaders." );
 
                 if ( settings.AoMode == AOMode::AO_HBAO ) {
                     ImGui::SeparatorText( "HBAO+ Settings" );

--- a/D3D11Engine/ShaderIDs.h
+++ b/D3D11Engine/ShaderIDs.h
@@ -95,6 +95,7 @@ enum class PShaderID : size_t {
     PS_PFX_CAS,
     PS_PFX_FSR1_EASU,
     PS_PFX_FSR1_RCAS,
+    PS_PFX_Composition,
     COUNT
 };
 

--- a/D3D11Engine/ShaderIDs.h
+++ b/D3D11Engine/ShaderIDs.h
@@ -112,5 +112,7 @@ enum class CShaderID : size_t {
     CS_AdvanceRain,
     CS_LightCulling,
     CS_TiledShading,
+    CS_PFX_GodRayMask,
+    CS_PFX_GodRayZoom,
     COUNT
 };

--- a/D3D11Engine/ShaderIDs.h
+++ b/D3D11Engine/ShaderIDs.h
@@ -114,5 +114,9 @@ enum class CShaderID : size_t {
     CS_TiledShading,
     CS_PFX_GodRayMask,
     CS_PFX_GodRayZoom,
+    CS_PFX_DoF_FocusResolve,
+    CS_PFX_DoF,
+    CS_PFX_DoF_Gauss,
+    CS_PFX_DoF_Composite,
     COUNT
 };

--- a/D3D11Engine/ShaderIDs.h
+++ b/D3D11Engine/ShaderIDs.h
@@ -48,6 +48,7 @@ enum class PShaderID : size_t {
     PS_PFX_ApplyParticleDistortion,
     PS_Grass,
     PS_PFX_Simple,
+    PS_PFX_Simple_R8,
     PS_PFX_VelocityDebug,
     PS_PFX_GaussBlur,
     PS_PFX_Heightfog,
@@ -118,5 +119,7 @@ enum class CShaderID : size_t {
     CS_PFX_DoF,
     CS_PFX_DoF_Gauss,
     CS_PFX_DoF_Composite,
+    CS_PFX_SAO,
+    CS_PFX_SAO_Blur,
     COUNT
 };

--- a/D3D11Engine/Shaders/ASSAO/ASSAO.hlsl
+++ b/D3D11Engine/Shaders/ASSAO/ASSAO.hlsl
@@ -1,0 +1,1202 @@
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2016, Intel Corporation
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of 
+// the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+// SOFTWARE.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// File changes (yyyy-mm-dd)
+// 2016-09-07: filip.strugar@intel.com: first commit
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+// Octahedral encoding: map a unit normal to [-1,1]^2 for R16G16_SNORM storage
+// Reference: "A Survey of Efficient Representations for Independent Unit Vectors" (Cigolle et al. 2014)
+float2 OctWrap(float2 v)
+{
+    return (1.0 - abs(v.yx)) * (v.xy >= 0.0 ? 1.0 : -1.0);
+}
+
+// Decode octahedral [-1,1]^2 back to a unit normal
+float3 DecodeNormalGBuffer(float2 encoded)
+{
+    float3 n;
+    n.z = 1.0 - abs(encoded.x) - abs(encoded.y);
+    n.xy = n.z >= 0.0 ? encoded.xy : OctWrap(encoded.xy);
+    return normalize(n);
+}
+
+
+// progressive poisson-like pattern; x, y are in [-1, 1] range, .z is length( float2(x,y) ), .w is log2( z )
+#define INTELSSAO_MAIN_DISK_SAMPLE_COUNT (32)
+static const float4 g_samplePatternMain[INTELSSAO_MAIN_DISK_SAMPLE_COUNT] =
+{
+     0.78488064,  0.56661671,  1.500000, -0.126083,     0.26022232, -0.29575172,  1.500000, -1.064030,     0.10459357,  0.08372527,  1.110000, -2.730563,    -0.68286800,  0.04963045,  1.090000, -0.498827,
+    -0.13570161, -0.64190155,  1.250000, -0.532765,    -0.26193795, -0.08205118,  0.670000, -1.783245,    -0.61177456,  0.66664219,  0.710000, -0.044234,     0.43675563,  0.25119025,  0.610000, -1.167283,
+     0.07884444,  0.86618668,  0.640000, -0.459002,    -0.12790935, -0.29869005,  0.600000, -1.729424,    -0.04031125,  0.02413622,  0.600000, -4.792042,     0.16201244, -0.52851415,  0.790000, -1.067055,
+    -0.70991218,  0.47301072,  0.640000, -0.335236,     0.03277707, -0.22349690,  0.600000, -1.982384,     0.68921727,  0.36800742,  0.630000, -0.266718,     0.29251814,  0.37775412,  0.610000, -1.422520,
+    -0.12224089,  0.96582592,  0.600000, -0.426142,     0.11071457, -0.16131058,  0.600000, -2.165947,     0.46562141, -0.59747696,  0.600000, -0.189760,    -0.51548797,  0.11804193,  0.600000, -1.246800,
+     0.89141309, -0.42090443,  0.600000,  0.028192,    -0.32402530, -0.01591529,  0.600000, -1.543018,     0.60771245,  0.41635221,  0.600000, -0.605411,     0.02379565, -0.08239821,  0.600000, -3.809046,
+     0.48951152, -0.23657045,  0.600000, -1.189011,    -0.17611565, -0.81696892,  0.600000, -0.513724,    -0.33930185, -0.20732205,  0.600000, -1.698047,    -0.91974425,  0.05403209,  0.600000,  0.062246,
+    -0.15064627, -0.14949332,  0.600000, -1.896062,     0.53180975, -0.35210401,  0.600000, -0.758838,     0.41487166,  0.81442589,  0.600000, -0.505648,    -0.24106961, -0.32721516,  0.600000, -1.665244
+};
+
+// these values can be changed (up to SSAO_MAX_TAPS) with no changes required elsewhere; values for 4th and 5th preset are ignored but array needed to avoid compilation errors
+// the actual number of texture samples is two times this value (each "tap" has two symmetrical depth texture samples)
+static const uint g_numTaps[5]   = { 3, 5, 12, 0, 0 };
+
+// an example of higher quality low/medium/high settings
+// static const uint g_numTaps[5]   = { 4, 9, 16, 0, 0 };
+
+// ** WARNING ** if changing anything here, please remember to update the corresponding C++ code!
+struct ASSAOConstants
+{
+    float2                  ViewportPixelSize;                      // .zw == 1.0 / ViewportSize.xy
+    float2                  HalfViewportPixelSize;                  // .zw == 1.0 / ViewportHalfSize.xy
+
+    float2                  DepthUnpackConsts;
+    float2                  CameraTanHalfFOV;
+
+    float2                  NDCToViewMul;
+    float2                  NDCToViewAdd;
+
+    int2                    PerPassFullResCoordOffset;
+    float2                  PerPassFullResUVOffset;
+
+    float2                  Viewport2xPixelSize;
+    float2                  Viewport2xPixelSize_x_025;              // Viewport2xPixelSize * 0.25 (for fusing add+mul into mad)
+
+    float                   EffectRadius;                           // world (viewspace) maximum size of the shadow
+    float                   EffectShadowStrength;                   // global strength of the effect (0 - 5)
+    float                   EffectShadowPow;
+    float                   EffectShadowClamp;
+
+    float                   EffectFadeOutMul;                       // effect fade out from distance (ex. 25)
+    float                   EffectFadeOutAdd;                       // effect fade out to distance   (ex. 100)
+    float                   EffectHorizonAngleThreshold;            // limit errors on slopes and caused by insufficient geometry tessellation (0.05 to 0.5)
+    float                   EffectSamplingRadiusNearLimitRec;          // if viewspace pixel closer than this, don't enlarge shadow sampling radius anymore (makes no sense to grow beyond some distance, not enough samples to cover everything, so just limit the shadow growth; could be SSAOSettingsFadeOutFrom * 0.1 or less)
+
+    float                   DepthPrecisionOffsetMod;
+    float                   NegRecEffectRadius;                     // -1.0 / EffectRadius
+    float                   LoadCounterAvgDiv;                      // 1.0 / ( halfDepthMip[SSAO_DEPTH_MIP_LEVELS-1].sizeX * halfDepthMip[SSAO_DEPTH_MIP_LEVELS-1].sizeY )
+    float                   AdaptiveSampleCountLimit;
+
+    float                   InvSharpness;
+    int                     PassIndex;
+    float2                  QuarterResPixelSize;                    // used for importance map only
+
+    float4                  PatternRotScaleMatrices[5];
+
+    float                   NormalsUnpackMul;
+    float                   NormalsUnpackAdd;
+    float                   DetailAOStrength;
+    float                   Dummy0;
+
+#if SSAO_ENABLE_NORMAL_WORLD_TO_VIEW_CONVERSION
+    float4x4                NormalsWorldToViewspaceMatrix;
+#endif
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Optional parts that can be enabled for a required quality preset level and above (0 == Low, 1 == Medium, 2 == High, 3 == Highest/Adaptive, 4 == reference/unused )
+// Each has its own cost. To disable just set to 5 or above.
+//
+// (experimental) tilts the disk (although only half of the samples!) towards surface normal; this helps with effect uniformity between objects but reduces effect distance and has other side-effects
+#define SSAO_TILT_SAMPLES_ENABLE_AT_QUALITY_PRESET                      (99)        // to disable simply set to 99 or similar
+#define SSAO_TILT_SAMPLES_AMOUNT                                        (0.4)
+//
+#define SSAO_HALOING_REDUCTION_ENABLE_AT_QUALITY_PRESET                 (1)         // to disable simply set to 99 or similar
+#define SSAO_HALOING_REDUCTION_AMOUNT                                   (0.6)       // values from 0.0 - 1.0, 1.0 means max weighting (will cause artifacts, 0.8 is more reasonable)
+//
+#define SSAO_NORMAL_BASED_EDGES_ENABLE_AT_QUALITY_PRESET                (2)         // to disable simply set to 99 or similar
+#define SSAO_NORMAL_BASED_EDGES_DOT_THRESHOLD                           (0.5)       // use 0-0.1 for super-sharp normal-based edges
+//
+#define SSAO_DETAIL_AO_ENABLE_AT_QUALITY_PRESET                         (1)         // whether to use DetailAOStrength; to disable simply set to 99 or similar
+//
+#define SSAO_DEPTH_MIPS_ENABLE_AT_QUALITY_PRESET                        (2)         // !!warning!! the MIP generation on the C++ side will be enabled on quality preset 2 regardless of this value, so if changing here, change the C++ side too
+#define SSAO_DEPTH_MIPS_GLOBAL_OFFSET                                   (-4.3)      // best noise/quality/performance tradeoff, found empirically
+//
+// !!warning!! the edge handling is hard-coded to 'disabled' on quality level 0, and enabled above, on the C++ side; while toggling it here will work for 
+// testing purposes, it will not yield performance gains (or correct results)
+#define SSAO_DEPTH_BASED_EDGES_ENABLE_AT_QUALITY_PRESET                 (1)     
+//
+#define SSAO_REDUCE_RADIUS_NEAR_SCREEN_BORDER_ENABLE_AT_QUALITY_PRESET  (99)        // 99 means disabled; only helpful if artifacts at the edges caused by lack of out of screen depth data are not acceptable with the depth sampler in either clamp or mirror modes
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+cbuffer SSAOConstantsBuffer                     : register( b0 )    // corresponds to SSAO_CONSTANTS_BUFFERSLOT
+{
+    ASSAOConstants                    g_ASSAOConsts;
+}
+
+SamplerState        g_PointClampSampler         : register( s0 );   // corresponds to SSAO_SAMPLERS_SLOT0
+SamplerState        g_LinearClampSampler        : register( s1 );   // corresponds to SSAO_SAMPLERS_SLOT1
+SamplerState        g_PointMirrorSampler        : register( s2 );   // corresponds to SSAO_SAMPLERS_SLOT2
+SamplerState        g_ViewspaceDepthTapSampler  : register( s3 );   // corresponds to SSAO_SAMPLERS_SLOT3
+
+Texture2D<float>    g_DepthSource               : register( t0 );   // corresponds to SSAO_TEXTURE_SLOT0
+Texture2D           g_NormalmapSource           : register( t1 );   // corresponds to SSAO_TEXTURE_SLOT1
+
+Texture2D<float>    g_ViewspaceDepthSource      : register( t0 );   // corresponds to SSAO_TEXTURE_SLOT0
+Texture2D<float>    g_ViewspaceDepthSource1     : register( t1 );   // corresponds to SSAO_TEXTURE_SLOT1
+Texture2D<float>    g_ViewspaceDepthSource2     : register( t2 );   // corresponds to SSAO_TEXTURE_SLOT2
+Texture2D<float>    g_ViewspaceDepthSource3     : register( t3 );   // corresponds to SSAO_TEXTURE_SLOT3
+
+Texture2D<float>    g_ImportanceMap             : register( t3 );   // corresponds to SSAO_TEXTURE_SLOT3
+
+Texture1D<uint>     g_LoadCounter               : register( t2 );   // corresponds to SSAO_TEXTURE_SLOT2
+
+Texture2D           g_BlurInput                 : register( t2 );   // corresponds to SSAO_TEXTURE_SLOT2
+
+Texture2DArray      g_FinalSSAO                 : register( t4 );   // corresponds to SSAO_TEXTURE_SLOT4
+
+RWTexture2D<unorm float4> g_NormalsOutputUAV    : register( u4 );   // corresponds to SSAO_NORMALMAP_OUT_UAV_SLOT
+RWTexture1D<uint>   g_LoadCounterOutputUAV      : register( u4 );   // corresponds to SSAO_LOAD_COUNTER_UAV_SLOT 
+
+
+// packing/unpacking for edges; 2 bits per edge mean 4 gradient values (0, 0.33, 0.66, 1) for smoother transitions!
+float PackEdges( float4 edgesLRTB )
+{
+//    int4 edgesLRTBi = int4( saturate( edgesLRTB ) * 3.0 + 0.5 );
+//    return ( (edgesLRTBi.x << 6) + (edgesLRTBi.y << 4) + (edgesLRTBi.z << 2) + (edgesLRTBi.w << 0) ) / 255.0;
+
+    // optimized, should be same as above
+    edgesLRTB = round( saturate( edgesLRTB ) * 3.05 );
+    return dot( edgesLRTB, float4( 64.0 / 255.0, 16.0 / 255.0, 4.0 / 255.0, 1.0 / 255.0 ) ) ;
+}
+
+float4 UnpackEdges( float _packedVal )
+{
+    uint packedVal = (uint)(_packedVal * 255.5);
+    float4 edgesLRTB;
+    edgesLRTB.x = float((packedVal >> 6) & 0x03) / 3.0;          // there's really no need for mask (as it's an 8 bit input) but I'll leave it in so it doesn't cause any trouble in the future
+    edgesLRTB.y = float((packedVal >> 4) & 0x03) / 3.0;
+    edgesLRTB.z = float((packedVal >> 2) & 0x03) / 3.0;
+    edgesLRTB.w = float((packedVal >> 0) & 0x03) / 3.0;
+
+    return saturate( edgesLRTB + g_ASSAOConsts.InvSharpness );
+}
+
+float ScreenSpaceToViewSpaceDepth( float screenDepth )
+{
+    float depthLinearizeMul = g_ASSAOConsts.DepthUnpackConsts.x;
+    float depthLinearizeAdd = g_ASSAOConsts.DepthUnpackConsts.y;
+
+    // Optimised version of "-cameraClipNear / (cameraClipFar - projDepth * (cameraClipFar - cameraClipNear)) * cameraClipFar"
+
+    // Set your depthLinearizeMul and depthLinearizeAdd to:
+    // depthLinearizeMul = ( cameraClipFar * cameraClipNear) / ( cameraClipFar - cameraClipNear );
+    // depthLinearizeAdd = cameraClipFar / ( cameraClipFar - cameraClipNear );
+
+    return depthLinearizeMul / ( depthLinearizeAdd - screenDepth );
+}
+
+// from [0, width], [0, height] to [-1, 1], [-1, 1]
+float2 ScreenSpaceToClipSpacePositionXY( float2 screenPos )
+{
+    return screenPos * g_ASSAOConsts.Viewport2xPixelSize.xy - float2( 1.0f, 1.0f );
+}
+
+float3 ScreenSpaceToViewSpacePosition( float2 screenPos, float viewspaceDepth )
+{
+    return float3( g_ASSAOConsts.CameraTanHalfFOV.xy * viewspaceDepth * ScreenSpaceToClipSpacePositionXY( screenPos ), viewspaceDepth );
+}
+
+float3 ClipSpaceToViewSpacePosition( float2 clipPos, float viewspaceDepth )
+{
+    return float3( g_ASSAOConsts.CameraTanHalfFOV.xy * viewspaceDepth * clipPos, viewspaceDepth );
+}
+
+float3 NDCToViewspace( float2 pos, float viewspaceDepth )
+{
+    float3 ret;
+
+    ret.xy = (g_ASSAOConsts.NDCToViewMul * pos.xy + g_ASSAOConsts.NDCToViewAdd) * viewspaceDepth;
+
+    ret.z = viewspaceDepth;
+
+    return ret;
+}
+
+// calculate effect radius and fit our screen sampling pattern inside it
+void CalculateRadiusParameters( const float pixCenterLength, const float2 pixelDirRBViewspaceSizeAtCenterZ, out float pixLookupRadiusMod, out float effectRadius, out float falloffCalcMulSq )
+{
+    effectRadius = g_ASSAOConsts.EffectRadius;
+
+    // leaving this out for performance reasons: use something similar if radius needs to scale based on distance
+    //effectRadius *= pow( pixCenterLength, g_ASSAOConsts.RadiusDistanceScalingFunctionPow);
+
+    // when too close, on-screen sampling disk will grow beyond screen size; limit this to avoid closeup temporal artifacts
+    const float tooCloseLimitMod = saturate( pixCenterLength * g_ASSAOConsts.EffectSamplingRadiusNearLimitRec ) * 0.8 + 0.2;
+    
+    effectRadius *= tooCloseLimitMod;
+
+    // 0.85 is to reduce the radius to allow for more samples on a slope to still stay within influence
+    pixLookupRadiusMod = (0.85 * effectRadius) / pixelDirRBViewspaceSizeAtCenterZ.x;
+
+    // used to calculate falloff (both for AO samples and per-sample weights)
+    falloffCalcMulSq= -1.0f / (effectRadius*effectRadius);
+}
+
+float4 CalculateEdges( const float centerZ, const float leftZ, const float rightZ, const float topZ, const float bottomZ )
+{
+    // slope-sensitive depth-based edge detection
+    float4 edgesLRTB = float4( leftZ, rightZ, topZ, bottomZ ) - centerZ;
+    float4 edgesLRTBSlopeAdjusted = edgesLRTB + edgesLRTB.yxwz;
+    edgesLRTB = min( abs( edgesLRTB ), abs( edgesLRTBSlopeAdjusted ) );
+    return saturate( ( 1.3 - edgesLRTB / (centerZ * 0.040) ) );
+
+    // cheaper version but has artifacts
+    // edgesLRTB = abs( float4( leftZ, rightZ, topZ, bottomZ ) - centerZ; );
+    // return saturate( ( 1.3 - edgesLRTB / (pixZ * 0.06 + 0.1) ) );
+}
+
+// pass-through vertex shader
+void VSMain( inout float4 Pos : SV_POSITION, inout float2 Uv : TEXCOORD0 ) { }
+
+void PSPrepareDepths( in float4 inPos : SV_POSITION, out float out0 : SV_Target0, out float out1 : SV_Target1, out float out2 : SV_Target2, out float out3 : SV_Target3 )
+{
+#if 0   // gather can be a bit faster but doesn't work with input depth buffers that don't match the working viewport
+    float2 gatherUV = inPos.xy * g_ASSAOConsts.Viewport2xPixelSize;
+    float4 depths = g_DepthSource.GatherRed( g_PointClampSampler, gatherUV );
+    float a = depths.w;  // g_DepthSource.Load( int3( int2(inPos.xy) * 2, 0 ), int2( 0, 0 ) ).x;
+    float b = depths.z;  // g_DepthSource.Load( int3( int2(inPos.xy) * 2, 0 ), int2( 1, 0 ) ).x;
+    float c = depths.x;  // g_DepthSource.Load( int3( int2(inPos.xy) * 2, 0 ), int2( 0, 1 ) ).x;
+    float d = depths.y;  // g_DepthSource.Load( int3( int2(inPos.xy) * 2, 0 ), int2( 1, 1 ) ).x;
+#else
+    int3 baseCoord = int3( int2(inPos.xy) * 2, 0 );
+    float a = g_DepthSource.Load( baseCoord, int2( 0, 0 ) ).x;
+    float b = g_DepthSource.Load( baseCoord, int2( 1, 0 ) ).x;
+    float c = g_DepthSource.Load( baseCoord, int2( 0, 1 ) ).x;
+    float d = g_DepthSource.Load( baseCoord, int2( 1, 1 ) ).x;
+#endif
+
+    out0 = ScreenSpaceToViewSpaceDepth( a );
+    out1 = ScreenSpaceToViewSpaceDepth( b );
+    out2 = ScreenSpaceToViewSpaceDepth( c );
+    out3 = ScreenSpaceToViewSpaceDepth( d );
+}
+
+void PSPrepareDepthsHalf( in float4 inPos : SV_POSITION, out float out0 : SV_Target0, out float out1 : SV_Target1 )
+{
+    int3 baseCoord = int3( int2(inPos.xy) * 2, 0 );
+    float a = g_DepthSource.Load( baseCoord, int2( 0, 0 ) ).x;
+    float d = g_DepthSource.Load( baseCoord, int2( 1, 1 ) ).x;
+
+    out0 = ScreenSpaceToViewSpaceDepth( a );
+    out1 = ScreenSpaceToViewSpaceDepth( d );
+}
+
+float3 CalculateNormal( const float4 edgesLRTB, float3 pixCenterPos, float3 pixLPos, float3 pixRPos, float3 pixTPos, float3 pixBPos )
+{
+    // Get this pixel's viewspace normal
+    float4 acceptedNormals  = float4( edgesLRTB.x*edgesLRTB.z, edgesLRTB.z*edgesLRTB.y, edgesLRTB.y*edgesLRTB.w, edgesLRTB.w*edgesLRTB.x );
+
+    pixLPos = normalize(pixLPos - pixCenterPos);
+    pixRPos = normalize(pixRPos - pixCenterPos);
+    pixTPos = normalize(pixTPos - pixCenterPos);
+    pixBPos = normalize(pixBPos - pixCenterPos);
+
+    float3 pixelNormal = float3( 0, 0, -0.0005 );
+    pixelNormal += ( acceptedNormals.x ) * cross( pixLPos, pixTPos );
+    pixelNormal += ( acceptedNormals.y ) * cross( pixTPos, pixRPos );
+    pixelNormal += ( acceptedNormals.z ) * cross( pixRPos, pixBPos );
+    pixelNormal += ( acceptedNormals.w ) * cross( pixBPos, pixLPos );
+    pixelNormal = normalize( pixelNormal );
+    
+    return pixelNormal;
+}
+
+void PSPrepareDepthsAndNormals( in float4 inPos : SV_POSITION, out float out0 : SV_Target0, out float out1 : SV_Target1, out float out2 : SV_Target2, out float out3 : SV_Target3 )
+{
+    int2 baseCoords = (( int2 )inPos.xy) * 2;
+    float2 upperLeftUV = (inPos.xy - 0.25) * g_ASSAOConsts.Viewport2xPixelSize;
+
+#if 0   // gather can be a bit faster but doesn't work with input depth buffers that don't match the working viewport
+    float2 gatherUV = inPos.xy * g_ASSAOConsts.Viewport2xPixelSize;
+    float4 depths = g_DepthSource.GatherRed( g_PointClampSampler, gatherUV );
+    out0 = ScreenSpaceToViewSpaceDepth( depths.w );
+    out1 = ScreenSpaceToViewSpaceDepth( depths.z );
+    out2 = ScreenSpaceToViewSpaceDepth( depths.x );
+    out3 = ScreenSpaceToViewSpaceDepth( depths.y );
+#else
+    int3 baseCoord = int3( int2(inPos.xy) * 2, 0 );
+    out0 = ScreenSpaceToViewSpaceDepth( g_DepthSource.Load( baseCoord, int2( 0, 0 ) ).x );
+    out1 = ScreenSpaceToViewSpaceDepth( g_DepthSource.Load( baseCoord, int2( 1, 0 ) ).x );
+    out2 = ScreenSpaceToViewSpaceDepth( g_DepthSource.Load( baseCoord, int2( 0, 1 ) ).x );
+    out3 = ScreenSpaceToViewSpaceDepth( g_DepthSource.Load( baseCoord, int2( 1, 1 ) ).x );
+#endif
+
+    float pixZs[4][4];
+
+    // middle 4
+    pixZs[1][1] = out0;
+    pixZs[2][1] = out1;
+    pixZs[1][2] = out2;
+    pixZs[2][2] = out3;
+    // left 2
+    pixZs[0][1] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2( -1, 0 ) ).x ); 
+    pixZs[0][2] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2( -1, 1 ) ).x ); 
+    // right 2
+    pixZs[3][1] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2(  2, 0 ) ).x ); 
+    pixZs[3][2] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2(  2, 1 ) ).x ); 
+    // top 2
+    pixZs[1][0] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2(  0, -1 ) ).x );
+    pixZs[2][0] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2(  1, -1 ) ).x );
+    // bottom 2
+    pixZs[1][3] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2(  0,  2 ) ).x );
+    pixZs[2][3] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2(  1,  2 ) ).x );
+
+    float4 edges0 = CalculateEdges( pixZs[1][1], pixZs[0][1], pixZs[2][1], pixZs[1][0], pixZs[1][2] );
+    float4 edges1 = CalculateEdges( pixZs[2][1], pixZs[1][1], pixZs[3][1], pixZs[2][0], pixZs[2][2] );
+    float4 edges2 = CalculateEdges( pixZs[1][2], pixZs[0][2], pixZs[2][2], pixZs[1][1], pixZs[1][3] );
+    float4 edges3 = CalculateEdges( pixZs[2][2], pixZs[1][2], pixZs[3][2], pixZs[2][1], pixZs[2][3] );
+
+    float3 pixPos[4][4];
+    // middle 4
+    pixPos[1][1] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 0.0,  0.0 ), pixZs[1][1] );
+    pixPos[2][1] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 1.0,  0.0 ), pixZs[2][1] );
+    pixPos[1][2] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 0.0,  1.0 ), pixZs[1][2] );
+    pixPos[2][2] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 1.0,  1.0 ), pixZs[2][2] );
+    // left 2
+    pixPos[0][1] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( -1.0,  0.0), pixZs[0][1] );
+    pixPos[0][2] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( -1.0,  1.0), pixZs[0][2] );
+    // right 2                                                                                     
+    pixPos[3][1] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2(  2.0,  0.0), pixZs[3][1] );
+    pixPos[3][2] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2(  2.0,  1.0), pixZs[3][2] );
+    // top 2                                                                                       
+    pixPos[1][0] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 0.0, -1.0 ), pixZs[1][0] );
+    pixPos[2][0] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 1.0, -1.0 ), pixZs[2][0] );
+    // bottom 2                                                                                    
+    pixPos[1][3] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 0.0,  2.0 ), pixZs[1][3] );
+    pixPos[2][3] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 1.0,  2.0 ), pixZs[2][3] );
+
+    float3 norm0 = CalculateNormal( edges0, pixPos[1][1], pixPos[0][1], pixPos[2][1], pixPos[1][0], pixPos[1][2] );
+    float3 norm1 = CalculateNormal( edges1, pixPos[2][1], pixPos[1][1], pixPos[3][1], pixPos[2][0], pixPos[2][2] );
+    float3 norm2 = CalculateNormal( edges2, pixPos[1][2], pixPos[0][2], pixPos[2][2], pixPos[1][1], pixPos[1][3] );
+    float3 norm3 = CalculateNormal( edges3, pixPos[2][2], pixPos[1][2], pixPos[3][2], pixPos[2][1], pixPos[2][3] );
+
+    g_NormalsOutputUAV[ baseCoords + int2( 0, 0 ) ] = float4( norm0 * 0.5 + 0.5, 0.0 );
+    g_NormalsOutputUAV[ baseCoords + int2( 1, 0 ) ] = float4( norm1 * 0.5 + 0.5, 0.0 );
+    g_NormalsOutputUAV[ baseCoords + int2( 0, 1 ) ] = float4( norm2 * 0.5 + 0.5, 0.0 );
+    g_NormalsOutputUAV[ baseCoords + int2( 1, 1 ) ] = float4( norm3 * 0.5 + 0.5, 0.0 );
+}
+
+void PSPrepareDepthsAndNormalsHalf( in float4 inPos : SV_POSITION, out float out0 : SV_Target0, out float out1 : SV_Target1 )
+{
+    int2 baseCoords = (( int2 )inPos.xy) * 2;
+    float2 upperLeftUV = (inPos.xy - 0.25) * g_ASSAOConsts.Viewport2xPixelSize;
+
+    int3 baseCoord = int3( int2(inPos.xy) * 2, 0 );
+    float z0 = ScreenSpaceToViewSpaceDepth( g_DepthSource.Load( baseCoord, int2( 0, 0 ) ).x );
+    float z1 = ScreenSpaceToViewSpaceDepth( g_DepthSource.Load( baseCoord, int2( 1, 0 ) ).x );
+    float z2 = ScreenSpaceToViewSpaceDepth( g_DepthSource.Load( baseCoord, int2( 0, 1 ) ).x );
+    float z3 = ScreenSpaceToViewSpaceDepth( g_DepthSource.Load( baseCoord, int2( 1, 1 ) ).x );
+
+    out0 = z0;
+    out1 = z3;
+
+    float pixZs[4][4];
+
+    // middle 4
+    pixZs[1][1] = z0;
+    pixZs[2][1] = z1;
+    pixZs[1][2] = z2;
+    pixZs[2][2] = z3;
+    // left 2
+    pixZs[0][1] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2( -1, 0 ) ).x ); 
+    pixZs[0][2] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2( -1, 1 ) ).x ); 
+    // right 2
+    pixZs[3][1] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2(  2, 0 ) ).x ); 
+    pixZs[3][2] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2(  2, 1 ) ).x ); 
+    // top 2
+    pixZs[1][0] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2(  0, -1 ) ).x );
+    pixZs[2][0] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2(  1, -1 ) ).x );
+    // bottom 2
+    pixZs[1][3] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2(  0,  2 ) ).x );
+    pixZs[2][3] = ScreenSpaceToViewSpaceDepth(  g_DepthSource.SampleLevel( g_PointClampSampler, upperLeftUV, 0.0, int2(  1,  2 ) ).x );
+
+    float4 edges0 = CalculateEdges( pixZs[1][1], pixZs[0][1], pixZs[2][1], pixZs[1][0], pixZs[1][2] );
+    float4 edges1 = CalculateEdges( pixZs[2][1], pixZs[1][1], pixZs[3][1], pixZs[2][0], pixZs[2][2] );
+    float4 edges2 = CalculateEdges( pixZs[1][2], pixZs[0][2], pixZs[2][2], pixZs[1][1], pixZs[1][3] );
+    float4 edges3 = CalculateEdges( pixZs[2][2], pixZs[1][2], pixZs[3][2], pixZs[2][1], pixZs[2][3] );
+
+    float3 pixPos[4][4];
+
+    // there is probably a way to optimize the math below; however no approximation will work, has to be precise.
+
+    // middle 4
+    pixPos[1][1] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 0.0,  0.0 ), pixZs[1][1] );
+    pixPos[2][1] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 1.0,  0.0 ), pixZs[2][1] );
+    pixPos[1][2] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 0.0,  1.0 ), pixZs[1][2] );
+    pixPos[2][2] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 1.0,  1.0 ), pixZs[2][2] );
+    // left 2
+    pixPos[0][1] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( -1.0,  0.0), pixZs[0][1] );
+    //pixPos[0][2] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( -1.0,  1.0), pixZs[0][2] );
+    // right 2                                                                                     
+    //pixPos[3][1] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2(  2.0,  0.0), pixZs[3][1] );
+    pixPos[3][2] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2(  2.0,  1.0), pixZs[3][2] );
+    // top 2                                                                                       
+    pixPos[1][0] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 0.0, -1.0 ), pixZs[1][0] );
+    //pixPos[2][0] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 1.0, -1.0 ), pixZs[2][0] );
+    // bottom 2                                                                                    
+    //pixPos[1][3] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 0.0,  2.0 ), pixZs[1][3] );
+    pixPos[2][3] = NDCToViewspace( upperLeftUV + g_ASSAOConsts.ViewportPixelSize * float2( 1.0,  2.0 ), pixZs[2][3] );
+
+    float3 norm0 = CalculateNormal( edges0, pixPos[1][1], pixPos[0][1], pixPos[2][1], pixPos[1][0], pixPos[1][2] );
+    float3 norm3 = CalculateNormal( edges3, pixPos[2][2], pixPos[1][2], pixPos[3][2], pixPos[2][1], pixPos[2][3] );
+
+    g_NormalsOutputUAV[ baseCoords + int2( 0, 0 ) ] = float4( norm0 * 0.5 + 0.5, 0.0 );
+    g_NormalsOutputUAV[ baseCoords + int2( 1, 1 ) ] = float4( norm3 * 0.5 + 0.5, 0.0 );
+}
+
+void PrepareDepthMip( const float4 inPos/*, const float2 inUV*/, int mipLevel, out float outD0, out float outD1, out float outD2, out float outD3 )
+{
+    int2 baseCoords = int2(inPos.xy) * 2;
+
+    float4 depthsArr[4];
+    float depthsOutArr[4];
+    
+    // how to Gather a specific mip level?
+    depthsArr[0].x = g_ViewspaceDepthSource[baseCoords + int2( 0, 0 )].x ;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[0].y = g_ViewspaceDepthSource[baseCoords + int2( 1, 0 )].x ;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[0].z = g_ViewspaceDepthSource[baseCoords + int2( 0, 1 )].x ;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[0].w = g_ViewspaceDepthSource[baseCoords + int2( 1, 1 )].x ;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[1].x = g_ViewspaceDepthSource1[baseCoords + int2( 0, 0 )].x;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[1].y = g_ViewspaceDepthSource1[baseCoords + int2( 1, 0 )].x;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[1].z = g_ViewspaceDepthSource1[baseCoords + int2( 0, 1 )].x;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[1].w = g_ViewspaceDepthSource1[baseCoords + int2( 1, 1 )].x;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[2].x = g_ViewspaceDepthSource2[baseCoords + int2( 0, 0 )].x;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[2].y = g_ViewspaceDepthSource2[baseCoords + int2( 1, 0 )].x;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[2].z = g_ViewspaceDepthSource2[baseCoords + int2( 0, 1 )].x;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[2].w = g_ViewspaceDepthSource2[baseCoords + int2( 1, 1 )].x;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[3].x = g_ViewspaceDepthSource3[baseCoords + int2( 0, 0 )].x;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[3].y = g_ViewspaceDepthSource3[baseCoords + int2( 1, 0 )].x;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[3].z = g_ViewspaceDepthSource3[baseCoords + int2( 0, 1 )].x;// * g_ASSAOConsts.MaxViewspaceDepth;
+    depthsArr[3].w = g_ViewspaceDepthSource3[baseCoords + int2( 1, 1 )].x;// * g_ASSAOConsts.MaxViewspaceDepth;
+
+    const uint2 SVPosui         = uint2( inPos.xy );
+    const uint pseudoRandomA    = (SVPosui.x ) + 2 * (SVPosui.y );
+
+    float dummyUnused1;
+    float dummyUnused2;
+    float falloffCalcMulSq, falloffCalcAdd;
+ 
+    [unroll]
+    for( int i = 0; i < 4; i++ )
+    {
+        float4 depths = depthsArr[i];
+
+        float closest = min( min( depths.x, depths.y ), min( depths.z, depths.w ) );
+
+        CalculateRadiusParameters( abs( closest ), 1.0, dummyUnused1, dummyUnused2, falloffCalcMulSq );
+
+        float4 dists = depths - closest.xxxx;
+
+        float4 weights = saturate( dists * dists * falloffCalcMulSq + 1.0 );
+
+        float smartAvg = dot( weights, depths ) / dot( weights, float4( 1.0, 1.0, 1.0, 1.0 ) );
+
+        const uint pseudoRandomIndex = ( pseudoRandomA + i ) % 4;
+
+        //depthsOutArr[i] = closest;
+        //depthsOutArr[i] = depths[ pseudoRandomIndex ];
+        depthsOutArr[i] = smartAvg;
+    }
+
+    outD0 = depthsOutArr[0];
+    outD1 = depthsOutArr[1];
+    outD2 = depthsOutArr[2];
+    outD3 = depthsOutArr[3];
+}
+
+void PSPrepareDepthMip1( in float4 inPos : SV_POSITION/*, in float2 inUV : TEXCOORD0*/, out float out0 : SV_Target0, out float out1 : SV_Target1, out float out2 : SV_Target2, out float out3 : SV_Target3 )
+{
+    PrepareDepthMip( inPos/*, inUV*/, 1, out0, out1, out2, out3 );
+}
+
+void PSPrepareDepthMip2( in float4 inPos : SV_POSITION/*, in float2 inUV : TEXCOORD0*/, out float out0 : SV_Target0, out float out1 : SV_Target1, out float out2 : SV_Target2, out float out3 : SV_Target3 )
+{
+    PrepareDepthMip( inPos/*, inUV*/, 2, out0, out1, out2, out3 );
+}
+
+void PSPrepareDepthMip3( in float4 inPos : SV_POSITION/*, in float2 inUV : TEXCOORD0*/, out float out0 : SV_Target0, out float out1 : SV_Target1, out float out2 : SV_Target2, out float out3 : SV_Target3 )
+{
+    PrepareDepthMip( inPos/*, inUV*/, 3, out0, out1, out2, out3 );
+}
+
+float3 DecodeNormal( float3 encodedNormal )
+{
+    float3 normal = encodedNormal * g_ASSAOConsts.NormalsUnpackMul.xxx + g_ASSAOConsts.NormalsUnpackAdd.xxx;
+
+#if SSAO_ENABLE_NORMAL_WORLD_TO_VIEW_CONVERSION
+    normal = mul( normal, (float3x3)g_ASSAOConsts.NormalsWorldToViewspaceMatrix ).xyz; 
+#endif
+
+    // normal = normalize( normal );    // normalize adds around 2.5% cost on High settings but makes little (PSNR 66.7) visual difference when normals are as in the sample (stored in R8G8B8A8_UNORM,
+    //                                  // decoded in the shader), however it will likely be required if using different encoding/decoding or the inputs are not normalized, etc.
+
+    return normal;
+}
+
+float3 LoadNormal( int2 pos )
+{
+    float2 encodedNormal = g_NormalmapSource.Load( int3( pos, 0 ) ).xy;
+    return DecodeNormalGBuffer( encodedNormal );
+}
+
+float3 LoadNormal( int2 pos, int2 offset )
+{
+    float2 encodedNormal = g_NormalmapSource.Load( int3( pos, 0 ), offset ).xy;
+    return DecodeNormalGBuffer( encodedNormal );
+}
+
+// all vectors in viewspace
+float CalculatePixelObscurance( float3 pixelNormal, float3 hitDelta, float falloffCalcMulSq )
+{
+  float lengthSq = dot( hitDelta, hitDelta );
+  float NdotD = dot(pixelNormal, hitDelta) / sqrt(lengthSq);
+
+  float falloffMult = max( 0.0, lengthSq * falloffCalcMulSq + 1.0 );
+
+  return max( 0, NdotD - g_ASSAOConsts.EffectHorizonAngleThreshold ) * falloffMult;
+}
+
+void SSAOTapInner( const int qualityLevel, inout float obscuranceSum, inout float weightSum, const float2 samplingUV, const float mipLevel, const float3 pixCenterPos, const float3 negViewspaceDir,float3 pixelNormal, const float falloffCalcMulSq, const float weightMod, const int dbgTapIndex )
+{
+    // get depth at sample
+    float viewspaceSampleZ = g_ViewspaceDepthSource.SampleLevel( g_ViewspaceDepthTapSampler, samplingUV.xy, mipLevel ).x; // * g_ASSAOConsts.MaxViewspaceDepth;
+
+    // convert to viewspace
+    float3 hitPos = NDCToViewspace( samplingUV.xy, viewspaceSampleZ ).xyz;
+    float3 hitDelta = hitPos - pixCenterPos;
+
+    float obscurance = CalculatePixelObscurance( pixelNormal, hitDelta, falloffCalcMulSq );
+    float weight = 1.0;
+        
+    if( qualityLevel >= SSAO_HALOING_REDUCTION_ENABLE_AT_QUALITY_PRESET )
+    {
+        //float reduct = max( 0, dot( hitDelta, negViewspaceDir ) );
+        float reduct = max( 0, -hitDelta.z ); // cheaper, less correct version
+        reduct = saturate( reduct * g_ASSAOConsts.NegRecEffectRadius + 2.0 ); // saturate( 2.0 - reduct / g_ASSAOConsts.EffectRadius );
+        weight = SSAO_HALOING_REDUCTION_AMOUNT * reduct + (1.0 - SSAO_HALOING_REDUCTION_AMOUNT);
+    }
+    weight *= weightMod;
+    obscuranceSum += obscurance * weight;
+    weightSum += weight;
+}
+
+void SSAOTap( const int qualityLevel, inout float obscuranceSum, inout float weightSum, const int tapIndex, const float2x2 rotScale, const float3 pixCenterPos, const float3 negViewspaceDir, float3 pixelNormal, const float2 normalizedScreenPos, const float mipOffset, const float falloffCalcMulSq, float weightMod, float2 normXY, float normXYLength )
+{
+    float2  sampleOffset;
+    float   samplePow2Len;
+
+    // patterns
+    {
+        float4 newSample = g_samplePatternMain[tapIndex];
+        sampleOffset    = mul( rotScale, newSample.xy );
+        samplePow2Len   = newSample.w;                      // precalculated, same as: samplePow2Len = log2( length( newSample.xy ) );
+        weightMod *= newSample.z;
+    }
+
+    // snap to pixel center (more correct obscurance math, avoids artifacts)
+    sampleOffset                    = round(sampleOffset);
+
+    // calculate MIP based on the sample distance from the centre, similar to as described 
+    // in http://graphics.cs.williams.edu/papers/SAOHPG12/.
+    float mipLevel = ( qualityLevel < SSAO_DEPTH_MIPS_ENABLE_AT_QUALITY_PRESET )?(0):(samplePow2Len + mipOffset);
+
+    float2 samplingUV = sampleOffset * g_ASSAOConsts.Viewport2xPixelSize + normalizedScreenPos;
+
+    SSAOTapInner( qualityLevel, obscuranceSum, weightSum, samplingUV, mipLevel, pixCenterPos, negViewspaceDir, pixelNormal, falloffCalcMulSq, weightMod, tapIndex * 2 );
+
+    // for the second tap, just use the mirrored offset
+    float2 sampleOffsetMirroredUV    = -sampleOffset;
+
+    // tilt the second set of samples so that the disk is effectively rotated by the normal
+    // effective at removing one set of artifacts, but too expensive for lower quality settings
+    if( qualityLevel >= SSAO_TILT_SAMPLES_ENABLE_AT_QUALITY_PRESET )
+    {
+        float dotNorm = dot( sampleOffsetMirroredUV, normXY );
+        sampleOffsetMirroredUV -= dotNorm * normXYLength * normXY;
+        sampleOffsetMirroredUV = round(sampleOffsetMirroredUV);
+    }
+    
+    // snap to pixel center (more correct obscurance math, avoids artifacts)
+    float2 samplingMirroredUV = sampleOffsetMirroredUV * g_ASSAOConsts.Viewport2xPixelSize + normalizedScreenPos;
+
+    SSAOTapInner( qualityLevel, obscuranceSum, weightSum, samplingMirroredUV, mipLevel, pixCenterPos, negViewspaceDir, pixelNormal, falloffCalcMulSq, weightMod, tapIndex * 2 + 1 );
+}
+
+// this function is designed to only work with half/half depth at the moment - there's a couple of hardcoded paths that expect pixel/texel size, so it will not work for full res
+void GenerateSSAOShadowsInternal( out float outShadowTerm, out float4 outEdges, out float outWeight, const float2 SVPos/*, const float2 normalizedScreenPos*/, uniform int qualityLevel, bool adaptiveBase )
+{
+    float2 SVPosRounded = trunc( SVPos );
+    uint2 SVPosui = uint2( SVPosRounded ); //same as uint2( SVPos )
+
+    const int numberOfTaps = (adaptiveBase)?(SSAO_ADAPTIVE_TAP_BASE_COUNT) : ( g_numTaps[qualityLevel] );
+    float pixZ, pixLZ, pixTZ, pixRZ, pixBZ;
+
+    float4 valuesUL     = g_ViewspaceDepthSource.GatherRed( g_PointMirrorSampler, SVPosRounded * g_ASSAOConsts.HalfViewportPixelSize );
+    float4 valuesBR     = g_ViewspaceDepthSource.GatherRed( g_PointMirrorSampler, SVPosRounded * g_ASSAOConsts.HalfViewportPixelSize, int2( 1, 1 ) );
+
+    // get this pixel's viewspace depth
+    pixZ = valuesUL.y; //float pixZ = g_ViewspaceDepthSource.SampleLevel( g_PointMirrorSampler, normalizedScreenPos, 0.0 ).x; // * g_ASSAOConsts.MaxViewspaceDepth;
+
+    // get left right top bottom neighbouring pixels for edge detection (gets compiled out on qualityLevel == 0)
+    pixLZ   = valuesUL.x;
+    pixTZ   = valuesUL.z;
+    pixRZ   = valuesBR.z;
+    pixBZ   = valuesBR.x;
+
+    float2 normalizedScreenPos = SVPosRounded * g_ASSAOConsts.Viewport2xPixelSize + g_ASSAOConsts.Viewport2xPixelSize_x_025;
+    float3 pixCenterPos = NDCToViewspace( normalizedScreenPos, pixZ ); // g
+
+    // Load this pixel's viewspace normal
+    uint2 fullResCoord = SVPosui * 2 + g_ASSAOConsts.PerPassFullResCoordOffset.xy;
+    float3 pixelNormal = LoadNormal( fullResCoord );
+
+    const float2 pixelDirRBViewspaceSizeAtCenterZ = pixCenterPos.z * g_ASSAOConsts.NDCToViewMul * g_ASSAOConsts.Viewport2xPixelSize;  // optimized approximation of:  float2 pixelDirRBViewspaceSizeAtCenterZ = NDCToViewspace( normalizedScreenPos.xy + g_ASSAOConsts.ViewportPixelSize.xy, pixCenterPos.z ).xy - pixCenterPos.xy;
+
+    float pixLookupRadiusMod;
+    float falloffCalcMulSq;
+
+    // calculate effect radius and fit our screen sampling pattern inside it
+    float effectViewspaceRadius;
+    CalculateRadiusParameters( length( pixCenterPos ), pixelDirRBViewspaceSizeAtCenterZ, pixLookupRadiusMod, effectViewspaceRadius, falloffCalcMulSq );
+
+    // calculate samples rotation/scaling
+    float2x2 rotScale;
+    {
+        // reduce effect radius near the screen edges slightly; ideally, one would render a larger depth buffer (5% on each side) instead
+        if( !adaptiveBase && (qualityLevel >= SSAO_REDUCE_RADIUS_NEAR_SCREEN_BORDER_ENABLE_AT_QUALITY_PRESET) )
+        {
+            float nearScreenBorder = min( min( normalizedScreenPos.x, 1.0 - normalizedScreenPos.x ), min( normalizedScreenPos.y, 1.0 - normalizedScreenPos.y ) );
+            nearScreenBorder = saturate( 10.0 * nearScreenBorder + 0.6 );
+            pixLookupRadiusMod *= nearScreenBorder;
+        }
+
+        // load & update pseudo-random rotation matrix
+        uint pseudoRandomIndex = uint( SVPosRounded.y * 2 + SVPosRounded.x ) % 5;
+        float4 rs = g_ASSAOConsts.PatternRotScaleMatrices[ pseudoRandomIndex ];
+        rotScale = float2x2( rs.x * pixLookupRadiusMod, rs.y * pixLookupRadiusMod, rs.z * pixLookupRadiusMod, rs.w * pixLookupRadiusMod );
+    }
+
+    // the main obscurance & sample weight storage
+    float obscuranceSum = 0.0;
+    float weightSum = 0.0;
+
+    // edge mask for between this and left/right/top/bottom neighbour pixels - not used in quality level 0 so initialize to "no edge" (1 is no edge, 0 is edge)
+    float4 edgesLRTB = float4( 1.0, 1.0, 1.0, 1.0 );
+
+    // Move center pixel slightly towards camera to avoid imprecision artifacts due to using of 16bit depth buffer; a lot smaller offsets needed when using 32bit floats
+    pixCenterPos *= g_ASSAOConsts.DepthPrecisionOffsetMod;
+
+    if( !adaptiveBase && (qualityLevel >= SSAO_DEPTH_BASED_EDGES_ENABLE_AT_QUALITY_PRESET) )
+    {
+        edgesLRTB = CalculateEdges( pixZ, pixLZ, pixRZ, pixTZ, pixBZ );
+    }
+
+    // adds a more high definition sharp effect, which gets blurred out (reuses left/right/top/bottom samples that we used for edge detection)
+    if( !adaptiveBase && (qualityLevel >= SSAO_DETAIL_AO_ENABLE_AT_QUALITY_PRESET) )
+    {
+        // disable in case of quality level 4 (reference)
+        if( qualityLevel != 4 )
+        {
+            //approximate neighbouring pixels positions (actually just deltas or "positions - pixCenterPos" )
+            float3 viewspaceDirZNormalized = float3( pixCenterPos.xy / pixCenterPos.zz, 1.0 );
+            float3 pixLDelta  = float3( -pixelDirRBViewspaceSizeAtCenterZ.x, 0.0, 0.0 ) + viewspaceDirZNormalized * (pixLZ - pixCenterPos.z); // very close approximation of: float3 pixLPos  = NDCToViewspace( normalizedScreenPos + float2( -g_ASSAOConsts.HalfViewportPixelSize.x, 0.0 ), pixLZ ).xyz - pixCenterPos.xyz;
+            float3 pixRDelta  = float3( +pixelDirRBViewspaceSizeAtCenterZ.x, 0.0, 0.0 ) + viewspaceDirZNormalized * (pixRZ - pixCenterPos.z); // very close approximation of: float3 pixRPos  = NDCToViewspace( normalizedScreenPos + float2( +g_ASSAOConsts.HalfViewportPixelSize.x, 0.0 ), pixRZ ).xyz - pixCenterPos.xyz;
+            float3 pixTDelta  = float3( 0.0, -pixelDirRBViewspaceSizeAtCenterZ.y, 0.0 ) + viewspaceDirZNormalized * (pixTZ - pixCenterPos.z); // very close approximation of: float3 pixTPos  = NDCToViewspace( normalizedScreenPos + float2( 0.0, -g_ASSAOConsts.HalfViewportPixelSize.y ), pixTZ ).xyz - pixCenterPos.xyz;
+            float3 pixBDelta  = float3( 0.0, +pixelDirRBViewspaceSizeAtCenterZ.y, 0.0 ) + viewspaceDirZNormalized * (pixBZ - pixCenterPos.z); // very close approximation of: float3 pixBPos  = NDCToViewspace( normalizedScreenPos + float2( 0.0, +g_ASSAOConsts.HalfViewportPixelSize.y ), pixBZ ).xyz - pixCenterPos.xyz;
+
+            const float rangeReductionConst         = 4.0f;                         // this is to avoid various artifacts
+            const float modifiedFalloffCalcMulSq    = rangeReductionConst * falloffCalcMulSq;
+
+            float4 additionalObscurance;
+            additionalObscurance.x = CalculatePixelObscurance( pixelNormal, pixLDelta, modifiedFalloffCalcMulSq );
+            additionalObscurance.y = CalculatePixelObscurance( pixelNormal, pixRDelta, modifiedFalloffCalcMulSq );
+            additionalObscurance.z = CalculatePixelObscurance( pixelNormal, pixTDelta, modifiedFalloffCalcMulSq );
+            additionalObscurance.w = CalculatePixelObscurance( pixelNormal, pixBDelta, modifiedFalloffCalcMulSq );
+
+            obscuranceSum += g_ASSAOConsts.DetailAOStrength * dot( additionalObscurance, edgesLRTB );
+        }
+    }
+
+    // Sharp normals also create edges - but this adds to the cost as well
+    if( !adaptiveBase && (qualityLevel >= SSAO_NORMAL_BASED_EDGES_ENABLE_AT_QUALITY_PRESET ) )
+    {
+        float3 neighbourNormalL  = LoadNormal( fullResCoord, int2( -2,  0 ) );
+        float3 neighbourNormalR  = LoadNormal( fullResCoord, int2(  2,  0 ) );
+        float3 neighbourNormalT  = LoadNormal( fullResCoord, int2(  0, -2 ) );
+        float3 neighbourNormalB  = LoadNormal( fullResCoord, int2(  0,  2 ) );
+
+        const float dotThreshold = SSAO_NORMAL_BASED_EDGES_DOT_THRESHOLD;
+
+        float4 normalEdgesLRTB;
+        normalEdgesLRTB.x = saturate( (dot( pixelNormal, neighbourNormalL ) + dotThreshold ) );
+        normalEdgesLRTB.y = saturate( (dot( pixelNormal, neighbourNormalR ) + dotThreshold ) );
+        normalEdgesLRTB.z = saturate( (dot( pixelNormal, neighbourNormalT ) + dotThreshold ) );
+        normalEdgesLRTB.w = saturate( (dot( pixelNormal, neighbourNormalB ) + dotThreshold ) );
+
+//#define SSAO_SMOOTHEN_NORMALS // fixes some aliasing artifacts but kills a lot of high detail and adds to the cost - not worth it probably but feel free to play with it
+#ifdef SSAO_SMOOTHEN_NORMALS
+        //neighbourNormalL  = LoadNormal( fullResCoord, int2( -1,  0 ) );
+        //neighbourNormalR  = LoadNormal( fullResCoord, int2(  1,  0 ) );
+        //neighbourNormalT  = LoadNormal( fullResCoord, int2(  0, -1 ) );
+        //neighbourNormalB  = LoadNormal( fullResCoord, int2(  0,  1 ) );
+        pixelNormal += neighbourNormalL * edgesLRTB.x + neighbourNormalR * edgesLRTB.y + neighbourNormalT * edgesLRTB.z + neighbourNormalB * edgesLRTB.w;
+        pixelNormal = normalize( pixelNormal );
+#endif
+
+        edgesLRTB *= normalEdgesLRTB;
+    }
+
+
+
+    const float globalMipOffset     = SSAO_DEPTH_MIPS_GLOBAL_OFFSET;
+    float mipOffset = ( qualityLevel < SSAO_DEPTH_MIPS_ENABLE_AT_QUALITY_PRESET ) ? ( 0 ) : ( log2( pixLookupRadiusMod ) + globalMipOffset );
+
+    // Used to tilt the second set of samples so that the disk is effectively rotated by the normal
+    // effective at removing one set of artifacts, but too expensive for lower quality settings
+    float2 normXY = float2( pixelNormal.x, pixelNormal.y );
+    float normXYLength = length( normXY );
+    normXY /= float2( normXYLength, -normXYLength );
+    normXYLength *= SSAO_TILT_SAMPLES_AMOUNT;
+
+    const float3 negViewspaceDir = -normalize( pixCenterPos );
+
+    // standard, non-adaptive approach
+    if( (qualityLevel != 3) || adaptiveBase )
+    {
+        // [unroll] // <- doesn't seem to help on any platform, although the compilers seem to unroll anyway if const number of tap used!
+        for( int i = 0; i < numberOfTaps; i++ )
+        {
+            SSAOTap( qualityLevel, obscuranceSum, weightSum, i, rotScale, pixCenterPos, negViewspaceDir, pixelNormal, normalizedScreenPos, mipOffset, falloffCalcMulSq, 1.0, normXY, normXYLength );
+        }
+    }
+    else // if( qualityLevel == 3 ) adaptive approach
+    {
+        // add new ones if needed
+        float2 fullResUV = normalizedScreenPos + g_ASSAOConsts.PerPassFullResUVOffset.xy;
+        float importance = g_ImportanceMap.SampleLevel( g_LinearClampSampler, fullResUV, 0.0 ).x;
+
+        // this is to normalize SSAO_DETAIL_AO_AMOUNT across all pixel regardless of importance
+        obscuranceSum *= (SSAO_ADAPTIVE_TAP_BASE_COUNT / (float)SSAO_MAX_TAPS) + (importance * SSAO_ADAPTIVE_TAP_FLEXIBLE_COUNT / (float)SSAO_MAX_TAPS);
+
+        // load existing base values
+        float2 baseValues = g_FinalSSAO.Load( int4( SVPosui, g_ASSAOConsts.PassIndex, 0 ) ).xy;
+        weightSum += baseValues.y * (float)(SSAO_ADAPTIVE_TAP_BASE_COUNT * 4.0);
+        obscuranceSum += (baseValues.x) * weightSum;
+        
+        // increase importance around edges
+        float edgeCount = dot( 1.0-edgesLRTB, float4( 1.0, 1.0, 1.0, 1.0 ) );
+        //importance += edgeCount / (float)SSAO_ADAPTIVE_TAP_FLEXIBLE_COUNT;
+
+        float avgTotalImportance = (float)g_LoadCounter[0] * g_ASSAOConsts.LoadCounterAvgDiv;
+
+        float importanceLimiter = saturate( g_ASSAOConsts.AdaptiveSampleCountLimit / avgTotalImportance );
+        importance *= importanceLimiter;
+
+        float additionalSampleCountFlt = SSAO_ADAPTIVE_TAP_FLEXIBLE_COUNT * importance;
+
+        const float blendRange = 3.0; // use 1 to just blend the last one; use larger number to blend over more for a more smooth transition
+        const float blendRangeInv = 1.0 / blendRange;
+
+        additionalSampleCountFlt += 0.5;
+        uint additionalSamples   = uint( additionalSampleCountFlt );
+        uint additionalSamplesTo = min( SSAO_MAX_TAPS, additionalSamples + SSAO_ADAPTIVE_TAP_BASE_COUNT );
+
+        // additional manual unroll doesn't help unfortunately
+        [loop]
+        for( uint i = SSAO_ADAPTIVE_TAP_BASE_COUNT; i < additionalSamplesTo; i++ )
+        {
+            additionalSampleCountFlt -= 1.0f;
+            float weightMod = saturate(additionalSampleCountFlt * blendRangeInv); // slowly blend in the last few samples
+            SSAOTap( qualityLevel, obscuranceSum, weightSum, i, rotScale, pixCenterPos, negViewspaceDir, pixelNormal, normalizedScreenPos, mipOffset, falloffCalcMulSq, weightMod, normXY, normXYLength );
+        }
+    }
+
+    // early out for adaptive base - just output weight (used for the next pass)
+    if( adaptiveBase )
+    {
+        float obscurance = obscuranceSum / weightSum;
+
+        outShadowTerm   = obscurance;
+        outEdges        = 0;
+        outWeight       = weightSum;
+        return;
+    }
+
+    // calculate weighted average
+    float obscurance = obscuranceSum / weightSum;
+
+    // calculate fadeout (1 close, gradient, 0 far)
+    float fadeOut = saturate( pixCenterPos.z * g_ASSAOConsts.EffectFadeOutMul + g_ASSAOConsts.EffectFadeOutAdd );
+  
+    // Reduce the SSAO shadowing if we're on the edge to remove artifacts on edges (we don't care for the lower quality one)
+    if( !adaptiveBase && (qualityLevel >= SSAO_DEPTH_BASED_EDGES_ENABLE_AT_QUALITY_PRESET) )
+    {
+        // float edgeCount = dot( 1.0-edgesLRTB, float4( 1.0, 1.0, 1.0, 1.0 ) );
+
+        // when there's more than 2 opposite edges, start fading out the occlusion to reduce aliasing artifacts
+        float edgeFadeoutFactor = saturate( (1.0 - edgesLRTB.x - edgesLRTB.y) * 0.35) + saturate( (1.0 - edgesLRTB.z - edgesLRTB.w) * 0.35 );
+
+        // (experimental) if you want to reduce the effect next to any edge
+        // edgeFadeoutFactor += 0.1 * saturate( dot( 1 - edgesLRTB, float4( 1, 1, 1, 1 ) ) );
+
+        fadeOut *= saturate( 1.0 - edgeFadeoutFactor );
+    }
+    
+    // same as a bove, but a lot more conservative version
+    // fadeOut *= saturate( dot( edgesLRTB, float4( 0.9, 0.9, 0.9, 0.9 ) ) - 2.6 );
+
+    // strength
+    obscurance = g_ASSAOConsts.EffectShadowStrength * obscurance;
+    
+    // clamp
+    obscurance = min( obscurance, g_ASSAOConsts.EffectShadowClamp );
+    
+    // fadeout
+    obscurance *= fadeOut;
+
+    // conceptually switch to occlusion with the meaning being visibility (grows with visibility, occlusion == 1 implies full visibility), 
+    // to be in line with what is more commonly used.
+    float occlusion = 1.0 - obscurance;
+
+    // modify the gradient
+    // note: this cannot be moved to a later pass because of loss of precision after storing in the render target
+    occlusion = pow( saturate( occlusion ), g_ASSAOConsts.EffectShadowPow );
+
+    // outputs!
+    outShadowTerm   = occlusion;    // Our final 'occlusion' term (0 means fully occluded, 1 means fully lit)
+    outEdges        = edgesLRTB;    // These are used to prevent blurring across edges, 1 means no edge, 0 means edge, 0.5 means half way there, etc.
+    outWeight       = weightSum;
+}
+
+void PSGenerateQ0( in float4 inPos : SV_POSITION/*, in float2 inUV : TEXCOORD0*/, out float2 out0 : SV_Target0 )
+{
+    float   outShadowTerm;
+    float   outWeight;
+    float4  outEdges;
+    GenerateSSAOShadowsInternal( outShadowTerm, outEdges, outWeight, inPos.xy/*, inUV*/, 0, false );
+    out0.x = outShadowTerm;
+    out0.y = PackEdges( float4( 1, 1, 1, 1 ) ); // no edges in low quality
+}
+
+void PSGenerateQ1( in float4 inPos : SV_POSITION/*, in float2 inUV : TEXCOORD0*/, out float2 out0 : SV_Target0 )
+{
+    float   outShadowTerm;
+    float   outWeight;
+    float4  outEdges;
+    GenerateSSAOShadowsInternal( outShadowTerm, outEdges, outWeight, inPos.xy/*, inUV*/, 1, false );
+    out0.x = outShadowTerm;
+    out0.y = PackEdges( outEdges );
+}
+
+void PSGenerateQ2( in float4 inPos : SV_POSITION/*, in float2 inUV : TEXCOORD0*/, out float2 out0 : SV_Target0 )
+{
+    float   outShadowTerm;
+    float   outWeight;
+    float4  outEdges;
+    GenerateSSAOShadowsInternal( outShadowTerm, outEdges, outWeight, inPos.xy/*, inUV*/, 2, false );
+    out0.x = outShadowTerm;
+    out0.y = PackEdges( outEdges );
+}
+
+void PSGenerateQ3Base( in float4 inPos : SV_POSITION/*, in float2 inUV : TEXCOORD0*/, out float2 out0 : SV_Target0 )
+{
+    float   outShadowTerm;
+    float   outWeight;
+    float4  outEdges;
+    GenerateSSAOShadowsInternal( outShadowTerm, outEdges, outWeight, inPos.xy/*, inUV*/, 3, true );
+    out0.x = outShadowTerm;
+    out0.y = outWeight / ((float)SSAO_ADAPTIVE_TAP_BASE_COUNT * 4.0); //0.0; //frac(outWeight / 6.0);// / (float)(SSAO_MAX_TAPS * 4.0);
+}
+
+void PSGenerateQ3( in float4 inPos : SV_POSITION/*, in float2 inUV : TEXCOORD0*/, out float2 out0 : SV_Target0 )
+{
+    float   outShadowTerm;
+    float   outWeight;
+    float4  outEdges;
+    GenerateSSAOShadowsInternal( outShadowTerm, outEdges, outWeight, inPos.xy/*, inUV*/, 3, false);
+    out0.x = outShadowTerm;
+    out0.y = PackEdges( outEdges );
+}
+
+// ********************************************************************************************************
+// Pixel shader that does smart blurring (to avoid bleeding)
+
+void AddSample( float ssaoValue, float edgeValue, inout float sum, inout float sumWeight )
+{
+    float weight = edgeValue;    
+
+    sum += (weight * ssaoValue);
+    sumWeight += weight;
+}
+
+float2 SampleBlurredWide( float4 inPos, float2 coord )
+{
+    float2 vC           = g_BlurInput.SampleLevel( g_PointMirrorSampler, coord, 0.0, int2( 0,  0 ) ).xy;
+    float2 vL           = g_BlurInput.SampleLevel( g_PointMirrorSampler, coord, 0.0, int2( -2, 0 ) ).xy;
+    float2 vT           = g_BlurInput.SampleLevel( g_PointMirrorSampler, coord, 0.0, int2( 0, -2 ) ).xy;
+    float2 vR           = g_BlurInput.SampleLevel( g_PointMirrorSampler, coord, 0.0, int2(  2, 0 ) ).xy;
+    float2 vB           = g_BlurInput.SampleLevel( g_PointMirrorSampler, coord, 0.0, int2( 0,  2 ) ).xy;
+
+    float packedEdges   = vC.y;
+    float4 edgesLRTB    = UnpackEdges( packedEdges );
+    edgesLRTB.x         *= UnpackEdges( vL.y ).y;
+    edgesLRTB.z         *= UnpackEdges( vT.y ).w;
+    edgesLRTB.y         *= UnpackEdges( vR.y ).x;
+    edgesLRTB.w         *= UnpackEdges( vB.y ).z;
+
+    float ssaoValue     = vC.x;
+    float ssaoValueL    = vL.x;
+    float ssaoValueT    = vT.x;
+    float ssaoValueR    = vR.x;
+    float ssaoValueB    = vB.x;
+
+    float sumWeight = 0.8f;
+    float sum = ssaoValue * sumWeight;
+
+    AddSample( ssaoValueL, edgesLRTB.x, sum, sumWeight );
+    AddSample( ssaoValueR, edgesLRTB.y, sum, sumWeight );
+    AddSample( ssaoValueT, edgesLRTB.z, sum, sumWeight );
+    AddSample( ssaoValueB, edgesLRTB.w, sum, sumWeight );
+
+    float ssaoAvg = sum / sumWeight;
+
+    ssaoValue = ssaoAvg; //min( ssaoValue, ssaoAvg ) * 0.2 + ssaoAvg * 0.8;
+
+    return float2( ssaoValue, packedEdges );
+}
+
+float2 SampleBlurred( float4 inPos, float2 coord )
+{
+    float packedEdges   = g_BlurInput.Load( int3( inPos.xy, 0 ) ).y;
+    float4 edgesLRTB    = UnpackEdges( packedEdges );
+
+    float4 valuesUL     = g_BlurInput.GatherRed( g_PointMirrorSampler, coord - g_ASSAOConsts.HalfViewportPixelSize * 0.5 );
+    float4 valuesBR     = g_BlurInput.GatherRed( g_PointMirrorSampler, coord + g_ASSAOConsts.HalfViewportPixelSize * 0.5 );
+
+    float ssaoValue     = valuesUL.y;
+    float ssaoValueL    = valuesUL.x;
+    float ssaoValueT    = valuesUL.z;
+    float ssaoValueR    = valuesBR.z;
+    float ssaoValueB    = valuesBR.x;
+
+    float sumWeight = 0.5f;
+    float sum = ssaoValue * sumWeight;
+
+    AddSample( ssaoValueL, edgesLRTB.x, sum, sumWeight );
+    AddSample( ssaoValueR, edgesLRTB.y, sum, sumWeight );
+
+    AddSample( ssaoValueT, edgesLRTB.z, sum, sumWeight );
+    AddSample( ssaoValueB, edgesLRTB.w, sum, sumWeight );
+
+    float ssaoAvg = sum / sumWeight;
+
+    ssaoValue = ssaoAvg; //min( ssaoValue, ssaoAvg ) * 0.2 + ssaoAvg * 0.8;
+
+    return float2( ssaoValue, packedEdges );
+}
+
+// edge-sensitive blur
+float2 PSSmartBlur( in float4 inPos : SV_POSITION, in float2 inUV : TEXCOORD0 ) : SV_Target
+{
+    return SampleBlurred( inPos, inUV );
+}
+
+// edge-sensitive blur (wider kernel)
+float2 PSSmartBlurWide( in float4 inPos : SV_POSITION, in float2 inUV : TEXCOORD0 ) : SV_Target
+{
+    return SampleBlurredWide( inPos, inUV );
+}
+
+float4 PSApply( in float4 inPos : SV_POSITION/*, in float2 inUV : TEXCOORD0*/ ) : SV_Target
+{
+    float ao;
+    uint2 pixPos     = (uint2)inPos.xy;
+    uint2 pixPosHalf = pixPos / uint2(2, 2);
+
+    // calculate index in the four deinterleaved source array texture
+    int mx = (pixPos.x % 2);
+    int my = (pixPos.y % 2);
+    int ic = mx + my * 2;       // center index
+    int ih = (1-mx) + my * 2;   // neighbouring, horizontal
+    int iv = mx + (1-my) * 2;   // neighbouring, vertical
+    int id = (1-mx) + (1-my)*2; // diagonal
+    
+    float2 centerVal = g_FinalSSAO.Load( int4( pixPosHalf, ic, 0 ) ).xy;
+    
+    ao = centerVal.x;
+
+#if 1   // change to 0 if you want to disable last pass high-res blur (for debugging purposes, etc.)
+    float4 edgesLRTB = UnpackEdges( centerVal.y );
+
+    // return 1.0 - float4( edgesLRTB.x, edgesLRTB.y * 0.5 + edgesLRTB.w * 0.5, edgesLRTB.z, 0.0 ); // debug show edges
+
+    // convert index shifts to sampling offsets
+    float fmx   = (float)mx;
+    float fmy   = (float)my;
+    
+    // in case of an edge, push sampling offsets away from the edge (towards pixel center)
+    float fmxe  = (edgesLRTB.y - edgesLRTB.x);
+    float fmye  = (edgesLRTB.w - edgesLRTB.z);
+
+    // calculate final sampling offsets and sample using bilinear filter
+    float2  uvH = (inPos.xy + float2( fmx + fmxe - 0.5, 0.5 - fmy ) ) * 0.5 * g_ASSAOConsts.HalfViewportPixelSize;
+    float   aoH = g_FinalSSAO.SampleLevel( g_LinearClampSampler, float3( uvH, ih ), 0 ).x;
+    float2  uvV = (inPos.xy + float2( 0.5 - fmx, fmy - 0.5 + fmye ) ) * 0.5 * g_ASSAOConsts.HalfViewportPixelSize;
+    float   aoV = g_FinalSSAO.SampleLevel( g_LinearClampSampler, float3( uvV, iv ), 0 ).x;
+    float2  uvD = (inPos.xy + float2( fmx - 0.5 + fmxe, fmy - 0.5 + fmye ) ) * 0.5 * g_ASSAOConsts.HalfViewportPixelSize;
+    float   aoD = g_FinalSSAO.SampleLevel( g_LinearClampSampler, float3( uvD, id ), 0 ).x;
+
+    // reduce weight for samples near edge - if the edge is on both sides, weight goes to 0
+    float4 blendWeights;
+    blendWeights.x = 1.0;
+    blendWeights.y = (edgesLRTB.x + edgesLRTB.y) * 0.5;
+    blendWeights.z = (edgesLRTB.z + edgesLRTB.w) * 0.5;
+    blendWeights.w = (blendWeights.y + blendWeights.z) * 0.5;
+
+    // calculate weighted average
+    float blendWeightsSum   = dot( blendWeights, float4( 1.0, 1.0, 1.0, 1.0 ) );
+    ao = dot( float4( ao, aoH, aoV, aoD ), blendWeights ) / blendWeightsSum;
+#endif
+
+    return float4( ao.xxx, 1.0 );
+}
+
+// edge-ignorant blur in x and y directions, 9 pixels touched (for the lowest quality level 0)
+float2 PSNonSmartBlur( in float4 inPos : SV_POSITION, in float2 inUV : TEXCOORD0 ) : SV_Target
+{
+    float2 halfPixel = g_ASSAOConsts.HalfViewportPixelSize * 0.5f;
+
+    float2 centre = g_BlurInput.SampleLevel( g_LinearClampSampler, inUV, 0.0 ).xy;
+
+    float4 vals;
+    vals.x = g_BlurInput.SampleLevel( g_LinearClampSampler, inUV + float2( -halfPixel.x * 3, -halfPixel.y ), 0.0 ).x;
+    vals.y = g_BlurInput.SampleLevel( g_LinearClampSampler, inUV + float2( +halfPixel.x, -halfPixel.y * 3 ), 0.0 ).x;
+    vals.z = g_BlurInput.SampleLevel( g_LinearClampSampler, inUV + float2( -halfPixel.x, +halfPixel.y * 3 ), 0.0 ).x;
+    vals.w = g_BlurInput.SampleLevel( g_LinearClampSampler, inUV + float2( +halfPixel.x * 3, +halfPixel.y ), 0.0 ).x;
+
+    return float2(dot( vals, 0.2.xxxx ) + centre.x * 0.2, centre.y);
+}
+
+// edge-ignorant blur & apply (for the lowest quality level 0)
+float4 PSNonSmartApply( in float4 inPos : SV_POSITION, in float2 inUV : TEXCOORD0 ) : SV_Target
+{
+    float a = g_FinalSSAO.SampleLevel( g_LinearClampSampler, float3( inUV.xy, 0 ), 0.0 ).x;
+    float b = g_FinalSSAO.SampleLevel( g_LinearClampSampler, float3( inUV.xy, 1 ), 0.0 ).x;
+    float c = g_FinalSSAO.SampleLevel( g_LinearClampSampler, float3( inUV.xy, 2 ), 0.0 ).x;
+    float d = g_FinalSSAO.SampleLevel( g_LinearClampSampler, float3( inUV.xy, 3 ), 0.0 ).x;
+    float avg = (a+b+c+d) * 0.25;
+    return float4( avg.xxx, 1.0 );
+}
+
+// edge-ignorant blur & apply, skipping half pixels in checkerboard pattern (for the Lowest quality level 0 and Settings::SkipHalfPixelsOnLowQualityLevel == true )
+float4 PSNonSmartHalfApply( in float4 inPos : SV_POSITION, in float2 inUV : TEXCOORD0 ) : SV_Target
+{
+    float a = g_FinalSSAO.SampleLevel( g_LinearClampSampler, float3( inUV.xy, 0 ), 0.0 ).x;
+    float d = g_FinalSSAO.SampleLevel( g_LinearClampSampler, float3( inUV.xy, 3 ), 0.0 ).x;
+    float avg = (a+d) * 0.5;
+    return float4( avg.xxx, 1.0 );
+}
+
+// Shaders below only needed for adaptive quality level
+
+float PSGenerateImportanceMap( in float4 inPos : SV_POSITION, in float2 inUV : TEXCOORD0 ) : SV_Target
+{
+    uint2 basePos = ((uint2)inPos.xy) * 2;
+
+    float2 baseUV = (float2(basePos) + float2( 0.5, 0.5 ) ) * g_ASSAOConsts.HalfViewportPixelSize;
+    float2 gatherUV = (float2(basePos) + float2( 1.0, 1.0 ) ) * g_ASSAOConsts.HalfViewportPixelSize;
+
+    float avg = 0.0;
+    float minV = 1.0;
+    float maxV = 0.0;
+    [unroll]
+    for( int i = 0; i < 4; i++ )
+    {
+        float4 vals = g_FinalSSAO.GatherRed( g_PointClampSampler, float3( gatherUV, i ) );
+
+        // apply the same modifications that would have been applied in the main shader
+        vals = g_ASSAOConsts.EffectShadowStrength * vals;
+
+        vals = 1-vals;
+
+        vals = pow( saturate( vals ), g_ASSAOConsts.EffectShadowPow );
+
+        avg += dot( float4( vals.x, vals.y, vals.z, vals.w ), float4( 1.0 / 16.0, 1.0 / 16.0, 1.0 / 16.0, 1.0 / 16.0 ) );
+
+        maxV = max( maxV, max( max( vals.x, vals.y ), max( vals.z, vals.w ) ) );
+        minV = min( minV, min( min( vals.x, vals.y ), min( vals.z, vals.w ) ) );
+    }
+
+    float minMaxDiff = maxV - minV;
+
+    //return pow( saturate( minMaxDiff * 1.2 + (1.0-avg) * 0.3 ), 0.8 );
+    return pow( saturate( minMaxDiff * 2.0 ), 0.8 );
+}
+
+static const float cSmoothenImportance = 1.0;
+
+float PSPostprocessImportanceMapA( in float4 inPos : SV_POSITION, in float2 inUV : TEXCOORD0 ) : SV_Target
+{
+    uint2 pos = ((uint2)inPos.xy);
+
+    float centre = g_ImportanceMap.SampleLevel( g_LinearClampSampler, inUV, 0.0 ).x;
+    //return centre;
+
+    float2 halfPixel = g_ASSAOConsts.QuarterResPixelSize * 0.5f;
+
+    float4 vals;
+    vals.x = g_ImportanceMap.SampleLevel( g_LinearClampSampler, inUV + float2( -halfPixel.x * 3, -halfPixel.y ), 0.0 ).x;
+    vals.y = g_ImportanceMap.SampleLevel( g_LinearClampSampler, inUV + float2( +halfPixel.x, -halfPixel.y * 3 ), 0.0 ).x;
+    vals.z = g_ImportanceMap.SampleLevel( g_LinearClampSampler, inUV + float2( +halfPixel.x * 3, +halfPixel.y ), 0.0 ).x;
+    vals.w = g_ImportanceMap.SampleLevel( g_LinearClampSampler, inUV + float2( -halfPixel.x, +halfPixel.y * 3 ), 0.0 ).x;
+
+    float avgVal = dot( vals, float4( 0.25, 0.25, 0.25, 0.25 ) );
+    vals.xy = max( vals.xy, vals.zw );
+    float maxVal = max( centre, max( vals.x, vals.y ) );
+
+    return lerp( maxVal, avgVal, cSmoothenImportance );
+}
+
+float PSPostprocessImportanceMapB( in float4 inPos : SV_POSITION, in float2 inUV : TEXCOORD0 ) : SV_Target
+{
+    uint2 pos = ((uint2)inPos.xy);
+
+    float centre = g_ImportanceMap.SampleLevel( g_LinearClampSampler, inUV, 0.0 ).x;
+    //return centre;
+
+    float2 halfPixel = g_ASSAOConsts.QuarterResPixelSize * 0.5f;
+
+    float4 vals;
+    vals.x = g_ImportanceMap.SampleLevel( g_LinearClampSampler, inUV + float2( -halfPixel.x, -halfPixel.y * 3 ), 0.0 ).x;
+    vals.y = g_ImportanceMap.SampleLevel( g_LinearClampSampler, inUV + float2( +halfPixel.x * 3, -halfPixel.y ), 0.0 ).x;
+    vals.z = g_ImportanceMap.SampleLevel( g_LinearClampSampler, inUV + float2( +halfPixel.x, +halfPixel.y * 3 ), 0.0 ).x;
+    vals.w = g_ImportanceMap.SampleLevel( g_LinearClampSampler, inUV + float2( -halfPixel.x * 3, +halfPixel.y ), 0.0 ).x;
+
+    float avgVal = dot( vals, float4( 0.25, 0.25, 0.25, 0.25 ) );
+    vals.xy = max( vals.xy, vals.zw );
+    float maxVal = max( centre, max( vals.x, vals.y ) );
+
+    float retVal = lerp( maxVal, avgVal, cSmoothenImportance );
+
+    // sum the average; to avoid overflowing we assume max AO resolution is not bigger than 16384x16384; so quarter res (used here) will be 4096x4096, which leaves us with 8 bits per pixel 
+    uint sum = (uint)(saturate(retVal) * 255.0 + 0.5);
+    
+    // save every 9th to avoid InterlockedAdd congestion - since we're blurring, this is good enough; compensated by multiplying LoadCounterAvgDiv by 9
+    if( ((pos.x % 3) + (pos.y % 3)) == 0  )
+        InterlockedAdd( g_LoadCounterOutputUAV[0], sum );
+
+    return retVal;
+}

--- a/D3D11Engine/Shaders/ASSAO/ASSAO.hlsl
+++ b/D3D11Engine/Shaders/ASSAO/ASSAO.hlsl
@@ -16,23 +16,8 @@
 // 2016-09-07: filip.strugar@intel.com: first commit
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-
-// Octahedral encoding: map a unit normal to [-1,1]^2 for R16G16_SNORM storage
-// Reference: "A Survey of Efficient Representations for Independent Unit Vectors" (Cigolle et al. 2014)
-float2 OctWrap(float2 v)
-{
-    return (1.0 - abs(v.yx)) * (v.xy >= 0.0 ? 1.0 : -1.0);
-}
-
-// Decode octahedral [-1,1]^2 back to a unit normal
-float3 DecodeNormalGBuffer(float2 encoded)
-{
-    float3 n;
-    n.z = 1.0 - abs(encoded.x) - abs(encoded.y);
-    n.xy = n.z >= 0.0 ? encoded.xy : OctWrap(encoded.xy);
-    return normalize(n);
-}
-
+// Contains `DecodeNormalGBuffer`
+#include "../DS_Defines.h"
 
 // progressive poisson-like pattern; x, y are in [-1, 1] range, .z is length( float2(x,y) ), .w is log2( z )
 #define INTELSSAO_MAIN_DISK_SAMPLE_COUNT (32)

--- a/D3D11Engine/Shaders/CS_PFX_DoF.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_DoF.hlsl
@@ -1,0 +1,144 @@
+//--------------------------------------------------------------------------------------
+// Compute Shader - Depth of Field Half-res Bokeh Blur
+// Samples full-res scene + depth, computes CoC, does 48-tap bokeh blur
+// Outputs blurred color (rgb) + CoC (a) at half resolution to UAV
+//--------------------------------------------------------------------------------------
+
+cbuffer DepthOfFieldConstantBuffer : register( b0 )
+{
+    float DoF_FocusDistance;
+    float DoF_FocusRange;
+    float DoF_BokehRadius;
+    float DoF_MaxBlur;
+
+    float4 DoF_ProjParams;
+    float DoF_NearPlane;
+    float DoF_FarPlane;
+    float DoF_Pad;
+    float DoF_Pad2;
+};
+
+SamplerState SS_Linear : register( s0 );
+Texture2D TX_Scene : register( t0 );   // Full-res scene color
+Texture2D TX_Depth : register( t1 );   // Full-res hardware depth
+Texture2D TX_Focus : register( t2 );   // 1x1 R32_FLOAT smoothed focus depth
+
+RWTexture2D<float4> OutputBlur : register( u0 ); // Half-res output
+
+float LinearizeDepth( float d )
+{
+    return DoF_ProjParams.z / ( d - DoF_ProjParams.w );
+}
+
+float ComputeCoC( float linearDepth, float focusDepth )
+{
+    return saturate( ( linearDepth - focusDepth ) / DoF_FocusRange );
+}
+
+static const int SAMPLE_COUNT = 48;
+
+float2 GetSpiralSample( int index, int count )
+{
+    float r = sqrt( ( float(index) + 0.5 ) / float(count) );
+    float theta = float(index) * 2.39996323;
+    return float2( r * cos( theta ), r * sin( theta ) );
+}
+
+[numthreads(8, 8, 1)]
+void CSMain( uint3 DTid : SV_DispatchThreadID )
+{
+    uint2 outSize;
+    OutputBlur.GetDimensions( outSize.x, outSize.y );
+
+    if ( DTid.x >= outSize.x || DTid.y >= outSize.y )
+        return;
+
+    float2 texcoord = ( float2( DTid.xy ) + 0.5 ) / float2( outSize );
+
+    // Texel size of the full-res scene for sampling offsets
+    float2 sceneSize;
+    TX_Scene.GetDimensions( sceneSize.x, sceneSize.y );
+    float2 texelSize = 1.0 / sceneSize;
+
+    float focusDepth = TX_Focus.SampleLevel( SS_Linear, float2( 0.5, 0.5 ), 0 ).r;
+
+    float centerDepth = TX_Depth.SampleLevel( SS_Linear, texcoord, 0 ).r;
+    float centerLinear = LinearizeDepth( centerDepth );
+    float centerCoC = ComputeCoC( centerLinear, focusDepth );
+
+    float3 centerColor = TX_Scene.SampleLevel( SS_Linear, texcoord, 0 ).rgb;
+
+    // Early out: pass through sharp pixel
+    if ( centerCoC < 0.01 )
+    {
+        OutputBlur[DTid.xy] = float4( centerColor, 0.0 );
+        return;
+    }
+
+    float blurRadius = min( centerCoC * DoF_BokehRadius, DoF_MaxBlur );
+
+#ifdef DOF_GAUSS_BLUR
+    // --- Simple Gaussian blur (16 taps) ---
+    // Uses a radial Gaussian kernel with exp(-r^2 * 3) weights.
+    // Much cheaper than the bokeh path; no highlight boost or
+    // foreground rejection — just a smooth, uniform blur.
+    static const int GAUSS_SAMPLE_COUNT = 16;
+
+    float3 colorAccum = 0.0;
+    float weightAccum = 0.0;
+
+    [unroll]
+    for ( int i = 0; i < GAUSS_SAMPLE_COUNT; i++ )
+    {
+        float2 offset = GetSpiralSample( i, GAUSS_SAMPLE_COUNT );
+        float2 sampleUV = texcoord + offset * blurRadius * texelSize;
+
+        float3 sampleColor = TX_Scene.SampleLevel( SS_Linear, sampleUV, 0 ).rgb;
+
+        float r2 = dot( offset, offset );
+        float weight = exp( -r2 * 3.0 );
+
+        colorAccum += sampleColor * weight;
+        weightAccum += weight;
+    }
+#else
+    // --- Bokeh spiral blur (48 taps) ---
+    // Seed accumulator with the center pixel so that if all 48 spiral
+    // samples are foreground-rejected (e.g. background visible through
+    // a leaf gap), the result falls back to the center color instead
+    // of producing black.  Weight uses the same luminance-boost formula
+    // applied to every spiral sample.
+    float centerLum = dot( centerColor, float3( 0.2126, 0.7152, 0.0722 ) );
+    float3 colorAccum = centerColor * ( 1.0 + centerLum * 2.0 );
+    float weightAccum = 1.0 + centerLum * 2.0;
+
+    [unroll]
+    for ( int i = 0; i < SAMPLE_COUNT; i++ )
+    {
+        float2 offset = GetSpiralSample( i, SAMPLE_COUNT );
+        float2 sampleUV = texcoord + offset * blurRadius * texelSize;
+
+        float3 sampleColor = TX_Scene.SampleLevel( SS_Linear, sampleUV, 0 ).rgb;
+        float sampleDepth = TX_Depth.SampleLevel( SS_Linear, sampleUV, 0 ).r;
+        float sampleLinear = LinearizeDepth( sampleDepth );
+        float sampleCoC = ComputeCoC( sampleLinear, focusDepth );
+
+        float weight = ( sampleCoC >= length( offset ) * centerCoC ) ? 1.0 : sampleCoC;
+
+        // Asymmetric foreground rejection
+        float depthMargin = max( centerLinear * 0.05, 5.0 );
+        float foregroundReject = saturate( ( sampleLinear - centerLinear + depthMargin ) / depthMargin );
+        weight *= foregroundReject;
+
+        float luminance = dot( sampleColor, float3( 0.2126, 0.7152, 0.0722 ) );
+        weight *= 1.0 + luminance * 2.0;
+
+        colorAccum += sampleColor * weight;
+        weightAccum += weight;
+    }
+#endif
+
+    colorAccum /= max( weightAccum, 0.001 );
+
+    OutputBlur[DTid.xy] = float4( colorAccum, centerCoC );
+}

--- a/D3D11Engine/Shaders/CS_PFX_DoF_Composite.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_DoF_Composite.hlsl
@@ -1,0 +1,70 @@
+//--------------------------------------------------------------------------------------
+// Compute Shader - Depth of Field Full-res Composite
+// Reads full-res scene + depth, upsampled half-res bokeh blur, and focus texture
+// Blends sharp and blurred based on per-pixel CoC, writes to UAV
+//--------------------------------------------------------------------------------------
+
+cbuffer DepthOfFieldConstantBuffer : register( b0 )
+{
+    float DoF_FocusDistance;
+    float DoF_FocusRange;
+    float DoF_BokehRadius;
+    float DoF_MaxBlur;
+
+    float4 DoF_ProjParams;
+    float DoF_NearPlane;
+    float DoF_FarPlane;
+    float DoF_Pad;
+    float DoF_Pad2;
+};
+
+SamplerState SS_Linear : register( s0 );
+Texture2D TX_Scene : register( t0 );   // Full-res sharp scene
+Texture2D TX_Blur  : register( t1 );   // Half-res bokeh (rgb=blur, a=CoC)
+Texture2D TX_Depth : register( t2 );   // Full-res hardware depth
+Texture2D TX_Focus : register( t3 );   // 1x1 smoothed focus depth
+
+RWTexture2D<float4> OutputComposite : register( u0 );
+
+float LinearizeDepth( float d )
+{
+    return DoF_ProjParams.z / ( d - DoF_ProjParams.w );
+}
+
+[numthreads(8, 8, 1)]
+void CSMain( uint3 DTid : SV_DispatchThreadID )
+{
+    uint2 outSize;
+    OutputComposite.GetDimensions( outSize.x, outSize.y );
+
+    if ( DTid.x >= outSize.x || DTid.y >= outSize.y )
+        return;
+
+    float2 texcoord = ( float2( DTid.xy ) + 0.5 ) / float2( outSize );
+
+    float3 sharpColor = TX_Scene.SampleLevel( SS_Linear, texcoord, 0 ).rgb;
+
+    float focusDepth = TX_Focus.SampleLevel( SS_Linear, float2( 0.5, 0.5 ), 0 ).r;
+
+    // Compute CoC at center and 4 neighbours, use the minimum.
+    // This erodes the blur zone by 1 pixel at depth discontinuities.
+    float2 depthSize;
+    TX_Depth.GetDimensions( depthSize.x, depthSize.y );
+    float2 dtexel = 1.0 / depthSize;
+
+    float cocC = saturate( ( LinearizeDepth( TX_Depth.SampleLevel( SS_Linear, texcoord, 0 ).r ) - focusDepth ) / DoF_FocusRange );
+    float cocL = saturate( ( LinearizeDepth( TX_Depth.SampleLevel( SS_Linear, texcoord + float2( -dtexel.x, 0 ), 0 ).r ) - focusDepth ) / DoF_FocusRange );
+    float cocR = saturate( ( LinearizeDepth( TX_Depth.SampleLevel( SS_Linear, texcoord + float2(  dtexel.x, 0 ), 0 ).r ) - focusDepth ) / DoF_FocusRange );
+    float cocU = saturate( ( LinearizeDepth( TX_Depth.SampleLevel( SS_Linear, texcoord + float2( 0, -dtexel.y ), 0 ).r ) - focusDepth ) / DoF_FocusRange );
+    float cocD = saturate( ( LinearizeDepth( TX_Depth.SampleLevel( SS_Linear, texcoord + float2( 0,  dtexel.y ), 0 ).r ) - focusDepth ) / DoF_FocusRange );
+
+    float minCoC = min( min( cocC, cocL ), min( cocR, min( cocU, cocD ) ) );
+
+    // Bilinear-upsampled half-res bokeh blur
+    float4 blurSample = TX_Blur.SampleLevel( SS_Linear, texcoord, 0 );
+
+    float blendFactor = smoothstep( 0.0, 1.0, minCoC );
+    float3 finalColor = lerp( sharpColor, blurSample.rgb, blendFactor );
+
+    OutputComposite[DTid.xy] = float4( finalColor, 1.0 );
+}

--- a/D3D11Engine/Shaders/CS_PFX_DoF_FocusResolve.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_DoF_FocusResolve.hlsl
@@ -1,0 +1,83 @@
+//--------------------------------------------------------------------------------------
+// Compute Shader - Depth of Field Focus Resolve
+// Samples depth in a disc around screen center and temporally smooths the result
+// Writes to a 1x1 R32_FLOAT UAV storing the linearized focus distance
+//--------------------------------------------------------------------------------------
+
+cbuffer DepthOfFieldConstantBuffer : register( b0 )
+{
+    float DoF_FocusDistance;
+    float DoF_FocusRange;
+    float DoF_BokehRadius;
+    float DoF_MaxBlur;
+
+    float4 DoF_ProjParams;
+    float DoF_NearPlane;
+    float DoF_FarPlane;
+    float DoF_Pad;
+    float DoF_Pad2;
+};
+
+SamplerState SS_Linear : register( s0 );
+Texture2D TX_Depth : register( t0 );
+Texture2D TX_PrevFocus : register( t1 ); // 1x1 R32_FLOAT from previous frame
+
+RWTexture2D<float> OutputFocus : register( u0 );
+
+float LinearizeDepth( float d )
+{
+    return DoF_ProjParams.z / ( d - DoF_ProjParams.w );
+}
+
+[numthreads(1, 1, 1)]
+void CSMain( uint3 DTid : SV_DispatchThreadID )
+{
+    static const float2 offsets[13] = {
+        float2( 0.000,  0.000),
+        float2(-0.035,  0.000), float2( 0.035,  0.000),
+        float2( 0.000, -0.035), float2( 0.000,  0.035),
+        float2(-0.025, -0.025), float2( 0.025, -0.025),
+        float2(-0.025,  0.025), float2( 0.025,  0.025),
+        float2(-0.060,  0.000), float2( 0.060,  0.000),
+        float2( 0.000, -0.060), float2( 0.000,  0.060),
+    };
+
+    static const float weights[13] = {
+        0.20,
+        0.08, 0.08,
+        0.08, 0.08,
+        0.06, 0.06,
+        0.06, 0.06,
+        0.04, 0.04,
+        0.04, 0.04,
+    };
+
+    float targetDepth = 0.0;
+    float totalWeight = 0.0;
+    for ( int i = 0; i < 13; i++ )
+    {
+        float2 uv = float2( 0.5, 0.5 ) + offsets[i];
+        float d = TX_Depth.SampleLevel( SS_Linear, uv, 0 ).r;
+        float linearD = LinearizeDepth( d );
+        targetDepth += linearD * weights[i];
+        totalWeight += weights[i];
+    }
+    targetDepth /= totalWeight;
+
+    float prevFocus = TX_PrevFocus.SampleLevel( SS_Linear, float2( 0.5, 0.5 ), 0 ).r;
+
+    // First frame: no previous data
+    if ( prevFocus <= 0.0 )
+    {
+        OutputFocus[uint2(0,0)] = targetDepth;
+        return;
+    }
+
+    // Adaptive smoothing
+    float relDiff = abs( targetDepth - prevFocus ) / max( prevFocus, 1.0 );
+    float smoothing = lerp( 0.015, 0.20, saturate( relDiff * 2.0 ) );
+
+    float newFocus = lerp( prevFocus, targetDepth, smoothing );
+
+    OutputFocus[uint2(0,0)] = newFocus;
+}

--- a/D3D11Engine/Shaders/CS_PFX_GodRayMask.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_GodRayMask.hlsl
@@ -1,11 +1,11 @@
 //--------------------------------------------------------------------------------------
 // Compute Shader - God Ray Mask Pass
-// Reads backbuffer + normals, outputs mask to UAV
+// Reads backbuffer + depth, outputs mask to UAV
 //--------------------------------------------------------------------------------------
 
 SamplerState SS_Linear : register( s0 );
 Texture2D TX_Texture0 : register( t0 ); // Backbuffer
-Texture2D TX_Texture1 : register( t1 ); // Normals
+Texture2D TX_Depth : register( t1 ); // Depth
 
 RWTexture2D<float4> OutputTexture : register( u0 );
 
@@ -21,9 +21,9 @@ void CSMain( uint3 DTid : SV_DispatchThreadID )
     float2 uv = ( float2( DTid.xy ) + 0.5 ) / float2( outSize );
 
     float4 color = TX_Texture0.SampleLevel( SS_Linear, uv, 0 );
-    float4 gb2 = TX_Texture1.SampleLevel( SS_Linear, uv, 0 );
+    float4 depth = TX_Depth.SampleLevel( SS_Linear, uv, 0 );
 
-    if ( gb2.w < 0.001f )
+    if ( depth.r < 0.00001f ) // likely sky pixel
         OutputTexture[DTid.xy] = color;
     else
         OutputTexture[DTid.xy] = float4( 0, 0, 0, 0 );

--- a/D3D11Engine/Shaders/CS_PFX_GodRayMask.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_GodRayMask.hlsl
@@ -1,0 +1,30 @@
+//--------------------------------------------------------------------------------------
+// Compute Shader - God Ray Mask Pass
+// Reads backbuffer + normals, outputs mask to UAV
+//--------------------------------------------------------------------------------------
+
+SamplerState SS_Linear : register( s0 );
+Texture2D TX_Texture0 : register( t0 ); // Backbuffer
+Texture2D TX_Texture1 : register( t1 ); // Normals
+
+RWTexture2D<float4> OutputTexture : register( u0 );
+
+[numthreads(8, 8, 1)]
+void CSMain( uint3 DTid : SV_DispatchThreadID )
+{
+    uint2 outSize;
+    OutputTexture.GetDimensions( outSize.x, outSize.y );
+
+    if ( DTid.x >= outSize.x || DTid.y >= outSize.y )
+        return;
+
+    float2 uv = ( float2( DTid.xy ) + 0.5 ) / float2( outSize );
+
+    float4 color = TX_Texture0.SampleLevel( SS_Linear, uv, 0 );
+    float4 gb2 = TX_Texture1.SampleLevel( SS_Linear, uv, 0 );
+
+    if ( gb2.w < 0.001f )
+        OutputTexture[DTid.xy] = color;
+    else
+        OutputTexture[DTid.xy] = float4( 0, 0, 0, 0 );
+}

--- a/D3D11Engine/Shaders/CS_PFX_GodRayZoom.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_GodRayZoom.hlsl
@@ -1,0 +1,71 @@
+//--------------------------------------------------------------------------------------
+// Compute Shader - God Ray Zoom (Radial Blur) Pass
+// Reads mask texture, applies radial blur toward sun center, writes to UAV
+//--------------------------------------------------------------------------------------
+
+cbuffer GodRayZoomConstantBuffer : register( b0 )
+{
+    float GR_Decay;
+    float GR_Weight;
+    float2 GR_Center;
+
+    float GR_Density;
+    float3 GR_ColorMod;
+};
+
+SamplerState SS_Linear : register( s0 );
+Texture2D TX_Texture0 : register( t0 ); // Mask from pass 1
+
+RWTexture2D<float4> OutputTexture : register( u0 );
+
+// Interleaved Gradient Noise for cheap, effective dithering
+float InterleavedGradientNoise( float2 uv )
+{
+    float3 magic = float3( 0.06711056f, 0.00583715f, 52.9829189f );
+    return frac( magic.z * frac( dot( uv, magic.xy ) ) );
+}
+
+[numthreads(8, 8, 1)]
+void CSMain( uint3 DTid : SV_DispatchThreadID )
+{
+    uint2 texSize;
+    OutputTexture.GetDimensions( texSize.x, texSize.y );
+
+    if ( DTid.x >= texSize.x || DTid.y >= texSize.y )
+        return;
+
+    float2 texcoord = ( float2( DTid.xy ) + 0.5 ) / float2( texSize );
+
+    const int NUM_SAMPLES = 64;
+    float2 center = GR_Center;
+    float3 color = 0;
+    float illumDecay = 1.0f;
+
+    float2 deltaTexCoord = texcoord - center;
+    deltaTexCoord *= 1.0f / NUM_SAMPLES * GR_Density;
+
+    float2 uv = texcoord;
+
+    // Dithering: Offset the starting UV by a random sub-texel fraction
+    float jitter = InterleavedGradientNoise( float2( DTid.xy ) );
+    uv -= deltaTexCoord * jitter;
+
+    [unroll(64)]
+    for ( int i = 0; i < NUM_SAMPLES; i++ )
+    {
+        uv -= deltaTexCoord;
+
+        // Anti-Smearing: Prevent sampling out of bounds
+        if ( uv.x < 0.0f || uv.x > 1.0f || uv.y < 0.0f || uv.y > 1.0f )
+        {
+            continue;
+        }
+
+        color += TX_Texture0.SampleLevel( SS_Linear, uv, 0 ).rgb * illumDecay * GR_Weight;
+
+        illumDecay *= GR_Decay;
+    }
+    color /= NUM_SAMPLES;
+
+    OutputTexture[DTid.xy] = float4( color * GR_ColorMod, 1.0f );
+}

--- a/D3D11Engine/Shaders/CS_PFX_SAO.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_SAO.hlsl
@@ -4,6 +4,8 @@
 // Reads depth + normals, writes AO to R8_UNORM UAV
 //--------------------------------------------------------------------------------------
 
+#include "DS_Defines.h"
+
 cbuffer SAOConstantBuffer : register( b0 )
 {
     float4 SAO_ProjParams;    // x = 1/P._11, y = 1/P._22, z = P._34, w = P._33
@@ -36,8 +38,8 @@ float3 VSPositionFromDepth( float depth, float2 texcoord )
 
 float3 DecodeNormal( float4 enc )
 {
-    // GBuffer normals are R8G8B8A8_SNORM - already in [-1,1] range
-    return normalize( enc.xyz );
+    // GBuffer normals are RG16_SNORM - already in [-1,1] range
+    return DecodeNormalGBuffer( enc.xy );
 }
 
 // Golden-angle spiral sampling

--- a/D3D11Engine/Shaders/CS_PFX_SAO.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_SAO.hlsl
@@ -1,0 +1,140 @@
+//--------------------------------------------------------------------------------------
+// Compute Shader - Scalable Ambient Obscurance (SAO)
+// Screen-space AO using 2D spiral sampling pattern
+// Reads depth + normals, writes AO to R8_UNORM UAV
+//--------------------------------------------------------------------------------------
+
+cbuffer SAOConstantBuffer : register( b0 )
+{
+    float4 SAO_ProjParams;    // x = 1/P._11, y = 1/P._22, z = P._34, w = P._33
+    float  SAO_Radius;        // World-space AO radius
+    float  SAO_Bias;          // Normal bias to reduce self-occlusion
+    float  SAO_Intensity;     // Darkening strength
+    int    SAO_NumSamples;    // Spiral sample count (16-48)
+    float2 SAO_InvResolution; // 1/width, 1/height
+    float  SAO_BlurSharpness; // Bilateral blur edge preservation (unused here)
+    float  SAO_Pad;
+};
+
+SamplerState SS_Linear : register( s0 );
+Texture2D TX_Depth   : register( t0 );
+Texture2D TX_Normals : register( t1 );
+
+RWTexture2D<float> OutputAO : register( u0 );
+
+float LinearizeDepth( float d )
+{
+    return SAO_ProjParams.z / ( d - SAO_ProjParams.w );
+}
+
+float3 VSPositionFromDepth( float depth, float2 texcoord )
+{
+    float2 ndc = texcoord * float2( 2.0f, -2.0f ) + float2( -1.0f, 1.0f );
+    float linearZ = LinearizeDepth( depth );
+    return float3( ndc * SAO_ProjParams.xy * linearZ, linearZ );
+}
+
+float3 DecodeNormal( float4 enc )
+{
+    // GBuffer normals are R8G8B8A8_SNORM - already in [-1,1] range
+    return normalize( enc.xyz );
+}
+
+// Golden-angle spiral sampling
+float2 GetSpiralSample( int index, int count )
+{
+    float r = sqrt( ( float(index) + 0.5 ) / float(count) );
+    float theta = float(index) * 2.39996323; // Golden angle
+    return float2( r * cos( theta ), r * sin( theta ) );
+}
+
+// Interleaved Gradient Noise for per-pixel rotation
+float InterleavedGradientNoise( float2 pos )
+{
+    float3 magic = float3( 0.06711056f, 0.00583715f, 52.9829189f );
+    return frac( magic.z * frac( dot( pos, magic.xy ) ) );
+}
+
+[numthreads(8, 8, 1)]
+void CSMain( uint3 DTid : SV_DispatchThreadID )
+{
+    uint2 outSize;
+    OutputAO.GetDimensions( outSize.x, outSize.y );
+
+    if ( DTid.x >= outSize.x || DTid.y >= outSize.y )
+        return;
+
+    float2 texcoord = ( float2( DTid.xy ) + 0.5 ) * SAO_InvResolution;
+
+    // Reconstruct view-space position
+    float rawDepth = TX_Depth.SampleLevel( SS_Linear, texcoord, 0 ).r;
+    float3 viewPos = VSPositionFromDepth( rawDepth, texcoord );
+
+    // Skip sky / far plane
+    if ( viewPos.z > 50000.0 )
+    {
+        OutputAO[DTid.xy] = 1.0;
+        return;
+    }
+
+    // Decode view-space normal from GBuffer
+    float4 normalSample = TX_Normals.SampleLevel( SS_Linear, texcoord, 0 );
+    float3 viewNormal = DecodeNormal( normalSample );
+
+    // Project world-space radius to screen-space pixel radius
+    float projScale = float(outSize.y) / ( 2.0 * SAO_ProjParams.y );
+    float screenRadius = SAO_Radius * projScale / viewPos.z;
+    screenRadius = max( screenRadius, 3.0 ); // Minimum 3 pixels
+
+    // Per-pixel random rotation angle for temporal noise
+    float rotAngle = InterleavedGradientNoise( float2( DTid.xy ) ) * 6.28318530718;
+    float sinR, cosR;
+    sincos( rotAngle, sinR, cosR );
+    float2x2 rotMatrix = float2x2( cosR, -sinR, sinR, cosR );
+
+    float occlusion = 0.0;
+    int numSamples = SAO_NumSamples;
+
+    for ( int i = 0; i < numSamples; i++ )
+    {
+        // Spiral sample in screen space
+        float2 spiralOffset = GetSpiralSample( i, numSamples );
+
+        // Apply per-pixel rotation
+        spiralOffset = mul( spiralOffset, rotMatrix );
+
+        float2 sampleUV = texcoord + spiralOffset * screenRadius * SAO_InvResolution;
+
+        // Skip out-of-bounds samples
+        if ( sampleUV.x < 0.0 || sampleUV.x > 1.0 || sampleUV.y < 0.0 || sampleUV.y > 1.0 )
+            continue;
+
+        // Reconstruct sample view-space position
+        float sampleRawDepth = TX_Depth.SampleLevel( SS_Linear, sampleUV, 0 ).r;
+        float3 sampleViewPos = VSPositionFromDepth( sampleRawDepth, sampleUV );
+
+        // Vector from center to sample
+        float3 delta = sampleViewPos - viewPos;
+        float dist2 = dot( delta, delta );
+        float radiusSq = SAO_Radius * SAO_Radius;
+
+        // Skip too-close or beyond-radius samples
+        if ( dist2 < 0.0001 || dist2 > radiusSq )
+            continue;
+
+        // Alchemy AO / SAO formula:
+        // dot(n, normalize(v)) with smooth distance attenuation
+        float invDist = rsqrt( dist2 );
+        float NdotD = max( dot( viewNormal, delta * invDist ) - SAO_Bias, 0.0 );
+
+        // Falloff: 1 - dist²/R² (linear in squared distance, much smoother than (1-dist/R)²)
+        float falloff = 1.0 - dist2 / radiusSq;
+
+        occlusion += NdotD * falloff;
+    }
+
+    occlusion /= max( numSamples, 1 );
+    float ao = saturate( 1.0 - occlusion * SAO_Intensity );
+
+    OutputAO[DTid.xy] = ao;
+}

--- a/D3D11Engine/Shaders/CS_PFX_SAO_Blur.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_SAO_Blur.hlsl
@@ -1,0 +1,74 @@
+//--------------------------------------------------------------------------------------
+// Compute Shader - SAO Bilateral Blur
+// Depth-aware separable Gaussian blur for denoising SAO output
+// Run twice: once horizontal (BlurDirection = 1,0), once vertical (0,1)
+//--------------------------------------------------------------------------------------
+
+cbuffer SAOBlurConstantBuffer : register( b0 )
+{
+    float2 SAO_Blur_InvResolution; // 1/width, 1/height
+    float2 SAO_Blur_Direction;     // (1,0) for horizontal, (0,1) for vertical
+    float  SAO_Blur_Sharpness;     // Depth-edge preservation strength
+    float3 SAO_Blur_Pad;
+    float4 SAO_Blur_ProjParams;    // x = 1/P._11, y = 1/P._22, z = P._34, w = P._33
+};
+
+SamplerState SS_Linear : register( s0 );
+Texture2D TX_AO    : register( t0 ); // AO input (R8_UNORM or R16_FLOAT)
+Texture2D TX_Depth : register( t1 ); // Full-res hardware depth
+
+RWTexture2D<float> OutputAO : register( u0 );
+
+float LinearizeDepth( float d )
+{
+    return SAO_Blur_ProjParams.z / ( d - SAO_Blur_ProjParams.w );
+}
+
+static const int BLUR_RADIUS = 4;
+static const float GAUSSIAN_WEIGHTS[5] = { 0.2270270270, 0.1945945946, 0.1216216216, 0.0540540541, 0.0162162162 };
+
+[numthreads(8, 8, 1)]
+void CSMain( uint3 DTid : SV_DispatchThreadID )
+{
+    uint2 outSize;
+    OutputAO.GetDimensions( outSize.x, outSize.y );
+
+    if ( DTid.x >= outSize.x || DTid.y >= outSize.y )
+        return;
+
+    float2 texcoord = ( float2( DTid.xy ) + 0.5 ) * SAO_Blur_InvResolution;
+
+    float centerAO = TX_AO.SampleLevel( SS_Linear, texcoord, 0 ).r;
+    float centerDepth = LinearizeDepth( TX_Depth.SampleLevel( SS_Linear, texcoord, 0 ).r );
+
+    float totalAO = centerAO * GAUSSIAN_WEIGHTS[0];
+    float totalWeight = GAUSSIAN_WEIGHTS[0];
+
+    [unroll]
+    for ( int i = 1; i <= BLUR_RADIUS; i++ )
+    {
+        float2 offset = SAO_Blur_Direction * SAO_Blur_InvResolution * float( i );
+
+        // Positive direction
+        float2 uvP = texcoord + offset;
+        float aoP = TX_AO.SampleLevel( SS_Linear, uvP, 0 ).r;
+        float depthP = LinearizeDepth( TX_Depth.SampleLevel( SS_Linear, uvP, 0 ).r );
+        float depthDiffP = abs( depthP - centerDepth );
+        float bilateralP = exp( -depthDiffP * SAO_Blur_Sharpness );
+        float weightP = GAUSSIAN_WEIGHTS[i] * bilateralP;
+        totalAO += aoP * weightP;
+        totalWeight += weightP;
+
+        // Negative direction
+        float2 uvN = texcoord - offset;
+        float aoN = TX_AO.SampleLevel( SS_Linear, uvN, 0 ).r;
+        float depthN = LinearizeDepth( TX_Depth.SampleLevel( SS_Linear, uvN, 0 ).r );
+        float depthDiffN = abs( depthN - centerDepth );
+        float bilateralN = exp( -depthDiffN * SAO_Blur_Sharpness );
+        float weightN = GAUSSIAN_WEIGHTS[i] * bilateralN;
+        totalAO += aoN * weightN;
+        totalWeight += weightN;
+    }
+
+    OutputAO[DTid.xy] = totalAO / max( totalWeight, 0.001 );
+}

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -1,3 +1,5 @@
+#include "DS_Defines.h"
+
 #define TILE_SIZE 16
 
 struct TiledPointLight {
@@ -105,8 +107,7 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
 
     // Read GBuffer
     float4 diffuse = TX_Diffuse.SampleLevel( SS_Linear, uv, 0 );
-    float4 gb2 = TX_Nrm.SampleLevel( SS_Linear, uv, 0 );
-    float3 normal = normalize( gb2.xyz );
+    float3 normal = DecodeNormalGBuffer( TX_Nrm.SampleLevel( SS_Linear, uv, 0 ).xy );
     float4 gb3 = TX_SI_SP.SampleLevel( SS_Linear, uv, 0 );
     float specIntensity = gb3.x;
     float specPower = gb3.y;

--- a/D3D11Engine/Shaders/DS_Defines.h
+++ b/D3D11Engine/Shaders/DS_Defines.h
@@ -1,7 +1,7 @@
 struct DEFERRED_PS_OUTPUT
 {
 	float4 vDiffuse : SV_TARGET0;
-	float4 vNrm : SV_TARGET1; 
+	float2 vNrm : SV_TARGET1; 
 	float2 vSI_SP : SV_TARGET2;
 	float2 vVelocity : SV_TARGET3;  // Screen-space velocity for motion vectors
 	float vReactiveMask : SV_TARGET4;  // Screen-space velocity for motion vectors
@@ -14,20 +14,25 @@ struct DEFERRED_PS_OUTPUT_ALPHA_TO_COVERAGE
 	uint fCoverage	: SV_Coverage;
 };
 
-
-
-float2 EncodeNormal(float3 n)
+// Octahedral encoding: map a unit normal to [-1,1]^2 for R16G16_SNORM storage
+// Reference: "A Survey of Efficient Representations for Independent Unit Vectors" (Cigolle et al. 2014)
+float2 OctWrap(float2 v)
 {
-    float f = sqrt(8*n.z+8);
-    return n.xy / f + 0.5;
+    return (1.0 - abs(v.yx)) * (v.xy >= 0.0 ? 1.0 : -1.0);
 }
-float3 DecodeNormal(float2 enc)
+
+float2 EncodeNormalGBuffer(float3 n)
 {
-    float2 fenc = enc.xy*4-2;
-    float f = dot(fenc,fenc);
-    float g = sqrt(1-f/4);
+    n /= (abs(n.x) + abs(n.y) + abs(n.z));
+    n.xy = n.z >= 0.0 ? n.xy : OctWrap(n.xy);
+    return n.xy;
+}
+
+// Decode octahedral [-1,1]^2 back to a unit normal
+float3 DecodeNormalGBuffer(float2 encoded)
+{
     float3 n;
-    n.xy = fenc*g;
-    n.z = 1-f/2;
-    return n;
+    n.z = 1.0 - abs(encoded.x) - abs(encoded.y);
+    n.xy = n.z >= 0.0 ? encoded.xy : OctWrap(encoded.xy);
+    return normalize(n);
 }

--- a/D3D11Engine/Shaders/PS_AtmosphereGround.hlsl
+++ b/D3D11Engine/Shaders/PS_AtmosphereGround.hlsl
@@ -83,8 +83,7 @@ DEFERRED_PS_OUTPUT PSMain( PS_INPUT Input ) : SV_TARGET
 	DEFERRED_PS_OUTPUT output;
 	output.vDiffuse = float4(color.rgb, Input.vDiffuse.y);
 	
-	output.vNrm.xyz = nrm;
-	output.vNrm.w = 1.0f;
+	output.vNrm = EncodeNormalGBuffer(nrm);
 	
 	output.vSI_SP.x = MI_SpecularIntensity;
 	output.vSI_SP.y = MI_SpecularPower;

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -718,15 +718,17 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
     float4 diffuse = TX_Diffuse.Sample(SS_Linear, uv);
     float vertLighting = diffuse.a;
 	
-	// Get the second GBuffer
-    float4 gb2 = TX_Nrm.Sample(SS_Linear, uv);
-	
-	// If we dont have a normal, just return the diffuse color
-    if (gb2.w < 0.001f)
+	// Sample depth first to detect sky pixels (reversed-Z: sky has depth == 0.0)
+    float expDepth = TX_Depth.Sample(SS_Linear, uv).r;
+    if (expDepth < 0.00001f)
+        // Sky pixel — no geometry was written, just return the diffuse (sky) color
         return float4(diffuse.rgb, 1);
 	
-	// Decode the view-space normal back
-    float3 normal = normalize(gb2.xyz);
+	// Get the second GBuffer
+    float2 gb2 = TX_Nrm.Sample(SS_Linear, uv).xy;
+	
+	// Decode the view-space normal from octahedral R16G16_SNORM
+    float3 normal = DecodeNormalGBuffer(gb2);
 	
 	// Get specular parameters
     float4 gb3 = TX_SI_SP.Sample(SS_Linear, uv);
@@ -734,7 +736,6 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
     float specPower = gb3.y;
 	
 	// Reconstruct VS World Position from depth
-    float expDepth = TX_Depth.Sample(SS_Linear, uv).r;
     float3 vsPosition = VSPositionFromDepth(expDepth, uv);
     float3 wsPosition = mul(float4(vsPosition, 1), SQ_InvView).xyz;
     float3 V = normalize(-vsPosition);

--- a/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
@@ -100,10 +100,10 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float4 diffuse = TX_Diffuse.Sample(SS_Linear, uv);
 	
 	// Get the second GBuffer
-	float4 gb2 = TX_Nrm.Sample(SS_Linear, uv);
+	float2 gb2 = TX_Nrm.Sample(SS_Linear, uv).xy;
 	
-	// Decode the view-space normal back
-	float3 normal = normalize(gb2.xyz);
+	// Decode the view-space normal from octahedral R16G16_SNORM
+	float3 normal = DecodeNormalGBuffer(gb2);
 	
 	// Get specular parameters
 	float4 gb3 = TX_SI_SP.Sample(SS_Linear, uv);

--- a/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
@@ -144,10 +144,10 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float4 diffuse = TX_Diffuse.Sample(SS_Linear, uv);
 	
 	// Get the second GBuffer
-	float4 gb2 = TX_Nrm.Sample(SS_Linear, uv);
+	float2 gb2 = TX_Nrm.Sample(SS_Linear, uv).xy;
 	
-	// Decode the view-space normal back
-	float3 normal = normalize(gb2.xyz);
+	// Decode the view-space normal from octahedral R16G16_SNORM
+	float3 normal = DecodeNormalGBuffer(gb2);
 	
 	// Get specular parameters
 	float4 gb3 = TX_SI_SP.Sample(SS_Linear, uv);

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -120,8 +120,7 @@ DEFERRED_PS_OUTPUT PSMain( PS_INPUT Input ) : SV_TARGET
 	//output.vDiffuse = float4(Input.vTexcoord2, 0, 1);
 	//output.vDiffuse = float4(Input.vNormalVS, 1);
 	
-	output.vNrm.xyz = nrm;
-	output.vNrm.w = 1.0f;
+	output.vNrm = EncodeNormalGBuffer(nrm);
 	
 	output.vSI_SP.x = MI_SpecularIntensity * fx.r;
 	output.vSI_SP.y = MI_SpecularPower * fx.g;

--- a/D3D11Engine/Shaders/PS_Grass.hlsl
+++ b/D3D11Engine/Shaders/PS_Grass.hlsl
@@ -65,8 +65,7 @@ DEFERRED_PS_OUTPUT PSMain( PS_INPUT Input ) : SV_TARGET
 	DEFERRED_PS_OUTPUT output;
 	output.vDiffuse = float4(color.rgb, 1);
 	
-	output.vNrm.xyz = normalize(Input.vNormalVS);
-	output.vNrm.w = 1.0f;
+	output.vNrm = EncodeNormalGBuffer(normalize(Input.vNormalVS));
 	
 	output.vSI_SP.xy = 0;
 	

--- a/D3D11Engine/Shaders/PS_PFX_Composition.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_Composition.hlsl
@@ -1,0 +1,140 @@
+//--------------------------------------------------------------------------------------
+// PostFX Composition Uber Shader
+// Merges SAO, HeightFog, and GodRays into a single full-screen pass.
+// Permutation macros: COMPOSE_SAO, COMPOSE_HEIGHTFOG, COMPOSE_GODRAYS
+//--------------------------------------------------------------------------------------
+
+#if COMPOSE_HEIGHTFOG
+#include <AtmosphericScattering.h>
+#endif
+
+//--------------------------------------------------------------------------------------
+// Constant Buffers
+//--------------------------------------------------------------------------------------
+#if COMPOSE_HEIGHTFOG
+cbuffer PFXBuffer : register( b0 )
+{
+    float4 HF_ProjParams;
+    matrix HF_InvView;
+    float3 HF_CameraPosition;
+    float HF_FogHeight;
+
+    float HF_HeightFalloff;
+    float HF_GlobalDensity;
+    float HF_WeightZNear;
+    float HF_WeightZFar;
+
+    float3 HF_FogColorMod;
+    float HF_pad2;
+
+    float2 HF_ProjAB;
+    float2 HF_Pad3;
+};
+#endif
+
+//--------------------------------------------------------------------------------------
+// Textures and Samplers
+//--------------------------------------------------------------------------------------
+SamplerState SS_Linear : register( s0 );
+
+Texture2D TX_Backbuffer : register( t0 );
+
+#if COMPOSE_SAO
+Texture2D TX_SAO : register( t1 );
+#endif
+
+#if COMPOSE_GODRAYS
+Texture2D TX_GodRays : register( t2 );
+#endif
+
+#if COMPOSE_HEIGHTFOG
+Texture2D TX_Depth : register( t3 );
+#endif
+
+//--------------------------------------------------------------------------------------
+// HeightFog helpers (inlined from PS_PFX_Heightfog.hlsl)
+//--------------------------------------------------------------------------------------
+#if COMPOSE_HEIGHTFOG
+float3 VSPositionFromDepth( float depth, float2 vTexCoord )
+{
+    float2 ndc = vTexCoord * float2( 2.0f, -2.0f ) + float2( -1.0f, 1.0f );
+    float linearZ = HF_ProjParams.z / ( depth - HF_ProjParams.w );
+    return float3( ndc * HF_ProjParams.xy * linearZ, linearZ );
+}
+
+float ComputeVolumetricFog( float3 cameraToWorldPos, float3 posOriginal )
+{
+    float cVolFogHeightDensityAtViewer = exp( -HF_HeightFalloff );
+
+    float lenOrig = length( posOriginal - HF_CameraPosition );
+    float len = length( cameraToWorldPos );
+    float fogInt = len * cVolFogHeightDensityAtViewer;
+    const float cSlopeThreshold = 0.01;
+
+    float w = saturate( ( lenOrig - HF_WeightZNear ) / ( HF_WeightZFar - HF_WeightZNear ) );
+
+    if ( abs( cameraToWorldPos.y ) > cSlopeThreshold )
+    {
+        float t = HF_HeightFalloff * cameraToWorldPos.y * w;
+        fogInt *= ( abs( t ) > 0.0001 ? ( ( 1.0 - exp( -t ) ) / t ) : 1.0 );
+    }
+
+    return exp( -HF_GlobalDensity * w * fogInt );
+}
+
+float4 ComputeHeightFog( float2 texcoord )
+{
+    float expDepth = TX_Depth.Sample( SS_Linear, texcoord ).r;
+    float3 position = VSPositionFromDepth( expDepth, texcoord );
+    position = mul( float4( position, 1 ), HF_InvView ).xyz;
+    float3 posOriginal = position;
+    position -= HF_CameraPosition;
+    position.y -= HF_FogHeight;
+
+    float fog = 1.0f - ComputeVolumetricFog( position, posOriginal );
+    float3 color = ApplyAtmosphericScatteringGround( position, HF_FogColorMod, true );
+
+    float darknessFactor = 2.0f;
+    if ( AC_LightPos.y < 0.0f ) { darknessFactor -= AC_LightPos.y * 3.0f; }
+    else if ( AC_LightPos.y > 0.0f ) { darknessFactor -= AC_LightPos.y; }
+
+    return float4( saturate( color / darknessFactor ), saturate( fog ) );
+}
+#endif
+
+//--------------------------------------------------------------------------------------
+// Input / Output structures
+//--------------------------------------------------------------------------------------
+struct PS_INPUT
+{
+    float2 vTexcoord  : TEXCOORD0;
+    float3 vEyeRay    : TEXCOORD1;
+    float4 vPosition  : SV_POSITION;
+};
+
+//--------------------------------------------------------------------------------------
+// Pixel Shader
+//--------------------------------------------------------------------------------------
+float4 PSMain( PS_INPUT Input ) : SV_TARGET
+{
+    float4 color = TX_Backbuffer.Sample( SS_Linear, Input.vTexcoord );
+
+    // Composition order: SAO (multiply) -> HeightFog (alpha blend) -> GodRays (additive)
+
+#if COMPOSE_SAO
+    float ao = TX_SAO.Sample( SS_Linear, Input.vTexcoord ).r;
+    color.rgb *= ao;
+#endif
+
+#if COMPOSE_HEIGHTFOG
+    float4 fog = ComputeHeightFog( Input.vTexcoord );
+    color.rgb = lerp( color.rgb, fog.rgb, fog.a );
+#endif
+
+#if COMPOSE_GODRAYS
+    float3 godrays = TX_GodRays.Sample( SS_Linear, Input.vTexcoord ).rgb;
+    color.rgb += godrays;
+#endif
+
+    return color;
+}

--- a/D3D11Engine/Shaders/PS_PFX_GodRayMask.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_GodRayMask.hlsl
@@ -8,7 +8,7 @@
 SamplerState SS_Linear : register( s0 );
 SamplerState SS_samMirror : register( s1 );
 Texture2D	TX_Texture0 : register( t0 );
-Texture2D	TX_Texture1 : register( t1 );
+Texture2D	TX_Depth : register( t1 );
 
 //--------------------------------------------------------------------------------------
 // Input / Output structures
@@ -26,9 +26,10 @@ struct PS_INPUT
 float4 PSMain( PS_INPUT Input ) : SV_TARGET
 {
 	float4 color = TX_Texture0.Sample(SS_Linear, Input.vTexcoord);
-	float4 gb2 = TX_Texture1.Sample(SS_Linear, Input.vTexcoord);
 	
-	if(gb2.w < 0.001f)
+	// Sky detection via depth buffer (reversed-Z: sky has depth == 0.0)
+	float depth = TX_Depth.Sample(SS_Linear, Input.vTexcoord).r;
+	if(depth < 0.00001f)
 		return color;
 	
 	return float4(0,0,0,0);

--- a/D3D11Engine/Shaders/PS_PFX_Simple_R8.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_Simple_R8.hlsl
@@ -1,0 +1,20 @@
+//--------------------------------------------------------------------------------------
+// Simple fullscreen pass that splatters a single-channel (R8) texture
+// across all RGB channels. Used for multiply-blending R8 AO buffers.
+//--------------------------------------------------------------------------------------
+
+SamplerState SS_Linear : register( s0 );
+Texture2D TX_Texture0 : register( t0 );
+
+struct PS_INPUT
+{
+    float2 vTexcoord  : TEXCOORD0;
+    float3 vEyeRay    : TEXCOORD1;
+    float4 vPosition  : SV_POSITION;
+};
+
+float4 PSMain( PS_INPUT Input ) : SV_TARGET
+{
+    float r = TX_Texture0.Sample( SS_Linear, Input.vTexcoord ).r;
+    return float4( r, r, r, 1.0 );
+}

--- a/D3D11Engine/Shaders/PS_World.hlsl
+++ b/D3D11Engine/Shaders/PS_World.hlsl
@@ -87,8 +87,7 @@ DEFERRED_PS_OUTPUT PSMain( PS_INPUT Input ) : SV_TARGET
 	DEFERRED_PS_OUTPUT output;
 	output.vDiffuse = float4(color.rgb, Input.vDiffuse.y);
 	
-	output.vNrm.xyz = normalize(Input.vNormalVS);
-	output.vNrm.w = 1.0f;
+	output.vNrm = EncodeNormalGBuffer(normalize(Input.vNormalVS));
 
 	output.vSI_SP.x = MI_SpecularIntensity;
 	output.vSI_SP.y = MI_SpecularPower;

--- a/D3D11Engine/Shaders/VS_ExInstancedObj.hlsl
+++ b/D3D11Engine/Shaders/VS_ExInstancedObj.hlsl
@@ -20,6 +20,21 @@ cbuffer WindParams : register(b1)
      float padding1;
 };
 
+#ifndef WIND_META_SRV
+#define WIND_META_SRV 0
+#endif
+
+#if WIND_META_SRV
+struct WindMetaDataEntry
+{
+    float minHeight;
+    float maxHeight;
+    float2 padding;
+};
+
+StructuredBuffer<WindMetaDataEntry> WindMetaData;
+#endif
+
 //--------------------------------------------------------------------------------------
 // Input / Output structures
 //--------------------------------------------------------------------------------------
@@ -34,6 +49,7 @@ struct VS_INPUT
     float4x4 InstancePrevWorldMatrix : INSTANCE_PREV_WORLD_MATRIX;
     float4 InstanceColor : INSTANCE_COLOR;
     float2 InstanceWind : INSTANCE_WINDFLUENCE;
+    uint InstanceWindMetaIndex : INSTANCE_WIND_META_INDEX;
 };
 
 struct VS_OUTPUT
@@ -57,20 +73,20 @@ static const float phaseVariation = 0.40f;
 static const float windStrengMult = 16.0f; // original engine uses [0.1 -> 5] range, we use higher values in formulas 
 static const float PI_2 = 6.283185; // 2 * PI
 
-float GetInstancePhaseOffset(float4x4 objMatrix)
+float GetInstancePhaseOffset(float4x4 objMatrix, float maxHeightValue)
 {
     // Random seed by object's matrix
     // Combine object matrix and maxHeight for more stable randomness
-    float seed = dot(objMatrix._11_22_33, float3(12.9898, 78.233, 53.539)) + maxHeight;
+    float seed = dot(objMatrix._11_22_33, float3(12.9898, 78.233, 53.539)) + maxHeightValue;
     return frac(sin(seed) * 43758.5453) * phaseVariation;
 }
 
-float3 ApplyTreeWind(float3 vertexPos, float3 direction, float heightNorm, float timeSec, float4x4 instMatrix, float windStrength)
+float3 ApplyTreeWind(float3 vertexPos, float3 direction, float heightNorm, float timeSec, float4x4 instMatrix, float maxHeightValue, float windStrength)
 {
     // Calculate if vertex should be affected (1 if heightNorm >= trunkStiffness, 0 otherwise)
     float shouldAffect = saturate(sign(heightNorm - trunkStiffness + 0.0001f));
     
-    float instancePhase = GetInstancePhaseOffset(instMatrix) * PI_2;
+    float instancePhase = GetInstancePhaseOffset(instMatrix, maxHeightValue) * PI_2;
     
     // Smooth height factor with more natural falloff
     float adjustedHeight = saturate((heightNorm - trunkStiffness) / (1.0 - trunkStiffness)) * shouldAffect;
@@ -151,12 +167,20 @@ VS_OUTPUT VSMain( VS_INPUT Input )
     // Base vertex position (local)
     float3 position = Input.vPosition;
 
+    float localMinHeight = minHeight;
+    float localMaxHeight = maxHeight;
+#if WIND_META_SRV
+    WindMetaDataEntry meta = WindMetaData[Input.InstanceWindMetaIndex];
+    localMinHeight = meta.minHeight;
+    localMaxHeight = meta.maxHeight;
+#endif
+
 #if SHD_INFLUENCE
     
     if (Input.InstanceWind.y > 0)
     {
         // HERO MOVING BUSHES SHADER
-        position += CalculatePlayerInfluence(playerPos, position, minHeight, maxHeight, Input.InstanceWorldMatrix);
+        position += CalculatePlayerInfluence(playerPos, position, localMinHeight, localMaxHeight, Input.InstanceWorldMatrix);
     }
 #endif
     
@@ -166,8 +190,8 @@ VS_OUTPUT VSMain( VS_INPUT Input )
     {
         // WIND SHADER
         // Protect 0 height
-        float heightRange = max(maxHeight - minHeight, 0.001);
-        float vertexHeightNorm = saturate((Input.vPosition.y - minHeight) / heightRange);
+        float heightRange = max(localMaxHeight - localMinHeight, 0.001);
+        float vertexHeightNorm = saturate((Input.vPosition.y - localMinHeight) / heightRange);
 
         // Apply wind
         position += ApplyTreeWind(
@@ -176,6 +200,7 @@ VS_OUTPUT VSMain( VS_INPUT Input )
             vertexHeightNorm,
             globalTime,
             Input.InstanceWorldMatrix,
+            localMaxHeight,
             Input.InstanceWind.x
         );
     }

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -32,14 +32,14 @@ WorldConverter::WorldConverter() {}
 WorldConverter::~WorldConverter() {}
 
 /** Collects all world-polys in the specific range. Drops all materials that have no alphablending */
-void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float range, std::map<int, std::map<int, WorldMeshSectionInfo>>& inSections, std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>& outMeshes ) {
+void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float range, std::map<int, std::map<int, WorldMeshSectionInfo>>& inSections, std::map<MeshKey, MeshInfo*, cmpMeshKey>& outMeshes ) {
     INT2 s = GetSectionOfPos( position );
     MeshKey opaqueKey;
     opaqueKey.Material = nullptr;
     opaqueKey.Info = nullptr;
     opaqueKey.Texture = nullptr;
 
-    WorldMeshInfo* opaqueMesh = new WorldMeshInfo;
+    MeshInfo* opaqueMesh = new MeshInfo;
     outMeshes[opaqueKey] = opaqueMesh;
 
     FXMVECTOR xmPosition = XMLoadFloat3( position.toXMFLOAT3() );
@@ -56,11 +56,11 @@ void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float ra
             if ( len < 2 ) {
                 // Check all polys from all meshes
                 for ( auto const& it : ity.second.WorldMeshes ) {
-                    WorldMeshInfo* m;
+                    MeshInfo* m;
 
                     // Create new mesh-part for alphatested surfaces
                     if ( it.first.Texture && it.first.Texture->HasAlphaChannel() ) {
-                        m = new WorldMeshInfo;
+                        m = new MeshInfo;
                         outMeshes[it.first] = m;
                     } else {
                         // Just use the same mesh for opaque surfaces
@@ -214,7 +214,7 @@ XRESULT WorldConverter::LoadWorldMeshFromFile( const std::string& file, std::map
             if ( section.WorldMeshes.find( key ) == section.WorldMeshes.end() ) {
                 key.Info = Engine::GAPI->GetMaterialInfoFrom( key.Texture );
 
-                section.WorldMeshes[key] = new WorldMeshInfo;
+                section.WorldMeshes[key] = new MeshInfo;
 
             }
 
@@ -419,7 +419,7 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
         auto it = sectionInfo.WorldMeshes.find( key );
         if ( it == sectionInfo.WorldMeshes.end() ) {
             key.Info = Engine::GAPI->GetMaterialInfoFrom( key.Texture );
-            it = sectionInfo.WorldMeshes.emplace( key, new WorldMeshInfo ).first;
+            it = sectionInfo.WorldMeshes.emplace( key, new MeshInfo ).first;
         }
 
         int matGroup = mat->GetMatGroup();

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -28,7 +28,7 @@ public:
     virtual ~WorldConverter();
 
     /** Collects all world-polys in the specific range. Drops all materials that have no alphablending */
-    static void WorldMeshCollectPolyRange( const float3& position, float range, std::map<int, std::map<int, WorldMeshSectionInfo>>& inSections, std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>& outMeshes );
+    static void WorldMeshCollectPolyRange( const float3& position, float range, std::map<int, std::map<int, WorldMeshSectionInfo>>& inSections, std::map<MeshKey, MeshInfo*, cmpMeshKey>& outMeshes );
 
     /** Converts the worldmesh into a more usable format */
     static HRESULT ConvertWorldMesh( zCPolygon** polys, unsigned int numPolygons, std::map<int, std::map<int, WorldMeshSectionInfo>>* outSections, WorldInfo* info, MeshInfo** outWrappedMesh, bool indoorLocation );

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -105,19 +105,6 @@ struct MeshInfo {
     uint16_t meshId;
 };
 
-struct WorldMeshInfo : public MeshInfo {
-    WorldMeshInfo() = default;
-    WorldMeshInfo( WorldMeshInfo&& other ) = default;
-    WorldMeshInfo& operator=( WorldMeshInfo&& ) = default;
-    WorldMeshInfo( const WorldMeshInfo& other ) = delete;
-    WorldMeshInfo& operator=(const WorldMeshInfo& other) = delete;
-
-    ~WorldMeshInfo() override = default;
-
-    /** If true we will save an info-file on next zen-resource-save */
-    bool SaveInfo;
-};
-
 struct QuadMarkInfo {
     QuadMarkInfo() = default;
     QuadMarkInfo( QuadMarkInfo&& other ) = default;
@@ -499,7 +486,7 @@ struct WorldMeshSectionInfo {
     /** Saves this sections mesh to a file */
     void SaveSectionMeshToFile( const std::string& name );
 
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey> WorldMeshes;
+    std::map<MeshKey, MeshInfo*, cmpMeshKey> WorldMeshes;
     std::map<D3D11Texture*, std::vector<MeshInfo*>> WorldMeshesByCustomTexture;
     std::map<zCMaterial*, std::vector<MeshInfo*>> WorldMeshesByCustomTextureOriginal;
     std::map<MeshKey, MeshInfo*, cmpMeshKey> SuppressedMeshes;

--- a/D3D11Engine/include/ASSAO/ASSAO.h
+++ b/D3D11Engine/include/ASSAO/ASSAO.h
@@ -1,0 +1,259 @@
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2016, Intel Corporation
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of 
+// the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+// SOFTWARE.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// File changes (yyyy-mm-dd)
+// 2016-09-07: filip.strugar@intel.com: first commit
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+struct ID3D11Device;
+struct ID3D11DeviceContext;
+struct ID3D11ShaderResourceView;
+struct ID3D11RenderTargetView;
+
+#pragma pack( push, 8 ) // Make sure we have consistent structure packings
+
+// Disabling adaptive quality uses a tiny bit less memory (21.75Mb instead of 22Mb at 1920x1080) and makes it easier to port
+#define INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+
+// If enabled, will use ASSAO_Inputs::NormalsWorldToViewspaceMatrix, otherwise it is ignored (compiled out) as it adds approx 3% to the overall cost
+// #define INTEL_SSAO_ENABLE_NORMAL_WORLD_TO_VIEW_CONVERSION
+
+struct ASSAO_Float4x4
+{
+    union
+    {
+        struct
+        {
+            float       _11, _12, _13, _14;
+            float       _21, _22, _23, _24;
+            float       _31, _32, _33, _34;
+            float       _41, _42, _43, _44;
+        };
+        float m[4][4];
+        float arr[16];
+    };
+
+    ASSAO_Float4x4( )
+    {
+        for( int i = 0; i < 16; i++ )
+            arr[i] = 0;
+    }
+    ASSAO_Float4x4( const float * inMatrix )
+    {
+        for( int i = 0; i < 16; i++ )
+            arr[i] = inMatrix[i];
+    }
+    inline void Transpose( )
+    {
+        swap( arr[1],  arr[4]);
+        swap( arr[2],  arr[8]);
+        swap( arr[3],  arr[12]);
+        swap( arr[6],  arr[9]);
+        swap( arr[7],  arr[13]);
+        swap( arr[11], arr[14]);        
+    }
+    inline void SetIdentity( )
+    {
+        _11 = 1.0f; _12 = 0.0f; _13 = 0.0f; _14 = 0.0f;
+        _21 = 0.0f; _22 = 1.0f; _23 = 0.0f; _24 = 0.0f;
+        _31 = 0.0f; _32 = 0.0f; _33 = 1.0f; _34 = 0.0f;
+        _41 = 0.0f; _42 = 0.0f; _43 = 0.0f; _44 = 1.0f;
+    }
+
+private:
+    inline static void swap( float & a, float & b ) { float temp = b; b = a; a = temp; }
+
+};
+
+// supported platforms - at the moment only DirectX11
+enum class ASSAO_SupportedPlatforms
+{
+    InvalidValue,
+    PC_DirectX11,
+};
+
+// effect visual settings
+struct ASSAO_Settings
+{
+    float       Radius;                             // [0.0,  ~ ] World (view) space size of the occlusion sphere.
+    float       ShadowMultiplier;                   // [0.0, 5.0] Effect strength linear multiplier
+    float       ShadowPower;                        // [0.5, 5.0] Effect strength pow modifier
+    float       ShadowClamp;                        // [0.0, 1.0] Effect max limit (applied after multiplier but before blur)
+    float       HorizonAngleThreshold;              // [0.0, 0.2] Limits self-shadowing (makes the sampling area less of a hemisphere, more of a spherical cone, to avoid self-shadowing and various artifacts due to low tessellation and depth buffer imprecision, etc.)
+    float       FadeOutFrom;                        // [0.0,  ~ ] Distance to start start fading out the effect.
+    float       FadeOutTo;                          // [0.0,  ~ ] Distance at which the effect is faded out.
+    int         QualityLevel;                       // [ -1,  3 ] Effect quality; -1 - lowest (low, half res checkerboard), 0 - low, 1 - medium, 2 - high, 3 - very high / adaptive; each quality level is roughly 2x more costly than the previous, except the q3 which is variable but, in general, above q2.
+    float       AdaptiveQualityLimit;               // [0.0, 1.0] (only for Quality Level 3)
+    int         BlurPassCount;                      // [  0,   6] Number of edge-sensitive smart blur passes to apply. Quality 0 is an exception with only one 'dumb' blur pass used.
+    float       Sharpness;                          // [0.0, 1.0] (How much to bleed over edges; 1: not at all, 0.5: half-half; 0.0: completely ignore edges)
+    float       TemporalSupersamplingAngleOffset;   // [0.0,  PI] Used to rotate sampling kernel; If using temporal AA / supersampling, suggested to rotate by ( (frame%3)/3.0*PI ) or similar. Kernel is already symmetrical, which is why we use PI and not 2*PI.
+    float       TemporalSupersamplingRadiusOffset;  // [0.0, 2.0] Used to scale sampling kernel; If using temporal AA / supersampling, suggested to scale by ( 1.0f + (((frame%3)-1.0)/3.0)*0.1 ) or similar.
+    float       DetailShadowStrength;               // [0.0, 5.0] Used for high-res detail AO using neighboring depth pixels: adds a lot of detail but also reduces temporal stability (adds aliasing).
+
+    ASSAO_Settings( )
+    {
+        Radius                              = 1.2f;
+        ShadowMultiplier                    = 1.0f;
+        ShadowPower                         = 1.50f;
+        ShadowClamp                         = 0.98f;
+        HorizonAngleThreshold               = 0.06f;
+        FadeOutFrom                         = 50.0f;
+        FadeOutTo                           = 300.0f;
+        AdaptiveQualityLimit                = 0.45f;
+        QualityLevel                        = 2;
+        BlurPassCount                       = 2;
+        Sharpness                           = 0.98f;
+        TemporalSupersamplingAngleOffset    = 0.0f;
+        TemporalSupersamplingRadiusOffset   = 1.0f;
+        DetailShadowStrength                = 0.5f;
+    }
+};
+
+struct ASSAO_CreateDesc
+{
+    ASSAO_SupportedPlatforms    Platform;
+protected:
+    ASSAO_CreateDesc( )             { Platform = ASSAO_SupportedPlatforms::InvalidValue; }
+public:
+    virtual ~ASSAO_CreateDesc( )    { }
+};
+
+struct ASSAO_Inputs
+{
+    // Output scissor rect - used to draw AO effect to a sub-rectangle, for example, for performance reasons when using wider-than-screen depth input to avoid close-to-border artifacts.
+    int                             ScissorLeft;
+    int                             ScissorTop;
+    int                             ScissorRight;
+    int                             ScissorBottom;
+
+    // Custom viewports not supported yet; this is here for future support. ViewportWidth and ViewportHeight must match or be smaller than source depth and normalmap sizes.
+    int                             ViewportX;
+    int                             ViewportY;
+    int                             ViewportWidth;
+    int                             ViewportHeight;
+
+    // Requires a projection matrix created with xxxPerspectiveFovLH or equivalent, not tested (yet) for right-handed
+    // coordinates and will likely break for ortho projections.
+    ASSAO_Float4x4                  ProjectionMatrix;
+
+#ifdef INTEL_SSAO_ENABLE_NORMAL_WORLD_TO_VIEW_CONVERSION
+    // In case normals are in world space, matrix used to convert them to viewspace
+    ASSAO_Float4x4                  NormalsWorldToViewspaceMatrix;
+#endif
+
+    bool                            MatricesRowMajorOrder;
+
+    // Used for expanding UINT normals from [0, 1] to [-1, 1] if needed.
+    float                           NormalsUnpackMul;
+    float                           NormalsUnpackAdd;
+
+    bool                            DrawOpaque;
+
+protected:
+    ASSAO_Inputs( )
+    {
+        ScissorLeft                 = 0;
+        ScissorTop                  = 0;
+        ScissorRight                = 0;
+        ScissorBottom               = 0;
+        ViewportX                   = 0;
+        ViewportY                   = 0;
+        ViewportWidth               = 0;
+        ViewportHeight              = 0;
+        MatricesRowMajorOrder       = true;
+        DrawOpaque                  = false;
+        NormalsUnpackMul            = 2.0f;
+        NormalsUnpackAdd            = -1.0f;
+#ifdef INTEL_SSAO_ENABLE_NORMAL_WORLD_TO_VIEW_CONVERSION
+        NormalsWorldToViewspaceMatrix.SetIdentity();
+#endif
+    }
+public:
+    virtual ~ASSAO_Inputs( )        { }
+};
+
+//
+struct ASSAO_CreateDescDX11 : ASSAO_CreateDesc
+{
+    ID3D11Device *                  Device;
+    const void *                    ShaderData;
+    size_t                          ShaderDataSize;
+
+    // data pointed to by shaderData is only used during a call to ASSAO_Effect::CreateInstance
+    ASSAO_CreateDescDX11( ID3D11Device * device, const void * shaderData, size_t shaderDataSize ) : Device( device ), ShaderData( shaderData ), ShaderDataSize( shaderDataSize ) { Platform = ASSAO_SupportedPlatforms::PC_DirectX11; }
+};
+
+// 
+struct ASSAO_InputsDX11 : ASSAO_Inputs
+{
+    ID3D11DeviceContext *           DeviceContext;
+
+    // Hardware screen depths
+    //  - R32_FLOAT (R32_TYPELESS) or R24_UNORM_X8_TYPELESS (R24G8_TYPELESS) texture formats are supported.
+    //  - Multisampling not yet supported.
+    //  - Decoded using provided ProjectionMatrix.
+    //  - For custom decoding see PSPrepareDepths/PSPrepareDepthsAndNormals where they get converted to linear viewspace storage.
+    ID3D11ShaderResourceView *      DepthSRV;
+
+    // Viewspace normals (optional) 
+    //  - If NULL, normals are generated from the depth buffer, otherwise provided normals are used for AO. ASSAO is less
+    //    costly when input normals are provided, and has a more defined effect. However, aliasing in normals can result in 
+    //    aliasing/flickering in the effect so, in some rare cases, normals generated from the depth buffer can look better.
+    //  - _FLOAT or _UNORM texture formats are supported.
+    //  - Input normals are expected to be in viewspace, encoded in [0, 1] with "encodedNormal.xyz = (normal.xyz * 0.5 + 0.5)" 
+    //    or similar. Decode is done in LoadNormal() function with "normal.xyz = (encodedNormal.xyz * 2.0 - 1.0)", which can be
+    //    easily modified for any custom decoding.
+    //  - Use SSAO_SMOOTHEN_NORMALS for additional normal smoothing to reduce aliasing/flickering. This, however, also reduces
+    //    high detail AO and increases cost.
+    ID3D11ShaderResourceView *      NormalSRV;
+
+    // If not NULL, instead writing into currently bound render target, Draw will use this. Current render target will be restored 
+    // to what it was originally after the Draw call.
+    ID3D11RenderTargetView *        OverrideOutputRTV;
+
+    ASSAO_InputsDX11( )
+    {
+        DeviceContext       = nullptr;
+        DepthSRV            = nullptr;
+        NormalSRV           = nullptr;
+        OverrideOutputRTV   = nullptr;
+    }
+};
+
+#pragma pack( pop )
+
+class ASSAO_Effect
+{
+protected:
+    ASSAO_Effect( ) { };
+    virtual ~ASSAO_Effect( ) { };
+public:
+
+    virtual void                PreAllocateVideoMemory( const ASSAO_Inputs * inputs )                           = 0;
+    virtual void                DeleteAllocatedVideoMemory( )                                                   = 0;
+
+    // Returns currently allocated video memory in bytes; only valid after PreAllocateVideoMemory / Draw calls
+    virtual unsigned int        GetAllocatedVideoMemory( )                                                      = 0;
+
+    virtual void                GetVersion( int & major, int & minor )                                          = 0;
+
+    // Apply the SSAO effect to the currently selected render target using provided settings and platform-dependent inputs
+    virtual void                Draw( const ASSAO_Settings & settings, const ASSAO_Inputs * inputs )    = 0;
+
+public:
+    static ASSAO_Effect *       CreateInstance( const ASSAO_CreateDescDX11 * createDesc );
+    static void                 DestroyInstance( ASSAO_Effect * effectInstance );
+};

--- a/D3D11Engine/include/ASSAO/ASSAODX11.cpp
+++ b/D3D11Engine/include/ASSAO/ASSAODX11.cpp
@@ -1,0 +1,1745 @@
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2016, Intel Corporation
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of 
+// the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+// SOFTWARE.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// File changes (yyyy-mm-dd)
+// 2016-09-07: filip.strugar@intel.com: first commit
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "ASSAO.h"
+
+#include <d3d11.h>
+// #include <d3d11_1.h>
+// #include <d3d11_2.h>
+#include <d3dcompiler.h>
+
+#pragma comment( lib, "d3d11.lib" )
+#pragma comment( lib, "d3dcompiler.lib" )
+
+#include <assert.h>
+#include <math.h>
+
+#ifndef SAFE_RELEASE
+#define SAFE_RELEASE(p)      { if (p) { (p)->Release(); (p)=NULL; } }
+#endif
+#ifndef SAFE_RELEASE_ARRAY
+#define SAFE_RELEASE_ARRAY(p)   { for( int i = 0; i < _countof(p); i++ ) if (p[i]) { (p[i])->Release(); (p[i])=NULL; } }
+#endif
+
+#define SSA_STRINGIZIZER( x )                       SSA_STRINGIZIZER_( x )
+#define SSA_STRINGIZIZER_( x )                      #x
+
+// ** WARNING ** if changing any of the slot numbers, please remember to update the corresponding shader code!
+#define SSAO_SAMPLERS_SLOT0                         0
+#define SSAO_SAMPLERS_SLOT1                         1
+#define SSAO_SAMPLERS_SLOT2                         2
+#define SSAO_SAMPLERS_SLOT3                         3
+#define SSAO_NORMALMAP_OUT_UAV_SLOT                 4
+#define SSAO_CONSTANTS_BUFFERSLOT                   0
+#define SSAO_TEXTURE_SLOT0                          0
+#define SSAO_TEXTURE_SLOT1                          1
+#define SSAO_TEXTURE_SLOT2                          2
+#define SSAO_TEXTURE_SLOT3                          3
+#define SSAO_TEXTURE_SLOT4                          4
+#define SSAO_LOAD_COUNTER_UAV_SLOT                  4
+
+#define SSAO_MAX_TAPS                               32
+#define SSAO_MAX_REF_TAPS                           512
+#define SSAO_ADAPTIVE_TAP_BASE_COUNT                5
+#define SSAO_ADAPTIVE_TAP_FLEXIBLE_COUNT            (SSAO_MAX_TAPS-SSAO_ADAPTIVE_TAP_BASE_COUNT)
+#define SSAO_DEPTH_MIP_LEVELS                       4
+
+#ifdef INTEL_SSAO_ENABLE_NORMAL_WORLD_TO_VIEW_CONVERSION
+#define SSAO_ENABLE_NORMAL_WORLD_TO_VIEW_CONVERSION 1
+#else
+#define SSAO_ENABLE_NORMAL_WORLD_TO_VIEW_CONVERSION 0
+#endif
+
+namespace
+{
+    class vaVector2
+    {
+    public:
+        float x, y;
+
+    public:
+        vaVector2( ) { };
+        vaVector2( float x, float y ) : x( x ), y( y ) { }
+    };
+
+    class vaVector2i
+    {
+    public:
+        int x, y;
+
+    public:
+        vaVector2i( ) { };
+        vaVector2i( int x, int y ) : x( x ), y( y ) { }
+    };
+
+    class vaVector4
+    {
+    public:
+        float x, y, z, w;
+
+    public:
+        vaVector4( ) { };
+        vaVector4( float x, float y, float z, float w ) : x(x), y(y), z(z), w(w)   { };
+    };
+
+    class vaVector4i
+    {
+    public:
+        int x, y, z, w;
+
+    public:
+        vaVector4i( ) { };
+        vaVector4i( int x, int y, int z, int w ) : x(x), y(y), z(z), w(w)   { };
+
+        bool operator == ( const vaVector4i & eq ) const                    { return this->x == eq.x && this->y == eq.y && this->z == eq.z && this->w == eq.w; }
+        bool operator != ( const vaVector4i & eq ) const                    { return this->x != eq.x || this->y != eq.y || this->z != eq.z || this->w != eq.w; }
+    };
+
+    struct CommonSimpleVertex
+    {
+        float   Position[4];
+        float   UV[2];
+
+        CommonSimpleVertex( ) {};
+        CommonSimpleVertex( float px, float py, float pz, float pw, float uvx, float uvy ) { Position[0] = px; Position[1] = py; Position[2] = pz; Position[3] = pw; UV[0] = uvx; UV[1] = uvy; }
+    };
+
+    // ** WARNING ** if changing anything here, update the corresponding shader code! ** WARNING **
+    struct ASSAOConstants
+    {
+        vaVector2               ViewportPixelSize;              // .zw == 1.0 / ViewportSize.xy
+        vaVector2               HalfViewportPixelSize;          // .zw == 1.0 / ViewportHalfSize.xy
+
+        vaVector2               DepthUnpackConsts;
+        vaVector2               CameraTanHalfFOV;
+
+        vaVector2               NDCToViewMul;
+        vaVector2               NDCToViewAdd;
+
+        vaVector2i              PerPassFullResCoordOffset;
+        vaVector2               PerPassFullResUVOffset;
+
+        vaVector2               Viewport2xPixelSize;
+        vaVector2               Viewport2xPixelSize_x_025;          // Viewport2xPixelSize * 0.25 (for fusing add+mul into mad)
+
+        float                   EffectRadius;                           // world (viewspace) maximum size of the shadow
+        float                   EffectShadowStrength;                   // global strength of the effect (0 - 5)
+        float                   EffectShadowPow;
+        float                   EffectShadowClamp;
+
+        float                   EffectFadeOutMul;                       // effect fade out from distance (ex. 25)
+        float                   EffectFadeOutAdd;                       // effect fade out to distance   (ex. 100)
+        float                   EffectHorizonAngleThreshold;            // limit errors on slopes and caused by insufficient geometry tessellation (0.05 to 0.5)
+        float                   EffectSamplingRadiusNearLimitRec;       // if viewspace pixel closer than this, don't enlarge shadow sampling radius anymore (makes no sense to grow beyond some distance, not enough samples to cover everything, so just limit the shadow growth; could be SSAOSettingsFadeOutFrom * 0.1 or less)
+
+        float                   DepthPrecisionOffsetMod;
+        float                   NegRecEffectRadius;                     // -1.0 / EffectRadius
+        float                   LoadCounterAvgDiv;                      // 1.0 / ( halfDepthMip[SSAO_DEPTH_MIP_LEVELS-1].sizeX * halfDepthMip[SSAO_DEPTH_MIP_LEVELS-1].sizeY )
+        float                   AdaptiveSampleCountLimit;
+
+        float                   InvSharpness;
+        int                     PassIndex;
+        vaVector2               QuarterResPixelSize;                    // used for importance map only
+
+        vaVector4               PatternRotScaleMatrices[5];
+
+        float                   NormalsUnpackMul;
+        float                   NormalsUnpackAdd;
+        float                   DetailAOStrength;
+        float                   Dummy0;
+
+#if SSAO_ENABLE_NORMAL_WORLD_TO_VIEW_CONVERSION
+        ASSAO_Float4x4          NormalsWorldToViewspaceMatrix;
+#endif
+    };
+
+    // Simplify texture creation and potential future porting
+    struct D3D11Texture2D
+    {
+        ID3D11Texture2D *           Texture2D;
+        ID3D11ShaderResourceView *  SRV;
+        //ID3D11DepthStencilView *    DSV;
+        ID3D11RenderTargetView *    RTV;
+        ID3D11UnorderedAccessView * UAV;
+        vaVector2i                  Size;
+
+        D3D11Texture2D( ) : Texture2D( NULL ), SRV( NULL ), /*DSV( NULL ),*/ RTV( NULL ), UAV( NULL ), Size( 0, 0 ) { }
+        ~D3D11Texture2D( )   { Reset(); }
+
+        void Reset( )       { SAFE_RELEASE( Texture2D ); SAFE_RELEASE( SRV ); /*SAFE_RELEASE( DSV );*/ SAFE_RELEASE( RTV ); SAFE_RELEASE( UAV ); Size = vaVector2i( 0, 0 ); }
+        bool ReCreateIfNeeded( ID3D11Device * device, vaVector2i size, DXGI_FORMAT format, float & inoutTotalSizeSum, int mipLevels, int arraySize, bool supportUAVs );
+        bool ReCreateMIPViewIfNeeded( ID3D11Device * device, D3D11Texture2D & original, int mipViewSlice );
+        bool ReCreateArrayViewIfNeeded( ID3D11Device * device, D3D11Texture2D & original, int arraySlice );
+    };
+
+    // Just to reduce clutter in the main code
+    class D3D11SSAOStateBackupRAII
+    {
+        ID3D11DeviceContext *       m_dx11Context;
+
+        D3D11_VIEWPORT              m_VPs[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE];
+        UINT                        m_numViewports;
+        D3D11_RECT                  m_scissorRects[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE];
+        UINT                        m_numScissorRects;
+        ID3D11SamplerState *        m_samplerStates[4];
+        ID3D11Buffer *              m_constantBuffers[1];
+        ID3D11ShaderResourceView *  m_SRVs[5];
+        ID3D11BlendState *          m_blendState;
+        FLOAT                       m_blendStateBlendFactor[4];
+        UINT                        m_blendStateSampleMask;
+        ID3D11DepthStencilState *   m_depthStencilState;
+        UINT                        m_depthStencilStateStencilRef;
+        D3D_PRIMITIVE_TOPOLOGY      m_primitiveTopology;
+        ID3D11InputLayout *         m_inputLayout;
+        ID3D11RasterizerState *     m_rasterizerState;
+        ID3D11RenderTargetView *    m_RTVs[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT];
+        ID3D11DepthStencilView *    m_DSV;
+
+
+    public:
+        D3D11SSAOStateBackupRAII( ID3D11DeviceContext * dx11Context ) : m_dx11Context( dx11Context )
+        {
+            m_numViewports = _countof( m_VPs );
+            m_dx11Context->RSGetViewports( &m_numViewports, m_VPs );
+            m_numScissorRects = _countof( m_scissorRects );
+            m_dx11Context->RSGetScissorRects( &m_numScissorRects, m_scissorRects );
+            m_dx11Context->PSGetSamplers( 0, _countof( m_samplerStates ), m_samplerStates );
+            m_dx11Context->PSGetConstantBuffers( 0, _countof( m_constantBuffers ), m_constantBuffers );
+            m_dx11Context->PSGetShaderResources( 0, _countof( m_SRVs ), m_SRVs );
+            m_dx11Context->OMGetBlendState( &m_blendState, m_blendStateBlendFactor, &m_blendStateSampleMask );
+            m_dx11Context->OMGetDepthStencilState( &m_depthStencilState, &m_depthStencilStateStencilRef );
+            m_dx11Context->IAGetPrimitiveTopology( &m_primitiveTopology );
+            m_dx11Context->IAGetInputLayout( &m_inputLayout );
+            m_dx11Context->RSGetState( &m_rasterizerState );
+
+            memset( m_RTVs, sizeof( m_RTVs ), 0 );
+            dx11Context->OMGetRenderTargets( _countof( m_RTVs ), m_RTVs, &m_DSV );
+
+#ifdef _DEBUG
+            ID3D11UnorderedAccessView * UAVs[D3D11_PS_CS_UAV_REGISTER_COUNT];
+            dx11Context->OMGetRenderTargetsAndUnorderedAccessViews( 0, NULL, NULL, 0, D3D11_PS_CS_UAV_REGISTER_COUNT, UAVs );
+            for( int i = 0; i < _countof( UAVs ); i++ )
+            {
+                // d3d state backup/restore does not work if UAVs are selected; please backup&restore or reset previously set UAVs manually. 
+                assert( UAVs[i] == NULL );
+            }
+#endif
+        }
+        ~D3D11SSAOStateBackupRAII( )
+        {
+            // Restore D3D11 states
+            m_dx11Context->RSSetViewports( m_numViewports, m_VPs );
+            m_dx11Context->RSSetScissorRects( m_numScissorRects, m_scissorRects );
+            m_dx11Context->PSSetSamplers( 0, _countof( m_samplerStates ), m_samplerStates );
+            m_dx11Context->PSSetConstantBuffers( 0, _countof( m_constantBuffers ), m_constantBuffers );
+            m_dx11Context->PSSetShaderResources( 0, _countof( m_SRVs ), m_SRVs );
+            m_dx11Context->OMSetRenderTargets( _countof( m_RTVs ), m_RTVs, m_DSV );
+            m_dx11Context->OMSetBlendState( m_blendState, m_blendStateBlendFactor, m_blendStateSampleMask );
+            m_dx11Context->OMSetDepthStencilState( m_depthStencilState, m_depthStencilStateStencilRef );
+            m_dx11Context->IASetPrimitiveTopology( m_primitiveTopology );
+            m_dx11Context->IASetInputLayout( m_inputLayout );
+            m_dx11Context->RSSetState( m_rasterizerState );
+
+            SAFE_RELEASE_ARRAY( m_constantBuffers );
+            SAFE_RELEASE_ARRAY( m_samplerStates );
+            SAFE_RELEASE_ARRAY( m_SRVs );
+            SAFE_RELEASE_ARRAY( m_RTVs );
+            SAFE_RELEASE( m_blendState );
+            SAFE_RELEASE( m_depthStencilState );
+            SAFE_RELEASE( m_inputLayout );
+            SAFE_RELEASE( m_rasterizerState );
+        }
+        void RestoreRTs( )
+        {
+            m_dx11Context->RSSetViewports( m_numViewports, m_VPs );
+            m_dx11Context->OMSetRenderTargets( _countof( m_RTVs ), m_RTVs, m_DSV );
+        }
+        const D3D11_VIEWPORT & GetFirstViewport() const { return m_VPs[0]; }
+    };
+
+    template<class T>
+    static inline T Min(T const & a, T const & b)
+    {
+        return (a < b)?(a):(b);
+    }
+
+    template<class T>
+    static inline T Max(T const & a, T const & b)
+    {
+        return (a > b)?(a):(b);
+    }
+
+    template<class T>
+    static inline T Clamp( T const & v, T const & min, T const & max )
+    {
+        if( v < min ) return min;
+        if( v > max ) return max;
+        return v;
+    }
+    template<class T>
+    static void     Swap( T & a, T & b )
+    {
+        assert( &a != &b ); // swapping with itself? 
+        T temp = b;
+        b = a;
+        a = temp;
+    }
+
+    static const int cMaxBlurPassCount = 6;
+
+    static GUID c_IID_ID3D11Texture2D = { 0x6f15aaf2,0xd208,0x4e89, { 0x9a,0xb4,0x48,0x95,0x35,0xd3,0x4f,0x9c } };
+}
+
+class ASSAODX11 : public ASSAO_Effect
+{
+    struct BufferFormats
+    {
+        DXGI_FORMAT         DepthBufferViewspaceLinear;
+        DXGI_FORMAT         AOResult;
+        DXGI_FORMAT         Normals;
+        DXGI_FORMAT         ImportanceMap;
+
+        BufferFormats( )
+        {
+            DepthBufferViewspaceLinear  = DXGI_FORMAT_R16_FLOAT;        // increase this to DXGI_FORMAT_R32_FLOAT if using very low FOVs (for a scope effect) or similar, or in case you suspect artifacts caused by lack of precision; performance will degrade
+            Normals                     = DXGI_FORMAT_R8G8B8A8_UNORM;
+            AOResult                    = DXGI_FORMAT_R8G8_UNORM;
+            ImportanceMap               = DXGI_FORMAT_R8_UNORM;
+        }
+    };
+
+private:
+    BufferFormats                           m_formats;
+
+    vaVector2i                              m_size;
+    vaVector2i                              m_halfSize;
+    vaVector2i                              m_quarterSize;
+    vaVector4i                              m_fullResOutScissorRect;
+    vaVector4i                              m_halfResOutScissorRect;
+
+    int                                     m_depthMipLevels;
+
+    ID3D11Device *                          m_device;
+
+    unsigned int                            m_allocatedVRAM;
+
+    ID3D11Buffer *                          m_constantsBuffer;
+
+    ID3D11Buffer *                          m_fullscreenVB;
+
+    ID3D11VertexShader *                    m_vertexShader;
+    ID3D11InputLayout *                     m_inputLayout;
+
+    ID3D11RasterizerState *                 m_rasterizerState;
+
+    ID3D11SamplerState *                    m_samplerStatePointClamp;
+    ID3D11SamplerState *                    m_samplerStateLinearClamp;
+    ID3D11SamplerState *                    m_samplerStatePointMirror;
+    ID3D11SamplerState *                    m_samplerStateViewspaceDepthTap;
+
+    ID3D11BlendState *                      m_blendStateMultiply;
+    ID3D11BlendState *                      m_blendStateOpaque;
+    ID3D11DepthStencilState *               m_depthStencilState;
+
+    ID3D11PixelShader *                     m_pixelShaderPrepareDepths;
+    ID3D11PixelShader *                     m_pixelShaderPrepareDepthsAndNormals;
+    ID3D11PixelShader *                     m_pixelShaderPrepareDepthsHalf;
+    ID3D11PixelShader *                     m_pixelShaderPrepareDepthsAndNormalsHalf;
+    ID3D11PixelShader *                     m_pixelShaderPrepareDepthMip[SSAO_DEPTH_MIP_LEVELS - 1];
+    ID3D11PixelShader *                     m_pixelShaderGenerate[5];
+    ID3D11PixelShader *                     m_pixelShaderSmartBlur;
+    ID3D11PixelShader *                     m_pixelShaderSmartBlurWide;
+    ID3D11PixelShader *                     m_pixelShaderApply;
+    ID3D11PixelShader *                     m_pixelShaderNonSmartBlur;
+    ID3D11PixelShader *                     m_pixelShaderNonSmartApply;
+    ID3D11PixelShader *                     m_pixelShaderNonSmartHalfApply;
+#ifdef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+    ID3D11PixelShader *                     m_pixelShaderGenerateImportanceMap;
+    ID3D11PixelShader *                     m_pixelShaderPostprocessImportanceMapA;
+    ID3D11PixelShader *                     m_pixelShaderPostprocessImportanceMapB;
+#endif
+
+    D3D11Texture2D                          m_halfDepths[4];
+    D3D11Texture2D                          m_halfDepthsMipViews[4][SSAO_DEPTH_MIP_LEVELS];
+    //D3D11Texture2D                          m_edges;
+    D3D11Texture2D                          m_pingPongHalfResultA;
+    D3D11Texture2D                          m_pingPongHalfResultB;
+    D3D11Texture2D                          m_finalResults;
+    D3D11Texture2D                          m_finalResultsArrayViews[4];
+    D3D11Texture2D                          m_normals;
+#ifdef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+    // Only needed for quality level 3 (adaptive quality)
+    D3D11Texture2D                          m_importanceMap;
+    D3D11Texture2D                          m_importanceMapPong;
+    ID3D11Texture1D *                       m_loadCounter;
+    ID3D11ShaderResourceView *              m_loadCounterSRV;
+    ID3D11UnorderedAccessView *             m_loadCounterUAV;
+#endif
+
+    bool                                    m_requiresClear;
+
+private:
+    friend class ASSAO_Effect;
+    
+    ASSAODX11( const ASSAO_CreateDescDX11 * createDesc );
+    virtual ~ASSAODX11( );
+
+    bool                                    InitializeDX( const ASSAO_CreateDescDX11 * createDesc );
+    void                                    CleanupDX( );
+
+private:
+    // ASSAO_Effect implementation
+    virtual void                            PreAllocateVideoMemory( const ASSAO_Inputs * inputs );
+    virtual void                            DeleteAllocatedVideoMemory( );
+    virtual unsigned int                    GetAllocatedVideoMemory( );
+    virtual void                            GetVersion( int & major, int & minor )                                          { major = 1; minor = 0; }
+    // Apply the SSAO effect to the currently selected render target using provided settings and platform-dependent inputs
+    virtual void                            Draw( const ASSAO_Settings & settings, const ASSAO_Inputs * inputs );
+
+private:
+    void                                    UpdateTextures( const ASSAO_InputsDX11 * inputs );
+    void                                    UpdateConstants( const ASSAO_Settings & settings, const ASSAO_InputsDX11 * inputs, int pass );
+    void                                    FullscreenPassDraw( ID3D11DeviceContext * context, ID3D11PixelShader * pixelShader, ID3D11BlendState * blendState = NULL, ID3D11DepthStencilState * depthStencilState = NULL, UINT stencilRef = 0 );
+    void                                    PrepareDepths( const ASSAO_Settings & settings, const ASSAO_InputsDX11 * inputs );
+    void                                    GenerateSSAO( const ASSAO_Settings & settings, const ASSAO_InputsDX11 * inputs, bool adaptiveBasePass );
+};
+
+
+ASSAO_Effect * ASSAO_Effect::CreateInstance( const ASSAO_CreateDescDX11 * createDesc )
+{
+    ASSAODX11 * effect = new ASSAODX11( createDesc );
+    if( effect->InitializeDX( createDesc ) )
+    {
+        return effect;
+    }
+    else
+    {
+        delete effect;
+        return NULL;
+    }
+}
+
+void ASSAO_Effect::DestroyInstance( ASSAO_Effect * effectInstance )
+{
+    delete effectInstance;
+}
+
+
+static int GetPixelSizeInBytes( DXGI_FORMAT val );
+
+//////////////////////////////////////////////////////////////////////////
+// ASSAODX11 implementation
+//////////////////////////////////////////////////////////////////////////
+
+ASSAODX11::ASSAODX11( const ASSAO_CreateDescDX11 * createDesc )
+{
+    m_device                                        = createDesc->Device;
+    m_device->AddRef();
+
+    m_size                                          = vaVector2i( 0, 0 );
+    m_halfSize                                      = vaVector2i( 0, 0 );
+    m_quarterSize                                   = vaVector2i( 0, 0 );
+    m_fullResOutScissorRect                         = vaVector4i( 0, 0, 0, 0 );
+    m_halfResOutScissorRect                         = vaVector4i( 0, 0, 0, 0 );
+    m_depthMipLevels                                = 0;
+
+    m_constantsBuffer                               = NULL;
+    m_fullscreenVB                                  = NULL;
+    m_allocatedVRAM                                 = 0;
+
+    m_vertexShader                                  = NULL;
+    m_inputLayout                                   = NULL;
+    m_rasterizerState                               = NULL;
+
+    m_pixelShaderPrepareDepths                      = NULL;
+    m_pixelShaderPrepareDepthsAndNormals            = NULL;
+    m_pixelShaderPrepareDepthsHalf                  = NULL;
+    m_pixelShaderPrepareDepthsAndNormalsHalf        = NULL;
+    for( int i = 0; i < _countof( m_pixelShaderPrepareDepthMip ); i++ )
+        m_pixelShaderPrepareDepthMip[ i ]           = NULL;
+    for( int i = 0; i < _countof( m_pixelShaderGenerate ); i++ )
+        m_pixelShaderGenerate[i]                    = NULL;
+    m_pixelShaderSmartBlur                          = NULL;
+    m_pixelShaderSmartBlurWide                      = NULL;
+    m_pixelShaderNonSmartBlur                       = NULL;
+    m_pixelShaderApply                              = NULL;
+    m_pixelShaderNonSmartApply                      = NULL;
+    m_pixelShaderNonSmartHalfApply                  = NULL;
+#ifdef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+    m_pixelShaderGenerateImportanceMap              = NULL;
+    m_pixelShaderPostprocessImportanceMapA          = NULL;
+    m_pixelShaderPostprocessImportanceMapB          = NULL;
+    m_loadCounter                                   = NULL;
+    m_loadCounterSRV                                = NULL;
+    m_loadCounterUAV                                = NULL;
+#endif
+
+    m_samplerStatePointClamp                        = NULL;
+    m_samplerStateLinearClamp                       = NULL;
+    m_samplerStatePointMirror                       = NULL;
+    m_samplerStateViewspaceDepthTap                 = NULL;
+
+    m_blendStateMultiply                            = NULL;
+    m_blendStateOpaque                              = NULL;
+    m_depthStencilState                             = NULL;
+
+    m_requiresClear                                 = false;
+}
+
+ASSAODX11::~ASSAODX11( )
+{
+    DeleteAllocatedVideoMemory( );
+    CleanupDX( );
+
+    assert( m_allocatedVRAM == 0 );
+}
+
+static HRESULT CompileShader( const ASSAO_CreateDescDX11 * createDesc, CONST D3D_SHADER_MACRO* pDefines, LPCSTR pFunctionName, LPCSTR pProfile, DWORD dwShaderFlags, ID3DBlob** ppShader )
+{
+    ID3DBlob* pErrorBlob = NULL;
+    HRESULT hr = D3DCompile( createDesc->ShaderData, createDesc->ShaderDataSize, NULL, pDefines, NULL/*D3D_COMPILE_STANDARD_FILE_INCLUDE*/, pFunctionName, pProfile, dwShaderFlags, 0, ppShader, &pErrorBlob );
+    if( FAILED( hr ) )
+    {
+        MessageBoxA( NULL, (LPCSTR)pErrorBlob->GetBufferPointer( ), "Pixel shader compilation error", MB_OK );
+
+        assert( false );
+    }
+    if( pErrorBlob != NULL ) pErrorBlob->Release( );
+    return hr;
+}
+
+static HRESULT CreateVertexShaderAndIL( const ASSAO_CreateDescDX11 * createDesc, CONST D3D_SHADER_MACRO* pDefines, LPCSTR pFunctionName, LPCSTR pProfile, DWORD dwShaderFlags, const D3D11_INPUT_ELEMENT_DESC *pInputElementDescs, UINT NumElements, ID3D11VertexShader ** ppShader, ID3D11InputLayout ** ppInputLayout )
+{
+    ID3DBlob * shaderBlob = NULL;
+
+    HRESULT hr = CompileShader( createDesc, pDefines, pFunctionName, pProfile, dwShaderFlags, &shaderBlob );
+    if( FAILED( hr ) ) { assert( false ); return hr; }
+
+    hr = createDesc->Device->CreateVertexShader( shaderBlob->GetBufferPointer(), shaderBlob->GetBufferSize(), NULL, ppShader );
+    if( FAILED( hr ) ) { SAFE_RELEASE( shaderBlob ); assert( false ); return hr; }
+
+    hr = createDesc->Device->CreateInputLayout( pInputElementDescs, NumElements, shaderBlob->GetBufferPointer( ), shaderBlob->GetBufferSize( ), ppInputLayout );
+    if( FAILED( hr ) ) { SAFE_RELEASE( shaderBlob ); SAFE_RELEASE( *ppInputLayout ); assert( false ); return hr; }
+
+    SAFE_RELEASE( shaderBlob );
+
+    return S_OK;
+}
+
+static HRESULT CreatePixelShader( const ASSAO_CreateDescDX11 * createDesc, CONST D3D_SHADER_MACRO* pDefines, LPCSTR pFunctionName, LPCSTR pProfile, DWORD dwShaderFlags, ID3D11PixelShader ** ppShader )
+{
+    ID3DBlob * shaderBlob = NULL;
+
+    HRESULT hr = CompileShader( createDesc, pDefines, pFunctionName, pProfile, dwShaderFlags, &shaderBlob );
+    if( FAILED( hr ) ) { assert( false ); return hr; }
+
+    hr = createDesc->Device->CreatePixelShader( shaderBlob->GetBufferPointer( ), shaderBlob->GetBufferSize( ), NULL, ppShader );
+    if( FAILED( hr ) ) { SAFE_RELEASE( shaderBlob ); assert( false ); return hr; }
+
+    SAFE_RELEASE( shaderBlob );
+
+    return S_OK;
+}
+
+bool ASSAODX11::InitializeDX( const ASSAO_CreateDescDX11 * createDesc )
+{
+    HRESULT hr;
+
+    // constant buffer
+    {
+        D3D11_BUFFER_DESC desc;
+        desc.ByteWidth = sizeof( ASSAOConstants );
+        desc.Usage = D3D11_USAGE_DYNAMIC;
+        desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+        desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+        desc.MiscFlags = 0;
+        desc.StructureByteStride = 0;
+
+        hr = m_device->CreateBuffer( &desc, NULL, &m_constantsBuffer );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+    }
+
+
+    // fullscreen vertex buffer
+    {
+        CD3D11_BUFFER_DESC desc( 3 * sizeof( CommonSimpleVertex ), D3D11_BIND_VERTEX_BUFFER );
+
+        // using one big triangle
+        CommonSimpleVertex fsVertices[3];
+        fsVertices[0] = CommonSimpleVertex( -1.0f,  1.0f, 0.0f, 1.0f, 0.0f, 0.0f );
+        fsVertices[1] = CommonSimpleVertex(  3.0f,  1.0f, 0.0f, 1.0f, 2.0f, 0.0f );
+        fsVertices[2] = CommonSimpleVertex( -1.0f, -3.0f, 0.0f, 1.0f, 0.0f, 2.0f );
+
+        D3D11_SUBRESOURCE_DATA initSubresData;
+        initSubresData.pSysMem          = fsVertices;
+        initSubresData.SysMemPitch      = 0;
+        initSubresData.SysMemSlicePitch = 0;
+
+        hr = m_device->CreateBuffer( &desc, &initSubresData, &m_fullscreenVB );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+    }
+
+    {
+        CD3D11_BLEND_DESC desc = CD3D11_BLEND_DESC( CD3D11_DEFAULT( ) );
+
+        desc.RenderTarget[0].BlendEnable = false;
+
+        hr = m_device->CreateBlendState( &desc, &m_blendStateOpaque );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+        desc.RenderTarget[0].BlendEnable = true;
+        desc.RenderTarget[0].SrcBlend = D3D11_BLEND_ZERO;
+        desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ZERO;
+        desc.RenderTarget[0].DestBlend = D3D11_BLEND_SRC_COLOR;
+        desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_SRC_ALPHA;
+
+        hr = m_device->CreateBlendState( &desc, &m_blendStateMultiply );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+    }
+
+    {
+        CD3D11_DEPTH_STENCIL_DESC desc = CD3D11_DEPTH_STENCIL_DESC( CD3D11_DEFAULT( ) );
+        desc.DepthEnable = FALSE;
+        hr = m_device->CreateDepthStencilState( &desc, &m_depthStencilState );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+    }
+
+    // samplers
+    {
+        CD3D11_SAMPLER_DESC desc = CD3D11_SAMPLER_DESC( CD3D11_DEFAULT( ) );
+
+        desc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+        desc.AddressU = desc.AddressV = desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+        hr = m_device->CreateSamplerState( &desc, &m_samplerStatePointClamp );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+        desc.AddressU = desc.AddressV = desc.AddressW = D3D11_TEXTURE_ADDRESS_MIRROR;
+        hr = m_device->CreateSamplerState( &desc, &m_samplerStatePointMirror );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+        desc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+        desc.AddressU = desc.AddressV = desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+        hr = m_device->CreateSamplerState( &desc, &m_samplerStateLinearClamp );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+        desc = CD3D11_SAMPLER_DESC( CD3D11_DEFAULT( ) );
+        desc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+        desc.AddressU = desc.AddressV = desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+        hr = m_device->CreateSamplerState( &desc, &m_samplerStateViewspaceDepthTap );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+    }
+
+    // rasterizer state
+    {
+        CD3D11_RASTERIZER_DESC desc = CD3D11_RASTERIZER_DESC( CD3D11_DEFAULT( ) );
+
+        desc.FillMode = D3D11_FILL_SOLID;
+        desc.CullMode = D3D11_CULL_NONE;
+        desc.ScissorEnable = true;
+        hr = m_device->CreateRasterizerState( &desc, &m_rasterizerState );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+    }
+
+    // shaders
+    {
+        D3D_SHADER_MACRO shaderMacros[] = { 
+            { "SSAO_MAX_TAPS" ,                              SSA_STRINGIZIZER( SSAO_MAX_TAPS                              ) },
+            { "SSAO_MAX_REF_TAPS" ,                          SSA_STRINGIZIZER( SSAO_MAX_REF_TAPS                          ) },
+            { "SSAO_ADAPTIVE_TAP_BASE_COUNT" ,               SSA_STRINGIZIZER( SSAO_ADAPTIVE_TAP_BASE_COUNT               ) },
+            { "SSAO_ADAPTIVE_TAP_FLEXIBLE_COUNT" ,           SSA_STRINGIZIZER( SSAO_ADAPTIVE_TAP_FLEXIBLE_COUNT           ) },
+            { "SSAO_DEPTH_MIP_LEVELS" ,                      SSA_STRINGIZIZER( SSAO_DEPTH_MIP_LEVELS                         ) },
+            { "SSAO_ENABLE_NORMAL_WORLD_TO_VIEW_CONVERSION", SSA_STRINGIZIZER( SSAO_ENABLE_NORMAL_WORLD_TO_VIEW_CONVERSION   ) },
+            
+            { NULL, NULL }
+        };
+
+        DWORD shaderFlags = D3DCOMPILE_ENABLE_STRICTNESS;
+#if defined( DEBUG ) || defined( _DEBUG )
+        // Set the D3D10_SHADER_DEBUG flag to embed debug information in the shaders.
+        // Setting this flag improves the shader debugging experience, but still allows 
+        // the shaders to be optimized and to run exactly the way they will run in 
+        // the release configuration of this program.
+        shaderFlags |= D3DCOMPILE_DEBUG;
+#endif
+        shaderFlags |= D3DCOMPILE_OPTIMIZATION_LEVEL3;
+        shaderFlags |= D3DCOMPILE_WARNINGS_ARE_ERRORS;
+
+
+        // vertex shader
+        {
+            D3D11_INPUT_ELEMENT_DESC inputElements[] = {    { "SV_Position", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+                                                            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 16, D3D11_INPUT_PER_VERTEX_DATA, 0 } };
+            hr = CreateVertexShaderAndIL( createDesc, shaderMacros, "VSMain", "vs_5_0", shaderFlags, inputElements, _countof(inputElements), &m_vertexShader, &m_inputLayout );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+        }
+
+        // pixel shaders
+        {
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSPrepareDepths", "ps_5_0", shaderFlags, &m_pixelShaderPrepareDepths );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSPrepareDepthsAndNormals", "ps_5_0", shaderFlags, &m_pixelShaderPrepareDepthsAndNormals );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSPrepareDepthsHalf", "ps_5_0", shaderFlags, &m_pixelShaderPrepareDepthsHalf );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSPrepareDepthsAndNormalsHalf", "ps_5_0", shaderFlags, &m_pixelShaderPrepareDepthsAndNormalsHalf );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSPrepareDepthMip1", "ps_5_0", shaderFlags, &m_pixelShaderPrepareDepthMip[0] );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSPrepareDepthMip2", "ps_5_0", shaderFlags, &m_pixelShaderPrepareDepthMip[1] );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSPrepareDepthMip3", "ps_5_0", shaderFlags, &m_pixelShaderPrepareDepthMip[2] );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSGenerateQ0", "ps_5_0", shaderFlags, &m_pixelShaderGenerate[0] );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSGenerateQ1", "ps_5_0", shaderFlags, &m_pixelShaderGenerate[1] );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSGenerateQ2", "ps_5_0", shaderFlags, &m_pixelShaderGenerate[2] );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+#ifdef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSGenerateQ3", "ps_5_0", shaderFlags, &m_pixelShaderGenerate[3] );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSGenerateQ3Base", "ps_5_0", shaderFlags, &m_pixelShaderGenerate[4] );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+#endif
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSSmartBlur", "ps_5_0", shaderFlags, &m_pixelShaderSmartBlur );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSSmartBlurWide", "ps_5_0", shaderFlags, &m_pixelShaderSmartBlurWide );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSNonSmartBlur", "ps_5_0", shaderFlags, &m_pixelShaderNonSmartBlur );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSApply", "ps_5_0", shaderFlags, &m_pixelShaderApply );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSNonSmartApply", "ps_5_0", shaderFlags, &m_pixelShaderNonSmartApply );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSNonSmartHalfApply", "ps_5_0", shaderFlags, &m_pixelShaderNonSmartHalfApply );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+#ifdef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSGenerateImportanceMap", "ps_5_0", shaderFlags, &m_pixelShaderGenerateImportanceMap );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSPostprocessImportanceMapA", "ps_5_0", shaderFlags, &m_pixelShaderPostprocessImportanceMapA );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+            hr = CreatePixelShader( createDesc, shaderMacros, "PSPostprocessImportanceMapB", "ps_5_0", shaderFlags, &m_pixelShaderPostprocessImportanceMapB );
+            if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+#endif
+        }
+
+    }
+
+#ifdef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+    // load counter stuff, only needed for adaptive quality (quality level 3)
+    {
+        CD3D11_TEXTURE1D_DESC desc( DXGI_FORMAT_R32_UINT, 1, 1, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS );
+
+        hr = m_device->CreateTexture1D( &desc, NULL, &m_loadCounter );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+        CD3D11_SHADER_RESOURCE_VIEW_DESC srvDesc( m_loadCounter, D3D11_SRV_DIMENSION_TEXTURE1D );
+        hr = m_device->CreateShaderResourceView( m_loadCounter, &srvDesc, &m_loadCounterSRV );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+
+        CD3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc( m_loadCounter, D3D11_UAV_DIMENSION_TEXTURE1D );
+        hr = m_device->CreateUnorderedAccessView( m_loadCounter, &uavDesc, &m_loadCounterUAV );
+        if( FAILED( hr ) ) { assert( false ); CleanupDX(); return false; }
+    }
+#endif
+
+    return true;
+}
+
+void ASSAODX11::CleanupDX( )
+{
+    SAFE_RELEASE( m_constantsBuffer );
+    SAFE_RELEASE( m_fullscreenVB );
+    
+    SAFE_RELEASE( m_vertexShader );
+    SAFE_RELEASE( m_inputLayout );
+    
+    SAFE_RELEASE( m_rasterizerState );
+
+    SAFE_RELEASE( m_pixelShaderPrepareDepths );
+    SAFE_RELEASE( m_pixelShaderPrepareDepthsAndNormals );
+    SAFE_RELEASE( m_pixelShaderPrepareDepthsHalf );
+    SAFE_RELEASE( m_pixelShaderPrepareDepthsAndNormalsHalf );
+    for( int i = 0; i < _countof( m_pixelShaderPrepareDepthMip ); i++ )
+        SAFE_RELEASE( m_pixelShaderPrepareDepthMip[ i ]         );
+    for( int i = 0; i < _countof( m_pixelShaderGenerate ); i++ )
+        SAFE_RELEASE( m_pixelShaderGenerate[i]                  );
+    SAFE_RELEASE( m_pixelShaderSmartBlur                        );
+    SAFE_RELEASE( m_pixelShaderSmartBlurWide                    );
+    SAFE_RELEASE( m_pixelShaderNonSmartBlur                     );
+    SAFE_RELEASE( m_pixelShaderApply                            );
+    SAFE_RELEASE( m_pixelShaderNonSmartApply                    );
+    SAFE_RELEASE( m_pixelShaderNonSmartHalfApply                );
+#ifdef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+    SAFE_RELEASE( m_pixelShaderGenerateImportanceMap            );
+    SAFE_RELEASE( m_pixelShaderPostprocessImportanceMapA        );
+    SAFE_RELEASE( m_pixelShaderPostprocessImportanceMapB        );
+    SAFE_RELEASE( m_loadCounter                                 );
+    SAFE_RELEASE( m_loadCounterSRV                              );
+    SAFE_RELEASE( m_loadCounterUAV                              );
+#endif
+
+    SAFE_RELEASE( m_device );
+
+    SAFE_RELEASE( m_samplerStatePointClamp                      );
+    SAFE_RELEASE( m_samplerStateLinearClamp                     );
+    SAFE_RELEASE( m_samplerStatePointMirror                     );
+    SAFE_RELEASE( m_samplerStateViewspaceDepthTap               );
+
+    SAFE_RELEASE( m_blendStateMultiply                          );
+    SAFE_RELEASE( m_blendStateOpaque                            );
+    SAFE_RELEASE( m_depthStencilState                           );
+}
+
+void           ASSAODX11::PreAllocateVideoMemory( const ASSAO_Inputs * _inputs )
+{
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // TODO: dynamic_cast if supported in _DEBUG to check for correct type cast below
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    const ASSAO_InputsDX11 * inputs = static_cast<const ASSAO_InputsDX11 *>( _inputs );
+
+    UpdateTextures( inputs );
+}
+
+void           ASSAODX11::DeleteAllocatedVideoMemory( )
+{
+
+}
+
+unsigned int   ASSAODX11::GetAllocatedVideoMemory( )
+{
+    return m_allocatedVRAM;
+}
+
+void           ASSAODX11::FullscreenPassDraw( ID3D11DeviceContext * context, ID3D11PixelShader * pixelShader, ID3D11BlendState * blendState, ID3D11DepthStencilState * depthStencilState, UINT stencilRef )
+{
+    if( blendState == NULL )        blendState          = m_blendStateOpaque;
+    if( depthStencilState == NULL ) depthStencilState   = m_depthStencilState;
+
+    // Topology
+    context->IASetPrimitiveTopology( D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP );
+
+    // Vertex buffer
+    const unsigned int stride = sizeof( CommonSimpleVertex );   UINT offsetInBytes = 0;
+    context->IASetVertexBuffers( 0, 1, &m_fullscreenVB, &stride, &offsetInBytes );
+
+    // Shaders and input layout
+
+    context->IASetInputLayout( m_inputLayout );
+    context->VSSetShader( m_vertexShader, NULL, 0 );
+    context->PSSetShader( pixelShader, NULL, 0 );
+
+    float blendFactor[4] = { 0, 0, 0, 0 };
+    context->OMSetBlendState( blendState, blendFactor, 0xFFFFFFFF );
+    context->OMSetDepthStencilState( depthStencilState, stencilRef );
+    context->RSSetState( m_rasterizerState );
+
+    context->Draw( 3, 0 );
+}
+
+void           ASSAODX11::PrepareDepths( const ASSAO_Settings & settings, const ASSAO_InputsDX11 * inputs )
+{
+    bool generateNormals = inputs->NormalSRV == NULL;
+
+    ID3D11DeviceContext * dx11Context = inputs->DeviceContext;
+
+    dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT0, 1, &inputs->DepthSRV );
+
+    {
+        CD3D11_VIEWPORT viewport = CD3D11_VIEWPORT( 0.0f, 0.0f, (float)m_halfSize.x, (float)m_halfSize.y );
+        CD3D11_RECT rect = CD3D11_RECT( 0, 0, m_halfSize.x, m_halfSize.y );
+        dx11Context->RSSetViewports( 1, &viewport );
+        dx11Context->RSSetScissorRects( 1, &rect );  // no scissor for this
+    }
+
+    ID3D11RenderTargetView* fourDepths[]    = { m_halfDepths[0].RTV, m_halfDepths[1].RTV, m_halfDepths[2].RTV, m_halfDepths[3].RTV };
+    ID3D11RenderTargetView* twoDepths[]     = { m_halfDepths[0].RTV, m_halfDepths[3].RTV };
+    if( !generateNormals )
+    {
+        //VA_SCOPE_CPUGPU_TIMER( PrepareDepths, drawContext.APIContext );
+
+        if( settings.QualityLevel < 0 )
+        {
+            dx11Context->OMSetRenderTargets( _countof(twoDepths), twoDepths, NULL );
+            FullscreenPassDraw( dx11Context, m_pixelShaderPrepareDepthsHalf );
+        }
+        else
+        {
+            dx11Context->OMSetRenderTargets( _countof(fourDepths), fourDepths, NULL );
+            FullscreenPassDraw( dx11Context, m_pixelShaderPrepareDepths );
+        }
+    }
+    else
+    {
+        //VA_SCOPE_CPUGPU_TIMER( PrepareDepthsAndNormals, drawContext.APIContext );
+
+        ID3D11UnorderedAccessView * UAVs[] = { m_normals.UAV };
+        if( settings.QualityLevel < 0 )
+        {
+            dx11Context->OMSetRenderTargetsAndUnorderedAccessViews( _countof(twoDepths), twoDepths, NULL, SSAO_NORMALMAP_OUT_UAV_SLOT, 1, UAVs, NULL );
+            FullscreenPassDraw( dx11Context, m_pixelShaderPrepareDepthsAndNormalsHalf );
+        }
+        else
+        {
+            dx11Context->OMSetRenderTargetsAndUnorderedAccessViews( _countof(fourDepths), fourDepths, NULL, SSAO_NORMALMAP_OUT_UAV_SLOT, 1, UAVs, NULL );
+            FullscreenPassDraw( dx11Context, m_pixelShaderPrepareDepthsAndNormals );
+        }
+    }
+
+    // only do mipmaps for higher quality levels (not beneficial on quality level 1, and detrimental on quality level 0)
+    if( settings.QualityLevel > 1 )
+    {
+        //VA_SCOPE_CPUGPU_TIMER( PrepareDepthMips, drawContext.APIContext );
+
+        for( int i = 1; i < m_depthMipLevels; i++ )
+        {
+            ID3D11RenderTargetView* fourDepthMips[] = { m_halfDepthsMipViews[0][i].RTV, m_halfDepthsMipViews[1][i].RTV, m_halfDepthsMipViews[2][i].RTV, m_halfDepthsMipViews[3][i].RTV };
+
+            CD3D11_VIEWPORT viewport = CD3D11_VIEWPORT( 0.0f, 0.0f, (float)m_halfDepthsMipViews[0][i].Size.x, (float)m_halfDepthsMipViews[0][i].Size.y );
+            dx11Context->RSSetViewports( 1, &viewport );
+
+            ID3D11ShaderResourceView * fourSRVs[] = { m_halfDepthsMipViews[0][i - 1].SRV, m_halfDepthsMipViews[1][i - 1].SRV, m_halfDepthsMipViews[2][i - 1].SRV, m_halfDepthsMipViews[3][i - 1].SRV };
+
+            dx11Context->OMSetRenderTargets( 4, fourDepthMips, NULL );
+            dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT0, 4, fourSRVs );
+            FullscreenPassDraw( dx11Context, m_pixelShaderPrepareDepthMip[i - 1] );
+        }
+    }
+}
+
+void           ASSAODX11::GenerateSSAO( const ASSAO_Settings & settings, const ASSAO_InputsDX11 * inputs, bool adaptiveBasePass )
+{
+    ID3D11ShaderResourceView * normalmapSRV = (inputs->NormalSRV==NULL)?(m_normals.SRV):(inputs->NormalSRV);
+
+    ID3D11DeviceContext * dx11Context = inputs->DeviceContext;
+
+    {
+        CD3D11_VIEWPORT viewport = CD3D11_VIEWPORT( 0.0f, 0.0f, (float)m_halfSize.x, (float)m_halfSize.y );
+        CD3D11_RECT rect = CD3D11_RECT( m_halfResOutScissorRect.x, m_halfResOutScissorRect.y, m_halfResOutScissorRect.z, m_halfResOutScissorRect.w );
+        dx11Context->RSSetViewports( 1, &viewport );
+        dx11Context->RSSetScissorRects( 1, &rect );
+    }
+
+    if( adaptiveBasePass )
+    {
+        assert( settings.QualityLevel == 3 );
+    }
+
+    int passCount = 4;
+
+    ID3D11ShaderResourceView * zeroSRVs[] = { NULL, NULL, NULL, NULL, NULL };
+
+    for( int pass = 0; pass < passCount; pass++ )
+    {
+        if( (settings.QualityLevel < 0) && ( (pass == 1) || (pass == 2) ) )
+            continue;
+
+        int blurPasses = settings.BlurPassCount;
+        blurPasses = Min( blurPasses, cMaxBlurPassCount );
+
+#ifdef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+        if( settings.QualityLevel == 3 )
+        {
+            // if adaptive, at least one blur pass needed as the first pass needs to read the final texture results - kind of awkward
+            if( adaptiveBasePass )
+                blurPasses = 0;
+            else
+                blurPasses = Max( 1, blurPasses );
+        } 
+        else 
+#endif
+        if( settings.QualityLevel <= 0 )
+        {
+            // just one blur pass allowed for minimum quality 
+            blurPasses = Min( 1, settings.BlurPassCount );
+        }
+
+        UpdateConstants( settings, inputs, pass );
+
+        D3D11Texture2D * pPingRT = &m_pingPongHalfResultA;
+        D3D11Texture2D * pPongRT = &m_pingPongHalfResultB;
+
+        // Generate
+        {
+            //VA_SCOPE_CPUGPU_TIMER_NAMED( Generate, vaStringTools::Format( "Generate_pass%d", pass ), drawContext.APIContext );
+
+            // remove textures from slots 0, 1, 2, 3 to avoid API complaints
+            dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT0, 5, zeroSRVs );
+
+            ID3D11RenderTargetView * rts[] = { pPingRT->RTV };
+
+            // no blur?
+            if( blurPasses == 0 )
+                rts[0] = m_finalResultsArrayViews[pass].RTV;
+
+            dx11Context->OMSetRenderTargets( _countof( rts ), rts, NULL );
+
+            ID3D11ShaderResourceView * SRVs[] = { m_halfDepths[pass].SRV, normalmapSRV, NULL, NULL, NULL }; // m_loadCounterSRV used only for quality level 3
+#ifdef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+            if( !adaptiveBasePass && (settings.QualityLevel == 3) )
+            {
+                SRVs[2] = m_loadCounterSRV;
+                SRVs[3] = m_importanceMap.SRV;
+                SRVs[4] = m_finalResults.SRV;
+            }
+#endif
+            dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT0, 5, SRVs );
+
+            int shaderIndex = Max( 0, (!adaptiveBasePass)?(settings.QualityLevel):(4) );
+            FullscreenPassDraw( dx11Context, m_pixelShaderGenerate[shaderIndex] );
+
+            // remove textures from slots 0, 1, 2, 3 to avoid API complaints
+            dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT0, 5, zeroSRVs );
+        }
+        
+        // Blur
+        if( blurPasses > 0 )
+        {
+            int wideBlursRemaining = Max( 0, blurPasses-2 );
+
+            for( int i = 0; i < blurPasses; i++ )
+            {
+                // remove textures to avoid API complaints
+                dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT0, _countof( zeroSRVs ), zeroSRVs );
+
+                ID3D11RenderTargetView * rts[] = { pPongRT->RTV };
+                
+                // last pass?
+                if( i == (blurPasses-1) )
+                    rts[0] = m_finalResultsArrayViews[pass].RTV;
+
+                dx11Context->OMSetRenderTargets( _countof( rts ), rts, NULL );
+
+                ID3D11ShaderResourceView * SRVs[] = { pPingRT->SRV };
+                dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT2, _countof(SRVs), SRVs );
+
+                if( settings.QualityLevel > 0 )
+                {
+                    if( wideBlursRemaining > 0 )
+                    {
+                        FullscreenPassDraw( dx11Context, m_pixelShaderSmartBlurWide );
+                        wideBlursRemaining--;
+                    }
+                    else
+                    {
+                        FullscreenPassDraw( dx11Context, m_pixelShaderSmartBlur );
+                    }
+                }
+                else
+                {
+                    FullscreenPassDraw( dx11Context, m_pixelShaderNonSmartBlur ); // just for quality level 0 (and -1)
+                }
+
+                Swap( pPingRT, pPongRT );
+            }
+        }
+        
+
+        // remove textures to avoid API complaints
+        dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT0, _countof(zeroSRVs), zeroSRVs );
+    }
+}
+
+void           ASSAODX11::Draw( const ASSAO_Settings & settings, const ASSAO_Inputs * _inputs )
+{
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // TODO: dynamic_cast if supported in _DEBUG to check for correct type cast below
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    const ASSAO_InputsDX11 * inputs = static_cast<const ASSAO_InputsDX11 *>( _inputs );
+
+    assert( settings.QualityLevel >= -1 && settings.QualityLevel <= 3 );
+#ifndef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+    if( settings.QualityLevel == 3 )
+    {
+        assert( false );
+        return;
+    }
+#endif
+
+    UpdateTextures( inputs );
+
+    UpdateConstants( settings, inputs, 0 );
+
+    ID3D11DeviceContext * dx11Context = inputs->DeviceContext;
+
+    {
+        // Backup D3D11 states (will be restored when it goes out of scope)
+        D3D11SSAOStateBackupRAII d3d11StatesBackup( dx11Context );
+
+        if( m_requiresClear )
+        {
+            float fourZeroes[4] = { 0, 0, 0, 0 };
+            float fourOnes[4]   = { 1, 1, 1, 1 };
+            dx11Context->ClearRenderTargetView( m_halfDepths[0].RTV, fourZeroes );
+            dx11Context->ClearRenderTargetView( m_halfDepths[1].RTV, fourZeroes );
+            dx11Context->ClearRenderTargetView( m_halfDepths[2].RTV, fourZeroes );
+            dx11Context->ClearRenderTargetView( m_halfDepths[3].RTV, fourZeroes );
+            dx11Context->ClearRenderTargetView( m_pingPongHalfResultA.RTV, fourOnes );
+            dx11Context->ClearRenderTargetView( m_pingPongHalfResultB.RTV, fourZeroes );
+            dx11Context->ClearRenderTargetView( m_finalResultsArrayViews[0].RTV, fourOnes );
+            dx11Context->ClearRenderTargetView( m_finalResultsArrayViews[1].RTV, fourOnes );
+            dx11Context->ClearRenderTargetView( m_finalResultsArrayViews[2].RTV, fourOnes );
+            dx11Context->ClearRenderTargetView( m_finalResultsArrayViews[3].RTV, fourOnes );
+            if( m_normals.RTV != NULL ) dx11Context->ClearRenderTargetView( m_normals.RTV, fourZeroes );
+#ifdef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+            dx11Context->ClearRenderTargetView( m_importanceMap.RTV, fourZeroes );
+            dx11Context->ClearRenderTargetView( m_importanceMapPong.RTV, fourZeroes );
+#endif
+
+            m_requiresClear = false;
+        }
+
+        // Set effect samplers
+        ID3D11SamplerState * samplers[] =
+        {
+            m_samplerStatePointClamp,
+            m_samplerStateLinearClamp,
+            m_samplerStatePointMirror,
+            m_samplerStateViewspaceDepthTap,
+        };
+        dx11Context->PSSetSamplers( 0, _countof( samplers ), samplers );
+
+        // Set constant buffer
+        dx11Context->PSSetConstantBuffers( SSAO_CONSTANTS_BUFFERSLOT, 1, &m_constantsBuffer );
+
+        // Generate depths
+        PrepareDepths( settings, inputs );
+
+#ifdef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+        // for adaptive quality, importance map pass
+        if( settings.QualityLevel == 3 )
+        {
+            // Generate simple quality SSAO
+            {
+                GenerateSSAO( settings, inputs, true );
+            }
+
+            // Generate importance map
+            {
+                CD3D11_VIEWPORT viewport = CD3D11_VIEWPORT( 0.0f, 0.0f, (float)m_quarterSize.x, (float)m_quarterSize.y );
+                CD3D11_RECT rect = CD3D11_RECT( 0, 0, m_quarterSize.x, m_quarterSize.y );
+                dx11Context->RSSetViewports( 1, &viewport );
+                dx11Context->RSSetScissorRects( 1, &rect );
+
+                ID3D11ShaderResourceView * zeroSRVs[] = { NULL, NULL, NULL, NULL, NULL };
+
+                // drawing into importanceMap
+                dx11Context->OMSetRenderTargets( 1, &m_importanceMap.RTV, NULL );
+
+                // select 4 deinterleaved AO textures (texture array)
+                dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT4, 1, &m_finalResults.SRV );
+                FullscreenPassDraw( dx11Context, m_pixelShaderGenerateImportanceMap, m_blendStateOpaque );
+            
+                // postprocess A
+                dx11Context->OMSetRenderTargets( 1, &m_importanceMapPong.RTV, NULL );
+                dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT3, 1, &m_importanceMap.SRV );
+                FullscreenPassDraw( dx11Context, m_pixelShaderPostprocessImportanceMapA, m_blendStateOpaque );
+                dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT3, 1, zeroSRVs );
+
+                // postprocess B
+                UINT fourZeroes[4] = { 0, 0, 0, 0 };
+                dx11Context->ClearUnorderedAccessViewUint( m_loadCounterUAV, fourZeroes );
+                dx11Context->OMSetRenderTargetsAndUnorderedAccessViews( 1, &m_importanceMap.RTV, NULL, SSAO_LOAD_COUNTER_UAV_SLOT, 1, &m_loadCounterUAV, NULL );
+                // select previous pass input importance map
+                dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT3, 1, &m_importanceMapPong.SRV );
+                FullscreenPassDraw( dx11Context, m_pixelShaderPostprocessImportanceMapB, m_blendStateOpaque );
+                dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT3, 1, zeroSRVs );
+            }
+        }
+#endif
+        // Generate SSAO
+        GenerateSSAO( settings, inputs, false );
+
+        if( inputs->OverrideOutputRTV != nullptr )
+        {
+            // drawing into OverrideOutputRTV
+            dx11Context->OMSetRenderTargets( 1, &inputs->OverrideOutputRTV, NULL );
+        }
+        else
+        {
+            // restore previous RTs
+            d3d11StatesBackup.RestoreRTs( );
+        }
+
+        // Apply
+        {
+            // select 4 deinterleaved AO textures (texture array)
+            dx11Context->PSSetShaderResources( SSAO_TEXTURE_SLOT4, 1, &m_finalResults.SRV );
+
+            CD3D11_VIEWPORT viewport = CD3D11_VIEWPORT( 0.0f, 0.0f, (float)m_size.x, (float)m_size.y );
+            CD3D11_RECT rect = CD3D11_RECT( m_fullResOutScissorRect.x, m_fullResOutScissorRect.y, m_fullResOutScissorRect.z, m_fullResOutScissorRect.w );
+            dx11Context->RSSetViewports( 1, &viewport );
+            dx11Context->RSSetScissorRects( 1, &rect );
+
+            ID3D11BlendState * blendState = ( inputs->DrawOpaque ) ? ( m_blendStateOpaque ) : ( m_blendStateMultiply );
+            
+            if( settings.QualityLevel < 0 )
+                FullscreenPassDraw( dx11Context, m_pixelShaderNonSmartHalfApply, blendState );
+            else if( settings.QualityLevel == 0 )
+                    FullscreenPassDraw( dx11Context, m_pixelShaderNonSmartApply, blendState );
+            else
+                FullscreenPassDraw( dx11Context, m_pixelShaderApply, blendState );
+        }
+
+        // restore previous RTs again (because of the viewport hack)
+        d3d11StatesBackup.RestoreRTs( );
+
+    //    FullscreenPassDraw( dx11Context, m_pixelShaderDebugDraw );
+
+    }
+
+}
+
+template<typename OutType>
+static OutType * QueryResourceInterface( ID3D11Resource * d3dResource, REFIID riid )
+{
+    OutType * ret = NULL;
+    if( SUCCEEDED( d3dResource->QueryInterface( riid, (void**)&ret ) ) )
+    {
+        return ret;
+    }
+    else
+    {
+        return NULL;
+    }
+}
+
+static vaVector4i GetTextureDimsFromSRV( ID3D11ShaderResourceView * srv )
+{
+    D3D11_SHADER_RESOURCE_VIEW_DESC desc;
+    srv->GetDesc( &desc );
+    
+    assert( desc.ViewDimension == D3D11_SRV_DIMENSION_TEXTURE2D );     if( desc.ViewDimension != D3D11_SRV_DIMENSION_TEXTURE2D ) return vaVector4i( 0, 0, 0, 0 );
+    
+    ID3D11Resource * res = NULL;
+    srv->GetResource( &res );
+    
+    assert( res != NULL );  if( res == NULL ) return vaVector4i( 0, 0, 0, 0 );
+
+    ID3D11Texture2D * tex = QueryResourceInterface<ID3D11Texture2D>( res, c_IID_ID3D11Texture2D );
+    SAFE_RELEASE( res );
+    assert( tex != NULL );  if( tex == NULL ) return vaVector4i( 0, 0, 0, 0 );
+
+    D3D11_TEXTURE2D_DESC texDesc;
+    tex->GetDesc( &texDesc );
+    SAFE_RELEASE( tex );
+
+    return vaVector4i( texDesc.Width, texDesc.Height, texDesc.MipLevels, texDesc.ArraySize );
+}
+
+void ASSAODX11::UpdateTextures( const ASSAO_InputsDX11 * inputs )
+{
+#ifdef _DEBUG
+    vaVector4i depthTexDims = GetTextureDimsFromSRV( inputs->DepthSRV );
+    assert( depthTexDims.x >= inputs->ViewportWidth );
+    assert( depthTexDims.y >= inputs->ViewportHeight );
+    assert( depthTexDims.w == 1 );  // no texture arrays supported
+
+    if( inputs->NormalSRV != NULL )
+    {
+        vaVector4i normTexDims = GetTextureDimsFromSRV( inputs->NormalSRV );
+        assert( normTexDims.x >= inputs->ViewportWidth );
+        assert( normTexDims.y >= inputs->ViewportHeight );
+    }
+#endif
+
+    bool needsUpdate = false;
+
+    // We've got input normals? No need to keep ours then.
+    if( inputs->NormalSRV != NULL )
+    {
+        if( m_normals.SRV != NULL )
+        {   
+            needsUpdate = true;
+            m_normals.Reset();
+        }
+    }
+    else
+    {
+        if( m_normals.SRV == NULL )
+        {   
+            needsUpdate = true;
+        }
+    }
+
+    int width = inputs->ViewportWidth;
+    int height = inputs->ViewportHeight;
+
+    needsUpdate |= (m_size.x != width) || (m_size.y != height);
+
+    m_size.x        = width;
+    m_size.y        = height;
+    m_halfSize.x    = ( width + 1 ) / 2;
+    m_halfSize.y    = ( height + 1 ) / 2;
+    m_quarterSize.x = (m_halfSize.x+1)/2;
+    m_quarterSize.y = (m_halfSize.y+1)/2;
+
+    vaVector4i prevScissorRect = m_fullResOutScissorRect;
+
+    if( (inputs->ScissorRight == 0) || (inputs->ScissorBottom == 0) )
+        m_fullResOutScissorRect = vaVector4i( 0, 0, width, height );
+    else
+        m_fullResOutScissorRect = vaVector4i( Max( 0, inputs->ScissorLeft ), Max( 0, inputs->ScissorTop ), Min( width, inputs->ScissorRight ), Min( height, inputs->ScissorBottom ) );
+
+    needsUpdate |= prevScissorRect != m_fullResOutScissorRect;
+    if( !needsUpdate )
+        return;
+    
+    m_halfResOutScissorRect = vaVector4i( m_fullResOutScissorRect.x/2, m_fullResOutScissorRect.y/2, (m_fullResOutScissorRect.z+1) / 2, (m_fullResOutScissorRect.w+1) / 2 );
+    int blurEnlarge = cMaxBlurPassCount + Max( 0, cMaxBlurPassCount-2 );  // +1 for max normal blurs, +2 for wide blurs
+    m_halfResOutScissorRect = vaVector4i( Max( 0, m_halfResOutScissorRect.x - blurEnlarge ), Max( 0, m_halfResOutScissorRect.y - blurEnlarge ), Min( m_halfSize.x, m_halfResOutScissorRect.z + blurEnlarge ), Min( m_halfSize.y, m_halfResOutScissorRect.w + blurEnlarge ) );
+
+    float totalSizeInMB = 0.0f;
+
+    m_depthMipLevels = SSAO_DEPTH_MIP_LEVELS;
+
+    for( int i = 0; i < 4; i++ )
+    {
+        if( m_halfDepths[i].ReCreateIfNeeded( m_device, m_halfSize, m_formats.DepthBufferViewspaceLinear, totalSizeInMB, m_depthMipLevels, 1, false ) )
+        {
+            for( int j = 0; j < m_depthMipLevels; j++ )
+                m_halfDepthsMipViews[i][j].Reset();
+
+            for( int j = 0; j < m_depthMipLevels; j++ )
+                m_halfDepthsMipViews[i][j].ReCreateMIPViewIfNeeded( m_device, m_halfDepths[i], j );
+        }
+
+    }
+    m_pingPongHalfResultA.ReCreateIfNeeded( m_device, m_halfSize, m_formats.AOResult, totalSizeInMB, 1, 1, false );
+    m_pingPongHalfResultB.ReCreateIfNeeded( m_device, m_halfSize, m_formats.AOResult, totalSizeInMB, 1, 1, false );
+    m_finalResults.ReCreateIfNeeded( m_device, m_halfSize, m_formats.AOResult, totalSizeInMB, 1, 4, false );
+#ifdef INTEL_SSAO_ENABLE_ADAPTIVE_QUALITY
+    m_importanceMap.ReCreateIfNeeded( m_device, m_quarterSize, m_formats.ImportanceMap, totalSizeInMB, 1, 1, false );
+    m_importanceMapPong.ReCreateIfNeeded( m_device, m_quarterSize, m_formats.ImportanceMap, totalSizeInMB, 1, 1, false );
+#endif
+    for( int i = 0; i < 4; i++ )
+        m_finalResultsArrayViews[i].ReCreateArrayViewIfNeeded( m_device, m_finalResults, i );
+
+    if( inputs->NormalSRV == NULL )
+        m_normals.ReCreateIfNeeded( m_device, m_size, m_formats.Normals, totalSizeInMB, 1, 1, true );
+
+    totalSizeInMB /= 1024 * 1024;
+    //    m_debugInfo = vaStringTools::Format( "SSAO (approx. %.2fMB memory used) ", totalSizeInMB );
+
+    // trigger a full buffers clear first time; only really required when using scissor rects
+    m_requiresClear = true;
+}
+
+void ASSAODX11::UpdateConstants( const ASSAO_Settings & settings, const ASSAO_InputsDX11 * inputs, int pass )
+{
+    ID3D11DeviceContext * dx11Context = inputs->DeviceContext;
+    bool generateNormals = inputs->NormalSRV == NULL;
+
+    // update constants
+    D3D11_MAPPED_SUBRESOURCE mappedResource;
+    if( dx11Context->Map( m_constantsBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResource ) != S_OK )
+    {
+        assert( false ); return;
+    }
+    else
+    {
+        ASSAOConstants & consts = *((ASSAOConstants*)mappedResource.pData);
+
+        const ASSAO_Float4x4 & proj = inputs->ProjectionMatrix;
+
+        consts.ViewportPixelSize                = vaVector2( 1.0f / (float)m_size.x, 1.0f / (float)m_size.y );
+        consts.HalfViewportPixelSize            = vaVector2( 1.0f / (float)m_halfSize.x, 1.0f / (float)m_halfSize.y );
+
+        consts.Viewport2xPixelSize              = vaVector2( consts.ViewportPixelSize.x * 2.0f, consts.ViewportPixelSize.y * 2.0f );
+        consts.Viewport2xPixelSize_x_025        = vaVector2( consts.Viewport2xPixelSize.x * 0.25f, consts.Viewport2xPixelSize.y * 0.25f );
+
+        float depthLinearizeMul                      = (inputs->MatricesRowMajorOrder)?(-proj.m[3][2]):(-proj.m[2][3]);           // float depthLinearizeMul = ( clipFar * clipNear ) / ( clipFar - clipNear );
+        float depthLinearizeAdd                      = (inputs->MatricesRowMajorOrder)?( proj.m[2][2]):( proj.m[2][2]);           // float depthLinearizeAdd = clipFar / ( clipFar - clipNear );
+        // correct the handedness issue. need to make sure this below is correct, but I think it is.
+        if( depthLinearizeMul * depthLinearizeAdd < 0 )
+            depthLinearizeAdd = -depthLinearizeAdd;
+        consts.DepthUnpackConsts                = vaVector2( depthLinearizeMul, depthLinearizeAdd );
+
+        float tanHalfFOVY                       = 1.0f / proj.m[1][1];    // = tanf( drawContext.Camera.GetYFOV( ) * 0.5f );
+        float tanHalfFOVX                       = 1.0F / proj.m[0][0];    // = tanHalfFOVY * drawContext.Camera.GetAspect( );
+        consts.CameraTanHalfFOV                 = vaVector2( tanHalfFOVX, tanHalfFOVY );
+
+        consts.NDCToViewMul                     = vaVector2( consts.CameraTanHalfFOV.x * 2.0f, consts.CameraTanHalfFOV.y * -2.0f );
+        consts.NDCToViewAdd                     = vaVector2( consts.CameraTanHalfFOV.x * -1.0f, consts.CameraTanHalfFOV.y * 1.0f );
+
+        consts.EffectRadius                     = Clamp( settings.Radius, 0.0f, 100000.0f );
+        consts.EffectShadowStrength             = Clamp( settings.ShadowMultiplier * 4.3f, 0.0f, 10.0f );
+        consts.EffectShadowPow                  = Clamp( settings.ShadowPower, 0.0f, 10.0f );
+        consts.EffectShadowClamp                = Clamp( settings.ShadowClamp, 0.0f, 1.0f );
+        consts.EffectFadeOutMul                 = -1.0f / ( settings.FadeOutTo - settings.FadeOutFrom );
+        consts.EffectFadeOutAdd                 = settings.FadeOutFrom / ( settings.FadeOutTo - settings.FadeOutFrom ) + 1.0f;
+        consts.EffectHorizonAngleThreshold      = Clamp( settings.HorizonAngleThreshold, 0.0f, 1.0f );
+
+        // 1.2 seems to be around the best trade off - 1.0 means on-screen radius will stop/slow growing when the camera is at 1.0 distance, so, depending on FOV, basically filling up most of the screen
+        // This setting is viewspace-dependent and not screen size dependent intentionally, so that when you change FOV the effect stays (relatively) similar.
+        float effectSamplingRadiusNearLimit     = ( settings.Radius * 1.2f );
+
+        // if the depth precision is switched to 32bit float, this can be set to something closer to 1 (0.9999 is fine)
+        consts.DepthPrecisionOffsetMod          = 0.9992f;
+
+        // consts.RadiusDistanceScalingFunctionPow     = 1.0f - Clamp( settings.RadiusDistanceScalingFunction, 0.0f, 1.0f );
+
+        int lastHalfDepthMipX = m_halfDepthsMipViews[0][SSAO_DEPTH_MIP_LEVELS - 1].Size.x;
+        int lastHalfDepthMipY = m_halfDepthsMipViews[0][SSAO_DEPTH_MIP_LEVELS - 1].Size.y;
+
+        // used to get average load per pixel; 9.0 is there to compensate for only doing every 9th InterlockedAdd in PSPostprocessImportanceMapB for performance reasons
+        consts.LoadCounterAvgDiv                = 9.0f / (float)( m_quarterSize.x * m_quarterSize.y * 255.0 );
+
+        // Special settings for lowest quality level - just nerf the effect a tiny bit
+        if( settings.QualityLevel <= 0 )
+        {
+            //consts.EffectShadowStrength     *= 0.9f;
+            effectSamplingRadiusNearLimit   *= 1.50f;
+
+            if( settings.QualityLevel < 0 )
+                consts.EffectRadius             *= 0.8f;
+        }
+        effectSamplingRadiusNearLimit /= tanHalfFOVY; // to keep the effect same regardless of FOV
+
+        consts.EffectSamplingRadiusNearLimitRec = 1.0f / effectSamplingRadiusNearLimit;
+
+        consts.AdaptiveSampleCountLimit         = settings.AdaptiveQualityLimit; 
+
+        consts.NegRecEffectRadius               = -1.0f / consts.EffectRadius;
+
+        consts.PerPassFullResCoordOffset        = vaVector2i( pass % 2, pass / 2 );
+        consts.PerPassFullResUVOffset           = vaVector2( ((pass % 2) - 0.0f) / m_size.x, ((pass / 2) - 0.0f) / m_size.y );
+
+        consts.InvSharpness                     = Clamp( 1.0f - settings.Sharpness, 0.0f, 1.0f );
+        consts.PassIndex                        = pass;
+        consts.QuarterResPixelSize              = vaVector2( 1.0f / (float)m_quarterSize.x, 1.0f / (float)m_quarterSize.y );
+
+        float additionalAngleOffset = settings.TemporalSupersamplingAngleOffset;  // if using temporal supersampling approach (like "Progressive Rendering Using Multi-frame Sampling" from GPU Pro 7, etc.)
+        float additionalRadiusScale = settings.TemporalSupersamplingRadiusOffset; // if using temporal supersampling approach (like "Progressive Rendering Using Multi-frame Sampling" from GPU Pro 7, etc.)
+        const int subPassCount = 5;
+        for( int subPass = 0; subPass < subPassCount; subPass++ )
+        {
+            int a = pass;
+            int b = subPass;
+
+            int spmap[5] { 0, 1, 4, 3, 2 };
+            b = spmap[subPass];
+
+            float ca, sa;
+            float angle0 = ( (float)a + (float)b / (float)subPassCount ) * (3.1415926535897932384626433832795f) * 0.5f;
+            angle0 += additionalAngleOffset;
+
+            ca = ::cosf( angle0 );
+            sa = ::sinf( angle0 );
+
+            float scale = 1.0f + (a-1.5f + (b - (subPassCount-1.0f) * 0.5f ) / (float)subPassCount ) * 0.07f;
+            scale *= additionalRadiusScale;
+
+            consts.PatternRotScaleMatrices[subPass] = vaVector4( scale * ca, scale * -sa, -scale * sa, -scale * ca );
+        }
+
+        if( !generateNormals )
+        {
+            consts.NormalsUnpackMul = inputs->NormalsUnpackMul;
+            consts.NormalsUnpackAdd = inputs->NormalsUnpackAdd;
+        }
+        else
+        {
+            consts.NormalsUnpackMul = 2.0f;
+            consts.NormalsUnpackAdd = -1.0f;
+        }
+        consts.DetailAOStrength = settings.DetailShadowStrength;
+        consts.Dummy0 = 0.0f;
+
+#if SSAO_ENABLE_NORMAL_WORLD_TO_VIEW_CONVERSION
+        if( !generateNormals )
+        {
+            consts.NormalsWorldToViewspaceMatrix = inputs->NormalsWorldToViewspaceMatrix;
+            if( !inputs->MatricesRowMajorOrder )
+                consts.NormalsWorldToViewspaceMatrix.Transpose();
+        }
+        else
+        {
+            consts.NormalsWorldToViewspaceMatrix.SetIdentity( );
+        }
+#endif
+
+
+        dx11Context->Unmap( m_constantsBuffer, 0 );
+        //m_constantsBuffer.Update( dx11Context, consts );
+    }
+}
+
+
+static int GetPixelSizeInBytes( DXGI_FORMAT val )
+{
+    switch( val )
+    {
+    case DXGI_FORMAT_UNKNOWN:                    return 0;
+    case DXGI_FORMAT_R32G32B32A32_TYPELESS:      return 4 * 4;
+    case DXGI_FORMAT_R32G32B32A32_FLOAT:         return 4 * 4;
+    case DXGI_FORMAT_R32G32B32A32_UINT:          return 4 * 4;
+    case DXGI_FORMAT_R32G32B32A32_SINT:          return 4 * 4;
+    case DXGI_FORMAT_R32G32B32_TYPELESS:         return 3 * 4;
+    case DXGI_FORMAT_R32G32B32_FLOAT:            return 3 * 4;
+    case DXGI_FORMAT_R32G32B32_UINT:             return 3 * 4;
+    case DXGI_FORMAT_R32G32B32_SINT:             return 3 * 4;
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS:      return 4 * 2;
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:         return 4 * 2;
+    case DXGI_FORMAT_R16G16B16A16_UNORM:         return 4 * 2;
+    case DXGI_FORMAT_R16G16B16A16_UINT:          return 4 * 2;
+    case DXGI_FORMAT_R16G16B16A16_SNORM:         return 4 * 2;
+    case DXGI_FORMAT_R16G16B16A16_SINT:          return 4 * 2;
+    case DXGI_FORMAT_R32G32_TYPELESS:            return 2 * 4;
+    case DXGI_FORMAT_R32G32_FLOAT:               return 2 * 4;
+    case DXGI_FORMAT_R32G32_UINT:                return 2 * 4;
+    case DXGI_FORMAT_R32G32_SINT:                return 2 * 4;
+    case DXGI_FORMAT_R32G8X24_TYPELESS:          return 4 + 1;
+    case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:       return 4 + 1;
+    case DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS:   return 4 + 1;
+    case DXGI_FORMAT_X32_TYPELESS_G8X24_UINT:    return 4 + 1;
+    case DXGI_FORMAT_R10G10B10A2_TYPELESS:       return 4;
+    case DXGI_FORMAT_R10G10B10A2_UNORM:          return 4;
+    case DXGI_FORMAT_R10G10B10A2_UINT:           return 4;
+    case DXGI_FORMAT_R11G11B10_FLOAT:            return 4;
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS:          return 4;
+    case DXGI_FORMAT_R8G8B8A8_UNORM:             return 4;
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:        return 4;
+    case DXGI_FORMAT_R8G8B8A8_UINT:              return 4;
+    case DXGI_FORMAT_R8G8B8A8_SNORM:             return 4;
+    case DXGI_FORMAT_R8G8B8A8_SINT:              return 4;
+    case DXGI_FORMAT_R16G16_TYPELESS:            return 4;
+    case DXGI_FORMAT_R16G16_FLOAT:               return 4;
+    case DXGI_FORMAT_R16G16_UNORM:               return 4;
+    case DXGI_FORMAT_R16G16_UINT:                return 4;
+    case DXGI_FORMAT_R16G16_SNORM:               return 4;
+    case DXGI_FORMAT_R16G16_SINT:                return 4;
+    case DXGI_FORMAT_R32_TYPELESS:               return 4;
+    case DXGI_FORMAT_D32_FLOAT:                  return 4;
+    case DXGI_FORMAT_R32_FLOAT:                  return 4;
+    case DXGI_FORMAT_R32_UINT:                   return 4;
+    case DXGI_FORMAT_R32_SINT:                   return 4;
+    case DXGI_FORMAT_R24G8_TYPELESS:             return 4;
+    case DXGI_FORMAT_D24_UNORM_S8_UINT:          return 4;
+    case DXGI_FORMAT_R24_UNORM_X8_TYPELESS:      return 4;
+    case DXGI_FORMAT_X24_TYPELESS_G8_UINT:       return 4;
+    case DXGI_FORMAT_R8G8_TYPELESS:              return 2;
+    case DXGI_FORMAT_R8G8_UNORM:                 return 2;
+    case DXGI_FORMAT_R8G8_UINT:                  return 2;
+    case DXGI_FORMAT_R8G8_SNORM:                 return 2;
+    case DXGI_FORMAT_R8G8_SINT:                  return 2;
+    case DXGI_FORMAT_R16_TYPELESS:               return 2;
+    case DXGI_FORMAT_R16_FLOAT:                  return 2;
+    case DXGI_FORMAT_D16_UNORM:                  return 2;
+    case DXGI_FORMAT_R16_UNORM:                  return 2;
+    case DXGI_FORMAT_R16_UINT:                   return 2;
+    case DXGI_FORMAT_R16_SNORM:                  return 2;
+    case DXGI_FORMAT_R16_SINT:                   return 2;
+    case DXGI_FORMAT_R8_TYPELESS:                return 1;
+    case DXGI_FORMAT_R8_UNORM:                   return 1;
+    case DXGI_FORMAT_R8_UINT:                    return 1;
+    case DXGI_FORMAT_R8_SNORM:                   return 1;
+    case DXGI_FORMAT_R8_SINT:                    return 1;
+    case DXGI_FORMAT_A8_UNORM:                   return 1;
+    case DXGI_FORMAT_R1_UNORM:                   return 1;
+    case DXGI_FORMAT_R9G9B9E5_SHAREDEXP:         return 4;
+    case DXGI_FORMAT_R8G8_B8G8_UNORM:            return 4;
+    case DXGI_FORMAT_G8R8_G8B8_UNORM:            return 4;
+    case DXGI_FORMAT_BC1_TYPELESS:               assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC1_UNORM:                  assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC1_UNORM_SRGB:             assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC2_TYPELESS:               assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC2_UNORM:                  assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC2_UNORM_SRGB:             assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC3_TYPELESS:               assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC3_UNORM:                  assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC3_UNORM_SRGB:             assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC4_TYPELESS:               assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC4_UNORM:                  assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC4_SNORM:                  assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC5_TYPELESS:               assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC5_UNORM:                  assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC5_SNORM:                  assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_B5G6R5_UNORM:               return 2;
+    case DXGI_FORMAT_B5G5R5A1_UNORM:             return 2;
+    case DXGI_FORMAT_B8G8R8A8_UNORM:             return 4;
+    case DXGI_FORMAT_B8G8R8X8_UNORM:             return 4;
+    case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM: return 4;
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:          return 4;
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:        return 4;
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:          return 4;
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:        return 4;
+    case DXGI_FORMAT_BC6H_TYPELESS:              assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC6H_UF16:                  assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC6H_SF16:                  assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC7_TYPELESS:               assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC7_UNORM:                  assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_BC7_UNORM_SRGB:             assert( false ); return 0; // not supported for compressed formats
+    case DXGI_FORMAT_AYUV:                       assert( false ); return 0; // not yet implemented
+    case DXGI_FORMAT_Y410:                       assert( false ); return 0; // not yet implemented
+    case DXGI_FORMAT_Y416:                       assert( false ); return 0; // not yet implemented
+    case DXGI_FORMAT_NV12:                       assert( false ); return 0; // not yet implemented
+    case DXGI_FORMAT_P010:                       assert( false ); return 0; // not yet implemented
+    case DXGI_FORMAT_P016:                       assert( false ); return 0; // not yet implemented
+    case DXGI_FORMAT_YUY2:                       assert( false ); return 0; // not yet implemented
+    case DXGI_FORMAT_Y210:                       assert( false ); return 0; // not yet implemented
+    case DXGI_FORMAT_Y216:                       assert( false ); return 0; // not yet implemented
+    case DXGI_FORMAT_NV11:                       assert( false ); return 0; // not yet implemented
+    case DXGI_FORMAT_AI44:                       assert( false ); return 0; // not yet implemented
+    case DXGI_FORMAT_IA44:                       assert( false ); return 0; // not yet implemented
+    case DXGI_FORMAT_P8:                         return 1;
+    case DXGI_FORMAT_A8P8:                       return 2;
+    case DXGI_FORMAT_B4G4R4A4_UNORM:             return 2;
+    default: break;
+    }
+    assert( false );
+    return 0;
+}
+
+bool D3D11Texture2D::ReCreateIfNeeded( ID3D11Device * device, vaVector2i size, DXGI_FORMAT format, float & inoutTotalSizeSum, int mipLevels, int arraySize, bool supportUAVs )
+{
+    int approxSize = size.x * size.y * GetPixelSizeInBytes( format );
+    if( mipLevels != 1 ) approxSize = approxSize * 2; // is this an overestimate?
+    inoutTotalSizeSum += approxSize * arraySize;
+
+    if( ( size.x == 0 ) || ( size.y == 0 ) || ( format == DXGI_FORMAT_UNKNOWN ) )
+    {
+        Reset( );
+    }
+    else
+    {
+        if( Texture2D != NULL )
+        {
+            D3D11_TEXTURE2D_DESC desc;
+            Texture2D->GetDesc( &desc );
+            if( ( desc.Format == format ) && ( desc.Width == size.x ) && ( desc.Height == size.y ) && ( desc.MipLevels == mipLevels ) && ( desc.ArraySize == arraySize ) )
+                return false;
+        }
+        Reset();
+
+        UINT bindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+        if( supportUAVs ) 
+            bindFlags |= D3D11_BIND_UNORDERED_ACCESS;
+        
+        HRESULT hr;
+
+        CD3D11_TEXTURE2D_DESC desc( format, size.x, size.y, arraySize, mipLevels, bindFlags );
+
+        hr = device->CreateTexture2D( &desc, NULL, &Texture2D );
+        if( FAILED( hr ) ) { assert( false ); Reset(); return false; }
+
+        CD3D11_SHADER_RESOURCE_VIEW_DESC srvDesc( Texture2D, (arraySize == 1)?(D3D11_SRV_DIMENSION_TEXTURE2D):(D3D11_SRV_DIMENSION_TEXTURE2DARRAY) );
+        hr = device->CreateShaderResourceView( Texture2D, &srvDesc, &SRV );
+        if( FAILED( hr ) ) { assert( false ); Reset( ); return false; }
+
+        if( arraySize == 1 )
+        {
+            CD3D11_RENDER_TARGET_VIEW_DESC rtvDesc( Texture2D, D3D11_RTV_DIMENSION_TEXTURE2D );
+            hr = device->CreateRenderTargetView( Texture2D, &rtvDesc, &RTV );
+            if( FAILED( hr ) ) { assert( false ); Reset( ); return false; }
+        }
+
+        if( supportUAVs )
+        {
+            CD3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc( Texture2D, D3D11_UAV_DIMENSION_TEXTURE2D );
+            hr = device->CreateUnorderedAccessView( Texture2D, &uavDesc, &UAV );
+            if( FAILED( hr ) ) { assert( false ); Reset( ); return false; }
+        }
+
+        this->Size = size;
+    }
+
+    return true;
+}
+
+bool D3D11Texture2D::ReCreateMIPViewIfNeeded( ID3D11Device * device, D3D11Texture2D & original, int mipViewSlice )
+{
+    if( original.Texture2D == this->Texture2D )
+        return true;
+
+    Reset( );
+
+    this->Texture2D = original.Texture2D;
+    this->Texture2D->AddRef();
+
+    HRESULT hr;
+
+    CD3D11_SHADER_RESOURCE_VIEW_DESC srvDesc( Texture2D, D3D11_SRV_DIMENSION_TEXTURE2D );
+    srvDesc.Texture2D.MipLevels         = 1;
+    srvDesc.Texture2D.MostDetailedMip   = mipViewSlice;
+    hr = device->CreateShaderResourceView( Texture2D, &srvDesc, &SRV );
+    if( FAILED( hr ) ) { assert( false ); Reset( ); return false; }
+
+    CD3D11_RENDER_TARGET_VIEW_DESC rtvDesc( Texture2D, D3D11_RTV_DIMENSION_TEXTURE2D );
+    rtvDesc.Texture2D.MipSlice          = mipViewSlice;
+    hr = device->CreateRenderTargetView( Texture2D, &rtvDesc, &RTV );
+    if( FAILED( hr ) ) { assert( false ); Reset( ); return false; }
+
+    this->Size = original.Size;
+
+    for( int i = 0; i < mipViewSlice; i++ )
+    {
+        this->Size.x = ( this->Size.x + 1 ) / 2;
+        this->Size.y = ( this->Size.y + 1 ) / 2;
+    }
+    this->Size.x = Max( this->Size.x, 1 );
+    this->Size.y = Max( this->Size.y, 1 );
+
+    return true;
+}
+
+bool D3D11Texture2D::ReCreateArrayViewIfNeeded( ID3D11Device * device, D3D11Texture2D & original, int arraySlice )
+{
+    if( original.Texture2D == this->Texture2D )
+        return true;
+
+    Reset( );
+
+    this->Texture2D = original.Texture2D;
+    this->Texture2D->AddRef();
+
+    HRESULT hr;
+
+    CD3D11_RENDER_TARGET_VIEW_DESC rtvDesc( Texture2D, D3D11_RTV_DIMENSION_TEXTURE2DARRAY );
+
+    rtvDesc.Texture2DArray.MipSlice        = 0;
+    rtvDesc.Texture2DArray.FirstArraySlice = arraySlice;
+    rtvDesc.Texture2DArray.ArraySize       = 1;
+
+    hr = device->CreateRenderTargetView( Texture2D, &rtvDesc, &RTV );
+    if( FAILED( hr ) ) { assert( false ); Reset( ); return false; }
+
+    this->Size = original.Size;
+
+    return true;
+}

--- a/D3D11Engine/include/ASSAO/ASSAODX11.cpp
+++ b/D3D11Engine/include/ASSAO/ASSAODX11.cpp
@@ -32,6 +32,7 @@
 #ifndef SAFE_RELEASE
 #define SAFE_RELEASE(p)      { if (p) { (p)->Release(); (p)=NULL; } }
 #endif
+#include "../../D3D11FileRelativeInclude.h"
 #ifndef SAFE_RELEASE_ARRAY
 #define SAFE_RELEASE_ARRAY(p)   { for( int i = 0; i < _countof(p); i++ ) if (p[i]) { (p[i])->Release(); (p[i])=NULL; } }
 #endif
@@ -512,7 +513,16 @@ ASSAODX11::~ASSAODX11( )
 static HRESULT CompileShader( const ASSAO_CreateDescDX11 * createDesc, CONST D3D_SHADER_MACRO* pDefines, LPCSTR pFunctionName, LPCSTR pProfile, DWORD dwShaderFlags, ID3DBlob** ppShader )
 {
     ID3DBlob* pErrorBlob = NULL;
-    HRESULT hr = D3DCompile( createDesc->ShaderData, createDesc->ShaderDataSize, NULL, pDefines, NULL/*D3D_COMPILE_STANDARD_FILE_INCLUDE*/, pFunctionName, pProfile, dwShaderFlags, 0, ppShader, &pErrorBlob );
+
+
+    std::filesystem::path shaderPath = std::filesystem::path("system") / "GD3D11" / "shaders" / "ASSAO" / "ASSAO.hlsl";
+
+    // absolute path
+    shaderPath = Engine::GAPI->GetStartDirectory().c_str() / shaderPath;
+
+    D3D11FileRelativeInclude includeHandler( shaderPath.parent_path() );
+
+    HRESULT hr = D3DCompile( createDesc->ShaderData, createDesc->ShaderDataSize, NULL, pDefines, &includeHandler, pFunctionName, pProfile, dwShaderFlags, 0, ppShader, &pErrorBlob );
     if( FAILED( hr ) )
     {
         MessageBoxA( NULL, (LPCSTR)pErrorBlob->GetBufferPointer( ), "Pixel shader compilation error", MB_OK );
@@ -669,7 +679,7 @@ bool ASSAODX11::InitializeDX( const ASSAO_CreateDescDX11 * createDesc )
         };
 
         DWORD shaderFlags = D3DCOMPILE_ENABLE_STRICTNESS;
-#if defined( DEBUG ) || defined( _DEBUG )
+#if defined( DEBUG ) || defined( _DEBUG ) || defined( DEBUG_D3D11 )
         // Set the D3D10_SHADER_DEBUG flag to embed debug information in the shaders.
         // Setting this flag improves the shader debugging experience, but still allows 
         // the shaders to be optimized and to run exactly the way they will run in 

--- a/D3D11Engine/include/ASSAO/ASSAODX11.cpp
+++ b/D3D11Engine/include/ASSAO/ASSAODX11.cpp
@@ -36,6 +36,7 @@
 #ifndef SAFE_RELEASE_ARRAY
 #define SAFE_RELEASE_ARRAY(p)   { for( int i = 0; i < _countof(p); i++ ) if (p[i]) { (p[i])->Release(); (p[i])=NULL; } }
 #endif
+#include "../../D3D11_Helpers.h"
 
 #define SSA_STRINGIZIZER( x )                       SSA_STRINGIZIZER_( x )
 #define SSA_STRINGIZIZER_( x )                      #x
@@ -546,6 +547,11 @@ static HRESULT CreateVertexShaderAndIL( const ASSAO_CreateDescDX11 * createDesc,
     hr = createDesc->Device->CreateInputLayout( pInputElementDescs, NumElements, shaderBlob->GetBufferPointer( ), shaderBlob->GetBufferSize( ), ppInputLayout );
     if( FAILED( hr ) ) { SAFE_RELEASE( shaderBlob ); SAFE_RELEASE( *ppInputLayout ); assert( false ); return hr; }
 
+#ifdef DEBUG_D3D11
+    SetDebugName( *ppShader,  "ASSAO::VS::" + std::string(pFunctionName));
+    SetDebugName( *ppInputLayout, "ASSAO::IL::" + std::string(pFunctionName));
+#endif
+
     SAFE_RELEASE( shaderBlob );
 
     return S_OK;
@@ -560,6 +566,10 @@ static HRESULT CreatePixelShader( const ASSAO_CreateDescDX11 * createDesc, CONST
 
     hr = createDesc->Device->CreatePixelShader( shaderBlob->GetBufferPointer( ), shaderBlob->GetBufferSize( ), NULL, ppShader );
     if( FAILED( hr ) ) { SAFE_RELEASE( shaderBlob ); assert( false ); return hr; }
+
+#ifdef DEBUG_D3D11
+    SetDebugName( *ppShader, "ASSAO::PS::" + std::string( pFunctionName ) );
+#endif
 
     SAFE_RELEASE( shaderBlob );
 

--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -109,3 +109,11 @@ namespace std {
 
     };
 }
+
+#if defined(BUILD_GOTHIC_2_6_fix)
+#define SWITCH_ENGINE(G1, G1A, G2A, OTHER) G2A
+#elif defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#define SWITCH_ENGINE(G1, G1A, G2A, OTHER) G1
+#elif defined(BUILD_GOTHIC_1_08k, OTHER) G1A
+#define SWITCH_ENGINE(G1, G1A, G2A, OTHER) OTHER
+#endif


### PR DESCRIPTION
This PR introduces Compute shader based effects as well as a simple "UBER-SHADER" that composes some of the fullscreen-passes into a single pass.

- Compute shader based effects:
  - Depth of Field
  - Godrays
  - Heightfog (part of `PS_PFX_Composition.hlsl`) 
  - SAO (a Scalable Ambient Obscurance implementation)
  - ASSAO (Intel _Adaptive Screen Space Ambient Occlusion_)

Additionally:
- Water patches are now drawn in batches to reduce cpu side draw calls where possible.
- our Normals are now stored as `RG16_SNORM` instead of `RGBA8_SNORM` which is also 32-bit but using Octahedral encoding for more evenly distributed and higher quality normals.
  - HBAO+ now only uses Depth and reconstructs its normals on the fly.
  - previous "depth" (skybox) testing ios now done using the depth buffer(copy) as SRV, instead of he `.w` component in the GBuffer normals, as we now only have 2 channels (R-G) instead of 4.

These changes allow cheaper hardware (with less bandwidth) to still be able to use Depth of Field/Godrays/Heightfog without if costing too many frames

In an experiment on an AMD mobile APU, each fullscreen-draw took around 0.6-1ms.

By implementing the above features as compute shaders, we can reduce the amount of pixels that are touched, and by composing the final Blend using an UBER-Shader we can further reduce fullscreen draws.

This brought back ~10 fps when all effects are enabled on that low end APU.

The other SSAO solutions are there to bridge a future removal of Nvidia HBAO+, as that is a black-box implementation and does not support custom normals encodings and is not composable.