### PR TITLE
feat: Settings to toggle `EnableDriverExtensions`. Dynamic shadows: Implement Static/Update Dynamic/Full 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,5 @@ redist*/
 /Launcher/ddraw.dll
 /Launcher/Launcher/Launcher.tlog/Cl.items.tlog
 /Launcher/Launcher/Launcher.tlog/link.secondary.1.tlog
+D3D11Engine/G2_Debug/
+G2_Debug/

--- a/D3D11Engine/D3D11ConstantBuffer.cpp
+++ b/D3D11Engine/D3D11ConstantBuffer.cpp
@@ -37,7 +37,13 @@ D3D11ConstantBuffer* D3D11ConstantBuffer::UpdateBuffer( const void* data ) {
     D3D11_MAPPED_SUBRESOURCE res;
     if ( SUCCEEDED( engine->GetContext()->Map( Buffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &res ) )) {
         // Copy data
-        memcpy( res.pData, data, OriginalSize );
+        if ( res.pData ) {
+            if ( data ) {
+                memcpy( res.pData, data, OriginalSize );
+            } else {
+                ZeroMemory( res.pData, OriginalSize );
+            }
+        }
         engine->GetContext()->Unmap( Buffer.Get(), 0 );
 
         BufferDirty = true;
@@ -54,7 +60,7 @@ D3D11ConstantBuffer* D3D11ConstantBuffer::UpdateBuffer( const void* data, UINT s
     if ( SUCCEEDED( engine->GetContext()->Map( Buffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &res ) )) {
         // Copy data
         if ( res.pData ) {
-            if (size< OriginalSize) {
+            if (size < OriginalSize) {
                 ZeroMemory( res.pData, OriginalSize );
             }
             if ( data ) {

--- a/D3D11Engine/D3D11ConstantBuffer.cpp
+++ b/D3D11Engine/D3D11ConstantBuffer.cpp
@@ -30,8 +30,6 @@ D3D11ConstantBuffer::D3D11ConstantBuffer( int size, void* data ) {
     BufferDirty = false;
 }
 
-D3D11ConstantBuffer::~D3D11ConstantBuffer() {}
-
 /** Updates the buffer */
 D3D11ConstantBuffer* D3D11ConstantBuffer::UpdateBuffer( const void* data ) {
     D3D11GraphicsEngineBase* engine = reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine);
@@ -55,7 +53,14 @@ D3D11ConstantBuffer* D3D11ConstantBuffer::UpdateBuffer( const void* data, UINT s
     D3D11_MAPPED_SUBRESOURCE res;
     if ( SUCCEEDED( engine->GetContext()->Map( Buffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &res ) )) {
         // Copy data
-        memcpy( res.pData, data, size );
+        if ( res.pData ) {
+            if (size< OriginalSize) {
+                ZeroMemory( res.pData, OriginalSize );
+            }
+            if ( data ) {
+                memcpy( res.pData, data, size );
+            }
+        }
         engine->GetContext()->Unmap( Buffer.Get(), 0 );
 
         BufferDirty = true;

--- a/D3D11Engine/D3D11ConstantBuffer.h
+++ b/D3D11Engine/D3D11ConstantBuffer.h
@@ -3,7 +3,7 @@
 class D3D11ConstantBuffer {
 public:
     D3D11ConstantBuffer( int size, void* data );
-    ~D3D11ConstantBuffer();
+    ~D3D11ConstantBuffer() = default;
 
     /** Updates the buffer */
     D3D11ConstantBuffer* UpdateBuffer( const void* data );

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -756,7 +756,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_;PUBLIC_RELEASE</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -726,7 +726,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Link>

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="G2_Debug|Win32">
+      <Configuration>G2_Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Launcher|Win32">
       <Configuration>Launcher</Configuration>
       <Platform>Win32</Platform>
@@ -131,6 +135,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -180,6 +191,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'" Label="PropertySheets">
@@ -259,6 +273,11 @@
     <TargetName>ddraw</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">
+    <IncludePath>$(IncludePath);include;include/imgui/;include/imgui/backends/</IncludePath>
+    <LibraryPath>$(directxtk-LibPath);lib;$(LibraryPath)</LibraryPath>
+    <TargetName>ddraw</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$(IncludePath);include;include/imgui/;include/imgui/backends/</IncludePath>
     <LibraryPath>$(directxtk-LibPath);lib;$(LibraryPath)</LibraryPath>
@@ -707,6 +726,44 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <OptimizeReferences>false</OptimizeReferences>
+      <ModuleDefinitionFile>ddraw.def</ModuleDefinitionFile>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+    </Link>
+    <CustomBuildStep>
+      <Command>copy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders\"
+copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G2_SYSTEM_PATH)\ddraw.dll"
+copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
+      <Outputs>xxx</Outputs>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>Disabled</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <DisableSpecificWarnings>4005;4530;4577;6246;6322;26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
@@ -855,6 +912,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="D3D11PFX_SimpleSharpen.h" />
     <ClInclude Include="D3D11PFX_SMAA.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">false</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">false</ExcludedFromBuild>
     </ClInclude>
@@ -1115,6 +1173,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="D3D11PFX_SimpleSharpen.cpp" />
     <ClCompile Include="D3D11PFX_SMAA.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">false</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">false</ExcludedFromBuild>
     </ClCompile>
@@ -1141,6 +1200,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
     </ClCompile>
@@ -1155,6 +1215,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
     </ClCompile>
@@ -1208,6 +1269,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">pch.h</PrecompiledHeaderFile>
@@ -1220,6 +1282,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">pch.h</PrecompiledHeaderFile>
     </ClCompile>
@@ -1237,6 +1300,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="Toolbox.cpp" />
     <ClCompile Include="VersionCheck.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">NotUsing</PrecompiledHeader>
@@ -1256,6 +1320,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="WorldObjects.cpp" />
     <ClCompile Include="XUnzip.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">NotUsing</PrecompiledHeader>

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -6280,7 +6280,11 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                         GetContext()->PSSetShaderResources( 0, 3, srv );
                     
                          // Force alphatest on vobs for now
-                        BindShaderForTexture( tx, true, 0 );
+                        BindShaderForTexture( tx, 
+                            tx->HasAlphaChannel()
+                            || meshKey.Material->HasAlphaTest()
+                            , meshKey.Material->GetAlphaFunc(),
+                            meshKey.Info->MaterialType);
                     }
 
                     if ( info && !info->IsSame( lastMatInfo ) ) {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2518,7 +2518,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
             continue;
         }
 
-        model->SetIsVisible( true );
+        model->SetIsVisible( true ); 
         if ( !vi->VisualInfo )
             continue; // Gothic fortunately sets this to 0 when it throws the model out of the cache
         if ( !vi->Vob->GetShowVisual() )
@@ -2547,6 +2547,15 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
             }
         }
 
+        if ( updateState) {
+            if ( vi->LastAniUpdateFrame != now ) {
+                vi->LastAniUpdateFrame = now;
+                // Update attachments
+                model->UpdateAttachedVobs();
+            }
+            model->UpdateMeshLibTexAniState();
+        }
+
         XMMATRIX scale = XMMatrixScalingFromVector( model->GetModelScaleXM() );
 
         XMMATRIX xmWorld = vi->Vob->GetWorldMatrixXM() * scale;
@@ -2559,14 +2568,6 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         auto boneIdx = boneOffset;
         boneOffset += numBones;
 
-        if ( updateState) {
-            if ( vi->LastAniUpdateFrame != now ) {
-                vi->LastAniUpdateFrame = now;
-                // Update attachments
-                model->UpdateAttachedVobs();
-            }
-            model->UpdateMeshLibTexAniState();
-        }
 
         if ( !static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->SkeletalMeshes.empty() ) {
 #ifdef BUILD_GOTHIC_2_6_fix
@@ -2798,7 +2799,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                 }
 
                 // MorphMesh: always per-draw
-                if ( isMMS ) {
+                if ( isMMS && distance < 1000 ) {
                     // Only 0.35f of the fatness wanted by gothic.
                     // They seem to compensate for that with the scaling.
                     
@@ -3015,17 +3016,19 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
     MaterialInfo* lastMaterialInfo = nullptr;
 
+    void* lastTex = nullptr;
     auto lastSwitches = graphicsState.FF_GSwitches;
     for ( const auto& batch : batches ) {
         MeshInfo* mi = batch.mesh;
 
         // Bind texture for non-shadow passes
-        if ( wantShader && batch.texture ) {
+        if ( wantShader && batch.texture && batch.texture != lastTex) {
             MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom( batch.texture );
             if ( !BindTextureNRFX( batch.texture, isMainOrGhost, info != lastMaterialInfo ) ) {
                 continue;
             }
             lastMaterialInfo = info;
+            lastTex = batch.texture;
         }
 
         // Set up alpha test state from material

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2879,7 +2879,9 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                     }
 
                     for ( unsigned int m = 0; m < itm.second.size(); m++ ) {
-                        instancedDrawItems.push_back( { itm.second[m], texture, itm.first, instData, texture && texture->HasAlphaChannel() } );
+                        instancedDrawItems.push_back( { itm.second[m], texture, itm.first, instData, 
+                            (texture && texture->HasAlphaChannel()) || (itm.first && itm.first->HasAlphaTest())
+                        } );
                     }
                 }
             }

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4374,9 +4374,17 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
     MeshInfo* meshInfo = Engine::GAPI->GetWrappedWorldMesh();
     DrawVertexBufferIndexedUINT( meshInfo->MeshVertexBuffer, meshInfo->MeshIndexBuffer, 0, 0 );
 
-    static std::vector<std::pair<MeshKey, WorldMeshInfo*>> meshList;
+    struct WorldMeshKey {
+        zCTexture* Texture;
+        zCMaterial* Material;
+        MaterialInfo* Info;
+        int AlphaLevel; // 0 = opaque, 1 = alpha test, 2 = alpha texture
+        //zCLightmap* Lightmap;
+    };
+
+    static std::vector<std::pair<WorldMeshKey, WorldMeshInfo*>> meshList;
+    meshList.clear();
     if ( meshList.capacity() == 0 ) meshList.reserve( 4096 );
-    auto CompareMesh = []( std::pair<MeshKey, WorldMeshInfo*>& a, std::pair<MeshKey, WorldMeshInfo*>& b ) -> bool { return a.first.Texture < b.first.Texture; };
 
     GetContext()->IASetPrimitiveTopology( D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
     GetContext()->DSSetShader( nullptr, nullptr, 0 );
@@ -4398,13 +4406,6 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                     continue;
                 }
 
-                // Check if the animated texture and the registered textures are the
-                // same
-                MeshKey key = worldMesh.first;
-                if ( worldMesh.first.Texture != aniTex ) {
-                    key.Texture = aniTex;
-                }
-
                 if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_Portal ) {
                     FrameTransparencyMeshesPortal.push_back( worldMesh );
                     continue;
@@ -4419,13 +4420,33 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                     && worldMesh.first.Texture->HasAlphaChannel()) {
                     FrameTransparencyMeshes.push_back( worldMesh );
                 } else {
+
+                    int alphaLevel = 0;
+                    if ( worldMesh.first.Texture && worldMesh.first.Texture->HasAlphaChannel() ) {
+                        alphaLevel = 2;
+                    } else if ( worldMesh.first.Material && worldMesh.first.Material->HasAlphaTest() ) {
+                        alphaLevel = 1;
+                    }
+
+                    WorldMeshKey key = {
+                        aniTex,
+                        worldMesh.first.Material,
+                        worldMesh.first.Info,
+                        alphaLevel,
+                    };
+
                     // Create a new pair using the animated texture
                     meshList.emplace_back( key, worldMesh.second );
-                    std::push_heap( meshList.begin(), meshList.end(), CompareMesh );
                 }
             }
         }
     }
+    auto CompareMesh = []( std::pair<WorldMeshKey, WorldMeshInfo*>& a, std::pair<WorldMeshKey, WorldMeshInfo*>& b ) -> bool {
+        if ( a.first.AlphaLevel != b.first.AlphaLevel )
+            return a.first.AlphaLevel < b.first.AlphaLevel;
+        return a.first.Texture < b.first.Texture;
+    };
+    std::sort( meshList.begin(), meshList.end(), CompareMesh );
 
     // Draw depth only
     if ( Engine::GAPI->GetRendererState().RendererSettings.DoZPrepass ) {
@@ -4435,7 +4456,7 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
             zCTexture* texture;
             if ( ( texture = mesh.first.Texture ) == nullptr ) continue;
 
-            if ( texture->HasAlphaChannel() )
+            if ( texture->HasAlphaChannel() || (mesh.first.Material && mesh.first.Material->HasAlphaTest()) )
                 continue;  // Don't pre-render stuff with alpha channel
 
             if ( mesh.first.Info->MaterialType == MaterialInfo::MT_Water )
@@ -4451,8 +4472,7 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
     // Now draw the actual pixels
     zCTexture* bound = nullptr;
     MaterialInfo* boundInfo = nullptr;
-    while ( !meshList.empty() ) {
-        auto const& mesh = meshList.front();
+    for ( auto const& mesh : meshList ) {
 
         int indicesNumMod = 1;
         if ( mesh.first.Texture != bound &&
@@ -4506,9 +4526,6 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
         if ( Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh > 2 ) {
             DrawVertexBufferIndexedUINT( nullptr, nullptr, mesh.second->Indices.size(), mesh.second->BaseIndexLocation );
         }
-
-        std::pop_heap( meshList.begin(), meshList.end(), CompareMesh );
-        meshList.pop_back();
     }
 
     UpdateOcclusion();

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4625,7 +4625,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
     FXMVECTOR position, float range, bool cullFront, bool indoor,
     bool noNPCs, std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache ) {
+    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache,
+    unsigned int casterMask ) {
 
     // Setup renderstates
     Engine::GAPI->GetRendererState().RasterizerState.SetDefault();
@@ -4696,7 +4697,12 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
     
     auto vsBufMPI = ActiveVS->GetBuffer( "Matrices_PerInstances" );
 
-    if ( Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh ) {
+    const bool drawWorldCasters = (casterMask & SHADOW_CASTER_WORLD) != 0;
+    const bool drawVobCasters = (casterMask & SHADOW_CASTER_VOBS) != 0;
+    const bool drawMobCasters = (casterMask & SHADOW_CASTER_MOBS) != 0;
+    const bool drawAnimatedCasters = (casterMask & SHADOW_CASTER_ANIMATED) != 0;
+
+    if ( drawWorldCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh ) {
         // Bind wrapped mesh vertex buffers
         DrawVertexBufferIndexedUINT( Engine::GAPI->GetWrappedWorldMesh()->MeshVertexBuffer,
             Engine::GAPI->GetWrappedWorldMesh()->MeshIndexBuffer, 0, 0 );
@@ -4791,7 +4797,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
         }
     }
     
-    if ( Engine::GAPI->GetRendererState().RendererSettings.DrawVOBs ) {
+    if ( drawVobCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawVOBs ) {
         // Draw visible vobs here
         std::list<VobInfo*> rndVob;
         // construct new renderedvob list or fake one
@@ -4859,8 +4865,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
         }
     }
 
-    bool renderNPCs = !noNPCs;
-    if ( Engine::GAPI->GetRendererState().RendererSettings.DrawMobs ) {
+    bool renderNPCs = !noNPCs && drawAnimatedCasters;
+    if ( drawMobCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawMobs ) {
         // Draw visible vobs here
         std::list<SkeletalVobInfo*> rndVob;
 
@@ -4907,7 +4913,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
         }
     }
 
-    if ( Engine::GAPI->GetRendererState().RendererSettings.DrawSkeletalMeshes ) {
+    if ( drawAnimatedCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawSkeletalMeshes ) {
         // Draw animated skeletal meshes if wanted
         if ( renderNPCs ) {
             for ( auto const& skeletalMeshVob : Engine::GAPI->GetAnimatedSkeletalMeshVobs() ) {
@@ -4942,7 +4948,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
     FXMVECTOR position, float range, bool cullFront, bool indoor,
     bool noNPCs, std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache ) {
+    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache,
+    unsigned int casterMask ) {
 
     // Setup renderstates
     Engine::GAPI->GetRendererState().RasterizerState.SetDefault();
@@ -5011,7 +5018,12 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
     auto rangeSquared = range * range;
     auto vRangeSquared = XMVectorReplicate(rangeSquared);
 
-    if ( Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh ) {
+    const bool drawWorldCasters = (casterMask & SHADOW_CASTER_WORLD) != 0;
+    const bool drawVobCasters = (casterMask & SHADOW_CASTER_VOBS) != 0;
+    const bool drawMobCasters = (casterMask & SHADOW_CASTER_MOBS) != 0;
+    const bool drawAnimatedCasters = (casterMask & SHADOW_CASTER_ANIMATED) != 0;
+
+    if ( drawWorldCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh ) {
         // Bind wrapped mesh vertex buffers
         DrawVertexBufferInstancedIndexedUINT( Engine::GAPI->GetWrappedWorldMesh()->MeshVertexBuffer,
             Engine::GAPI->GetWrappedWorldMesh()->MeshIndexBuffer, 0, 0, 0 );
@@ -5106,7 +5118,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
         }
     }
     
-    if ( Engine::GAPI->GetRendererState().RendererSettings.DrawVOBs ) {
+    if ( drawVobCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawVOBs ) {
         // Draw visible vobs here
         std::list<VobInfo*> rndVob;
         // construct new renderedvob list or fake one
@@ -5177,8 +5189,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
         }
     }
 
-    bool renderNPCs = !noNPCs;
-    if ( Engine::GAPI->GetRendererState().RendererSettings.DrawMobs ) {
+    bool renderNPCs = !noNPCs && drawAnimatedCasters;
+    if ( drawMobCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawMobs ) {
         // Draw visible vobs here
         std::list<SkeletalVobInfo*> rndVob;
 
@@ -5226,7 +5238,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
         }
     }
 
-    if ( Engine::GAPI->GetRendererState().RendererSettings.DrawSkeletalMeshes ) {
+    if ( drawAnimatedCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawSkeletalMeshes ) {
         // Draw animated skeletal meshes if wanted
         if ( renderNPCs ) {
             auto _ = Engine::GraphicsEngine->RecordGraphicsEvent(L"Draw animated skeletal meshes (layered)");
@@ -6735,10 +6747,12 @@ void XM_CALLCONV D3D11GraphicsEngine::RenderShadowCube(
     Microsoft::WRL::ComPtr<ID3D11RenderTargetView> debugRTV, bool cullFront, bool indoor, bool noNPCs,
     std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache ) {
+    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache,
+    bool clearDepth,
+    unsigned int casterMask ) {
     
     ShadowMaps->RenderShadowCube( position, range, targetCube, face, debugRTV,
-        cullFront, indoor, noNPCs, renderedVobs, renderedMobs, worldMeshCache );
+        cullFront, indoor, noNPCs, renderedVobs, renderedMobs, worldMeshCache, clearDepth, casterMask );
 }
 
 /** Renders the shadowmaps for the sun */

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -169,10 +169,10 @@ D3D11GraphicsEngine::D3D11GraphicsEngine() :
     m_FrameLimiter = std::make_unique<FpsLimiter>();
 
     // Initialize previous view-proj matrix to identity for motion vectors
-    XMStoreFloat4x4( &m_PrevViewProjMatrix, XMMatrixIdentity() );
+    XMStoreFloat4x4(&m_PrevViewProjMatrix, XMMatrixIdentity());
 
     // Match the resolution with the current desktop resolution
-    Resolution = m_scaledResolution = 
+    Resolution = m_scaledResolution =
         Engine::GAPI->GetRendererState().RendererSettings.LoadedResolution;
     unionCurrentCustomFontMultiplier = 1.0;
 }
@@ -2452,6 +2452,8 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
     tempVobList.clear();
     BoneTransformCache.clear();
     BoneTransformCache.reserve( 150 );
+    
+    GothicGraphicsState& graphicsState = Engine::GAPI->GetRendererState().GraphicsState;
 
     int boneOffset = 0;
     
@@ -2490,7 +2492,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
     
     bool wantShader = true;
     if ( RenderingStage != DES_GHOST ) {
-        bool linearDepth = (Engine::GAPI->GetRendererState().GraphicsState.FF_GSwitches & GSWITCH_LINEAR_DEPTH) != 0;
+        bool linearDepth = (graphicsState.FF_GSwitches & GSWITCH_LINEAR_DEPTH) != 0;
         if ( linearDepth ) {
             ActivePS = ShaderManager->GetPShader( PShaderID::PS_LinDepth );
             ActivePS->Apply();
@@ -2504,11 +2506,12 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         }
     }
     // Ensure we have correct Constantbuffer for eventual Alphatest stuff.
-    ShaderManager->GetPShader( Resolved_DiffuseNormalmappedAlphatest )
+    auto cbFFPipelineConstantBuffer = ShaderManager->GetPShader( Resolved_DiffuseNormalmappedAlphatest )
         ->GetBuffer( "FFPipelineConstantBuffer" )
-        .Update( &Engine::GAPI->GetRendererState().GraphicsState )
+        .Update( &graphicsState )
         .Bind();
     
+    const bool enableShadows = Engine::GAPI->GetRendererState().RendererSettings.EnableShadows;
     for ( SkeletalVobInfo* vi : vis ) {
         zCModel* model = static_cast<zCModel*>(vi->Vob->GetVisual());
         if ( !model ) {
@@ -2522,7 +2525,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
             continue;
 
         float4 modelColor;
-        if ( Engine::GAPI->GetRendererState().RendererSettings.EnableShadows ) {
+        if ( enableShadows ) {
             // Let shadows do the work
             modelColor = 0xFFFFFFFF;
         } else {
@@ -2996,7 +2999,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
     if ( !isMainOrGhost && !isShadowPass ) {
         // ghost or other: keep the pixel shader whatever was set
     } else if ( isShadowPass ) {
-        bool linearDepth = (Engine::GAPI->GetRendererState().GraphicsState.FF_GSwitches & GSWITCH_LINEAR_DEPTH) != 0;
+        bool linearDepth = (graphicsState.FF_GSwitches & GSWITCH_LINEAR_DEPTH) != 0;
         if ( linearDepth ) {
             ActivePS = ShaderManager->GetPShader( PShaderID::PS_LinDepth );
             ActivePS->Apply();
@@ -3010,9 +3013,9 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
     D3D11VertexBuffer* lastVB = nullptr;
     D3D11VertexBuffer* lastIB = nullptr;
 
-
     MaterialInfo* lastMaterialInfo = nullptr;
 
+    auto lastSwitches = graphicsState.FF_GSwitches;
     for ( const auto& batch : batches ) {
         MeshInfo* mi = batch.mesh;
 
@@ -3028,9 +3031,15 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         // Set up alpha test state from material
         if ( batch.material ) {
             if ( batch.material->GetAlphaFunc() == zRND_ALPHA_FUNC_TEST )
-                Engine::GAPI->GetRendererState().GraphicsState.FF_GSwitches |= GSWITCH_ALPHAREF;
+                graphicsState.FF_GSwitches |= GSWITCH_ALPHAREF;
             else
-                Engine::GAPI->GetRendererState().GraphicsState.FF_GSwitches &= ~GSWITCH_ALPHAREF;
+                graphicsState.FF_GSwitches &= ~GSWITCH_ALPHAREF;
+            
+            if (lastSwitches != graphicsState.FF_GSwitches) {
+                lastSwitches = graphicsState.FF_GSwitches;
+                cbFFPipelineConstantBuffer.Update( &lastSwitches );
+                UpdateRenderStates();
+            }
         }
 
         // Bind mesh VB to slot 0 (only when changed)

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -144,27 +144,29 @@ namespace
     }
 }
 
-D3D11GraphicsEngine::D3D11GraphicsEngine() {
-    DebugPointlight = nullptr;
-    OutputWindow = nullptr;
-    ActiveHDS = nullptr;
-    ActivePS = nullptr;
-    InverseUnitSphereMesh = nullptr;
-    frameLatencyWaitableObject = nullptr;
-
+D3D11GraphicsEngine::D3D11GraphicsEngine() :
+    DebugPointlight(nullptr),
+    m_LastFrameLimit(0),
+    RenderingStage(DES_MAIN),
+    InverseUnitSphereMesh(nullptr),
+    QuadVertexBuffer(nullptr),
+    QuadIndexBuffer(nullptr),
+    CachedRefreshRate{0, 0},
+    frameLatencyWaitableObject(nullptr),
+    SaveScreenshotNextFrame(false),
+    m_flipWithTearing(false),
+    m_swapchainflip(false),
+    m_lowlatency(false),
+    m_HDR(false),
+    m_previousFpsLimit(0),
+    m_isWindowActive(false),
+    m_FrameNeedsJitter(false)
+{
     Effects = std::make_unique<D3D11Effect>();
-    RenderingStage = DES_MAIN;
-    PresentPending = false;
-    SaveScreenshotNextFrame = false;
     LineRenderer = std::make_unique<D3D11LineRenderer>();
     Occlusion = std::make_unique<D3D11OcclusionQuerry>();
 
     m_FrameLimiter = std::make_unique<FpsLimiter>();
-    m_LastFrameLimit = 0;
-    m_flipWithTearing = false;
-    m_HDR = false;
-    m_lowlatency = false;
-    m_isWindowActive = false;
 
     // Initialize previous view-proj matrix to identity for motion vectors
     XMStoreFloat4x4( &m_PrevViewProjMatrix, XMMatrixIdentity() );
@@ -172,8 +174,6 @@ D3D11GraphicsEngine::D3D11GraphicsEngine() {
     // Match the resolution with the current desktop resolution
     Resolution = m_scaledResolution = 
         Engine::GAPI->GetRendererState().RendererSettings.LoadedResolution;
-    CachedRefreshRate.Numerator = 0;
-    CachedRefreshRate.Denominator = 0;
     unionCurrentCustomFontMultiplier = 1.0;
 }
 
@@ -421,7 +421,7 @@ XRESULT D3D11GraphicsEngine::Init() {
         dxgiVKInterop->Release();
     }
     
-    if ( !dxvkAvailable ) {
+    if ( !dxvkAvailable && Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.FeatureSet.EnableDriverExtensions ) {
         if ( adpDesc.VendorId == 0x10DE ) {
             nvapiDevice.reset( new D3D11NVAPI );
             if ( !nvapiDevice->InitNVAPI() ) {
@@ -509,7 +509,7 @@ XRESULT D3D11GraphicsEngine::Init() {
         exit( 2 );
     }
 
-    if ( dxvkAvailable ) {
+    if ( dxvkAvailable && Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.FeatureSet.EnableDriverExtensions) {
         Microsoft::WRL::ComPtr<ID3D11VkExtDevice> DXVKDevice;
         if ( SUCCEEDED( Device11.As( &DXVKDevice ) ) ) {
             if ( DXVKDevice->GetExtensionSupport( D3D11_VK_EXT_MULTI_DRAW_INDIRECT ) ) {
@@ -723,7 +723,8 @@ XRESULT D3D11GraphicsEngine::Init() {
     OutdoorVobsConstantBuffer.reset(outdoorVobsConstantBuffer);
 
     // Init inf-buffer now
-    InfiniteRangeConstantBuffer->UpdateBuffer( &float4( FLT_MAX, 0, 0, 0 ) );
+    static const float4 infiniteRange( FLT_MAX, 0, 0, 0 );
+    InfiniteRangeConstantBuffer->UpdateBuffer( &infiniteRange );
     SetDebugName( InfiniteRangeConstantBuffer->Get().Get(), "InfiniteRangeConstantBuffer" );
     SetDebugName( OutdoorSmallVobsConstantBuffer->Get().Get(), "OutdoorSmallVobsConstantBuffer" );
     SetDebugName( OutdoorVobsConstantBuffer->Get().Get(), "OutdoorVobsConstantBuffer" );
@@ -2912,9 +2913,13 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
     // Ensure instance buffer is large enough
     const size_t neededBytes = instancedDrawItems.size() * sizeof( NodeAttachmentInstanceData );
     if ( NodeAttachmentInstancingBuffer->GetSizeInBytes() < neededBytes ) {
-        NodeAttachmentInstancingBuffer->Init(
-            nullptr, static_cast<unsigned int>(neededBytes),
-            D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_DYNAMIC, D3D11VertexBuffer::CA_WRITE );
+        if (XR_FAILED == NodeAttachmentInstancingBuffer->Init(
+            nullptr, neededBytes,
+            D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_DYNAMIC, D3D11VertexBuffer::CA_WRITE ) )
+        {
+            LogError() << "Failed to create instance buffer for node attachments!";
+            return;
+        }
         SetDebugName( NodeAttachmentInstancingBuffer->GetVertexBuffer().Get(), "NodeAttachmentInstancingBuffer" );
     }
 
@@ -2934,6 +2939,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
     UINT mappedSize;
     if ( XR_SUCCESS != NodeAttachmentInstancingBuffer->Map( D3D11VertexBuffer::M_WRITE_DISCARD,
         &mappedData, &mappedSize ) ) {
+        LogError() << "Failed to map instance buffer for node attachments!";
         return;
     }
 
@@ -3240,13 +3246,14 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     GetContext()->CSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
 
     // Update view distances
-    InfiniteRangeConstantBuffer->UpdateBuffer( float4( FLT_MAX, 0, 0, 0 ).toPtr() );
-    OutdoorSmallVobsConstantBuffer->UpdateBuffer(
-        float4( rendererState.RendererSettings.OutdoorSmallVobDrawRadius,
-            0, 0, 0 ).toPtr() );
-    OutdoorVobsConstantBuffer->UpdateBuffer( float4(
-        rendererState.RendererSettings.OutdoorVobDrawRadius,
-        0, 0, 0 ).toPtr() );
+    static const float4 defaultInfiniteRange = float4( FLT_MAX, 0, 0, 0 );
+    InfiniteRangeConstantBuffer->UpdateBuffer( &defaultInfiniteRange );
+
+    const float4 outdoorSmallRange( rendererState.RendererSettings.OutdoorSmallVobDrawRadius, 0, 0, 0 );
+    OutdoorSmallVobsConstantBuffer->UpdateBuffer( &outdoorSmallRange );
+
+    const float4 outdoorRange( rendererState.RendererSettings.OutdoorVobDrawRadius, 0, 0, 0 );
+    OutdoorVobsConstantBuffer->UpdateBuffer( &outdoorRange );
 
     rendererState.RasterizerState.FrontCounterClockwise = false;
     rendererState.RasterizerState.SetDirty();

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -6278,8 +6278,8 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                         lastFxTex = srv[2];
                         
                         GetContext()->PSSetShaderResources( 0, 3, srv );
-                    
-                         // Force alphatest on vobs for now
+
+                        // Previously this forced alpha testing, now we need to check material flags as well for that and only enable the shader if absolutely necessery
                         BindShaderForTexture( tx, 
                             tx->HasAlphaChannel()
                             || meshKey.Material->HasAlphaTest()

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -22,6 +22,14 @@ enum D3D11ENGINE_RENDER_STAGE {
     DES_GHOST
 };
 
+enum ShadowCubeCasterMask : unsigned int {
+    SHADOW_CASTER_WORLD = 1u << 0,
+    SHADOW_CASTER_VOBS = 1u << 1,
+    SHADOW_CASTER_MOBS = 1u << 2,
+    SHADOW_CASTER_ANIMATED = 1u << 3,
+    SHADOW_CASTER_ALL = SHADOW_CASTER_WORLD | SHADOW_CASTER_VOBS | SHADOW_CASTER_MOBS | SHADOW_CASTER_ANIMATED,
+};
+
 const unsigned int DRAWVERTEXARRAY_BUFFER_SIZE = 4096 * sizeof( ExVertexStruct );
 const unsigned int POLYS_BUFFER_SIZE = 1024 * sizeof( ExVertexStruct );
 const unsigned int PARTICLES_BUFFER_SIZE = 3072 * sizeof( ParticleInstanceInfo );
@@ -231,13 +239,15 @@ public:
         bool cullFront = true,
         bool indoor = false,
         bool noNPCs = false,
-        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache = nullptr );
+        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache = nullptr,
+        unsigned int casterMask = SHADOW_CASTER_ALL );
     void XM_CALLCONV DrawWorldAround_Layered( FXMVECTOR position,
         float range,
         bool cullFront = true,
         bool indoor = false,
         bool noNPCs = false,
-        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache = nullptr );
+        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache = nullptr,
+        unsigned int casterMask = SHADOW_CASTER_ALL );
 
     /** Update morph mesh visual */
     void UpdateMorphMeshVisual();
@@ -267,7 +277,9 @@ public:
         bool cullFront = true,
         bool indoor = false,
         bool noNPCs = false,
-        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache = nullptr );
+        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache = nullptr,
+        bool clearDepth = true,
+        unsigned int casterMask = SHADOW_CASTER_ALL );
 
     /** Updates the occlusion for the bsp-tree */
     void UpdateOcclusion();

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -378,7 +378,6 @@ protected:
     std::unique_ptr<D3D11ShadowMap> ShadowMaps;
 
     /** Temp-Arrays for storing data to be put in constant buffers */
-    XMFLOAT4X4 Temp2D3DXMatrix[2];
     float2 Temp2Float2[2];
     std::unique_ptr<D3D11VertexBuffer> DynamicInstancingBuffer;
     std::unique_ptr<D3D11VertexBuffer> NodeAttachmentInstancingBuffer;

--- a/D3D11Engine/D3D11GraphicsEngineBase.cpp
+++ b/D3D11Engine/D3D11GraphicsEngineBase.cpp
@@ -14,7 +14,9 @@ const int NUM_MAX_BONES = 96;
 const unsigned int INSTANCING_BUFFER_SIZE = sizeof( VobInstanceInfo ) * 2048;
 
 // If defined, creates a debug-version of the d3d11-device
-//#define DEBUG_D3D11
+#if !PUBLIC_RELEASE
+#define DEBUG_D3D11
+#endif
 
 D3D11GraphicsEngineBase::D3D11GraphicsEngineBase() {
     OutputWindow = HWND( 0 );

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -5,6 +5,7 @@
 #include "D3D11GraphicsEngineBase.h"
 #include "D3D11GraphicsEngine.h" // TODO: Remove and use newer system!
 #include "Engine.h"
+#include "D3D11PfxRenderer.h"
 #include "zCVobLight.h"
 #include "BaseLineRenderer.h"
 #include "WorldConverter.h"
@@ -23,6 +24,7 @@ D3D11PointLight::D3D11PointLight( VobLightInfo* info, bool dynamicLight ) {
     XMStoreFloat3( &LastUpdatePosition, LightInfo->Vob->GetPositionWorldXM() );
 
     m_DepthCubemap = nullptr;
+    m_StaticDepthCubemap = nullptr;
     WorldCacheInvalid = true;
 
     StartReInit();
@@ -76,7 +78,9 @@ void D3D11PointLight::AcquireShadowMap( DepthStencilPool* pool, int resolution )
 void D3D11PointLight::ReleaseShadowMap() {
     // This calls the custom deleter, returning the texture to the pool
     m_DepthCubemap.reset();
+    ReleaseStaticAsideShadowMap();
     m_CurrentResolution = 0;
+    DrawnOnce = false;
 
 }
 
@@ -86,6 +90,8 @@ void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target
     m_TiledOwner = owner;
 
     StartReInit();
+    DrawnOnce = false;
+    m_StaticShadowReady = false;
 }
 
 void D3D11PointLight::ClearTiledSlot() {
@@ -95,7 +101,114 @@ void D3D11PointLight::ClearTiledSlot() {
     m_TiledSlotIndex = -1;
     m_TiledDepthTarget = nullptr;
     m_TiledOwner = nullptr;
+    m_StaticShadowReady = false;
 
+}
+
+int D3D11PointLight::GetCurrentShadowMode() const {
+    return static_cast<int>(Engine::GAPI->GetRendererState().RendererSettings.EnablePointlightShadows);
+}
+
+void D3D11PointLight::HandleShadowModeChange( int shadowMode ) {
+    if ( m_LastShadowMode == shadowMode ) {
+        return;
+    }
+
+    m_LastShadowMode = shadowMode;
+    m_StaticShadowReady = false;
+    DrawnOnce = false;
+
+    if ( shadowMode != GothicRendererSettings::PLS_UPDATE_DYNAMIC ) {
+        ReleaseStaticAsideShadowMap();
+    }
+}
+
+RenderToDepthStencilBuffer* D3D11PointLight::GetActiveShadowTarget() const {
+    if ( m_TiledDepthTarget ) {
+        return m_TiledDepthTarget;
+    }
+    if ( m_DepthCubemap ) {
+        return m_DepthCubemap.get();
+    }
+    return nullptr;
+}
+
+void D3D11PointLight::AcquireStaticAsideShadowMap( DepthStencilPool* pool, int resolution ) {
+    if ( !pool || resolution <= 0 ) {
+        return;
+    }
+
+    if ( m_StaticDepthCubemap
+        && static_cast<int>(m_StaticDepthCubemap->GetSizeX()) == resolution
+        && static_cast<int>(m_StaticDepthCubemap->GetSizeY()) == resolution ) {
+        return;
+    }
+
+    ReleaseStaticAsideShadowMap();
+
+    DepthStencilPool::Description desc;
+    desc.Width = resolution;
+    desc.Height = resolution;
+    desc.Format = DXGI_FORMAT_R16_TYPELESS;
+    desc.DSVFormat = DXGI_FORMAT_D16_UNORM;
+    desc.SRVFormat = DXGI_FORMAT_R16_UNORM;
+    desc.ArraySize = 6;
+
+    m_StaticDepthCubemap = pool->Acquire( desc );
+    m_StaticShadowReady = false;
+}
+
+void D3D11PointLight::ReleaseStaticAsideShadowMap() {
+    m_StaticDepthCubemap.reset();
+    m_StaticShadowReady = false;
+}
+
+void D3D11PointLight::CopyStaticAsideToActiveTarget() const {
+    if ( !m_StaticDepthCubemap ) {
+        return;
+    }
+
+    RenderToDepthStencilBuffer* target = GetActiveShadowTarget();
+    if ( !target ) {
+        return;
+    }
+
+    ID3D11Texture2D* srcTexture = m_StaticDepthCubemap->GetTexture().Get();
+    ID3D11Texture2D* dstTexture = target->GetTexture().Get();
+    auto context = reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine)->GetContext();
+    if ( !srcTexture || !dstTexture || !context ) {
+        return;
+    }
+
+    const UINT dstBaseSlice = m_TiledDepthTarget ? static_cast<UINT>(std::max( m_TiledSlotIndex, 0 ) * 6) : 0u;
+    for ( UINT face = 0; face < 6; ++face ) {
+        const UINT srcSubresource = D3D11CalcSubresource( 0, face, 1 );
+        const UINT dstSubresource = D3D11CalcSubresource( 0, dstBaseSlice + face, 1 );
+        context->CopySubresourceRegion( dstTexture, dstSubresource, 0, 0, 0, srcTexture, srcSubresource, nullptr );
+    }
+}
+
+void D3D11PointLight::RenderStaticShadowPass( RenderToDepthStencilBuffer& target, bool clearDepth ) {
+    D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    const float range = LightInfo->Vob->GetLightRange() * 1.1f;
+
+    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* wc = &WorldMeshCache;
+    if ( WorldCacheInvalid ) {
+        wc = nullptr;
+    }
+
+    const unsigned int staticCasterMask = SHADOW_CASTER_WORLD | SHADOW_CASTER_VOBS | SHADOW_CASTER_MOBS;
+    engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), range, target, nullptr, nullptr, false, LightInfo->IsIndoorVob, false,
+        &VobCache, &SkeletalVobCache, wc, clearDepth, staticCasterMask );
+}
+
+void D3D11PointLight::RenderAnimatedShadowPass( RenderToDepthStencilBuffer& target, bool clearDepth ) {
+    D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    const float range = LightInfo->Vob->GetLightRange() * 1.1f;
+
+    const unsigned int animatedCasterMask = SHADOW_CASTER_ANIMATED;
+    engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), range, target, nullptr, nullptr, false, LightInfo->IsIndoorVob, false,
+        nullptr, nullptr, nullptr, clearDepth, animatedCasterMask );
 }
 
 /** Returns true if this is the first time that light is being rendered */
@@ -136,8 +249,24 @@ bool D3D11PointLight::IsInited() {
 bool D3D11PointLight::NeedsUpdate() {
     if ( !IsReady() )
         return false;
+
+    const int shadowMode = GetCurrentShadowMode();
+    if ( shadowMode != m_LastShadowMode ) {
+        return true;
+    }
+
     FXMVECTOR lastPos = XMLoadFloat3( &LastUpdatePosition );
-    return !XMVector3Equal( LightInfo->Vob->GetPositionWorldXM(), lastPos ) || NotYetDrawn();
+    const bool moved = !XMVector3Equal( LightInfo->Vob->GetPositionWorldXM(), lastPos );
+
+    if ( shadowMode == GothicRendererSettings::PLS_STATIC_ONLY ) {
+        return moved || !m_StaticShadowReady || NotYetDrawn();
+    }
+
+    if ( shadowMode == GothicRendererSettings::PLS_UPDATE_DYNAMIC ) {
+        return moved || !m_StaticShadowReady || NotYetDrawn();
+    }
+
+    return moved || NotYetDrawn();
 }
 
 /** Returns true if the light could need an update, but it's not very important */
@@ -145,9 +274,14 @@ bool D3D11PointLight::WantsUpdate() {
     if ( !IsReady() )
         return false;
 
+    const int shadowMode = GetCurrentShadowMode();
+    if ( shadowMode == GothicRendererSettings::PLS_STATIC_ONLY ) {
+        return false;
+    }
+
     // If dynamic, update colorchanging lights too, because they are mostly lamps and campfires
     // They wouldn't need an update just because of the colorchange, but most of them are dominant lights so it looks better
-    if ( Engine::GAPI->GetRendererState().RendererSettings.EnablePointlightShadows >= GothicRendererSettings::PLS_UPDATE_DYNAMIC )
+    if ( shadowMode >= GothicRendererSettings::PLS_UPDATE_DYNAMIC )
         if ( LightInfo->Vob->GetLightColor() != LastUpdateColor )
             return true;
 
@@ -161,23 +295,33 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate, D3D11ConstantBuffer* View
     if ( !ViewMatricesCB || (!m_DepthCubemap && !m_TiledDepthTarget) )
         return;
 
+    const int shadowMode = GetCurrentShadowMode();
+    HandleShadowModeChange( shadowMode );
+
     //if (!GetAsyncKeyState('X'))
     //	return;
     D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine); // TODO: Remove and use newer system!
 
+    FXMVECTOR xmlastPos = XMLoadFloat3( &LastUpdatePosition );
+    const bool moved = !XMVector3Equal( LightInfo->Vob->GetPositionWorldXM(), xmlastPos );
+
+    if ( moved ) {
+        // Position changed, refresh our caches
+        VobCache.clear();
+        SkeletalVobCache.clear();
+
+        // Invalidate worldcache
+        WorldCacheInvalid = true;
+        m_StaticShadowReady = false;
+    }
+
+    if ( shadowMode == GothicRendererSettings::PLS_STATIC_ONLY && !moved && m_StaticShadowReady && DrawnOnce ) {
+        return;
+    }
+
     if ( !NeedsUpdate() && !WantsUpdate() ) {
         if ( !forceUpdate )
             return; // Don't update when we don't need to
-    } else {
-        FXMVECTOR xmlastPos = XMLoadFloat3( &LastUpdatePosition );
-        if ( !XMVector3Equal( LightInfo->Vob->GetPositionWorldXM(), xmlastPos ) ) {
-            // Position changed, refresh our caches
-            VobCache.clear();
-            SkeletalVobCache.clear();
-
-            // Invalidate worldcache
-            WorldCacheInvalid = true;
-        }
     }
 
     FXMVECTOR vEyePt = LightInfo->Vob->GetPositionWorldXM();
@@ -255,28 +399,49 @@ void D3D11PointLight::RenderFullCubemap() {
     if ( !IsReady() )
         return;
     D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine); // TODO: Remove and use newer system!
-
-    // Disable shadows for NPCs
-    // TODO: Only for the player himself, because his shadows look ugly when using a torch
-    //bool oldDrawSkel = Engine::GAPI->GetRendererState().RendererSettings.DrawSkeletalMeshes;
-    //Engine::GAPI->GetRendererState().RendererSettings.DrawSkeletalMeshes = false;
-
-    float range = LightInfo->Vob->GetLightRange() * 1.1f;
-
-    // Draw no npcs if this is a static light. This is archived by simply not drawing them in the first update
-    bool noNPCs = !DrawnOnce;//!LightInfo->Vob->IsStatic();
-
-    // Draw cubemap
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* wc = &WorldMeshCache;
-
-    // Don't use the cache if we have moved
-    if ( WorldCacheInvalid )
-        wc = nullptr;
     auto _ = engine->RecordGraphicsEvent( L"RenderFullCubemap->RenderFullCubemap" );
-    RenderToDepthStencilBuffer& target = m_TiledDepthTarget ? *m_TiledDepthTarget : *m_DepthCubemap;
-    engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), range, target, nullptr, nullptr, false, LightInfo->IsIndoorVob, noNPCs, &VobCache, &SkeletalVobCache, wc );
 
-    //Engine::GAPI->GetRendererState().RendererSettings.DrawSkeletalMeshes = oldDrawSkel;
+    RenderToDepthStencilBuffer* activeTarget = GetActiveShadowTarget();
+    if ( !activeTarget ) {
+        return;
+    }
+
+    const int shadowMode = GetCurrentShadowMode();
+    if ( shadowMode == GothicRendererSettings::PLS_STATIC_ONLY ) {
+        RenderStaticShadowPass( *activeTarget, true );
+        m_StaticShadowReady = true;
+        return;
+    }
+
+    if ( shadowMode == GothicRendererSettings::PLS_UPDATE_DYNAMIC ) {
+        DepthStencilPool* dsPool = engine->GetPfxRenderer()->GetDepthStencilPool();
+        AcquireStaticAsideShadowMap( dsPool, m_CurrentResolution );
+
+        if ( !m_StaticShadowReady || !m_StaticDepthCubemap ) {
+            if ( m_StaticDepthCubemap ) {
+                RenderStaticShadowPass( *m_StaticDepthCubemap, true );
+                m_StaticShadowReady = true;
+            } else {
+                RenderStaticShadowPass( *activeTarget, true );
+                m_StaticShadowReady = true;
+            }
+        }
+
+        if ( m_StaticDepthCubemap ) {
+            CopyStaticAsideToActiveTarget();
+        }
+
+        RenderAnimatedShadowPass( *activeTarget, false );
+        return;
+    }
+
+    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* wc = &WorldMeshCache;
+    if ( WorldCacheInvalid ) {
+        wc = nullptr;
+    }
+
+    engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), LightInfo->Vob->GetLightRange() * 1.1f, *activeTarget,
+        nullptr, nullptr, false, LightInfo->IsIndoorVob, false, &VobCache, &SkeletalVobCache, wc, true, SHADOW_CASTER_ALL );
 }
 
 bool D3D11PointLight::IsReady()
@@ -288,6 +453,7 @@ bool D3D11PointLight::IsReady()
 
 void D3D11PointLight::Invalidate() {
     DrawnOnce = false;
+    m_StaticShadowReady = false;
     VobCache.clear();
     SkeletalVobCache.clear();
     WorldCacheInvalid = true;
@@ -376,6 +542,7 @@ void D3D11PointLight::OnVobRemovedFromWorld( BaseVobInfo* vob ) {
         VobCache.clear();
         SkeletalVobCache.clear();
         DrawnOnce = false;
+        m_StaticShadowReady = false;
     }
 
     if (vob->Vob == LightInfo->Vob) {

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -46,7 +46,11 @@ public:
     virtual void OnVobRemovedFromWorld( BaseVobInfo* vob );
 
     bool HasAnyShadowMap() const {
-        return HasShadowMap(0) || HasShadowMap(1);
+        return HasShadowMap(0) || HasShadowMap(1) || m_StaticDepthCubemap != nullptr;
+    }
+
+    bool IsStaticShadowReady() const {
+        return m_StaticShadowReady;
     }
 
     bool HasShadowMap(int shadowMapKind ) const { 
@@ -66,6 +70,15 @@ public:
     void SetCurrentResolution( int r ) { m_CurrentResolution = r; }
 
 protected:
+    int GetCurrentShadowMode() const;
+    void HandleShadowModeChange( int shadowMode );
+    RenderToDepthStencilBuffer* GetActiveShadowTarget() const;
+    void AcquireStaticAsideShadowMap( DepthStencilPool* pool, int resolution );
+    void ReleaseStaticAsideShadowMap();
+    void CopyStaticAsideToActiveTarget() const;
+    void RenderStaticShadowPass( RenderToDepthStencilBuffer& target, bool clearDepth );
+    void RenderAnimatedShadowPass( RenderToDepthStencilBuffer& target, bool clearDepth );
+
     bool IsReady();
     void Invalidate();
     void StartReInit();
@@ -83,6 +96,7 @@ protected:
 
     VobLightInfo* LightInfo;
     DepthStencilHandle m_DepthCubemap;
+    DepthStencilHandle m_StaticDepthCubemap;
     int m_CurrentResolution = 0; // Track current LOD size
     XMFLOAT4X4 CubeMapViewMatrices[6];
     XMFLOAT3 LastUpdatePosition;
@@ -90,6 +104,8 @@ protected:
     bool DynamicLight;
     std::atomic<bool> InitDone;
     bool DrawnOnce;
+    bool m_StaticShadowReady = false;
+    int m_LastShadowMode = -1;
 
     // Tiled deferred slot (non-owning, owned by D3D11TiledDeferredShading)
     int m_TiledSlotIndex = -1;

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -794,6 +794,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
         : xmFltMax;
 
     bool partialShadowUpdate = settings.PartialDynamicShadowUpdates;
+    const bool staticOnlyMode = settings.EnablePointlightShadows == GothicRendererSettings::PLS_STATIC_ONLY;
 
     // Draw pointlight shadows
     std::list<VobLightInfo*> importantUpdates;
@@ -825,7 +826,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
 
             // pick shadow resolution based on distance.
             int desiredResolution = SHADOW_CUBE_SIZE; // Fallback / far distance
-            if ( d < distVeryCloseSq ) {
+            if ( d < distVeryCloseSq && !staticOnlyMode ) {
                 light->UpdateShadows = true;
                 // for now, keep all lights/shadows the same size, otherwise they change their "volume"
                 // desiredResolution = 256; // High res for close lights
@@ -869,10 +870,16 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
                         importantUpdates.emplace_back( light );
                     }
                     // Background Priority: Add to round-robin queue if not already there
-                    else if ( partialShadowUpdate ) {
+                    else if ( partialShadowUpdate && !staticOnlyMode ) {
                         auto& queue = graphicsEngine->FrameShadowUpdateLights;
                         if ( std::find( queue.begin(), queue.end(), light ) == queue.end() ) {
                             queue.emplace_back( light );
+                        }
+                    } else if ( staticOnlyMode ) {
+                        auto& queue = graphicsEngine->FrameShadowUpdateLights;
+                        auto queued = std::find( queue.begin(), queue.end(), light );
+                        if ( queued != queue.end() ) {
+                            queue.erase( queued );
                         }
                     }
                 }
@@ -917,6 +924,11 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
 
         D3D11PointLight* l = static_cast<D3D11PointLight*>( light->LightShadowBuffers.get() );
         if ( !l ) continue;
+
+        if ( staticOnlyMode && l->IsStaticShadowReady() && !l->NeedsUpdate() ) {
+            light->UpdateShadows = false;
+            continue;
+        }
 
         light->UpdateShadows = false;
 
@@ -1331,7 +1343,9 @@ void XM_CALLCONV D3D11ShadowMap::RenderShadowCube(
     Microsoft::WRL::ComPtr<ID3D11RenderTargetView> debugRTV, bool cullFront, bool indoor, bool noNPCs,
     std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
-    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache ) {
+    std::map<MeshKey, WorldMeshInfo*, cmpMeshKey>* worldMeshCache,
+    bool clearDepth,
+    unsigned int casterMask ) {
 
     auto graphicsEngine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
 
@@ -1387,16 +1401,17 @@ void XM_CALLCONV D3D11ShadowMap::RenderShadowCube(
         Engine::GAPI->GetRendererState().BlendState.SetDirty();
     }
 
-    // Always render shadowcube when dynamic shadows are enabled
-    m_context->ClearDepthStencilView( face.Get(), D3D11_CLEAR_DEPTH, 1.0f, 0 );
+    if ( clearDepth ) {
+        m_context->ClearDepthStencilView( face.Get(), D3D11_CLEAR_DEPTH, 1.0f, 0 );
+    }
 
     // Draw the world mesh without textures
     if ( useLayeredPath ) {
         graphicsEngine->DrawWorldAround_Layered( position, range, cullFront, indoor, noNPCs, renderedVobs,
-            renderedMobs, worldMeshCache );
+            renderedMobs, worldMeshCache, casterMask );
     } else {
         graphicsEngine->DrawWorldAround( position, range, cullFront, indoor, noNPCs, renderedVobs,
-            renderedMobs, worldMeshCache );
+            renderedMobs, worldMeshCache, casterMask );
     }
 
     // Restore state

--- a/D3D11Engine/D3D11ShadowMap.h
+++ b/D3D11Engine/D3D11ShadowMap.h
@@ -158,7 +158,9 @@ public:
         std::list<SkeletalVobInfo*>* renderedMobs = nullptr,
         std::map<MeshKey,
         WorldMeshInfo*,
-        cmpMeshKey>* worldMeshCache = nullptr );
+        cmpMeshKey>* worldMeshCache = nullptr,
+        bool clearDepth = true,
+        unsigned int casterMask = 0xFFFFFFFFu );
 
     inline static struct { float lambda; float bias; } lambdaBiasTable[] {
         /* 0 */ { 0, 0 },

--- a/D3D11Engine/D3D11VertexBuffer.h
+++ b/D3D11Engine/D3D11VertexBuffer.h
@@ -11,8 +11,11 @@ enum XRESULT;
 
 class D3D11VertexBuffer {
 public:
-    D3D11VertexBuffer();
-    ~D3D11VertexBuffer();
+    D3D11VertexBuffer()
+        : SizeInBytes( 0 )
+    {}
+
+    ~D3D11VertexBuffer() = default;
 
     /** Layed out for D3D11*/
     enum ECPUAccessFlags {

--- a/D3D11Engine/D3D11Vertexbuffer.cpp
+++ b/D3D11Engine/D3D11Vertexbuffer.cpp
@@ -6,10 +6,6 @@
 #include <DirectXMesh.h>
 #include "D3D11_Helpers.h"
 
-D3D11VertexBuffer::D3D11VertexBuffer() {}
-
-D3D11VertexBuffer::~D3D11VertexBuffer() {}
-
 /** Creates the vertexbuffer with the given arguments */
 XRESULT D3D11VertexBuffer::Init( void* initData, unsigned int sizeInBytes, EBindFlags EBindFlags, EUsageFlags usage, ECPUAccessFlags cpuAccess, const std::string& fileName, unsigned int structuredByteSize ) {
     HRESULT hr;
@@ -93,10 +89,6 @@ XRESULT D3D11VertexBuffer::Init( void* initData, unsigned int sizeInBytes, EBind
 
 /** Updates the vertexbuffer with the given data */
 XRESULT D3D11VertexBuffer::UpdateBuffer( void* data, UINT size ) {
-    if ( !data || size == 0 ) {
-        return XR_SUCCESS;
-    }
-
     if ( SizeInBytes < size ) {
         size = SizeInBytes;
     }
@@ -113,7 +105,9 @@ XRESULT D3D11VertexBuffer::UpdateBuffer( void* data, UINT size ) {
                 ZeroMemory( mappedData, SizeInBytes );
             }
             // Copy data
-            memcpy( mappedData, data, size );
+            if ( data ) {
+                memcpy( mappedData, data, size );
+            }
         }
 
         return Unmap();

--- a/D3D11Engine/D3D11Vertexbuffer.cpp
+++ b/D3D11Engine/D3D11Vertexbuffer.cpp
@@ -93,22 +93,30 @@ XRESULT D3D11VertexBuffer::Init( void* initData, unsigned int sizeInBytes, EBind
 
 /** Updates the vertexbuffer with the given data */
 XRESULT D3D11VertexBuffer::UpdateBuffer( void* data, UINT size ) {
-    void* mappedData;
-    UINT bsize;
+    if ( !data || size == 0 ) {
+        return XR_SUCCESS;
+    }
 
     if ( SizeInBytes < size ) {
         size = SizeInBytes;
     }
 
-    if ( XR_SUCCESS == Map( EMapFlags::M_WRITE_DISCARD, &mappedData, &bsize ) ) {
-        if ( size ) {
-            bsize = size;
-        }
-        // Copy data
-        memcpy( mappedData, data, bsize );
-        Unmap();
+    void* mappedData;
+    UINT bsize;
 
-        return XR_SUCCESS;
+    if ( XR_SUCCESS == Map( EMapFlags::M_WRITE_DISCARD, &mappedData, &bsize ) ) {
+        if ( mappedData ) {
+            if ( size ) {
+                size = std::min(size, bsize);
+            }
+            if ( size < bsize ) {
+                ZeroMemory( mappedData, SizeInBytes );
+            }
+            // Copy data
+            memcpy( mappedData, data, size );
+        }
+
+        return Unmap();
     }
 
     return XR_FAILED;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4890,6 +4890,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "FontRendering", "Enable", std::to_string( s.EnableCustomFontRendering ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Debug", "UseShadowAtlas", std::to_string( s.DebugSettings.FeatureSet.UseShadowAtlas ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Debug", "ForceFeatureLevel10", std::to_string( s.DebugSettings.FeatureSet.ForceFeatureLevel10 ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Debug", "EnableDriverExtensions", std::to_string( s.DebugSettings.FeatureSet.EnableDriverExtensions ? TRUE : FALSE ).c_str(), ini.c_str() );
 
     return XR_SUCCESS;
 }
@@ -5018,6 +5019,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.EnableCustomFontRendering = GetPrivateProfileBoolA( "FontRendering", "Enable", defaultRendererSettings.EnableCustomFontRendering, ini );
         s.DebugSettings.FeatureSet.UseShadowAtlas = GetPrivateProfileBoolA( "Debug", "UseShadowAtlas", defaultRendererSettings.DebugSettings.FeatureSet.UseShadowAtlas, ini );
         s.DebugSettings.FeatureSet.ForceFeatureLevel10 = GetPrivateProfileBoolA( "Debug", "ForceFeatureLevel10", defaultRendererSettings.DebugSettings.FeatureSet.ForceFeatureLevel10, ini );
+        s.DebugSettings.FeatureSet.EnableDriverExtensions = GetPrivateProfileBoolA( "Debug", "EnableDriverExtensions", defaultRendererSettings.DebugSettings.FeatureSet.EnableDriverExtensions, ini );
 
         // Fix the resolution if the players maximum resolution got lower
         /*RECT r;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -771,6 +771,7 @@ struct GothicRendererSettings {
         DebugSettings.Culling.CullBspSections = true;
         DebugSettings.Culling.CullVobs = true;
         DebugSettings.ShadowCascades.LazyCascadeUpdate = true;
+        DebugSettings.FeatureSet.EnableDriverExtensions = true;
     }
 
     void SetupOldWorldSpecificValues() {
@@ -964,6 +965,7 @@ struct GothicRendererSettings {
             bool CullBspSections;
         } Culling;
         struct {
+            bool EnableDriverExtensions;
             bool UseMDI;
             bool UseLayeredRendering;
             bool UseShadowAtlas;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1357,6 +1357,9 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
             }
             
             if (ImGui::BeginTabItem("Featureset", nullptr, ImGuiTabItemFlags_::ImGuiTabItemFlags_NoReorder)) {
+                ImGui::Checkbox("Enable GPU Driver Extensions", &settings.DebugSettings.FeatureSet.EnableDriverExtensions );
+                ImGui::SetItemTooltip("Allow Driver Extensions (AMD, Nvidia, Intel).\nRequires restart.");
+
                 if (!FeatureLevel10Compatibility){
                     ImGui::Checkbox("Use MDI", &settings.DebugSettings.FeatureSet.UseMDI );
                     ImGui::SetItemTooltip("Support for MultiDrawInstancedIndirect via Driver Extensions (AMD, Nvidia, Intel).");

--- a/D3D11Engine/zCMaterial.h
+++ b/D3D11Engine/zCMaterial.h
@@ -159,7 +159,7 @@ public:
     }
 
     bool HasAlphaTest() {
-        int f = GetAlphaFunc();
+        const int f = GetAlphaFunc();
         return f == zMAT_ALPHA_FUNC_TEST || f == zMAT_ALPHA_FUNC_BLEND_TEST;
     }
 

--- a/Direct3D7Wrapper.sln
+++ b/Direct3D7Wrapper.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.14.35906.104 d17.14
+# Visual Studio Version 18
+VisualStudioVersion = 18.5.11723.231 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D11Engine", "D3D11Engine\D3D11Engine.vcxproj", "{4F42CE68-EB4D-4355-9DCA-28F611D3845F}"
 EndProject
@@ -14,6 +14,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Launcher", "Launcher\Launch
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		G2_Debug|Win32 = G2_Debug|Win32
 		Launcher|Win32 = Launcher|Win32
 		Release_AVX|Win32 = Release_AVX|Win32
 		Release_AVX2|Win32 = Release_AVX2|Win32
@@ -29,6 +30,8 @@ Global
 		Spacer_NET|Win32 = Spacer_NET|Win32
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.G2_Debug|Win32.ActiveCfg = G2_Debug|Win32
+		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.G2_Debug|Win32.Build.0 = G2_Debug|Win32
 		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Launcher|Win32.ActiveCfg = Launcher|Win32
 		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Release_AVX|Win32.ActiveCfg = Release_AVX|Win32
 		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Release_AVX|Win32.Build.0 = Release_AVX|Win32
@@ -54,6 +57,7 @@ Global
 		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Spacer_NET_G1|Win32.Build.0 = Spacer_NET_G1|Win32
 		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Spacer_NET|Win32.ActiveCfg = Spacer_NET|Win32
 		{4F42CE68-EB4D-4355-9DCA-28F611D3845F}.Spacer_NET|Win32.Build.0 = Spacer_NET|Win32
+		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.G2_Debug|Win32.ActiveCfg = Launcher|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Launcher|Win32.ActiveCfg = Launcher|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Launcher|Win32.Build.0 = Launcher|Win32
 		{BEFEFF75-393C-4C06-A9F0-5E5FDB0C0109}.Release_AVX|Win32.ActiveCfg = Launcher|Win32

--- a/Launcher/Launcher.vcxproj
+++ b/Launcher/Launcher.vcxproj
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="G2_Debug|Win32">
+      <Configuration>G2_Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Launcher|Win32">
       <Configuration>Launcher</Configuration>
       <Platform>Win32</Platform>
@@ -21,6 +25,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -29,12 +40,43 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Launcher|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Launcher|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <TargetName>ddraw</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>ddraw</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Launcher|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;LAUNCHER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <ModuleDefinitionFile>ddraw.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <IntrinsicFunctions>true</IntrinsicFunctions>


### PR DESCRIPTION
- Add a new Debug->FeatureSet->EnableDriverExtensions toggle
  - default: `true`
  - In case of GPU/Driver bugs, this can be disabled (saved, and the game restarted) to not use those extensions and completely bypass the GPU vendor extension setup.
- Rework the Dynamic Shadows
  - The different Modes `Static`, `Update Dynamic` and `Full` now do the following
    - `Static`: Render the shadows of static meshes/vobs once and cache them for the lifetime of the pointlight (basically free in terms of performance when combined with `Tiled Lighting`)
    - `Update Dynamic`: On top of `Static` also draw shadows of NPCs (pretty cheap)
    - `Full`: Always compute up-to-date dynamic shadows (most expensive)
- Improve performance of World mesh rendering when not using `MDI` (which requires a driver extension) by sorting the meshes and reducing pipeline state changes.
- Ensure ConstantBuffers are always Zero-initialized or zero-filled
- Ensure VertexBuffers are zero padded if the `UpdateBuffer` size does not match the buffers size.