### PR TITLE
Fix transparent world mesh, like Ice lake in G2

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -421,4 +421,10 @@ struct ForwardPlusTileConstantBuffer {
     uint32_t NumTilesX;
     uint32_t LimitLightIntensity;
 };
+
+struct PsSimpleFFdata {
+    float4 textureFactor;
+};
+
 #pragma pack (pop)
+

--- a/D3D11Engine/D3D11DeferredRenderer.cpp
+++ b/D3D11Engine/D3D11DeferredRenderer.cpp
@@ -151,7 +151,7 @@ bool D3D11DeferredRenderer::BindShaderForTexture( D3D11ShaderManager& shaderMana
     } else if ( linZ ) {
         newShader = shaderManager.GetPShader( PShaderID::PS_LinDepth );
     } else if ( blendAdd || blendBlend ) {
-        newShader = shaderManager.GetPShader( PShaderID::PS_Simple );
+        newShader = shaderManager.GetPShader( PShaderID::PS_Simple_FF );
     } else if ( texture->HasAlphaChannel() || forceAlphaTest ) {
         if ( texture->GetSurface()->GetFxMap() ) {
             newShader = shaderManager.GetPShader( resolvedDiffuseNormalmappedAlphatestFxMap );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4700,9 +4700,18 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
         //zCLightmap* Lightmap;
     };
 
+    struct TransparencyWorldMeshEntry {
+        std::pair<MeshKey, MeshInfo*> Mesh;
+        float DistanceSq;
+    };
+
     static std::vector<std::pair<WorldMeshKey, MeshInfo*>> meshList;
     meshList.clear();
     if ( meshList.capacity() == 0 ) meshList.reserve( 4096 );
+
+    std::vector<TransparencyWorldMeshEntry> transparencyMeshes;
+    std::vector<TransparencyWorldMeshEntry> portalTransparencyMeshes;
+    std::vector<TransparencyWorldMeshEntry> waterfallTransparencyMeshes;
 
     GetContext()->IASetPrimitiveTopology( D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
     GetContext()->DSSetShader( nullptr, nullptr, 0 );
@@ -4735,14 +4744,17 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                         continue;
                     }
 
+                    const float distanceSq = ComputeWorldMeshDistanceSqFromCamera( renderItem, worldMesh.second, cameraPosition );
+                    const std::pair<MeshKey, MeshInfo*> transparencyMesh = { worldMesh.first, worldMesh.second };
+
                     if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_Portal ) {
                         if ( !isZPrepass ) {
-                            FrameTransparencyMeshesPortal.push_back( worldMesh );
+                            portalTransparencyMeshes.push_back( { transparencyMesh, distanceSq } );
                         }
                         continue;
                     } else if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_WaterfallFoam ) {
                         if ( !isZPrepass ) {
-                            FrameTransparencyMeshesWaterfall.push_back( worldMesh );
+                            waterfallTransparencyMeshes.push_back( { transparencyMesh, distanceSq } );
                         }
                         continue;
                     }
@@ -4750,11 +4762,10 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                     // Check for alphablending
                     if ( (worldMesh.first.Material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
                         worldMesh.first.Material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST)
-                        || (worldMesh.first.Material->GetAlphaFunc() == 0 && zColor( worldMesh.first.Material->GetColor() ).bgra.alpha < 255)
                         // || (worldMesh.first.Material->GetEnvMapEnabled())
                         ) {
                         if ( !isZPrepass ) {
-                            FrameTransparencyMeshes.push_back( worldMesh );
+                            transparencyMeshes.push_back( { transparencyMesh, distanceSq } );
                         }
                         continue;
                     } else {
@@ -4771,7 +4782,7 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                             worldMesh.first.Material,
                             worldMesh.first.Info,
                             alphaLevel,
-                            ComputeWorldMeshDistanceSqFromCamera( renderItem, worldMesh.second, cameraPosition ),
+                            distanceSq,
                         };
 
                         // Create a new pair using the animated texture
@@ -4780,6 +4791,40 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                 }
             }
         }
+
+        auto sortAndAppendTransparencyMeshes = []( std::vector<TransparencyWorldMeshEntry>& source,
+            std::vector<std::pair<MeshKey, MeshInfo*>>& destination ) {
+            if ( source.empty() ) {
+                return;
+            }
+
+            std::sort( source.begin(), source.end(),
+                []( const TransparencyWorldMeshEntry& a, const TransparencyWorldMeshEntry& b ) {
+                    if ( a.DistanceSq > b.DistanceSq )
+                        return true;
+                    if ( a.DistanceSq < b.DistanceSq )
+                        return false;
+                    if ( a.Mesh.first.Material != b.Mesh.first.Material )
+                        return a.Mesh.first.Material < b.Mesh.first.Material;
+                    if ( a.Mesh.first.Texture != b.Mesh.first.Texture )
+                        return a.Mesh.first.Texture < b.Mesh.first.Texture;
+                    if ( a.Mesh.first.Info != b.Mesh.first.Info )
+                        return a.Mesh.first.Info < b.Mesh.first.Info;
+
+                    const unsigned int aBaseIndex = a.Mesh.second ? a.Mesh.second->BaseIndexLocation : 0u;
+                    const unsigned int bBaseIndex = b.Mesh.second ? b.Mesh.second->BaseIndexLocation : 0u;
+                    return aBaseIndex < bBaseIndex;
+                } );
+
+            destination.reserve( destination.size() + source.size() );
+            for ( auto& entry : source ) {
+                destination.emplace_back( std::move( entry.Mesh ) );
+            }
+        };
+
+        sortAndAppendTransparencyMeshes( transparencyMeshes, FrameTransparencyMeshes );
+        sortAndAppendTransparencyMeshes( portalTransparencyMeshes, FrameTransparencyMeshesPortal );
+        sortAndAppendTransparencyMeshes( waterfallTransparencyMeshes, FrameTransparencyMeshesWaterfall );
     }
     auto CompareMesh = []( std::pair<WorldMeshKey, MeshInfo*>& a, std::pair<WorldMeshKey, MeshInfo*>& b ) -> bool {
         if ( a.first.AlphaLevel != b.first.AlphaLevel )

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3952,6 +3952,13 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         builder.Write( backBufferHandle );
 
         pass.m_executeCallback = [this](const RenderGraph&) {
+
+            SetDefaultStates();
+
+            // Setup renderstates
+            Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
+            Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+
             DrawMeshInfoListAlphablended( FrameTransparencyMeshes );
         };
     });
@@ -3962,6 +3969,13 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
             builder.Write( backBufferHandle );
 
             pass.m_executeCallback = [this](const RenderGraph&) {
+
+                SetDefaultStates();
+
+                // Setup renderstates
+                Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
+                Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+
                 DrawMeshInfoListAlphablended( FrameTransparencyMeshesPortal );
             };
         });
@@ -3972,6 +3986,13 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         builder.Write( backBufferHandle );
 
         pass.m_executeCallback = [this](const RenderGraph&) {
+
+            SetDefaultStates();
+
+            // Setup renderstates
+            Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
+            Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+
             DrawMeshInfoListAlphablended( FrameTransparencyMeshesWaterfall );
         };
     });
@@ -4481,14 +4502,6 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
     if ( list.empty() ) {
         return XR_SUCCESS;
     }
-
-    SetDefaultStates();
-
-    // Setup renderstates
-    Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_NONE;
-    Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
-    Engine::GAPI->GetRendererState().DepthState.SetDirty();
-    Engine::GAPI->GetRendererState().DepthState.SetDirty();
 
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
     Engine::GAPI->SetViewTransformXM( view );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4487,6 +4487,8 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
     // Setup renderstates
     Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_NONE;
     Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+    Engine::GAPI->GetRendererState().DepthState.SetDirty();
+    Engine::GAPI->GetRendererState().DepthState.SetDirty();
 
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
     Engine::GAPI->SetViewTransformXM( view );
@@ -4537,9 +4539,15 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
                 : nullptr;
 
             // Bind both
-            GetContext()->PSSetShaderResources( 0, 3, srv );
+            GetContext()->PSSetShaderResources( 0, 3, srv  );
 
             int alphaFunc = meshKey.Material->GetAlphaFunc();
+
+            if ( alphaFunc == 0 ) {
+                alphaFunc = zColor( meshKey.Material->GetColor() ).bgra.alpha < 255
+                    ? zMAT_ALPHA_FUNC_BLEND
+                    : zMAT_ALPHA_FUNC_MAT_DEFAULT;
+            }
 
             //Get the right shader for it
             BindShaderForTexture( texture, false, alphaFunc, meshKey.Info->MaterialType );
@@ -4560,6 +4568,34 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
                 UpdateRenderStates();
                 lastAlphaFunc = alphaFunc;
             }
+
+            struct FFData {
+                float4 textureFactor;
+            } ffdata;
+            
+            if (meshKey.Material->GetEnvMapEnabled()) {
+                if (Engine::GAPI->GetSky()->GetAtmosphereCB().AC_LightPos.y > 0) {
+                    // sun is up
+
+                    float sunHeight = Engine::GAPI->GetSky()->GetAtmosphereCB().AC_LightPos.y;
+                    const float maxSunHeight = 1.0f;
+                    float lerpFactor = std::clamp( sunHeight / maxSunHeight, 0.0f, 1.0f );
+
+                    float minIntensity = 0.1f;
+                    float maxIntensity = 0.5f;
+                    float currentIntensity = std::clamp( meshKey.Material->GetEnvMapStrength() * std::lerp( minIntensity, maxIntensity, lerpFactor ), 0.0f, 1.0f);
+                    ffdata.textureFactor = zColor( 255, 255, 255, (uint8_t)(255.0f * currentIntensity) ).ToFloat4();
+                    
+                } else {
+                    ffdata.textureFactor = zColor( 255, 255, 255, (uint8_t)(255.0f * meshKey.Material->GetEnvMapStrength() * 0.1f) ).ToFloat4();
+                }
+            } else {
+                ffdata.textureFactor = zColor( meshKey.Material->GetColor() ).ToFloat4();
+            }
+
+            ActivePS->GetBuffer( "cbFFData" )
+                .Update( &ffdata )
+                .Bind();
 
             MaterialInfo* info = meshKey.Info;
             if ( !info->Constantbuffer ) info->UpdateConstantbuffer();
@@ -4676,6 +4712,11 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
         ZoneScopedN( "DrawWorldMesh::BuildMeshList" );
         auto _scopeBuildMeshList = RecordGraphicsEvent( GE_NAME( "DrawWorldMesh::BuildMeshList" ) );
         const XMVECTOR cameraPosition = Engine::GAPI->GetCameraPositionXM();
+
+        static std::vector<WorldMeshSectionInfo*> alphaBlendedThings;
+        alphaBlendedThings.clear();
+        alphaBlendedThings.reserve( 200 );
+
         for ( auto const& renderItem : renderList ) {
             for ( auto const& worldMesh : renderItem->WorldMeshes ) {
                 if ( worldMesh.first.Material ) {
@@ -4707,12 +4748,15 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                     }
 
                     // Check for alphablending
-                    if ( worldMesh.first.Material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
-                        worldMesh.first.Material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST
-                        && worldMesh.first.Texture->HasAlphaChannel()) {
+                    if ( (worldMesh.first.Material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
+                        worldMesh.first.Material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST)
+                        || (worldMesh.first.Material->GetAlphaFunc() == 0 && zColor( worldMesh.first.Material->GetColor() ).bgra.alpha < 255)
+                        // || (worldMesh.first.Material->GetEnvMapEnabled())
+                        ) {
                         if ( !isZPrepass ) {
                             FrameTransparencyMeshes.push_back( worldMesh );
                         }
+                        continue;
                     } else {
 
                         int alphaLevel = 0;
@@ -5784,6 +5828,13 @@ void D3D11GraphicsEngine::ShadowPass_DrawWorldMesh_Indirect( const std::vector<W
                     continue;
                 }
 
+                // we don't draw alpha stuff into shadowmaps.
+                if ( (meshPair.first.Material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
+                    meshPair.first.Material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST)
+                        || (meshPair.first.Material->GetAlphaFunc() == 0 && zColor( meshPair.first.Material->GetColor() ).bgra.alpha < 255) ) {
+                    continue;
+                }
+
                 zCTexture* tex = meshPair.first.Material ? meshPair.first.Material->GetTexture() : nullptr;
                 unsigned int indexCount = 0;
 
@@ -5880,6 +5931,13 @@ void D3D11GraphicsEngine::ShadowPass_DrawWorldMesh( const std::vector<WorldMeshS
                     continue;
 
                 if ( cullingFrustum && !Engine::GAPI->IsWorldMeshVisibleInFrustum( meshPair.second, *cullingFrustum ) ) {
+                    continue;
+                }
+
+                // we don't draw alpha stuff into shadowmaps.
+                if ( (meshPair.first.Material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
+                    meshPair.first.Material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST)
+                        || (meshPair.first.Material->GetAlphaFunc() == 0 && zColor( meshPair.first.Material->GetColor() ).bgra.alpha < 255) ) {
                     continue;
                 }
 
@@ -6034,7 +6092,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
         visibleSections.clear();
         Engine::GAPI->CollectVisibleSections( visibleSections, currentFrustum, false );
 
-        if ( Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.FeatureSet.UseMDI ) {
+        /*if ( Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.FeatureSet.UseMDI ) {
             MeshInfo* wrappedWorldMesh = Engine::GAPI->GetWrappedWorldMesh();
             if ( wrappedWorldMesh ) {
                 D3D11VertexBuffer* wrappedIndexBuffer = wrappedWorldMesh->MeshShadowIndexBuffer
@@ -6042,7 +6100,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
                     : wrappedWorldMesh->MeshIndexBuffer;
                 DrawVertexBufferIndexedUINT( wrappedWorldMesh->MeshVertexBuffer, wrappedIndexBuffer, 0, 0 );
             }
-        }
+        }*/
         
         if (Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.FeatureSet.UseMDI) {
             ShadowPass_DrawWorldMesh_Indirect( visibleSections, currentFrustum );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4595,10 +4595,9 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
                     float lerpFactor = std::clamp( sunHeight / maxSunHeight, 0.0f, 1.0f );
 
                     float minIntensity = 0.1f;
-                    float maxIntensity = 0.5f;
+                    float maxIntensity = 0.7f;
                     float currentIntensity = std::clamp( meshKey.Material->GetEnvMapStrength() * std::lerp( minIntensity, maxIntensity, lerpFactor ), 0.0f, 1.0f);
                     ffdata.textureFactor = zColor( 255, 255, 255, (uint8_t)(255.0f * currentIntensity) ).ToFloat4();
-                    
                 } else {
                     ffdata.textureFactor = zColor( 255, 255, 255, (uint8_t)(255.0f * meshKey.Material->GetEnvMapStrength() * 0.1f) ).ToFloat4();
                 }

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4536,6 +4536,8 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
     int lastAlphaFunc = 0;
 
     // Draw the list
+    PsSimpleFFdata ffdata = { };
+    ffdata.textureFactor = float4( 1.0f, 1.0f, 1.0f, 1.0f );
     for ( auto const& [meshKey, meshInfo] : list ) {
         if ( zCTexture* texture = meshKey.Material->GetAniTexture() ) {
             MyDirectDrawSurface7* surface = texture->GetSurface();
@@ -4581,10 +4583,6 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
                 UpdateRenderStates();
                 lastAlphaFunc = alphaFunc;
             }
-
-            struct FFData {
-                float4 textureFactor;
-            } ffdata;
             
             if (meshKey.Material->GetEnvMapEnabled()) {
                 if (Engine::GAPI->GetSky()->GetAtmosphereCB().AC_LightPos.y > 0) {
@@ -4678,7 +4676,7 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
     ActiveVS->GetBuffer( "Matrices_PerInstances" )
         .Update( &identityMatrix )
         .Bind();
-
+    
     auto updatePSBuffers = [this] {
         ActivePS->GetBuffer( "FFPipelineConstantBuffer" )
             .Update( &Engine::GAPI->GetRendererState().GraphicsState )
@@ -4690,6 +4688,12 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
             .Bind();
 
         ActivePS->BindBuffer( "DIST_Distance", InfiniteRangeConstantBuffer.get() );
+
+        PsSimpleFFdata ffdata = { };
+        ffdata.textureFactor = float4( 1.0f, 1.0f, 1.0f, 1.0f );
+        ActivePS->GetBuffer( "cbFFData" )
+            .Update( &ffdata )
+            .Bind();
     };
     updatePSBuffers();
 
@@ -7060,11 +7064,18 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                             if ( wantShader ) {
                                 GetContext()->PSSetShaderResources( 0, isZPrepass ? 1 : 3, srv );
 
-                                BindShaderForTexture( tx,
+                                if ( BindShaderForTexture( tx,
                                     tx->HasAlphaChannel()
                                     || meshKey.Material->HasAlphaTest()
                                     , meshKey.Material->GetAlphaFunc(),
-                                    meshKey.Info->MaterialType );
+                                    meshKey.Info->MaterialType ) ) {
+                                    
+                                    PsSimpleFFdata ffdata = { };
+                                    ffdata.textureFactor = float4( 1.0f, 1.0f, 1.0f, 1.0f );
+                                    ActivePS->GetBuffer( "cbFFData" )
+                                        .Update( &ffdata )
+                                        .Bind();
+                                }
 
                                 if ( info && !info->IsSame( lastMatInfo ) ) {
                                     if ( !info->Constantbuffer ) info->UpdateConstantbuffer();
@@ -7386,7 +7397,13 @@ XRESULT D3D11GraphicsEngine::DrawPolyStrips( bool noTextures ) {
             MyDirectDrawSurface7* surface = tx->GetSurface();
             ID3D11ShaderResourceView* srv[3];
 
-            BindShaderForTexture( tx, false, mat->GetAlphaFunc() );
+            if ( BindShaderForTexture( tx, false, mat->GetAlphaFunc() ) ) {
+                PsSimpleFFdata ffdata = { };
+                ffdata.textureFactor = float4( 1.0f, 1.0f, 1.0f, 1.0f );
+                ActivePS->GetBuffer( "cbFFData" )
+                    .Update( &ffdata )
+                    .Bind();
+            }
 
             // Get diffuse and normalmap
             srv[0] = surface->GetEngineTexture()->GetShaderResourceView().Get();

--- a/D3D11Engine/D3D11PFX_FSR3.cpp
+++ b/D3D11Engine/D3D11PFX_FSR3.cpp
@@ -240,7 +240,7 @@ XRESULT D3D11PFX_FSR3::Apply(
     // Optional Resources (Passing nullptr handles them internally, e.g., Auto Exposure)
     // dispatchDesc.exposure = ffxGetResourceDX11_Fsr31_( nullptr, GetFfxResourceDescriptionDX11(nullptr), L"" );
     // dispatchDesc.reactive = ffxGetResourceDX11_Fsr31_( tncRes, GetFfxResourceDescriptionDX11( tncRes ), L"" );
-    dispatchDesc.transparencyAndComposition = GetAsFfxResource( reactiveMask, L"FSR3_TNC" );
+    // dispatchDesc.transparencyAndComposition = GetAsFfxResource( reactiveMask, L"FSR3_TNC" );
 
     // Set Dispatch Properties
     dispatchDesc.renderSize.width = inputSize.x;

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -200,6 +200,8 @@ XRESULT D3D11ShaderManager::Init() {
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_LinesSel>( "PS_LinesSel.hlsl" ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Simple>( "PS_Simple.hlsl" ) );
+    Shaders.push_back( ShaderInfo::make<PShaderID::PS_Simple_FF>( "PS_Simple.hlsl" )
+        .with_macros( { { "USE_FFDATA", "1" } } ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Rain>( "PS_Rain.hlsl" ) );
 

--- a/D3D11Engine/D3D11Upscaling.cpp
+++ b/D3D11Engine/D3D11Upscaling.cpp
@@ -48,7 +48,7 @@ namespace {
     {
         graph.AddPass( RG_PASS_NAME("FSR 2"), [&]( RGBuilder& builder, RenderPass& pass ) {
             builder.Read( velocityBufferHandle );
-            builder.Read( reactiveMaskResource );
+            // builder.Read( reactiveMaskResource );
             builder.Read( backBufferHandle );
 
             builder.Write( backBufferHandle );
@@ -88,7 +88,7 @@ namespace {
                     backbufferTex->GetShaderResView().Get(),
                     depth,
                     velocityBufferTex->GetShaderResView().Get(),
-                    reactiveMask->GetShaderResView().Get(),
+                    nullptr, // reactiveMask->GetShaderResView().Get(),
                     outputRTV,
                     inputSize,
                     engine.GetBackbufferResolution(),
@@ -115,7 +115,7 @@ namespace {
     {
         graph.AddPass( RG_PASS_NAME("FSR 3"), [&]( RGBuilder& builder, RenderPass& pass ) {
             builder.Read( velocityBufferHandle );
-            builder.Read( reactiveMaskResource );
+            // builder.Read( reactiveMaskResource );
             builder.Read( backBufferHandle );
 
             builder.Write( backBufferHandle );
@@ -155,7 +155,7 @@ namespace {
                     backbufferTex->GetShaderResView().Get(),
                     depth,
                     velocityBufferTex->GetShaderResView().Get(),
-                    reactiveMask->GetShaderResView().Get(),
+                    nullptr, // reactiveMask->GetShaderResView().Get(),
                     outputRTV,
                     inputSize,
                     engine.GetBackbufferResolution(),

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -85,8 +85,12 @@ void MaterialInfo::WriteToFile( const std::string& name ) {
 }
 
 /** Loads this info from a file */
-void MaterialInfo::LoadFromFile( const std::string& name ) {
-    FILE* f = fopen( ("system\\GD3D11\\textures\\infos\\" + name + ".mi").c_str(), "rb" );
+void MaterialInfo::LoadFromFile( const std::string_view name ) {
+    char filePath[MAX_PATH]{};
+    if (snprintf( filePath, MAX_PATH, R"(system\GD3D11\textures\infos\%.*s.mi)", static_cast<int>(name.size()), name.data() ) >= MAX_PATH) {
+        return;
+    }
+    FILE* f = fopen( filePath, "rb" );
 
     if ( !f )
         return;
@@ -4790,7 +4794,7 @@ MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex ) {
     return mi;
 }
 
-MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex, const std::string& textureName ) {
+MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex, const std::string_view textureName ) {
         auto it = MaterialInfos.find( tex );
         MaterialInfo* mi = nullptr;
         if ( it == MaterialInfos.end() ) {
@@ -4799,7 +4803,7 @@ MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex, const std::string&
             mi = MaterialInfos[tex].get();
             if ( tex ) {
                 mi->LoadFromFile( textureName );
-                if ( std::string_view{ textureName } == "NW_MISC_FULLALPHA_01" ) {
+                if ( textureName == "NW_MISC_FULLALPHA_01" ) {
                     mi->MaterialType = MaterialInfo::MT_FullAlpha;
                 }
             }

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -211,7 +211,7 @@ struct MaterialInfo {
     void WriteToFile( const std::string& name );
 
     /** Loads this info from a file */
-    void LoadFromFile( const std::string& name );
+    void LoadFromFile( const std::string_view name );
 
     struct Buffer {
         float SpecularIntensity;
@@ -689,7 +689,7 @@ public:
 
     /** Returns the material info associated with the given material */
     MaterialInfo* GetMaterialInfoFrom( zCTexture* tex );
-    MaterialInfo* GetMaterialInfoFrom( zCTexture* tex, const std::string& textureName );
+    MaterialInfo* GetMaterialInfoFrom( zCTexture* tex, const std::string_view textureName );
 
     /** Adds a surface */
     void AddSurface( const std::string& name, MyDirectDrawSurface7* surface );

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -569,9 +569,11 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_MatGroup = 0x40;
         static const unsigned int Offset_TexAniCtrl = 0x4C;
 
+        static const unsigned int Offset_EnvMapStrength = 0x6C;
         static const unsigned int Offset_Flags = 0x70;
         static const unsigned int Offset_TexAniMapDelta = 0x94;
         static const unsigned int Mask_FlagTexAniMap = 0x4;
+        static const unsigned int Mask_FlagEnvMapEnabled = 0x40;
 
         static const unsigned int Offset_WaveMode = 0x7C;
         static const unsigned int Offset_WaveSpeed = 0x80;

--- a/D3D11Engine/ShaderIDs.h
+++ b/D3D11Engine/ShaderIDs.h
@@ -36,6 +36,7 @@ enum class PShaderID : size_t {
     PS_Lines,
     PS_LinesSel,
     PS_Simple,
+    PS_Simple_FF,
     PS_Rain,
     PS_Rain_Snow,
     PS_Transparency,

--- a/D3D11Engine/Shaders/PS_Simple.hlsl
+++ b/D3D11Engine/Shaders/PS_Simple.hlsl
@@ -39,8 +39,9 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 {
 	float4 color = TX_Texture0.Sample(SS_Linear, Input.vTexcoord);
 	color *= Input.vDiffuse;
+#ifdef USE_FFDATA
 	color *= cbFFData.textureFactor;
-
+#endif
 	//return float4(1,0,0,1);
 	
 	return color;

--- a/D3D11Engine/Shaders/PS_Simple.hlsl
+++ b/D3D11Engine/Shaders/PS_Simple.hlsl
@@ -8,6 +8,14 @@
 SamplerState SS_Linear : register( s0 );
 Texture2D	TX_Texture0 : register( t0 );
 
+struct FFData {
+	float4 textureFactor;
+};
+
+cbuffer cbFFData : register( b0 ) {
+	FFData cbFFData;
+};
+
 //--------------------------------------------------------------------------------------
 // Input / Output structures
 //--------------------------------------------------------------------------------------
@@ -23,6 +31,7 @@ struct PS_INPUT
 	float4 vPosition		: SV_POSITION;
 };
 
+
 //--------------------------------------------------------------------------------------
 // Pixel Shader
 //--------------------------------------------------------------------------------------
@@ -30,6 +39,8 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 {
 	float4 color = TX_Texture0.Sample(SS_Linear, Input.vTexcoord);
 	color *= Input.vDiffuse;
+	color *= cbFFData.textureFactor;
+
 	//return float4(1,0,0,1);
 	
 	return color;

--- a/D3D11Engine/Shaders/ShadowSampling.h
+++ b/D3D11Engine/Shaders/ShadowSampling.h
@@ -160,6 +160,13 @@ float2x2 GetPoissonRotationMatrix(float2 screenPos)
 
 float2x2 GetPoissonRotationMatrixR(float2 screenPos, out float rawNoise)
 {
+    // If TAA is disabled return an identity matrix to get standard PCF instead of noise.
+    if (SQ_FrameIndex == 0)
+	{
+        rawNoise = 0.5f;
+        return float2x2(1.0f, 0.0f, 0.0f, 1.0f);
+	}
+
     // Interleaved Gradient Noise (IGN)
     float temporalOffset = (float)(SQ_FrameIndex % 8) * 0.6180339887f;
     
@@ -367,32 +374,36 @@ float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoor
         {
             float sum = 0.0f;
 
-            if (cascadeIndex < 2) {
-				// some dithering to reduce the visible "shears" of the noise
-				float radiusJitter = lerp(0.85f, 1.15f, noiseVal);
-				float finalRadius = pcssRadius * radiusJitter;
-				
-				for (int i = 0; i < 32; i++)
-				{
-					float2 offset = mul(rotMat, g_PoissonDisk32[i]) * finalRadius;
-					
-					sum += SampleShadowMapCmp(
-						projectedTexCoords.xy + offset, cascadeIndex,
-						zReceiver);
-				}
-				shadow = sum / 32.0f;
-			} else {
+            if (cascadeIndex < 2) { // You could also change this to CSM_PCF_LIMIT
+                // some dithering to reduce the visible "shears" of the noise
+                float radiusJitter = lerp(0.85f, 1.15f, noiseVal);
+                float finalRadius = pcssRadius * radiusJitter;
+                
+                [unroll]
+                for (int i = 0; i < 32; i++)
+                {
+                    float2 offset = mul(rotMat, g_PoissonDisk32[i]) * finalRadius;
+                    
+                    sum += SampleShadowMapCmp(
+                        projectedTexCoords.xy + offset, cascadeIndex,
+                        zReceiver);
+                }
+                shadow = sum / 32.0f;
+            } else {
+                // FIX: Upgraded from 8 to 16 taps to prevent extreme noise spread
                 float radiusJitter = lerp(0.95f, 1.05f, noiseVal);
                 float finalRadius = pcssRadius * radiusJitter;
-				for (int i = 0; i < 8; i++)
-				{
-                    float2 offset = mul(rotMat, g_PoissonDisk8[i]) * finalRadius;
-					sum += SampleShadowMapCmp(
-						projectedTexCoords.xy + offset, cascadeIndex,
+                
+                [unroll]
+                for (int i = 0; i < 16; i++)
+                {
+                    float2 offset = mul(rotMat, g_PoissonDisk16[i]) * finalRadius;
+                    sum += SampleShadowMapCmp(
+                        projectedTexCoords.xy + offset, cascadeIndex,
                         zReceiver);
-				}
-				shadow = sum / 8.0f;
-			}
+                }
+                shadow = sum / 16.0f;
+            }
         }
     }
 #elif SHD_FILTER_16TAP_PCF

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -429,6 +429,13 @@ bool AdditionalCheckWaterFall(zCTexture* texture)
     return false;
 }
 
+static bool IsPortalMaterial( std::string_view matName )
+{
+    return matName.starts_with( "P:" )
+        || matName.starts_with( "PN:" )
+        || matName.starts_with( "PI:" );
+}
+
 /** Converts the worldmesh into a more usable format */
 HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPolygons, std::map<int, std::map<int, WorldMeshSectionInfo>>* outSections, WorldInfo* info, MeshInfo** outWrappedMesh, bool indoorLocation ) {
     ZoneScoped;
@@ -447,12 +454,12 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
         if ( !mat ) {
             continue;
         }
-        // std::string_view matName = mat->__GetName().ToChar();
+        std::string_view matName = mat->__GetName().ToChar();
         // std::string_view textureName = mat->GetTextureSingle() ? mat->GetTextureSingle()->__GetName().ToChar() : "";
 
         // Flag portals so that we can apply a different PS shader later
         zCTexture* _tex = nullptr;
-        if ( poly->GetPolyFlags()->PortalPoly ) {
+        if ( poly->GetPolyFlags()->PortalPoly || IsPortalMaterial( matName ) ) {
             if ( const zCTexture* tex = mat->GetTextureSingle() ) {
                 std::string_view textureName = tex->__GetName().ToChar();
                 if ( textureName.starts_with("OWODFLWOODGROUND.") ) {

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -434,6 +434,7 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
     ZoneScoped;
     
     // Go through every polygon and put it into its section
+    std::vector<ExVertexStruct> polyVertices;
     for ( unsigned int i = 0; i < numPolygons; i++ ) {
         zCPolygon* poly = polys[i];
 
@@ -442,13 +443,19 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
             continue;
         }
 
+        zCMaterial* mat = poly->GetMaterial();
+        if ( !mat ) {
+            continue;
+        }
+        // std::string_view matName = mat->__GetName().ToChar();
+        // std::string_view textureName = mat->GetTextureSingle() ? mat->GetTextureSingle()->__GetName().ToChar() : "";
+
         // Flag portals so that we can apply a different PS shader later
         zCTexture* _tex = nullptr;
         if ( poly->GetPolyFlags()->PortalPoly ) {
-            zCMaterial* polymat = poly->GetMaterial();
-            if ( zCTexture* tex = polymat->GetTextureSingle() ) {
-                std::string textureName = tex->GetNameWithoutExt();
-                if ( textureName == "OWODFLWOODGROUND" ) {
+            if ( const zCTexture* tex = mat->GetTextureSingle() ) {
+                std::string_view textureName = tex->__GetName().ToChar();
+                if ( textureName.starts_with("OWODFLWOODGROUND.") ) {
                     continue; // this is a ground texture that is sometimes re-used for visual tricks to darken tunnels, etc. We don't want to treat this as a portal.
                 } else {
                     // unsafe hack to avoid portal polys assigning material for valid normal polygons
@@ -474,10 +481,6 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
         XMFLOAT3& bbmin = sectionInfo.BoundingBox.Min;
         XMFLOAT3& bbmax = sectionInfo.BoundingBox.Max;
 
-        zCMaterial* mat = poly->GetMaterial();
-        if ( !mat ) {
-            continue;
-        }
         if ( poly->GetNumPolyVertices() < 3 ) {
             LogWarn() << "Poly with less than 3 vertices!";
         }
@@ -503,7 +506,7 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
 #endif
 
         // Extract poly vertices
-        std::vector<ExVertexStruct> polyVertices;
+        polyVertices.clear();
         polyVertices.reserve( poly->GetNumPolyVertices() );
         for ( int v = 0; v < poly->GetNumPolyVertices(); v++ ) {
             zCVertex* vertex = poly->getVertices()[v];

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -58,7 +58,9 @@ struct MeshKey {
 
 struct cmpMeshKey {
     bool operator()( const MeshKey& a, const MeshKey& b ) const {
-        return (a.Texture < b.Texture);
+        return (a.Material != b.Material) 
+            ? (a.Material < b.Material)
+            : (a.Texture < b.Texture);
     }
 };
 

--- a/D3D11Engine/zCMaterial.h
+++ b/D3D11Engine/zCMaterial.h
@@ -168,11 +168,19 @@ public:
     }
 
     bool GetEnvMapEnabled() const {
+#if defined(BUILD_GOTHIC_1_08k)
+        return false;
+#else
         return *reinterpret_cast<unsigned char*>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_Flags )) & GothicMemoryLocations::zCMaterial::Mask_FlagEnvMapEnabled;
+#endif
     }
 
     float GetEnvMapStrength() const {
+#if defined(BUILD_GOTHIC_1_08k)
+        return 0.0f;
+#else
         return *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_EnvMapStrength ));
+#endif
     }
 
     XMFLOAT2 GetTexAniMapDelta() const {

--- a/D3D11Engine/zCMaterial.h
+++ b/D3D11Engine/zCMaterial.h
@@ -90,12 +90,12 @@ public:
     }
 
     /** Returns the color-mod of this material */
-    DWORD GetColor() {
+    DWORD GetColor() const {
         return *reinterpret_cast<DWORD*>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_Color ));
     }
 
     /** Returns single texture, because not all seem to be animated and returned by GetAniTexture? */
-    zCTexture* GetTextureSingle() {
+    zCTexture* GetTextureSingle() const {
         return *reinterpret_cast<zCTexture**>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_Texture ));
     }
 
@@ -163,7 +163,7 @@ public:
         return f == zMAT_ALPHA_FUNC_TEST || f == zMAT_ALPHA_FUNC_BLEND_TEST;
     }
 
-    bool HasTexAniMap() {
+    bool HasTexAniMap() const {
         return *reinterpret_cast<unsigned char*>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_Flags )) & GothicMemoryLocations::zCMaterial::Mask_FlagTexAniMap;
     }
 
@@ -171,7 +171,7 @@ public:
         return *reinterpret_cast<XMFLOAT2*>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_TexAniMapDelta ));
     }
 
-    zTMat_WaveMode GetWaveMode() {
+    zTMat_WaveMode GetWaveMode() const {
 #ifdef BUILD_GOTHIC_1_08k
         return zTMode_NONE;
 #else
@@ -199,6 +199,10 @@ public:
 #else
         return *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_WaveMaxAmplitude ));
 #endif
+    }
+    
+    const zSTRING& __GetName() const {
+        return reinterpret_cast<zSTRING&(__fastcall*)( const zCMaterial* )>( GothicMemoryLocations::zCObject::GetObjectName )( this );
     }
 };
 

--- a/D3D11Engine/zCMaterial.h
+++ b/D3D11Engine/zCMaterial.h
@@ -167,7 +167,15 @@ public:
         return *reinterpret_cast<unsigned char*>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_Flags )) & GothicMemoryLocations::zCMaterial::Mask_FlagTexAniMap;
     }
 
-    XMFLOAT2 GetTexAniMapDelta() {
+    bool GetEnvMapEnabled() const {
+        return *reinterpret_cast<unsigned char*>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_Flags )) & GothicMemoryLocations::zCMaterial::Mask_FlagEnvMapEnabled;
+    }
+
+    float GetEnvMapStrength() const {
+        return *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_EnvMapStrength ));
+    }
+
+    XMFLOAT2 GetTexAniMapDelta() const {
         return *reinterpret_cast<XMFLOAT2*>(THISPTR_OFFSET( GothicMemoryLocations::zCMaterial::Offset_TexAniMapDelta ));
     }
 

--- a/D3D11Engine/zCTexture.h
+++ b/D3D11Engine/zCTexture.h
@@ -138,8 +138,8 @@ public:
         return (flags & GothicMemoryLocations::zCTexture::Mask_FlagHasAlpha) != 0;
     }
 
-    const zSTRING& __GetName() {
-        return reinterpret_cast<zSTRING&(__fastcall*)( zCTexture* )>( GothicMemoryLocations::zCObject::GetObjectName )( this );
+    const zSTRING& __GetName() const {
+        return reinterpret_cast<zSTRING&(__fastcall*)( const zCTexture* )>( GothicMemoryLocations::zCObject::GetObjectName )( this );
     }
 };
 


### PR DESCRIPTION
- Fix incorrect mesh poly collection by fixing cmpMeshKey.
- reduce std::string allocations and `std::vector<ExVertexStruct> polyVertices` is shared acros whole loop.
- use `GetEnvMapEnabled` and `GetEnvMapStrength`
- enable back-face culling for frame transparent meshes to fix incorrect shading on ice shards.
- reduce PCSS artifacts