### PR TITLE
fix: Rain Shadowmap is always drawn when it rains. Preventing "raining indoors", ...

### DIFF
--- a/D3D11Engine/D3D11Effect.cpp
+++ b/D3D11Engine/D3D11Effect.cpp
@@ -488,26 +488,45 @@ XRESULT D3D11Effect::LoadRainResources()
 
 /** Renders the rain-shadowmap */
 XRESULT D3D11Effect::DrawRainShadowmap() {
-    if ( !RainShadowmap.get() )
-        return XR_SUCCESS;
-
     D3D11GraphicsEngine* e = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine); // TODO: This has to be a cast to D3D11GraphicsEngineBase!
     //D3D11GraphicsEngineBase* e = (D3D11GraphicsEngineBase*)Engine::GraphicsEngine; //RenderShadowmaps to be moved then to D3D11GraphicsEngineBase
-    GothicRendererState& state = Engine::GAPI->GetRendererState();
+
+    if ( !RainShadowmap ) {
+        const int s = 2048;
+        RainShadowmap = std::make_unique<RenderToDepthStencilBuffer>( e->GetDevice().Get(), s, s,
+            DXGI_FORMAT_R16_TYPELESS, nullptr, DXGI_FORMAT_D16_UNORM, DXGI_FORMAT_R16_UNORM );
+        SetDebugName( RainShadowmap->GetDepthStencilView().Get(), "RainShadowmap->DepthStencilView" );
+        SetDebugName( RainShadowmap->GetShaderResView().Get(), "RainShadowmap->ShaderResView" );
+        SetDebugName( RainShadowmap->GetTexture().Get(), "RainShadowmap->Texture" );
+    }
+
+    if ( !RainShadowmap ) {
+        return XR_SUCCESS;
+    }
 
     CameraReplacement& cr = RainShadowmapCameraRepl;
 
     // Get the section we are currently in
     XMVECTOR p = Engine::GAPI->GetCameraPositionXM();
-    FXMVECTOR dir = XMVector3Normalize( XMLoadFloat3( &Engine::GAPI->GetRendererState().RendererSettings.RainGlobalVelocity ) * -1 ); //check was previous XMVector3NormalizeEst
+    XMVECTOR rainVelocity = XMLoadFloat3( &Engine::GAPI->GetRendererState().RendererSettings.RainGlobalVelocity );
+    if ( XMVectorGetX( XMVector3LengthSq( rainVelocity ) ) < 0.0001f ) {
+        rainVelocity = XMVectorSet( 0, -1, 0, 0 );
+    }
+    XMVECTOR dir = XMVector3Normalize( rainVelocity * -1.0f );
+
     // Set the camera height to the highest point in this section
-    //p.y = 0;
     p += dir * 6000.0f;
 
-    FXMVECTOR lookAt = p - dir;
+    XMVECTOR lookAt = p - dir;
+
+    XMVECTOR forward = XMVector3Normalize( lookAt - p );
+    XMVECTOR up = XMVectorSet( 0, 1, 0, 0 );
+    if ( fabsf( XMVectorGetX( XMVector3Dot( forward, up ) ) ) > 0.95f ) {
+        up = XMVectorSet( 0, 0, 1, 0 );
+    }
 
     // Create shadowmap view-matrix
-    XMMATRIX crViewReplacement = XMMatrixLookAtLH( p, lookAt, XMVectorSet( 0, 1, 0, 0 ) );
+    XMMATRIX crViewReplacement = XMMatrixLookAtLH( p, lookAt, up );
 
     const auto size = RainShadowmap->GetSizeX();
     const auto legacySingleShadowMapScaleFactor = Toolbox::GetRecommendedWorldShadowRangeScaleForSize( size );
@@ -529,6 +548,22 @@ XRESULT D3D11Effect::DrawRainShadowmap() {
         size * legacySingleShadowMapScaleFactor,
         1.0f,
         20000.f );
+
+    if ( !cr.frustum.IsValid() ) {
+        // Keep rain occlusion alive even if a custom rain direction produced a degenerate camera basis.
+        XMVECTOR fallbackUp = XMVectorSet( 1, 0, 0, 0 );
+        crViewReplacement = XMMatrixLookAtLH( p, lookAt, fallbackUp );
+        XMStoreFloat4x4( &cr.ViewReplacement, XMMatrixTranspose( crViewReplacement ) );
+        cr.frustum.BuildOrthographic( crViewReplacement,
+            size * legacySingleShadowMapScaleFactor,
+            size * legacySingleShadowMapScaleFactor,
+            1.0f,
+            20000.f );
+    }
+
+    if ( !cr.frustum.IsValid() ) {
+        return XR_SUCCESS;
+    }
 
     // Replace gothics camera
     Engine::GAPI->SetCameraReplacementPtr( &cr );

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -539,7 +539,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       </AssemblyDebug>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G2_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>
@@ -853,7 +853,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <EnableCOMDATFolding>false</EnableCOMDATFolding>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G1_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G1_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G1_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>

--- a/D3D11Engine/D3D11ForwardPlusRenderer.cpp
+++ b/D3D11Engine/D3D11ForwardPlusRenderer.cpp
@@ -98,13 +98,15 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
             ZoneScopedN( "FR Shadow Maps" );
             auto* shadowMaps = engine.GetShadowMaps();
             engine.SetDefaultStates();
+            const auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
 
             shadowMaps->DrawPointlightShadows( engine.GetFrameLights() );
-            shadowMaps->DrawWorldShadow();
+            if ( settings.EnableShadows ) {
+                shadowMaps->DrawWorldShadow();
+            }
             engine.SetDefaultStates();
             shadowMaps->DrawRainShadowmap();
 
-            auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
             Engine::GAPI->SetFarPlane( static_cast<float>( settings.SectionDrawRadius ) * WORLD_SECTION_SIZE );
         };
     } );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -6011,11 +6011,19 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
     bool colorWritesEnabled =
         Engine::GAPI->GetRendererState().BlendState.ColorWritesEnabled;
     float alphaRef = Engine::GAPI->GetRendererState().GraphicsState.FF_AlphaRef;
-    auto& currentFrustum = params.CascadeIndex != -1
-        ? params.CascadeCameraReplacements->at(params.CascadeIndex).frustum
-        : Engine::GAPI->GetCameraReplacementPtr() != nullptr
-            ? Engine::GAPI->GetCameraReplacementPtr()->frustum
-            : Frustum::AlwaysContainingFrustum();
+    const Frustum* currentFrustum = nullptr;
+    Frustum alwaysContainingFrustum;
+
+    if ( params.CascadeIndex != -1 && params.CascadeCameraReplacements ) {
+        currentFrustum = &params.CascadeCameraReplacements->at( params.CascadeIndex ).frustum;
+    } else if ( Engine::GAPI->GetCameraReplacementPtr() != nullptr ) {
+        currentFrustum = &Engine::GAPI->GetCameraReplacementPtr()->frustum;
+    }
+
+    if ( !currentFrustum || !currentFrustum->IsValid() ) {
+        alwaysContainingFrustum = Frustum::AlwaysContainingFrustum();
+        currentFrustum = &alwaysContainingFrustum;
+    }
 
     if ( Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh ) {
         TracyD3D11ZoneCGX( "Shadows::DrawWorldMesh" );
@@ -6024,7 +6032,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
 
         static thread_local std::vector<WorldMeshSectionInfo*> visibleSections;
         visibleSections.clear();
-        Engine::GAPI->CollectVisibleSections( visibleSections, &currentFrustum, false );
+        Engine::GAPI->CollectVisibleSections( visibleSections, currentFrustum, false );
 
         if ( Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.FeatureSet.UseMDI ) {
             MeshInfo* wrappedWorldMesh = Engine::GAPI->GetWrappedWorldMesh();
@@ -6037,9 +6045,9 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
         }
         
         if (Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.FeatureSet.UseMDI) {
-            ShadowPass_DrawWorldMesh_Indirect( visibleSections, &currentFrustum );
+            ShadowPass_DrawWorldMesh_Indirect( visibleSections, currentFrustum );
         } else {
-            ShadowPass_DrawWorldMesh( visibleSections, &currentFrustum );
+            ShadowPass_DrawWorldMesh( visibleSections, currentFrustum );
         }
     }    
     
@@ -6064,7 +6072,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
             ctx.queue = &q;
             ctx.cameraPosition = Engine::GAPI->GetCameraPosition();
             ctx.stage = RenderStage::STAGE_DRAW_WORLD;
-            ctx.frustum = currentFrustum;
+            ctx.frustum = *currentFrustum;
             const auto& rs = Engine::GAPI->GetRendererState().RendererSettings;
             ctx.drawDistances.OutdoorVobs = rs.OutdoorVobDrawRadius;
             ctx.drawDistances.OutdoorVobsSmall = rs.OutdoorSmallVobDrawRadius;
@@ -6345,7 +6353,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
             }
 
             if ( enableCulling ) {
-                if ( !currentFrustum.Intersects( skeletalMeshVob->Vob->GetBBox()) ) {
+                if ( !currentFrustum->Intersects( skeletalMeshVob->Vob->GetBBox()) ) {
                     // Not hitting our frustum and not the active view.
                     continue;
                 }

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -576,7 +576,7 @@ XRESULT D3D11GraphicsEngine::Init() {
 
             maxFeatureLevel = D3D_FEATURE_LEVEL::D3D_FEATURE_LEVEL_9_1;
         }
-    } else {
+    } else { 
         for ( size_t i = 0; i < featureLevelCount; ++i ) {
             hr = D3D11CreateDeviceFunc( DXGIAdapter2.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, flags, &featureLevels[i], featureLevelCount - i,
                 D3D11_SDK_VERSION, Device11.GetAddressOf(), &maxFeatureLevel, Context11.GetAddressOf() );
@@ -589,7 +589,7 @@ XRESULT D3D11GraphicsEngine::Init() {
     }
 
     if ( FAILED( hr ) ) {
-        LogErrorBox() << "D3D11CreateDevice failed with code: " << hr << "!";
+        LogErrorBox() << "D3D11CreateDevice failed with code: " << std::hex << hr << "!";
         exit( 2 );
     }
 

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -362,7 +362,7 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate, D3D11ConstantBuffer* View
     XMStoreFloat4x4( &CubeMapViewMatrices[5], XMMatrixTranspose( XMMatrixLookAtLH( vEyePt, vLookDir, c_XM_Up ) ) );
 
     // Create the projection matrix
-    float zNear = 15.0f;
+    float zNear = 5.0f;
     float zFar = LightInfo->Vob->GetLightRange() * 2.0f;
 
     XMMATRIX proj = XMMatrixPerspectiveFovLH( XM_PIDIV2, 1.0f, zNear, zFar );

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1158,7 +1158,7 @@ XRESULT D3D11ShadowMap::DrawWorldShadow( )
 
 XRESULT D3D11ShadowMap::DrawRainShadowmap() {
     // Draw rainmap, if raining
-    if ( Engine::GAPI->GetSceneWetness() > 0.00001f ) {
+    if ( Engine::GAPI->GetRainFXWeight() > 0.00001f ) {
         auto graphicsEngine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
         auto _ = graphicsEngine->RecordGraphicsEvent( GE_NAME( "DrawRainShadowmap" ) );
         ZoneScopedN( "DrawRainShadowmap" );
@@ -1198,7 +1198,9 @@ XRESULT D3D11ShadowMap::DrawLighting(
     // Draw pointlight shadows
     DrawPointlightShadows(lights);
 
-    DrawWorldShadow();
+    if ( settings.EnableShadows ) {
+        DrawWorldShadow();
+    }
 
     graphicsEngine->SetDefaultStates();
 

--- a/D3D11Engine/Frustum.h
+++ b/D3D11Engine/Frustum.h
@@ -3,6 +3,8 @@
 #include <DirectXMath.h>
 #include <DirectXCollision.h>
 #include <array>
+#include <cmath>
+#include <cfloat>
 #include "zTypes.h"
 
 using namespace DirectX;
@@ -26,6 +28,31 @@ enum EGothicCullFlags : unsigned char
 class Frustum
 {
 public:
+    static bool IsFiniteVector( FXMVECTOR value ) {
+        return !XMVector4IsInfinite( value );
+    }
+
+    static bool IsFiniteMatrix( CXMMATRIX matrix ) {
+        return IsFiniteVector( matrix.r[0] )
+            && IsFiniteVector( matrix.r[1] )
+            && IsFiniteVector( matrix.r[2] )
+            && IsFiniteVector( matrix.r[3] );
+    }
+
+    static bool IsFiniteOrientedBox( const BoundingOrientedBox& box ) {
+        return IsFiniteVector( XMLoadFloat3( &box.Center ) )
+            && IsFiniteVector( XMLoadFloat3( &box.Extents ) )
+            && IsFiniteVector( XMLoadFloat4( &box.Orientation ) );
+    }
+
+    void Invalidate() {
+        m_useSphere = false;
+        m_useBoundingOrientedBox = false;
+        m_always_containing = false;
+        m_hasPlanes = false;
+        isValid = false;
+    }
+
     // Für orthografische Projektion (Sonnen-Shadowmap)
     // shadowCasterExpansion: Extra distance to expand the frustum to include shadow casters
     //                        behind/beside the camera that may cast shadows into the view
@@ -40,7 +67,23 @@ public:
         float expandBack = 0.0f
     )
     {
-        XMMATRIX invView = XMMatrixInverse( nullptr, view );
+        if ( !IsFiniteMatrix( view ) ) {
+            Invalidate();
+            return;
+        }
+
+        XMVECTOR determinant = XMMatrixDeterminant( view );
+        const float determinantScalar = XMVectorGetX( determinant );
+        if ( !std::isfinite( determinantScalar ) || fabsf( determinantScalar ) <= FLT_EPSILON ) {
+            Invalidate();
+            return;
+        }
+
+        XMMATRIX invView = XMMatrixInverse( &determinant, view );
+        if ( !IsFiniteMatrix( invView ) ) {
+            Invalidate();
+            return;
+        }
 
         // Calculate new Z bounds directly in Light Space
         float newNearZ = nearZ - expandBack;
@@ -58,6 +101,10 @@ public:
 
         // Transform correctly to World Space
         viewSpaceFrustum.Transform( m_orientedBox, invView );
+        if ( !IsFiniteOrientedBox( m_orientedBox ) ) {
+            Invalidate();
+            return;
+        }
 
         CacheOBBPlanes();
         m_hasPlanes = true;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4251,13 +4251,18 @@ void GothicAPI::CollectVisibleSections( std::vector<WorldMeshSectionInfo*>& sect
         }
 
         if ( queryFrustum ) {
+            if ( !queryFrustum->IsValid() ) {
+                return true;
+            }
             return queryFrustum->Contains( section.BoundingBox ) != DirectX::ContainmentType::DISJOINT;
         }
 
         return GetCameraBBox3DInFrustum( section.BoundingBox, EGothicCullFlags::CullSidesNear ) != ZTCAM_CLIPTYPE_OUT;
     };
 
-    if ( UseWorldSectionBVH() && WorldSectionBVHValid && cullingEnabled && (queryFrustum || !drawSectionIntersections) ) {
+    const bool queryFrustumValid = queryFrustum == nullptr || queryFrustum->IsValid();
+    if ( UseWorldSectionBVH() && WorldSectionBVHValid && cullingEnabled && queryFrustumValid
+        && (queryFrustum || !drawSectionIntersections) ) {
         ZoneScopedN( "GothicAPI::CollectVisibleSections->BVH" );
 
         Frustum generatedFrustum;
@@ -4273,7 +4278,7 @@ void GothicAPI::CollectVisibleSections( std::vector<WorldMeshSectionInfo*>& sect
                     XMLoadFloat4x4( &proj )
                 );
             } else {
-                generatedFrustum.AlwaysContainingFrustum();
+                generatedFrustum = Frustum::AlwaysContainingFrustum();
             }
             activeFrustum = &generatedFrustum;
         }

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -154,7 +154,7 @@ void ApplyRainNormalDeformation(inout float3 vsNormal, float3 wsPosition, inout 
 }
 
 /** Returns new diffusecolor (rgb)*/
-void ApplySceneWettness(float3 wsPosition, float3 vsPosition, float3 vsDir, inout float3 vsNormal, in out float3 diffuse, in out float specIntensity, in out float specPower, out float specAdd)
+void ApplySceneWettness(float3 wsPosition, float3 vsPosition, float3 vsDir, inout float3 vsNormal, in out float3 diffuse, in out float specIntensity, in out float specPower, out float specAdd, out float localWettness)
 {
 	// Ask the rain-shadowmap if we can hit this pixel
     float pixelWettnes = ComputeShadowValue(0.0f, wsPosition, TX_RainShadowmap, SS_Comp, vsPosition.z, 1.0f, SQ_RainViewProj, 0.0001f, 2.5f) * AC_SceneWettness;
@@ -174,6 +174,12 @@ void ApplySceneWettness(float3 wsPosition, float3 vsPosition, float3 vsDir, inou
 	float wDot = saturate(dot(wsNormal, float3(0, -1, 0))); 
 	float wDot2 = wDot * wDot;
 	pixelWettnes *= 1.0f - (wDot2 * wDot2);
+
+    // Rain mostly settles on upward-facing surfaces.
+    float surfaceExposure = saturate(dot(wsNormal, float3(0, 1, 0)));
+    surfaceExposure *= surfaceExposure;
+    pixelWettnes *= surfaceExposure;
+    localWettness = pixelWettnes;
 	
     vsNormal = lerp(vsNormal, nrm, AC_RainFXWeight * pixelWettnes * 0.5f); // Only apply deformation if it's actually raining
 	
@@ -270,9 +276,10 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 
 	// Compute wettness
     float specWet = 0.0f;
+    float localWettness = 0.0f;
 	
 #ifdef APPLY_RAIN_EFFECTS
-	ApplySceneWettness(wsPosition, vsPosition, V, normal, diffuse.rgb, specIntensity, specPower, specWet);
+    ApplySceneWettness(wsPosition, vsPosition, V, normal, diffuse.rgb, specIntensity, specPower, specWet, localWettness);
 	
 	// Boost specWet when not in shadow
 	specWet += specWet * shadow;
@@ -288,7 +295,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	//return float4(diffuse.rgb, 1);
 	
     float4 lightColor = SQ_LightColor;
-    lightColor.rgb = lerp(lightColor.rgb, lightColor.rgb * 0.8f, AC_SceneWettness);
+    lightColor.rgb = lerp(lightColor.rgb, lightColor.rgb * 0.8f, localWettness);
 	
 	// Apply sunlight
     float sunStrength = dot(lightColor.rgb, float3(0.333f, 0.333f, 0.333f));


### PR DESCRIPTION
- Rain Shadowmap is always drawn when it rains. Preventing "raining indoors"
- Rain only applies on mostly up-facing normals, preventing raining in indoor walls