### PR TITLE
fix: Depth buffer accuracy increased by using infinite reverse-Z instead of linearized-Z projection. CMake: add linux build instructions.

### DIFF
--- a/D3D11Engine/D3D11DeferredRenderer.cpp
+++ b/D3D11Engine/D3D11DeferredRenderer.cpp
@@ -109,9 +109,7 @@ void D3D11DeferredRenderer::AddLightingPasses( RenderGraph& graph,
             auto normalsTexture = graph.GetPhysicalTexture( normalsResource );
             auto specularTexture = graph.GetPhysicalTexture( specularResource );
 
-            if ( Engine::GAPI->GetRendererState().RendererSettings.EnableShadows ) {
-                engine.CopyDepthStencil();
-            }
+            engine.CopyDepthStencil(); // always needed due to depth testing!
 
             engine.GetShadowMaps()->DrawLighting( frameLights,
                 *colorTexture,

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -718,7 +718,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>TRACY_ENABLE;TRACY_CALLSTACK=8;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TRACY_ENABLE;TRACY_ON_DEMAND;TRACY_CALLSTACK=8;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/D3D11Engine/D3D11IndirectBuffer.h
+++ b/D3D11Engine/D3D11IndirectBuffer.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 
-#include <D3D11_4.h>
+#include <d3d11_4.h>
 
 #include <wrl/client.h>
 

--- a/D3D11Engine/D3D11PFX_FSR2.cpp
+++ b/D3D11Engine/D3D11PFX_FSR2.cpp
@@ -46,6 +46,11 @@ D3D11PFX_FSR2::~D3D11PFX_FSR2() {
     Destroy();
 }
 
+static void Ffx_log( FfxMsgType type,
+    const wchar_t* message ) {
+    LogError() << "FFX2 Error (" << type << "): " << message;
+}
+
 bool D3D11PFX_FSR2::Init( const INT2& maxInputSize, const INT2& maxOutputSize ) {
     if ( Initialized ) {
         if (maxInputSize == MaxInputSize 
@@ -92,9 +97,11 @@ bool D3D11PFX_FSR2::Init( const INT2& maxInputSize, const INT2& maxOutputSize ) 
         | FFX_FSR2_ENABLE_AUTO_EXPOSURE
         | FFX_FSR2_ENABLE_DYNAMIC_RESOLUTION
         | FFX_FSR2_ENABLE_DEPTH_INVERTED
+        | FFX_FSR2_ENABLE_DEPTH_INFINITE
         ;
 #ifdef DEBUG_D3D11
     contextDesc.flags |= FFX_FSR2_ENABLE_DEBUG_CHECKING;
+    contextDesc.fpMessage = &Ffx_log;
 #endif
 
     // If your depth buffer is inverted (1.0 = near, 0.0 = far), uncomment the following line:

--- a/D3D11Engine/D3D11PFX_FSR3.cpp
+++ b/D3D11Engine/D3D11PFX_FSR3.cpp
@@ -48,7 +48,7 @@ D3D11PFX_FSR3::~D3D11PFX_FSR3() {
 
 static void Ffx_log( FfxMsgType type,
     const wchar_t* message ) {
-    LogError() << "FFX Error (" << type << "): " << message;
+    LogError() << "FFX3 Error (" << type << "): " << message;
 }
 
 bool D3D11PFX_FSR3::Init( const INT2& maxInputSize, const INT2& maxOutputSize ) {
@@ -88,6 +88,7 @@ bool D3D11PFX_FSR3::Init( const INT2& maxInputSize, const INT2& maxOutputSize ) 
     contextDesc.flags = FFX_FSR3UPSCALER_ENABLE_HIGH_DYNAMIC_RANGE
         | FFX_FSR3UPSCALER_ENABLE_AUTO_EXPOSURE
         | FFX_FSR3UPSCALER_ENABLE_DEPTH_INVERTED 
+        | FFX_FSR3UPSCALER_ENABLE_DEPTH_INFINITE
         | FFX_FSR3UPSCALER_ENABLE_DYNAMIC_RESOLUTION;
 #ifdef DEBUG_D3D11
     contextDesc.flags |= FFX_FSR3UPSCALER_ENABLE_DEBUG_CHECKING;

--- a/D3D11Engine/D3D11Upscaling.cpp
+++ b/D3D11Engine/D3D11Upscaling.cpp
@@ -70,11 +70,12 @@ namespace {
                 auto cam = ((zCCamera*)oCGame::GetGame()->_zCSession_camera);
                 cam->GetFOV( fovY, fovX );
 
-                // Our depth projection uses reversed-Z with infinite far plane.
-                // FSR still expects finite camera metrics, so use camera near and
-                // the finite world culling distance as a stable surrogate far.
-                float nearZ = std::max( cam ? cam->GetNearPlane() : 1.0f, 0.001f );
-                float farZ = std::max( static_cast<float>( settings.SectionDrawRadius ) * WORLD_SECTION_SIZE, nearZ + 1.0f );
+                // With ENABLE_DEPTH_INVERTED | ENABLE_DEPTH_INFINITE flags,
+                // FSR expects inverted metrics: cameraNear=FLT_MAX (infinity),
+                // cameraFar=actual near plane (since depth is inverted: 1=near, 0=far)
+                float nearZ = FLT_MAX;  // Infinity in view space
+                float farZ = cam ? cam->GetNearPlane() : 0.01f;
+                farZ = std::max( farZ, 0.075f );  // FSR2 validation requires cameraFar >= 0.075f
 
                 ID3D11SamplerState* linearSampler = engine.GetLinearSamplerState();
                 engine.GetContext()->CSSetSamplers( 0, 1, &linearSampler );
@@ -136,11 +137,12 @@ namespace {
                 auto cam = ((zCCamera*)oCGame::GetGame()->_zCSession_camera);
                 cam->GetFOV( fovY, fovX );
 
-                // Our depth projection uses reversed-Z with infinite far plane.
-                // FSR still expects finite camera metrics, so use camera near and
-                // the finite world culling distance as a stable surrogate far.
-                float nearZ = std::max( cam ? cam->GetNearPlane() : 1.0f, 0.001f );
-                float farZ = std::max( static_cast<float>( settings.SectionDrawRadius ) * WORLD_SECTION_SIZE, nearZ + 1.0f );
+                // With ENABLE_DEPTH_INVERTED | ENABLE_DEPTH_INFINITE flags,
+                // FSR expects inverted metrics: cameraNear=FLT_MAX (infinity),
+                // cameraFar=actual near plane (since depth is inverted: 1=near, 0=far)
+                float nearZ = FLT_MAX;  // Infinity in view space
+                float farZ = cam ? cam->GetNearPlane() : 0.01f;
+                farZ = std::max( farZ, 0.075f );  // FSR2 validation requires cameraFar >= 0.075f
 
                 ID3D11SamplerState* linearSampler = engine.GetLinearSamplerState();
                 engine.GetContext()->CSSetSamplers( 0, 1, &linearSampler );

--- a/D3D11Engine/D3D11Upscaling.cpp
+++ b/D3D11Engine/D3D11Upscaling.cpp
@@ -70,10 +70,11 @@ namespace {
                 auto cam = ((zCCamera*)oCGame::GetGame()->_zCSession_camera);
                 cam->GetFOV( fovY, fovX );
 
-                // Our Depth Buffer uses reversed Z, so we need to tell FSR2 about it to get correct results
-                // calculations from GothicAPI::GetProjectionMatrix()
-                float NearZ = settings.SectionDrawRadius * WORLD_SECTION_SIZE;
-                float FarZ = 1.0f;
+                // Our depth projection uses reversed-Z with infinite far plane.
+                // FSR still expects finite camera metrics, so use camera near and
+                // the finite world culling distance as a stable surrogate far.
+                float nearZ = std::max( cam ? cam->GetNearPlane() : 1.0f, 0.001f );
+                float farZ = std::max( static_cast<float>( settings.SectionDrawRadius ) * WORLD_SECTION_SIZE, nearZ + 1.0f );
 
                 ID3D11SamplerState* linearSampler = engine.GetLinearSamplerState();
                 engine.GetContext()->CSSetSamplers( 0, 1, &linearSampler );
@@ -95,8 +96,8 @@ namespace {
                     float2( static_cast<float>(inputSize.x), static_cast<float>(inputSize.y) ),
                     false,
                     fovY,
-                    NearZ,
-                    FarZ,
+                    nearZ,
+                    farZ,
                     sharpenFactor >= 0.001f,
                     sharpenFactor /* FSR2 has 0..1 (sharp)*/ );
                 };
@@ -135,10 +136,11 @@ namespace {
                 auto cam = ((zCCamera*)oCGame::GetGame()->_zCSession_camera);
                 cam->GetFOV( fovY, fovX );
 
-                // Our Depth Buffer uses reversed Z, so we need to tell FSR2 about it to get correct results
-                // calculations from GothicAPI::GetProjectionMatrix()
-                float NearZ = settings.SectionDrawRadius * WORLD_SECTION_SIZE;
-                float FarZ = 1.0f;
+                // Our depth projection uses reversed-Z with infinite far plane.
+                // FSR still expects finite camera metrics, so use camera near and
+                // the finite world culling distance as a stable surrogate far.
+                float nearZ = std::max( cam ? cam->GetNearPlane() : 1.0f, 0.001f );
+                float farZ = std::max( static_cast<float>( settings.SectionDrawRadius ) * WORLD_SECTION_SIZE, nearZ + 1.0f );
 
                 ID3D11SamplerState* linearSampler = engine.GetLinearSamplerState();
                 engine.GetContext()->CSSetSamplers( 0, 1, &linearSampler );
@@ -160,8 +162,8 @@ namespace {
                     float2( static_cast<float>(inputSize.x), static_cast<float>(inputSize.y) ),
                     false,
                     fovY,
-                    NearZ,
-                    FarZ,
+                    nearZ,
+                    farZ,
                     sharpenFactor >= 0.001f,
                     sharpenFactor /* FSR3 has 0..1 (sharp)*/ );
                 };

--- a/D3D11Engine/D3D11VertexBuffer.h
+++ b/D3D11Engine/D3D11VertexBuffer.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 
-#include <D3D11_4.h>
+#include <d3d11_4.h>
 
 #include "VertexTypes.h"
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -3611,12 +3611,11 @@ XMFLOAT4X4& GothicAPI::GetProjectionMatrix() {
         return CameraReplacementPtr->ProjectionReplacement;
     }
 
-    // Reverse depth buffer
-    float NearZ = RendererState.RendererSettings.SectionDrawRadius * WORLD_SECTION_SIZE;
-    float FarZ = 1.0f;
-    float zRange = FarZ / (FarZ - NearZ);
-    RendererState.TransformState.TransformProj._33 = zRange;
-    RendererState.TransformState.TransformProj._34 = -zRange * NearZ;
+    // Reverse depth buffer with infinite far plane:
+    // depth = NearClip / viewZ, where NearClip is fixed at 1.0 in engine units.
+    constexpr float NearClip = 1.0f;
+    RendererState.TransformState.TransformProj._33 = 0.0f;
+    RendererState.TransformState.TransformProj._34 = NearClip;
     return RendererState.TransformState.TransformProj;
 }
 

--- a/D3D11Engine/HookExceptionFilter.h
+++ b/D3D11Engine/HookExceptionFilter.h
@@ -1,6 +1,6 @@
 #pragma once
 #if _MSC_VER >= 1300
-#include <Tlhelp32.h>
+#include <TlHelp32.h>
 #endif
 
 #include "pch.h"

--- a/D3D11Engine/HookedFunctions.cpp
+++ b/D3D11Engine/HookedFunctions.cpp
@@ -29,7 +29,7 @@
 #include "zMat4.h"
 
 #if _MSC_VER >= 1300
-#include <Tlhelp32.h>
+#include <TlHelp32.h>
 #endif
 
 #include "StackWalker.h"

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1130,9 +1130,15 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 Engine::GAPI->SaveRendererWorldSettings(settings, MENU_SETTINGS_FILE);
             }
         }
+        if ( ImGui::Button( "Reset Settings", ImVec2( ImGui::GetContentRegionAvail().x, 30.f ) ) ) {
+            settings.SetDefault();
+            Engine::GraphicsEngine->ReloadShaders( ShaderCategory::All );
+        }
+        ImGui::SetItemTooltip( "Reset all settings to their default values." );
         if ( ImGui::Button( "Reload all Shaders", ImVec2( ImGui::GetContentRegionAvail().x, 30.f ) ) ) {
             Engine::GraphicsEngine->ReloadShaders( ShaderCategory::All );
         }
+
         ImGui::Separator();
         ImGui::Checkbox( "DisableRendering", &settings.DisableRendering );
         ImGui::SliderInt( "SectionDrawRadius", &settings.SectionDrawRadius, 0, 20, "%d", ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput );

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -417,8 +417,10 @@ void ApplyFeatureLevel10Downgrades(GothicRendererSettings& s) {
 }
 
 void ApplyGraphicsPresets( GothicRendererSettings& s ) {
-    const auto preset = s.GraphicsPreset; // remember before setting defaults
-    s.SetDefault();
+    const auto preset = s.GraphicsPreset;
+    if ( preset == GothicRendererSettings::E_GraphicsPreset::GRAPHICS_CUSTOM ) {
+        return;
+    }
 
     switch ( preset ) {
     case GothicRendererSettings::GRAPHICS_LOW:
@@ -444,7 +446,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.textureMaxSize = static_cast<int>(TX_QUALITY::Medium);
 
         s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_NONE;
-        s.SectionDrawRadius = 2;
+        s.SectionDrawRadius = 5;
         s.VisualFXDrawRadius = 5'000;
         s.OutdoorVobDrawRadius = 30'000;
         s.OutdoorSmallVobDrawRadius = 10'000;
@@ -479,7 +481,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.textureMaxSize = static_cast<int>(TX_QUALITY::Medium);
 
         s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_SMAA;
-        s.SectionDrawRadius = 4;
+        s.SectionDrawRadius = 5;
         s.VisualFXDrawRadius = 6'000;
         s.OutdoorVobDrawRadius = 30'000;
         s.OutdoorSmallVobDrawRadius = 15'000;
@@ -515,7 +517,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.textureMaxSize = static_cast<int>(TX_QUALITY::High);
 
         s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_SMAA;
-        s.SectionDrawRadius = 4;
+        s.SectionDrawRadius = 5;
         s.VisualFXDrawRadius = 8'000;
         s.OutdoorVobDrawRadius = 40'000;
         s.OutdoorSmallVobDrawRadius = 25'000;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -446,7 +446,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.textureMaxSize = static_cast<int>(TX_QUALITY::Medium);
 
         s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_NONE;
-        s.SectionDrawRadius = 5;
+        s.SectionDrawRadius = 2;
         s.VisualFXDrawRadius = 5'000;
         s.OutdoorVobDrawRadius = 30'000;
         s.OutdoorSmallVobDrawRadius = 10'000;
@@ -481,7 +481,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.textureMaxSize = static_cast<int>(TX_QUALITY::Medium);
 
         s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_SMAA;
-        s.SectionDrawRadius = 5;
+        s.SectionDrawRadius = 4;
         s.VisualFXDrawRadius = 6'000;
         s.OutdoorVobDrawRadius = 30'000;
         s.OutdoorSmallVobDrawRadius = 15'000;
@@ -517,7 +517,7 @@ void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.textureMaxSize = static_cast<int>(TX_QUALITY::High);
 
         s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_SMAA;
-        s.SectionDrawRadius = 5;
+        s.SectionDrawRadius = 4;
         s.VisualFXDrawRadius = 8'000;
         s.OutdoorVobDrawRadius = 40'000;
         s.OutdoorSmallVobDrawRadius = 25'000;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1,7 +1,7 @@
 #include "ImGuiShim.h"
 #include "GSky.h"
 #include <VersionHelpers.h>
-#include <ShellScalingAPI.h>
+#include <ShellScalingApi.h>
 
 #include "ImGuiEditorView.h"
 #include "zCParser.h"

--- a/D3D11Engine/Shaders/CS_PFX_DoF.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_DoF.hlsl
@@ -4,6 +4,8 @@
 // Outputs blurred color (rgb) + CoC (a) at half resolution to UAV
 //--------------------------------------------------------------------------------------
 
+#include "DepthReconstruction.h"
+
 cbuffer DepthOfFieldConstantBuffer : register( b0 )
 {
     float DoF_FocusDistance;
@@ -27,7 +29,7 @@ RWTexture2D<float4> OutputBlur : register( u0 ); // Half-res output
 
 float LinearizeDepth( float d )
 {
-    return DoF_ProjParams.z / ( d - DoF_ProjParams.w );
+    return LinearizeDepthReverseZInfinite( d );
 }
 
 float ComputeCoC( float linearDepth, float focusDepth )

--- a/D3D11Engine/Shaders/CS_PFX_DoF_Composite.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_DoF_Composite.hlsl
@@ -4,6 +4,8 @@
 // Blends sharp and blurred based on per-pixel CoC, writes to UAV
 //--------------------------------------------------------------------------------------
 
+#include "DepthReconstruction.h"
+
 cbuffer DepthOfFieldConstantBuffer : register( b0 )
 {
     float DoF_FocusDistance;
@@ -28,7 +30,7 @@ RWTexture2D<float4> OutputComposite : register( u0 );
 
 float LinearizeDepth( float d )
 {
-    return DoF_ProjParams.z / ( d - DoF_ProjParams.w );
+    return LinearizeDepthReverseZInfinite( d );
 }
 
 [numthreads(8, 8, 1)]

--- a/D3D11Engine/Shaders/CS_PFX_DoF_FocusResolve.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_DoF_FocusResolve.hlsl
@@ -4,6 +4,8 @@
 // Writes to a 1x1 R32_FLOAT UAV storing the linearized focus distance
 //--------------------------------------------------------------------------------------
 
+#include "DepthReconstruction.h"
+
 cbuffer DepthOfFieldConstantBuffer : register( b0 )
 {
     float DoF_FocusDistance;
@@ -26,7 +28,7 @@ RWTexture2D<float> OutputFocus : register( u0 );
 
 float LinearizeDepth( float d )
 {
-    return DoF_ProjParams.z / ( d - DoF_ProjParams.w );
+    return LinearizeDepthReverseZInfinite( d );
 }
 
 [numthreads(1, 1, 1)]

--- a/D3D11Engine/Shaders/CS_PFX_SAO.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_SAO.hlsl
@@ -5,6 +5,7 @@
 //--------------------------------------------------------------------------------------
 
 #include "DS_Defines.h"
+#include "DepthReconstruction.h"
 
 cbuffer SAOConstantBuffer : register( b0 )
 {
@@ -26,14 +27,12 @@ RWTexture2D<float> OutputAO : register( u0 );
 
 float LinearizeDepth( float d )
 {
-    return SAO_ProjParams.z / ( d - SAO_ProjParams.w );
+    return LinearizeDepthReverseZInfinite( d );
 }
 
 float3 VSPositionFromDepth( float depth, float2 texcoord )
 {
-    float2 ndc = texcoord * float2( 2.0f, -2.0f ) + float2( -1.0f, 1.0f );
-    float linearZ = LinearizeDepth( depth );
-    return float3( ndc * SAO_ProjParams.xy * linearZ, linearZ );
+    return ReconstructVSPositionFromDepthReverseZInfinite( depth, texcoord, SAO_ProjParams.xy );
 }
 
 float3 DecodeNormal( float4 enc )

--- a/D3D11Engine/Shaders/CS_PFX_SAO_Blur.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_SAO_Blur.hlsl
@@ -1,3 +1,4 @@
+#include "DepthReconstruction.h"
 //--------------------------------------------------------------------------------------
 // Compute Shader - SAO Bilateral Blur
 // Depth-aware separable Gaussian blur for denoising SAO output
@@ -21,7 +22,7 @@ RWTexture2D<float> OutputAO : register( u0 );
 
 float LinearizeDepth( float d )
 {
-    return SAO_Blur_ProjParams.z / ( d - SAO_Blur_ProjParams.w );
+    return LinearizeDepthReverseZInfinite( d );
 }
 
 static const int BLUR_RADIUS = 4;

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -1,4 +1,5 @@
 #include "DS_Defines.h"
+#include "DepthReconstruction.h"
 
 #define TILE_SIZE 16
 
@@ -40,9 +41,7 @@ TextureCubeArray TX_ShadowCubeArray : register( t11 );
 RWTexture2D<float4> RW_HDR : register( u0 );
 
 float3 VSPositionFromDepth( float depth, uint2 pixelCoord ) {
-    float2 ndc = ((float2( pixelCoord ) + 0.5f) / ViewportSize) * float2( 2.0f, -2.0f ) + float2( -1.0f, 1.0f );
-    float linearZ = ProjParams.z / (depth - ProjParams.w);
-    return float3( ndc * ProjParams.xy * linearZ, linearZ );
+    return ReconstructVSPositionFromDepthReverseZInfinite( depth, pixelCoord, ViewportSize, ProjParams.xy );
 }
 
 float CalcBlinnPhongLighting( float3 N, float3 H ) {

--- a/D3D11Engine/Shaders/DepthReconstruction.h
+++ b/D3D11Engine/Shaders/DepthReconstruction.h
@@ -1,0 +1,30 @@
+#ifndef DEPTH_RECONSTRUCTION_H
+#define DEPTH_RECONSTRUCTION_H
+
+// Reversed-Z infinite far plane helper set.
+// Main camera projection writes depth ~= 1 / viewZ, so linear view-space depth
+// can be reconstructed via reciprocal depth.
+float LinearizeDepthReverseZInfinite( float depth )
+{
+    return rcp( max( depth, 1e-8f ) );
+}
+
+float2 ReconstructNdcFromTexcoord( float2 texcoord )
+{
+    return texcoord * float2( 2.0f, -2.0f ) + float2( -1.0f, 1.0f );
+}
+
+float3 ReconstructVSPositionFromDepthReverseZInfinite( float depth, float2 texcoord, float2 invProjXY )
+{
+    float linearZ = LinearizeDepthReverseZInfinite( depth );
+    float2 ndc = ReconstructNdcFromTexcoord( texcoord );
+    return float3( ndc * invProjXY * linearZ, linearZ );
+}
+
+float3 ReconstructVSPositionFromDepthReverseZInfinite( float depth, uint2 pixelCoord, float2 viewportSize, float2 invProjXY )
+{
+    float2 texcoord = (float2( pixelCoord ) + 0.5f) / viewportSize;
+    return ReconstructVSPositionFromDepthReverseZInfinite( depth, texcoord, invProjXY );
+}
+
+#endif

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -2,6 +2,7 @@
 // World/VOB-Pixelshader for G2D3D11 by Degenerated
 //--------------------------------------------------------------------------------------
 #include <DS_Defines.h>
+#include "DepthReconstruction.h"
 
 #include <AtmosphericScattering.h>
 
@@ -70,11 +71,7 @@ struct PS_INPUT
 
 float3 VSPositionFromDepth(float depth, float2 vTexCoord)
 {
-	// Reconstruct view-space position from depth using projection parameters
-	// Avoids full 4x4 inverse projection matrix multiply
-    float2 ndc = vTexCoord * float2(2.0f, -2.0f) + float2(-1.0f, 1.0f);
-    float linearZ = SQ_ProjParams.z / (depth - SQ_ProjParams.w);
-    return float3(ndc * SQ_ProjParams.xy * linearZ, linearZ);
+    return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord, SQ_ProjParams.xy );
 }
 
 //--------------------------------------------------------------------------------------

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -240,7 +240,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	
 	// Sample depth first to detect sky pixels (reversed-Z: sky has depth == 0.0)
     float expDepth = TX_Depth.Sample(SS_Linear, uv).r;
-    if (expDepth < 0.00001f)
+    if (!(expDepth > 0.0f))
         // Sky pixel — no geometry was written, just return the diffuse (sky) color
         return float4(diffuse.rgb, 1);
 	
@@ -260,17 +260,15 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
     float3 wsPosition = mul(float4(vsPosition, 1), SQ_InvView).xyz;
     float3 V = normalize(-vsPosition);
 	
+	float shadow = vertLighting;
 #if SHD_ENABLE
 	// CSM: Use soft cascaded shadow map with configurable softness
-	float shadow = 0.0f;
 	if(AC_LightPos.y > 0) // only get shadow value if it isn't night-time
 	{
 		float bias = lerp(0.00005f, 0.0001f, abs(vsPosition.z) / 1000);
 		// Use screen position for per-pixel rotation (TAA-friendly)
 		shadow = ComputeCascadedShadowValueSoft(wsPosition, vsPosition.z, vertLighting, bias, Input.vPosition.xy);
 	}
-#else
-    float shadow = vertLighting;
 #endif
 
 	// Compute wettness

--- a/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
@@ -2,6 +2,7 @@
 // World/VOB-Pixelshader for G2D3D11 by Degenerated
 //--------------------------------------------------------------------------------------
 #include <DS_Defines.h>
+#include "DepthReconstruction.h"
 
 cbuffer DS_PointLightConstantBuffer : register( b0 )
 {
@@ -43,10 +44,7 @@ struct PS_INPUT
 
 float3 VSPositionFromDepth(float depth, float2 vTexCoord)
 {
-	// Reconstruct view-space position from depth using projection parameters
-	float2 ndc = vTexCoord * float2(2.0f, -2.0f) + float2(-1.0f, 1.0f);
-	float linearZ = PL_ProjParams.z / (depth - PL_ProjParams.w);
-	return float3(ndc * PL_ProjParams.xy * linearZ, linearZ);
+	return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord, PL_ProjParams.xy );
 }
 
 //--------------------------------------------------------------------------------------

--- a/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
@@ -2,6 +2,7 @@
 // World/VOB-Pixelshader for G2D3D11 by Degenerated
 //--------------------------------------------------------------------------------------
 #include <DS_Defines.h>
+#include "DepthReconstruction.h"
 
 cbuffer DS_PointLightConstantBuffer : register( b0 )
 {
@@ -85,10 +86,7 @@ struct PS_INPUT
 
 float3 VSPositionFromDepth(float depth, float2 vTexCoord)
 {
-	// Reconstruct view-space position from depth using projection parameters
-	float2 ndc = vTexCoord * float2(2.0f, -2.0f) + float2(-1.0f, 1.0f);
-	float linearZ = PL_ProjParams.z / (depth - PL_ProjParams.w);
-	return float3(ndc * PL_ProjParams.xy * linearZ, linearZ);
+	return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord, PL_ProjParams.xy );
 }
 
 //--------------------------------------------------------------------------------------

--- a/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
+++ b/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
@@ -88,7 +88,7 @@ float PSMain( PS_INPUT Input ) : SV_TARGET
 
     // Sample depth.  Reversed-Z: sky pixels have depth == 0 (no geometry written).
     float depth = TX_Depth.Sample( SS_Linear, uv ).r;
-    if ( depth < 0.00001f )
+    if ( !(depth > 0.0f) )
         return 1.0f; // Sky — treat as fully lit
 
     // Reconstruct positions

--- a/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
+++ b/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
@@ -57,6 +57,7 @@ Texture2DArray TX_ShadowmapArray : register( t3 );
 #endif
 
 #include "ShadowSampling.h"
+#include "DepthReconstruction.h"
 
 //--------------------------------------------------------------------------------------
 // Input / Output structures  (must match VS_PFX output)
@@ -73,9 +74,7 @@ struct PS_INPUT
 //--------------------------------------------------------------------------------------
 float3 VSPositionFromDepth( float depth, float2 vTexCoord )
 {
-    float2 ndc    = vTexCoord * float2( 2.0f, -2.0f ) + float2( -1.0f, 1.0f );
-    float linearZ = SQ_ProjParams.z / (depth - SQ_ProjParams.w);
-    return float3( ndc * SQ_ProjParams.xy * linearZ, linearZ );
+    return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord, SQ_ProjParams.xy );
 }
 
 //--------------------------------------------------------------------------------------

--- a/D3D11Engine/Shaders/PS_PFX_Composition.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_Composition.hlsl
@@ -6,6 +6,7 @@
 
 #if COMPOSE_HEIGHTFOG
 #include <AtmosphericScattering.h>
+#include "DepthReconstruction.h"
 #endif
 
 //--------------------------------------------------------------------------------------
@@ -57,9 +58,7 @@ Texture2D TX_Depth : register( t3 );
 #if COMPOSE_HEIGHTFOG
 float3 VSPositionFromDepth( float depth, float2 vTexCoord )
 {
-    float2 ndc = vTexCoord * float2( 2.0f, -2.0f ) + float2( -1.0f, 1.0f );
-    float linearZ = HF_ProjParams.z / ( depth - HF_ProjParams.w );
-    return float3( ndc * HF_ProjParams.xy * linearZ, linearZ );
+    return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord, HF_ProjParams.xy );
 }
 
 float ComputeVolumetricFog( float3 cameraToWorldPos, float3 posOriginal )

--- a/D3D11Engine/Shaders/PS_PFX_DoF.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_DoF.hlsl
@@ -4,6 +4,8 @@
 // Outputs blurred color (rgb) + CoC (a) at half resolution
 //--------------------------------------------------------------------------------------
 
+#include "DepthReconstruction.h"
+
 cbuffer DepthOfFieldConstantBuffer : register( b0 )
 {
     float DoF_FocusDistance;
@@ -32,7 +34,7 @@ struct PS_INPUT
 
 float LinearizeDepth( float d )
 {
-    return DoF_ProjParams.z / ( d - DoF_ProjParams.w );
+    return LinearizeDepthReverseZInfinite( d );
 }
 
 float ComputeCoC( float linearDepth, float focusDepth )

--- a/D3D11Engine/Shaders/PS_PFX_DoF_Composite.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_DoF_Composite.hlsl
@@ -4,6 +4,8 @@
 // Blends sharp and blurred based on per-pixel CoC
 //--------------------------------------------------------------------------------------
 
+#include "DepthReconstruction.h"
+
 cbuffer DepthOfFieldConstantBuffer : register( b0 )
 {
     float DoF_FocusDistance;
@@ -33,7 +35,7 @@ struct PS_INPUT
 
 float LinearizeDepth( float d )
 {
-    return DoF_ProjParams.z / ( d - DoF_ProjParams.w );
+    return LinearizeDepthReverseZInfinite( d );
 }
 
 float4 PSMain( PS_INPUT Input ) : SV_TARGET

--- a/D3D11Engine/Shaders/PS_PFX_DoF_FocusResolve.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_DoF_FocusResolve.hlsl
@@ -4,6 +4,8 @@
 // Renders to a 1x1 R32_FLOAT target storing the linearized focus distance
 //--------------------------------------------------------------------------------------
 
+#include "DepthReconstruction.h"
+
 cbuffer DepthOfFieldConstantBuffer : register( b0 )
 {
     float DoF_FocusDistance;
@@ -31,7 +33,7 @@ struct PS_INPUT
 
 float LinearizeDepth( float d )
 {
-    return DoF_ProjParams.z / ( d - DoF_ProjParams.w );
+    return LinearizeDepthReverseZInfinite( d );
 }
 
 float4 PSMain( PS_INPUT Input ) : SV_TARGET

--- a/D3D11Engine/Shaders/PS_PFX_GodRayMask.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_GodRayMask.hlsl
@@ -29,7 +29,7 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	
 	// Sky detection via depth buffer (reversed-Z: sky has depth == 0.0)
 	float depth = TX_Depth.Sample(SS_Linear, Input.vTexcoord).r;
-	if(depth < 0.00001f)
+	if(!(depth > 0.0f))
 		return color;
 	
 	return float4(0,0,0,0);

--- a/D3D11Engine/Shaders/PS_PFX_Heightfog.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_Heightfog.hlsl
@@ -3,6 +3,7 @@
 //--------------------------------------------------------------------------------------
 
 #include <AtmosphericScattering.h>
+#include "DepthReconstruction.h"
 
 cbuffer PFXBuffer : register( b0 )
 {
@@ -33,10 +34,7 @@ Texture2D	TX_Depth : register( t1 );
 
 float3 VSPositionFromDepth(float depth, float2 vTexCoord)
 {
-	// Reconstruct view-space position from depth using projection parameters
-	float2 ndc = vTexCoord * float2(2.0f, -2.0f) + float2(-1.0f, 1.0f);
-	float linearZ = HF_ProjParams.z / (depth - HF_ProjParams.w);
-	return float3(ndc * HF_ProjParams.xy * linearZ, linearZ);
+	return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord, HF_ProjParams.xy );
 }
 
 float ComputeVolumetricFog(float3 cameraToWorldPos, float3 posOriginal)

--- a/D3D11Engine/Shaders/PS_PFX_Velocity.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_Velocity.hlsl
@@ -59,7 +59,7 @@ float2 ProjectToPreviousFrame(float3 worldPos) {
 // Calculate velocity for a single sample point
 float2 CalculateVelocity(float2 texCoord, float depth) {
     // Skip sky pixels (depth = 0 in reversed-Z means far plane/sky)
-    if (depth < 0.0001) {
+    if (!(depth > 0.0f)) {
         return float2(0.0, 0.0);
     }
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,39 @@ When using a Release target, those same exceptions will very likely stop the exe
 > [!TIP]
 > Check out the GitHub Actions workflow to see how the releases are build.
 
+### [EXPERIMENTAL] Building on Linux
+
+1. install clang & llvm
+1. grab/install xwin
+   ```shell
+   xwin --accept-license --arch x86 splat --use-winsysroot-style --preserve-ms-arch-notation --output ~/.xwin
+   ```
+1. ensure vcpkg dependencies are installed in `./packages` (see bottom of `D3D11Engine.vcxproj`)
+  - `directxmath.2025.4.3.1`
+  - `directxmesh_desktop_2019.2023.4.28.1`
+  - `directxtk_desktop_2019.2023.4.28.1`
+  - `Microsoft.XAudio2.Redist.1.2.13`
+1. export correct vcpkg triplets in current terminal session
+   ```shell
+   export VCPKG_DEFAULT_TRIPLET="x86-windows-static-md"
+   ```
+1. prepare preset
+   ```shell
+   cmake --preset Release_NoOpt_Clang -DCMAKE_TOOLCHAIN_FILE=./cmake/msvc-clang-linux.cmake
+   ```
+1. build the project
+   ```shell
+   cmake --build --preset Release_NoOpt_Clang
+   ```
+1. copy `out/build/Release_NoOpt_Clang/D3D11Engine/ddraw.dll` (& `ddraw.pdb` for debugging) into `Gothic2\system\`
+  
+#### building a "release" version of G2 for example would mean
+
+```shell
+> cmake --preset Release_AVX2_Clang -DCMAKE_TOOLCHAIN_FILE=./cmake/msvc-clang-linux.cmake
+> cmake --build --preset Release_AVX2_Clang
+```
+
 ### Dependencies
 
 - HBAO+ files from [dboleslawski/VVVV.HBAOPlus](https://github.com/dboleslawski/VVVV.HBAOPlus/tree/master/Dependencies/NVIDIA-HBAOPlus)

--- a/cmake/GD3D11Helpers.cmake
+++ b/cmake/GD3D11Helpers.cmake
@@ -217,7 +217,7 @@ function(gd3d11_apply_common_compile_settings target_name)
       /MP
       /fp:fast
       /Zi
-      /EHs-c-
+      /EHsc
       /wd4005
       /wd4530
       /wd4577

--- a/cmake/msvc-clang-linux.cmake
+++ b/cmake/msvc-clang-linux.cmake
@@ -1,0 +1,24 @@
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR i686)
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+set(triple i686-pc-windows-msvc)
+
+set(CMAKE_C_COMPILER clang-cl)
+set(CMAKE_CXX_COMPILER clang-cl)
+set(CMAKE_LINKER lld-link)
+
+set(CMAKE_AR llvm-lib)
+set(CMAKE_RC_COMPILER llvm-rc)
+set(CMAKE_MT llvm-mt)
+
+set(XWIN_DIR "$ENV{HOME}/.xwin" CACHE PATH "Path to xwin directory")
+message(STATUS "Using XWIN_DIR: ${XWIN_DIR}")
+
+# Use the elegant winsysroot flag now that xwin is formatted correctly
+set(CMAKE_CXX_FLAGS "--target=${triple} /winsysroot ${XWIN_DIR} /EHsc" CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS "--target=${triple} /winsysroot ${XWIN_DIR}" CACHE STRING "" FORCE)
+
+set(CMAKE_EXE_LINKER_FLAGS "/machine:X86 /MANIFEST:NO /winsysroot:${XWIN_DIR}" CACHE STRING "" FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS "/machine:X86 /MANIFEST:NO /winsysroot:${XWIN_DIR}" CACHE STRING "" FORCE)
+set(CMAKE_MODULE_LINKER_FLAGS "/machine:X86 /MANIFEST:NO /winsysroot:${XWIN_DIR}" CACHE STRING "" FORCE)


### PR DESCRIPTION
- cmake:
  - fix some filenames and include paths to be correctly cased.
  - add experimental linux build instructions to Readme.
- Depth Buffer
  - Use infinite Far - Reverse Z buffer instead of linearized far.
  - Introduce shared header for depth->VS reconstruction
  - instead of `depth < 0.00001f` use `!(depth > 0.0f)` for "sky" testing