### PR TITLE
Improve Pointlight shadow resolution to 128, introduce slope scaled normals to fight G1 old camp lights a bit

### DIFF
--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -718,7 +718,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>TRACY_ENABLE;TRACY_ON_DEMAND;TRACY_CALLSTACK=8;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -743,7 +743,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <EnableCOMDATFolding>false</EnableCOMDATFolding>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G2_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -362,7 +362,7 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate, D3D11ConstantBuffer* View
     XMStoreFloat4x4( &CubeMapViewMatrices[5], XMMatrixTranspose( XMMatrixLookAtLH( vEyePt, vLookDir, c_XM_Up ) ) );
 
     // Create the projection matrix
-    float zNear = 5.0f;
+    float zNear = 15.0f;
     float zFar = LightInfo->Vob->GetLightRange() * 2.0f;
 
     XMMATRIX proj = XMMatrixPerspectiveFovLH( XM_PIDIV2, 1.0f, zNear, zFar );

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -206,9 +206,8 @@ static void CalculateCascadeMatrices(
                 sceneMaxZ = std::max( sceneMaxZ, z );
             }
 
-            // Absolute hard limit: We never need to start the shadow camera further back 
-            // than the edge of the world geometry itself.
-            orthoNear = std::max( orthoNear, sceneMinZ - 100.0f );
+            // Pushes the near plane further back if the scene geometry requires it
+            orthoNear = std::min( orthoNear, sceneMinZ - 100.0f );
 
             // Tighten Far Plane so we don't shoot miles past the level boundaries when looking down
             orthoFar = std::min( orthoFar, sceneMaxZ + 500.0f );

--- a/D3D11Engine/D3D11ShadowMap.h
+++ b/D3D11Engine/D3D11ShadowMap.h
@@ -38,7 +38,7 @@ enum PS_DS_AtmosphericScatteringSlots {
     TX_SI_SP = 7,
 };
 
-const int POINTLIGHT_SHADOWMAP_SIZE = 64;
+const int POINTLIGHT_SHADOWMAP_SIZE = 128;
 
 /** Parameters for rendering shadow maps */
 struct RenderShadowmapsParams {

--- a/D3D11Engine/D3D11TiledDeferredShading.h
+++ b/D3D11Engine/D3D11TiledDeferredShading.h
@@ -14,7 +14,7 @@ struct RenderToDepthStencilBuffer;
 constexpr uint32_t MAX_TILED_LIGHTS = 1024;
 
 constexpr uint32_t MAX_SHADOW_CUBEMAPS = 128;
-constexpr uint32_t SHADOW_CUBE_SIZE = 64; // Must match POINTLIGHT_SHADOWMAP_SIZE
+constexpr uint32_t SHADOW_CUBE_SIZE = 128; // Must match POINTLIGHT_SHADOWMAP_SIZE
 
 struct TiledPointLight {
     DirectX::XMFLOAT3 PositionView;

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -64,6 +64,7 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
 
     // World-space position for shadow sampling (computed once, shared by all shadowed lights)
     float3 wsPosition = mul( float4( vsPosition, 1 ), InvView ).xyz;
+    float3 wsNormal = normalize( mul( float4( normal, 0 ), InvView ).xyz );
 
     // Compute tile index
     uint tileX = pixelCoord.x / TILE_SIZE;
@@ -100,7 +101,7 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
 
         // Apply shadow if this light has a shadow cubemap and contribution is non-negligible
         if ( light.ShadowCubeIndex >= 0 && any( lighting > 0.001f ) ) {
-            float shadow = PLS_SampleShadowCube( TX_ShadowCubeArray, SS_Comp, wsPosition, light.PositionWorld, light.Range, light.ShadowCubeIndex );
+            float shadow = PLS_SampleShadowCubeArray( TX_ShadowCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex );
             lighting *= shadow;
         }
 

--- a/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
@@ -75,7 +75,8 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	// Reconstruct VS World Position from depth
 	float expDepth = TX_Depth.Sample(SS_Linear, uv).r;
 	float3 vsPosition = VSPositionFromDepth(expDepth, uv);
-	float3 wsPosition = mul(float4(vsPosition, 1), PL_InvView);
+	float3 wsPosition = mul(float4(vsPosition, 1), PL_InvView).xyz;
+	float3 wsNormal = normalize(mul(float4(normal, 0), PL_InvView).xyz);
 	
 	//return float4(normalize(wsPosition - Pl_PositionWorld), 1.0f);
 	
@@ -96,7 +97,7 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float ndl = max(0, dot(lightDir, normal));
 	
 	// Apply dynamic shadow
-	float shadow = PLS_SampleShadowCube(TX_ShadowCube, SS_Comp, wsPosition, Pl_PositionWorld, PL_Range);
+	float shadow = PLS_SampleShadowCube(TX_ShadowCube, SS_Comp, wsPosition, wsNormal, Pl_PositionWorld, PL_Range);
 	//return float4(ndl.rrr,1);
 	
 	// Get rid of lighting on the backfaces of normalmapped surfaces

--- a/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
+++ b/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
@@ -141,6 +141,7 @@ float3 FP_ComputePointLighting(
     // These only need to be calculated once per pixel
     float3 V = normalize( -vsPosition );
     float specMod = PLS_ComputeSpecMod( diffuseColor );
+    float3 wsNormal = normalize( mul( float4( normal, 0 ), SQ_InvView ).xyz );
     
     for ( uint i = 0; i < grid.Count; i++ )
     {
@@ -167,7 +168,7 @@ float3 FP_ComputePointLighting(
         // Don't fetch shadows if the light contribution is effectively zero.
         if ( light.ShadowCubeIndex >= 0 && any(lighting > 0.001f) )
         {
-            float shadow = PLS_SampleShadowCube( FP_ShadowCubeArray, SS_Comp, wsPosition, light.PositionWorld, light.Range, light.ShadowCubeIndex );
+            float shadow = PLS_SampleShadowCubeArray( FP_ShadowCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex );
             lighting *= shadow;
         }
 

--- a/D3D11Engine/Shaders/include/PointLightShadows.h
+++ b/D3D11Engine/Shaders/include/PointLightShadows.h
@@ -8,20 +8,27 @@
 
 static const int PLS_SHADOW_BLUR_COUNT = 8;
 static const float2 PLS_SHADOW_BLUR_OFFSETS[PLS_SHADOW_BLUR_COUNT] = {
-    float2( 0.500f, 0.000f ),
-    float2( 0.000f, 0.500f ),
-    float2( -0.500f, 0.000f ),
-    float2( 0.000f, -0.500f ),
-    float2( 0.924f, 0.383f ),
-    float2( -0.383f, 0.924f ),
-    float2( -0.924f, -0.383f ),
-    float2( 0.383f, -0.924f ),
+    float2( 0.076849f, -0.078216f),
+    float2(-0.165415f,  0.370808f),
+    float2(-0.551062f, -0.407284f),
+    float2( 0.449733f, -0.518174f),
+    float2( 0.347526f,  0.730303f),
+    float2(-0.840654f,  0.134261f),
+    float2( 0.896791f,  0.038446f),
+    float2(-0.258169f, -0.912648f)
 };
+
+float PLS_AggressiveNoise(float3 p)
+{
+    float3 p3  = frac(p * 0.1031f);
+    p3 += dot(p3, p3.zyx + 31.32f);
+    return frac((p3.x + p3.y) * p3.z);
+}
 
 float PLS_Hash3D( float3 p )
 {
-    float3 p3 = frac( p * 0.1031f );
-    p3 += dot( p3, p3.yzx + 33.33f );
+    float3 p3  = frac( p * 0.1031f );
+    p3 += dot( p3, p3.zyx + 31.32f );
     return frac( (p3.x + p3.y) * p3.z );
 }
 
@@ -60,6 +67,7 @@ float3 PLS_ComputePointLightLighting(
 
 void PLS_PrepareShadowSampling(
     float3 wsPosition,
+    float3 N, 
     float3 lightPosWorld,
     float lightRange,
     out float3 dir,
@@ -71,26 +79,39 @@ void PLS_PrepareShadowSampling(
     out float sinA,
     out float cosA )
 {
-    float3 toPixel = wsPosition - lightPosWorld;
+    float3 toPixelOriginal = wsPosition - lightPosWorld;
+    float distOriginal = length( toPixelOriginal );
+    float3 L = toPixelOriginal / distOriginal; 
+
+    // Slope-Scaled Normal Bias
+    float nDotL = saturate( dot( N, -L ) );
+    float slopeScale = 1.0f - nDotL; 
+    float normalOffsetScale = distOriginal * 0.02f * (slopeScale + 0.1f); 
+    float3 biasedWsPosition = wsPosition + N * normalOffsetScale;
+
+    // Recalculate vectors
+    float3 toPixel = biasedWsPosition - lightPosWorld;
+    dir = normalize( toPixel );
+
     float distance = length( toPixel );
-    dir = toPixel / (distance + 0.00001f);
-
-    float zFar = lightRange * 2.0f;
+    float zFar = lightRange * 2.0f; 
     compareDistance = distance / zFar;
+    float distance01 = saturate( compareDistance );
+    
+    float depthCurve = distance01 * distance01; 
+    
+    fixedBias = lerp( 0.002f, 0.008f, depthCurve );
 
-    float visualDistance01 = saturate( distance / lightRange );
-    
-    // Cubic ramp to keep bias extremely low near the center, but aggressively ramp up at the edges
-    float distRamp = visualDistance01 * visualDistance01 * visualDistance01;
-    
-    fixedBias = lerp( 0.006f, 0.150f, distRamp );
-    fixedBlurScale = lerp( 0.034f, 0.060f, visualDistance01 * visualDistance01 );
+    float baseBlur = lerp( 0.02f, 0.08f, depthCurve );
+
+    float noise = PLS_AggressiveNoise(wsPosition * 50.0f);
+    fixedBlurScale = baseBlur * lerp(0.5f, 1.5f, noise);
 
     up = abs( dir.y ) < 0.999f ? float3( 0, 1, 0 ) : float3( 1, 0, 0 );
     right = normalize( cross( up, dir ) );
     up = cross( dir, right );
 
-    float angle = PLS_Hash3D( wsPosition * 100.0f ) * 6.2831853f;
+    float angle = noise * 6.2831853f;
     sincos( angle, sinA, cosA );
 }
 
@@ -98,6 +119,7 @@ float PLS_SampleShadowCube(
     TextureCube shadowCube,
     SamplerComparisonState samplerState,
     float3 wsPosition,
+    float3 N, 
     float3 lightPosWorld,
     float lightRange )
 {
@@ -111,29 +133,9 @@ float PLS_SampleShadowCube(
     float cosA;
 
     PLS_PrepareShadowSampling(
-        wsPosition,
-        lightPosWorld,
-        lightRange,
-        dir,
-        compareDistance,
-        fixedBias,
-        fixedBlurScale,
-        right,
-        up,
-        sinA,
-        cosA );
-
-    uint width, height;
-    shadowCube.GetDimensions(width, height); // TODO: Optimize out by passing in shadowmap resolution!
-
-    float resScale = 128.0f / max((float)width, 1.0f); 
-
-    float3 absDir = abs(dir);
-    float maxFaceDist = max(absDir.x, max(absDir.y, absDir.z));
-    float edgeFactor = 1.0f / maxFaceDist;
-
-    fixedBias *= resScale * (edgeFactor * edgeFactor);
-    fixedBlurScale *= resScale * edgeFactor;
+        wsPosition, N, lightPosWorld, lightRange,
+        dir, compareDistance, fixedBias, fixedBlurScale,
+        right, up, sinA, cosA );
 
     float shd = 0;
     [unroll] for ( int i = 0; i < PLS_SHADOW_BLUR_COUNT; i++ )
@@ -145,19 +147,23 @@ float PLS_SampleShadowCube(
         shd += shadowCube.SampleCmpLevelZero( samplerState, perturbedDir, compareDistance - fixedBias );
     }
 
-    shd /= PLS_SHADOW_BLUR_COUNT;
+    float finalShadow = shd / PLS_SHADOW_BLUR_COUNT;
 
-    // Smoothly transition shadows to unshadowed (1.0) in the final 15% of the light's radius
-    float visualDistance01 = saturate( compareDistance * 2.0f );
-    float shadowFade = smoothstep( 0.85f, 1.0f, visualDistance01 );
+    // Shadow Distance Fading
+    // Calculate how far we are through the light's actual range (0.0 to 1.0)
+    float distanceToLight = length(wsPosition - lightPosWorld);
+    float normalizedDist = saturate(distanceToLight / lightRange);
     
-    return lerp( shd, 1.0f, shadowFade );
+    // Smoothly fade the shadow to 1.0 (unshadowed) starting at 65% of the range, fully gone by 95%
+    float shadowFade = smoothstep(0.65f, 0.95f, normalizedDist);
+    return lerp(finalShadow, 1.0f, shadowFade);
 }
 
-float PLS_SampleShadowCube(
+float PLS_SampleShadowCubeArray(
     TextureCubeArray shadowCubeArray,
     SamplerComparisonState samplerState,
     float3 wsPosition,
+    float3 N, 
     float3 lightPosWorld,
     float lightRange,
     int cubeIndex )
@@ -172,28 +178,9 @@ float PLS_SampleShadowCube(
     float cosA;
 
     PLS_PrepareShadowSampling(
-        wsPosition,
-        lightPosWorld,
-        lightRange,
-        dir,
-        compareDistance,
-        fixedBias,
-        fixedBlurScale,
-        right,
-        up,
-        sinA,
-        cosA );
-
-    uint width, height, elements;
-    shadowCubeArray.GetDimensions(width, height, elements); // TODO: Optimize out by passing in shadowmap resolution!
-    float resScale = 128.0f / max((float)width, 1.0f);
-
-    float3 absDir = abs(dir);
-    float maxFaceDist = max(absDir.x, max(absDir.y, absDir.z));
-    float edgeFactor = 1.0f / maxFaceDist;
-
-    fixedBias *= resScale * (edgeFactor * edgeFactor);
-    fixedBlurScale *= resScale * edgeFactor;
+        wsPosition, N, lightPosWorld, lightRange,
+        dir, compareDistance, fixedBias, fixedBlurScale,
+        right, up, sinA, cosA );
 
     float shd = 0;
     [unroll] for ( int i = 0; i < PLS_SHADOW_BLUR_COUNT; i++ )
@@ -206,13 +193,14 @@ float PLS_SampleShadowCube(
         shd += shadowCubeArray.SampleCmpLevelZero( samplerState, sampleCoord, compareDistance - fixedBias );
     }
 
-    shd /= PLS_SHADOW_BLUR_COUNT;
+    float finalShadow = shd / PLS_SHADOW_BLUR_COUNT;
 
-    // Smoothly transition shadows to unshadowed (1.0) in the final 15% of the light's radius
-    float visualDistance01 = saturate( compareDistance * 2.0f );
-    float shadowFade = smoothstep( 0.85f, 1.0f, visualDistance01 );
+    // Shadow Distance Fading
+    float distanceToLight = length(wsPosition - lightPosWorld);
+    float normalizedDist = saturate(distanceToLight / lightRange);
     
-    return lerp( shd, 1.0f, shadowFade );
+    float shadowFade = smoothstep(0.65f, 0.95f, normalizedDist);
+    return lerp(finalShadow, 1.0f, shadowFade);
 }
 
 #endif // !defined(__cplusplus)


### PR DESCRIPTION
- use slope scaled normals for pointlight (cubemaps) to reduce shadow artifacts.
- increase pointlight resolution to 128x128, which raises (video)memory usage per to up-to 48 MiB from previously up-to 12 MiB.
- Fix incorrectly calculated shadow frustum NEAR, causing clipped geometry and vanishing shadows depending on view angle.
  - technically, we should also disable Depth Clipping and lean just on our culling frustum, which should ensure that any and every "likely" shadow caster is a least always in the shadowmap. But that may cause other issues. Will see later.
  -