### PR TITLE
Fix a bunch of clang warnings

### DIFF
--- a/D3D11Engine/CGameManager.h
+++ b/D3D11Engine/CGameManager.h
@@ -30,7 +30,7 @@ public:
         // Some plugins or patches override savegame behavior and cause crashing.
         // THIS CRASHES SAVING IN CHRONICLES OF MYRTANA! :/ need a better fix for this.
         // for now we undo 04b215a6e9
-        // DetourAttach( &reinterpret_cast<PVOID&>(original_CGameManagerWrite_Savegame), hooked_Write_Savegame );
+        // DetourAttachTyped( &original_CGameManagerWrite_Savegame, hooked_Write_Savegame  );
 #endif
     }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -6885,8 +6885,8 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                     bool clear = true;
                     for ( auto& [meshKey, _] : cv.Visual->MeshesByTexture ) {
                         if ( meshKey.Material &&
-                            meshKey.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_BLEND ||
-                            meshKey.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_ADD ) {
+                            (meshKey.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_BLEND ||
+                                meshKey.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_ADD) ) {
                             clear = false;
                             break;
                         }

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -1372,8 +1372,6 @@ XRESULT D3D11GraphicsEngine::OnBeginFrame() {
         }
     }
 
-    static bool s_firstFrame = true;
-
     SteamOverlay::Update();
 #ifdef BUILD_1_12F
     // Some shitty workaround for weird hidden window bug that happen on d3d11 renderer
@@ -1437,7 +1435,6 @@ XRESULT D3D11GraphicsEngine::OnBeginFrame() {
         Resolved_DiffuseNormalmappedAlphatest = PShaderID::PS_DiffuseAlphaTest;
     }
 
-    s_firstFrame = false;
     return XR_SUCCESS;
 }
 
@@ -3471,7 +3468,6 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
             context->ClearRenderTargetView( HDRBackBuffer->GetRenderTargetView().Get(), clearColor );
             context->ClearRenderTargetView( Backbuffer->GetRenderTargetView().Get(), clearColor );
 
-            constexpr float black[]{ 0.f, 0.f, 0.f, 0.f };
             float4 fogColor( rendererState.GraphicsState.FF_FogColor, 0.0f );
             GetContext()->ClearRenderTargetView( graph.GetPhysicalTexture( colorResource )->GetRenderTargetView().Get(), reinterpret_cast<const float*>(&fogColor) );
         };
@@ -3728,16 +3724,13 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         if ( compositionActive ) {
             // GodRays compute-only pass — writes to pool texture, skips the final additive blit
             graph.AddPass( RG_PASS_NAME("GodRays Compute"), [&]( RGBuilder& builder, RenderPass& pass ) {
-                builder.Read( normalsResource );
                 builder.Read( backBufferHandle );
 
-                pass.m_executeCallback = [this, backBufferHandle, normalsResource, &compositionGodRaysSRV](const RenderGraph& graph) {
+                pass.m_executeCallback = [this, backBufferHandle, &compositionGodRaysSRV](const RenderGraph& graph) {
                     Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> srv;
                     GetContext()->PSSetShaderResources( 5, 1, srv.GetAddressOf() );
 
                     auto backbufferResource = graph.GetPhysicalTexture(backBufferHandle);
-                    auto normalsTexture = graph.GetPhysicalTexture(normalsResource);
-
                     PfxRenderer->RenderGodRaysToTexture(
                         backbufferResource->GetShaderResView().Get(),
                         GetDepthBuffer()->GetShaderResView().Get(),
@@ -4182,7 +4175,6 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
 
     // Draw the list
     for ( auto const& [meshKey, meshInfo] : list ) {
-        int indicesNumMod = 1;
         if ( zCTexture* texture = meshKey.Material->GetAniTexture() ) {
             MyDirectDrawSurface7* surface = texture->GetSurface();
             ID3D11ShaderResourceView* srv[3];
@@ -4791,7 +4783,6 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
         auto _scopeOpaqueSubmission = RecordGraphicsEvent( GE_NAME( "DrawWorldMesh::OpaqueSubmission" ) );
         for ( auto const& mesh : meshList ) {
 
-            int indicesNumMod = 1;
             if ( mesh.first.Texture != bound &&
                 Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh > 1 ) {
                 MyDirectDrawSurface7* surface = mesh.first.Texture->GetSurface();
@@ -5936,8 +5927,6 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
         .Bind();
 
     float3 fPosition; XMStoreFloat3( fPosition.toXMFLOAT3(), position );
-    INT2 s = WorldConverter::GetSectionOfPos( fPosition );
-
     DistortionTexture->BindToPixelShader( 0 );
 
     ActivePS->BindBuffer( "DIST_Distance", InfiniteRangeConstantBuffer.get() );
@@ -5958,7 +5947,6 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
     if ( Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh ) {
         TracyD3D11ZoneCGX( "Shadows::DrawWorldMesh" );
         auto _1 = RecordGraphicsEvent( GE_NAME( "Shadows::DrawWorldMesh" ) );
-        const auto sectionRangeSq = sectionRange * sectionRange;
         // Bind wrapped mesh vertex buffers
         DrawVertexBufferIndexedUINT(
             Engine::GAPI->GetWrappedWorldMesh()->MeshVertexBuffer,
@@ -6163,8 +6151,6 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
         } );
 
         zCTexture* previousTx = nullptr;
-        ID3D11ShaderResourceView* lastNrmTex = nullptr;
-        ID3D11ShaderResourceView* lastFxTex = nullptr;
         MeshVisualInfo* lastWindVisual = nullptr;
 
         for ( auto const& [staticMeshVisual, meshKey, meshInfo, _] : instancedMeshesToDraw ) {
@@ -6266,9 +6252,6 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
 
         static std::vector<SkeletalVobInfo*> animatedSkeletalMeshVobs;
         animatedSkeletalMeshVobs.clear();
-        
-        const bool isLastCascade = params.CascadeSplits.size() == 0
-            || params.CascadeIndex == params.CascadeSplits.size() - 2;
         
         for ( auto const& skeletalMeshVob : Engine::GAPI->GetSkeletalMeshVobs() ) {
             if ( !skeletalMeshVob->VisualInfo ) continue;
@@ -6483,9 +6466,6 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
         ActivePS->GetBuffer( "MI_MaterialInfo" )
             .Update( &defInfo )
             .Bind();
-
-        float3 camPos = Engine::GAPI->GetCameraPosition();
-        INT2 camSection = WorldConverter::GetSectionOfPos( camPos );
 
         XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
         Engine::GAPI->SetViewTransformXM( view );
@@ -6718,9 +6698,6 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
 
             float cachedSmallVobRadius = -1.0f;
             float cachedVobRadius = -1.0f;
-            float cachedMinHeight = -999999.0f;
-            float cachedMaxHeight = -999999.0f;
-
             // Ensure we have correct Constantbuffer for eventual Alphatest stuff.
             ShaderManager->GetPShader( Resolved_DiffuseNormalmappedAlphatest )
                 ->GetBuffer( "FFPipelineConstantBuffer" )
@@ -6740,7 +6717,6 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
             ID3D11ShaderResourceView* lastFxTex = nullptr;
             MeshVisualInfo* lastWindVisual = nullptr;
 
-            void* lastShader = nullptr;
             if ( !cache.sortedInstancedMeshes.empty() ) {
                 TracyD3D11ZoneCGX( "DrawVOBsInstanced::OpaqueSubmission" );
                 auto _scopeOpaqueSubmission = RecordGraphicsEvent( GE_NAME( "DrawVOBsInstanced::OpaqueSubmission" ) );
@@ -7900,7 +7876,6 @@ void D3D11GraphicsEngine::DrawQuadMarks() {
 
     SetDefaultStates();
 
-    FXMVECTOR camPos = Engine::GAPI->GetCameraPositionXM();
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
     Engine::GAPI->SetViewTransformXM( view );  // Update view transform
 
@@ -7918,7 +7893,7 @@ void D3D11GraphicsEngine::DrawQuadMarks() {
 
     auto vfxRadiusSq = Engine::GAPI->GetRendererState().RendererSettings.VisualFXDrawRadius * Engine::GAPI->GetRendererState().RendererSettings.VisualFXDrawRadius;
     auto vVfxRadiusSq = XMVectorReplicate(vfxRadiusSq);
-    
+    const auto camPos = Engine::GAPI->GetCameraPositionXM();
     for ( auto const& it : quadMarks ) {
         if ( !it.first->GetConnectedVob() ) continue;
 
@@ -7981,7 +7956,6 @@ void D3D11GraphicsEngine::DrawMQuadMarks() {
 
     SetDefaultStates();
 
-    FXMVECTOR camPos = Engine::GAPI->GetCameraPositionXM();
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
     Engine::GAPI->SetViewTransformXM( view );  // Update view transform
 
@@ -8256,7 +8230,6 @@ void D3D11GraphicsEngine::DrawFrameParticles(
 
     for ( auto const& textureParticleRenderInfo : pvecAdd ) {
         zCTexture* tx = std::get<0>( textureParticleRenderInfo );
-        ParticleRenderInfo& partInfo = *std::get<1>( textureParticleRenderInfo );
         std::vector<ParticleInstanceInfo>& instances = *std::get<2>( textureParticleRenderInfo );
 
         if ( instances.empty() ) continue;

--- a/D3D11Engine/D3D11GraphicsEngineBase.cpp
+++ b/D3D11Engine/D3D11GraphicsEngineBase.cpp
@@ -9,10 +9,6 @@
 #include "RenderToTextureBuffer.h"
 #include "zCView.h"
 
-const unsigned int DRAWVERTEXARRAY_BUFFER_SIZE = 4096 * sizeof( ExVertexStruct );
-const int NUM_MAX_BONES = 96;
-const unsigned int INSTANCING_BUFFER_SIZE = sizeof( VobInstanceInfo ) * 2048;
-
 // If defined, creates a debug-version of the d3d11-device
 #if !PUBLIC_RELEASE
 #define DEBUG_D3D11

--- a/D3D11Engine/D3D11IndirectBuffer.h
+++ b/D3D11Engine/D3D11IndirectBuffer.h
@@ -5,7 +5,7 @@
 
 #include <wrl/client.h>
 
-enum XRESULT;
+enum XRESULT : int;
 
 class D3D11IndirectBuffer {
 public:

--- a/D3D11Engine/D3D11PFX_FSR2.cpp
+++ b/D3D11Engine/D3D11PFX_FSR2.cpp
@@ -214,7 +214,6 @@ XRESULT D3D11PFX_FSR2::Apply(
     // Optional Resources (Passing nullptr handles them internally, e.g., Auto Exposure)
     // dispatchDesc.exposure = ffxGetResourceDX11_Fsr31_( nullptr, GetFfxResourceDescriptionDX11(nullptr), L"" );
     if (reactiveMask != nullptr) {
-        ID3D11Resource* reactiveRes = GetResourceFromView( reactiveMask );
         // dispatchDesc.reactive = GetAsFfxResource( reactiveMask, L"FSR2_ReactiveMask" );
         dispatchDesc.transparencyAndComposition = GetAsFfxResource( reactiveMask, L"FSR2_T_C" );
     }

--- a/D3D11Engine/D3D11PFX_GodRays.cpp
+++ b/D3D11Engine/D3D11PFX_GodRays.cpp
@@ -22,8 +22,9 @@ D3D11PFX_GodRays::D3D11PFX_GodRays( D3D11PfxRenderer* rnd ) : D3D11PFX_Effect( r
 XRESULT D3D11PFX_GodRays::Render( 
     ID3D11ShaderResourceView* backbuffer, 
     ID3D11ShaderResourceView* depth ) {
-    if ( Engine::GAPI->GetSky()->GetAtmoshpereSettings().LightDirection.y <= 0 )
+    if ( Engine::GAPI->GetSky()->GetAtmoshpereSettings().LightDirection.y <= 0 ) {
         return XR_SUCCESS; // Don't render the godrays in the night-time
+    }
 
 	D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
 

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -431,6 +431,11 @@ XRESULT D3D11ShadowMap::PrepareRender()
         }
     }
 
+    zCCamera* camera = (zCCamera*)oCGame::GetGame()->_zCSession_camera;
+    if ( !camera ) {
+        return XR_SUCCESS;
+    }
+    camera->Activate();
     const XMVECTOR cameraPositionXm = Engine::GAPI->GetCameraPositionXM();
     XMFLOAT3 cameraPosition;
     XMStoreFloat3( &cameraPosition, cameraPositionXm );
@@ -440,12 +445,6 @@ XRESULT D3D11ShadowMap::PrepareRender()
     // ********************************
     // Cascade Shadow Map Rendering (Simple Sequential Version)
     // ********************************
-
-    zCCamera* camera = (zCCamera*)oCGame::GetGame()->_zCSession_camera;
-    if ( !camera ) {
-        return XR_SUCCESS;
-    }
-     camera->Activate();
 
     const float nearPlane = std::max( 1.0f, camera->GetNearPlane() );
     // Clamp far plane to avoid extreme shadow distances
@@ -618,7 +617,7 @@ XRESULT D3D11ShadowMap::PrepareRender()
         Frustum playerFrustum = Frustum::AlwaysContainingFrustum();
         if ( auto cam = (zCCamera*)oCGame::GetGame()->_zCSession_camera ) {
             const auto& view = cam->trafoView; // Column-Major, needs Transpose for DxMath
-            const auto& proj = Engine::GAPI->GetProjectionMatrix(); // Row-Major, does not need transpose.
+            const auto& proj = cam->trafoProjection; // Row-Major, does not need transpose.
             playerFrustum.BuildPerspective(
                 XMMatrixTranspose( XMLoadFloat4x4( &view ) ),
                 XMLoadFloat4x4( &proj )

--- a/D3D11Engine/D3D11VShader.cpp
+++ b/D3D11Engine/D3D11VShader.cpp
@@ -30,7 +30,9 @@ XRESULT D3D11VShader::LoadShader( const ShaderInfo& si, const std::vector<D3D_SH
         return XR_FAILED;
     }
 
-    auto hrReflected = ReflectShaderResources( vsBlob.Get() );
+    if ( ReflectShaderResources( vsBlob.Get() ) != XR_SUCCESS ) {
+        return XR_FAILED;
+    }
     
     // Create the shader
     LE( engine->GetDevice()->CreateVertexShader( vsBlob->GetBufferPointer(),

--- a/D3D11Engine/D3D11VertexBuffer.h
+++ b/D3D11Engine/D3D11VertexBuffer.h
@@ -7,7 +7,7 @@
 
 #include <wrl/client.h>
 
-enum XRESULT;
+enum XRESULT : int;
 
 class D3D11VertexBuffer {
 public:

--- a/D3D11Engine/D3D7/MyClipper.h
+++ b/D3D11Engine/D3D7/MyClipper.h
@@ -2,7 +2,7 @@
 #include "../pch.h"
 #include <ddraw.h>
 
-class MyClipper : public IDirectDrawClipper {
+class MyClipper final : public IDirectDrawClipper {
 public:
 	MyClipper() : hWnd(nullptr), refCount(1) {
 	}

--- a/D3D11Engine/D3D7/MyDirect3D7.h
+++ b/D3D11Engine/D3D7/MyDirect3D7.h
@@ -4,7 +4,7 @@
 #include "MyDirect3DVertexBuffer7.h"
 #include "../Engine.h"
 
-class MyDirect3D7 : public IDirect3D7 {
+class MyDirect3D7 final : public IDirect3D7 {
 public:
 	MyDirect3D7( IDirect3D7* direct3d7 ) {
 		DebugWrite( "MyDirect3D7::MyDirect3D7\n" );

--- a/D3D11Engine/D3D7/MyDirect3DDevice7.h
+++ b/D3D11Engine/D3D7/MyDirect3DDevice7.h
@@ -29,7 +29,7 @@
 
 const int DRAW_PRIM_INDEX_BUFFER_SIZE = 4096 * sizeof( VERTEX_INDEX );
 
-class MyDirect3DDevice7 : public IDirect3DDevice7 {
+class MyDirect3DDevice7 final : public IDirect3DDevice7 {
 public:
 	MyDirect3DDevice7( IDirect3D7* direct3D7, IDirect3DDevice7* direct3DDevice7 ) {
 		DebugWrite( "MyDirect3DDevice7::MyDirect3DDevice7" );
@@ -225,7 +225,6 @@ public:
 
 		case D3DRENDERSTATETYPE::D3DRENDERSTATE_FOGCOLOR:
 		{
-			BYTE a = Value >> 24;
 			BYTE r = (Value >> 16) & 0xFF;
 			BYTE g = (Value >> 8) & 0xFF;
 			BYTE b = Value & 0xFF;
@@ -235,7 +234,6 @@ public:
 
 		case D3DRENDERSTATETYPE::D3DRENDERSTATE_AMBIENT:
 		{
-			BYTE a = Value >> 24;
 			BYTE r = (Value >> 16) & 0xFF;
 			BYTE g = (Value >> 8) & 0xFF;
 			BYTE b = Value & 0xFF;

--- a/D3D11Engine/D3D7/MyDirectDraw.h
+++ b/D3D11Engine/D3D7/MyDirectDraw.h
@@ -176,37 +176,6 @@ public:
                 lpDDSurfaceDesc2->ddpfPixelFormat.dwFourCC = 0;
         }
 
-		// Calculate bpp
-		int redBits = Toolbox::GetNumberOfBits( lpDDSurfaceDesc2->ddpfPixelFormat.dwRBitMask );
-		int greenBits = Toolbox::GetNumberOfBits( lpDDSurfaceDesc2->ddpfPixelFormat.dwGBitMask );
-		int blueBits = Toolbox::GetNumberOfBits( lpDDSurfaceDesc2->ddpfPixelFormat.dwBBitMask );
-		int alphaBits = Toolbox::GetNumberOfBits( lpDDSurfaceDesc2->ddpfPixelFormat.dwRGBAlphaBitMask );
-
-		// Figure out format
-		DXGI_FORMAT fmt;
-		int bpp = 0;
-		if ( (lpDDSurfaceDesc2->ddpfPixelFormat.dwFlags & DDPF_FOURCC) == DDPF_FOURCC ) {
-			switch ( lpDDSurfaceDesc2->ddpfPixelFormat.dwFourCC ) {
-			case FOURCC_DXT1:
-				fmt = DXGI_FORMAT_BC1_UNORM;
-				break;
-			case FOURCC_DXT2:
-			case FOURCC_DXT3:
-				fmt = DXGI_FORMAT_BC2_UNORM;
-				break;
-			case FOURCC_DXT4:
-			case FOURCC_DXT5:
-				fmt = DXGI_FORMAT_BC3_UNORM;
-				break;
-			}
-		} else {
-			fmt = DXGI_FORMAT_B8G8R8A8_UNORM;
-			bpp = 32;
-		}
-
-		if ( redBits == 5 )
-			bpp = 16;
-
 		// Create surface
 		MyDirectDrawSurface7* mySurface = new MyDirectDrawSurface7();
 

--- a/D3D11Engine/D3D7/MyDirectDraw.h
+++ b/D3D11Engine/D3D7/MyDirectDraw.h
@@ -6,7 +6,7 @@
 #include "FakeDirectDrawSurface7.h"
 #include "MyClipper.h"
 
-class MyDirectDraw : public IDirectDraw7 {
+class MyDirectDraw final : public IDirectDraw7 {
 public:
 	MyDirectDraw( IDirectDraw7* directDraw7 ) : directDraw7( directDraw7 ) {
 		DebugWrite( "MyDirectDraw::MyDirectDraw\n" );

--- a/D3D11Engine/DLLMain.cpp
+++ b/D3D11Engine/DLLMain.cpp
@@ -436,7 +436,7 @@ int WINAPI hooked_WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR l
     // TODO: Implement!
     if ( !GMPModeActive ) {
         DetourTransactionBegin();
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCActiveSndAutoCalcObstruction), HookedFunctionInfo::hooked_zCActiveSndAutoCalcObstruction );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCActiveSndAutoCalcObstruction, HookedFunctionInfo::hooked_zCActiveSndAutoCalcObstruction  );
         DetourTransactionCommit();
     }
     return originalWinMain( hInstance, hPrevInstance, lpCmdLine, nShowCmd );
@@ -496,7 +496,7 @@ BOOL WINAPI DllMain( HINSTANCE hInst, DWORD reason, LPVOID ) {
         Engine::PassThrough = false;
 
 #if defined(BUILD_GOTHIC_2_6_fix)
-        DetourAttach( &reinterpret_cast<PVOID&>(originalWinMain), hooked_WinMain );
+        DetourAttachTyped( &originalWinMain, hooked_WinMain  );
 #endif
 
         //_CrtSetDbgFlag (_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);

--- a/D3D11Engine/EditorLinePrimitive.cpp
+++ b/D3D11Engine/EditorLinePrimitive.cpp
@@ -576,7 +576,6 @@ float XM_CALLCONV EditorLinePrimitive::IntersectPrimitive( FXMVECTOR RayOrigin, 
     if ( NumSolidVertices > 0 ) {
         FLOAT fBary1, fBary2;
         FLOAT fDist;
-        int NumIntersections = 0;
         Shortest = FLT_MAX;
 
         for ( DWORD i = 0; i < NumSolidVertices; i += 3 ) {
@@ -587,7 +586,6 @@ float XM_CALLCONV EditorLinePrimitive::IntersectPrimitive( FXMVECTOR RayOrigin, 
             // Check if the pick ray passes through this point
             if ( IntersectTriangle( Origin, Dir, v0, v1, v2, &fDist, &fBary1, &fBary2 ) ) {
                 if ( fDist < Shortest || Shortest == -1 ) {
-                    NumIntersections++;
                     Shortest = 0;
 
                     //if (NumIntersections == MAX_INTERSECTIONS)

--- a/D3D11Engine/GMesh.h
+++ b/D3D11Engine/GMesh.h
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 
-enum XRESULT;
+enum XRESULT : int;
 struct MeshInfo;
 
 class GMesh {

--- a/D3D11Engine/GMeshSimple.cpp
+++ b/D3D11Engine/GMeshSimple.cpp
@@ -46,8 +46,6 @@ XRESULT GMeshSimple::LoadMesh( const std::string& file ) {
 
         LogInfo() << " - Submesh: (Num Vertices: " << s->mMeshes[i]->mNumVertices << ") (Texture: " << texture.C_Str() << ")";
 
-        MeshInfo* mi = new MeshInfo;
-
         SimpleObjectVertexStruct* vertices = new SimpleObjectVertexStruct[s->mMeshes[i]->mNumVertices];
         VERTEX_INDEX* indices = new VERTEX_INDEX[s->mMeshes[i]->mNumFaces * 3];
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -3128,7 +3128,6 @@ void GothicAPI::DrawParticleFX( zCVob* source, zCParticleFX* fx, ParticleFrameDa
             break;
         }
 
-        int i = 0;
         for ( p = pfx; p; p = p->Next ) {
             for ( ;;) {
                 kill = p->Next;
@@ -3185,8 +3184,6 @@ void GothicAPI::DrawParticleFX( zCVob* source, zCParticleFX* fx, ParticleFrameDa
             }
 
             fx->UpdateParticle( p );
-
-            i++;
         }
     }
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -6097,6 +6097,12 @@ void GothicAPI::CollectVisibleVobs( const RndCullContext& ctx ) {
     if ( LeafLinearCache.Count > 0 && ctx.frustum.UsesPlaneFrustum() ) {
         ZoneScopedN( "GothicAPI::CollectVisibleVobsWithLeafCache" );
         CollectVisibleVobsWithLeafCache( ctx, &bspVobVisitor );
+        ZoneText( "vobs", std::size( "vobs" ) - 1 );
+        ZoneValue( bspVobVisitor.GetSeenVobs() );
+        ZoneText( "mobs", std::size( "mobs" ) - 1 );
+        ZoneValue( bspVobVisitor.GetSeenMobs() );
+        ZoneText( "lights", std::size( "lights" ) - 1 );
+        ZoneValue( bspVobVisitor.GetSeenLights() );
     } else
 #endif
     {
@@ -6108,6 +6114,12 @@ void GothicAPI::CollectVisibleVobs( const RndCullContext& ctx ) {
             ContainmentType::INTERSECTS,
             Engine::GAPI->GetLoadedWorldInfo()->BspTree->GetRootNode()->BBox3D.Max.y
         );
+        ZoneText( "vobs", std::size( "vobs" ) - 1 );
+        ZoneValue( bspVobVisitor.GetSeenVobs() );
+        ZoneText( "mobs", std::size( "mobs" ) - 1 );
+        ZoneValue( bspVobVisitor.GetSeenMobs() );
+        ZoneText( "lights", std::size( "lights" ) - 1 );
+        ZoneValue( bspVobVisitor.GetSeenLights() );
     }
 
     FXMVECTOR camPos = XMLoadFloat3( &ctx.cameraPosition );

--- a/D3D11Engine/HookedFunctions.h
+++ b/D3D11Engine/HookedFunctions.h
@@ -4,6 +4,7 @@
 #include "GothicMemoryLocations.h"
 #include "zTypes.h"
 #include "HookExceptionFilter.h"
+#include <cstring>
 
 /** This file stores the original versions of the hooked functions and the function declerations */
 
@@ -100,6 +101,25 @@ typedef void( __thiscall* zCCamera__UpdateViewport )(void*);
 typedef void( __thiscall* zCSkyControler_ClearBackground )(void*, zColor);
 
 struct zTRndSurfaceDesc;
+
+template <typename TOriginal, typename THook>
+inline LONG DetourAttachTyped( TOriginal* originalFunction, THook hookFunction ) {
+    static_assert( sizeof( TOriginal ) == sizeof( PVOID ), "Unexpected original function pointer size" );
+    static_assert( sizeof( THook ) == sizeof( PVOID ), "Unexpected hook function pointer size" );
+
+    PVOID* ppOriginal = reinterpret_cast<PVOID*>(originalFunction);
+
+    // 2. Cast the hook function safely.
+    // Standard C++ forbids reinterpret_cast from a function pointer to a void pointer.
+    union {
+        THook func;
+        PVOID ptr;
+    } hookCast;
+    hookCast.func = hookFunction;
+
+    return DetourAttach( ppOriginal, hookCast.ptr );
+}
+
 struct HookedFunctionInfo {
 
     /** Init all hooks here */

--- a/D3D11Engine/IkarusBindings.cpp
+++ b/D3D11Engine/IkarusBindings.cpp
@@ -71,8 +71,6 @@ extern "C"
         - Type: 0 = OK, 1 = YES/NO
         - Callback: Script-Function ID to use as a callback. */
     __declspec(dllexport) void __cdecl GDX_OpenMessageBox( zSTRING* message, zSTRING* caption, int type, int callbackID ) {
-        D3D11GraphicsEngine* g = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
-
         // Check again, in case it failed
         // TODO: Re-Implement this on top of the new UI-System
         

--- a/D3D11Engine/InstructionSet.h
+++ b/D3D11Engine/InstructionSet.h
@@ -188,9 +188,7 @@ const InstructionSet::InstructionSet_Internal InstructionSet::CPU_Rep;
 
 // Print out supported instruction set extensions
 void LogInstructionSet() {
-    auto& outstream = std::cout;
-
-    auto support_message = [&outstream]( std::string isa_feature, bool is_supported ) {
+    auto support_message = []( std::string isa_feature, bool is_supported ) {
         LogInfo() << isa_feature << (is_supported ? " supported" : " not supported");
     };
 

--- a/D3D11Engine/Logger.h
+++ b/D3D11Engine/Logger.h
@@ -174,7 +174,12 @@ public:
     }
 
 
-    inline Log& operator << ( std::wostream& (*fn)(std::wostream&) ) {
+    inline Log& operator << ( std::ostream& (*fn)(std::ostream&) ) {
+        Message << fn;
+        return *this;
+    }
+
+    inline Log& operator << ( std::ios_base& (*fn)(std::ios_base&) ) {
         Message << fn;
         return *this;
     }

--- a/D3D11Engine/RenderGraph.cpp
+++ b/D3D11Engine/RenderGraph.cpp
@@ -128,7 +128,7 @@ void RenderGraph::AllocateResourcesForPass( size_t passIndex )
             const RGTextureDesc& desc = m_resourceDescs[i];
             TexturePool::Description poolDesc{ (int)desc.width, (int)desc.height, static_cast<DXGI_FORMAT>( desc.format ), (DXGI_USAGE)desc.textureFlags };
 
-            m_activeTextures[i] = std::move( m_texturePool->Acquire( poolDesc ) );
+            m_activeTextures[i] = m_texturePool->Acquire( poolDesc );
         }
     }
 }

--- a/D3D11Engine/RenderQueue.h
+++ b/D3D11Engine/RenderQueue.h
@@ -103,6 +103,10 @@ public:
         lights.clear();
         skeltalVobs.clear();
     }
+
+    size_t GetSeenLights() const { return lights.size(); }
+    size_t GetSeenVobs() const { return vobs.size(); }
+    size_t GetSeenMobs() const { return skeltalVobs.size(); }
 private:
     size_t seen_flag_id;
     std::vector<VobInfo*> vobs;

--- a/D3D11Engine/RenderQueue.h
+++ b/D3D11Engine/RenderQueue.h
@@ -56,7 +56,7 @@ public:
     std::vector<TransparencyVobInfo> transparent;
 };
 
-static std::atomic<size_t> g_nextSeenId = 1;
+static std::atomic<size_t> g_nextSeenId = 0;
 // Marks any visited vob 
 class BspTreeVobVisitor {
 public:

--- a/D3D11Engine/ThreadPool.h
+++ b/D3D11Engine/ThreadPool.h
@@ -55,10 +55,38 @@ public:
         size_t threads = std::clamp(static_cast<size_t>(std::thread::hardware_concurrency()), static_cast<size_t>(1),
                                     static_cast<size_t>(4)));
 
-    // 3. enqueue returns a TaskHandle and expects 'F' to accept CancellationToken as its first param
-    template <class F, class... Args>
-    auto enqueue(F&& f, Args&&... args)
-        -> TaskHandle<typename std::invoke_result<F, CancellationToken, Args...>::type>;
+    //  enqueue returns a TaskHandle and expects 'F' to accept CancellationToken as its first param
+    template <typename F, typename... Args>
+    auto enqueue( F&& f, Args&&... args ) {
+        using ReturnType = std::invoke_result_t<F, CancellationToken, Args...>;
+
+        CancellationToken token;
+
+        auto task = std::make_shared<std::packaged_task<ReturnType()>>(
+            [f = std::forward<F>( f ),
+             token,
+             ...args = std::forward<Args>( args )]() mutable {
+                     return std::invoke( std::move( f ), token, std::forward<Args>( args )... );
+            }
+        );
+
+        std::future<ReturnType> future = task->get_future();
+        {
+            std::scoped_lock lock( queue_mutex );
+
+            if ( stop ) {
+                throw std::runtime_error( "enqueue on stopped ThreadPool" );
+            }
+
+            tasks.emplace( [task]() 
+            { 
+                (*task)(); 
+            }, token );
+        }
+        condition.notify_one();
+
+        return TaskHandle<ReturnType>{std::move( future ), token};
+    }
 
     ~ThreadPool();
 
@@ -145,38 +173,6 @@ inline ThreadPool::ThreadPool(const wchar_t* poolIdentifier, size_t threads)
                 }
             }, this, i, identifier
         );
-}
-
-template <class F, class... Args>
-auto ThreadPool::enqueue(F&& f, Args&&... args)
-    -> TaskHandle<typename std::invoke_result<F, CancellationToken, Args...>::type>
-{
-    using return_type = typename std::invoke_result<F, CancellationToken, Args...>::type;
-
-    CancellationToken token;
-
-    auto task = std::make_shared<std::packaged_task<return_type()>>(
-        [f = std::forward<F>(f), token, ...args = std::forward<Args>(args)]() mutable {
-            return f(token, std::forward<Args>(args)...);
-        }
-    );
-
-    std::future<return_type> res = task->get_future();
-    {
-        std::unique_lock<std::mutex> lock(queue_mutex);
-
-        if (stop)
-            throw std::runtime_error("enqueue on stopped ThreadPool");
-
-        // Store the task function and its token together
-        tasks.emplace(std::make_pair([task]()
-        {
-            (*task)();
-        }, token));
-    }
-    condition.notify_one();
-
-    return {std::move(res), token};
 }
 
 inline ThreadPool::~ThreadPool()

--- a/D3D11Engine/Toolbox.cpp
+++ b/D3D11Engine/Toolbox.cpp
@@ -143,7 +143,6 @@ namespace Toolbox {
     /** Computes the Distance of a point to an AABB */
     float ComputePointAABBDistance( const XMFLOAT3& p, const XMFLOAT3& min, const XMFLOAT3& max ) {
         float dx = std::max( std::max( min.x - p.x, 0.0f ), p.x - max.x );
-        float dy = std::max( std::max( min.y - p.y, 0.0f ), p.y - max.y );
         float dz = std::max( std::max( min.z - p.z, 0.0f ), p.z - max.z );
         //return sqrtf( dx * dx + dz * dz );
         return _mm_cvtss_f32( _mm_rcp_ss( _mm_rsqrt_ss( _mm_set_ss( dx * dx + dz * dz ) ) ) );

--- a/D3D11Engine/Types.h
+++ b/D3D11Engine/Types.h
@@ -9,7 +9,7 @@ using namespace DirectX;
 /** Defines types used for the project */
 
 /** Errorcodes */
-enum XRESULT {
+enum XRESULT : int {
     XR_SUCCESS,
     XR_FAILED,
     XR_INVALID_ARG,

--- a/D3D11Engine/VersionCheck.cpp
+++ b/D3D11Engine/VersionCheck.cpp
@@ -12,11 +12,13 @@
 
 namespace VersionCheck {
 
+#ifndef DISABLE_EXECUTABLE_CHECKSUM_CHECK
 	static const int CHECKSUM_G2_2_6_FIX = 0x008a3e89;
 	static const int CHECKSUM_G2_2_6_FIX_4GB = 0x008a3ea9;
 	static const int CHECKSUM_G1_1_08k = 0x0000eb3d;
 	static const int CHECKSUM_G1_1_08k_4GB = 0x08608228;
 	static const int CHECKSUM_G1_1_12f = 0x00862362;
+#endif
 
 	/** Returns whether the given file exists */
 	bool FileExists( const std::string& file ) {

--- a/D3D11Engine/Widget_TransRot.cpp
+++ b/D3D11Engine/Widget_TransRot.cpp
@@ -190,7 +190,6 @@ void Widget_TransRot::DoHoverTest( HWND hw ) {
 	}
 
 	float Dist = Width;
-	EditorLinePrimitive* Prim = nullptr;
 	ActiveSelection = WTR_None;
 
 

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -328,12 +328,12 @@ XRESULT WorldConverter::LoadWorldMeshFromFile( const std::string& file, std::map
     avgSections /= static_cast<float>(numSections);
 
     if ( info ) {
-        WorldInfo i;
+        WorldInfo i{};
         XMStoreFloat2( &i.MidPoint, avgSections * WORLD_SECTION_SIZE );
         i.LowestVertex = 0;
         i.HighestVertex = 0;
 
-        memcpy( info, &i, sizeof( WorldInfo ) );
+        *info = std::move(i);
     }
 
 

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -8,9 +8,6 @@
 #include "zCTexture.h"
 #include "D3D11_Helpers.h"
 
-const int WORLDMESHINFO_VERSION = 5;
-const int VISUALINFO_VERSION = 5;
-
 /** Updates the vobs constantbuffer */
 void VobInfo::UpdateVobConstantBuffer() {
     VS_ExConstantBuffer_PerInstance cb;

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -303,7 +303,7 @@ struct VobInfo : public BaseVobInfo {
     bool IsIndoorVob;
 
     /** Flag to see if this vob was drawn in the current render pass. Used to collect the same vob only once. */
-    std::atomic<size_t> VisibleInRenderPass;
+    std::atomic<size_t> VisibleInRenderPass{};
 
     /** Section this vob is in */
     WorldMeshSectionInfo* VobSection;
@@ -312,7 +312,7 @@ struct VobInfo : public BaseVobInfo {
     XMFLOAT4X4 WorldMatrix;
 
     /** BSP-Node this is stored in */
-    std::vector<BspInfo*> ParentBSPNodes;
+    std::vector<BspInfo*> ParentBSPNodes{};
 
     /** Color the underlaying polygon has */
     DWORD GroundColor;
@@ -341,14 +341,14 @@ struct VobLightInfo {
     zCVobLight* Vob;
 
     /** Flag to see if this vob was drawn in the current render pass. Used to collect the same vob only once. Cleared immediately. */
-    std::atomic<size_t> VisibleInRenderPass;
+    std::atomic<size_t> VisibleInRenderPass{};
     bool IsPFXVobLight;
 
     /** True if this is an indoor-vob */
     bool IsIndoorVob;
 
     /** BSP-Node this is stored in */
-    std::vector<BspInfo*> ParentBSPNodes;
+    std::vector<BspInfo*> ParentBSPNodes{};
 
     /** Buffers for doing shadows on this light */
     std::unique_ptr<BaseShadowedPointLight> LightShadowBuffers;
@@ -412,21 +412,21 @@ struct SkeletalVobInfo : public BaseVobInfo {
     std::unique_ptr<D3D11ConstantBuffer> VobConstantBuffer;
 
     /** Map of visuals attached to nodes */
-    gtl::flat_hash_map<int, std::vector<MeshVisualInfo*>> NodeAttachments;
+    gtl::flat_hash_map<int, std::vector<MeshVisualInfo*>> NodeAttachments{};
 
     /** Indoor* */
     bool IndoorVob;
 
     /** Flag to see if this vob was drawn in the current render pass. Used to collect the same vob only once. */
-    std::atomic<size_t> VisibleInRenderPass;
+    std::atomic<size_t> VisibleInRenderPass{};
 
     /** Current world transform */
     XMFLOAT4X4 WorldMatrix;
 
     /** BSP-Node this is stored in */
-    std::vector<BspInfo*> ParentBSPNodes;
+    std::vector<BspInfo*> ParentBSPNodes{};
 
-    std::vector<XMFLOAT4X4> PrevBoneTransforms;
+    std::vector<XMFLOAT4X4> PrevBoneTransforms{};
     XMFLOAT4X4 PrevWorldMatrix;
     bool HasValidPrevTransforms;
     size_t LastAniUpdateFrame;

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -518,7 +518,9 @@ struct WorldInfo {
     }
     
     WorldInfo(WorldInfo&& other) = default;
+    WorldInfo& operator=(WorldInfo&& other) = default;
     WorldInfo(const WorldInfo& other) = delete;
+    WorldInfo& operator=(const WorldInfo& other) = delete;
 
     XMFLOAT2 MidPoint;
     float LowestVertex;

--- a/D3D11Engine/oCGame.h
+++ b/D3D11Engine/oCGame.h
@@ -32,9 +32,9 @@ public:
 
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_oCGameEnterWorld), hooked_EnterWorld );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCGameEnterWorld, hooked_EnterWorld  );
 #if defined(BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_oCGameDefineExternals_Ulfi), hooked_DefineExternals_Ulfi );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCGameDefineExternals_Ulfi, hooked_DefineExternals_Ulfi  );
 #endif
     }
 

--- a/D3D11Engine/oCNPC.h
+++ b/D3D11Engine/oCNPC.h
@@ -22,9 +22,9 @@ public:
 
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_oCNPCEnable), hooked_oCNPCEnable );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_oCNPCDisable), hooked_oCNPCDisable );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_oCNPCInitModel), hooked_oCNPCInitModel );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCNPCEnable, hooked_oCNPCEnable  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCNPCDisable, hooked_oCNPCDisable  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCNPCInitModel, hooked_oCNPCInitModel  );
     }
 
     static void __fastcall hooked_oCNPCInitModel( zCVob* thisptr, void* unknwn ) {

--- a/D3D11Engine/oCSpawnManager.h
+++ b/D3D11Engine/oCSpawnManager.h
@@ -13,10 +13,10 @@ public:
 
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_oCSpawnManagerSpawnNpc), hooked_oCSpawnManagerSpawnNpc );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCSpawnManagerSpawnNpc, hooked_oCSpawnManagerSpawnNpc  );
 
-        //DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_oCSpawnManagerCheckInsertNpc), hooked_oCSpawnManagerCheckInsertNpc );
-        //DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_oCSpawnManagerCheckRemoveNpc), hooked_oCSpawnManagerCheckRemoveNpc );
+        //DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCSpawnManagerCheckInsertNpc, hooked_oCSpawnManagerCheckInsertNpc  );
+        //DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCSpawnManagerCheckRemoveNpc, hooked_oCSpawnManagerCheckRemoveNpc  );
     }
 
     /** Reads config stuff */

--- a/D3D11Engine/pch.cpp
+++ b/D3D11Engine/pch.cpp
@@ -39,9 +39,6 @@ void DebugWrite_i( LPCSTR lpDebugMessage, void* thisptr ) {
 int ComputeFVFSize( DWORD fvf ) {
 	//Those -inc s are the offset for the vertexptr to get to the data you want..
 	//i.e. :if you want the normal data you can do vertexptr+nromalinc and you have a pointer to it
-	int normalinc = 0;
-	int texcoordinc = 0;
-	int szfloat = sizeof( float );
 	int size = 0;
 	DWORD test = fvf;
 	//test which fvf-code are included in fvf:
@@ -54,7 +51,6 @@ int ComputeFVFSize( DWORD fvf ) {
 		test &= ~D3DFVF_XYZRHW;
 	}
 	if ( (fvf & D3DFVF_NORMAL) == D3DFVF_NORMAL ) {
-		normalinc = size;
 		size += 3 * sizeof( float );
 		test &= ~D3DFVF_NORMAL;
 	}
@@ -67,35 +63,27 @@ int ComputeFVFSize( DWORD fvf ) {
 		test &= ~D3DFVF_SPECULAR;
 	}
 	if ( (fvf & D3DFVF_TEX1) == D3DFVF_TEX1 ) {
-		texcoordinc = size;
 		size += 2 * sizeof( float );
 		test &= ~D3DFVF_TEX1;
 	} else if ( (fvf & D3DFVF_TEX2) == D3DFVF_TEX2 ) {
-		texcoordinc = size;
 		size += 2 * sizeof( float ) * 2;
 		test &= ~D3DFVF_TEX2;
 	} else if ( (fvf & D3DFVF_TEX3) == D3DFVF_TEX3 ) {
-		texcoordinc = size;
 		size += 2 * sizeof( float ) * 3;
 		test &= ~D3DFVF_TEX3;
 	} else if ( (fvf & D3DFVF_TEX4) == D3DFVF_TEX4 ) {
-		texcoordinc = size;
 		size += 2 * sizeof( float ) * 4;
 		test &= ~D3DFVF_TEX4;
 	} else if ( (fvf & D3DFVF_TEX5) == D3DFVF_TEX5 ) {
-		texcoordinc = size;
 		size += 2 * sizeof( float ) * 5;
 		test &= ~D3DFVF_TEX5;
 	} else if ( (fvf & D3DFVF_TEX6) == D3DFVF_TEX6 ) {
-		texcoordinc = size;
 		size += 2 * sizeof( float ) * 6;
 		test &= ~D3DFVF_TEX6;
 	} else if ( (fvf & D3DFVF_TEX7) == D3DFVF_TEX7 ) {
-		texcoordinc = size;
 		size += 2 * sizeof( float ) * 7;
 		test &= ~D3DFVF_TEX7;
 	} else if ( (fvf & D3DFVF_TEX8) == D3DFVF_TEX8 ) {
-		texcoordinc = size;
 		size += 2 * sizeof( float ) * 8;
 		test &= ~D3DFVF_TEX8;
 	}

--- a/D3D11Engine/win32ClipboardWrapper.cpp
+++ b/D3D11Engine/win32ClipboardWrapper.cpp
@@ -16,11 +16,13 @@ int clipput(char *toclipdata)
 	OpenClipboard(nullptr);
 	EmptyClipboard();
 	clipbuffer = GlobalAlloc(GMEM_DDESHARE,bytes+1);
-    if ( clipbuffer == nullptr )
+    if ( clipbuffer == nullptr ) {
         return GetLastError() * -1; // Do what you want to signal error
+    }
 	buffer = (char far*)GlobalLock(clipbuffer);
-	if (buffer == nullptr)
+    if ( buffer == nullptr ) {
 		return GetLastError() * -1; // Do what you want to signal error
+    }
 	strcpy(buffer,toclipdata);
 
 	GlobalUnlock(clipbuffer);
@@ -34,52 +36,51 @@ int clipput(char *toclipdata)
 char *clipget(int &bytes)
 	{
 		int k;
-		char *buffer=nullptr;
-		char *data=nullptr;
-		char empty[80]="<Clipboard is empty>";
+		char *data = nullptr;
+		char empty[80] = "<Clipboard is empty>";
 
 		bytes = 0;
 
 		// open the clipboard
-		if (OpenClipboard(nullptr))
+		if ( OpenClipboard( nullptr ) )
 		{
-			HANDLE hData = GetClipboardData(CF_TEXT);
-			char * buffer = (char*)GlobalLock(hData);
-			GlobalUnlock(hData);
-			CloseClipboard();
+			HANDLE hData = GetClipboardData( CF_TEXT );
+			char* clipboardBuffer = hData ? static_cast<char*>(GlobalLock( hData )) : nullptr;
 
-			// Return an error message
-			if (buffer == nullptr)
+			if ( clipboardBuffer == nullptr )
 			{
-				bytes = strlen(empty);
-				data = (char *) malloc(bytes+1);
-                if ( data ) {
-                    strcpy( data, empty );
-                }
+				bytes = strlen( empty );
+				data = static_cast<char*>(malloc( bytes + 1 ));
+				if ( data ) {
+					strcpy( data, empty );
+				}
 			}
-			// Return pointer to retrieved data
 			else
 			{
-				bytes = strlen(buffer);
-				data = (char *) malloc(bytes+1);
-                if ( data ) {
-                    strcpy( data, buffer );
-                }
+				bytes = strlen( clipboardBuffer );
+				data = static_cast<char*>(malloc( bytes + 1 ));
+				if ( data ) {
+					strcpy( data, clipboardBuffer );
+				}
+
+				GlobalUnlock( hData );
 			}
+
+			CloseClipboard();
 		}
 		// Return an open clipboard failed message
 		else
 		{
 			k = GetLastError();
-			if (k < 0)
+			if ( k < 0 )
 				bytes = k;
 			else
 				bytes = k * -1;
-			sprintf(empty,"Error occurred opening clipboard - RC: %d",k);
-			k = strlen(empty);
-			data = (char *) malloc(k + 1);
-			if (data) {
-				strcpy(data, empty);
+			sprintf( empty, "Error occurred opening clipboard - RC: %d", k );
+			k = strlen( empty );
+			data = static_cast<char*>(malloc( k + 1 ));
+			if ( data ) {
+				strcpy( data, empty );
 			}
 		}
 		// Return pointer to data field allocated

--- a/D3D11Engine/zCBspTree.h
+++ b/D3D11Engine/zCBspTree.h
@@ -51,13 +51,13 @@ public:
 
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCBspNodeRender), hooked_zCBspNodeRender );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCBspNodeRender, hooked_zCBspNodeRender  );
 
 #ifdef BUILD_GOTHIC_1_08k
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCBspBaseCollectPolysInBBox3D), hooked_zCBspBaseCollectPolysInBBox3D );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCBspBaseCheckRayAgainstPolys), hooked_zCBspBaseCheckRayAgainstPolys );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCBspBaseCheckRayAgainstPolysCache), hooked_zCBspBaseCheckRayAgainstPolysCache );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCBspBaseCheckRayAgainstPolysNearestHit), hooked_zCBspBaseCheckRayAgainstPolysNearestHit );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCBspBaseCollectPolysInBBox3D, hooked_zCBspBaseCollectPolysInBBox3D  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCBspBaseCheckRayAgainstPolys, hooked_zCBspBaseCheckRayAgainstPolys  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCBspBaseCheckRayAgainstPolysCache, hooked_zCBspBaseCheckRayAgainstPolysCache  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCBspBaseCheckRayAgainstPolysNearestHit, hooked_zCBspBaseCheckRayAgainstPolysNearestHit  );
 #endif
     }
 
@@ -213,8 +213,8 @@ class zCBspTree {
 public:
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCBspTreeLoadBIN), hooked_LoadBIN );
-        //DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCBspTreeAddVob), hooked_AddVob );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCBspTreeLoadBIN, hooked_LoadBIN  );
+        //DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCBspTreeAddVob, hooked_AddVob  );
     }
 
     /** Called when a vob gets added to a bsp-tree */

--- a/D3D11Engine/zCCamera.h
+++ b/D3D11Engine/zCCamera.h
@@ -20,8 +20,8 @@ public:
     };
 
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCCamera__Activate), Activate_Hook );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCCamera__UpdateViewport), UpdateViewport_Hook );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCCamera__Activate, Activate_Hook  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCCamera__UpdateViewport, UpdateViewport_Hook  );
     }
 
     static bool IsFreeLookActive() {

--- a/D3D11Engine/zCFlash.h
+++ b/D3D11Engine/zCFlash.h
@@ -8,8 +8,8 @@ class zCFlash {
 public:
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCFlashSetVisualUsedBy), Hooked_SetVisualUsedBy );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCFlashDestructor), Hooked_Destructor );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCFlashSetVisualUsedBy, Hooked_SetVisualUsedBy  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCFlashDestructor, Hooked_Destructor  );
     }
 
     // We use SetVisualUsedBy instead of Create here because we need connect visual to vob to avoid leaks

--- a/D3D11Engine/zCInput_Win32.h
+++ b/D3D11Engine/zCInput_Win32.h
@@ -11,7 +11,7 @@ public:
     static void Hook() {
 #if (defined( BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)))
         // TODO: Also implement for other gothics
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCInput_Win32__GetKey), hooked_GetKey );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCInput_Win32__GetKey, hooked_GetKey  );
 #endif
     }
 

--- a/D3D11Engine/zCMaterial.h
+++ b/D3D11Engine/zCMaterial.h
@@ -32,9 +32,9 @@ class zCMaterial {
 public:
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCMaterialDestructor), Hooked_Destructor );
-        //DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCMaterialConstruktor), Hooked_Constructor );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCMaterialInitValues), Hooked_InitValues );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCMaterialDestructor, Hooked_Destructor  );
+        //DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCMaterialConstruktor, Hooked_Constructor  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCMaterialInitValues, Hooked_InitValues  );
 
     }
 

--- a/D3D11Engine/zCModel.h
+++ b/D3D11Engine/zCModel.h
@@ -119,8 +119,8 @@ class zCModelPrototype {
 public:
     /** Hooks the functions of this Class */
     static void Hook() {
-        //DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCModelPrototypeLoadModelASC), Hooked_LoadModelASC );
-        //DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCModelPrototypeReadMeshAndTreeMSB), Hooked_ReadMeshAndTreeMSB );
+        //DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCModelPrototypeLoadModelASC, Hooked_LoadModelASC  );
+        //DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCModelPrototypeReadMeshAndTreeMSB, Hooked_ReadMeshAndTreeMSB  );
     }
 
     /** This is called on load time for models */
@@ -187,8 +187,8 @@ public:
         #endif*/
 
 #ifdef BUILD_GOTHIC_2_6_fix
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCModelGetLowestLODNumPolys), Hooked_zCModelGetLowestLODNumPolys );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCModelGetLowestLODPoly), Hooked_zCModelGetLowestLODPoly );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCModelGetLowestLODNumPolys, Hooked_zCModelGetLowestLODNumPolys  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCModelGetLowestLODPoly, Hooked_zCModelGetLowestLODPoly  );
 #endif
     }
 

--- a/D3D11Engine/zCOption.h
+++ b/D3D11Engine/zCOption.h
@@ -152,7 +152,6 @@ public:
 
     /** Reads config stuff */
     static unsigned long __fastcall hooked_zOptionReadDWORD( void* thisptr, void* unknwn, zSTRING const& section, char const* var, unsigned long def ) {
-        BaseGraphicsEngine* engine = Engine::GraphicsEngine;
         // TODO: Make Option checkable
         // LogInfo() << "Reading Gothic-Config: " << var;
 

--- a/D3D11Engine/zCOption.h
+++ b/D3D11Engine/zCOption.h
@@ -12,9 +12,9 @@ public:
 
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCOptionReadInt), hooked_zOptionReadInt );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCOptionReadBool), hooked_zOptionReadBool );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCOptionReadDWORD), hooked_zOptionReadDWORD );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCOptionReadInt, hooked_zOptionReadInt  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCOptionReadBool, hooked_zOptionReadBool  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCOptionReadDWORD, hooked_zOptionReadDWORD  );
     }
 
     /** Returns true if the given string is in the commandline of the game */

--- a/D3D11Engine/zCParticleFX.h
+++ b/D3D11Engine/zCParticleFX.h
@@ -181,7 +181,7 @@ class zCParticleFX {
 public:
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCParticleFXDestructor), Hooked_Destructor );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCParticleFXDestructor, Hooked_Destructor  );
     }
 
     static void __fastcall Hooked_Destructor( zCParticleFX* thisptr, void* unknwn ) {

--- a/D3D11Engine/zCQuadMark.h
+++ b/D3D11Engine/zCQuadMark.h
@@ -11,9 +11,9 @@ public:
 
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCQuadMarkCreateQuadMark), Hooked_CreateQuadMark );
-        //DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCQuadMarkConstructor), Hooked_Constructor );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCQuadMarkDestructor), Hooked_Destructor );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCQuadMarkCreateQuadMark, Hooked_CreateQuadMark  );
+        //DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCQuadMarkConstructor, Hooked_Constructor  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCQuadMarkDestructor, Hooked_Destructor  );
     }
 
     static void __fastcall Hooked_CreateQuadMark( zCQuadMark* thisptr, void* unknwn, zCPolygon* poly, const float3& position, const float2& size, struct zTEffectParams* params ) {

--- a/D3D11Engine/zCResourceManager.h
+++ b/D3D11Engine/zCResourceManager.h
@@ -19,7 +19,7 @@ public:
 
     /** Hooks the functions of this Class */
     static void Hook() {
-        //DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCResourceManagerCacheOut), hooked_CacheOut );
+        //DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCResourceManagerCacheOut, hooked_CacheOut  );
     }
 
     /*

--- a/D3D11Engine/zCRndD3D.h
+++ b/D3D11Engine/zCRndD3D.h
@@ -10,17 +10,17 @@ public:
 
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCRnd_D3D_DrawLineZ), hooked_zCRndD3DDrawLineZ );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCRnd_D3D_DrawLine), hooked_zCRndD3DDrawLine );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCRnd_D3D_DrawLineZ, hooked_zCRndD3DDrawLineZ  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCRnd_D3D_DrawLine, hooked_zCRndD3DDrawLine  );
 
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCRnd_D3D_DrawPoly), hooked_zCRndD3DDrawPoly );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCRnd_D3D_DrawPolySimple), hooked_zCRndD3DDrawPolySimple );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCRnd_D3D_DrawPoly, hooked_zCRndD3DDrawPoly  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCRnd_D3D_DrawPolySimple, hooked_zCRndD3DDrawPolySimple  );
 
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCRnd_D3D_CacheInSurface), hooked_zCSurfaceCache_D3DCacheInSurface );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCRnd_D3D_CacheOutSurface), hooked_zCSurfaceCache_D3DCacheOutSurface );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCRnd_D3D_CacheInSurface, hooked_zCSurfaceCache_D3DCacheInSurface  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCRnd_D3D_CacheOutSurface, hooked_zCSurfaceCache_D3DCacheOutSurface  );
 
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCRnd_D3D_RenderScreenFade), hooked_zCCameraRenderScreenFade );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCRnd_D3D_RenderCinemaScope), hooked_zCCameraRenderCinemaScope );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCRnd_D3D_RenderScreenFade, hooked_zCCameraRenderScreenFade  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCRnd_D3D_RenderCinemaScope, hooked_zCCameraRenderCinemaScope  );
     }
 
     /** Disable caching surfaces to let engine create new surfaces for every textures */

--- a/D3D11Engine/zCSkyController_Outdoor.h
+++ b/D3D11Engine/zCSkyController_Outdoor.h
@@ -139,7 +139,7 @@ public:
 #endif
 
         if ( HookedFunctions::OriginalFunctions.original_zCSkyControler_ClearBackground )
-            DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCSkyControler_ClearBackground), &zCSkyController_Outdoor::hooked_zCSkyControler_ClearBackground );
+            DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCSkyControler_ClearBackground, &zCSkyController_Outdoor::hooked_zCSkyControler_ClearBackground  );
     }
 
     static void __fastcall hooked_zCSkyControler_ClearBackground( void* thisPtr, void* vtbl, zColor color ) {

--- a/D3D11Engine/zCTexture.h
+++ b/D3D11Engine/zCTexture.h
@@ -20,8 +20,8 @@ class zCTexture {
 public:
     /** Hooks the functions of this Class */
     static void Hook() {
-        //DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCTex_D3DXTEX_BuildSurfaces), hooked_XTEX_BuildSurfaces );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.ofiginal_zCTextureLoadResourceData), hooked_LoadResourceData );
+        //DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCTex_D3DXTEX_BuildSurfaces, hooked_XTEX_BuildSurfaces  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.ofiginal_zCTextureLoadResourceData, hooked_LoadResourceData  );
 
         zCTextureCacheHack::NumNotCachedTexturesInFrame = 0;
         zCTextureCacheHack::ForceCacheIn = false;

--- a/D3D11Engine/zCThread.h
+++ b/D3D11Engine/zCThread.h
@@ -11,7 +11,7 @@ public:
 
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCThreadSuspendThread), hooked_SuspendThread );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCThreadSuspendThread, hooked_SuspendThread  );
     }
 
     /** Reads config stuff */

--- a/D3D11Engine/zCView.h
+++ b/D3D11Engine/zCView.h
@@ -36,7 +36,7 @@ public:
         }
 
 #if (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)) || defined(BUILD_GOTHIC_2_6_fix)
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCViewPrintChars), hooked_PrintChars );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCViewPrintChars, hooked_PrintChars  );
 #endif
     }
 

--- a/D3D11Engine/zCVisual.h
+++ b/D3D11Engine/zCVisual.h
@@ -17,7 +17,7 @@ public:
 
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCVisualDestructor), Hooked_Destructor );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCVisualDestructor, Hooked_Destructor  );
     }
 
     static void __fastcall Hooked_Destructor( zCVisual* thisptr, void* unknwn ) {

--- a/D3D11Engine/zCVob.h
+++ b/D3D11Engine/zCVob.h
@@ -41,9 +41,9 @@ class zCVob {
 public:
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCVobSetVisual), Hooked_SetVisual );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCVobDestructor), Hooked_Destructor );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCVobEndMovement), Hooked_EndMovement );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCVobSetVisual, Hooked_SetVisual  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCVobDestructor, Hooked_Destructor  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCVobEndMovement, Hooked_EndMovement  );
     }
     
     /** Called when this vob got it's world-matrix changed */

--- a/D3D11Engine/zCWorld.h
+++ b/D3D11Engine/zCWorld.h
@@ -28,25 +28,25 @@ public:
     static void Hook() {
 
         if ( HookedFunctions::OriginalFunctions.original_ContainerDraw ) {
-            DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_ContainerDraw), hooked_ContainerDraw );
+            DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_ContainerDraw, hooked_ContainerDraw  );
         }
 
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCWorldRender), hooked_Render );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCWorldVobAddedToWorld), hooked_VobAddedToWorld );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCWorldRender, hooked_Render  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCWorldVobAddedToWorld, hooked_VobAddedToWorld  );
 
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCWorldLoadWorld), hooked_LoadWorld );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCWorldVobRemovedFromWorld), hooked_zCWorldVobRemovedFromWorld );
-        //DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCWorldDisposeWorld), hooked_zCWorldDisposeWorld );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCWorldDisposeVobs), hooked_zCWorldDisposeVobs );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCWorldLoadWorld, hooked_LoadWorld  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCWorldVobRemovedFromWorld, hooked_zCWorldVobRemovedFromWorld  );
+        //DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCWorldDisposeWorld, hooked_zCWorldDisposeWorld  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCWorldDisposeVobs, hooked_zCWorldDisposeVobs  );
 
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_oCWorldRemoveFromLists), hooked_oCWorldRemoveFromLists );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_oCWorldEnableVob), hooked_oCWorldEnableVob );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_oCWorldDisableVob), hooked_oCWorldDisableVob );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_oCWorldRemoveVob), hooked_oCWorldRemoveVob );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCWorldRemoveFromLists, hooked_oCWorldRemoveFromLists  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCWorldEnableVob, hooked_oCWorldEnableVob  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCWorldDisableVob, hooked_oCWorldDisableVob  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCWorldRemoveVob, hooked_oCWorldRemoveVob  );
 
 #ifdef BUILD_SPACER_NET
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCWorldCompileWorld), hooked_zCWorldCompileWorld );
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zCWorldGenerateStaticWorldLighting), hooked_zCWorldGenerateStaticWorldLighting );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCWorldCompileWorld, hooked_zCWorldCompileWorld  );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCWorldGenerateStaticWorldLighting, hooked_zCWorldGenerateStaticWorldLighting  );
 #endif
     }
 

--- a/D3D11Engine/zFILE.h
+++ b/D3D11Engine/zFILE.h
@@ -11,7 +11,7 @@ class zFILE {
 public:
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttach( &reinterpret_cast<PVOID&>(HookedFunctions::OriginalFunctions.original_zFILEOpen), hooked_Open );
+        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zFILEOpen, hooked_Open  );
     }
 
     static int __fastcall hooked_Open( void* thisptr, void* unknwn, zSTRING& str, bool b ) {

--- a/cmake/GD3D11Helpers.cmake
+++ b/cmake/GD3D11Helpers.cmake
@@ -250,8 +250,6 @@ function(gd3d11_apply_common_compile_settings target_name)
         -m32
         $<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fms-extensions>
         -Wno-switch
-        -Wno-microsoft-cast
-        -Wno-microsoft-enum-forward-reference
         -Wno-defaulted-function-deleted # DirectXMath uses = default for XMFLOAT4X4 which causes this warning
       )
       target_link_options(${target_name} PRIVATE -m32)


### PR DESCRIPTION
- Clang warnings
  - Remove `-Wmicrosoft-cast` by introducing `DetourAttachTyped` which uses a union to allow type-pruning.
  - Remove a lot of unused variables
    - Fixes a memoryleak with `MeshInfo* mi = new MeshInfo` in `GMeshSimple::LoadMesh`
  - fix a broken condition for checking if a vob is alpha blend/add
  - Zero-initialize `WorldInfo` and use move-assignment instead of manual memcpy
  - fix enum forwarding by defining underlying type size.
  - return XR_FAILED from `D3D11VShader::LoadShader` when shader reflection fails
- Begin `g_nextSeenId` with flag bit `1` instead of `2`
- don't use `std::move(pool->Acquire)` as that breaks copy-elision
- use more modern c++ for threadpool::enqueue
- Shadowmap: make sure we use the same frustum as the main scene, by using the same cam->trafoProjection