### PR TITLE
block zCSkyControler::ClearBackground as it causes issues when viewport != window size (upscaling), batching stuff, fixing concurrency issue with dynamic lights

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -5627,7 +5627,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
         }
 
         GraphicsShaderConstantBuffer windBuffer = {};
-        if ( ActiveVS ) {
+        if ( ActiveVS && 
+            (Engine::GAPI->GetRendererState().RendererSettings.WindQuality > 0 || Engine::GAPI->GetRendererState().RendererSettings.HeroAffectsObjects) ) {
             windBuffer = ActiveVS->GetBuffer( "WindParams" );
             windBuffer.Bind();
         }
@@ -5644,118 +5645,136 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
 
         GetContext()->IASetVertexBuffers( 1, 1, buffers, dynuStride, dynOffset );
 
-        // Sort visuals by whether they need alpha testing to minimize shader switches
-        if ( alphaRef > 0.0f ) {
-            std::sort( activeVisuals.begin(), activeVisuals.end(), [alphaRef, colorWritesEnabled]( const MeshVisualInfo* a, const MeshVisualInfo* b ) {
-                return a->NeedsAlphaTesting < b->NeedsAlphaTesting || (a->NeedsAlphaTesting == b->NeedsAlphaTesting && a->Visual < b->Visual);
-            } );
-        } else {
-            std::sort( activeVisuals.begin(), activeVisuals.end(), [alphaRef, colorWritesEnabled]( const MeshVisualInfo* a, const MeshVisualInfo* b ) {
-                return a->Visual < b->Visual;
-            } );
-        }
-
         // Draw all vobs the player currently sees
         D3D11PShader* currPs = nullptr;
 
+        size_t numMeshesToDraw = 0;
         for ( auto const& staticMeshVisual : activeVisuals ) {
             if ( staticMeshVisual->Instances.empty() ) continue;
- 
-            g_windBuffer.minHeight = staticMeshVisual->BBox.Min.y;
-            g_windBuffer.maxHeight = staticMeshVisual->BBox.Max.y;
-
-            windBuffer.Update( &g_windBuffer );
-
-            bool doReset = true;
-            zCTexture* previousTx = nullptr;
             for ( auto const& itt : staticMeshVisual->MeshesByTexture ) {
                 std::vector<MeshInfo*>& mlist = staticMeshVisual->MeshesByTexture[itt.first];
                 if ( mlist.empty() ) continue;
-
-                // Check for alphablend
-                bool blendAdd =
-                    itt.first.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_ADD;
-                bool blendBlend =
-                    itt.first.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_BLEND;
-                // if one part of the mesh uses blending, all do, which means that
-                // the mesh likely is transparent and can't cast shadows
-                if ( !doReset || blendAdd || blendBlend ) {
-                    doReset = false;
-                    continue;
+                for ( unsigned int i = 0; i < mlist.size(); i++ ) {
+                    ++numMeshesToDraw;
                 }
+            }
+        }
+        std::vector<std::tuple<MeshVisualInfo*, MeshKey, MeshInfo*>> instancedMeshesToDraw;
+        instancedMeshesToDraw.reserve( numMeshesToDraw );
 
-                zCTexture* tx = itt.first.Texture;
-                bool bindTexture = previousTx != tx
-                    && tx
-                    && (tx->HasAlphaChannel() || colorWritesEnabled)
-                    && alphaRef > 0.0f;
+        for ( auto const& staticMeshVisual : activeVisuals ) {
+            if ( staticMeshVisual->Instances.empty() ) continue;
+            for ( auto const& itt : staticMeshVisual->MeshesByTexture ) {
+                const std::vector<MeshInfo*>& mlist = itt.second;
+                if ( mlist.empty() ) continue;
+                for ( unsigned int i = 0; i < mlist.size(); i++ ) {
+                    MeshInfo* mi = mlist[i];
+                    instancedMeshesToDraw.emplace_back( staticMeshVisual, itt.first, mi );
+                }
+            }
+        }
 
-                // Bind texture
-                if ( bindTexture ) {
+        std::sort( instancedMeshesToDraw.begin(), instancedMeshesToDraw.end(), []( const std::tuple<MeshVisualInfo*, MeshKey, MeshInfo*>& a, const std::tuple<MeshVisualInfo*, MeshKey, MeshInfo*>& b ) {
+            auto aTex = std::get<1>( a ).Texture;
+            auto bTex = std::get<1>( b ).Texture;
+
+            if ( aTex && bTex && aTex->HasAlphaChannel() != bTex->HasAlphaChannel() ) {
+                return aTex->HasAlphaChannel() < bTex->HasAlphaChannel();
+            }
+
+            if ( aTex != bTex ) {
+                return aTex < bTex;
+            }
+
+            return std::get<2>( a )->meshId < std::get<2>( b )->meshId;
+        } );
+
+        zCTexture* previousTx = nullptr;
+        ID3D11ShaderResourceView* lastNrmTex = nullptr;
+        ID3D11ShaderResourceView* lastFxTex = nullptr;
+
+        for ( auto const& [staticMeshVisual, meshKey, meshInfo] : instancedMeshesToDraw ) {
+            // Shadow wind buffer state
+            if ( std::abs( g_windBuffer.minHeight - staticMeshVisual->BBox.Min.y ) > 0.1f ||
+                std::abs( g_windBuffer.maxHeight - staticMeshVisual->BBox.Max.y ) > 0.1f ) {
+
+                g_windBuffer.minHeight = staticMeshVisual->BBox.Min.y;
+                g_windBuffer.maxHeight = staticMeshVisual->BBox.Max.y;
+                windBuffer.Update( &g_windBuffer );
+            }
+
+            zCTexture* tx = meshKey.Material->GetAniTexture();
+
+            bool bindTexture = tx
+                && (tx->HasAlphaChannel() || colorWritesEnabled || meshKey.Material->HasAlphaTest())
+                && alphaRef > 0.0f;
+
+            // Bind texture
+            if ( bindTexture ) {
+                if ( previousTx != tx ) {
                     if ( tx->CacheIn( 0.6f ) == zRES_CACHED_IN ) {
                         auto t = tx->GetSurface()->GetEngineTexture()->GetShaderResourceView().Get();
                         Context->PSSetShaderResources( 0, 1, &t );
-                        auto nextPs = ActivePS.get();
-                        if ( currPs != nextPs ) { 
+                        auto nextPs = defaultPS.get();
+                        if ( currPs != nextPs ) {
                             currPs = nextPs;
-                            ActivePS->Apply();
+                            currPs->Apply();
                         }
                         previousTx = tx;
                     } else
                         continue;
-                } else {
-                    if ( !linearDepth )  // Only unbind when not rendering linear depth
-                    {
-                        // Unbind PS
-                        if ( currPs != nullptr ) {
-                            Context->PSSetShader( nullptr, nullptr, 0 );
-                            currPs = nullptr;
-                        }
-                    }
                 }
 
-                for ( unsigned int i = 0; i < mlist.size(); i++ ) {
-
-                    MeshInfo* mi = mlist[i];
-
-                    // Draw batch
-
-                    /* Dont re-bind buffer all the time*/
-                    const auto vb = mi->MeshVertexBuffer;
-                    const auto ib = mi->MeshIndexBuffer;
-
-                    UINT offset[] = { 0 };
-                    UINT uStride[] = { sizeof( ExVertexStruct ) };
-                    ID3D11Buffer* buffers[1] = {
-                        vb->GetVertexBuffer().Get()
-                    };
-                    
-                    auto numIndices = mi->Indices.size();
-                    const auto numInstances = staticMeshVisual->Instances.size();
-                    const auto startInstanceNum = staticMeshVisual->StartInstanceNum;
-                    const auto indexOffset = 0;
-
-                    GetContext()->IASetVertexBuffers( 0, 1, buffers, uStride, offset );
-
-                    Context->IASetIndexBuffer( ib->GetVertexBuffer().Get(), VERTEX_INDEX_DXGI_FORMAT, 0 );
-
-                    unsigned int max =
-                        Engine::GAPI->GetRendererState().RendererSettings.MaxNumFaces * 3;
-                    numIndices = max != 0 ? (numIndices < max ? numIndices : max) : numIndices;
-
-                    // Draw the batch
-                    GetContext()->DrawIndexedInstanced( numIndices, numInstances, indexOffset, 0,
-                        startInstanceNum );
-
-                    Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnTriangles +=
-                        (numIndices / 3) * numInstances;
-
-                    Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnVobs++;
+            } else {
+                if ( !linearDepth )  // Only unbind when not rendering linear depth
+                {
+                    // Unbind PS
+                    if ( currPs != nullptr ) {
+                        Context->PSSetShader( nullptr, nullptr, 0 );
+                        currPs = nullptr;
+                    }
                 }
             }
 
-            // Reset visual
-            if ( doReset ) staticMeshVisual->StartNewFrame();
+            MeshInfo* mi = meshInfo;
+
+            // Draw batch
+
+            /* Dont re-bind buffer all the time*/
+            const auto vb = mi->MeshVertexBuffer;
+            const auto ib = mi->MeshIndexBuffer;
+
+            UINT offset[] = { 0 };
+            UINT uStride[] = { sizeof( ExVertexStruct ) };
+            ID3D11Buffer* buffers[1] = {
+                vb->GetVertexBuffer().Get()
+            };
+
+            auto numIndices = mi->Indices.size();
+            const auto numInstances = staticMeshVisual->Instances.size();
+            const auto startInstanceNum = staticMeshVisual->StartInstanceNum;
+            const auto indexOffset = 0;
+
+            GetContext()->IASetVertexBuffers( 0, 1, buffers, uStride, offset );
+
+            Context->IASetIndexBuffer( ib->GetVertexBuffer().Get(), VERTEX_INDEX_DXGI_FORMAT, 0 );
+
+            unsigned int max =
+                Engine::GAPI->GetRendererState().RendererSettings.MaxNumFaces * 3;
+            numIndices = max != 0 ? (numIndices < max ? numIndices : max) : numIndices;
+
+            // Draw the batch
+            GetContext()->DrawIndexedInstanced( numIndices, numInstances, indexOffset, 0,
+                startInstanceNum );
+
+            Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnTriangles +=
+                (numIndices / 3) * numInstances;
+
+            Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnVobs++;
+        }
+
+        for ( auto [_, sm] : Engine::GAPI->GetStaticMeshVisuals() ) {
+            sm->Instances.clear();
         }
     }
 
@@ -5939,7 +5958,8 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
         SetupVS_ExConstantBuffer();
 
         GraphicsShaderConstantBuffer windBuffer = {};
-        if ( ActiveVS ) {
+        if ( ActiveVS &&
+            (Engine::GAPI->GetRendererState().RendererSettings.WindQuality > 0 || Engine::GAPI->GetRendererState().RendererSettings.HeroAffectsObjects) ) {
             windBuffer = ActiveVS->GetBuffer("WindParams");
             windBuffer.Bind();
         }
@@ -6026,9 +6046,54 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                 .Bind();
 
             MaterialInfo* lastMatInfo = nullptr;
+
+            size_t numMeshesToDraw = 0;
             for ( auto const& staticMeshVisual : activeVisuals ) {
                 if ( staticMeshVisual->Instances.empty() ) continue;
+                for ( auto const& itt : staticMeshVisual->MeshesByTexture ) {
+                    std::vector<MeshInfo*>& mlist = staticMeshVisual->MeshesByTexture[itt.first];
+                    if ( mlist.empty() ) continue;
+                    for ( unsigned int i = 0; i < mlist.size(); i++ ) {
+                        ++numMeshesToDraw;
+                    }
+                }
+            }
+            std::vector<std::tuple<MeshVisualInfo*, MeshKey, MeshInfo*>> instancedMeshesToDraw;
+            instancedMeshesToDraw.reserve( numMeshesToDraw );
 
+            for ( auto const& staticMeshVisual : activeVisuals ) {
+                if ( staticMeshVisual->Instances.empty() ) continue;
+                for ( auto const& itt : staticMeshVisual->MeshesByTexture ) {
+                    const std::vector<MeshInfo*>& mlist = itt.second;
+                    if ( mlist.empty() ) continue;
+                    for ( unsigned int i = 0; i < mlist.size(); i++ ) {
+                        MeshInfo* mi = mlist[i];
+                        instancedMeshesToDraw.emplace_back( staticMeshVisual, itt.first, mi );
+                    }
+                }
+            }
+
+            std::sort( instancedMeshesToDraw.begin(), instancedMeshesToDraw.end(), []( const std::tuple<MeshVisualInfo*, MeshKey, MeshInfo*>& a, const std::tuple<MeshVisualInfo*, MeshKey, MeshInfo*>& b ) {
+                auto aTex = std::get<1>( a ).Texture;
+                auto bTex = std::get<1>( b ).Texture;
+
+                if ( aTex && bTex && aTex->HasAlphaChannel() != bTex->HasAlphaChannel() ) {
+                    return aTex->HasAlphaChannel() < bTex->HasAlphaChannel();
+                }
+
+                if ( aTex != bTex ) {
+                    return aTex < bTex;
+                }
+
+                return std::get<2>(a)->meshId < std::get<2>( b )->meshId;
+            } );
+
+
+            zCTexture* lastTex = nullptr;
+            ID3D11ShaderResourceView* lastNrmTex = nullptr;
+            ID3D11ShaderResourceView* lastFxTex = nullptr;
+
+            for ( auto const& [staticMeshVisual, meshKey, meshInfo] : instancedMeshesToDraw ) {
                 float expectedSmallRadius = renderSettings.OutdoorSmallVobDrawRadius - staticMeshVisual->MeshSize;
                 float expectedVobRadius = renderSettings.OutdoorVobDrawRadius - staticMeshVisual->MeshSize;
 
@@ -6059,133 +6124,115 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                     windBuffer.Update( &g_windBuffer );
                 }
 
-                bool doReset = true;  // Don't reset alpha-vobs here
-                for ( auto const& itt : staticMeshVisual->MeshesByTexture ) {
-                    const std::vector<MeshInfo*>& mlist = itt.second;
-                    if ( mlist.empty() ) continue;
-                    {
-                        // Check for alphablending on vob mesh
-                        bool blendAdd = itt.first.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_ADD;
-                        bool blendBlend = itt.first.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_BLEND;
-                        if ( !doReset || blendAdd || blendBlend ) {
-                            MeshVisualInfo* info = staticMeshVisual;
-                            for ( MeshInfo* mesh : mlist ) {
-                                AlphaMeshData data = {};
-                                data.mk = itt.first;
-                                data.vi = info;
-                                data.mi = mesh;
-                                // TODO: only store this once!
-                                // but as of now, this only seems to happen VERY rarely
-                                // and the only usage i found was a bug (?) in pirates camp
-                                // where there would be cobwebs randomly.
-                                data.instances = staticMeshVisual->Instances;
-                                m_AlphaMeshes.emplace_back( data );
-                            }
+                zCTexture* tx = meshKey.Material->GetAniTexture();
 
-                            doReset = false;
-                            continue;
-                        }
-                    }
-
-                    zCTexture* tx = itt.first.Material->GetAniTexture();
-
-                    if ( !tx ) {
+                if ( !tx ) {
 #ifndef BUILD_SPACER_NET
 #ifndef BUILD_SPACER
-                        continue;  // Don't render meshes without texture if not in spacer
+                    continue;  // Don't render meshes without texture if not in spacer
 #else
-                        // This is most likely some spacer helper-vob
+                    // This is most likely some spacer helper-vob
+                    WhiteTexture->BindToPixelShader( 0 );
+                    ShaderManager->GetPShader( PShaderID::PS_Diffuse )->Apply();
+
+                    /*// Apply colors for these meshes
+                    MaterialInfo::Buffer b;
+                    ZeroMemory(&b, sizeof(b));
+                    b.Color = itt->first.Material->GetColor();
+                    PS_Diffuse->GetConstantBuffer()[2]->UpdateBuffer(&b);
+                    PS_Diffuse->GetConstantBuffer()[2]->BindToPixelShader(2);*/
+#endif
+#else
+                    if ( !renderSettings.RunInSpacerNet ) {
+                        continue;
+                    }
+                    bool showHelpers = *reinterpret_cast<int*>(GothicMemoryLocations::zCVob::s_ShowHelperVisuals) != 0;
+
+                    if ( showHelpers ) {
                         WhiteTexture->BindToPixelShader( 0 );
-                        ShaderManager->GetPShader( PShaderID::PS_Diffuse )->Apply();
+                        ShaderManager->GetPShader( PShaderID::PS_DiffuseAlphaTest )->Apply();
 
-                        /*// Apply colors for these meshes
-                        MaterialInfo::Buffer b;
-                        ZeroMemory(&b, sizeof(b));
-                        b.Color = itt->first.Material->GetColor();
-                        PS_Diffuse->GetConstantBuffer()[2]->UpdateBuffer(&b);
-                        PS_Diffuse->GetConstantBuffer()[2]->BindToPixelShader(2);*/
-#endif
-#else
-                        if ( !renderSettings.RunInSpacerNet ) {
-                            continue;
-                        }
-                        bool showHelpers = *reinterpret_cast<int*>(GothicMemoryLocations::zCVob::s_ShowHelperVisuals) != 0;
+                        MaterialInfo::Buffer b = {};
 
-                        if ( showHelpers ) {
-                            WhiteTexture->BindToPixelShader( 0 );
-                            ShaderManager->GetPShader( PShaderID::PS_DiffuseAlphaTest )->Apply();
+                        b.Color = itt.first.Material->GetColor();
+                        ShaderManager->GetPShader( PShaderID::PS_DiffuseAlphaTest )->GetBuffer( "MI_MaterialInfo" ).Update( &b ).Bind();
 
-                            MaterialInfo::Buffer b = {};
-
-                            b.Color = itt.first.Material->GetColor();
-                            ShaderManager->GetPShader( PShaderID::PS_DiffuseAlphaTest )->GetBuffer( "MI_MaterialInfo" ).Update( &b ).Bind();
-
-                        } else {
-                            continue;
-                        }
-
-#endif
                     } else {
-                        // Bind texture
-                        if ( tx->CacheIn( 0.6f ) == zRES_CACHED_OUT ) {
-                            continue;
-                        }
-
-                        MyDirectDrawSurface7* surface = tx->GetSurface();
-                        ID3D11ShaderResourceView* srv[3];
-                        MaterialInfo* info = itt.first.Info;
-
-                        // Get diffuse and normalmap
-                        srv[0] = surface->GetEngineTexture()->GetShaderResourceView().Get();
-                        srv[1] = surface->GetNormalmap()
-                            ? surface->GetNormalmap()->GetShaderResourceView().Get()
-                            : nullptr;
-                        srv[2] = surface->GetFxMap()
-                            ? surface->GetFxMap()->GetShaderResourceView().Get()
-                            : nullptr;
-
-                        // Bind a default normalmap in case the scene is wet and we
-                        // currently have none
-                        if ( !srv[1] ) {
-                            // Modify the strength of that default normalmap for the
-                            // material info
-                            if ( info->buffer.NormalmapStrength
-                                != DEFAULT_NORMALMAP_STRENGTH ) {
-                                // update values for distortion texture
-                                info->buffer.NormalmapStrength = DEFAULT_NORMALMAP_STRENGTH;
-                                info->UpdateConstantbuffer();
-                                lastMatInfo = info;
-                            }
-                            srv[1] = DistortionTexture->GetShaderResourceView().Get();
-                        }
-                        // Bind both
-                        GetContext()->PSSetShaderResources( 0, 3, srv );
-
-                        // Force alphatest on vobs for now
-                        BindShaderForTexture( tx, true, 0 );
-
-                            if ( info && !info->IsSame( lastMatInfo ) ) {
-                            	if ( !info->Constantbuffer ) info->UpdateConstantbuffer();
-                            	info->Constantbuffer->BindToPixelShader( materialInfoSlot );
-                                lastMatInfo = info;
-                            }
+                        continue;
                     }
 
-                    for ( unsigned int i = 0; i < mlist.size(); i++ ) {
-                        MeshInfo* mi = mlist[i];
+#endif
+                } else {
+                    // Bind texture
+                    if ( tx->CacheIn( 0.6f ) == zRES_CACHED_OUT ) {
+                        continue;
+                    }
 
-                        // Draw batch
-                        DrawInstanced( mi->MeshVertexBuffer, mi->MeshIndexBuffer,
-                            mi->Indices.size(), DynamicInstancingBuffer.get(),
-                            sizeof( VobInstanceInfo ), staticMeshVisual->Instances.size(),
-                            sizeof( ExVertexStruct ), staticMeshVisual->StartInstanceNum );
+                    MyDirectDrawSurface7* surface = tx->GetSurface();
+                    ID3D11ShaderResourceView* srv[3];
+                    MaterialInfo* info = meshKey.Info;
+
+                    // Get diffuse and normalmap
+                    srv[0] = surface->GetEngineTexture()->GetShaderResourceView().Get();
+                    srv[1] = surface->GetNormalmap()
+                        ? surface->GetNormalmap()->GetShaderResourceView().Get()
+                        : nullptr;
+                    srv[2] = surface->GetFxMap()
+                        ? surface->GetFxMap()->GetShaderResourceView().Get()
+                        : nullptr;
+
+                    // Bind a default normalmap in case the scene is wet and we
+                    // currently have none
+                    if ( !srv[1] ) {
+                        // Modify the strength of that default normalmap for the
+                        // material info
+                        if ( info->buffer.NormalmapStrength
+                            != DEFAULT_NORMALMAP_STRENGTH ) {
+                            // update values for distortion texture
+                            info->buffer.NormalmapStrength = DEFAULT_NORMALMAP_STRENGTH;
+                            info->UpdateConstantbuffer();
+                            lastMatInfo = info;
+                        }
+                        srv[1] = DistortionTexture->GetShaderResourceView().Get();
+                    }
+                    if ( lastTex != tx 
+                        || lastNrmTex != srv[1]
+                        || lastFxTex != srv[2] ) {
+
+                        lastTex = tx;
+                        lastNrmTex = srv[1];
+                        lastFxTex = srv[2];
+                        
+                        GetContext()->PSSetShaderResources( 0, 3, srv );
+                    
+                         // Force alphatest on vobs for now
+                        BindShaderForTexture( tx, true, 0 );
+                    }
+
+                    if ( info && !info->IsSame( lastMatInfo ) ) {
+                        if ( !info->Constantbuffer ) info->UpdateConstantbuffer();
+                        info->Constantbuffer->BindToPixelShader( materialInfoSlot );
+                        lastMatInfo = info;
                     }
                 }
 
-                // Reset visual
-                if ( doReset &&
-                    !renderSettings.FixViewFrustum ) {
-                    staticMeshVisual->StartNewFrame();
+                // Draw batch
+                DrawInstanced( meshInfo->MeshVertexBuffer, meshInfo->MeshIndexBuffer,
+                    meshInfo->Indices.size(), DynamicInstancingBuffer.get(),
+                    sizeof( VobInstanceInfo ), staticMeshVisual->Instances.size(),
+                    sizeof( ExVertexStruct ), staticMeshVisual->StartInstanceNum );
+            }
+            for ( auto sm : activeVisuals ) {
+                bool clear = true;
+                for ( auto& [meshKey, _] : sm->MeshesByTexture ) {
+                    if ( meshKey.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_BLEND ||
+                        meshKey.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_ADD ) {
+                        clear = false;
+                        break;
+                    }
+                }
+                if ( clear ) {
+                    sm->Instances.clear();
                 }
             }
         }
@@ -6265,7 +6312,8 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
     }
 
     GraphicsShaderConstantBuffer windBuffer = {};
-    if ( ActiveVS ) {
+    if ( ActiveVS &&
+        (Engine::GAPI->GetRendererState().RendererSettings.WindQuality > 0 || Engine::GAPI->GetRendererState().RendererSettings.HeroAffectsObjects) ) {
         windBuffer = ActiveVS->GetBuffer( "WindParams" );
         windBuffer.Bind();
     }

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -6154,7 +6154,7 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
 
                         MaterialInfo::Buffer b = {};
 
-                        b.Color = itt.first.Material->GetColor();
+                        b.Color = meshKey.Material->GetColor();
                         ShaderManager->GetPShader( PShaderID::PS_DiffuseAlphaTest )->GetBuffer( "MI_MaterialInfo" ).Update( &b ).Bind();
 
                     } else {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2061,10 +2061,15 @@ XRESULT D3D11GraphicsEngine::DrawVertexBufferFF( D3D11VertexBuffer* vb,
 
 /** Sets up texture with normalmap and fxmap for rendering */
 bool D3D11GraphicsEngine::BindTextureNRFX( zCTexture* tex, bool bindShader, bool updateMaterialInfo ) {
-    if ( tex->CacheIn( 0.6f ) == zRES_CACHED_IN ) 
-        tex->Bind( 0 );
-    else
+    if ( tex->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
         return false;
+    }
+
+    ID3D11ShaderResourceView* srvs[3] = {
+        tex->GetSurface()->GetEngineTexture()->GetShaderResourceView().Get(),
+        nullptr, 
+        nullptr,
+    };
 
     MaterialInfo* info = nullptr;
     if ( updateMaterialInfo ) {
@@ -2081,20 +2086,24 @@ bool D3D11GraphicsEngine::BindTextureNRFX( zCTexture* tex, bool bindShader, bool
     }
 
     // Bind a default normalmap in case the scene is wet and we currently have none
-    if ( !tex->GetSurface()->GetNormalmap() ) {
+    if ( D3D11Texture* nrm = tex->GetSurface()->GetNormalmap() ) {
         // Modify the strength of that default normalmap for the material info
+        srvs[1] = nrm->GetShaderResourceView().Get();
+    } else {
         if ( info &&
             info->buffer.NormalmapStrength != DEFAULT_NORMALMAP_STRENGTH ) {
             info->buffer.NormalmapStrength = DEFAULT_NORMALMAP_STRENGTH;
             info->UpdateConstantbuffer();
         }
-
-        DistortionTexture->BindToPixelShader( 1 );
+        srvs[1] = DistortionTexture->GetShaderResourceView().Get();
     }
 
     if ( D3D11Texture* fxmap = tex->GetSurface()->GetFxMap() ) {
+        srvs[2] = fxmap->GetShaderResourceView().Get();
         fxmap->BindToPixelShader( 2 );
     }
+
+    GetContext()->PSSetShaderResources( 0, 3, srvs );
 
     // Select shader
     if ( bindShader ) {
@@ -6016,6 +6025,7 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                 .Update( &Engine::GAPI->GetRendererState().GraphicsState )
                 .Bind();
 
+            MaterialInfo* lastMatInfo = nullptr;
             for ( auto const& staticMeshVisual : activeVisuals ) {
                 if ( staticMeshVisual->Instances.empty() ) continue;
 
@@ -6139,11 +6149,12 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                         if ( !srv[1] ) {
                             // Modify the strength of that default normalmap for the
                             // material info
-                            if ( info->buffer.NormalmapStrength /* *
-                                                      Engine::GAPI->GetSceneWetness()*/
+                            if ( info->buffer.NormalmapStrength
                                 != DEFAULT_NORMALMAP_STRENGTH ) {
+                                // update values for distortion texture
                                 info->buffer.NormalmapStrength = DEFAULT_NORMALMAP_STRENGTH;
                                 info->UpdateConstantbuffer();
+                                lastMatInfo = info;
                             }
                             srv[1] = DistortionTexture->GetShaderResourceView().Get();
                         }
@@ -6153,9 +6164,11 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                         // Force alphatest on vobs for now
                         BindShaderForTexture( tx, true, 0 );
 
-                        if ( !info->Constantbuffer ) info->UpdateConstantbuffer();
-
-                        info->Constantbuffer->BindToPixelShader( materialInfoSlot );
+                            if ( info && !info->IsSame( lastMatInfo ) ) {
+                            	if ( !info->Constantbuffer ) info->UpdateConstantbuffer();
+                            	info->Constantbuffer->BindToPixelShader( materialInfoSlot );
+                                lastMatInfo = info;
+                            }
                     }
 
                     for ( unsigned int i = 0; i < mlist.size(); i++ ) {

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -281,7 +281,14 @@ void D3D11PointLight::StartReInit() {
         InitDone = false;
 
         // Add to queue
-        Engine::WorkerThreadPool->enqueue( [this] { InitResources(); } );
+        Engine::WorkerThreadPool->enqueue( [this] (const CancellationToken& token)
+        {
+            if (token.isCancelled()) {
+                InitDone = true;
+                return;
+            }
+            InitResources();
+        } );
 
     } else {
         InitResources();

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -15,6 +15,10 @@ const float LIGHT_COLORCHANGE_POS_MOD = 0.1f;
 D3D11PointLight::D3D11PointLight( VobLightInfo* info, bool dynamicLight ) {
     LightInfo = info;
     DynamicLight = dynamicLight;
+    
+    // Ensure this light is actually in the VobLightMap
+    // some lights don't seem to be in here!
+    Engine::GAPI->VobLightMap[info->Vob] = info;
 
     XMStoreFloat3( &LastUpdatePosition, LightInfo->Vob->GetPositionWorldXM() );
 
@@ -28,7 +32,9 @@ D3D11PointLight::D3D11PointLight( VobLightInfo* info, bool dynamicLight ) {
 
 D3D11PointLight::~D3D11PointLight() {
     // Make sure we are out of the init-queue
-    while ( !InitDone );
+    while ( !InitDone.load() ) {
+        std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+    }
 
     ClearTiledSlot();
     ReleaseShadowMap();
@@ -94,7 +100,12 @@ bool D3D11PointLight::NotYetDrawn() {
 
 /** Initializes the resources of this light */
 void D3D11PointLight::InitResources() {
-    D3D11GraphicsEngineBase* engine = reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine);
+    InitDone = false;
+    if (!LightInfo || !LightInfo->Vob) {
+        // Light got removed before we could init, just return
+        InitDone = true;
+        return;
+    }
 
     //Engine::GAPI->EnterResourceCriticalSection();
 
@@ -333,6 +344,13 @@ void D3D11PointLight::OnVobRemovedFromWorld( BaseVobInfo* vob ) {
         VobCache.clear();
         SkeletalVobCache.clear();
         DrawnOnce = false;
+    }
+
+    if (vob->Vob == LightInfo->Vob) {
+        // Our light got removed, release shadowmap
+        ReleaseShadowMap();
+        ClearTiledSlot();
+        LightInfo->Vob = nullptr;
     }
 
     //Engine::GAPI->LeaveResourceCriticalSection();

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -18,7 +18,7 @@ class D3D11ConstantBuffer;
 class D3D11PointLight : public BaseShadowedPointLight {
 public:
     D3D11PointLight( VobLightInfo* info, bool dynamicLight = false );
-    ~D3D11PointLight();
+    ~D3D11PointLight() override;
 
     /** Initializes the resources of this light */
     void InitResources();

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -48,6 +48,7 @@
 // TODO: REMOVE THIS!
 #include "D3D11GraphicsEngine.h"
 #include "MeshManager.h"
+#include "Threadpool.h"
 
 #ifndef PUBLIC_RELEASE
 #define OPT_DBG_NOINLINE __declspec(noinline)
@@ -711,9 +712,8 @@ void GothicAPI::RemoveVegetationBox( GVegetationBox* box ) {
 
 /** Resets the object, like at level load */
 void GothicAPI::ResetWorld() {
-    WorldSections.clear();
-
     ResetVobs();
+    WorldSections.clear();
 
     SAFE_DELETE( WrappedWorldMesh );
 
@@ -735,6 +735,18 @@ void GothicAPI::ReloadPlayerVob() {
 }
 /** Resets only the vobs */
 void GothicAPI::ResetVobs() {
+    
+    // complete what ever is currently working, and clear everything else.
+    Engine::WorkerThreadPool->clearAndFlush();
+    
+    // Delete light vobs, those depend on world sections and load stuff in the background.
+    // by deleting them first we block the thread until the destructor finished
+    for ( auto const& it : VobLightMap ) {
+        Engine::GraphicsEngine->OnVobRemovedFromWorld( it.first );
+        delete it.second;
+    }
+    VobLightMap.clear();
+    
     // Clear sections
     for ( auto&& itx : Engine::GAPI->GetWorldSections() ) {
         for ( auto&& ity : itx.second ) {
@@ -788,13 +800,6 @@ void GothicAPI::ResetVobs() {
     }
     SkeletalMeshVobs.clear();
     AnimatedSkeletalVobs.clear();
-
-    // Delete light vobs
-    for ( auto const& it : VobLightMap ) {
-        Engine::GraphicsEngine->OnVobRemovedFromWorld( it.first );
-        delete it.second;
-    }
-    VobLightMap.clear();
 }
 
 /** Called when the game loaded a new level */

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4408,19 +4408,31 @@ void GothicAPI::ResetMaterialInfo() {
 /** Returns the material info associated with the given material */
 MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex ) {
     auto it = MaterialInfos.find( tex );
+    MaterialInfo* mi = nullptr;
     if ( it == MaterialInfos.end() && tex ) {
         // Make a new one and try to load it
         MaterialInfos[tex].LoadFromFile( tex->GetNameWithoutExt() );
+        mi = &MaterialInfos[tex];
+        if ( std::string_view{ tex->__GetName().ToChar() } == "NW_MISC_FULLALPHA_01.TGA" ) {
+            mi->MaterialType = MaterialInfo::MT_FullAlpha;
+        }
+    } else {
+        mi = &it->second;
     }
 
-    return &MaterialInfos[tex];
+    return mi;
 }
 
 MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex, const std::string& textureName ) {
     auto it = MaterialInfos.find( tex );
+    
+    MaterialInfo* mi = nullptr;
     if ( it == MaterialInfos.end() && tex ) {
         // Make a new one and try to load it
-        MaterialInfos[tex].LoadFromFile( textureName );
+        mi = &MaterialInfos[tex];
+        mi->LoadFromFile( textureName );
+    } else {
+        mi = &it->second;
     }
 
     return &MaterialInfos[tex];
@@ -5140,12 +5152,26 @@ void GothicAPI::DrawMorphMesh( zCMorphMesh* msh, std::map<zCMaterial*, std::vect
         
     // Ensure to call `WorldConverter::UpdateMorphMeshVisual( ... );` once per frame for this mesh to update the vertex buffers before drawing.
 
+    D3D11GraphicsEngine* g = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+
+    const bool isZPrepass = g->GetRenderingStage() == DES_Z_PRE_PASS;
+    const bool bindShader = g->GetRenderingStage() == DES_MAIN || isZPrepass;
+
+    zCTexture* lastTex = nullptr;
     for ( int i = 0; i < morphMesh->GetNumSubmeshes(); i++ ) {
         zCSubMesh* s = morphMesh->GetSubmesh( i );
         if ( zCTexture* texture = s->Material->GetAniTexture() ) {
-            D3D11GraphicsEngine* g = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
-            if ( !g->BindTextureNRFX( texture, (g->GetRenderingStage() == DES_MAIN || g->GetRenderingStage() == DES_Z_PRE_PASS) ) )
-                continue;
+            if ( lastTex != texture ) {
+                if ( texture->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
+                    continue;
+                }
+                lastTex = texture;
+                if ( isZPrepass ) {
+                    texture->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
+                } else if ( !g->BindTextureNRFX( texture, bindShader ) ) {
+                    continue;
+                }
+            }
         }
 
         for ( auto const& it : meshes ) {

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -150,7 +150,8 @@ struct MaterialInfo {
         MT_Water,
         MT_Ocean,
         MT_Portal,
-        MT_WaterfallFoam
+        MT_WaterfallFoam,
+        MT_FullAlpha, // why does this exist "NW_MISC_FULLALPHA_01" ?? This is just a block of nothing
     };
 
     MaterialInfo() :
@@ -183,8 +184,15 @@ struct MaterialInfo {
         float SpecularPower;
         float NormalmapStrength;
         float DisplacementFactor;
-
         float4 Color;
+
+        bool operator==( const Buffer& other ) const noexcept {
+            return SpecularIntensity == other.SpecularIntensity &&
+                SpecularPower == other.SpecularPower &&
+                NormalmapStrength == other.NormalmapStrength &&
+                DisplacementFactor == other.DisplacementFactor &&
+                Color == other.Color;
+        }
     };
 
     /** creates/updates the constantbuffer */
@@ -195,6 +203,13 @@ struct MaterialInfo {
     PShaderID PixelShader;
     EMaterialType MaterialType;
     Buffer buffer;
+
+    bool IsSame( MaterialInfo* other ) {
+        if ( other == nullptr ) return false;
+        return PixelShader == other->PixelShader
+            && MaterialType == other->MaterialType
+            && buffer == other->buffer;
+    }
 };
 
 struct ParticleFrameData {

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -770,7 +770,7 @@ struct GothicRendererSettings {
         DebugSettings = {};
         DebugSettings.Culling.CullBspSections = true;
         DebugSettings.Culling.CullVobs = true;
-        DebugSettings.ShadowCascades.LazyCascadeUpdate = false;
+        DebugSettings.ShadowCascades.LazyCascadeUpdate = true;
     }
 
     void SetupOldWorldSpecificValues() {

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -177,6 +177,7 @@ struct GothicMemoryLocations {
         static const unsigned int VTBL_RenderSkyPre = 20; //0x50 / 4
         static const unsigned int VTBL_RenderSkyPost = 21;
         static const unsigned int static_skyEffectsEnabled = 0x8422A0; // int*
+        static const unsigned int ClearBackground = 0x005ba2f0;
     };
 
     struct zCParticleEmitter {

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -148,6 +148,7 @@ struct GothicMemoryLocations {
         static const unsigned int VTBL_RenderSkyPre = 20;
         static const unsigned int VTBL_RenderSkyPost = 21;
         static const unsigned int static_skyEffectsEnabled = 0x887EDC; // int*
+        static const unsigned int ClearBackground = 0;
     };
 
     struct zCParticleEmitter {

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -237,6 +237,7 @@ struct GothicMemoryLocations {
         static const unsigned int VTBL_RenderSkyPre = 27; //0x6C / 4
         static const unsigned int VTBL_RenderSkyPost = 28;
         static const unsigned int static_skyEffectsEnabled = 0x8A5DB0; // int*
+        static const unsigned int ClearBackground = 0x005df930;
     };
 
     struct zCParticleEmitter {

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -125,6 +125,7 @@ struct GothicMemoryLocations {
     struct zCSkyController {
         static const unsigned int VTBL_RenderSkyPre = 27; //0x6C / 4
         static const unsigned int VTBL_RenderSkyPost = (0x78 / 4);
+        static const unsigned int ClearBackground = 0;
     };
 
     struct zCParticleEmitter {

--- a/D3D11Engine/HookedFunctions.h
+++ b/D3D11Engine/HookedFunctions.h
@@ -97,6 +97,8 @@ typedef void( __cdecl* oCItemContainer__Container_Draw )();
 typedef void( __thiscall* zCCamera__Activate )(void*);
 typedef void( __thiscall* zCCamera__UpdateViewport )(void*);
 
+typedef void( __thiscall* zCSkyControler_ClearBackground )(void*, zColor);
+
 struct zTRndSurfaceDesc;
 struct HookedFunctionInfo {
 
@@ -182,6 +184,7 @@ struct HookedFunctionInfo {
     zCModelGetLowestLODPoly original_zCModelGetLowestLODPoly = reinterpret_cast<zCModelGetLowestLODPoly>(GothicMemoryLocations::zCModel::GetLowestLODPoly);
 #endif
     zCInput_Win32__GetKey original_zCInput_Win32__GetKey = reinterpret_cast<zCInput_Win32__GetKey>(GothicMemoryLocations::zCInput_Win32::GetKey);
+    zCSkyControler_ClearBackground original_zCSkyControler_ClearBackground = reinterpret_cast<zCSkyControler_ClearBackground>(GothicMemoryLocations::zCSkyController::ClearBackground);
     //zCModelPrototypeLoadModelASC original_zCModelPrototypeLoadModelASC = reinterpret_cast<zCModelPrototypeLoadModelASC>(GothicMemoryLocations::zCModelPrototype::LoadModelASC);
     //zCModelPrototypeReadMeshAndTreeMSB original_zCModelPrototypeReadMeshAndTreeMSB = reinterpret_cast<zCModelPrototypeReadMeshAndTreeMSB>(GothicMemoryLocations::zCModelPrototype::ReadMeshAndTreeMSB);
 

--- a/D3D11Engine/ThreadPool.h
+++ b/D3D11Engine/ThreadPool.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <iostream>
 #include <deque>
 #include <functional>
 #include <thread>
@@ -10,114 +9,178 @@
 #include <vector>
 #include <queue>
 #include <memory>
-#include <thread>
-#include <mutex>
-#include <condition_variable>
 #include <future>
-#include <functional>
 #include <stdexcept>
+#include <algorithm>
+#include <utility>
 
-class ThreadPool {
-public:
-    ThreadPool( 
-	    const wchar_t* poolIdentifier,
-	    size_t threads = std::clamp(std::thread::hardware_concurrency(), static_cast<size_t>(1), static_cast<size_t>(4) ) );
-
-	template<class F, class... Args>
-	auto enqueue( F&& f, Args&&... args )
-		->std::future<typename std::invoke_result<F, Args...>::type>;
-	~ThreadPool();
-
-	size_t getNumThreads() { return numThreads; }
-    bool getIsBusy() {
-	    std::unique_lock<std::mutex> lock(queue_mutex);
-	    return !tasks.empty() || activeTasks.load() > 0;
-    }
-    void clearAndFlush() {
-        while ( getIsBusy() ) {
-            std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
-        }
-    }
+class CancellationToken
+{
 private:
-	// need to keep track of threads so we can join them
-	std::vector< std::thread > workers;
-	// the task queue
-	std::queue< std::function<void()> > tasks;
+    std::shared_ptr<std::atomic<bool>> cancelledFlag;
 
-	// synchronization
-    std::atomic_int activeTasks;
-	std::mutex queue_mutex;
-	std::condition_variable condition;
-	bool stop;
-	size_t numThreads;
+public:
+    CancellationToken() : cancelledFlag(std::make_shared<std::atomic<bool>>(false))
+    {
+    }
+
+    bool isCancelled() const
+    {
+        return cancelledFlag->load(std::memory_order_acquire);
+    }
+
+    void cancel()
+    {
+        cancelledFlag->store(true, std::memory_order_release);
+    }
 };
 
-// the constructor just launches some amount of workers
-inline ThreadPool::ThreadPool( const wchar_t* poolIdentifier, size_t threads )
-	: stop( false ) {
-	numThreads = threads;
+template <typename T>
+struct TaskHandle
+{
+    std::future<T> future;
+    CancellationToken token;
+
+    void cancel()
+    {
+        token.cancel();
+    }
+};
+
+class ThreadPool
+{
+public:
+    ThreadPool(
+        const wchar_t* poolIdentifier,
+        size_t threads = std::clamp(static_cast<size_t>(std::thread::hardware_concurrency()), static_cast<size_t>(1),
+                                    static_cast<size_t>(4)));
+
+    // 3. enqueue returns a TaskHandle and expects 'F' to accept CancellationToken as its first param
+    template <class F, class... Args>
+    auto enqueue(F&& f, Args&&... args)
+        -> TaskHandle<typename std::invoke_result<F, CancellationToken, Args...>::type>;
+
+    ~ThreadPool();
+
+    size_t getNumThreads() { return numThreads; }
+
+    bool getIsBusy()
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+        return !tasks.empty() || activeTasks.load() > 0;
+    }
+
+    void clearAndFlush()
+    {
+        // Swap out the tasks quickly to minimize mutex lock time
+        std::queue<std::pair<std::function<void()>, CancellationToken>> pending_tasks;
+        {
+            std::unique_lock<std::mutex> lock(queue_mutex);
+            std::swap(tasks, pending_tasks);
+        }
+
+        // Cancel and invoke all pending tasks so promises are fulfilled gracefully
+        while (!pending_tasks.empty())
+        {
+            auto& taskItem = pending_tasks.front();
+            taskItem.second.cancel(); // Trigger the cancellation state
+            taskItem.first(); // Invoke the task, assume it will immediately return.
+            pending_tasks.pop();
+        }
+
+        // Wait for actively running tasks to finish
+        while (getIsBusy()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+private:
+    std::vector<std::thread> workers;
+    std::queue<std::pair<std::function<void()>, CancellationToken>> tasks;
+
+    std::atomic_int activeTasks{0};
+    std::mutex queue_mutex;
+    std::condition_variable condition;
+    bool stop;
+    size_t numThreads;
+};
+
+inline ThreadPool::ThreadPool(const wchar_t* poolIdentifier, size_t threads)
+    : stop(false)
+{
+    numThreads = threads;
 
     std::wstring identifier = std::wstring(L"GD3D11-") + std::wstring(poolIdentifier);
-	for ( size_t i = 0; i < threads; ++i )
-		workers.emplace_back(
-			[](ThreadPool* pool, size_t workerId, const std::wstring& descriptionPrefix) {
-			    SetThreadDescription( GetCurrentThread(), (descriptionPrefix+std::to_wstring(workerId)).c_str() );
-				for ( ;;) {
-					std::function<void()> task;
+    for (size_t i = 0; i < threads; ++i)
+        workers.emplace_back(
+            [](ThreadPool* pool, size_t workerId, const std::wstring& descriptionPrefix)
+            {
+                SetThreadDescription( GetCurrentThread(), (descriptionPrefix+std::to_wstring(workerId)).c_str() );
+                for (;;)
+                {
+                    std::function<void()> task;
 
-					{
-						std::unique_lock<std::mutex> lock( pool->queue_mutex );
-						pool->condition.wait( lock,
-							[pool] { return pool->stop || !pool->tasks.empty(); } );
+                    {
+                        std::unique_lock<std::mutex> lock(pool->queue_mutex);
+                        pool->condition.wait(lock,
+                                             [pool] { return pool->stop || !pool->tasks.empty(); });
 
-					    pool->activeTasks.fetch_add(1);
-						if ( pool->stop && pool->tasks.empty() )
-						{
-						    pool->activeTasks.fetch_sub(1);
-							return;
-						}
-						task = std::move( pool->tasks.front() );
-						pool->tasks.pop();
-					}
+                        pool->activeTasks.fetch_add(1);
+                        if (pool->stop && pool->tasks.empty())
+                        {
+                            pool->activeTasks.fetch_sub(1);
+                            return;
+                        }
 
-					task();
-				    pool->activeTasks.fetch_sub(1);
-				}
-			}, this, i, identifier
-	);
+                        // Extract just the function to execute
+                        task = std::move(pool->tasks.front().first);
+                        pool->tasks.pop();
+                    }
+
+                    task();
+                    pool->activeTasks.fetch_sub(1);
+                }
+            }, this, i, identifier
+        );
 }
 
-// add new work item to the pool
-template<class F, class... Args>
-auto ThreadPool::enqueue( F&& f, Args&&... args )
--> std::future<typename std::invoke_result<F, Args...>::type> {
-	using return_type = typename std::invoke_result<F, Args...>::type;
+template <class F, class... Args>
+auto ThreadPool::enqueue(F&& f, Args&&... args)
+    -> TaskHandle<typename std::invoke_result<F, CancellationToken, Args...>::type>
+{
+    using return_type = typename std::invoke_result<F, CancellationToken, Args...>::type;
 
-	auto task = std::make_shared< std::packaged_task<return_type()> >(
-		std::bind( std::forward<F>( f ), std::forward<Args>( args )... )
-		);
+    CancellationToken token;
 
-	std::future<return_type> res = task->get_future();
-	{
-		std::unique_lock<std::mutex> lock( queue_mutex );
+    auto task = std::make_shared<std::packaged_task<return_type()>>(
+        std::bind(std::forward<F>(f), token, std::forward<Args>(args)...)
+    );
 
-		// don't allow enqueueing after stopping the pool
-		if ( stop )
-			throw std::runtime_error( "enqueue on stopped ThreadPool" );
+    std::future<return_type> res = task->get_future();
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex);
 
-		tasks.emplace( [task]() { (*task)(); } );
-	}
-	condition.notify_one();
-	return res;
+        if (stop)
+            throw std::runtime_error("enqueue on stopped ThreadPool");
+
+        // Store the task function and its token together
+        tasks.emplace(std::make_pair([task]()
+        {
+            (*task)();
+        }, token));
+    }
+    condition.notify_one();
+
+    return {std::move(res), token};
 }
 
-// the destructor joins all threads
-inline ThreadPool::~ThreadPool() {
-	{
-		std::unique_lock<std::mutex> lock( queue_mutex );
-		stop = true;
-	}
-	condition.notify_all();
-	for ( std::thread& worker : workers )
-		worker.join();
+inline ThreadPool::~ThreadPool()
+{
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+        stop = true;
+    }
+    condition.notify_all();
+    for (std::thread& worker : workers)
+        worker.join();
 }

--- a/D3D11Engine/ThreadPool.h
+++ b/D3D11Engine/ThreadPool.h
@@ -29,6 +29,15 @@ public:
 	~ThreadPool();
 
 	size_t getNumThreads() { return numThreads; }
+    bool getIsBusy() {
+	    std::unique_lock<std::mutex> lock(queue_mutex);
+	    return !tasks.empty() || activeTasks.load() > 0;
+    }
+    void clearAndFlush() {
+        while ( getIsBusy() ) {
+            std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+        }
+    }
 private:
 	// need to keep track of threads so we can join them
 	std::vector< std::thread > workers;
@@ -36,6 +45,7 @@ private:
 	std::queue< std::function<void()> > tasks;
 
 	// synchronization
+    std::atomic_int activeTasks;
 	std::mutex queue_mutex;
 	std::condition_variable condition;
 	bool stop;
@@ -59,13 +69,19 @@ inline ThreadPool::ThreadPool( const wchar_t* poolIdentifier, size_t threads )
 						std::unique_lock<std::mutex> lock( pool->queue_mutex );
 						pool->condition.wait( lock,
 							[pool] { return pool->stop || !pool->tasks.empty(); } );
+
+					    pool->activeTasks.fetch_add(1);
 						if ( pool->stop && pool->tasks.empty() )
+						{
+						    pool->activeTasks.fetch_sub(1);
 							return;
+						}
 						task = std::move( pool->tasks.front() );
 						pool->tasks.pop();
 					}
 
 					task();
+				    pool->activeTasks.fetch_sub(1);
 				}
 			}, this, i, identifier
 	);

--- a/D3D11Engine/Types.h
+++ b/D3D11Engine/Types.h
@@ -200,6 +200,13 @@ struct float4 {
         return static_cast<DWORD>((a << 24) | (r << 16) | (g << 8) | b);
     }
 
+    bool operator==( const float4& b ) const noexcept {
+        return x == b.x 
+            && y == b.y
+            && z == b.z
+            && w == b.w;
+    }
+
     float x, y, z, w;
 };
 

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -41,7 +41,9 @@ void SkeletalVobInfo::UpdateVobConstantBuffer() {
     WorldMatrix = cb.World;
 
     if ( !VobConstantBuffer ) {
-        Engine::GraphicsEngine->CreateConstantBuffer( &VobConstantBuffer, &cb, sizeof( cb ) );
+        D3D11ConstantBuffer* d3dcb;
+        Engine::GraphicsEngine->CreateConstantBuffer( &d3dcb, &cb, sizeof( cb ) );
+        VobConstantBuffer.reset(d3dcb);
 #ifdef DEBUG_D3D11
         SetDebugName( VobConstantBuffer->Get().Get(), "VS_ExConstantBuffer_PerInstance::"+Vob->GetName());
 #endif

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -88,6 +88,7 @@ struct MeshInfo {
     MeshInfo( MeshInfo&& other ) = default;
     MeshInfo& operator=( MeshInfo&& ) = default;
     MeshInfo( const MeshInfo& other ) = delete;
+    MeshInfo& operator=(const MeshInfo& other) = delete;
 
     virtual ~MeshInfo();
 
@@ -109,6 +110,7 @@ struct WorldMeshInfo : public MeshInfo {
     WorldMeshInfo( WorldMeshInfo&& other ) = default;
     WorldMeshInfo& operator=( WorldMeshInfo&& ) = default;
     WorldMeshInfo( const WorldMeshInfo& other ) = delete;
+    WorldMeshInfo& operator=(const WorldMeshInfo& other) = delete;
 
     ~WorldMeshInfo() override = default;
 
@@ -121,6 +123,7 @@ struct QuadMarkInfo {
     QuadMarkInfo( QuadMarkInfo&& other ) = default;
     QuadMarkInfo& operator=( QuadMarkInfo&& ) = default;
     QuadMarkInfo( const QuadMarkInfo& other ) = delete;
+    QuadMarkInfo& operator=(const QuadMarkInfo& other) = delete;
 
     ~QuadMarkInfo() = default;
 
@@ -138,6 +141,7 @@ struct SkeletalMeshInfo {
     SkeletalMeshInfo(SkeletalMeshInfo&& other) = default;
     SkeletalMeshInfo& operator=( SkeletalMeshInfo&& ) = default;
     SkeletalMeshInfo(const SkeletalMeshInfo& other) = delete;
+    SkeletalMeshInfo& operator=(const SkeletalMeshInfo& other) = delete;
 
     ~SkeletalMeshInfo();
 
@@ -155,8 +159,9 @@ class zCVisual;
 struct BaseVisualInfo {
     BaseVisualInfo() = default;
     BaseVisualInfo(BaseVisualInfo&& other) = default;
-    BaseVisualInfo& operator=( BaseVisualInfo&& ) = default;
+    BaseVisualInfo& operator=( BaseVisualInfo&& ) noexcept = default;
     BaseVisualInfo(const BaseVisualInfo& other) = delete;
+    BaseVisualInfo& operator=(const BaseVisualInfo& other) = delete;
 
     virtual ~BaseVisualInfo() {
         for ( auto& [k, meshes] : Meshes ) {
@@ -195,11 +200,13 @@ struct MeshVisualInfo : public BaseVisualInfo {
         StartInstanceNum = 0;
         FullMesh = nullptr;
         LastAniUpdateFrame = 0;
+        NeedsAlphaTesting = false;
     }
     
     MeshVisualInfo(MeshVisualInfo&& other) = default;
     MeshVisualInfo& operator=( MeshVisualInfo&& ) = default;
     MeshVisualInfo(const MeshVisualInfo& other) = delete;
+    MeshVisualInfo& operator=(const MeshVisualInfo& other) = delete;
 
     ~MeshVisualInfo() override
     {
@@ -243,6 +250,7 @@ struct SkeletalMeshVisualInfo : public BaseVisualInfo {
     SkeletalMeshVisualInfo(SkeletalMeshVisualInfo&& other) = default;
     SkeletalMeshVisualInfo& operator=( SkeletalMeshVisualInfo&& ) = default;
     SkeletalMeshVisualInfo(const SkeletalMeshVisualInfo& other) = delete;
+    SkeletalMeshVisualInfo& operator=(const SkeletalMeshVisualInfo& other) = delete;
     
     ~SkeletalMeshVisualInfo() override
     {
@@ -275,6 +283,7 @@ struct BaseVobInfo {
     BaseVobInfo(BaseVobInfo&& other) = default;
     BaseVobInfo& operator=( BaseVobInfo&& ) = default;
     BaseVobInfo(const BaseVobInfo& other) = delete;
+    BaseVobInfo& operator=(const BaseVobInfo& other) = delete;
     
     virtual ~BaseVobInfo() = default;
     /** Visual for this vob */
@@ -290,6 +299,7 @@ struct VobInfo : public BaseVobInfo {
     VobInfo(VobInfo&& other) = default;
     VobInfo& operator=( VobInfo&& ) = default;
     VobInfo(const VobInfo& other) = delete;
+    VobInfo& operator=(const VobInfo& other) = delete;
     
     ~VobInfo() override = default;
 
@@ -336,6 +346,7 @@ struct VobLightInfo {
     VobLightInfo(VobLightInfo&& other) = default;
     VobLightInfo& operator=( VobLightInfo&& ) = default;
     VobLightInfo(const VobLightInfo& other) = delete;
+    VobLightInfo& operator=(const VobLightInfo& other) = delete;
 
     ~VobLightInfo() = default;
 
@@ -364,10 +375,16 @@ struct VobLightInfo {
     bool VisibleInFrame;
 };
 
-
+static auto g_MatIdentity = XMFLOAT4X4(
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1
+);
 /** Holds the converted mesh of a VOB */
 struct SkeletalVobInfo : public BaseVobInfo {
-    SkeletalVobInfo() {
+    SkeletalVobInfo() : WorldMatrix(g_MatIdentity), PrevWorldMatrix(g_MatIdentity)
+    {
         Vob = nullptr;
         VisualInfo = nullptr;
         IndoorVob = false;
@@ -376,10 +393,11 @@ struct SkeletalVobInfo : public BaseVobInfo {
         HasValidPrevTransforms = false;
         LastAniUpdateFrame = 0;
     }
-    
+
     SkeletalVobInfo(SkeletalVobInfo&& other) = default;
     SkeletalVobInfo& operator=( SkeletalVobInfo&& ) = default;
     SkeletalVobInfo(const SkeletalVobInfo& other) = delete;
+    SkeletalVobInfo& operator=(const SkeletalVobInfo& other) = delete;
 
     ~SkeletalVobInfo() override
     {
@@ -391,7 +409,7 @@ struct SkeletalVobInfo : public BaseVobInfo {
             }
         }
 
-        delete VobConstantBuffer;
+        VobConstantBuffer.reset();
     }
 
     /** Updates the vobs constantbuffer */
@@ -404,7 +422,8 @@ struct SkeletalVobInfo : public BaseVobInfo {
     }
 
     /** Constantbuffer which holds this vobs world matrix */
-    D3D11ConstantBuffer* VobConstantBuffer;
+    D3D11ConstantBuffer* GetVobConstantBuffer() const { return VobConstantBuffer.get(); };
+    std::unique_ptr<D3D11ConstantBuffer> VobConstantBuffer;
 
     /** Map of visuals attached to nodes */
     phmap::flat_hash_map<int, std::vector<MeshVisualInfo*>> NodeAttachments;

--- a/D3D11Engine/zCSkyController_Outdoor.h
+++ b/D3D11Engine/zCSkyController_Outdoor.h
@@ -137,6 +137,19 @@ public:
         PatchAddr( 0x006BB643, "\x90" );
         PatchCall( 0x006BB644, reinterpret_cast<DWORD>(&zCSkyController_Outdoor::RenderThunderPolyStrip) );
 #endif
+
+        if ( HookedFunctions::OriginalFunctions.original_zCSkyControler_ClearBackground )
+            DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCSkyControler_ClearBackground), &zCSkyController_Outdoor::hooked_zCSkyControler_ClearBackground );
+    }
+
+    static void __fastcall hooked_zCSkyControler_ClearBackground( void* thisPtr, void* vtbl, zColor color ) {
+        // Prevent the skycontroller from clearing the backbuffer/depth buffer.
+        // We do this anyway, and this here causes issues with upscaling, as the code for "clearing" explicitly only clears if the viewport == window size.
+        // But keep the original code from working if we don't upscale, in case there are any more issues with it.
+        if (Engine::GAPI->GetRendererState().RendererSettings.ResolutionScalePercent < 100) {
+            return;
+        }
+        HookedFunctions::OriginalFunctions.original_zCSkyControler_ClearBackground( thisPtr, color );
     }
 
     /** Updates the rain-weight and sound-effects */

--- a/D3D11Engine/zCTexture.h
+++ b/D3D11Engine/zCTexture.h
@@ -138,7 +138,6 @@ public:
         return (flags & GothicMemoryLocations::zCTexture::Mask_FlagHasAlpha) != 0;
     }
 
-private:
     const zSTRING& __GetName() {
         return reinterpret_cast<zSTRING&(__fastcall*)( zCTexture* )>( GothicMemoryLocations::zCObject::GetObjectName )( this );
     }


### PR DESCRIPTION
Causes issues as original engine code only "properly" clears buffers if viewport == window, otherwise it tries to blend the clear color in some weird way.

also

- fix threading issue when loading Pointlights in the worker thread, by pruning the worker thread before resetting vobs.
  - Introduced `CancellationToken` argument for worker thread tasks to cooperatively cancel running jobs.
- delete a few `copy assignment` operators, whose copy-constructor already was deleted.
- draw static vobs by texture->mesh, instead of visual->texture->mesh, allowing for more efficient GPU utilization, by sacrificing a bit of CPU for sorting and collecting the meshes.
- Enable `LazyCascadeUpdate` by default (`General -> Debug -> Shadows -> Lazy update`)
  This causes further away shadows to be updated less frequently and provides a substantial improvement to FPS, while possibly causing some amount of frame-time uneven-ness (is that a word?)