### PR TITLE
Fix/clang warnings normals

### DIFF
--- a/D3D11Engine/D3D11DeferredRenderer.cpp
+++ b/D3D11Engine/D3D11DeferredRenderer.cpp
@@ -29,7 +29,7 @@ void D3D11DeferredRenderer::AddGeometryPasses( RenderGraph& graph,
 
     graph.AddPass( RG_PASS_NAME("G-Buffer Pass"), [&, colorResource, velocityBufferHandle, backBufferHandle]( RGBuilder& builder, RenderPass& pass ) {
         auto size = engine.GetResolution();
-        normalsResource = builder.CreateTexture( { static_cast<uint32_t>(size.x), static_cast<uint32_t>(size.y), DXGI_FORMAT_R8G8B8A8_SNORM, L"GBufferNormals" } );
+        normalsResource = builder.CreateTexture( { static_cast<uint32_t>(size.x), static_cast<uint32_t>(size.y), DXGI_FORMAT_R16G16_FLOAT, L"GBufferNormals" } );
         specularResource = builder.CreateTexture( { static_cast<uint32_t>(size.x), static_cast<uint32_t>(size.y), DXGI_FORMAT_R16G16_FLOAT, L"GBufferSpecular" } );
         reactiveMaskResource = builder.CreateTexture( { static_cast<uint32_t>(size.x), static_cast<uint32_t>(size.y), DXGI_FORMAT_R8_UNORM, L"ReactiveMask" } );
 

--- a/D3D11Engine/D3D11DeferredRenderer.cpp
+++ b/D3D11Engine/D3D11DeferredRenderer.cpp
@@ -41,6 +41,7 @@ void D3D11DeferredRenderer::AddGeometryPasses( RenderGraph& graph,
         builder.Write( backBufferHandle );
 
         pass.m_executeCallback = [&engine, colorResource, normalsResource, specularResource, reactiveMaskResource, velocityBufferHandle]( const RenderGraph& graph ) -> void {
+            ZoneScopedN( "DR GBuffer" );
             const auto& context = engine.GetContext();
             context->VSSetShaderResources( 0, 8, s_nullSRVs );
             context->PSSetShaderResources( 0, 8, s_nullSRVs );
@@ -105,6 +106,7 @@ void D3D11DeferredRenderer::AddLightingPasses( RenderGraph& graph,
         builder.Write( backBufferHandle );
 
         pass.m_executeCallback = [&engine, &frameLights, colorResource, normalsResource, specularResource]( const RenderGraph& graph ) -> void {
+            ZoneScopedN( "DR Draw Lighting" );
             auto colorTexture = graph.GetPhysicalTexture( colorResource );
             auto normalsTexture = graph.GetPhysicalTexture( normalsResource );
             auto specularTexture = graph.GetPhysicalTexture( specularResource );

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -503,7 +503,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <ExceptionHandling>false</ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OpenMPSupport>true</OpenMPSupport>
@@ -515,7 +515,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
       <AdditionalOptions>/Zc:inline /Zc:throwingNew %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>Default</LanguageStandard_C>
@@ -529,7 +529,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>ddraw.def</ModuleDefinitionFile>
-      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+      <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
       <AdditionalLibraryDirectories>

--- a/D3D11Engine/D3D11ForwardPlusRenderer.cpp
+++ b/D3D11Engine/D3D11ForwardPlusRenderer.cpp
@@ -43,6 +43,7 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
         builder.Write( backBufferHandle );
 
         pass.m_executeCallback = [&engine]( const RenderGraph& ) -> void {
+            ZoneScopedN( "FR Depth Prepass" );
             auto& context = engine.GetContext();
 
             // Clear all SRVs to avoid resource hazards
@@ -76,6 +77,7 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
         builder.Write( backBufferHandle );
 
         pass.m_executeCallback = [&engine]( const RenderGraph& ) -> void {
+            ZoneScopedN( "FR Light Culling" );
             // CopyDepthStencil so depth can be read as SRV
             engine.CopyDepthStencil();
 
@@ -92,6 +94,7 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
         builder.Write( backBufferHandle );
 
         pass.m_executeCallback = [&engine]( const RenderGraph& ) -> void {
+            ZoneScopedN( "FR Shadow Maps" );
             auto* shadowMaps = engine.GetShadowMaps();
             engine.SetDefaultStates();
 

--- a/D3D11Engine/D3D11ForwardPlusRenderer.cpp
+++ b/D3D11Engine/D3D11ForwardPlusRenderer.cpp
@@ -174,7 +174,7 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
     // --- Forward+ lit geometry pass ---
     graph.AddPass( RG_PASS_NAME("FP Lit Geometry"), [&]( RGBuilder& builder, RenderPass& pass ) {
         auto size = engine.GetResolution();
-        normalsResource = builder.CreateTexture( { static_cast<uint32_t>( size.x ), static_cast<uint32_t>( size.y ), DXGI_FORMAT_R8G8B8A8_SNORM, L"GBufferNormals" } );
+        normalsResource = builder.CreateTexture( { static_cast<uint32_t>( size.x ), static_cast<uint32_t>( size.y ), DXGI_FORMAT_R16G16_FLOAT, L"GBufferNormals" } );
         specularResource = builder.CreateTexture( { static_cast<uint32_t>( size.x ), static_cast<uint32_t>( size.y ), DXGI_FORMAT_R16G16_FLOAT, L"GBufferSpecular" } );
         reactiveMaskResource = builder.CreateTexture( { static_cast<uint32_t>( size.x ), static_cast<uint32_t>( size.y ), DXGI_FORMAT_R8_UNORM, L"ReactiveMask" } );
         builder.Write( reactiveMaskResource );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -64,10 +64,7 @@
 
 namespace wrl = Microsoft::WRL;
 
-const int NUM_UNLOADEDTEXCOUNT_FORCE_LOAD_TEXTURES = 100;
-
 const float DEFAULT_NORMALMAP_STRENGTH = 0.10f;
-const float DEFAULT_FAR_PLANE = 50000.0f;
 const XMFLOAT4 UNDERWATER_COLOR_MOD = XMFLOAT4( 0.5f, 0.7f, 1.0f, 1.0f );
 
 static const GUID IID_IDXGIVkInteropAdapter = { 0x3A6D8F2C, 0xB0E8, 0x4AB4, { 0xB4, 0xDC, 0x4F, 0xD2, 0x48, 0x91, 0xBF, 0xA5 } };
@@ -2828,8 +2825,6 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         instancedDrawItems.clear();
 
         // For the cube shadow path and MorphMesh, we need the old per-draw setup
-        bool needPerDrawSetup = useCubePath; // cube always needs it
-        // We'll lazily set it up if we encounter MorphMesh
 
         auto ensurePerDrawShaderSetup = [&]() {
             if ( useCubePath )
@@ -4833,7 +4828,7 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                     updatePSBuffers();
                 }
 
-                if ( info ) {
+                if ( info && !info->IsSame( boundInfo) ) {
                     if ( !info->Constantbuffer ) info->UpdateConstantbuffer();
 
                     info->Constantbuffer->BindToPixelShader( 2 );
@@ -5097,12 +5092,6 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
 
     float3 pos; XMStoreFloat3( pos.toXMFLOAT3(), position );
     INT2 s = WorldConverter::GetSectionOfPos( pos );
-
-    float vobOutdoorDist =
-        Engine::GAPI->GetRendererState().RendererSettings.OutdoorVobDrawRadius;
-    float vobOutdoorSmallDist = Engine::GAPI->GetRendererState().RendererSettings.OutdoorSmallVobDrawRadius;
-    float vobSmallSize =
-        Engine::GAPI->GetRendererState().RendererSettings.SmallVobSize;
 
     DistortionTexture->BindToPixelShader( 0 );
 
@@ -5421,12 +5410,6 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
 
     float3 pos; XMStoreFloat3( pos.toXMFLOAT3(), position );
     INT2 s = WorldConverter::GetSectionOfPos( pos );
-
-    float vobOutdoorDist =
-        Engine::GAPI->GetRendererState().RendererSettings.OutdoorVobDrawRadius;
-    float vobOutdoorSmallDist = Engine::GAPI->GetRendererState().RendererSettings.OutdoorSmallVobDrawRadius;
-    float vobSmallSize =
-        Engine::GAPI->GetRendererState().RendererSettings.SmallVobSize;
 
     DistortionTexture->BindToPixelShader( 0 );
 
@@ -5899,7 +5882,6 @@ void D3D11GraphicsEngine::ShadowPass_DrawWorldMesh(const std::vector<WorldMeshSe
 void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR position,
     float sectionRange,
     const RenderShadowmapsParams& params ) {
-    int timerLabelIndex = std::clamp(params.CascadeIndex, 0, MAX_CSM_CASCADES-1);
 
     // Setup renderstates
     Engine::GAPI->GetRendererState().RasterizerState.SetDefault();

--- a/D3D11Engine/D3D11GraphicsEngineBase.cpp
+++ b/D3D11Engine/D3D11GraphicsEngineBase.cpp
@@ -260,7 +260,6 @@ XRESULT D3D11GraphicsEngineBase::SetActiveGShader( GShaderID shader ) {
 
 /** Updates the transformsCB with new values from the GAPI */
 void D3D11GraphicsEngineBase::UpdateTransformsCB() {
-    const XMFLOAT4X4& world = Engine::GAPI->GetRendererState().TransformState.TransformWorld;
     const XMFLOAT4X4& view = Engine::GAPI->GetRendererState().TransformState.TransformView;
     const XMFLOAT4X4& proj = Engine::GAPI->GetProjectionMatrix();
 

--- a/D3D11Engine/D3D11PFX_HeightFog.cpp
+++ b/D3D11Engine/D3D11PFX_HeightFog.cpp
@@ -36,8 +36,6 @@ XRESULT D3D11PFX_HeightFog::Render( RenderToTextureBuffer* fxbuffer ) {
 	XMStoreFloat4x4( &cb.InvView, XMMatrixInverse( nullptr, Engine::GAPI->GetViewMatrixXM() ) );
 
 	cb.CameraPosition = Engine::GAPI->GetCameraPosition();
-	float NearPlane = Engine::GAPI->GetRendererState().RendererInfo.NearPlane;
-	float FarPlane = Engine::GAPI->GetRendererState().RendererInfo.FarPlane;
 
 	cb.HF_GlobalDensity = Engine::GAPI->GetRendererState().RendererSettings.FogGlobalDensity;
 	cb.HF_HeightFalloff = Engine::GAPI->GetRendererState().RendererSettings.FogHeightFalloff;
@@ -83,7 +81,6 @@ XRESULT D3D11PFX_HeightFog::Render( RenderToTextureBuffer* fxbuffer ) {
 
 #if !defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
 		// Use other fog-values for fog-zones
-		float distNear = WORLD_SECTION_SIZE * ((ffar - fnear) / ffar);
 		cb.HF_WeightZNear = Toolbox::lerp( cb.HF_WeightZNear, WORLD_SECTION_SIZE * 0.09f, Engine::GAPI->GetFogOverride() );
 		cb.HF_WeightZFar = Toolbox::lerp( cb.HF_WeightZFar, WORLD_SECTION_SIZE * 0.8, Engine::GAPI->GetFogOverride() );
 #endif

--- a/D3D11Engine/DLLMain.cpp
+++ b/D3D11Engine/DLLMain.cpp
@@ -83,7 +83,7 @@ void QuantizeHalfFloats_X4_SSE41( float* input, unsigned short* output )
     QuantizeHalfFloats_X4_SSE2( input, output );
 }
 
-#ifdef _XM_AVX_INTRINSICS_
+#ifdef _XM_AVX2_INTRINSICS_
 unsigned short QuantizeHalfFloat_F16C( float input )
 {
     return static_cast<unsigned short>(_mm_cvtsi128_si32( _mm_cvtps_ph( _mm_set_ss( input ), _MM_FROUND_CUR_DIRECTION ) ));
@@ -174,7 +174,7 @@ void UnquantizeHalfFloat_X8_SSE2( unsigned short* input, float* output )
     _mm_store_si128( reinterpret_cast<__m128i*>(output + 4), _mm_or_si128( s4, _mm_or_si128( e4, m4 ) ) );
 }
 
-#ifdef _XM_AVX_INTRINSICS_
+#ifdef _XM_AVX2_INTRINSICS_
 float UnquantizeHalfFloat_F16C( unsigned short input )
 {
     return _mm_cvtss_f32( _mm_cvtph_ps( _mm_cvtsi32_si128( input ) ) );
@@ -402,7 +402,7 @@ void CheckPlatformSupport() {
     support_message( "SSE", InstructionSet::SSE() );
 #endif
 
-#ifdef _XM_AVX_INTRINSICS_
+#ifdef _XM_AVX2_INTRINSICS_
     if ( InstructionSet::F16C() ) {
         QuantizeHalfFloat = QuantizeHalfFloat_F16C;
         QuantizeHalfFloat_X4 = QuantizeHalfFloats_X4_F16C;

--- a/D3D11Engine/HookExceptionFilter.h
+++ b/D3D11Engine/HookExceptionFilter.h
@@ -10,7 +10,9 @@
 // Simple implementation of an additional output to the console:
 class MyStackWalker : public StackWalker {
 public:
-    MyStackWalker() : StackWalker() { LoadModules(); }
+    MyStackWalker() : StackWalker() { 
+        // LoadModules();
+    }
     MyStackWalker( DWORD dwProcessId, HANDLE hProcess ) : StackWalker( dwProcessId, hProcess ) {}
     void OnOutput( LPCSTR szText ) override { Log( "STACK", __FILE__, __LINE__, __FUNCSIG__ ) << szText; StackWalker::OnOutput( szText ); }
 

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1458,11 +1458,6 @@ void RenderAdvancedColumn3( GothicRendererSettings& settings, GothicAPI* gapi ) 
                 ImGui::TableSetColumnIndex( 1 );
                 };
 
-            static auto addRowText = []( const char* label, const char* text ) {
-                addRowLabel( label );
-                ImGui::TextUnformatted( text );
-                };
-
             static auto addRowInt = []( const char* label, int value ) {
                 addRowLabel( label );
                 ImGui::Text( "%d", value );

--- a/D3D11Engine/RenderPass.h
+++ b/D3D11Engine/RenderPass.h
@@ -16,7 +16,7 @@ class RenderPass {
     friend class RenderGraph;
 
 public:
-    RenderPass( RGPassName name ) : m_name( name ) {}
+    RenderPass( RGPassName name ) : m_name( std::move(name) ) {}
 
     RGPassName m_name;
     std::vector<RGResourceHandle> m_reads;  // Sources

--- a/D3D11Engine/Shaders/DS_Defines.h
+++ b/D3D11Engine/Shaders/DS_Defines.h
@@ -17,7 +17,7 @@ struct DEFERRED_PS_OUTPUT_ALPHA_TO_COVERAGE
 struct FORWARD_PLUS_PS_OUTPUT
 {
 	float4 vColor : SV_TARGET0;
-	float4 vNrm : SV_TARGET1;
+	float2 vNrm : SV_TARGET1;
 	float2 vSI_SP : SV_TARGET2;
 	float2 vVelocity : SV_TARGET3;
 	float vReactiveMask : SV_TARGET4;

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -142,7 +142,7 @@ FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 	litPixel = ApplyAtmosphericScatteringGround(wsPosition, litPixel);
 
 	output.vColor = float4(litPixel, 1);
-	output.vNrm = float4(nrm, 1.0f);
+	output.vNrm = EncodeNormalGBuffer(nrm);
 	output.vSI_SP = float2(specIntensity, specPower);
 	output.vVelocity = CalculateVelocity(Input.vCurrClipPos, Input.vPrevClipPos);
 

--- a/D3D11Engine/Shaders/PS_PFX_Composition.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_Composition.hlsl
@@ -92,13 +92,23 @@ float4 ComputeHeightFog( float2 texcoord )
 
     float fog = 1.0f - ComputeVolumetricFog( position, posOriginal );
     float3 color = ApplyAtmosphericScatteringGround( position, HF_FogColorMod, true );
+	
+	// (Increased the R, G, B values. Tweak these up/down if you want it brighter/darker!)
+	float3 nightFogColor = float3(0.04f, 0.06f, 0.09f); 
+	        nightFogColor = float3(0.12f, 0.18f, 0.27f); 
+	float nightTimeBlend = saturate(-AC_LightPos.y * 4.0f);
+	color = lerp(color, nightFogColor, nightTimeBlend);
 
-    float darknessFactor = 2.0f;
-    if ( AC_LightPos.y < 0.0f ) { darknessFactor -= AC_LightPos.y * 3.0f; }
-    else if ( AC_LightPos.y > 0.0f ) { darknessFactor -= AC_LightPos.y; }
+	// Starts darker (2.5) and doesn't drop as much at noon.
+	float darknessFactor = 2.5f; 
+	if (AC_LightPos.y > 0.0f) { 
+		darknessFactor -= (AC_LightPos.y * 0.8f); 
+	}
+	
+	// Never let the fog become a 100% solid wall of color.
+	float maxFogOpacity = 0.85f;
 
-    return float4( saturate( color / darknessFactor ), saturate( fog ) );
-}
+	return float4(saturate(color / darknessFactor), saturate(fog) * maxFogOpacity);}
 #endif
 
 //--------------------------------------------------------------------------------------

--- a/D3D11Engine/Shaders/PS_PFX_Heightfog.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_Heightfog.hlsl
@@ -91,10 +91,21 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float3 color = ApplyAtmosphericScatteringGround(position, HF_FogColorMod, true);
 
 	//darken / lighten fog based on the day / night cycle
-	float darknessFactor = 2.0f;
-	if (AC_LightPos.y < 0.0f) { darknessFactor -= AC_LightPos.y * 3.0f; }
-	else if (AC_LightPos.y > 0.0f) { darknessFactor -= AC_LightPos.y; }
+	// (Increased the R, G, B values. Tweak these up/down if you want it brighter/darker!)
+	float3 nightFogColor = float3(0.04f, 0.06f, 0.09f); 
+	        nightFogColor = float3(0.12f, 0.18f, 0.27f); 
+	float nightTimeBlend = saturate(-AC_LightPos.y * 4.0f);
+	color = lerp(color, nightFogColor, nightTimeBlend);
 
-	return float4(saturate(color / darknessFactor), saturate(fog));
+	// Starts darker (2.5) and doesn't drop as much at noon.
+	float darknessFactor = 2.0f; 
+	if (AC_LightPos.y > 0.0f) { 
+		darknessFactor -= (AC_LightPos.y * 0.8f); 
+	}
+	
+	// Never let the fog become a 100% solid wall of color.
+	float maxFogOpacity = 0.85f;
+
+	return float4(saturate(color / darknessFactor), saturate(fog) * maxFogOpacity);}
 }
 

--- a/D3D11Engine/Shaders/PS_PFX_Heightfog.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_Heightfog.hlsl
@@ -106,6 +106,6 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	// Never let the fog become a 100% solid wall of color.
 	float maxFogOpacity = 0.85f;
 
-	return float4(saturate(color / darknessFactor), saturate(fog) * maxFogOpacity);}
+	return float4(saturate(color / darknessFactor), saturate(fog) * maxFogOpacity);
 }
 

--- a/D3D11Engine/TexturePool.h
+++ b/D3D11Engine/TexturePool.h
@@ -77,7 +77,7 @@ public:
         found->LastFrameUsed = m_currentFrame;
 
         // Return RAII handle with custom deleter to "return" to pool
-        return TextureHandle( found->Texture.get(), [this, found]( RenderToTextureBuffer* ) {
+        return TextureHandle( found->Texture.get(), [found]( RenderToTextureBuffer* ) {
             found->InUse = false;
         } );
     }
@@ -180,7 +180,7 @@ public:
         found->LastFrameUsed = m_currentFrame;
 
         // Return RAII handle with custom deleter to "return" to pool
-        return DepthStencilHandle( found->Buffer.get(), [this, found]( RenderToDepthStencilBuffer* ) {
+        return DepthStencilHandle( found->Buffer.get(), [found]( RenderToDepthStencilBuffer* ) {
             found->InUse = false;
         } );
     }

--- a/D3D11Engine/Toolbox.h
+++ b/D3D11Engine/Toolbox.h
@@ -6,9 +6,9 @@
 #include <Windows.h>
 
 #include "Types.h"
+#include "zTypes.h"
 
 /** Misc. tools */
-enum zTCam_ClipType;
 struct zTBBox3D;
 struct zTPlane;
 

--- a/D3D11Engine/Types.h
+++ b/D3D11Engine/Types.h
@@ -2,7 +2,6 @@
 #include <string>
 #include <sstream>
 #include <Windows.h>
-
 #include <DirectXMath.h>
 
 using namespace DirectX;

--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -11,7 +11,7 @@
 #define DEBUG_D3D11
 // assume SSE3 is available when compiling in debug mode for SSE2
 #if _M_IX86_FP == 2 // SSE2
-#define _XM_SSE3_INTRINSICS_
+// #define _XM_SSE3_INTRINSICS_
 #endif
 #endif
 

--- a/D3D11Engine/zCWorld.h
+++ b/D3D11Engine/zCWorld.h
@@ -52,6 +52,7 @@ public:
 
     inline static bool isDrawingContainers = false;
     static void __cdecl hooked_ContainerDraw() {
+        ZoneScoped;
         isDrawingContainers = true;
 
         auto _ = Engine::GraphicsEngine->RecordGraphicsEvent( GE_NAME( "Draw Inventory World" ) );
@@ -108,6 +109,7 @@ public:
     */
 
     static void __fastcall hooked_zCWorldDisposeVobs( zCWorld* thisptr, void* unknwn, zCTree<zCVob>* tree ) {
+        ZoneScoped;
         // Reset only if this is the main world, inventory worlds are handled differently
         if ( thisptr == Engine::GAPI->GetLoadedWorldInfo()->MainWorld )
             Engine::GAPI->ResetVobs();
@@ -127,6 +129,7 @@ public:
     }
 
     static void __fastcall hooked_LoadWorld( zCWorld* thisptr, void* unknwn, const zSTRING& fileName, const int loadMode ) {
+        ZoneScoped;
         Engine::GAPI->OnLoadWorld( fileName.ToChar(), loadMode );
 
         HookedFunctions::OriginalFunctions.original_zCWorldLoadWorld( thisptr, fileName, loadMode );

--- a/D3D11Engine/zTypes.h
+++ b/D3D11Engine/zTypes.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "pch.h"
+#include "Types.h"
 
 enum zTCam_ClipType {
     ZTCAM_CLIPTYPE_IN,
@@ -40,8 +40,8 @@ enum zTMat_WaveSpeed
 
 #pragma pack (push, 1)	
 struct zTBBox3D {
-    XMFLOAT3	Min;
-    XMFLOAT3	Max;
+    DirectX::XMFLOAT3	Min;
+    DirectX::XMFLOAT3	Max;
 
     enum zTPlaneClass {
         zPLANE_INFRONT,
@@ -61,7 +61,7 @@ struct zTBBox3D {
 
 struct zTPlane {
     float Distance;
-    XMFLOAT3 Normal;
+    DirectX::XMFLOAT3 Normal;
 };
 #pragma pack (pop)
 
@@ -81,13 +81,13 @@ struct zTRenderContext {
 
 struct zCRenderLight {
     int	LightType;
-    XMFLOAT3	ColorDiffuse;
-    XMFLOAT3	Position;
-    XMFLOAT3	Direction;
+    DirectX::XMFLOAT3	ColorDiffuse;
+    DirectX::XMFLOAT3	Position;
+    DirectX::XMFLOAT3	Direction;
     float Range;
     float RangeInv;
-    XMFLOAT3 PositionLS;
-    XMFLOAT3 DirectionLS;
+    DirectX::XMFLOAT3 PositionLS;
+    DirectX::XMFLOAT3 DirectionLS;
     float Dir_approxFalloff;
 };
 
@@ -99,7 +99,7 @@ private:
     int	DoPrelight;
     int	DoSmoothPrelit;
     float PreLightDist;
-    XMFLOAT4X4 MatObjToCam;
+    DirectX::XMFLOAT4X4 MatObjToCam;
 };
 
 enum zTRnd_AlphaBlendFunc {


### PR DESCRIPTION
- Fixes broken normals.
  - we introduced Octahedral encoding in the past, but during rebase it got lost and broke stuff like SAO and ASSAO
- Adjust HeightFog to be a little less "dense"
- Add some instrumentation around world load stuff
- fix a bunch of `clang(-cl)` warnings