### PR TITLE
safety checks for changing shading modes. fix runtime toggle of Tiled/legacy shading, delete fallback code in TiledDeferredShading

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -366,7 +366,7 @@ struct LightCullingConstantBuffer {
     uint32_t ScreenWidth;
     uint32_t ScreenHeight;
     uint32_t TotalLights;
-    uint32_t Pad;
+    uint32_t MaxBufferIndices;
 };
 
 struct TiledShadingConstantBuffer {

--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -361,6 +361,9 @@ struct VelocityDebugConstantBuffer {
     float Padding;
 };
 
+#define TILE_SIZE 16
+#define MAX_LIGHTS_PER_TILE 32
+
 struct LightCullingConstantBuffer {
     XMFLOAT4X4 Proj;
     uint32_t ScreenWidth;

--- a/D3D11Engine/D3D11LegacyDeferredShading.cpp
+++ b/D3D11Engine/D3D11LegacyDeferredShading.cpp
@@ -75,7 +75,7 @@ XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
         if ( settings.EnablePointlightShadows > 0 ) {
             D3D11PointLight* pl = light->LightShadowBuffers ? static_cast<D3D11PointLight*>(light->LightShadowBuffers.get()) : nullptr;
 
-            if ( pl && pl->IsInited() && pl->HasShadowMap() ) {
+            if ( pl && pl->IsInited() && pl->HasShadowMap( 0 ) ) {
                 if ( graphicsEngine->GetActivePS() != psPointLightDynShadow ) {
                     graphicsEngine->SetActivePS( psPointLightDynShadow )->Apply();
                 }

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -45,7 +45,14 @@ public:
     /** Called when a vob got removed from the world */
     virtual void OnVobRemovedFromWorld( BaseVobInfo* vob );
 
-    bool HasShadowMap() const { return m_DepthCubemap != nullptr || m_TiledDepthTarget != nullptr; }
+    bool HasAnyShadowMap() const {
+        return HasShadowMap(0) || HasShadowMap(1);
+    }
+
+    bool HasShadowMap(int shadowMapKind ) const { 
+        if ( shadowMapKind == 0 ) return m_DepthCubemap != nullptr;
+        return m_TiledDepthTarget != nullptr;
+    }
     int GetShadowMapResolution() const { return m_CurrentResolution; }
     ID3D11Texture2D* GetShadowCubeTexture() const { return m_DepthCubemap ? m_DepthCubemap->GetTexture().Get() : nullptr; }
 

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -504,7 +504,11 @@ XRESULT D3D11ShaderManager::Init() {
 
         Shaders.push_back( ShaderInfo::make<CShaderID::CS_AdvanceRain>( "CS_AdvanceRain.hlsl" ));
 
-        Shaders.push_back( ShaderInfo::make<CShaderID::CS_LightCulling>( "CS_LightCulling.hlsl" ));
+        Shaders.push_back( ShaderInfo::make<CShaderID::CS_LightCulling>( "CS_LightCulling.hlsl" )
+        .with_macros( {
+            { "TILE_SIZE", TO_LITERAL( TILE_SIZE ) },
+            { "MAX_LIGHTS_PER_TILE", TO_LITERAL( MAX_LIGHTS_PER_TILE ) },
+        }));
 
         Shaders.push_back( ShaderInfo::make<CShaderID::CS_TiledShading>( "CS_TiledShading.hlsl" ));
     }

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -800,6 +800,8 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
 
     DepthStencilPool* dsPool = graphicsEngine->GetPfxRenderer()->GetDepthStencilPool();
     
+    const bool isTiledShadingEnabled = m_TiledDeferred && settings.EnableTiledLighting;
+    const int requiredShadowMapKind = isTiledShadingEnabled ? 1 : 0;
     for ( auto const& light : lights ) {
         if ( !light->Vob->IsEnabled() || !light->VisibleInFrame ) {
             continue;
@@ -833,18 +835,23 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
             bool inShadowRange = d < distMaxShadowSq;
             if ( inShadowRange ) {
                 // Acquire memory if it doesn't have it (or resolution changed)
-                if ( !pl->HasShadowMap() || pl->GetShadowMapResolution() != desiredResolution ) {
+                if ( !pl->HasShadowMap( requiredShadowMapKind ) || pl->GetShadowMapResolution() != desiredResolution ) {
                     pl->ClearTiledSlot();
                     pl->ReleaseShadowMap();
 
                     // Try tiled slot for small (64×64) lights when tiled lighting is active
-                    if ( desiredResolution == SHADOW_CUBE_SIZE && m_TiledDeferred && settings.EnableTiledLighting ) {
+                    if ( isTiledShadingEnabled ) {
+                        if ( desiredResolution != SHADOW_CUBE_SIZE ) {
+                            light->UpdateShadows = false;
+                            continue; // should never happen, as we currently only use one resolution, but just in case, don't try to put bigger shadowmaps into tiled slots
+                        }
                         int slot = m_TiledDeferred->AllocateSlot();
                         if ( slot >= 0 ) {
                             pl->SetTiledSlot( slot, m_TiledDeferred->GetSlotTarget( slot ), m_TiledDeferred.get() );
                             pl->SetCurrentResolution( desiredResolution );
                         } else {
-                            pl->AcquireShadowMap( dsPool, desiredResolution );
+                            light->UpdateShadows = false;
+                            continue; // failed to allocate tiled slot, skip shadow rendering for this light this frame
                         }
                     } else {
                         pl->AcquireShadowMap( dsPool, desiredResolution );
@@ -872,7 +879,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
                 }
             } else {
                 // Out of range: Return VRAM to the pool!
-                if ( pl->HasShadowMap() ) {
+                if ( pl->HasAnyShadowMap() ) {
                     // TODO: actually fix memory leakage, as many lights can spawn without ever releasing their shadowmaps
                     // because if they suddenly go out of range (Frustum or VisualFX distance),
                     // we never "collect" them and thus never get to call ReleasShadowMap().
@@ -885,6 +892,11 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
                     auto it = std::find( graphicsEngine->FrameShadowUpdateLights.begin(), graphicsEngine->FrameShadowUpdateLights.end(), light );
                     if ( it != graphicsEngine->FrameShadowUpdateLights.end() ) {
                         graphicsEngine->FrameShadowUpdateLights.erase( it );
+                    }
+
+                    auto importantIt = std::find( importantUpdates.begin(), importantUpdates.end(), light );
+                    if ( importantIt != importantUpdates.end() ) {
+                        importantUpdates.erase( importantIt );
                     }
                 }
             }

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -254,7 +254,7 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
         bool hasShadow = false;
         if ( settings.EnablePointlightShadows > 0 ) {
             pl = light->LightShadowBuffers ? static_cast<D3D11PointLight*>(light->LightShadowBuffers.get()) : nullptr;
-            if ( pl && pl->IsInited() && pl->HasShadowMap() ) {
+            if ( pl && pl->IsInited() && pl->HasShadowMap( 1 ) ) {
                 hasShadow = true;
             }
         }

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -336,7 +336,7 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
             cullCB.ScreenWidth = static_cast<uint32_t>(resolution.x);
             cullCB.ScreenHeight = static_cast<uint32_t>(resolution.y);
             cullCB.TotalLights = tiledLightCount;
-            cullCB.Pad = 0;
+            cullCB.MaxBufferIndices = (numTilesX * numTilesY) * MAX_LIGHTS_PER_TILE;
 
             csLightCull->GetBuffer( "LightCullingConstantBuffer" ).Update( &cullCB ).Bind();
 

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -64,35 +64,6 @@ void D3D11TiledDeferredShading::Init(
         SetDebugName( m_IndexCounterUAV.Get(), "TiledDeferred_IndexCounter_UAV" );
     }
 
-    // Light index list: global flat array of light indices
-    {
-        D3D11_BUFFER_DESC desc = {};
-        desc.ByteWidth = MAX_LIGHT_INDEX_ENTRIES * sizeof( uint32_t );
-        desc.Usage = D3D11_USAGE_DEFAULT;
-        desc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
-        desc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
-        desc.StructureByteStride = sizeof( uint32_t );
-
-        m_device->CreateBuffer( &desc, nullptr, m_LightIndexList.ReleaseAndGetAddressOf() );
-        SetDebugName( m_LightIndexList.Get(), "TiledDeferred_LightIndexList" );
-
-        D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-        srvDesc.Format = DXGI_FORMAT_UNKNOWN;
-        srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
-        srvDesc.Buffer.ElementWidth = MAX_LIGHT_INDEX_ENTRIES;
-
-        m_device->CreateShaderResourceView( m_LightIndexList.Get(), &srvDesc, m_LightIndexListSRV.ReleaseAndGetAddressOf() );
-        SetDebugName( m_LightIndexListSRV.Get(), "TiledDeferred_LightIndexList_SRV" );
-
-        D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
-        uavDesc.Format = DXGI_FORMAT_UNKNOWN;
-        uavDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
-        uavDesc.Buffer.NumElements = MAX_LIGHT_INDEX_ENTRIES;
-
-        m_device->CreateUnorderedAccessView( m_LightIndexList.Get(), &uavDesc, m_LightIndexListUAV.ReleaseAndGetAddressOf() );
-        SetDebugName( m_LightIndexListUAV.Get(), "TiledDeferred_LightIndexList_UAV" );
-    }
-
     // Shadow cube array is lazy-created on first AllocateSlot() to save memory when shadows are off
 }
 
@@ -175,6 +146,38 @@ void D3D11TiledDeferredShading::EnsureBuffers( uint32_t numTilesX, uint32_t numT
 
     m_lastNumTilesX = numTilesX;
     m_lastNumTilesY = numTilesY;
+
+
+    // Light index list: global flat array of light indices
+    {
+        const uint32_t MAX_LIGHT_INDEX_ENTRIES = MAX_LIGHTS_PER_TILE * totalTiles;
+
+        D3D11_BUFFER_DESC desc = {};
+        desc.ByteWidth = MAX_LIGHT_INDEX_ENTRIES * sizeof( uint32_t );
+        desc.Usage = D3D11_USAGE_DEFAULT;
+        desc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+        desc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+        desc.StructureByteStride = sizeof( uint32_t );
+
+        m_device->CreateBuffer( &desc, nullptr, m_LightIndexList.ReleaseAndGetAddressOf() );
+        SetDebugName( m_LightIndexList.Get(), "TiledDeferred_LightIndexList" );
+
+        D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+        srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+        srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
+        srvDesc.Buffer.ElementWidth = MAX_LIGHT_INDEX_ENTRIES;
+
+        m_device->CreateShaderResourceView( m_LightIndexList.Get(), &srvDesc, m_LightIndexListSRV.ReleaseAndGetAddressOf() );
+        SetDebugName( m_LightIndexListSRV.Get(), "TiledDeferred_LightIndexList_SRV" );
+
+        D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+        uavDesc.Format = DXGI_FORMAT_UNKNOWN;
+        uavDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
+        uavDesc.Buffer.NumElements = MAX_LIGHT_INDEX_ENTRIES;
+
+        m_device->CreateUnorderedAccessView( m_LightIndexList.Get(), &uavDesc, m_LightIndexListUAV.ReleaseAndGetAddressOf() );
+        SetDebugName( m_LightIndexListUAV.Get(), "TiledDeferred_LightIndexList_UAV" );
+    }
 
     // Recreate light grid buffer for new tile count
     D3D11_BUFFER_DESC desc = {};

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -228,7 +228,6 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
     // Partition lights: all lights go tiled where possible.
     // Shadowed lights with a tiled slot render directly into the shared array (no copies).
     // Shadowed lights without a tiled slot (256×256 or overflow) fall back to legacy.
-    std::vector<VobLightInfo*> legacyLights;
     uint32_t tiledLightCount = 0;
     bool hasShadowedTiledLights = false;
 
@@ -260,9 +259,7 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
         }
 
         // Shadowed lights need a tiled slot (assigned earlier in DrawPointlightShadows).
-        // If they don't have one (256×256 or slot overflow), fall back to legacy.
         if ( hasShadow && pl->GetTiledSlot() < 0 ) {
-            legacyLights.push_back( light );
             continue;
         }
 
@@ -426,12 +423,6 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
             context->OMSetRenderTargets( 1, graphicsEngine->GetHDRBackBuffer().GetRenderTargetView().GetAddressOf(),
                 graphicsEngine->GetDepthBuffer()->GetDepthStencilView().Get() );
         }
-    }
-
-    // Draw lights that couldn't go through the tiled path (mismatched shadow cube size, overflow)
-    if ( !legacyLights.empty() ) {
-        D3D11LegacyDeferredShading legacy;
-        legacy.DrawPointlightLights( legacyLights, color, normals, specular, depthCopy );
     }
 
     return XR_SUCCESS;

--- a/D3D11Engine/D3D11TiledDeferredShading.h
+++ b/D3D11Engine/D3D11TiledDeferredShading.h
@@ -12,8 +12,6 @@ struct RenderToTextureBuffer;
 struct RenderToDepthStencilBuffer;
 
 constexpr uint32_t MAX_TILED_LIGHTS = 1024;
-constexpr uint32_t TILE_SIZE = 16;
-constexpr uint32_t MAX_LIGHTS_PER_TILE = 256;
 
 constexpr uint32_t MAX_SHADOW_CUBEMAPS = 128;
 constexpr uint32_t SHADOW_CUBE_SIZE = 64; // Must match POINTLIGHT_SHADOWMAP_SIZE

--- a/D3D11Engine/D3D11TiledDeferredShading.h
+++ b/D3D11Engine/D3D11TiledDeferredShading.h
@@ -14,7 +14,6 @@ struct RenderToDepthStencilBuffer;
 constexpr uint32_t MAX_TILED_LIGHTS = 1024;
 constexpr uint32_t TILE_SIZE = 16;
 constexpr uint32_t MAX_LIGHTS_PER_TILE = 256;
-constexpr uint32_t MAX_LIGHT_INDEX_ENTRIES = 256 * 1024;
 
 constexpr uint32_t MAX_SHADOW_CUBEMAPS = 128;
 constexpr uint32_t SHADOW_CUBE_SIZE = 64; // Must match POINTLIGHT_SHADOWMAP_SIZE

--- a/D3D11Engine/Shaders/CS_LightCulling.hlsl
+++ b/D3D11Engine/Shaders/CS_LightCulling.hlsl
@@ -1,5 +1,10 @@
+#ifndef TILE_SIZE
 #define TILE_SIZE 16
-#define MAX_LIGHTS_PER_TILE 256
+#endif
+
+#ifndef MAX_LIGHTS_PER_TILE
+#define MAX_LIGHTS_PER_TILE 32
+#endif
 
 struct TiledPointLight {
     float3 PositionView;

--- a/D3D11Engine/Shaders/CS_LightCulling.hlsl
+++ b/D3D11Engine/Shaders/CS_LightCulling.hlsl
@@ -21,7 +21,7 @@ cbuffer LightCullingConstantBuffer : register( b0 ) {
     matrix Proj;
     uint2 ScreenDimensions;
     uint TotalLights;
-    uint Pad;
+    uint MaxBufferIndices;
 };
 
 RWStructuredBuffer<LightGrid> RW_LightGrid : register( u0 );
@@ -138,6 +138,13 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
 
         uint numTilesX = (ScreenDimensions.x + TILE_SIZE - 1) / TILE_SIZE;
         uint tileIndex = groupID.y * numTilesX + groupID.x;
+		
+		if (offset >= MaxBufferIndices) {
+			count = 0; // Completely full
+		} else if (offset + count > MaxBufferIndices) {
+			count = MaxBufferIndices - offset; // Write remaining
+		}
+		
         RW_LightGrid[tileIndex].Offset = offset;
         RW_LightGrid[tileIndex].Count = count;
 

--- a/D3D11Engine/Shaders/PS_PFX_FSR1_EASU.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_FSR1_EASU.hlsl
@@ -48,8 +48,9 @@ AF4 FsrEasuBF(AF2 p)
 
 struct PS_INPUT
 {
-    float4 Position : SV_POSITION;
     float2 TexCoord : TEXCOORD0;
+	float3 vEyeRay	: TEXCOORD1;
+    float4 Position : SV_POSITION;
 };
 
 float4 PSMain(PS_INPUT input) : SV_TARGET

--- a/D3D11Engine/Shaders/PS_PFX_FSR1_RCAS.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_FSR1_RCAS.hlsl
@@ -40,8 +40,9 @@ void FsrRcasInputF(inout AF1 r, inout AF1 g, inout AF1 b)
 
 struct PS_INPUT
 {
-    float4 Position : SV_POSITION;
     float2 TexCoord : TEXCOORD0;
+	float3 vEyeRay	: TEXCOORD1;
+    float4 Position : SV_POSITION;
 };
 
 float4 PSMain(PS_INPUT input) : SV_TARGET


### PR DESCRIPTION
- Ensure we allocate the correct type of shadowmap for a pointlight for the current active rendering format
- remove legacy fallback in Tiled shading code, as it was obsoleted.
- add a few safety checks to prevent un-allocated lights
- allocate a correctly sized Index buffer for Tiled shading, with dependency on the resolution / total Tiles and total Lights per Tile