### PR TITLE
Pointlights: cancel any pending background Init on delete or re-init

### DIFF
--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -28,10 +28,12 @@ D3D11PointLight::D3D11PointLight( VobLightInfo* info, bool dynamicLight ) {
     StartReInit();
 
     DrawnOnce = false;
+    m_PendingInit = {};
 }
 
 D3D11PointLight::~D3D11PointLight() {
     // Make sure we are out of the init-queue
+    m_PendingInit.cancel(); // ensure any pending job is cancelled such that we get to InitDone state
     while ( !InitDone.load() ) {
         std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
     }
@@ -281,14 +283,15 @@ void D3D11PointLight::StartReInit() {
         InitDone = false;
 
         // Add to queue
-        Engine::WorkerThreadPool->enqueue( [this] (const CancellationToken& token)
+        m_PendingInit.cancel(); // Cancel any pending init first, we only care about the latest one
+        m_PendingInit = Engine::WorkerThreadPool->enqueue( [this] (const CancellationToken& token)
         {
             if (token.isCancelled()) {
                 InitDone = true;
                 return;
             }
             InitResources();
-        } );
+        } ).token;
 
     } else {
         InitResources();

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -5,6 +5,7 @@
 #include <condition_variable>
 #include <atomic>
 #include "TexturePool.h"
+#include "Threadpool.h"
 
 class D3D11PointLight;
 class D3D11TiledDeferredShading;
@@ -86,4 +87,5 @@ protected:
     int m_TiledSlotIndex = -1;
     RenderToDepthStencilBuffer* m_TiledDepthTarget = nullptr;
     D3D11TiledDeferredShading* m_TiledOwner = nullptr;
+    CancellationToken m_PendingInit;
 };


### PR DESCRIPTION
When re-init or ~dtor is called, invoke `CancellationToken.cancel()` on the currently pending task.