### PR TITLE
fix blend artifacts when frame-copying an uncompressed backbuffer

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -7505,6 +7505,8 @@ XRESULT D3D11GraphicsEngine::DrawPolyStrips( bool noTextures ) {
         DrawVertexBuffer( TempPolysVertexBuffer.get(), vertices.size(), sizeof( ExVertexStruct ) );
     }
 
+    SetDefaultStates();
+
     return XR_SUCCESS;
 }
 


### PR DESCRIPTION
Fixes issue where this happened when using the uncompressed backbuffer, due to alpha being blended into the final image, causing issues.


<img width="893" height="589" alt="image" src="https://github.com/user-attachments/assets/7052df2f-4ee6-430a-aad9-80b2845bf9ce" />
