### PR TITLE
fix some lighting and shadowing issues

### DIFF
--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -193,7 +193,7 @@ void D3D11PointLight::CopyStaticAsideToActiveTarget() const {
 
 void D3D11PointLight::RenderStaticShadowPass( RenderToDepthStencilBuffer& target, bool clearDepth ) {
     D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
-    const float range = LightInfo->Vob->GetLightRange() * 1.1f;
+    const float range = LightInfo->Vob->GetLightRange();
 
     std::map<MeshKey, MeshInfo*, cmpMeshKey>* wc = &WorldMeshCache;
     if ( WorldCacheInvalid ) {
@@ -207,7 +207,7 @@ void D3D11PointLight::RenderStaticShadowPass( RenderToDepthStencilBuffer& target
 
 void D3D11PointLight::RenderAnimatedShadowPass( RenderToDepthStencilBuffer& target, bool clearDepth ) {
     D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
-    const float range = LightInfo->Vob->GetLightRange() * 1.1f;
+    const float range = LightInfo->Vob->GetLightRange();
 
     const unsigned int animatedCasterMask = SHADOW_CASTER_ANIMATED;
     engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), range, target, nullptr, nullptr, false, LightInfo->IsIndoorVob, false,
@@ -363,7 +363,7 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate, D3D11ConstantBuffer* View
 
     // Create the projection matrix
     float zNear = 15.0f;
-    float zFar = LightInfo->Vob->GetLightRange() * 2.0f;
+    float zFar = LightInfo->Vob->GetLightRange()*2.0f;
 
     XMMATRIX proj = XMMatrixPerspectiveFovLH( XM_PIDIV2, 1.0f, zNear, zFar );
     proj = XMMatrixTranspose( proj );
@@ -443,7 +443,7 @@ void D3D11PointLight::RenderFullCubemap() {
         wc = nullptr;
     }
 
-    engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), LightInfo->Vob->GetLightRange() * 1.1f, *activeTarget,
+    engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), LightInfo->Vob->GetLightRange(), *activeTarget,
         nullptr, nullptr, false, LightInfo->IsIndoorVob, false, &VobCache, &SkeletalVobCache, wc, true, SHADOW_CASTER_ALL );
 }
 
@@ -493,7 +493,7 @@ void D3D11PointLight::RenderCubemapFace( const XMFLOAT4X4& view, const XMFLOAT4X
 
     D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine); // TODO: Remove and use newer system!
     auto lightPos = LightInfo->Vob->GetPositionWorldXM();
-    float range = LightInfo->Vob->GetLightRange() * 1.1f;
+    float range = LightInfo->Vob->GetLightRange();
     
     CameraReplacement cr;
     XMStoreFloat3( &cr.PositionReplacement, lightPos );

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1384,7 +1384,7 @@ DS_ScreenQuadConstantBuffer D3D11ShadowMap::FillSunCSMConstantBuffer() const {
     scb.SQ_ShadowAOStrength = settings.ShadowAOStrength;
     scb.SQ_WorldAOStrength = settings.WorldAOStrength;
     scb.SQ_ShadowSoftness = settings.ShadowSoftness;
-    scb.SQ_LightSize = 0.04f;
+    scb.SQ_LightSize = std::clamp( settings.PCSSLightSize, 0.005f, 0.5f );
 
     if ( auto bspTree = Engine::GAPI->GetLoadedWorldInfo()->BspTree )
         if ( bspTree->GetBspTreeMode() == zBSP_MODE_INDOOR ) {
@@ -1503,7 +1503,7 @@ XRESULT D3D11ShadowMap::DrawWorldLights()
     scb.SQ_ShadowAOStrength = settings.ShadowAOStrength;
     scb.SQ_WorldAOStrength = settings.WorldAOStrength;
     scb.SQ_ShadowSoftness = settings.ShadowSoftness;
-    scb.SQ_LightSize = 0.04f; // PCSS light size in shadow UV space
+    scb.SQ_LightSize = std::clamp( settings.PCSSLightSize, 0.005f, 0.5f );
 
     // Modify lightsettings when indoor
     if ( auto bspTree = Engine::GAPI->GetLoadedWorldInfo()->BspTree )

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -694,6 +694,7 @@ struct GothicRendererSettings {
         ShadowAOStrength = 0.50f;
         WorldAOStrength = 0.50f;
         ShadowSoftness = 1.0f; // 1.0 = default softness, higher = softer shadows
+        PCSSLightSize = 0.140f; // Shadow-UV light radius used by PCSS blocker search
 
         BloomStrength = 1.0f;
         GlobalWindStrength = 1.0f;
@@ -964,6 +965,7 @@ struct GothicRendererSettings {
     float ShadowAOStrength;
     float WorldAOStrength;
     float ShadowSoftness;
+    float PCSSLightSize;
 
     float GodRayDecay;
     float GodRayWeight;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1316,6 +1316,8 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
             ImGui::DragFloat( "ShadowStrength", &settings.ShadowStrength, 0.01f, 0.01f, 5.0f, "%.2f" );
             ImGui::DragFloat( "ShadowSoftness", &settings.ShadowSoftness, 0.05f, 0.2f, 8.0f, "%.2f" );
             ImGui::SetItemTooltip( "PCF kernel scale (1.0=sharp default, <1.0=sharper, >1.0=softer)" );
+            ImGui::DragFloat( "PCSSLightSize", &settings.PCSSLightSize, 0.002f, 0.005f, 0.5f, "%.3f" );
+            ImGui::SetItemTooltip( "PCSS light radius in shadow UV space. Higher values increase contact hardening and penumbra growth." );
             ImGui::DragFloat( "ShadowAOStrength", &settings.ShadowAOStrength, 0.01f, -5.0f, 2.0f, "%.2f" );
             ImGui::DragFloat( "WorldAOStrength", &settings.WorldAOStrength, 0.01f, -5.0f, 2.0f, "%.2f" );
             ImGui::EndDisabled();

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -268,9 +268,21 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	// CSM: Use soft cascaded shadow map with configurable softness
 	if(AC_LightPos.y > 0) // only get shadow value if it isn't night-time
 	{
-		float bias = lerp(0.00005f, 0.0001f, abs(vsPosition.z) / 1000);
-		// Use screen position for per-pixel rotation (TAA-friendly)
-		shadow = ComputeCascadedShadowValueSoft(wsPosition, vsPosition.z, vertLighting, bias, Input.vPosition.xy);
+        float3 wsNormal = normalize(mul(float4(normal, 0.0f), SQ_InvView).xyz);
+        float3 wsLightDirection = normalize(mul(float4(SQ_LightDirectionVS, 0.0f), SQ_InvView).xyz);
+
+        float NoL = saturate(abs(dot(wsNormal, wsLightDirection)));
+        float slopeScale = sqrt(saturate(1.0f - NoL * NoL));
+
+        int cascadeIndex = GetPrimaryCascadeIndex(wsPosition);
+        float texelWorldSize = GetCascadeWorldTexelSize(cascadeIndex);
+
+        const float normalBiasMultiplier = 1.5f;
+
+        float3 biasedWsPosition = wsPosition + wsNormal * (slopeScale * texelWorldSize * normalBiasMultiplier);
+
+        // Use screen position for per-pixel rotation (TAA-friendly)
+        shadow = ComputeCascadedShadowValueSoft(biasedWsPosition, vsPosition.z, vertLighting, 0.0f, Input.vPosition.xy);
 	}
 #endif
 

--- a/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
@@ -3,6 +3,7 @@
 //--------------------------------------------------------------------------------------
 #include <DS_Defines.h>
 #include "DepthReconstruction.h"
+#include "include/PointLightShadows.h"
 
 cbuffer DS_PointLightConstantBuffer : register( b0 )
 {
@@ -121,23 +122,17 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float ndl = max(0, dot(lightDir, normal));
 	
 	// Compute range falloff
-	float falloff = pow(saturate(1.0f - (distance / PL_Range)), 1.2f);
+	float falloff = PLS_ComputeRangeFalloff(distance, PL_Range);
 	//float falloff = saturate(1.0f / (pow(distance / PL_Range * 2, 2)));
 	
 	// Compute specular lighting
-	float3 V = normalize(-Pl_PositionView);
+	float3 V = normalize(-vsPosition);
 	float3 H = normalize(lightDir + V);
-	float spec = CalcBlinnPhongLighting(normal, H);
-	float specMod = pow(dot(float3(0.333f,0.333f,0.333f), diffuse.rgb), 2);
-	float3 specBare = pow(spec, specPower) * specIntensity * PL_Color.rgb * falloff;
-	float3 specColored = lerp(specBare, specBare * diffuse.rgb, specMod);
+	float spec = PLS_CalcBlinnPhongLighting(normal, H);
+	float specMod = PLS_ComputeSpecMod(diffuse.rgb);
 	
-	float3 color = falloff * ndl * PL_Color.rgb;
-	color = saturate(color);
-	
-	// Blend this with the lights color and the worlds diffuse color
-	// Also apply specular lighting
-	float3 lighting = color * diffuse.rgb + specColored;
+	// Blend this with the light color, world diffuse and specular term.
+	float3 lighting = PLS_ComputePointLightLighting(diffuse.rgb, PL_Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod);
 	
 	return float4(saturate(lighting),1);
 }

--- a/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
@@ -107,7 +107,7 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float falloff = PLS_ComputeRangeFalloff(distance, PL_Range);
 	
 	// Compute specular lighting
-	float3 V = normalize(-Pl_PositionView);
+	float3 V = normalize(-vsPosition);
 	float3 H = normalize(lightDir + V);
 	float spec = PLS_CalcBlinnPhongLighting(normal, H);
 	float specMod = PLS_ComputeSpecMod(diffuse.rgb);

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -128,8 +128,20 @@ FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 			float2 screenUV = Input.vPosition.xy / FP_ViewportSize;
 			shadow = FP_ShadowMask.SampleLevel( SS_Linear, screenUV, 0 ).r;
 		#else
-			float bias = lerp(0.00005f, 0.0001f, abs(vsPosition.z) / 1000.0f);
-			shadow = ComputeCascadedShadowValueSoft(wsPosition, vsPosition.z, vertLighting, bias, Input.vPosition.xy);
+			float3 wsNormal = normalize(mul(float4(nrm, 0.0f), SQ_InvView).xyz);
+			float3 wsLightDirection = normalize(mul(float4(SQ_LightDirectionVS, 0.0f), SQ_InvView).xyz);
+
+			float NoL = saturate(abs(dot(wsNormal, wsLightDirection)));
+			float slopeScale = sqrt(saturate(1.0f - NoL * NoL));
+
+			int cascadeIndex = GetPrimaryCascadeIndex(wsPosition);
+			float texelWorldSize = GetCascadeWorldTexelSize(cascadeIndex);
+
+			const float normalBiasMultiplier = 1.5f;
+
+			float3 biasedWsPosition = wsPosition + wsNormal * (slopeScale * texelWorldSize * normalBiasMultiplier);
+
+			shadow = ComputeCascadedShadowValueSoft(biasedWsPosition, vsPosition.z, vertLighting, 0.0f, Input.vPosition.xy);
 		#endif
 	}
 #endif

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -136,15 +136,15 @@ FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 
 	// Sun lighting
 	float3 litPixel = FP_ComputeSunLighting(wsPosition, vsPosition, nrm, color.rgb, specIntensity, specPower, shadow, vertLighting);
+	
+	// Atmospheric scattering
+	litPixel = ApplyAtmosphericScatteringGround(wsPosition, litPixel);
 
 	// Point lights, only when close enough
 	if (pixelDistZ < 6000.0f) 
 	{
 		litPixel += FP_ComputePointLighting(wsPosition, vsPosition, nrm, color.rgb, specIntensity, specPower, Input.vPosition.xy);
 	}
-
-	// Atmospheric scattering
-	litPixel = ApplyAtmosphericScatteringGround(wsPosition, litPixel);
 
 	output.vColor = float4(litPixel, 1);
 	output.vNrm = EncodeNormalGBuffer(nrm);

--- a/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
+++ b/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
@@ -94,11 +94,23 @@ float PSMain( PS_INPUT Input ) : SV_TARGET
     float3 vsPosition = VSPositionFromDepth( depth, uv );
     float3 wsPosition = mul( float4( vsPosition, 1.0f ), SQ_InvView ).xyz;
 
-    // Same bias ramp used in PS_Diffuse.hlsl
-    float bias = lerp( 0.00005f, 0.0001f, abs( vsPosition.z ) / 1000.0f );
+    float3 wsDx = ddx( wsPosition );
+    float3 wsDy = ddy( wsPosition );
+    float3 wsNormal = normalize( cross( wsDx, wsDy ) );
+    float3 wsLightDirection = normalize( mul( float4( SQ_LightDirectionVS, 0.0f ), SQ_InvView ).xyz );
+
+    float NoL = saturate( abs( dot( wsNormal, wsLightDirection ) ) );
+    float slopeScale = sqrt( saturate( 1.0f - NoL * NoL ) );
+
+    int cascadeIndex = GetPrimaryCascadeIndex( wsPosition );
+    float texelWorldSize = GetCascadeWorldTexelSize( cascadeIndex );
+
+    const float normalBiasMultiplier = 1.5f;
+
+    float3 biasedWsPosition = wsPosition + wsNormal * (slopeScale * texelWorldSize * normalBiasMultiplier);
 
     // ComputeCascadedShadowValueSoft is defined in ShadowSampling.h.
     // Pass 1.0 for vertLighting (the shadow mask carries only the cascade shadow;
     // vertex-AO is applied separately in FP_ComputeSunLighting).
-    return ComputeCascadedShadowValueSoft( wsPosition, vsPosition.z, 1.0f, bias, Input.vPosition.xy );
+    return ComputeCascadedShadowValueSoft( biasedWsPosition, vsPosition.z, 1.0f, 0.0f, Input.vPosition.xy );
 }

--- a/D3D11Engine/Shaders/ShadowSampling.h
+++ b/D3D11Engine/Shaders/ShadowSampling.h
@@ -21,6 +21,10 @@
 #define SHADOW_ATLAS 0
 #endif
 
+#ifndef PCSS_BLOCKER_SEARCH_TEXEL_CAP
+#define PCSS_BLOCKER_SEARCH_TEXEL_CAP 24
+#endif
+
 //--------------------------------------------------------------------------------------
 // Shadow map sampling helpers
 // Abstracts Texture2DArray (FL11+) vs Texture2D atlas (FL10) sampling
@@ -201,8 +205,8 @@ void FindBlockers(out float avgBlockerDepth, out float numBlockers,
 float EstimatePCSSFilterRadius(float2 uv, float zReceiver, int cascadeIndex,
                                float lightSize, float2x2 rotMat, float texelSize)
 {
-    // Capped slightly lower to match the 16-tap blocker limit efficiently
-    float searchRadius = min(lightSize, texelSize * 16.0f);
+    // Cap search radius in texel units to keep blocker search cost predictable.
+    float searchRadius = min(lightSize, texelSize * PCSS_BLOCKER_SEARCH_TEXEL_CAP);
     
     float avgBlockerDepth = 0.0f;
     float numBlockers = 0.0f;
@@ -276,6 +280,52 @@ void GetCascadeUVAndBounds(float3 wsPosition, int cascadeIndex,
 }
 
 //--------------------------------------------------------------------------------------
+// Returns the first cascade that contains wsPosition. If no cascade contains the
+// position, returns -1.
+//--------------------------------------------------------------------------------------
+int GetPrimaryCascadeIndex(float3 wsPosition)
+{
+    float4 vShadowPos;
+    float2 projCoords;
+    float inBounds;
+    float blendFactor;
+
+    for (int c = 0; c < NUM_CSM_CASCADES; c++)
+    {
+        GetCascadeUVAndBounds(wsPosition, c, vShadowPos, projCoords, inBounds, blendFactor);
+        if (inBounds > 0.5f)
+            return c;
+    }
+
+    return -1;
+}
+
+//--------------------------------------------------------------------------------------
+// Estimates current-cascade world-space texel size from the orthographic shadow matrix.
+//--------------------------------------------------------------------------------------
+float GetCascadeWorldTexelSize(int cascadeIndex)
+{
+    if (cascadeIndex < 0)
+        return 0.0f;
+
+    matrix shadowViewProj = SQ_ShadowViewProj[cascadeIndex];
+
+    float shadowScaleX = length(float3(shadowViewProj[0][0], shadowViewProj[1][0], shadowViewProj[2][0]));
+    float shadowScaleY = length(float3(shadowViewProj[0][1], shadowViewProj[1][1], shadowViewProj[2][1]));
+
+    float worldSpanX = (shadowScaleX > 1e-6f) ? (2.0f / shadowScaleX) : 0.0f;
+    float worldSpanY = (shadowScaleY > 1e-6f) ? (2.0f / shadowScaleY) : 0.0f;
+
+    float cascadeResolution = SQ_ShadowmapSize;
+#if SHADOW_ATLAS
+    float4 atlasRect = SQ_CascadeAtlasRect[cascadeIndex];
+    cascadeResolution *= max(atlasRect.z, atlasRect.w);
+#endif
+
+    return 0.5f * (worldSpanX + worldSpanY) / max(cascadeResolution, 1.0f);
+}
+
+//--------------------------------------------------------------------------------------
 // High-quality shadow sampling with configurable softness
 // Uses rotated Poisson disk for TAA-friendly results
 //--------------------------------------------------------------------------------------
@@ -306,7 +356,8 @@ float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoor
         float zReceiver = vShadowSamplingPos.z - bias;
         
         float pcssRadius = EstimatePCSSFilterRadius(projectedTexCoords.xy, zReceiver,
-            cascadeIndex, SQ_LightSize * SQ_ShadowSoftness, rotMat, texelSize);
+            cascadeIndex, SQ_LightSize, rotMat, texelSize);
+        pcssRadius *= SQ_ShadowSoftness;
 
         if (pcssRadius < 0.0f)
         {
@@ -331,12 +382,14 @@ float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoor
 				}
 				shadow = sum / 32.0f;
 			} else {
+                float radiusJitter = lerp(0.95f, 1.05f, noiseVal);
+                float finalRadius = pcssRadius * radiusJitter;
 				for (int i = 0; i < 8; i++)
 				{
-					float2 offset = mul(rotMat, g_PoissonDisk8[i]) * (texelSize * 4.0f);
+                    float2 offset = mul(rotMat, g_PoissonDisk8[i]) * finalRadius;
 					sum += SampleShadowMapCmp(
 						projectedTexCoords.xy + offset, cascadeIndex,
-						vShadowSamplingPos.z - bias);
+                        zReceiver);
 				}
 				shadow = sum / 8.0f;
 			}

--- a/D3D11Engine/Shaders/include/PointLightShadows.h
+++ b/D3D11Engine/Shaders/include/PointLightShadows.h
@@ -48,6 +48,14 @@ float PLS_ComputeRangeFalloff( float distance, float lightRange )
     return normalizedDist * (normalizedDist * 0.2f + 0.8f);
 }
 
+float PLS_ApplyShadowDistanceFade( float finalShadow, float normalizedDist )
+{
+    // Keep fade-out for mostly lit samples, but preserve strong occlusion to avoid wall bleed.
+    float shadowFade = smoothstep( 0.65f, 0.95f, normalizedDist );
+    float fadeWeight = shadowFade * smoothstep( 0.45f, 0.90f, finalShadow );
+    return lerp( finalShadow, 1.0f, fadeWeight );
+}
+
 float3 PLS_ComputePointLightLighting(
     float3 diffuseColor,
     float3 lightColor,
@@ -154,9 +162,7 @@ float PLS_SampleShadowCube(
     float distanceToLight = length(wsPosition - lightPosWorld);
     float normalizedDist = saturate(distanceToLight / lightRange);
     
-    // Smoothly fade the shadow to 1.0 (unshadowed) starting at 65% of the range, fully gone by 95%
-    float shadowFade = smoothstep(0.65f, 0.95f, normalizedDist);
-    return lerp(finalShadow, 1.0f, shadowFade);
+    return PLS_ApplyShadowDistanceFade( finalShadow, normalizedDist );
 }
 
 float PLS_SampleShadowCubeArray(
@@ -199,8 +205,7 @@ float PLS_SampleShadowCubeArray(
     float distanceToLight = length(wsPosition - lightPosWorld);
     float normalizedDist = saturate(distanceToLight / lightRange);
     
-    float shadowFade = smoothstep(0.65f, 0.95f, normalizedDist);
-    return lerp(finalShadow, 1.0f, shadowFade);
+    return PLS_ApplyShadowDistanceFade( finalShadow, normalizedDist );
 }
 
 #endif // !defined(__cplusplus)


### PR DESCRIPTION
- Make all lighting renderers draw light the same way.
  - ensures Forward+ and (Tiled-)Deferred shading do lighten up the scene the same way
- remove linear shadow map bias, and replace (again) with slope scaed normals, as the peter panning is tooooo noticible.