### PR TITLE
feat: fix frame statistics, hide them by default. update defaults. cleanup code structure, ...

### DIFF
--- a/D3D11Engine/BasicTimer.h
+++ b/D3D11Engine/BasicTimer.h
@@ -22,6 +22,9 @@ public:
         Reset();
     }
 
+    BasicTimer( const BasicTimer& other ) = delete;
+    BasicTimer( BasicTimer&& other ) = default;
+
     void Reset() {
         m_total = 0;
         m_delta = 1.0f / 60.0f;
@@ -39,7 +42,7 @@ public:
         m_total = static_cast<float>( static_cast<double>( m_currentTime.QuadPart - m_startTime.QuadPart ) / static_cast<double>( m_frequency.QuadPart ) );
 
         if ( m_lastTime.QuadPart == m_startTime.QuadPart ) {
-            m_delta = 0.01f; // report a very low number
+            m_delta = 0.000001f; // report a very low number
         } else {
             m_delta = static_cast<float>( static_cast<double>( m_currentTime.QuadPart - m_lastTime.QuadPart ) / static_cast<double>( m_frequency.QuadPart ) );
         }
@@ -55,4 +58,34 @@ public:
         return m_delta;
     }
 
+};
+
+class OneShotTimer {
+private:
+private:
+    // Frequency is constant, cache it once
+    static inline const double s_inverseFrequency = []() {
+        LARGE_INTEGER freq;
+        QueryPerformanceFrequency( &freq );
+        return 1.0 / static_cast<double>(freq.QuadPart);
+    }();
+
+    LARGE_INTEGER m_startTime;
+
+public:
+    OneShotTimer() {
+        QueryPerformanceCounter( &m_startTime );
+    }
+
+    OneShotTimer( const OneShotTimer& other ) = delete;
+    OneShotTimer( OneShotTimer&& other ) = default;
+
+    float GetDelta() const {
+        LARGE_INTEGER m_currentTime;
+        QueryPerformanceCounter( &m_currentTime );
+
+        float total = static_cast<float>(static_cast<double>(m_currentTime.QuadPart - m_startTime.QuadPart) * s_inverseFrequency);
+
+        return total;
+    }
 };

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -849,6 +849,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="D3D11TiledDeferredShading.h" />
     <ClInclude Include="D3D11LegacyDeferredShading.h" />
     <ClInclude Include="D3D11Texture.h" />
+    <ClInclude Include="D3D11Upscaling.h" />
     <ClInclude Include="D3D11VertexBuffer.h" />
     <ClInclude Include="D3D11VShader.h" />
     <ClInclude Include="D3D11_Helpers.h" />
@@ -1107,6 +1108,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="D3D11TiledDeferredShading.cpp" />
     <ClCompile Include="D3D11LegacyDeferredShading.cpp" />
     <ClCompile Include="D3D11Texture.cpp" />
+    <ClCompile Include="D3D11Upscaling.cpp" />
     <ClCompile Include="D3D11VertexBuffer.cpp" />
     <ClCompile Include="D3D11VShader.cpp" />
     <ClCompile Include="D3D7\FakeDirectDrawSurface7.cpp">

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -842,6 +842,9 @@
     <ClInclude Include="zCSoundSystem.h">
       <Filter>ZenGin\Classes</Filter>
     </ClInclude>
+    <ClInclude Include="D3D11Upscaling.h">
+      <Filter>Engine\D3D11</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -1143,6 +1146,9 @@
     </ClCompile>
     <ClCompile Include="zSndMss.cpp">
       <Filter>ZenGin\Classes</Filter>
+    </ClCompile>
+    <ClCompile Include="D3D11Upscaling.cpp">
+      <Filter>Engine\D3D11</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -7545,7 +7545,7 @@ void D3D11GraphicsEngine::DrawFrameParticles(
     bufferParticleColor->BindToPixelShader( Context.Get(), 1 );
     bufferParticleDistortion->BindToPixelShader( Context.Get(), 2 );
 
-    // Copy scene behind the particle systems
+    // Copy scene behind the particle systems 
     auto tempBuffer = PfxRenderer->GetTempBuffer();
     PfxRenderer->CopyTextureToRTV(
         HDRBackBuffer->GetShaderResView(),
@@ -7560,6 +7560,8 @@ void D3D11GraphicsEngine::DrawFrameParticles(
         tempBuffer->GetShaderResView(),
         HDRBackBuffer->GetRenderTargetView(),
         GetResolution(), true );
+
+    GetContext()->PSSetShaderResources( 1, 2, s_nullSRVs );
 }
 
 /** Called when a vob was removed from the world */

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -54,6 +54,7 @@
 #include "zCOption.h"
 #include "RenderGraph.h"
 #include "RGBuilder.h"
+#include "D3D11Upscaling.h"
 
 #ifdef BUILD_SPACER
 #define IS_SPACER_BUILD true
@@ -3134,7 +3135,8 @@ namespace {
 /** Called when we started to render the world */
 XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     SetDefaultStates();
-    
+    m_FrameNeedsJitter = false;
+
     auto& rendererState = Engine::GAPI->GetRendererState();
 
     if ( rendererState.RendererSettings.DisableRendering )
@@ -3157,10 +3159,11 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
 
     GetContext()->OMSetRenderTargets( 1, HDRBackBuffer->GetRenderTargetView().GetAddressOf(), nullptr );
 
-    bool requireJitter = 
-        rendererState.RendererSettings.AntiAliasingMode == GothicRendererSettings::AA_FSR
-        || rendererState.RendererSettings.AntiAliasingMode == GothicRendererSettings::AA_TAA
-        ;
+    D3D11Upscaling u;
+    u.UpdateUpscaling( *this );
+
+    bool requireJitter = m_FrameNeedsJitter
+        || rendererState.RendererSettings.AntiAliasingMode == GothicRendererSettings::AA_TAA;
 
     if ( requireJitter ) {
         if ( PfxRenderer && PfxRenderer->GetTAAEffect() ) {
@@ -3699,149 +3702,19 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         };
     } );
 
+    const bool isUpscaling = u.AddUpscalingPass( graph,
+        *this,
+        Backbuffer->GetRenderTargetView().Get(), 
+        backBufferHandle, 
+        DepthStencilBufferCopy->GetShaderResView().Get(),
+        velocityBufferHandle, 
+        reactiveMaskResource );
+
     // Before returning to gothics UI, set render target to backbuffer
     {
         // Copy HDR scene to backbuffer
-        if ( rendererState.RendererSettings.ResolutionScalePercent < 100 
-            && rendererState.RendererSettings.Upscaler == GothicRendererSettings::E_Upscaler::UPSCALER_FSR_1 ) {
-            
-            graph.AddPass( L"FSR 1 Upscale", [&]( RGBuilder& builder, RenderPass& pass ) {
-                builder.Read( velocityBufferHandle );
-                builder.Read( reactiveMaskResource );
-                builder.Read( backBufferHandle );
-                builder.Write( backBufferHandle );
-
-                builder.Write( backBufferHandle );
-
-                auto unscaledRes = GetBackbufferResolution();
-                // needs DXGI_FORMAT_R8G8B8A8_UNORM to allow for UAV
-                // auto fsrTexHandle = builder.CreateTexture( { static_cast<uint32_t>( unscaledRes.x ), static_cast<uint32_t>( unscaledRes.y ), DXGI_FORMAT_R8G8B8A8_UNORM, L"FSR3_Temporary" } );
-
-                pass.m_executeCallback = [this, &rendererState, backBufferHandle, velocityBufferHandle, reactiveMaskResource](const RenderGraph& graph) {
-                    auto backbufferTex = graph.GetPhysicalTexture( backBufferHandle );
-
-                    // Now upscale it to backbuffer with sharpening
-                    auto sharpenFactor = rendererState.RendererSettings.SharpenFactor;
-                    PfxRenderer->GetFSR1()->Apply(
-                        backbufferTex->GetShaderResView(),
-                        Backbuffer->GetRenderTargetView(),
-                        GetResolution(),
-                        GetBackbufferResolution(),
-                        sharpenFactor >= 0.001f,
-                        1.0f - sharpenFactor );
-                };
-            } );
-        } else if ( rendererState.RendererSettings.Upscaler == GothicRendererSettings::E_Upscaler::UPSCALER_FSR_2
-            && (rendererState.RendererSettings.ResolutionScalePercent <= 100)
-            && rendererState.RendererSettings.AntiAliasingMode == GothicRendererSettings::AA_FSR
-            ) {
-
-            graph.AddPass( L"FSR 2", [&]( RGBuilder& builder, RenderPass& pass ) {
-                builder.Read( velocityBufferHandle );
-                builder.Read( reactiveMaskResource );
-                builder.Read( backBufferHandle );
-
-                builder.Write( backBufferHandle );
-
-                pass.m_executeCallback = [this, &rendererState, backBufferHandle, velocityBufferHandle, reactiveMaskResource]( const RenderGraph& graph ) {
-                    auto backbufferTex = graph.GetPhysicalTexture( backBufferHandle );
-
-                    auto sharpenFactor = rendererState.RendererSettings.SharpenFactor;
-
-                    auto velocityBufferTex = graph.GetPhysicalTexture( velocityBufferHandle );
-                    auto reactiveMask = graph.GetPhysicalTexture( reactiveMaskResource );
-
-                    auto jitter = PfxRenderer->GetTAAEffect()->GetJitterOffsetUnscaled();
-                    const auto inputSize = GetResolution();
-
-                    float fovY, fovX;
-                    auto cam = ((zCCamera*)oCGame::GetGame()->_zCSession_camera);
-                    cam->GetFOV( fovY, fovX );
-
-                    // Our Depth Buffer uses reversed Z, so we need to tell FSR2 about it to get correct results
-                    // calculations from GothicAPI::GetProjectionMatrix()
-                    float NearZ = rendererState.RendererSettings.SectionDrawRadius * WORLD_SECTION_SIZE;
-                    float FarZ = 1.0f;
-                    GetContext()->CSSetSamplers( 0, 1, LinearSamplerState.GetAddressOf() );
-                    GetContext()->CSSetSamplers( 1, 1, LinearSamplerState.GetAddressOf() );
-
-                    ID3D11Buffer* nullCBs[5]{};
-                    GetContext()->CSSetConstantBuffers( 0, std::size( nullCBs ), nullCBs);
-
-                    PfxRenderer->GetFSR2()->Apply(
-                        backbufferTex->GetShaderResView().Get(),
-                        DepthStencilBufferCopy->GetShaderResView().Get(),
-                        velocityBufferTex->GetShaderResView().Get(),
-                        reactiveMask->GetShaderResView().Get(),
-                        Backbuffer->GetRenderTargetView().Get(),
-                        inputSize,
-                        GetBackbufferResolution(),
-                        Engine::GAPI->GetDeltaTime() * 1000.f,
-                        jitter,
-                        float2( static_cast<float>(inputSize.x), static_cast<float>(inputSize.y) ),
-                        false,
-                        fovY,
-                        NearZ,
-                        FarZ,
-                        sharpenFactor >= 0.001f,
-                        sharpenFactor /* FSR2 has 0..1 (sharp)*/);
-                    };
-            } );
-        } else if ( rendererState.RendererSettings.Upscaler == GothicRendererSettings::E_Upscaler::UPSCALER_FSR_3
-            && (rendererState.RendererSettings.ResolutionScalePercent <= 100)
-            && rendererState.RendererSettings.AntiAliasingMode == GothicRendererSettings::AA_FSR ) {
-
-            graph.AddPass( L"FSR 3", [&]( RGBuilder& builder, RenderPass& pass ) {
-                builder.Read( velocityBufferHandle );
-                builder.Read( reactiveMaskResource );
-                builder.Read( backBufferHandle );
-
-                builder.Write( backBufferHandle );
-
-                pass.m_executeCallback = [this, &rendererState, backBufferHandle, velocityBufferHandle, reactiveMaskResource]( const RenderGraph& graph ) {
-                    auto backbufferTex = graph.GetPhysicalTexture( backBufferHandle );
-
-                    auto sharpenFactor = rendererState.RendererSettings.SharpenFactor;
-
-                    auto velocityBufferTex = graph.GetPhysicalTexture( velocityBufferHandle );
-                    auto reactiveMask = graph.GetPhysicalTexture( reactiveMaskResource );
-
-                    auto jitter = PfxRenderer->GetTAAEffect()->GetJitterOffsetUnscaled();
-                    const auto inputSize = GetResolution();
-
-                    float fovY, fovX;
-                    auto cam = ((zCCamera*)oCGame::GetGame()->_zCSession_camera);
-                    cam->GetFOV( fovY, fovX );
-
-                    // Our Depth Buffer uses reversed Z, so we need to tell FSR2 about it to get correct results
-                    // calculations from GothicAPI::GetProjectionMatrix()
-                    float NearZ = rendererState.RendererSettings.SectionDrawRadius * WORLD_SECTION_SIZE;
-                    float FarZ = 1.0f;
-                    GetContext()->CSSetSamplers( 0, 1, LinearSamplerState.GetAddressOf() );
-                    GetContext()->CSSetSamplers( 1, 1, LinearSamplerState.GetAddressOf() );
-
-                    ID3D11Buffer* nullCBs[5]{};
-                    GetContext()->CSSetConstantBuffers( 0, std::size( nullCBs ), nullCBs );
-
-                    PfxRenderer->GetFSR3()->Apply(
-                        backbufferTex->GetShaderResView().Get(),
-                        DepthStencilBufferCopy->GetShaderResView().Get(),
-                        velocityBufferTex->GetShaderResView().Get(),
-                        reactiveMask->GetShaderResView().Get(),
-                        Backbuffer->GetRenderTargetView().Get(),
-                        inputSize,
-                        GetBackbufferResolution(),
-                        Engine::GAPI->GetDeltaTime() * 1000.f,
-                        jitter,
-                        float2( static_cast<float>(inputSize.x), static_cast<float>(inputSize.y) ),
-                        false,
-                        fovY,
-                        NearZ,
-                        FarZ,
-                        sharpenFactor >= 0.001f,
-                        sharpenFactor /* FSR3 has 0..1 (sharp)*/ );
-                    };
-            } );
+        if ( isUpscaling ) {
+            // do don't sharpen, scale or blit. Upscalers do the work themselves.
         } else if (rendererState.RendererSettings.SharpeningMode
                 && rendererState.RendererSettings.SharpenFactor > 0.0f ) {
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -5396,26 +5396,26 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
     float sectionRange,
     const RenderShadowmapsParams& params ) {
     int timerLabelIndex = std::clamp(params.CascadeIndex, 0, MAX_CSM_CASCADES-1);
-    static const char* timer_labels_world_mesh[MAX_CSM_CASCADES]
+    static const wchar_t* timer_labels_world_mesh[MAX_CSM_CASCADES]
     {
-        "World Mesh 0",
-        "World Mesh 1",
-        "World Mesh 2",
-        "World Mesh 3",
+        L"World Mesh 0",
+        L"World Mesh 1",
+        L"World Mesh 2",
+        L"World Mesh 3",
     };
-    static const char* timer_labels_vobs[MAX_CSM_CASCADES]
+    static const wchar_t* timer_labels_vobs[MAX_CSM_CASCADES]
     {
-        "VOBs 0",
-        "VOBs 1",
-        "VOBs 2",
-        "VOBs 3",
+        L"VOBs 0",
+        L"VOBs 1",
+        L"VOBs 2",
+        L"VOBs 3",
     };
-    static const char* timer_labels_skeletal[MAX_CSM_CASCADES]
+    static const wchar_t* timer_labels_skeletal[MAX_CSM_CASCADES]
     {
-        "Skeletal Meshes 0",
-        "Skeletal Meshes 1",
-        "Skeletal Meshes 2",
-        "Skeletal Meshes 3",
+        L"Skeletal Meshes 0",
+        L"Skeletal Meshes 1",
+        L"Skeletal Meshes 2",
+        L"Skeletal Meshes 3",
     };
     
     // Setup renderstates
@@ -5893,7 +5893,7 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
     m_AlphaMeshes.reserve( 64 );
 
     {
-        auto _ = START_TIMING( "VOBs" );
+        auto _ = START_TIMING( L"VOBs" );
         SetDefaultStates();
 
         SetActivePixelShader( PShaderID::PS_Diffuse );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -1265,38 +1265,6 @@ XRESULT D3D11GraphicsEngine::OnBeginFrame() {
         }
     }
 
-    static int oldToneMap = -1;
-    if ( rendererState.RendererSettings.HDRToneMap != oldToneMap ) {
-        oldToneMap = rendererState.RendererSettings.HDRToneMap;
-        std::vector<D3D_SHADER_MACRO> makros;
-
-        D3D_SHADER_MACRO m;
-        m.Name = "USE_TONEMAP";
-        if ( oldToneMap == GothicRendererSettings::E_HDRToneMap::ToneMap_jafEq4 ) {
-            m.Definition = "0";
-        } else if ( oldToneMap == GothicRendererSettings::E_HDRToneMap::Uncharted2Tonemap ) {
-            m.Definition = "1";
-        } else if ( oldToneMap == GothicRendererSettings::E_HDRToneMap::ACESFilmTonemap ) {
-            m.Definition = "2";
-        } else if ( oldToneMap == GothicRendererSettings::E_HDRToneMap::PerceptualQuantizerTonemap ) {
-            m.Definition = "3";
-        } else if ( oldToneMap == GothicRendererSettings::E_HDRToneMap::ACESFittedTonemap ) {
-            m.Definition = "5";
-        } else {
-            m.Definition = "4";
-            oldToneMap = 4;
-            rendererState.RendererSettings.HDRToneMap = GothicRendererSettings::E_HDRToneMap::ToneMap_Simple;
-        }
-        makros.push_back( m );
-
-        auto si = ShaderInfo::make<PShaderID::PS_PFX_HDR>( "PS_PFX_HDR.hlsl" )
-            .with_macros( makros );
-        ShaderManager->UpdateShaderInfo( si );
-        si = ShaderInfo::make<PShaderID::PS_PFX_Tonemap>( "PS_PFX_Tonemap.hlsl" )
-            .with_macros( makros );
-        ShaderManager->UpdateShaderInfo( si );
-    }
-
     static bool s_firstFrame = true;
 
     SteamOverlay::Update();

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -180,7 +180,7 @@ public:
     RenderToDepthStencilBuffer* GetDepthBuffer() const { return DepthStencilBuffer.get(); }
     RenderToTextureBuffer* GetDepthBufferCopy() const { return DepthStencilBufferCopy.get(); }
 
-    /** Returns the HDRBackbuffer */
+    /** Returns the HDRBackbuffer for regular geometry and effects */
     RenderToTextureBuffer& GetHDRBackBuffer() const { return *HDRBackBuffer; }
 
     /** Unbinds the texture at the given slot */
@@ -355,6 +355,8 @@ public:
     auto GetLinearSamplerState() -> auto { return LinearSamplerState.Get(); }
 
     D3D11ShadowMap* GetShadowMaps() const { return ShadowMaps.get(); }
+
+    void SetFrameNeedsJitter() { m_FrameNeedsJitter = true; }
 protected:
 
     void StoreVobPreviousTransforms();
@@ -466,6 +468,7 @@ private:
     bool m_HDR;
     int m_previousFpsLimit;
     bool m_isWindowActive;
+    bool m_FrameNeedsJitter;
     float unionCurrentCustomFontMultiplier;
 
     std::unique_ptr<RenderToTextureBuffer> VelocityBuffer;

--- a/D3D11Engine/D3D11GraphicsEngineBase.cpp
+++ b/D3D11Engine/D3D11GraphicsEngineBase.cpp
@@ -13,10 +13,6 @@ const unsigned int DRAWVERTEXARRAY_BUFFER_SIZE = 4096 * sizeof( ExVertexStruct )
 const int NUM_MAX_BONES = 96;
 const unsigned int INSTANCING_BUFFER_SIZE = sizeof( VobInstanceInfo ) * 2048;
 
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
-extern bool haveWindAnimations;
-#endif
-
 // If defined, creates a debug-version of the d3d11-device
 //#define DEBUG_D3D11
 
@@ -232,77 +228,6 @@ XRESULT D3D11GraphicsEngineBase::DrawVertexArray( ExVertexStruct* vertices, unsi
     GetContext()->Draw( numVertices, startVertex );
 
     return XR_SUCCESS;
-}
-
-/** Constructs the makro list for shader compilation */
-void D3D11GraphicsEngineBase::ConstructShaderMakroList( std::vector<D3D_SHADER_MACRO>& list ) {
-    const GothicRendererSettings& s = Engine::GAPI->GetRendererState().RendererSettings;
-    D3D_SHADER_MACRO m;
-
-    m.Name = "SHD_ENABLE";
-    m.Definition = s.EnableShadows ? "1" : "0";
-    list.push_back( m );
-
-    m.Name = "SHD_FILTER_16TAP_PCF";
-    m.Definition = (s.ShadowFilterMode >= GothicRendererSettings::SHADOW_FILTER_SIMPLE) ? "1" : "0";
-    list.push_back( m );
-
-    m.Name = "SHD_FILTER_PCSS";
-    m.Definition = (s.ShadowFilterMode == GothicRendererSettings::SHADOW_FILTER_PCSS) ? "1" : "0";
-    list.push_back( m );
-
-    m.Name = "MAX_CSM_CASCADES";
-    m.Definition = TO_LITERAL( MAX_CSM_CASCADES );
-    list.push_back( m );
-
-    m.Name = "NUM_CSM_CASCADES";
-    static const char* staticNumbers[] = { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15" };
-    m.Definition = staticNumbers[std::clamp<size_t>( s.NumShadowCascades, 1, MAX_CSM_CASCADES)];
-    list.push_back( m );
-
-    m.Name = "CSM_PCF_LIMIT";
-    m.Definition = staticNumbers[std::clamp<size_t>( s.ShadowCascadePCFLimit, 0, MAX_CSM_CASCADES )];
-    list.push_back( m );
-
-    m.Name = "SHADOW_ATLAS";
-    m.Definition = (FeatureLevel10Compatibility || s.DebugSettings.FeatureSet.UseShadowAtlas) ? "1" : "0";
-    list.push_back( m );
-
-    m.Name = "SHD_WIND";
-#ifdef BUILD_GOTHIC_2_6_fix
-    m.Definition = s.WindQuality == GothicRendererSettings::EWindQuality::WIND_QUALITY_ADVANCED ? "1" : "0";
-#else
-#ifdef BUILD_1_12F
-    m.Definition = "0";
-#else
-    m.Definition = (haveWindAnimations && s.WindQuality == GothicRendererSettings::EWindQuality::WIND_QUALITY_ADVANCED) ? "1" : "0";
-#endif
-#endif
-    list.push_back( m );
-
-    m.Name = "SHD_INFLUENCE";
-#ifdef BUILD_GOTHIC_2_6_fix
-    m.Definition = Engine::GAPI->GetRendererState().RendererSettings.HeroAffectsObjects ? "1" : "0";
-#else
-#ifdef BUILD_1_12F
-    m.Definition = "0";
-#else
-    m.Definition = (haveWindAnimations && Engine::GAPI->GetRendererState().RendererSettings.HeroAffectsObjects) ? "1" : "0";
-#endif
-#endif
-    list.push_back( m );
-
-    m.Name = "SHD_WATERANI";
-#ifdef BUILD_GOTHIC_2_6_fix
-    m.Definition = s.EnableWaterAnimation ? "1" : "0";
-#else
-    m.Definition = "0";
-#endif
-    list.push_back( m );
-
-    m.Name = nullptr;
-    m.Definition = nullptr;
-    list.push_back( m );
 }
 
 /** Sets the active pixel shader object */

--- a/D3D11Engine/D3D11GraphicsEngineBase.h
+++ b/D3D11Engine/D3D11GraphicsEngineBase.h
@@ -106,9 +106,6 @@ public:
     /** Recreates the renderstates */
     XRESULT UpdateRenderStates() override PURE;
 
-    /** Constructs the makro list for shader compilation */
-    static void ConstructShaderMakroList( std::vector<D3D_SHADER_MACRO>& list );
-
     /** Sets up the default rendering state */
     void SetDefaultStates();
 

--- a/D3D11Engine/D3D11PFX_FSR1.cpp
+++ b/D3D11Engine/D3D11PFX_FSR1.cpp
@@ -77,7 +77,7 @@ void D3D11PFX_FSR1::ReleaseResources() {
 
 XRESULT D3D11PFX_FSR1::ApplyEASU(
     const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& input,
-    const Microsoft::WRL::ComPtr<ID3D11RenderTargetView>& output,
+    ID3D11RenderTargetView* output,
     const INT2& inputSize,
     const INT2& outputSize ) {
     
@@ -123,7 +123,7 @@ XRESULT D3D11PFX_FSR1::ApplyEASU(
     context->OMGetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.GetAddressOf() );
 
     // Set output render target
-    context->OMSetRenderTargets( 1, output.GetAddressOf(), nullptr );
+    context->OMSetRenderTargets( 1, &output, nullptr );
 
     // Set viewport to output size
     D3D11_VIEWPORT vp = {};
@@ -155,7 +155,7 @@ XRESULT D3D11PFX_FSR1::ApplyEASU(
 
 XRESULT D3D11PFX_FSR1::ApplyRCAS(
     const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& input,
-    const Microsoft::WRL::ComPtr<ID3D11RenderTargetView>& output,
+    ID3D11RenderTargetView* output,
     float sharpness ) {
     
     if ( !Initialized && !Init() ) {
@@ -189,7 +189,7 @@ XRESULT D3D11PFX_FSR1::ApplyRCAS(
     context->OMGetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.GetAddressOf() );
 
     // Set output render target
-    context->OMSetRenderTargets( 1, output.GetAddressOf(), nullptr );
+    context->OMSetRenderTargets( 1, &output, nullptr );
 
     // Bind input texture and point sampler
     context->PSSetShaderResources( 0, 1, input.GetAddressOf() );
@@ -213,7 +213,7 @@ XRESULT D3D11PFX_FSR1::ApplyRCAS(
 
 XRESULT D3D11PFX_FSR1::Apply(
     const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& input,
-    const Microsoft::WRL::ComPtr<ID3D11RenderTargetView>& output,
+    ID3D11RenderTargetView* output,
     const INT2& inputSize,
     const INT2& outputSize,
     bool enableRCAS,
@@ -231,7 +231,7 @@ XRESULT D3D11PFX_FSR1::Apply(
         auto tempBuffer = Renderer->GetBackbufferTempBuffer();
 
         // Two-pass: EASU to intermediate buffer, then RCAS to final output
-        XRESULT result = ApplyEASU( input, tempBuffer->GetRenderTargetView(), inputSize, outputSize );
+        XRESULT result = ApplyEASU( input, tempBuffer->GetRenderTargetView().Get(), inputSize, outputSize);
         if ( result != XR_SUCCESS ) {
             return result;
         }

--- a/D3D11Engine/D3D11PFX_FSR1.h
+++ b/D3D11Engine/D3D11PFX_FSR1.h
@@ -24,7 +24,7 @@ public:
      */
     XRESULT ApplyEASU( 
         const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& input,
-        const Microsoft::WRL::ComPtr<ID3D11RenderTargetView>& output,
+        ID3D11RenderTargetView* output,
         const INT2& inputSize,
         const INT2& outputSize );
 
@@ -35,7 +35,7 @@ public:
      */
     XRESULT ApplyRCAS(
         const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& input,
-        const Microsoft::WRL::ComPtr<ID3D11RenderTargetView>& output,
+        ID3D11RenderTargetView* output,
         float sharpness = 0.2f );
 
     /** Applies full FSR1 pipeline (EASU + optional RCAS)
@@ -48,7 +48,7 @@ public:
      */
     XRESULT Apply(
         const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& input,
-        const Microsoft::WRL::ComPtr<ID3D11RenderTargetView>& output,
+        ID3D11RenderTargetView* output,
         const INT2& inputSize,
         const INT2& outputSize,
         bool enableRCAS = true,

--- a/D3D11Engine/D3D11PShader.cpp
+++ b/D3D11Engine/D3D11PShader.cpp
@@ -17,17 +17,17 @@ D3D11PShader::D3D11PShader() = default;
 D3D11PShader::~D3D11PShader() = default;
 
 /** Loads both shaders at the same time */
-XRESULT D3D11PShader::LoadShader( const ShaderInfo& shaderInfo, const char* filePath ) {
+XRESULT D3D11PShader::LoadShader( const ShaderInfo& si, const std::vector<D3D_SHADER_MACRO>& macros, const char* filePath ) {
     HRESULT hr;
     D3D11GraphicsEngineBase* engine = reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine);
 
     Microsoft::WRL::ComPtr<ID3DBlob> psBlob;
 
     if ( Engine::GAPI->GetRendererState().RendererSettings.EnableDebugLog )
-        LogInfo() << "Compilling pixel shader: " << shaderInfo.name;
+        LogInfo() << "Compilling pixel shader: " << si.name;
 
     // Compile shaders
-    if ( FAILED( D3D11ShaderManager::CompileShaderFromFile( filePath, !shaderInfo.entryPoint.empty() ? shaderInfo.entryPoint.c_str() : "PSMain", (FeatureLevel10Compatibility ? "ps_4_0" : "ps_5_0"), psBlob.GetAddressOf(), shaderInfo.shaderMakros)) ) {
+    if ( FAILED( D3D11ShaderManager::CompileShaderFromFile( filePath, !si.entryPoint.empty() ? si.entryPoint.c_str() : "PSMain", (FeatureLevel10Compatibility ? "ps_4_0" : "ps_5_0"), psBlob.GetAddressOf(), macros)) ) {
         return XR_FAILED;
     }
 
@@ -36,7 +36,7 @@ XRESULT D3D11PShader::LoadShader( const ShaderInfo& shaderInfo, const char* file
     // Create the shader
     LE( engine->GetDevice()->CreatePixelShader( psBlob->GetBufferPointer(), psBlob->GetBufferSize(), nullptr, PixelShader.GetAddressOf() ) );
 
-    SetDebugName( PixelShader.Get(), shaderInfo.name );
+    SetDebugName( PixelShader.Get(), si.name );
 
     return XR_SUCCESS;
 }

--- a/D3D11Engine/D3D11PShader.h
+++ b/D3D11Engine/D3D11PShader.h
@@ -11,7 +11,7 @@ public:
     ~D3D11PShader() override;
 
     /** Loads shader */
-    XRESULT LoadShader(const ShaderInfo& shaderInfo, const char* filePath);
+    XRESULT LoadShader( const ShaderInfo& si, const std::vector<D3D_SHADER_MACRO>& macros, const char* filePath );
 
     /** Applys the shader */
     XRESULT Apply() override;

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -123,6 +123,9 @@ const int NUM_MAX_BONES = 96;
 
 extern bool FeatureLevel10Compatibility;
 extern bool FeatureRTArrayIndexFromAnyShader;
+#if !defined(BUILD_GOTHIC_2_6_fix) && !defined(BUILD_1_12F)
+extern bool haveWindAnimations;
+#endif
 
 D3D11ShaderManager::D3D11ShaderManager()
     : VShaders( static_cast<size_t>(VShaderID::COUNT) )
@@ -169,12 +172,9 @@ HRESULT D3D11ShaderManager::CompileShaderFromFile( const WCHAR* szFileName, LPCS
     dwShaderFlags |= D3DCOMPILE_OPTIMIZATION_LEVEL3
     ;
 
-    // Construct makros
-    std::vector<D3D_SHADER_MACRO> m;
-    D3D11GraphicsEngineBase::ConstructShaderMakroList( m );
-
-    // Push these to the front
-    m.insert( m.begin(), makros.begin(), makros.end() );
+    // Build the final macro list, adding the required null terminator for D3DCompileFromFile
+    std::vector<D3D_SHADER_MACRO> m = makros;
+    m.push_back( {nullptr, nullptr} );
 
     Microsoft::WRL::ComPtr<ID3DBlob> pErrorBlob;
 
@@ -202,9 +202,7 @@ HRESULT D3D11ShaderManager::CompileShaderFromFile( const WCHAR* szFileName, LPCS
 /** Creates list with ShaderInfos */
 XRESULT D3D11ShaderManager::Init() {
     Shaders = std::vector<ShaderInfo>();
-
-    D3D_SHADER_MACRO m;
-    std::vector<D3D_SHADER_MACRO> makros;
+    static const char* sNums[] = { "0","1","2","3","4","5","6","7","8","9","10","11","12","13","14","15" };
 
     Shaders.push_back( ShaderInfo::make<VShaderID::VS_Ex>( "VS_Ex.hlsl" )
         .with_layout( 1 )  );
@@ -216,7 +214,15 @@ XRESULT D3D11ShaderManager::Init() {
         .with_layout( 1 )  );
 
     Shaders.push_back( ShaderInfo::make<VShaderID::VS_ExWater>( "VS_ExWater.hlsl" )
-        .with_layout( 1 ) );
+        .with_layout( 1 )
+        .with_macros( [](std::vector<D3D_SHADER_MACRO>& list) {
+            const auto& s = Engine::GAPI->GetRendererState().RendererSettings;
+#ifdef BUILD_GOTHIC_2_6_fix
+            list.push_back( {"SHD_WATERANI", s.EnableWaterAnimation ? "1" : "0"} );
+#else
+            list.push_back( {"SHD_WATERANI", "0"} );
+#endif
+        }) );
 
     Shaders.push_back( ShaderInfo::make<VShaderID::VS_ParticlePoint>( "VS_ParticlePoint.hlsl" )
         .with_layout( 11 ) );
@@ -243,7 +249,20 @@ XRESULT D3D11ShaderManager::Init() {
         .with_layout( 7 ) );
 
     Shaders.push_back( ShaderInfo::make<VShaderID::VS_ExInstancedObj>( "VS_ExInstancedObj.hlsl" )
-        .with_layout( 10 )  );
+        .with_layout( 10 )
+        .with_macros( [](std::vector<D3D_SHADER_MACRO>& list) {
+            const auto& s = Engine::GAPI->GetRendererState().RendererSettings;
+#ifdef BUILD_GOTHIC_2_6_fix
+            list.push_back( {"SHD_WIND",      s.WindQuality == GothicRendererSettings::EWindQuality::WIND_QUALITY_ADVANCED ? "1" : "0"} );
+            list.push_back( {"SHD_INFLUENCE", s.HeroAffectsObjects ? "1" : "0"} );
+#elif defined(BUILD_1_12F)
+            list.push_back( {"SHD_WIND",      "0"} );
+            list.push_back( {"SHD_INFLUENCE", "0"} );
+#else
+            list.push_back( {"SHD_WIND",      (haveWindAnimations && s.WindQuality == GothicRendererSettings::EWindQuality::WIND_QUALITY_ADVANCED) ? "1" : "0"} );
+            list.push_back( {"SHD_INFLUENCE", (haveWindAnimations && s.HeroAffectsObjects) ? "1" : "0"} );
+#endif
+        }) );
 
 
     Shaders.push_back( ShaderInfo::make<VShaderID::VS_ExInstanced>( "VS_ExInstanced.hlsl" )
@@ -265,10 +284,8 @@ XRESULT D3D11ShaderManager::Init() {
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Rain>( "PS_Rain.hlsl" ) );
 
-    makros.push_back( D3D_SHADER_MACRO{ "SNOW_FEATURE", "1" } );
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Rain_Snow>( "PS_Rain.hlsl" )
-        .with_macros( makros ) );
-    makros.clear();
+        .with_macros( { { "SNOW_FEATURE", "1" } }));
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Transparency>( "PS_Transparency.hlsl" )  );
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_TransparencySkel>( "PS_TransparencySkel.hlsl" )  );
@@ -308,24 +325,22 @@ XRESULT D3D11ShaderManager::Init() {
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_LumConvert>( "PS_PFX_LumConvert.hlsl" ) );
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_LumAdapt>( "PS_PFX_LumAdapt.hlsl" )  );
 
-    m.Name = "USE_TONEMAP";
-    m.Definition = "4";
-    makros.push_back( m );
-
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_HDR>( "PS_PFX_HDR.hlsl" )
-        .with_macros( makros )  );
-    makros.clear();
+        .with_category(ShaderCategory::Tonemapping)
+        .with_macros( []( std::vector<D3D_SHADER_MACRO>& list ) {
+            const auto& s = Engine::GAPI->GetRendererState().RendererSettings;
+            list.push_back( { "USE_TONEMAP", sNums[std::clamp( size_t(s.HDRToneMap), size_t(0), std::size(sNums)-1)]});
+        } )  );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_GodRayMask>( "PS_PFX_GodRayMask.hlsl" ) );
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_GodRayZoom>( "PS_PFX_GodRayZoom.hlsl" ) );
 
-    m.Name = "USE_TONEMAP";
-    m.Definition = "4";
-    makros.push_back( m );
-
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_Tonemap>( "PS_PFX_Tonemap.hlsl" )
-        .with_macros( makros )  );
-    makros.clear();
+        .with_category(ShaderCategory::Tonemapping)
+        .with_macros( []( std::vector<D3D_SHADER_MACRO>& list ) {
+            const auto& s = Engine::GAPI->GetRendererState().RendererSettings;
+            list.push_back( { "USE_TONEMAP", sNums[std::clamp( size_t( s.HDRToneMap ), size_t( 0 ), std::size( sNums ) - 1 )] } );
+        } ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_AtmosphereGround>( "PS_AtmosphereGround.hlsl" )  );
 
@@ -343,142 +358,87 @@ XRESULT D3D11ShaderManager::Init() {
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DS_PointLightDynShadow>( "PS_DS_PointLightDynShadow.hlsl" )
         .with_category( ShaderCategory::LightsAndShadows ) );
 
+    // Shadow macro builder shared by both atmospheric scattering shader variants
+    ShaderInfo::MacroBuilder shadowMacroBuilder = [](std::vector<D3D_SHADER_MACRO>& list) {
+        const auto& s = Engine::GAPI->GetRendererState().RendererSettings;
+        list.push_back( {"SHD_ENABLE",           s.EnableShadows ? "1" : "0"} );
+        list.push_back( {"SHD_FILTER_16TAP_PCF", (s.ShadowFilterMode >= GothicRendererSettings::SHADOW_FILTER_SIMPLE) ? "1" : "0"} );
+        list.push_back( {"SHD_FILTER_PCSS",      (s.ShadowFilterMode == GothicRendererSettings::SHADOW_FILTER_PCSS) ? "1" : "0"} );
+        list.push_back( {"MAX_CSM_CASCADES",     TO_LITERAL(MAX_CSM_CASCADES)} );
+        list.push_back( {"NUM_CSM_CASCADES",     sNums[std::clamp<size_t>(s.NumShadowCascades, 1, MAX_CSM_CASCADES)]} );
+        list.push_back( {"CSM_PCF_LIMIT",        sNums[std::clamp<size_t>(s.ShadowCascadePCFLimit, 0, MAX_CSM_CASCADES)]} );
+        list.push_back( {"SHADOW_ATLAS",         (FeatureLevel10Compatibility || s.DebugSettings.FeatureSet.UseShadowAtlas) ? "1" : "0"} );
+    };
+
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DS_AtmosphericScattering>( "PS_DS_AtmosphericScattering.hlsl" )
-        .with_category( ShaderCategory::LightsAndShadows ) // see ConstructShaderMakroList 
-        );
+        .with_macros( shadowMacroBuilder )
+        .with_category( ShaderCategory::LightsAndShadows ) );
 
     Shaders.push_back( ShaderInfo::make<GShaderID::GS_VertexNormals>( "GS_VertexNormals.hlsl" ) );
 
-    m.Name = "NORMALMAPPING";
-    m.Definition = "0";
-    makros.push_back( m );
-
-    m.Name = "ALPHATEST";
-    m.Definition = "0";
-    makros.push_back( m );
-
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Diffuse>( "PS_Diffuse.hlsl" )
-        .with_macros( makros )  );
+        .with_macros( {
+            {"NORMALMAPPING", "0"},
+            {"ALPHATEST", "0"}
+        } ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PortalDiffuse>( "PS_PortalDiffuse.hlsl" ) ); //forest portals, doors, etc.
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_WaterfallFoam>( "PS_WaterfallFoam.hlsl" ) );     //foam on at the base of waterfalls
 
-    makros.clear();
-
-    m.Name = "APPLY_RAIN_EFFECTS";
-    m.Definition = "1";
-    makros.push_back( m );
-
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DS_AtmosphericScattering_Rain>( "PS_DS_AtmosphericScattering.hlsl" )
-        .with_macros( makros )
+        .with_macros( { { "APPLY_RAIN_EFFECTS", "1" } })
+        .with_macros( shadowMacroBuilder )
         .with_category( ShaderCategory::LightsAndShadows ) );
-
-    makros.clear();
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_LinDepth>( "PS_LinDepth.hlsl" )  );
 
-
-    m.Name = "NORMALMAPPING";
-    m.Definition = "1";
-    makros.push_back( m );
-
-    m.Name = "ALPHATEST";
-    m.Definition = "0";
-    makros.push_back( m );
-
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DiffuseNormalmapped>( "PS_Diffuse.hlsl" )
-        .with_macros( makros )  );
-
-    makros.clear();
-    m.Name = "NORMALMAPPING";
-    m.Definition = "1";
-    makros.push_back( m );
-
-    m.Name = "ALPHATEST";
-    m.Definition = "0";
-    makros.push_back( m );
-
-    m.Name = "FXMAP";
-    m.Definition = "1";
-    makros.push_back( m );
+        .with_macros( {
+            {"NORMALMAPPING", "1"},
+            {"ALPHATEST", "0"},
+        } ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DiffuseNormalmappedFxMap>( "PS_Diffuse.hlsl" )
-        .with_macros( makros )  );
+        .with_macros( {
+            {"NORMALMAPPING", "1"},
+            {"ALPHATEST", "0"},
+            {"FXMAP", "1"}
+        } ) );
 
-    makros.clear();
-    m.Name = "NORMALMAPPING";
-    m.Definition = "0";
-    makros.push_back( m );
-
-    m.Name = "ALPHATEST";
-    m.Definition = "1";
-    makros.push_back( m );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DiffuseAlphaTest>( "PS_Diffuse.hlsl" )
-        .with_macros( makros ) );
-
-    makros.clear();
-    m.Name = "NORMALMAPPING";
-    m.Definition = "0";
-    makros.push_back( m );
-
-    m.Name = "ALPHATEST_SHADOWS";
-    m.Definition = "1";
-    makros.push_back( m );
+        .with_macros( {
+            {"NORMALMAPPING", "0"},
+            {"ALPHATEST", "1"},
+        } ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DiffuseAlphaTestShadows>( "PS_Diffuse.hlsl" )
-        .with_macros( makros )  );
-
-    makros.clear();
-    m.Name = "NORMALMAPPING";
-    m.Definition = "1";
-    makros.push_back( m );
-
-    m.Name = "ALPHATEST";
-    m.Definition = "1";
-    makros.push_back( m );
+        .with_macros( {
+            {"NORMALMAPPING", "0"},
+            {"ALPHATEST_SHADOWS", "1"},
+            } ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DiffuseNormalmappedAlphaTest>( "PS_Diffuse.hlsl" )
-        .with_macros( makros )  );
-
-    makros.clear();
-    m.Name = "NORMALMAPPING";
-    m.Definition = "1";
-    makros.push_back( m );
-
-    m.Name = "ALPHATEST";
-    m.Definition = "1";
-    makros.push_back( m );
-
-    m.Name = "FXMAP";
-    m.Definition = "1";
-    makros.push_back( m );
+        .with_macros( {
+            {"NORMALMAPPING", "1"},
+            {"ALPHATEST", "1"},
+        } ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DiffuseNormalmappedAlphaTestFxMap>( "PS_Diffuse.hlsl" )
-        .with_macros( makros )  );
+        .with_macros( {
+            {"NORMALMAPPING", "1"},
+            {"ALPHATEST", "1"},
+            {"FXMAP", "1"}
+        } ) );
 
-    makros.clear();
-    m.Name = "RENDERMODE";
-    m.Definition = "0";
-    makros.push_back( m );
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Preview_White>( "PS_Preview.hlsl" )
-        .with_macros( makros ) );
+        .with_macros( { {"RENDERMODE", "0"} }));
 
-    makros.clear();
-    m.Name = "RENDERMODE";
-    m.Definition = "1";
-    makros.push_back( m );
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Preview_Textured>( "PS_Preview.hlsl" )
-        .with_macros( makros ) );
+        .with_macros( { {"RENDERMODE", "1"} } ) );
 
-    makros.clear();
-    m.Name = "RENDERMODE";
-    m.Definition = "2";
-    makros.push_back( m );
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Preview_TexturedLit>( "PS_Preview.hlsl" )
-        .with_macros( makros ) );
-
-    makros.clear();
+        .with_macros( { {"RENDERMODE", "2"} } ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_PFX_Sharpen>( "PS_PFX_Sharpen.hlsl" ) );
 
@@ -552,7 +512,67 @@ XRESULT D3D11ShaderManager::Init() {
     return XR_SUCCESS;
 }
 
-XRESULT D3D11ShaderManager::CompileShader( const ShaderInfo& si ) {
+static size_t HashCombine( size_t seed, size_t val ) noexcept {
+    return seed ^ (val + 0x9e3779b9 + (seed << 6) + (seed >> 2));
+}
+
+static size_t ComputeShaderHash( const ShaderInfo& si ) {
+    size_t h = 0;
+
+    // Hash file last-modified timestamp
+    std::string fullPath = Engine::GAPI->GetStartDirectory() + "\\system\\GD3D11\\shaders\\" + si.fileName;
+    std::error_code ec;
+    auto lwt = std::filesystem::last_write_time( std::filesystem::path( fullPath ), ec );
+    if ( !ec ) {
+        h = HashCombine( h, static_cast<size_t>(lwt.time_since_epoch().count()) );
+    }
+
+    // Hash per-shader macros
+    for ( const auto& macro : si.shaderMakros ) {
+        if ( macro.Name )       h = HashCombine( h, std::hash<std::string_view>{}( macro.Name ) );
+        if ( macro.Definition ) h = HashCombine( h, std::hash<std::string_view>{}( macro.Definition ) );
+    }
+
+    // Hash dynamic macros via the per-shader builder (only macros this shader actually uses).
+    // Shaders without a builder have no renderer-setting-dependent macros to hash.
+    if ( si.macroBuilder ) {
+        std::vector<D3D_SHADER_MACRO> dynamicMakros;
+        si.macroBuilder( dynamicMakros );
+        for ( const auto& macro : dynamicMakros ) {
+            if ( macro.Name )       h = HashCombine( h, std::hash<std::string_view>{}( macro.Name ) );
+            if ( macro.Definition ) h = HashCombine( h, std::hash<std::string_view>{}( macro.Definition ) );
+        }
+    }
+
+    return h;
+}
+
+XRESULT D3D11ShaderManager::CompileShader( ShaderInfo& si ) {
+    // Compute hash (file timestamp + per-shader macros + global renderer macros).
+    // Skip recompilation when the shader is already loaded and nothing has changed.
+    size_t newHash = ComputeShaderHash( si );
+
+    auto IsKnown = [&]() -> bool {
+        switch ( si.type ) {
+        case ShaderType::Vertex:     return IsVShaderKnown( si.shaderIndex );
+        case ShaderType::Pixel:      return IsPShaderKnown( si.shaderIndex );
+        case ShaderType::Geometry:   return IsGShaderKnown( si.shaderIndex );
+        case ShaderType::HullDomain: return IsHDShaderKnown( si.shaderIndex );
+        case ShaderType::Compute:    return IsCShaderKnown( si.shaderIndex );
+        default: return false;
+        }
+    };
+
+    if ( IsKnown() && newHash != 0 && si.compiledHash == newHash ) {
+        return XR_SUCCESS;
+    }
+
+    // Build compile-time macro list: static shaderMakros merged with any dynamic builder macros.
+    std::vector<D3D_SHADER_MACRO> compileMakros = si.shaderMakros;
+    if ( si.macroBuilder ) {
+        si.macroBuilder( compileMakros );
+    }
+
     //Check if shader src-file exists
     std::string fileName = Engine::GAPI->GetStartDirectory() + "\\system\\GD3D11\\shaders\\" + si.fileName;
     if ( FILE* f = fopen( fileName.c_str(), "r" ) ) {
@@ -564,19 +584,21 @@ XRESULT D3D11ShaderManager::CompileShader( const ShaderInfo& si ) {
                 if ( Engine::GAPI->GetRendererState().RendererSettings.EnableDebugLog )
                     LogInfo() << "Reloading shader: " << si.name;
 
-                if ( XR_SUCCESS != vs->LoadShader( si, ("system\\GD3D11\\shaders\\" + si.fileName).c_str() ) ) {
+                if ( XR_SUCCESS != vs->LoadShader( si, compileMakros, ("system\\GD3D11\\shaders\\" + si.fileName).c_str() ) ) {
                     LogError() << "Failed to reload shader: " << si.fileName;
 
                     delete vs;
                 } else {
                     UpdateVShader( si.shaderIndex, vs );
+                    si.compiledHash = newHash;
                 }
             } else {
                 if ( Engine::GAPI->GetRendererState().RendererSettings.EnableDebugLog )
                     LogInfo() << "Loading shader: " << si.name;
 
-                XLE( vs->LoadShader( si, ("system\\GD3D11\\shaders\\" + si.fileName).c_str() ) );
+                XLE( vs->LoadShader( si, compileMakros, ("system\\GD3D11\\shaders\\" + si.fileName).c_str() ) );
                 UpdateVShader( si.shaderIndex, vs );
+                si.compiledHash = newHash;
             }
         } else if ( si.type == ShaderType::Pixel ) {
             // See if this is a reload
@@ -585,19 +607,21 @@ XRESULT D3D11ShaderManager::CompileShader( const ShaderInfo& si ) {
                 if ( Engine::GAPI->GetRendererState().RendererSettings.EnableDebugLog )
                     LogInfo() << "Reloading shader: " << si.name;
 
-                if ( XR_SUCCESS != ps->LoadShader( si, ("system\\GD3D11\\shaders\\" + si.fileName).c_str() ) ) {
+                if ( XR_SUCCESS != ps->LoadShader( si, compileMakros, ("system\\GD3D11\\shaders\\" + si.fileName).c_str() ) ) {
                     LogError() << "Failed to reload shader: " << si.fileName;
 
                     delete ps;
                 } else {
                     UpdatePShader( si.shaderIndex, ps );
+                    si.compiledHash = newHash;
                 }
             } else {
                 if ( Engine::GAPI->GetRendererState().RendererSettings.EnableDebugLog )
                     LogInfo() << "Loading shader: " << si.name;
 
-                XLE( ps->LoadShader( si, ("system\\GD3D11\\shaders\\" + si.fileName).c_str() ) );
+                XLE( ps->LoadShader( si, compileMakros, ("system\\GD3D11\\shaders\\" + si.fileName).c_str() ) );
                 UpdatePShader( si.shaderIndex, ps );
+                si.compiledHash = newHash;
             }
         } else if ( si.type == ShaderType::Geometry ) {
             // See if this is a reload
@@ -606,20 +630,22 @@ XRESULT D3D11ShaderManager::CompileShader( const ShaderInfo& si ) {
                 if ( Engine::GAPI->GetRendererState().RendererSettings.EnableDebugLog )
                     LogInfo() << "Reloading shader: " << si.name;
 
-                if ( XR_SUCCESS != gs->LoadShader( ("system\\GD3D11\\shaders\\" + si.fileName).c_str(), si.shaderMakros, si.layout != 0, si.layout ) ) {
+                if ( XR_SUCCESS != gs->LoadShader( ("system\\GD3D11\\shaders\\" + si.fileName).c_str(), compileMakros, si.layout != 0, si.layout ) ) {
                     LogError() << "Failed to reload shader: " << si.fileName;
 
                     delete gs;
                 } else {
                     // Compilation succeeded, switch the shader
                     UpdateGShader( si.shaderIndex, gs );
+                    si.compiledHash = newHash;
                 }
             } else {
                 if ( Engine::GAPI->GetRendererState().RendererSettings.EnableDebugLog )
                     LogInfo() << "Loading shader: " << si.name;
 
-                XLE( gs->LoadShader( ("system\\GD3D11\\shaders\\" + si.fileName).c_str(), si.shaderMakros, si.layout != 0, si.layout ) );
+                XLE( gs->LoadShader( ("system\\GD3D11\\shaders\\" + si.fileName).c_str(), compileMakros, si.layout != 0, si.layout ) );
                 UpdateGShader( si.shaderIndex, gs );
+                si.compiledHash = newHash;
             }
         } else if ( si.type == ShaderType::Compute ) {
             // See if this is a reload
@@ -628,19 +654,21 @@ XRESULT D3D11ShaderManager::CompileShader( const ShaderInfo& si ) {
                 if ( Engine::GAPI->GetRendererState().RendererSettings.EnableDebugLog )
                     LogInfo() << "Reloading shader: " << si.name;
 
-                if ( XR_SUCCESS != cs->LoadShader( ("system\\GD3D11\\shaders\\" + si.fileName).c_str(), !si.entryPoint.empty() ? si.entryPoint.c_str() : nullptr, si.shaderMakros ) ) {
+                if ( XR_SUCCESS != cs->LoadShader( ("system\\GD3D11\\shaders\\" + si.fileName).c_str(), !si.entryPoint.empty() ? si.entryPoint.c_str() : nullptr, compileMakros ) ) {
                     LogError() << "Failed to reload shader: " << si.fileName;
 
                     delete cs;
                 } else {
                     UpdateCShader( si.shaderIndex, cs );
+                    si.compiledHash = newHash;
                 }
             } else {
                 if ( Engine::GAPI->GetRendererState().RendererSettings.EnableDebugLog )
                     LogInfo() << "Loading shader: " << si.name;
 
-                XLE( cs->LoadShader( ("system\\GD3D11\\shaders\\" + si.fileName).c_str(), !si.entryPoint.empty() ? si.entryPoint.c_str() : nullptr, si.shaderMakros ) );
+                XLE( cs->LoadShader( ("system\\GD3D11\\shaders\\" + si.fileName).c_str(), !si.entryPoint.empty() ? si.entryPoint.c_str() : nullptr, compileMakros ) );
                 UpdateCShader( si.shaderIndex, cs );
+                si.compiledHash = newHash;
             }
         }
 
@@ -660,11 +688,13 @@ XRESULT D3D11ShaderManager::CompileShader( const ShaderInfo& si ) {
             } else {
                 // Compilation succeeded, switch the shader
                 UpdateHDShader( si.shaderIndex, hds );
+                si.compiledHash = newHash;
             }
         } else {
             XLE( hds->LoadShader( ("system\\GD3D11\\shaders\\" + si.fileName).c_str(),
                 ("system\\GD3D11\\shaders\\" + si.fileName).c_str() ) );
             UpdateHDShader( si.shaderIndex, hds );
+            si.compiledHash = newHash;
         }
     }
     return XR_SUCCESS;
@@ -682,7 +712,7 @@ XRESULT D3D11ShaderManager::LoadShaders( ShaderCategory categories ) {
     LogInfo() << "Compiling/Reloading shaders with " << compilationTP->getNumThreads() << " threads";
     */
     LogInfo() << "Compiling/Reloading shaders";
-    for ( const ShaderInfo& si : Shaders ) {
+    for ( ShaderInfo& si : Shaders ) {
         // Determine shader type category
         ShaderCategory shaderTypeCategory = ShaderCategory::None;
         if ( si.type == ShaderType::Vertex ) {
@@ -760,10 +790,10 @@ void D3D11ShaderManager::UpdateShaderInfo( ShaderInfo& shader ) {
     for ( size_t i = 0; i < Shaders.size(); i++ ) {
         if ( Shaders[i].type == shader.type && Shaders[i].shaderIndex == shader.shaderIndex ) {
             Shaders[i] = shader;
-            CompileShader( shader );
+            CompileShader( Shaders[i] );
             return;
         }
     }
     Shaders.push_back( shader );
-    CompileShader( shader );
+    CompileShader( Shaders.back() );
 }

--- a/D3D11Engine/D3D11ShaderManager.h
+++ b/D3D11Engine/D3D11ShaderManager.h
@@ -6,6 +6,7 @@
 #include "D3D11HDShader.h"
 #include "D3D11GShader.h"
 #include "D3D11CShader.h"
+#include <functional>
 #include <type_traits>
 #include <string_view>
 
@@ -20,6 +21,12 @@ public:
     int layout;						//Shader's input layout
     std::vector<D3D_SHADER_MACRO> shaderMakros;
     ShaderCategory contentCategory;	//Content category for selective reloading
+    size_t compiledHash = 0;			//Hash of last successful compilation (file timestamp + macros)
+
+    // Optional: builds per-shader dynamic macros (renderer-settings-dependent) at compile/hash time.
+    // Only macros this shader actually uses should be emitted — keeps hashing precise.
+    using MacroBuilder = std::function<void( std::vector<D3D_SHADER_MACRO>& )>;
+    MacroBuilder macroBuilder;
 
     /** Builder-style factory: infers name, type, and entrypoint from enum template parameter */
     template<auto ID>
@@ -38,7 +45,8 @@ public:
 
     /** Chainable setters for builder pattern */
     ShaderInfo& with_layout( int l ) { layout = l; return *this; }
-    ShaderInfo& with_macros( const std::vector<D3D_SHADER_MACRO>& m ) { shaderMakros = m; return *this; }
+    ShaderInfo& with_macros( std::vector<D3D_SHADER_MACRO> m ) { shaderMakros = std::move(m); return *this; }
+    ShaderInfo& with_macros( MacroBuilder b ) { macroBuilder = std::move( b ); return *this; }
     ShaderInfo& with_category( ShaderCategory c ) { contentCategory = c; return *this; }
     ShaderInfo& with_entrypoint( std::string ep ) { entryPoint = std::move( ep ); return *this; }
 
@@ -97,7 +105,7 @@ public:
     std::shared_ptr<D3D11CShader> GetCShader( CShaderID id ) { return CShaders[static_cast<size_t>(id)]; }
 
 private:
-    XRESULT CompileShader( const ShaderInfo& si );
+    XRESULT CompileShader( ShaderInfo& si );
 
     void UpdateVShader( size_t index, D3D11VShader* shader ) { std::unique_lock<std::mutex> lock( _VShaderMutex ); VShaders[index].reset( shader ); }
     void UpdatePShader( size_t index, D3D11PShader* shader ) { std::unique_lock<std::mutex> lock( _PShaderMutex );  PShaders[index].reset( shader ); }

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1138,12 +1138,12 @@ void D3D11ShadowMap::RenderShadowmaps( const RenderShadowmapsParams& params ) {
 
         XMVECTOR cameraPosition = XMLoadFloat3( &params.CameraPosition );
         int timerLabelIndex = std::clamp(params.CascadeIndex, 0, MAX_CSM_CASCADES-1);
-        static const char* timer_labels_cascades[MAX_CSM_CASCADES]
+        static const wchar_t* timer_labels_cascades[MAX_CSM_CASCADES]
         {
-            "Cascade 0",
-            "Cascade 1",
-            "Cascade 2",
-            "Cascade 3",
+            L"Cascade 0",
+            L"Cascade 1",
+            L"Cascade 2",
+            L"Cascade 3",
         };
         auto _1 = START_TIMING(timer_labels_cascades[timerLabelIndex]);
         graphicsEngine->DrawWorldAroundForWorldShadow( cameraPosition, 2, params );

--- a/D3D11Engine/D3D11Upscaling.cpp
+++ b/D3D11Engine/D3D11Upscaling.cpp
@@ -1,0 +1,224 @@
+#include "D3D11Upscaling.h"
+#include "Engine.h"
+#include "GothicAPI.h"
+#include "D3D11GraphicsEngine.h"
+#include "D3D11PfxRenderer.h"
+#include "D3D11PFX_FSR1.h"
+#include "D3D11PFX_FSR2.h"
+#include "D3D11PFX_FSR3.h"
+#include "D3D11PFX_TAA.h"
+#include "oCGame.h"
+
+namespace {
+
+    void AddFSR1Pass( RenderGraph& graph,
+        D3D11GraphicsEngine& engine,
+        ID3D11RenderTargetView* outputRTV,
+        RGResourceHandle backBufferHandle)
+    {
+        graph.AddPass( L"FSR 1 Upscale", [&]( RGBuilder& builder, RenderPass& pass ) {
+            builder.Read( backBufferHandle );
+            builder.Write( backBufferHandle );
+
+            pass.m_executeCallback = [&engine, backBufferHandle, outputRTV]( const RenderGraph& graph ) {
+                auto backbufferTex = graph.GetPhysicalTexture( backBufferHandle );
+                auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+
+                // Now upscale it to backbuffer with sharpening
+                auto sharpenFactor = settings.SharpenFactor;
+                engine.GetPfxRenderer()->GetFSR1()->Apply(
+                    backbufferTex->GetShaderResView(),
+                    outputRTV,
+                    engine.GetResolution(),
+                    engine.GetBackbufferResolution(),
+                    sharpenFactor >= 0.001f,
+                    1.0f - sharpenFactor );
+                };
+            } );
+
+    }
+
+    void AddFSR2Pass( RenderGraph& graph,
+        D3D11GraphicsEngine& engine,
+        ID3D11RenderTargetView* outputRTV,
+        RGResourceHandle backBufferHandle,
+        ID3D11ShaderResourceView* depth,
+        RGResourceHandle velocityBufferHandle,
+        RGResourceHandle reactiveMaskResource )
+    {
+        graph.AddPass( L"FSR 2", [&]( RGBuilder& builder, RenderPass& pass ) {
+            builder.Read( velocityBufferHandle );
+            builder.Read( reactiveMaskResource );
+            builder.Read( backBufferHandle );
+
+            builder.Write( backBufferHandle );
+
+            pass.m_executeCallback = [&engine, backBufferHandle, outputRTV, velocityBufferHandle, reactiveMaskResource, depth]( const RenderGraph& graph ) {
+                auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+
+                auto backbufferTex = graph.GetPhysicalTexture( backBufferHandle );
+
+                auto sharpenFactor = settings.SharpenFactor;
+
+                auto velocityBufferTex = graph.GetPhysicalTexture( velocityBufferHandle );
+                auto reactiveMask = graph.GetPhysicalTexture( reactiveMaskResource );
+
+                auto jitter = engine.GetPfxRenderer()->GetTAAEffect()->GetJitterOffsetUnscaled();
+                const auto inputSize = engine.GetResolution();
+
+                float fovY, fovX;
+                auto cam = ((zCCamera*)oCGame::GetGame()->_zCSession_camera);
+                cam->GetFOV( fovY, fovX );
+
+                // Our Depth Buffer uses reversed Z, so we need to tell FSR2 about it to get correct results
+                // calculations from GothicAPI::GetProjectionMatrix()
+                float NearZ = settings.SectionDrawRadius * WORLD_SECTION_SIZE;
+                float FarZ = 1.0f;
+
+                ID3D11SamplerState* linearSampler = engine.GetLinearSamplerState();
+                engine.GetContext()->CSSetSamplers( 0, 1, &linearSampler );
+                engine.GetContext()->CSSetSamplers( 1, 1, &linearSampler );
+
+                ID3D11Buffer* nullCBs[5]{};
+                engine.GetContext()->CSSetConstantBuffers( 0, std::size( nullCBs ), nullCBs );
+
+                engine.GetPfxRenderer()->GetFSR2()->Apply(
+                    backbufferTex->GetShaderResView().Get(),
+                    depth,
+                    velocityBufferTex->GetShaderResView().Get(),
+                    reactiveMask->GetShaderResView().Get(),
+                    outputRTV,
+                    inputSize,
+                    engine.GetBackbufferResolution(),
+                    Engine::GAPI->GetDeltaTime() * 1000.f,
+                    jitter,
+                    float2( static_cast<float>(inputSize.x), static_cast<float>(inputSize.y) ),
+                    false,
+                    fovY,
+                    NearZ,
+                    FarZ,
+                    sharpenFactor >= 0.001f,
+                    sharpenFactor /* FSR2 has 0..1 (sharp)*/ );
+                };
+            } );
+    }
+
+    void AddFSR3Pass( RenderGraph& graph,
+        D3D11GraphicsEngine& engine,
+        ID3D11RenderTargetView* outputRTV,
+        RGResourceHandle backBufferHandle,
+        ID3D11ShaderResourceView* depth,
+        RGResourceHandle velocityBufferHandle,
+        RGResourceHandle reactiveMaskResource )
+    {
+        graph.AddPass( L"FSR 3", [&]( RGBuilder& builder, RenderPass& pass ) {
+            builder.Read( velocityBufferHandle );
+            builder.Read( reactiveMaskResource );
+            builder.Read( backBufferHandle );
+
+            builder.Write( backBufferHandle );
+
+            pass.m_executeCallback = [&engine, backBufferHandle, outputRTV, velocityBufferHandle, reactiveMaskResource, depth]( const RenderGraph& graph ) {
+                auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+
+                auto backbufferTex = graph.GetPhysicalTexture( backBufferHandle );
+
+                auto sharpenFactor = settings.SharpenFactor;
+
+                auto velocityBufferTex = graph.GetPhysicalTexture( velocityBufferHandle );
+                auto reactiveMask = graph.GetPhysicalTexture( reactiveMaskResource );
+
+                auto jitter = engine.GetPfxRenderer()->GetTAAEffect()->GetJitterOffsetUnscaled();
+                const auto inputSize = engine.GetResolution();
+
+                float fovY, fovX;
+                auto cam = ((zCCamera*)oCGame::GetGame()->_zCSession_camera);
+                cam->GetFOV( fovY, fovX );
+
+                // Our Depth Buffer uses reversed Z, so we need to tell FSR2 about it to get correct results
+                // calculations from GothicAPI::GetProjectionMatrix()
+                float NearZ = settings.SectionDrawRadius * WORLD_SECTION_SIZE;
+                float FarZ = 1.0f;
+
+                ID3D11SamplerState* linearSampler = engine.GetLinearSamplerState();
+                engine.GetContext()->CSSetSamplers( 0, 1, &linearSampler );
+                engine.GetContext()->CSSetSamplers( 1, 1, &linearSampler );
+
+                ID3D11Buffer* nullCBs[5]{};
+                engine.GetContext()->CSSetConstantBuffers( 0, std::size( nullCBs ), nullCBs );
+
+                engine.GetPfxRenderer()->GetFSR3()->Apply(
+                    backbufferTex->GetShaderResView().Get(),
+                    depth,
+                    velocityBufferTex->GetShaderResView().Get(),
+                    reactiveMask->GetShaderResView().Get(),
+                    outputRTV,
+                    inputSize,
+                    engine.GetBackbufferResolution(),
+                    Engine::GAPI->GetDeltaTime() * 1000.f,
+                    jitter,
+                    float2( static_cast<float>(inputSize.x), static_cast<float>(inputSize.y) ),
+                    false,
+                    fovY,
+                    NearZ,
+                    FarZ,
+                    sharpenFactor >= 0.001f,
+                    sharpenFactor /* FSR3 has 0..1 (sharp)*/ );
+                };
+        } );
+    }
+}
+
+void D3D11Upscaling::UpdateUpscaling( D3D11GraphicsEngine& engine )
+{
+    if ( engine.GetDevice()->GetFeatureLevel() < D3D_FEATURE_LEVEL_11_0 ) {
+        return;
+    }
+
+    auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+
+    const bool needsJitteredProj = settings.AntiAliasingMode == GothicRendererSettings::AA_FSR
+        || settings.AntiAliasingMode == GothicRendererSettings::AA_TAA
+        || settings.AntiAliasingMode == GothicRendererSettings::AA_FSR3;
+
+    if ( needsJitteredProj ) {
+        engine.SetFrameNeedsJitter();
+    }
+}
+
+bool D3D11Upscaling::AddUpscalingPass( RenderGraph& graph,
+    D3D11GraphicsEngine& engine, 
+    ID3D11RenderTargetView* outputRTV,
+    RGResourceHandle color, 
+    ID3D11ShaderResourceView* depth,
+    RGResourceHandle motionVectors,
+    RGResourceHandle reactiveMask )
+{
+
+    auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+
+    if ( settings.ResolutionScalePercent < 100
+            && settings.Upscaler == GothicRendererSettings::E_Upscaler::UPSCALER_FSR_1 ) {
+
+        AddFSR1Pass( graph, engine, outputRTV, color );
+        return true;
+    } 
+    
+    if ( engine.GetDevice()->GetFeatureLevel() < D3D_FEATURE_LEVEL_11_0 ) {
+        return false;
+    }
+
+    if ( settings.Upscaler == GothicRendererSettings::E_Upscaler::UPSCALER_FSR_2
+            && (settings.ResolutionScalePercent <= 100)
+            && settings.AntiAliasingMode == GothicRendererSettings::AA_FSR ) {
+        AddFSR2Pass( graph, engine, outputRTV, color, depth, motionVectors, reactiveMask );
+        return true;
+    } else if ( settings.Upscaler == GothicRendererSettings::E_Upscaler::UPSCALER_FSR_3
+            && (settings.ResolutionScalePercent <= 100)
+            && settings.AntiAliasingMode == GothicRendererSettings::AA_FSR ) {
+
+        AddFSR3Pass( graph, engine, outputRTV, color, depth, motionVectors, reactiveMask );
+        return true;
+    }
+    return false;
+}

--- a/D3D11Engine/D3D11Upscaling.h
+++ b/D3D11Engine/D3D11Upscaling.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "RenderGraph.h"
+#include "RenderPass.h"
+
+class D3D11GraphicsEngine;
+
+class D3D11Upscaling
+{
+public:
+    void UpdateUpscaling( D3D11GraphicsEngine& engine );
+
+    bool AddUpscalingPass(
+        RenderGraph& graph,
+        D3D11GraphicsEngine& engine,
+        ID3D11RenderTargetView* outputRTV,
+        RGResourceHandle color,
+        ID3D11ShaderResourceView* depth,
+        RGResourceHandle motionVectors,
+        RGResourceHandle reactiveMask );
+private:
+};
+

--- a/D3D11Engine/D3D11VShader.cpp
+++ b/D3D11Engine/D3D11VShader.cpp
@@ -16,17 +16,17 @@ D3D11VShader::D3D11VShader() = default;
 D3D11VShader::~D3D11VShader() = default;
 
 /** Loads shader */
-XRESULT D3D11VShader::LoadShader( const ShaderInfo& shaderInfo, const char* filePath ) {
+XRESULT D3D11VShader::LoadShader( const ShaderInfo& si, const std::vector<D3D_SHADER_MACRO>& macros, const char* filePath ) {
     HRESULT hr;
     D3D11GraphicsEngineBase* engine = reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine);
 
     Microsoft::WRL::ComPtr<ID3DBlob> vsBlob;
 
 
-    LogInfo() << "Compilling vertex shader: " << shaderInfo.name;
+    LogInfo() << "Compilling vertex shader: " << si.name;
 
     // Compile shader
-    if ( FAILED( D3D11ShaderManager::CompileShaderFromFile( filePath, !shaderInfo.entryPoint.empty() ? shaderInfo.entryPoint.c_str() : "VSMain", (FeatureLevel10Compatibility ? "vs_4_0" : "vs_5_0"), vsBlob.GetAddressOf(), shaderInfo.shaderMakros)) ) {
+    if ( FAILED( D3D11ShaderManager::CompileShaderFromFile( filePath, !si.entryPoint.empty() ? si.entryPoint.c_str() : "VSMain", (FeatureLevel10Compatibility ? "vs_4_0" : "vs_5_0"), vsBlob.GetAddressOf(), macros)) ) {
         return XR_FAILED;
     }
 
@@ -36,9 +36,9 @@ XRESULT D3D11VShader::LoadShader( const ShaderInfo& shaderInfo, const char* file
     LE( engine->GetDevice()->CreateVertexShader( vsBlob->GetBufferPointer(),
         vsBlob->GetBufferSize(), nullptr, VertexShader.ReleaseAndGetAddressOf() ) );
 
-    SetDebugName( VertexShader.Get(), shaderInfo.name );
+    SetDebugName( VertexShader.Get(), si.name );
 
-    if (shaderInfo.layout == 0) {
+    if (si.layout == 0) {
         // No layout, skip input layout creation
         // Likely VS_PFX or similar, where we work with SV_VertexID
         return XR_SUCCESS;
@@ -193,7 +193,7 @@ XRESULT D3D11VShader::LoadShader( const ShaderInfo& shaderInfo, const char* file
         { "INSTANCE_COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 1, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_INSTANCE_DATA, 1 },
     };
 
-    switch ( shaderInfo.layout ) {
+    switch ( si.layout ) {
     case 1:
         LE( engine->GetDevice()->CreateInputLayout( layout1, std::size( layout1 ), vsBlob->GetBufferPointer(),
             vsBlob->GetBufferSize(), InputLayout.ReleaseAndGetAddressOf() ) );

--- a/D3D11Engine/D3D11VShader.h
+++ b/D3D11Engine/D3D11VShader.h
@@ -12,7 +12,7 @@ public:
     ~D3D11VShader() override;
 
     /** Loads both shader at the same time */
-    XRESULT LoadShader( const ShaderInfo& shaderInfo, const char* filePath );
+    XRESULT LoadShader( const ShaderInfo& si, const std::vector<D3D_SHADER_MACRO>& macros, const char* filePath );
 
     /** Applys the shader */
     XRESULT Apply() override;

--- a/D3D11Engine/D3D11_Helpers.h
+++ b/D3D11Engine/D3D11_Helpers.h
@@ -9,6 +9,7 @@
 template<UINT TNameLength>
 inline void SetDebugObjectName( _In_ ID3D11DeviceChild* resource, _In_z_ const char( &name )[TNameLength] ) {
 #if defined(_DEBUG) || defined(PROFILE) || defined(DEBUG_D3D11)
+    if ( !resource ) return;
     HRESULT nameSet = resource->SetPrivateData( WKPDID_D3DDebugObjectName, TNameLength - 1, name );
     if ( FAILED( nameSet ) ) LogError() << "Failed to set debug name";
 #endif
@@ -34,7 +35,7 @@ inline void SetDebugName( _In_  ID3D11DeviceChild* resource, const std::string& 
 inline void SetDebugName( _In_  ID3D11DeviceChild* resource, const char* debugName ) {
 #if defined(_DEBUG) || defined(PROFILE)|| defined(DEBUG_D3D11)
     if ( !resource ) return;
-    HRESULT nameSet = resource->SetPrivateData( WKPDID_D3DDebugObjectName, strlen(debugName), debugName );
+    HRESULT nameSet = resource->SetPrivateData( WKPDID_D3DDebugObjectName, std::strlen(debugName), debugName );
     if ( FAILED( nameSet ) ) LogError() << "Failed to set debug name";
 #endif
 }
@@ -47,10 +48,60 @@ inline void SetDebugName( _In_  IDXGIObject* resource, const std::string& debugN
 #endif
 }
 
-inline void SetDebugName( _In_  ID3D11Device1* resource, const std::string& debugName ) {
+inline void SetDebugName( _In_  ID3D11Device* resource, const std::string& debugName ) {
 #if defined(_DEBUG) || defined(PROFILE)|| defined(DEBUG_D3D11)
     if ( !resource ) return;
     HRESULT nameSet = resource->SetPrivateData( WKPDID_D3DDebugObjectName, debugName.size(), debugName.c_str() );
+    if ( FAILED( nameSet ) ) LogError() << "Failed to set debug name";
+#endif
+}
+
+template<UINT TNameLength>
+inline void SetDebugObjectName( _In_ ID3D11DeviceChild* resource, _In_z_ const wchar_t( &name )[TNameLength] ) {
+#if defined(_DEBUG) || defined(PROFILE) || defined(DEBUG_D3D11)
+    if ( !resource ) return;
+    HRESULT nameSet = resource->SetPrivateData( WKPDID_D3DDebugObjectNameW, (TNameLength - 1) * sizeof( wchar_t ), name);
+    if ( FAILED( nameSet ) ) LogError() << "Failed to set debug name";
+#endif
+}
+
+template<UINT TNameLength>
+inline void SetDebugObjectName( _In_ IDXGIObject* resource, _In_z_ const wchar_t( &name )[TNameLength] ) {
+#if defined(_DEBUG) || defined(PROFILE)|| defined(DEBUG_D3D11)
+    if ( !resource ) return;
+    HRESULT nameSet = resource->SetPrivateData( WKPDID_D3DDebugObjectNameW, (TNameLength - 1) * sizeof( wchar_t ), name );
+    if ( FAILED( nameSet ) ) LogError() << "Failed to set debug name";
+#endif
+}
+
+inline void SetDebugName( _In_  ID3D11DeviceChild* resource, const std::wstring& debugName ) {
+#if defined(_DEBUG) || defined(PROFILE)|| defined(DEBUG_D3D11)
+    if ( !resource ) return;
+    HRESULT nameSet = resource->SetPrivateData( WKPDID_D3DDebugObjectNameW, debugName.size() * sizeof( wchar_t ), debugName.c_str() );
+    if ( FAILED( nameSet ) ) LogError() << "Failed to set debug name";
+#endif
+}
+
+inline void SetDebugName( _In_  ID3D11DeviceChild* resource, const wchar_t* debugName ) {
+#if defined(_DEBUG) || defined(PROFILE)|| defined(DEBUG_D3D11)
+    if ( !resource ) return;
+    HRESULT nameSet = resource->SetPrivateData( WKPDID_D3DDebugObjectNameW, wcslen( debugName ) * sizeof( wchar_t ), debugName );
+    if ( FAILED( nameSet ) ) LogError() << "Failed to set debug name";
+#endif
+}
+
+inline void SetDebugName( _In_  IDXGIObject* resource, const std::wstring& debugName ) {
+#if defined(_DEBUG) || defined(PROFILE)|| defined(DEBUG_D3D11)
+    if ( !resource ) return;
+    HRESULT nameSet = resource->SetPrivateData( WKPDID_D3DDebugObjectNameW, debugName.size() * sizeof( wchar_t ), debugName.c_str() );
+    if ( FAILED( nameSet ) ) LogError() << "Failed to set debug name";
+#endif
+}
+
+inline void SetDebugName( _In_  ID3D11Device* resource, const std::wstring& debugName ) {
+#if defined(_DEBUG) || defined(PROFILE)|| defined(DEBUG_D3D11)
+    if ( !resource ) return;
+    HRESULT nameSet = resource->SetPrivateData( WKPDID_D3DDebugObjectNameW, debugName.size() * sizeof( wchar_t ), debugName.c_str() );
     if ( FAILED( nameSet ) ) LogError() << "Failed to set debug name";
 #endif
 }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1247,7 +1247,7 @@ void GothicAPI::DrawWorldMeshNaive() {
     FrameMeshInstances.clear();
 
     {
-        auto _ = START_TIMING( "World Mesh" );
+        auto _ = START_TIMING( L"World Mesh" );
         auto _1 = Engine::GraphicsEngine->RecordGraphicsEvent( L"World Mesh" );
         
         if ( Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.FeatureSet.UseMDI ) {
@@ -1265,7 +1265,7 @@ void GothicAPI::DrawWorldMeshNaive() {
     const auto cameraPosXm = GetCameraPositionXM();
 
     if ( RendererState.RendererSettings.DrawSkeletalMeshes ) {
-        auto _ = START_TIMING( "Animated Skeletal Meshes" );
+        auto _ = START_TIMING( L"Animated Skeletal Meshes" );
         auto _1 = Engine::GraphicsEngine->RecordGraphicsEvent( L"Animated Skeletal Meshes" );
 
         // Set up frustum for the camera

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -989,7 +989,7 @@ struct GothicRendererTiming {
     }
 
     float TotalMS;
-    std::vector<std::pair<const char*, float>> frameRecordings;
+    std::vector<std::pair<const wchar_t*, float>> frameRecordings;
 
 private:
     BasicTimer _timer;
@@ -998,20 +998,19 @@ private:
 
 class TimerScope {
 public:
-    TimerScope( const char* label, std::vector<std::pair<const char*, float>>* collection )
+    TimerScope( const wchar_t* label, std::vector<std::pair<const wchar_t*, float>>* collection )
         : _timer( {} ),
         _type( label ),
         _collection(collection) {
-        _timer.Update();
     }
     ~TimerScope() {
-        _timer.Update();
-        _collection->push_back( std::make_pair( _type, _timer.GetDelta() * 1000.0f ) );
+        const float delta = _timer.GetDelta();
+        _collection->push_back( std::make_pair( _type, delta * 1000.0f ) );
     }
 private:
-    BasicTimer _timer;
-    std::vector<std::pair<const char*, float>>* _collection;
-    const char* _type;
+    OneShotTimer _timer;
+    std::vector<std::pair<const wchar_t*, float>>* _collection;
+    const wchar_t* _type;
 };
 
 struct GothicRendererInfo {

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -590,7 +590,7 @@ struct GothicRendererSettings {
 
         DrawSky = true;
         DrawFog = true;
-        FogRange = 0;
+        FogRange = 1.0f;
         EnableHDR = false;
         HDRToneMap = E_HDRToneMap::ToneMap_Simple;
         ReplaceSunDirection = false;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -603,7 +603,11 @@ void ImGuiShim::RenderSettingsWindow()
     ImVec2 buttonWidth( 275, 0 );
     auto& style = ImGui::GetStyle();
 
+#ifdef IS_DEV_BUILD
+    static const char* settingsLabel = "GD3D11 " VERSION_NUMBER " - (" BUILD_DATE ")";
+#else
     static const char* settingsLabel = "GD3D11 " VERSION_NUMBER;
+#endif
 
     ShaderCategory shadersToReload = ShaderCategory::None;
 
@@ -1074,8 +1078,12 @@ void RenderAdvancedColumn1( GothicRendererSettings& settings, GothicAPI* gapi ) 
 void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicAPI* gapi ) {
     if ( ImGui::Begin( "General", nullptr, ImGuiWindowFlags_NoCollapse ) ) {
 
+#ifdef IS_DEV_BUILD
+        ImGui::Text( "Version: %s", VERSION_NUMBER " - (" BUILD_DATE ")" );
+#else
         ImGui::Text( "Version: %s", VERSION_NUMBER );
-
+#endif
+        
         ImGui::Checkbox( "Enable DebugLog", &settings.EnableDebugLog );
         ImGui::Checkbox( "Toggle frame stats", &m_FrameStatisticsVisible );
         if ( ImGui::Button( "Save ZEN-Resources", ImVec2( ImGui::GetContentRegionAvail().x, 30.f ) ) ) {

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1071,14 +1071,13 @@ void RenderAdvancedColumn1( GothicRendererSettings& settings, GothicAPI* gapi ) 
 }
 
 
-void RenderAdvancedColumn2( GothicRendererSettings& settings, GothicAPI* gapi ) {
+void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicAPI* gapi ) {
     if ( ImGui::Begin( "General", nullptr, ImGuiWindowFlags_NoCollapse ) ) {
 
-        ImGui::Text( "Version: " );
-        ImGui::SameLine();
-        ImGui::Text( VERSION_NUMBER );
+        ImGui::Text( "Version: %s", VERSION_NUMBER );
 
         ImGui::Checkbox( "Enable DebugLog", &settings.EnableDebugLog );
+        ImGui::Checkbox( "Toggle frame stats", &m_FrameStatisticsVisible );
         if ( ImGui::Button( "Save ZEN-Resources", ImVec2( ImGui::GetContentRegionAvail().x, 30.f ) ) ) {
             gapi->SaveCustomZENResources();
         }
@@ -1576,30 +1575,43 @@ void ImGuiShim::RenderAdvancedSettingsWindow()
     IMGUI_CHECKVERSION();
 
     auto windowSize = CurrentResolution;
-    auto columnWidth = windowSize.x / 4;
+    
+    int numCols = m_FrameStatisticsVisible ? 4 : 3;
+    auto columnWidth = static_cast<float>(windowSize.x) / numCols;
     auto columnOffset = 0.0f;
-    auto columnHeight = std::max( 400.0f, windowSize.y / 2.f );
+    auto columnHeight = std::max( 400.0f, static_cast<float>(windowSize.y) / 2.f );
 
     GothicRendererSettings& settings = Engine::GAPI->GetRendererState().RendererSettings;
     FixupSettings(settings);
 
-    ImGui::SetNextWindowPos( ImVec2( columnOffset, 0.0f ), ImGuiCond_Appearing, ImVec2( 0, 0 ) );
-    ImGui::SetNextWindowSize( ImVec2( windowSize.x / 4, columnHeight ), ImGuiCond_Appearing );
+    static bool lastStatisticsVisible = m_FrameStatisticsVisible;
+    bool forceReappear = false;
+    if ( m_FrameStatisticsVisible != lastStatisticsVisible ) {
+        lastStatisticsVisible = m_FrameStatisticsVisible;
+        forceReappear = true;
+    }
+    int ImGuiCond_Appearing_Or_ForceReappear = forceReappear ? ImGuiCond_Always : ImGuiCond_Appearing;
+    
+    ImGui::SetNextWindowPos( ImVec2( columnOffset, 0.0f ), ImGuiCond_Appearing_Or_ForceReappear, ImVec2( 0, 0 ) );
+    ImGui::SetNextWindowSize( ImVec2( columnWidth, columnHeight ), ImGuiCond_Appearing_Or_ForceReappear );
     RenderAdvancedColumn1( settings, Engine::GAPI );
     columnOffset += columnWidth;
 
-    ImGui::SetNextWindowPos( ImVec2( columnOffset, 0.0f ), ImGuiCond_Appearing, ImVec2( 0, 0 ) );
-    ImGui::SetNextWindowSize( ImVec2( windowSize.x / 4, columnHeight ), ImGuiCond_Appearing );
+    ImGui::SetNextWindowPos( ImVec2( columnOffset, 0.0f ), ImGuiCond_Appearing_Or_ForceReappear, ImVec2( 0, 0 ) );
+    ImGui::SetNextWindowSize( ImVec2( columnWidth, columnHeight ), ImGuiCond_Appearing_Or_ForceReappear );
     RenderAdvancedColumn2( settings, Engine::GAPI );
     columnOffset += columnWidth;
 
-    ImGui::SetNextWindowPos( ImVec2( columnOffset, 0.0f ), ImGuiCond_Appearing, ImVec2( 0, 0 ) );
-    ImGui::SetNextWindowSize( ImVec2( windowSize.x / 4, columnHeight ), ImGuiCond_Appearing );
-    RenderAdvancedColumn3( settings, Engine::GAPI );
-    columnOffset += columnWidth;
+    if (m_FrameStatisticsVisible)
+    {
+        ImGui::SetNextWindowPos( ImVec2( columnOffset, 0.0f ), ImGuiCond_Appearing_Or_ForceReappear, ImVec2( 0, 0 ) );
+        ImGui::SetNextWindowSize( ImVec2( columnWidth, columnHeight ), ImGuiCond_Appearing_Or_ForceReappear );
+        RenderAdvancedColumn3( settings, Engine::GAPI );
+        columnOffset += columnWidth;
+    }
 
-    ImGui::SetNextWindowPos( ImVec2( columnOffset, 0.0f ), ImGuiCond_Appearing, ImVec2( 0, 0 ) );
-    ImGui::SetNextWindowSize( ImVec2( windowSize.x / 4, columnHeight ), ImGuiCond_Appearing );
+    ImGui::SetNextWindowPos( ImVec2( columnOffset, 0.0f ), ImGuiCond_Appearing_Or_ForceReappear, ImVec2( 0, 0 ) );
+    ImGui::SetNextWindowSize( ImVec2( columnWidth, columnHeight ), ImGuiCond_Appearing_Or_ForceReappear );
     RenderAdvancedColumn4( settings, Engine::GAPI );
 
 }

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -494,7 +494,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_CONSERVATIVE;
         s.ShadowSoftness = 1.0f;
         s.SmoothShadowCameraUpdate = false;
-        s.SmoothShadowFrequency = 20000;
+        s.SmoothShadowFrequency = 1000;
         s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_SIMPLE;
 
         s.EnableDynamicLighting = true;
@@ -529,7 +529,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_CONSERVATIVE;
         s.ShadowSoftness = 1.0f;
         s.SmoothShadowCameraUpdate = false;
-        s.SmoothShadowFrequency = 20000;
+        s.SmoothShadowFrequency = 1000;
         s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_PCSS;
 
         s.EnableDynamicLighting = true;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1134,7 +1134,10 @@ void RenderAdvancedColumn2( GothicRendererSettings& settings, GothicAPI* gapi ) 
         };
 
         ImGui::BeginDisabled( !settings.EnableHDR );
-        if ( ImComboBox( "HDR ToneMap", hdrToneMapValues, (int*)(&settings.HDRToneMap) ) ) {
+        if ( ImComboBoxC( "HDR ToneMap", hdrToneMapValues, reinterpret_cast<int*>(&settings.HDRToneMap), []
+        {
+            Engine::GraphicsEngine->ReloadShaders( ShaderCategory::Tonemapping );
+        } ) ) {
             ImGui::EndCombo();
         }
         ImGui::EndDisabled();

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -11,6 +11,16 @@
 #include <algorithm>
 #include <chrono>
 #include <numeric>
+#include <codecvt>
+
+namespace ImGui {
+    void TextUnformatted( const wchar_t* text ) {
+        char dest[64];
+        auto len = WideCharToMultiByte(CP_UTF8, 0, text, -1, dest, sizeof(dest), NULL, NULL);
+        dest[std::min(static_cast<size_t>(len), sizeof(dest) - 1)] = '\0';
+        ImGui::TextUnformatted( dest );
+    }
+}
 
 #if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
 extern bool haveWindAnimations;
@@ -1400,6 +1410,14 @@ void RenderAdvancedColumn3( GothicRendererSettings& settings, GothicAPI* gapi ) 
                 ImGui::Text( fmt, value );
                 };
 
+            static auto addRowFloatW = []( const wchar_t* label, float value, const char* fmt ) {
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex( 0 );
+                ImGui::TextUnformatted( label );
+                ImGui::TableSetColumnIndex( 1 );
+                ImGui::Text( fmt, value );
+                };
+
             addRowInt( "FPS", rendererInfo.FPS );
             addRowUInt( "StateChanges", rendererInfo.StateChanges );
             addRowInt( "DrawnVobs", rendererInfo.FrameDrawnVobs );
@@ -1412,10 +1430,10 @@ void RenderAdvancedColumn3( GothicRendererSettings& settings, GothicAPI* gapi ) 
             addRowFloat( "NearPlane", rendererInfo.NearPlane, "%.0f" );
 
             rendererInfo.Timing.StopTotal();
-            rendererInfo.Timing.frameRecordings.push_back({"Total", rendererInfo.Timing.TotalMS});
+            rendererInfo.Timing.frameRecordings.push_back({L"Total", rendererInfo.Timing.TotalMS});
             
-            static std::unordered_map<const char*, std::vector<float>> timingHistory;
-            static std::unordered_map<const char*, float> timingAvg;
+            static std::unordered_map<const wchar_t*, std::vector<float>> timingHistory;
+            static std::unordered_map<const wchar_t*, float> timingAvg;
             static std::chrono::time_point<std::chrono::steady_clock> lastUpdate = std::chrono::steady_clock::now();
             for ( auto& record : rendererInfo.Timing.frameRecordings ) {
                 timingHistory[record.first].push_back(record.second);
@@ -1439,7 +1457,7 @@ void RenderAdvancedColumn3( GothicRendererSettings& settings, GothicAPI* gapi ) 
             
             // Anzeige: aktuelle Werte, Durchschnitt und Perzentil
             for ( auto& record : rendererInfo.Timing.frameRecordings ) {
-                addRowFloat( record.first, timingAvg[record.first], "%05.2f" );
+                addRowFloatW( record.first, timingAvg[record.first], "%05.2f" );
             }
 
             addRowInt( "SC_PipelineStates", rendererInfo.FramePipelineStates );

--- a/D3D11Engine/ImGuiShim.h
+++ b/D3D11Engine/ImGuiShim.h
@@ -68,6 +68,8 @@ public:
 private:
     void RenderSettingsWindow();
     void RenderAdvancedSettingsWindow();
+    void RenderAdvancedColumn2(GothicRendererSettings& settings, GothicAPI* gapi);
     bool m_lastFrameBlockGameInput = false;
+    bool m_FrameStatisticsVisible = false;
     std::unique_ptr<ImGuiEditorView> m_EditorView;
 };

--- a/D3D11Engine/RenderGraph.cpp
+++ b/D3D11Engine/RenderGraph.cpp
@@ -1,1 +1,117 @@
 #include "RenderGraph.h"
+#include "BaseGraphicsEngine.h"
+#include "Engine.h"
+#include "GothicAPI.h"
+
+RGResourceHandle RenderGraph::ImportResource( const std::wstring& name, RenderToTextureBuffer* externalBuffer )
+{
+    uint32_t index = m_nextHandle++;
+
+    // Resize vectors to accommodate the new index
+    m_externalTextures.resize( m_nextHandle, nullptr );
+    m_activeTextures.resize( m_nextHandle );
+    m_resourceDescs.resize( m_nextHandle );
+
+    m_externalTextures[index] = externalBuffer;
+    m_resourceDescs[index] = { 0, 0, 0, name }; // Dummy desc for name tracking
+
+    return MakeHandle( index, true ); // Sets the first bit to 1
+}
+
+RGResourceHandle RenderGraph::RegisterResource( const RGTextureDesc& desc )
+{
+    uint32_t index = m_nextHandle++;
+
+    m_externalTextures.resize( m_nextHandle, nullptr );
+    m_activeTextures.resize( m_nextHandle );
+    m_resourceDescs.resize( m_nextHandle );
+
+    m_resourceDescs[index] = desc;
+
+    return MakeHandle( index, false ); // First bit remains 0
+}
+
+void RenderGraph::Compile()
+{
+    m_resourceLifetimes.assign( m_nextHandle, { UINT32_MAX, 0, false } );
+
+    for ( size_t passIndex = 0; passIndex < m_passes.size(); ++passIndex ) {
+        const auto& pass = m_passes[passIndex];
+
+        // Track writes (creation/modification)
+        for ( RGResourceHandle writeHandle : pass->m_writes ) {
+            uint32_t index = GetHandleIndex( writeHandle );
+
+            // If this is the first time we are writing to this resource, record its birth
+            if ( m_resourceLifetimes[index].firstPass == UINT32_MAX ) {
+                m_resourceLifetimes[index].firstPass = (uint32_t)passIndex;
+            }
+
+            // Every write extends its lifetime to this pass
+            m_resourceLifetimes[index].lastPass = (uint32_t)passIndex;
+        }
+
+        // Track reads (usage)
+        for ( RGResourceHandle readHandle : pass->m_reads ) {
+            uint32_t index = GetHandleIndex( readHandle );
+
+            // Reads extend the lifetime of the resource to this pass
+            m_resourceLifetimes[index].lastPass = (uint32_t)passIndex;
+
+            // Mark that this resource actually serves a read dependency downstream
+            m_resourceLifetimes[index].isRead = true;
+        }
+    }
+}
+
+void RenderGraph::Execute()
+{
+    for ( size_t i = 0; i < m_passes.size(); ++i ) {
+        const auto& pass = m_passes[i];
+
+        AllocateResourcesForPass( i );
+
+        // Eliminate any passes whose writes are never read
+        bool isPassDead = false;
+        if ( !pass->m_writes.empty() ) {
+            isPassDead = true;
+            for ( RGResourceHandle writeHandle : pass->m_writes ) {
+                uint32_t index = GetHandleIndex( writeHandle );
+                // A pass is alive if it writes to an external resource OR an internal resource that gets read
+                if ( IsExternalHandle( writeHandle ) || m_resourceLifetimes[index].isRead ) {
+                    isPassDead = false;
+                    break;
+                }
+            }
+        }
+
+        // Only execute if it provides a meaningful side-effect/write
+        if ( !isPassDead && pass->m_executeCallback ) {
+            auto _ = Engine::GraphicsEngine->RecordGraphicsEvent( pass->m_name );
+            auto _timing = START_TIMING( pass->m_name );
+
+            pass->m_executeCallback( *this );
+        }
+
+        ReleaseResourcesForPass( i );
+    }
+}
+
+void RenderGraph::AllocateResourcesForPass( size_t passIndex )
+{
+    for ( uint32_t i = 0; i < m_resourceLifetimes.size(); ++i ) {
+        // We only allocate for Graph-Managed resources
+        if ( m_resourceLifetimes[i].firstPass == (uint32_t)passIndex ) {
+            // If this index is meant to be external, we don't allocate it from the pool.
+            if ( m_externalTextures[i] != nullptr ) continue;
+
+            // Do NOT allocate if the resource is completely unread downstream
+            if ( !m_resourceLifetimes[i].isRead ) continue;
+
+            const RGTextureDesc& desc = m_resourceDescs[i];
+            TexturePool::Description poolDesc{ (int)desc.width, (int)desc.height, static_cast<DXGI_FORMAT>( desc.format ), (DXGI_USAGE)desc.textureFlags };
+
+            m_activeTextures[i] = std::move( m_texturePool->Acquire( poolDesc ) );
+        }
+    }
+}

--- a/D3D11Engine/RenderGraph.h
+++ b/D3D11Engine/RenderGraph.h
@@ -3,8 +3,7 @@
 #include <memory>
 #include <vector>
 
-#include "BaseGraphicsEngine.h"
-#include "Engine.h"
+#include "Logger.h"
 #include "RenderPass.h"
 #include "RGBuilder.h"
 #include "TexturePool.h"
@@ -27,23 +26,11 @@ public:
     RenderGraph( TexturePool* pool ) : m_texturePool( pool ) {}
 
     // Bring an existing engine resource (like the DX11 BackBuffer) into the graph
-    RGResourceHandle ImportResource(const std::wstring& name, RenderToTextureBuffer* externalBuffer) {
-        uint32_t index = m_nextHandle++;
-        
-        // Resize vectors to accommodate the new index
-        m_externalTextures.resize(m_nextHandle, nullptr);
-        m_activeTextures.resize(m_nextHandle); 
-        m_resourceDescs.resize(m_nextHandle);
-        
-        m_externalTextures[index] = externalBuffer;
-        m_resourceDescs[index] = {0, 0, 0, name}; // Dummy desc for name tracking
-
-        return MakeHandle(index, true); // Sets the first bit to 1
-    }
+    RGResourceHandle ImportResource( const std::wstring& name, RenderToTextureBuffer* externalBuffer );
 
     // Add a pass using modern C++ lambdas
     template<typename SetupFunc>
-    void AddPass( const std::wstring& name, SetupFunc setupFunc ) {
+    void AddPass( const wchar_t* name, SetupFunc setupFunc ) {
         auto pass = std::make_unique<RenderPass>( name );
         RGBuilder builder( *this, *pass );
 
@@ -54,79 +41,11 @@ public:
     }
 
     // Called by RGBuilder to register handles
-    RGResourceHandle RegisterResource(const RGTextureDesc& desc) {
-        uint32_t index = m_nextHandle++;
-        
-        m_externalTextures.resize(m_nextHandle, nullptr);
-        m_activeTextures.resize(m_nextHandle); 
-        m_resourceDescs.resize(m_nextHandle);
-        
-        m_resourceDescs[index] = desc;
+    RGResourceHandle RegisterResource( const RGTextureDesc& desc );
 
-        return MakeHandle(index, false); // First bit remains 0
-    }
+    void Compile();
 
-    void Compile() {
-        m_resourceLifetimes.assign(m_nextHandle, { UINT32_MAX, 0, false });
-
-        for ( size_t passIndex = 0; passIndex < m_passes.size(); ++passIndex ) {
-            const auto& pass = m_passes[passIndex];
-
-            // Track writes (creation/modification)
-            for ( RGResourceHandle writeHandle : pass->m_writes ) {
-                uint32_t index = GetHandleIndex(writeHandle);
-
-                // If this is the first time we are writing to this resource, record its birth
-                if ( m_resourceLifetimes[index].firstPass == UINT32_MAX ) {
-                    m_resourceLifetimes[index].firstPass = (uint32_t)passIndex;
-                }
-                
-                // Every write extends its lifetime to this pass
-                m_resourceLifetimes[index].lastPass = (uint32_t)passIndex;
-            }
-
-            // Track reads (usage)
-            for ( RGResourceHandle readHandle : pass->m_reads ) {
-                uint32_t index = GetHandleIndex(readHandle);
-                
-                // Reads extend the lifetime of the resource to this pass
-                m_resourceLifetimes[index].lastPass = (uint32_t)passIndex;
-                
-                // Mark that this resource actually serves a read dependency downstream
-                m_resourceLifetimes[index].isRead = true;
-            }
-        }
-    }
-
-    void Execute() {
-        for ( size_t i = 0; i < m_passes.size(); ++i ) {
-            const auto& pass = m_passes[i];
-
-            AllocateResourcesForPass( i );
-
-            // Eliminate any passes whose writes are never read
-            bool isPassDead = false;
-            if (!pass->m_writes.empty()) {
-                isPassDead = true; 
-                for (RGResourceHandle writeHandle : pass->m_writes) {
-                    uint32_t index = GetHandleIndex(writeHandle);
-                    // A pass is alive if it writes to an external resource OR an internal resource that gets read
-                    if (IsExternalHandle(writeHandle) || m_resourceLifetimes[index].isRead) {
-                        isPassDead = false;
-                        break;
-                    }
-                }
-            }
-
-            // Only execute if it provides a meaningful side-effect/write
-            if ( !isPassDead && pass->m_executeCallback ) {
-                auto _ = Engine::GraphicsEngine->RecordGraphicsEvent( pass->m_name.c_str() );
-                pass->m_executeCallback(*this);
-            }
-
-            ReleaseResourcesForPass( i );
-        }
-    }
+    void Execute();
 
     RenderToTextureBuffer* GetPhysicalTexture(RGResourceHandle handle) const {
         uint32_t index = GetHandleIndex(handle);
@@ -148,23 +67,7 @@ private:
     std::vector<TextureHandle> m_activeTextures;
     std::vector<RenderToTextureBuffer*> m_externalTextures;
     
-    void AllocateResourcesForPass(size_t passIndex) {
-        for (uint32_t i = 0; i < m_resourceLifetimes.size(); ++i) {
-            // We only allocate for Graph-Managed resources
-            if (m_resourceLifetimes[i].firstPass == (uint32_t)passIndex) {
-                // If this index is meant to be external, we don't allocate it from the pool.
-                if (m_externalTextures[i] != nullptr) continue; 
-                
-                // Do NOT allocate if the resource is completely unread downstream
-                if (!m_resourceLifetimes[i].isRead) continue;
-
-                const RGTextureDesc& desc = m_resourceDescs[i];
-                TexturePool::Description poolDesc{ (int)desc.width, (int)desc.height, static_cast<DXGI_FORMAT>(desc.format), (DXGI_USAGE)desc.textureFlags };
-                
-                m_activeTextures[i] = std::move(m_texturePool->Acquire(poolDesc));
-            }
-        }
-    }
+    void AllocateResourcesForPass( size_t passIndex );
 
     void ReleaseResourcesForPass(size_t passIndex) {
         for (uint32_t i = 0; i < m_resourceLifetimes.size(); ++i) {

--- a/D3D11Engine/RenderPass.h
+++ b/D3D11Engine/RenderPass.h
@@ -9,9 +9,9 @@ class RenderPass {
     friend class RenderGraph;
 
 public:
-    RenderPass(std::wstring name ) : m_name(std::move(name)) {}
+    RenderPass(const wchar_t* name ) : m_name(name) {}
 
-    std::wstring m_name;
+    const wchar_t* m_name;
     std::vector<RGResourceHandle> m_reads;  // Sources
     std::vector<RGResourceHandle> m_writes; // Sinks
 

--- a/D3D11Engine/ShaderCategory.h
+++ b/D3D11Engine/ShaderCategory.h
@@ -26,6 +26,7 @@ enum class ShaderCategory : uint32_t {
     LightsAndShadows = 1 << 8,
     Water = 1 << 9,
     Other = 1 << 10,
+    Tonemapping = 1 << 11,
     AllContent = LightsAndShadows | Water | Other,
 
     // Combined: All types and all content

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -222,13 +222,29 @@ float2x2 GetPoissonRotationMatrix(float2 screenPos)
 {
 	// If TAA is disabled return an identity matrix to get standard PCF instead of noise.
     if (SQ_FrameIndex == 0)
-    {
-        return float2x2(1.0f, 0.0f, 0.0f, 1.0f);
-    }
+	{
+			return float2x2(1.0f, 0.0f, 0.0f, 1.0f);
+	}
 
     float temporalOffset = (float)(SQ_FrameIndex % 8) * 0.6180339887f;
     
     float angle = frac(52.9829189f * frac(dot(screenPos, float2(0.06711056f, 0.00583715f)) + temporalOffset)) * 6.283185307f;
+
+    float s, c;
+    sincos(angle, s, c);
+    return float2x2(c, -s, s, c);
+}
+
+float2x2 GetPoissonRotationMatrixR(float2 screenPos, out float rawNoise)
+{
+    // Interleaved Gradient Noise (IGN)
+    float temporalOffset = (float)(SQ_FrameIndex % 8) * 0.6180339887f;
+    
+    // Calculate noise once
+    rawNoise = frac(52.9829189f * frac(dot(screenPos, float2(0.06711056f, 0.00583715f)) + temporalOffset));
+    
+    // Create rotation angle
+    float angle = rawNoise * 6.283185307f;
 
     float s, c;
     sincos(angle, s, c);
@@ -247,10 +263,10 @@ void FindBlockers(out float avgBlockerDepth, out float numBlockers,
     float blockerSum = 0.0f;
     numBlockers = 0.0f;
 
-    [unroll]
-    for (int i = 0; i < 32; ++i)
+    for (int i = 0; i < 16; ++i)
     {
-        float2 offset = mul(rotMat, g_PoissonDisk32[i]) * searchRadius;
+        // Re-use your 16-tap Poisson disk for the blocker search
+        float2 offset = mul(rotMat, g_PoissonDisk16[i]) * searchRadius;
         float shadowMapDepth = SampleShadowMapLevel(uv + offset, cascadeIndex);
 
         if (shadowMapDepth < zReceiver)
@@ -266,10 +282,9 @@ void FindBlockers(out float avgBlockerDepth, out float numBlockers,
 float EstimatePCSSFilterRadius(float2 uv, float zReceiver, int cascadeIndex,
                                float lightSize, float2x2 rotMat, float texelSize)
 {
-    // For directional lights (orthographic CSM): search radius in UV space
-    // Cap to ensure adequate sampling density with 16 Poisson taps
-    float searchRadius = min(lightSize, texelSize * 24.0f);
-
+    // Capped slightly lower to match the 16-tap blocker limit efficiently
+    float searchRadius = min(lightSize, texelSize * 16.0f);
+    
     float avgBlockerDepth = 0.0f;
     float numBlockers = 0.0f;
     FindBlockers(avgBlockerDepth, numBlockers, uv, zReceiver, searchRadius, cascadeIndex, rotMat);
@@ -277,13 +292,9 @@ float EstimatePCSSFilterRadius(float2 uv, float zReceiver, int cascadeIndex,
     if (numBlockers < 1.0f)
         return -1.0f; // No blockers found - fully lit
 
-    // Orthographic penumbra: linear depth difference, no perspective divide.
-    // Division by avgBlockerDepth is only correct for perspective (point/spot) lights.
-    // For directional lights the rays are parallel, so penumbra scales linearly.
     float penumbraWidth = (zReceiver - avgBlockerDepth) * lightSize;
     
-    // Clamp: minimum half-texel for stability, maximum 16 texels to prevent bloom
-    return clamp(penumbraWidth, texelSize * 0.5f, texelSize * 16.0f);
+    return clamp(penumbraWidth, texelSize * 0.5f, texelSize * 32.0f);
 }
 #endif
 
@@ -291,7 +302,7 @@ float EstimatePCSSFilterRadius(float2 uv, float zReceiver, int cascadeIndex,
 float IsInShadow(float3 wsPosition, Texture2D shadowmapAtlas, SamplerComparisonState samplerState)
 {
     float4 vShadowSamplingPos = mul(float4(wsPosition, 1), SQ_ShadowViewProj[0]);
-    vShadowSamplingPos.xyz /= vShadowSamplingPos.www;
+    // vShadowSamplingPos.xyz /= vShadowSamplingPos.www; // no need for perspective divide, as this is an orthographic sun light
 	
     float2 projectedTexCoords = vShadowSamplingPos.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
     return SampleShadowMapCmp(projectedTexCoords.xy, 0, vShadowSamplingPos.z);
@@ -300,7 +311,7 @@ float IsInShadow(float3 wsPosition, Texture2D shadowmapAtlas, SamplerComparisonS
 float IsInShadow(float3 wsPosition, Texture2DArray shadowmapArray, SamplerComparisonState samplerState)
 {
     float4 vShadowSamplingPos = mul(float4(wsPosition, 1), SQ_ShadowViewProj[0]);
-    vShadowSamplingPos.xyz /= vShadowSamplingPos.www;
+    // vShadowSamplingPos.xyz /= vShadowSamplingPos.www; // no need for perspective divide, as this is an orthographic sun light
 	
     float2 projectedTexCoords = vShadowSamplingPos.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
     return shadowmapArray.SampleCmpLevelZero(samplerState, float3(projectedTexCoords.xy, 0), vShadowSamplingPos.z);
@@ -321,41 +332,37 @@ float IsWet(float3 wsPosition, Texture2D shadowmap, SamplerComparisonState sampl
 // Helper: Get shadow map UV and check if position is within cascade bounds
 // Returns: projectedTexCoords in xy, isInBounds as 0 or 1 in z, blend factor in w
 //--------------------------------------------------------------------------------------
-float4 GetCascadeUVAndBounds(float3 wsPosition, int cascadeIndex)
+void GetCascadeUVAndBounds(float3 wsPosition, int cascadeIndex, 
+                           out float4 vShadowSamplingPos, out float2 projectedTexCoords, 
+                           out float inBounds, out float blendFactor)
 {
     matrix viewProj = SQ_ShadowViewProj[cascadeIndex];
-    float4 vShadowSamplingPos = mul(float4(wsPosition, 1), viewProj);
-    vShadowSamplingPos.xyz /= vShadowSamplingPos.www;
-	
-    float2 projectedTexCoords = vShadowSamplingPos.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
+    
+    // Calculate once and pass out
+    vShadowSamplingPos = mul(float4(wsPosition, 1), viewProj);
+    projectedTexCoords = vShadowSamplingPos.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
     
     // Check if within bounds (with margin for blend zone)
     const float margin = 0.02f;
-    bool inBounds = projectedTexCoords.x > margin && projectedTexCoords.x < (1.0f - margin) &&
-                    projectedTexCoords.y > margin && projectedTexCoords.y < (1.0f - margin);
+    bool isInBounds = projectedTexCoords.x > margin && projectedTexCoords.x < (1.0f - margin) &&
+                      projectedTexCoords.y > margin && projectedTexCoords.y < (1.0f - margin);
+    inBounds = isInBounds ? 1.0f : 0.0f;
     
     // Calculate blend factor based on distance to edge
     // Wide blend zone (30%) with smoothstep for gradual cascade transitions
     const float blendZoneStart = 0.30f;
     float distToEdge = min(min(projectedTexCoords.x, 1.0f - projectedTexCoords.x),
                            min(projectedTexCoords.y, 1.0f - projectedTexCoords.y));
-    float blendFactor = 1.0f - smoothstep(margin, blendZoneStart, distToEdge);
-    
-    return float4(projectedTexCoords, inBounds ? 1.0f : 0.0f, blendFactor);
+    blendFactor = 1.0f - smoothstep(margin, blendZoneStart, distToEdge);
 }
 
 //--------------------------------------------------------------------------------------
 // High-quality shadow sampling with configurable softness
 // Uses rotated Poisson disk for TAA-friendly results
 //--------------------------------------------------------------------------------------
-float SampleCascadeShadowSoft(float3 wsPosition, int cascadeIndex, float vertLighting, float bias, float2 screenPos, float softness)
+float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoords, 
+                              int cascadeIndex, float bias, float2 screenPos, float softness)
 {
-    matrix viewProj = SQ_ShadowViewProj[cascadeIndex];
-    float4 vShadowSamplingPos = mul(float4(wsPosition, 1), viewProj);
-    vShadowSamplingPos.xyz /= vShadowSamplingPos.www;
-	
-    float2 projectedTexCoords = vShadowSamplingPos.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
-    
     if (projectedTexCoords.x < 0.0f || projectedTexCoords.x > 1.0f ||
         projectedTexCoords.y < 0.0f || projectedTexCoords.y > 1.0f)
     {
@@ -368,32 +375,36 @@ float SampleCascadeShadowSoft(float3 wsPosition, int cascadeIndex, float vertLig
     // Scale the filter radius based on softness setting
     // softness of 1.0 = default, < 1.0 = sharper, > 1.0 = softer
     float filterRadius = texelSize * softness;
-    
+
 #if SHD_FILTER_PCSS
     // PCSS: Percentage-Closer Soft Shadows
     // Variable-width PCF based on blocker distance for contact-hardening shadows
     // Use SQ_ShadowSoftness directly (not distance-scaled 'softness') because
     // PCSS inherently handles distance-based penumbra via the blocker depth difference.
     {
-        float2x2 rotMat = GetPoissonRotationMatrix(screenPos);
+        float noiseVal;
+        float2x2 rotMat = GetPoissonRotationMatrixR(screenPos, noiseVal);
         float zReceiver = vShadowSamplingPos.z - bias;
         
         float pcssRadius = EstimatePCSSFilterRadius(projectedTexCoords.xy, zReceiver,
             cascadeIndex, SQ_LightSize * SQ_ShadowSoftness, rotMat, texelSize);
-        
+
         if (pcssRadius < 0.0f)
         {
-            // No blockers found - fully lit
             shadow = 1.0f;
         }
         else
         {
-            // Variable PCF filtering with PCSS-derived radius
             float sum = 0.0f;
-            [unroll]
+            
+            // some dithering to reduce the visible "shears" of the noise
+            float radiusJitter = lerp(0.85f, 1.15f, noiseVal);
+            float finalRadius = pcssRadius * radiusJitter;
+            
             for (int i = 0; i < 32; i++)
             {
-                float2 offset = mul(rotMat, g_PoissonDisk32[i]) * pcssRadius;
+                float2 offset = mul(rotMat, g_PoissonDisk32[i]) * finalRadius;
+                
                 sum += SampleShadowMapCmp(
                     projectedTexCoords.xy + offset, cascadeIndex,
                     zReceiver);
@@ -466,7 +477,7 @@ float ComputeShadowValueDirect(float3 wsPosition, Texture2D shadowmap, SamplerCo
 {
 	// Reconstruct VS World ShadowViewPosition from depth
     float4 vShadowSamplingPos = mul(float4(wsPosition, 1), viewProj);
-    vShadowSamplingPos.xyz /= vShadowSamplingPos.www;
+    // vShadowSamplingPos.xyz /= vShadowSamplingPos.www; // no need for perspective divide, as this is an orthographic sun light
 	
     float2 projectedTexCoords = vShadowSamplingPos.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
     float shadow = 1.0f;
@@ -512,38 +523,43 @@ float ComputeShadowValue(float2 uv, float3 wsPosition, Texture2D shadowmap, Samp
 //--------------------------------------------------------------------------------------
 float ComputeCascadedShadowValueSoft(float3 wsPosition, float viewSpaceZ, float vertLighting, float bias, float2 screenPos)
 {
-    // Get cascade bounds info for all cascades
-    float4 cascadeInfo[NUM_CSM_CASCADES];
-    [unroll]
-    for (int i = 0; i < NUM_CSM_CASCADES; i++)
-    {
-        cascadeInfo[i] = GetCascadeUVAndBounds(wsPosition, i);
-    }
-    
     float shadow = vertLighting;
-    
     // Apply distance-based softness scaling
     // Shadows get slightly softer with distance (simulating penumbra growth)
     float distanceFactor = saturate(abs(viewSpaceZ) / 5000.0f);
     float softness = SQ_ShadowSoftness * (1.0f + distanceFactor * 0.5f);
-    
-    // Determine which cascade to use based on projection bounds
-    // Start with highest resolution cascade and fall back to lower ones
+
     [unroll]
     for (int c = 0; c < NUM_CSM_CASCADES; c++)
     {
-        if (cascadeInfo[c].z > 0.5f) // In bounds of this cascade
+        float4 vShadowPos;
+        float2 projCoords;
+        float inBounds;
+        float blendFactor;
+
+        GetCascadeUVAndBounds(wsPosition, c, vShadowPos, projCoords, inBounds, blendFactor);
+        
+        if (inBounds > 0.5f) 
         {
-            shadow = SampleCascadeShadowSoft(wsPosition, c, vertLighting, bias, screenPos, softness);
+            shadow = SampleCascadeShadowSoft(vShadowPos, projCoords, c, bias, screenPos, softness);
             
-            // Blend with next cascade near edges (if next cascade exists and has this pixel in bounds)
-            // Pure lerp avoids the darkening artifact that min() causes at transitions
-            if (c < NUM_CSM_CASCADES - 1 && cascadeInfo[c].w > 0.0f && cascadeInfo[c + 1].z > 0.5f)
+            // 3. Check if we need to blend with the next cascade
+            if (c < NUM_CSM_CASCADES - 1 && blendFactor > 0.0f)
             {
-                float shadowNext = SampleCascadeShadowSoft(wsPosition, c + 1, vertLighting, bias, screenPos, softness);
-                shadow = lerp(shadow, shadowNext, cascadeInfo[c].w);
+                float4 nextShadowPos;
+                float2 nextProjCoords;
+                float nextInBounds;
+                float nextBlendFactor;
+                
+                GetCascadeUVAndBounds(wsPosition, c + 1, nextShadowPos, nextProjCoords, nextInBounds, nextBlendFactor);
+                
+                if (nextInBounds > 0.5f)
+                {
+                    float shadowNext = SampleCascadeShadowSoft(nextShadowPos, nextProjCoords, c + 1, bias, screenPos, softness);
+                    shadow = lerp(shadow, shadowNext, blendFactor);
+                }
             }
-            break;
+            break; // Exit loop early once shadow is found
         }
     }
     
@@ -600,7 +616,10 @@ void ApplyRainNormalDeformation(inout float3 vsNormal, float3 wsPosition, inout 
 					  normalize((TX_Distortion.Sample(SS_Linear, uv[3]).xyz * 2 - 1))
     };
 		
-    weights = pow(weights, 4.0f);
+	// weights = pow(weights, 4.0f);
+	// inline "pow 4"
+	weights *= weights;
+	weights *= weights;
 		
     const float distWeight = 0.9f;
 	
@@ -632,12 +651,17 @@ void ApplySceneWettness(float3 wsPosition, float3 vsPosition, float3 vsDir, inou
     float3 nrm = vsNormal;
     float3 wsNormal;
     ApplyRainNormalDeformation(nrm, wsPosition, diffuse.rgb, wsNormal);
-    pixelWettnes *= 1 - pow(saturate(dot(wsNormal, float3(0, -1, 0))), 4.0f);
+
+    // pixelWettnes *= 1 - pow(saturate(dot(wsNormal, float3(0, -1, 0))), 4.0f);
+	// simplify pow
+	float wDot = saturate(dot(wsNormal, float3(0, -1, 0))); 
+	float wDot2 = wDot * wDot;
+	pixelWettnes *= 1.0f - (wDot2 * wDot2);
 	
     vsNormal = lerp(vsNormal, nrm, AC_RainFXWeight * pixelWettnes * 0.5f); // Only apply deformation if it's actually raining
 	
 	// Get fresnel-effect
-    float fresnel = pow(1.0f - max(0.0f, dot(vsNormal, -vsDir)), 160.0f);
+    // float fresnel = pow(1.0f - max(0.0f, dot(vsNormal, -vsDir)), 160.0f);
     
     	
 	//vsNormalCpy.z *= 0.3f;
@@ -753,7 +777,9 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	// Apply sunlight
     float sunStrength = dot(lightColor.rgb, float3(0.333f, 0.333f, 0.333f));
 	
-    float vertAO = lerp(pow(saturate(vertLighting * 2), 2), 1.0f, 0.5f);
+	float vl = saturate(vertLighting * 2);
+	float vertAO = lerp(vl * vl, 1.0f, 0.5f);
+
     float sun = saturate(dot(normalize(SQ_LightDirectionVS), normal) * shadow) * 1.0f;
 
     spec = pow(spec, specPower) * specIntensity;
@@ -767,7 +793,13 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 							diffuse.rgb * lightColor.rgb * lightColor.a * worldAO, sun)
 				  + specColored;
 	
-    float fresnel = pow(1.0f - saturate(dot(normal, V)), 10.0f);
+    float f = 1.0f - saturate(dot(normal, V));
+    // float fresnel = pow(f, 10.0f);
+	// use optimized pow alternative
+	float f2 = f*f;
+	float f4 = f2*f2;
+	float f8 = f4*f4; 
+	float fresnel = f8*f2;
     litPixel += lerp(fresnel * litPixel * 0.5f, 0.0f, sun);
 	
 	// Run scattering

--- a/D3D11Engine/Shaders/PS_PortalDiffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_PortalDiffuse.hlsl
@@ -24,10 +24,15 @@ struct PS_INPUT
 	float4 vPosition		: SV_POSITION;
 };
 
+struct PS_OUTPUT
+{
+	float4 vDiffuse : SV_TARGET0;
+};
+
 //--------------------------------------------------------------------------------------
 // Pixel Shader
 //--------------------------------------------------------------------------------------
-DEFERRED_PS_OUTPUT PSMain(PS_INPUT Input) : SV_TARGET
+PS_OUTPUT PSMain(PS_INPUT Input) : SV_TARGET
 {
 	//how far is the nameless hero from the object?
 	float distFromCamera = distance(Input.vViewPosition, Input.vPosition);
@@ -51,7 +56,7 @@ else if (AC_LightPos.y > 0.05f) { darknessFactor = 7.5f - (1 + AC_LightPos.y) * 
 float4 color = TX_Texture0.Sample(SS_Linear, Input.vTexcoord) / darknessFactor;
 
 //apply fade
-DEFERRED_PS_OUTPUT output;
+PS_OUTPUT output;
 output.vDiffuse = float4(color.rgb, percentageFade);
 
 return output;

--- a/D3D11Engine/Shaders/PS_WaterfallFoam.hlsl
+++ b/D3D11Engine/Shaders/PS_WaterfallFoam.hlsl
@@ -13,7 +13,12 @@ Texture2D	TX_Texture0 : register(t0);
 struct PS_INPUT
 {
 	float2 vTexcoord		: TEXCOORD0;
-	float3 vEyeRay			: TEXCOORD1;
+	float2 vTexcoord2		: TEXCOORD1;
+	float4 vDiffuse			: TEXCOORD2;
+	float3 vNormalVS		: TEXCOORD4;
+	float3 vViewPosition	: TEXCOORD5;
+	float4 vCurrClipPos     : TEXCOORD6;
+	float4 vPrevClipPos     : TEXCOORD7;
 	float4 vPosition		: SV_POSITION;
 };
 

--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -36,7 +36,7 @@
 using namespace DirectX;
 
 #ifndef VERSION_NUMBER
-#define VERSION_NUMBER "17.8-rev'SK9"
+#define VERSION_NUMBER "17.10-dev"
 #endif
 #ifndef BUILD_DATE
 #define BUILD_DATE __DATE__

--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -37,6 +37,7 @@ using namespace DirectX;
 
 #ifndef VERSION_NUMBER
 #define VERSION_NUMBER "17.10-dev"
+#define IS_DEV_BUILD
 #endif
 #ifndef BUILD_DATE
 #define BUILD_DATE __DATE__


### PR DESCRIPTION
- Fix shader linkage mismatch for PS_PortalDiffuse.hlsl & PS_WaterfallFoam.hlsl
- add overloads for `SetDebugName` with support for `wchar_t`
- improve performance of PS_DS_AtmosphericScattering a tiny bit by reducing [unroll] usage and making use of early-out in PCSS filtering, as well as reducing calculations a bit.
- Shader (re-)compilation overhaul
  - recompiling shaders now only happens for changed shaders. This includes timestamp of the shader file as well as all used shader macros for the compilation.
    reduces stutter/hangs when changing some settings that require shader recompilation.
- extract Upscaling renderpasses into a separate class `D3D11Upscaling` to reduce clutter in already way too big `D3D11GraphicsEngine.cpp`
- track timings for rendergraph passes. Required changing `TimerScope` to use `wchar_t` to re-use renderpass name which is also used in `RecordGraphicsEvent` which requires `wchar_t`
- `TimerScope` now uses `OneShotTimer` which reduces the overhead of timings.
- fix resource hazard after `D3D11GraphicsEngine::DrawFrameParticles` as some SRV was still bound but  used as RTV later
- fix default `FogRange` from `0.0f` to `1.0f`
- Hide Frame Statistics window in advanced settings (CTRL+F11) by default. Added new checkbox "Toggle frame stats" in General-Tab window
- Update Versioning for dev-builds to use "next" version and contain build-date information.
- fix quality presets: don't set `SmoothShadowFrequency` to 20000 on high/highest, as we already disable "smooth" (fixed) updates