### PR TITLE
Reduce calls to update vobs matrices/vertices, ...

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3062,26 +3062,40 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         builder.Write( reactiveMaskResource );
         builder.Write( backBufferHandle );
 
-        pass.m_executeCallback = [this, colorResource, normalsResource, specularResource, reactiveMaskResource](const RenderGraph& graph)-> void {
+        pass.m_executeCallback = [this, colorResource, normalsResource, specularResource, reactiveMaskResource, velocityBufferHandle](const RenderGraph& graph)-> void {
             GetContext()->VSSetShaderResources( 0, 8, s_nullSRVs );
             GetContext()->PSSetShaderResources( 0, 8, s_nullSRVs );
             GetContext()->DSSetShaderResources( 0, 8, s_nullSRVs );
             GetContext()->HSSetShaderResources( 0, 8, s_nullSRVs );
             GetContext()->CSSetShaderResources( 0, 8, s_nullSRVs );
+            
+            auto normals = graph.GetPhysicalTexture( normalsResource );
+            auto specular = graph.GetPhysicalTexture( specularResource );
+            auto reactiveMask = graph.GetPhysicalTexture( reactiveMaskResource );
+            auto velocityBuffer = graph.GetPhysicalTexture( velocityBufferHandle );
 
+            const auto aaMode = Engine::GAPI->GetRendererState().RendererSettings.AntiAliasingMode;
+            if ( aaMode != GothicRendererSettings::AA_TAA
+                && aaMode != GothicRendererSettings::AA_FSR
+                && aaMode != GothicRendererSettings::AA_FSR3 ) {
+                velocityBuffer = nullptr; // don't write velocity if not needed.
+                // NOTE: we should automate this, by putting the velocity 
+                // buffer creation INTO the rendergraph instead of passing it in via external handle
+            }
             ID3D11RenderTargetView* rtvs[] = {
-                graph.GetPhysicalTexture(colorResource)->GetRenderTargetView().Get(),
-                graph.GetPhysicalTexture(normalsResource)->GetRenderTargetView().Get(),
-                graph.GetPhysicalTexture(specularResource)->GetRenderTargetView().Get(),
-                VelocityBuffer->GetRenderTargetView().Get(),
-                graph.GetPhysicalTexture( reactiveMaskResource )->GetRenderTargetView().Get(),
+                graph.GetPhysicalTexture( colorResource )->GetRenderTargetView().Get(),
+                normals ? normals->GetRenderTargetView().Get() : nullptr,
+                specular ? specular->GetRenderTargetView().Get() : nullptr,
+                velocityBuffer ? velocityBuffer->GetRenderTargetView().Get() : nullptr,
+                reactiveMask ? reactiveMask->GetRenderTargetView().Get() : nullptr,
             };
 
             constexpr float black[] { 0.f, 0.f, 0.f, 0.f };
-            GetContext()->ClearRenderTargetView( rtvs[1], black );
-            GetContext()->ClearRenderTargetView( rtvs[2], black );
-            GetContext()->ClearRenderTargetView( rtvs[3], black );
-            GetContext()->ClearRenderTargetView( rtvs[4], black );
+            // skip color target, clear all others.
+            for ( size_t i = 1; i < std::size( rtvs ); i++ ) {
+                if ( rtvs[i] )
+                    GetContext()->ClearRenderTargetView( rtvs[i], black );
+            }
             GetContext()->OMSetRenderTargets( 5, rtvs, DepthStencilBuffer->GetDepthStencilView().Get() );
 
 
@@ -3512,7 +3526,6 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
                 builder.Read( velocityBufferHandle );
                 builder.Read( reactiveMaskResource );
                 builder.Read( backBufferHandle );
-                builder.Write( backBufferHandle );
 
                 builder.Write( backBufferHandle );
 
@@ -3568,7 +3581,6 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
                 builder.Read( velocityBufferHandle );
                 builder.Read( reactiveMaskResource );
                 builder.Read( backBufferHandle );
-                builder.Write( backBufferHandle );
 
                 builder.Write( backBufferHandle );
 
@@ -3651,6 +3663,7 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
             } );
         } else {
             graph.AddPass( L"Copy into native-size backbuffer", [&]( RGBuilder& builder, RenderPass& pass ) {
+                builder.Read( backBufferHandle );
                 builder.Write( backBufferHandle );
 
                 pass.m_executeCallback = [this, &rendererState, backBufferHandle](const RenderGraph& graph) {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -5710,6 +5710,15 @@ void D3D11GraphicsEngine::UpdateMorphMeshVisual() {
         WorldConverter::UpdateMorphMeshVisual( staticMeshVisual.second->MorphMeshVisual, staticMeshVisual.second );
     }
 }
+namespace {
+    void UpdateMorphMeshVisuals( std::vector<MeshVisualInfo*>& staticMeshVisuals ) {
+        for ( auto const& staticMeshVisual : staticMeshVisuals ) {
+            if ( !staticMeshVisual->MorphMeshVisual ) continue;
+            if ( staticMeshVisual->Instances.empty() ) continue;
+            WorldConverter::UpdateMorphMeshVisual( staticMeshVisual->MorphMeshVisual, staticMeshVisual );
+        }
+    }
+}
 
 /** Updates wind direction and set time for shader */
 void D3D11GraphicsEngine::ApplyWindProps( VS_ExConstantBuffer_Wind& windBuff ) {
@@ -5838,10 +5847,6 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
             }
         }
 
-        if ( renderSettings.AnimateStaticVobs ) {
-            UpdateMorphMeshVisual();
-        }
-
         if ( renderSettings.DrawVOBs ) {
             auto _1 = Engine::GraphicsEngine->RecordGraphicsEvent( L"DrawVOBsInstanced->DrawVOBs" );
 
@@ -5851,6 +5856,10 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                 if ( !pair.second->Instances.empty() ) {
                     activeVisuals.push_back( pair.second );
                 }
+            }
+
+            if ( renderSettings.AnimateStaticVobs ) {
+                UpdateMorphMeshVisuals( activeVisuals );
             }
 
             // Create instancebuffer for this frame

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2468,6 +2468,8 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
     auto boneTransformsCb = ActiveVS->GetBuffer("BoneTransforms").Bind();
     auto prevBoneTransformsCb = ActiveVS->GetBuffer("PrevBoneTransforms").Bind();
 
+    const auto now = Engine::GAPI->GetTotalTimeDW();
+
     // Copy previous frame bone transforms for motion vectors (only for main scene rendering, not shadow maps)
     if ( GetRenderingStage() == DES_SHADOWMAP_CUBE ) {
         // Don't bind previous, as we don't use them here yet.
@@ -2547,9 +2549,12 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         auto boneIdx = boneOffset;
         boneOffset += numBones;
 
-        if ( updateState ) {
-            // Update attachments
-            model->UpdateAttachedVobs();
+        if ( updateState) {
+            if ( vi->LastAniUpdateFrame != now ) {
+                vi->LastAniUpdateFrame = now;
+                // Update attachments
+                model->UpdateAttachedVobs();
+            }
             model->UpdateMeshLibTexAniState();
         }
 
@@ -2773,8 +2778,11 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                             // Update constantbuffer
 
                             if ( updateState ) {
-                                mm->AdvanceAnis();
-                                mm->CalcVertexPositions();
+                                if ( mvi->LastAniUpdateFrame != now ) {
+                                    mvi->LastAniUpdateFrame = now;
+                                    mm->AdvanceAnis();
+                                    mm->CalcVertexPositions();
+                                }
                             }
                             Engine::GAPI->DrawMorphMesh( mm, mvi->Meshes );
                             continue;

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -622,11 +622,11 @@ XRESULT D3D11ShadowMap::PrepareRender()
             if ( lazyCascadeUpdate ) {
                 if ( cascadeIdx == 2 ) {
                     // pre-last cascade updates every 2nd frame which is 30 FPS = 15 updates per second
-                    shouldUpdateCascade = (perFrameCascadeData.frameCount % 2) == 0;
+                    shouldUpdateCascade = (perFrameCascadeData.frameCount % 5) == 0;
                 } else if ( cascadeIdx == MAX_CSM_CASCADES-1 ) {
                     // final cascade updates every 3rd frame which is 30 FPS = 10 updates per second
                     // it covers the whole world, so this can help improve avg fps.
-                    shouldUpdateCascade = (perFrameCascadeData.frameCount % 3) == 0;
+                    shouldUpdateCascade = (perFrameCascadeData.frameCount % 10) == 0;
                 }
             } 
             m_ShouldUpdateCascade[cascadeIdx] = shouldUpdateCascade;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -2471,10 +2471,13 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
     static std::vector<XMFLOAT4X4> transforms;
     transforms.clear();
     model->GetBoneTransforms( &transforms );
-
+    const auto now = Engine::GAPI->GetTotalTimeDW();
     if ( updateState ) {
         // Update attachments
-        model->UpdateAttachedVobs();
+        if ( vi->LastAniUpdateFrame != now ) {
+            vi->LastAniUpdateFrame = now;
+            model->UpdateAttachedVobs();
+        }
         model->UpdateMeshLibTexAniState();
     }
 
@@ -2614,8 +2617,11 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
                         vsBufMPI.Update( &instanceInfo );
 
                         if ( updateState ) {
-                            mm->AdvanceAnis();
-                            mm->CalcVertexPositions();
+                            if ( mvi->LastAniUpdateFrame != now ) {
+                                mvi->LastAniUpdateFrame = now;
+                                mm->AdvanceAnis();
+                                mm->CalcVertexPositions();
+                            }
                         }
                         DrawMorphMesh( mm, mvi->Meshes );
                         continue;
@@ -2709,10 +2715,15 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
     transforms.clear();
     model->GetBoneTransforms( &transforms );
 
+    const auto now = Engine::GAPI->GetTotalTimeDW();
+
     if ( updateState ) {
         // Update attachments
-        model->UpdateAttachedVobs();
-        model->UpdateMeshLibTexAniState();
+        if ( vi->LastAniUpdateFrame != now ) {
+            vi->LastAniUpdateFrame = now;
+            model->UpdateAttachedVobs();
+            model->UpdateMeshLibTexAniState();
+        }
     }
 
     if ( !static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->SkeletalMeshes.empty() ) {
@@ -2836,8 +2847,11 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
                         vsBufMPI.Update( &instanceInfo );
 
                         if ( updateState ) {
-                            mm->AdvanceAnis();
-                            mm->CalcVertexPositions();
+                            if ( mvi->LastAniUpdateFrame != now ) {
+                                mvi->LastAniUpdateFrame = now;
+                                mm->AdvanceAnis();
+                                mm->CalcVertexPositions();
+                            }
                         }
                         DrawMorphMesh_Layered( mm, mvi->Meshes );
                         continue;

--- a/D3D11Engine/RenderGraph.h
+++ b/D3D11Engine/RenderGraph.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "RGTextureDesc.h"
 #include <memory>
+#include <vector>
 
 #include "BaseGraphicsEngine.h"
 #include "Engine.h"
@@ -66,7 +67,7 @@ public:
     }
 
     void Compile() {
-        m_resourceLifetimes.assign(m_nextHandle, { UINT32_MAX, 0 });
+        m_resourceLifetimes.assign(m_nextHandle, { UINT32_MAX, 0, false });
 
         for ( size_t passIndex = 0; passIndex < m_passes.size(); ++passIndex ) {
             const auto& pass = m_passes[passIndex];
@@ -90,10 +91,11 @@ public:
                 
                 // Reads extend the lifetime of the resource to this pass
                 m_resourceLifetimes[index].lastPass = (uint32_t)passIndex;
+                
+                // Mark that this resource actually serves a read dependency downstream
+                m_resourceLifetimes[index].isRead = true;
             }
         }
-
-        // TODO: remove all passes whose writes are never read.
     }
 
     void Execute() {
@@ -102,7 +104,22 @@ public:
 
             AllocateResourcesForPass( i );
 
-            if ( pass->m_executeCallback ) {
+            // Eliminate any passes whose writes are never read
+            bool isPassDead = false;
+            if (!pass->m_writes.empty()) {
+                isPassDead = true; 
+                for (RGResourceHandle writeHandle : pass->m_writes) {
+                    uint32_t index = GetHandleIndex(writeHandle);
+                    // A pass is alive if it writes to an external resource OR an internal resource that gets read
+                    if (IsExternalHandle(writeHandle) || m_resourceLifetimes[index].isRead) {
+                        isPassDead = false;
+                        break;
+                    }
+                }
+            }
+
+            // Only execute if it provides a meaningful side-effect/write
+            if ( !isPassDead && pass->m_executeCallback ) {
                 auto _ = Engine::GraphicsEngine->RecordGraphicsEvent( pass->m_name.c_str() );
                 pass->m_executeCallback(*this);
             }
@@ -119,7 +136,7 @@ public:
             : m_activeTextures[index].get();
     }
 private:
-    struct Lifetime { uint32_t firstPass; uint32_t lastPass; };
+    struct Lifetime { uint32_t firstPass; uint32_t lastPass; bool isRead; };
 
     TexturePool* m_texturePool;
     uint32_t m_nextHandle = 0;
@@ -134,12 +151,12 @@ private:
     void AllocateResourcesForPass(size_t passIndex) {
         for (uint32_t i = 0; i < m_resourceLifetimes.size(); ++i) {
             // We only allocate for Graph-Managed resources
-            // (Assuming we track external handles in the lifetimes list too, we just skip them)
-
             if (m_resourceLifetimes[i].firstPass == (uint32_t)passIndex) {
-                // If this index is meant to be external, m_externalTextures[i] will be populated,
-                // so we don't allocate it from the pool.
+                // If this index is meant to be external, we don't allocate it from the pool.
                 if (m_externalTextures[i] != nullptr) continue; 
+                
+                // Do NOT allocate if the resource is completely unread downstream
+                if (!m_resourceLifetimes[i].isRead) continue;
 
                 const RGTextureDesc& desc = m_resourceDescs[i];
                 TexturePool::Description poolDesc{ (int)desc.width, (int)desc.height, static_cast<DXGI_FORMAT>(desc.format), (DXGI_USAGE)desc.textureFlags };

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -1200,7 +1200,14 @@ void WorldConverter::ExtractNodeVisual( int index, zCModelNodeInst* node, phmap:
 /** Updates a Morph-Mesh visual */
 void WorldConverter::UpdateMorphMeshVisual( void* v, MeshVisualInfo* meshInfo ) {
     zCMorphMesh* visual = reinterpret_cast<zCMorphMesh*>(v);
-    visual->GetTexAniState()->UpdateTexList();
+    visual->GetTexAniState()->UpdateTexList(); // always update tex list, otherwise texture corrupt (very rarely).
+
+    const auto now = Engine::GAPI->GetTotalTimeDW();
+    if ( meshInfo->LastAniUpdateFrame == now ) {
+        return;
+    }
+    meshInfo->LastAniUpdateFrame = now;
+
     visual->AdvanceAnis();
     visual->CalcVertexPositions();
 

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -191,6 +191,7 @@ struct MeshVisualInfo : public BaseVisualInfo {
         UnloadedSomething = false;
         StartInstanceNum = 0;
         FullMesh = nullptr;
+        LastAniUpdateFrame = 0;
     }
     
     MeshVisualInfo(MeshVisualInfo&& other) = default;
@@ -228,6 +229,7 @@ struct MeshVisualInfo : public BaseVisualInfo {
 
     /** Flag wether some mesh inside needs alpha testing, to allow sorting for shader usage */
     bool NeedsAlphaTesting;
+    size_t LastAniUpdateFrame;
 };
 
 /** Holds the converted mesh of a VOB */
@@ -369,6 +371,7 @@ struct SkeletalVobInfo : public BaseVobInfo {
         VisibleInRenderPass = false;
         VobConstantBuffer = nullptr;
         HasValidPrevTransforms = false;
+        LastAniUpdateFrame = 0;
     }
     
     SkeletalVobInfo(SkeletalVobInfo&& other) = default;
@@ -418,6 +421,7 @@ struct SkeletalVobInfo : public BaseVobInfo {
     std::vector<XMFLOAT4X4> PrevBoneTransforms;
     XMFLOAT4X4 PrevWorldMatrix;
     bool HasValidPrevTransforms;
+    size_t LastAniUpdateFrame;
 };
 
 struct SectionInstanceCache {


### PR DESCRIPTION
- reduce the amount UpdateAttachedVobs, AdvanceAnis and CalcVertexPositions are called in a frame for a vob, by doing it only once per `LastAniUpdateFrame`
- only update static vob visuals with `UpdateMorphMeshVisuals` which actually get drawn this frame.
- prune unused rendertargets in rendergraph
  - normals, specular, velocityBuffer, reactiveMask only get created and drawn to if any dependency down the line exists.
  - This helps low bandwidth devices like notebooks with iGPU to run the renderer better if certain features are disabled.
- `Lazy update` for shadows is now even lazier, farther away shadows are re-computed only every 5th/10th frame