### PR TITLE
zAllocator, string usage optimizations, VDF file support for renderer resources

### DIFF
--- a/D3D11Engine/D3D11Effect.cpp
+++ b/D3D11Engine/D3D11Effect.cpp
@@ -17,6 +17,7 @@
 // TODO: Remove this!
 #include "D3D11GraphicsEngine.h"
 #include "oCGame.h"
+#include "zFILE_VDFS.h"
 
 constexpr float snowSpeedFactor = 0.15f;
 
@@ -441,12 +442,22 @@ XRESULT D3D11Effect::LoadRainResources()
 {
     D3D11GraphicsEngineBase* e = reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine);
 
+    std::string path;
+    path.resize( MAX_PATH );
+    path.resize(GetModuleFileNameA( nullptr, path.data(), path.size()-1 ));
+
+    std::filesystem::path basePath = std::filesystem::path( path ).parent_path() / "GD3D11" / "Textures";
+    
     if ( !RainTextureArray.Get() ) {
         HRESULT hr = S_OK;
         // Load textures...
         LogInfo() << "Loading rain-drop textures";
         ZoneScopedN( "LoadRainTextures" );
-        LE( LoadTextureArray( e->GetDevice().Get(), e->GetContext().Get(), "system\\GD3D11\\Textures\\Raindrops\\cv0_vPositive_", 370, &RainTextureArray, &RainTextureArraySRV ) );
+        LE( LoadTextureArray( e->GetDevice().Get(), e->GetContext().Get(), "\\_work\\Data\\Textures\\GD3D11\\Raindrops\\cv0_vPositive_", 370, &RainTextureArray, &RainTextureArraySRV ) );
+        if (!SUCCEEDED(hr)) {
+            // try old file paths
+            LE( LoadTextureArray( e->GetDevice().Get(), e->GetContext().Get(), (basePath / "Raindrops"/"cv0_vPositive_").string().c_str(), 370, &RainTextureArray, &RainTextureArraySRV ) );
+        }
     }
 
     if ( !SnowTextureArray.Get() ) {
@@ -454,7 +465,10 @@ XRESULT D3D11Effect::LoadRainResources()
         // Load textures...
         LogInfo() << "Loading snow flake textures";
         ZoneScopedN( "LoadSnowTextures" );
-        LE( LoadTextureArray( e->GetDevice().Get(), e->GetContext().Get(), "system\\GD3D11\\Textures\\Snowflakes\\Snow_", 256, &SnowTextureArray, &SnowTextureArraySRV ) );
+        LE( LoadTextureArray( e->GetDevice().Get(), e->GetContext().Get(), "\\_work\\Data\\Textures\\GD3D11\\Snowflakes\\Snow_", 256, &SnowTextureArray, &SnowTextureArraySRV ) );
+        if (!SUCCEEDED(hr)) {
+            LE( LoadTextureArray( e->GetDevice().Get(), e->GetContext().Get(), (basePath / "Snowflakes"/"Snow_").string().c_str(), 256, &SnowTextureArray, &SnowTextureArraySRV ) );
+        }
     }
 
     if ( !RainShadowmap.get() ) {
@@ -625,11 +639,33 @@ HRESULT LoadTextureArray( Microsoft::WRL::ComPtr<ID3D11Device1> pd3dDevice, Micr
 
     //	CHAR szTextureName[MAX_PATH];
     CHAR str[MAX_PATH];
+
+    std::vector<uint8_t> storage{};
     for ( int i = 0; i < iNumTextures; i++ ) {
         sprintf( str, "%s%.4d.dds", sTexturePrefix, i );
 
+        auto file = zFILE_VDFS::Create( str );
+        if ( !file->Exists() ) {
+            LogError() << "File does not exist: " << str;
+            return E_FAIL;
+        }
+        auto retOpen = file->Open( false );
+        if ( retOpen != 0 ) {
+            LogError() << "Failed to open filepath: " << str;
+            return E_FAIL;
+        }
+        auto size = file->Size();
+
+        if ( storage.size() < size ) {
+            storage.resize( size*2 );
+        }
+        // assume single op file read.
+        auto numRead = file->Read( storage.data(), size );
+        auto retClose = file->Close();
+
+
         Microsoft::WRL::ComPtr<ID3D11Resource> pRes;
-        LE( CreateDDSTextureFromFileEx( pd3dDevice.Get(), Toolbox::ToWideChar( str ).c_str(), 0, D3D11_USAGE_STAGING, 0, D3D11_CPU_ACCESS_WRITE, 0, DDS_LOADER_DEFAULT, pRes.GetAddressOf(), nullptr ) );
+        LE( CreateDDSTextureFromMemoryEx( pd3dDevice.Get(), storage.data(), size, 0, D3D11_USAGE_STAGING, 0, D3D11_CPU_ACCESS_WRITE, 0, DDS_LOADER_DEFAULT, pRes.GetAddressOf(), nullptr));
         if ( pRes.Get() ) {
             Microsoft::WRL::ComPtr<ID3D11Texture2D> pTemp;
             pRes.As( &pTemp );

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1110,6 +1110,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="zCModelTexAniState.h" />
     <ClInclude Include="zCMorphMesh.h" />
     <ClInclude Include="zCObject.h" />
+    <ClInclude Include="zFILE_VDFS.h" />
     <ClInclude Include="zCOption.h" />
     <ClInclude Include="zCParser.h" />
     <ClInclude Include="zCParticleFX.h" />

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1088,6 +1088,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="Widget_TransRot.h" />
     <ClInclude Include="win32ClipboardWrapper.h" />
     <ClInclude Include="WorldObjects.h" />
+    <ClInclude Include="zAllocator.h" />
     <ClInclude Include="zCArray.h" />
     <ClInclude Include="zCArrayAdapt.h" />
     <ClInclude Include="zCCamera.h" />

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -847,6 +847,9 @@
     <ClInclude Include="zFILE_VDFS.h">
       <Filter>Engine\GAPI</Filter>
     </ClInclude>
+    <ClInclude Include="zAllocator.h">
+      <Filter>Engine\GAPI</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -732,24 +732,6 @@
     <ClInclude Include="SMAA\D3D11SMAA.h">
       <Filter>Engine\D3D11\PFX</Filter>
     </ClInclude>
-    <ClInclude Include="include\ImGuizmo\GraphEditor.h">
-      <Filter>Librarys\ImGuizmo</Filter>
-    </ClInclude>
-    <ClInclude Include="include\ImGuizmo\ImCurveEdit.h">
-      <Filter>Librarys\ImGuizmo</Filter>
-    </ClInclude>
-    <ClInclude Include="include\ImGuizmo\ImGradient.h">
-      <Filter>Librarys\ImGuizmo</Filter>
-    </ClInclude>
-    <ClInclude Include="include\ImGuizmo\ImGuizmo.h">
-      <Filter>Librarys\ImGuizmo</Filter>
-    </ClInclude>
-    <ClInclude Include="include\ImGuizmo\ImSequencer.h">
-      <Filter>Librarys\ImGuizmo</Filter>
-    </ClInclude>
-    <ClInclude Include="include\ImGuizmo\ImZoomSlider.h">
-      <Filter>Librarys\ImGuizmo</Filter>
-    </ClInclude>
     <ClInclude Include="D3D11CascadedShadowMapBuffer.h">
       <Filter>Engine\D3D11</Filter>
     </ClInclude>
@@ -855,6 +837,15 @@
     <ClInclude Include="D3D11FileRelativeInclude.h" />
     <ClInclude Include="D3D11TracyDebug.h">
       <Filter>Engine\D3D11</Filter>
+    </ClInclude>
+    <ClInclude Include="include\ImGuizmo\src\GraphEditor.h" />
+    <ClInclude Include="include\ImGuizmo\src\ImCurveEdit.h" />
+    <ClInclude Include="include\ImGuizmo\src\ImGradient.h" />
+    <ClInclude Include="include\ImGuizmo\src\ImGuizmo.h" />
+    <ClInclude Include="include\ImGuizmo\src\ImSequencer.h" />
+    <ClInclude Include="include\ImGuizmo\src\ImZoomSlider.h" />
+    <ClInclude Include="zFILE_VDFS.h">
+      <Filter>Engine\GAPI</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -1078,21 +1069,6 @@
     <ClCompile Include="SMAA\D3D11SMAA.cpp">
       <Filter>Engine\D3D11\PFX</Filter>
     </ClCompile>
-    <ClCompile Include="include\ImGuizmo\GraphEditor.cpp">
-      <Filter>Librarys\ImGuizmo</Filter>
-    </ClCompile>
-    <ClCompile Include="include\ImGuizmo\ImCurveEdit.cpp">
-      <Filter>Librarys\ImGuizmo</Filter>
-    </ClCompile>
-    <ClCompile Include="include\ImGuizmo\ImGradient.cpp">
-      <Filter>Librarys\ImGuizmo</Filter>
-    </ClCompile>
-    <ClCompile Include="include\ImGuizmo\ImGuizmo.cpp">
-      <Filter>Librarys\ImGuizmo</Filter>
-    </ClCompile>
-    <ClCompile Include="include\ImGuizmo\ImSequencer.cpp">
-      <Filter>Librarys\ImGuizmo</Filter>
-    </ClCompile>
     <ClCompile Include="D3D11CascadedShadowMapBuffer.cpp">
       <Filter>Engine\D3D11</Filter>
     </ClCompile>
@@ -1172,6 +1148,11 @@
     <ClCompile Include="include\meshoptimizer\src\quantization.cpp" />
     <ClCompile Include="include\meshoptimizer\src\vcacheoptimizer.cpp" />
     <ClCompile Include="include\meshoptimizer\src\vfetchoptimizer.cpp" />
+    <ClCompile Include="include\ImGuizmo\src\GraphEditor.cpp" />
+    <ClCompile Include="include\ImGuizmo\src\ImCurveEdit.cpp" />
+    <ClCompile Include="include\ImGuizmo\src\ImGradient.cpp" />
+    <ClCompile Include="include\ImGuizmo\src\ImGuizmo.cpp" />
+    <ClCompile Include="include\ImGuizmo\src\ImSequencer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ddraw.def">

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -55,6 +55,7 @@
 #include "zCOption.h"
 #include "RenderGraph.h"
 #include "D3D11Upscaling.h"
+#include "zFILE_VDFS.h"
 
 #ifdef BUILD_SPACER
 #define IS_SPACER_BUILD true
@@ -1415,6 +1416,9 @@ static const char* beginFrameEventName = "Frame";
 
 /** Called when the game wants to render a new frame */
 XRESULT D3D11GraphicsEngine::OnBeginFrame() {
+
+    zFILE_VDFS::Create( "_WORK\\DATA\\TEXTURES\\_COMPILED\\AL_D_CELLAR-C.TEX" );
+
     FrameMarkStart( beginFrameEventName );
 
     auto& rendererState = Engine::GAPI->GetRendererState();

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -55,7 +55,6 @@
 #include "zCOption.h"
 #include "RenderGraph.h"
 #include "D3D11Upscaling.h"
-#include "zFILE_VDFS.h"
 
 #ifdef BUILD_SPACER
 #define IS_SPACER_BUILD true
@@ -1416,9 +1415,6 @@ static const char* beginFrameEventName = "Frame";
 
 /** Called when the game wants to render a new frame */
 XRESULT D3D11GraphicsEngine::OnBeginFrame() {
-
-    zFILE_VDFS::Create( "_WORK\\DATA\\TEXTURES\\_COMPILED\\AL_D_CELLAR-C.TEX" );
-
     FrameMarkStart( beginFrameEventName );
 
     auto& rendererState = Engine::GAPI->GetRendererState();

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -6730,7 +6730,7 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
         // Use default material info for now
         MaterialInfo defInfo = {};
         ActivePS->GetBuffer( "MI_MaterialInfo" )
-            .Update( &defInfo )
+            .Update( &defInfo.buffer )
             .Bind();
 
         XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
@@ -7439,9 +7439,9 @@ XRESULT D3D11GraphicsEngine::DrawPolyStrips( bool noTextures ) {
         .Bind();
 
     // Use default material info for now
-    MaterialInfo defInfo;
+    MaterialInfo defInfo{};
     ActivePS->GetBuffer( "MI_MaterialInfo" )
-        .Update( &defInfo )
+        .Update( &defInfo.buffer )
         .Bind();
 
     auto vsBufMPI = ActiveVS->GetBuffer( "Matrices_PerInstances" );

--- a/D3D11Engine/D3D11Texture.cpp
+++ b/D3D11Engine/D3D11Texture.cpp
@@ -101,6 +101,33 @@ XRESULT D3D11Texture::Init( const std::string& file ) {
     return XR_SUCCESS;
 }
 
+XRESULT D3D11Texture::Init( const uint8_t* data, size_t size, const std::string& debugFileName ) {
+    HRESULT hr;
+    D3D11GraphicsEngineBase* engine = reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine);
+
+    //LogInfo() << "Loading Engine-Texture: " << debugFileName;
+
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> res;
+    LE( CreateDDSTextureFromMemory( engine->GetDevice().Get(), data, size,
+        reinterpret_cast<ID3D11Resource**>(res.ReleaseAndGetAddressOf()), ShaderResourceView.GetAddressOf() ) );
+
+    if ( !ShaderResourceView.Get() || !res.Get() )
+        return XR_FAILED;
+
+    D3D11_TEXTURE2D_DESC desc;
+    res->GetDesc( &desc );
+
+    Texture = res;
+    TextureFormat = desc.Format;
+
+    TextureSize.x = desc.Width;
+    TextureSize.y = desc.Height;
+    SetDebugName( res.Get(), "D3D11Texture(\"" + debugFileName + "\")->Texture" );
+    SetDebugName( ShaderResourceView.Get(), "D3D11Texture(\"" + debugFileName + "\")->ShaderResourceView" );
+
+    return XR_SUCCESS;
+}
+
 /** Updates the Texture-Object */
 XRESULT D3D11Texture::UpdateData( void* data, int mip ) {
     D3D11GraphicsEngineBase* engine = reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine);

--- a/D3D11Engine/D3D11Texture.h
+++ b/D3D11Engine/D3D11Texture.h
@@ -24,6 +24,8 @@ public:
     /** Initializes the texture from a file */
     XRESULT Init( const std::string& file );
 
+    XRESULT Init( const uint8_t* data, size_t size, const std::string& debugFileName );
+
     /** Updates the Texture-Object */
     XRESULT UpdateData( void* data, int mip = 0 );
 

--- a/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
+++ b/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
@@ -5,6 +5,7 @@
 #include "../D3D11Texture.h"
 #include "../zCTexture.h"
 #include "../D3D11_Helpers.h"
+#include "../zFILE_VDFS.h"
 
 #define DebugWriteTex(x)  DebugWrite(x)
 
@@ -114,10 +115,50 @@ void MyDirectDrawSurface7::LoadAdditionalResources( zCTexture* ownedTexture ) {
     D3D11Texture* fxMapTexture = nullptr;
     D3D11Texture* nrmmapTexture = nullptr;
 
+    auto file = zFILE_VDFS::Create( (R"(\_WORK\DATA\TEXTURES\REPLACEMENTS\)" + TextureName + "_NORMAL.DDS").c_str() );
+    if ( file->Exists() ) {
+        auto retOpen = file->Open( false );
+        if ( retOpen == 0 ) {
+            auto size = file->Size();
+
+            std::vector<uint8_t> storage( size );
+            // assume single op file read.
+            auto numRead = file->Read( storage.data(), size );
+            Engine::GraphicsEngine->CreateTexture( &nrmmapTexture );
+            if ( XR_SUCCESS != nrmmapTexture->Init( storage.data(), size, TextureName + "_NORMAL.DDS" ) ) {
+                SAFE_DELETE( nrmmapTexture );
+                LogWarn() << "Failed to load normalmap: " << TextureName;
+            }
+
+            auto retClose = file->Close();
+        }
+    }
+    file.reset();
+
+    file = zFILE_VDFS::Create( (R"(\_WORK\DATA\TEXTURES\REPLACEMENTS\)" + TextureName + "_ORM.DDS").c_str() );
+    if ( file->Exists() ) {
+        auto retOpen = file->Open( false );
+        if ( retOpen == 0 ) {
+            auto size = file->Size();
+
+            std::vector<uint8_t> storage( size );
+            // assume single op file read.
+            auto numRead = file->Read( storage.data(), size );
+            Engine::GraphicsEngine->CreateTexture( &ormMapTexture );
+            if ( XR_SUCCESS != ormMapTexture->Init( storage.data(), size, TextureName + "_ORM.DDS" ) ) {
+                SAFE_DELETE( ormMapTexture );
+                LogWarn() << "Failed to load ORM map: " << TextureName;
+            }
+
+            auto retClose = file->Close();
+        }
+    }
+    file.reset();
+
     // Check for normalmap in our mods folder first, then in the original games
     int j = 0;
     std::string replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
-    while ( Toolbox::FolderExists( replacementsFolder ) ) {
+    while ( !nrmmapTexture && Toolbox::FolderExists( replacementsFolder ) ) {
         std::string normalmap = replacementsFolder + "\\" + TextureName + "_normal.dds";
         if ( Toolbox::FileExists( normalmap ) ) {
             // Create the texture object this is linked with

--- a/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
+++ b/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
@@ -157,57 +157,67 @@ void MyDirectDrawSurface7::LoadAdditionalResources( zCTexture* ownedTexture ) {
 
     // Check for normalmap in our mods folder first, then in the original games
     int j = 0;
+    thread_local std::string replacementsFolder;
+    thread_local std::string tmpFilename;
     if ( !nrmmapTexture ) {
-        std::string replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
+        replacementsFolder.resize( 0 );
+        replacementsFolder.append("system\\GD3D11\\textures\\replacements\\Normalmaps_").append(std::to_string(j));
         while ( !nrmmapTexture && Toolbox::FolderExists( replacementsFolder ) ) {
-            std::string normalmap = replacementsFolder + "\\" + TextureName + "_normal.dds";
-            if ( Toolbox::FileExists( normalmap ) ) {
+            tmpFilename.resize( 0 );
+            tmpFilename.append(replacementsFolder).append("\\").append(TextureName).append("_normal.dds");
+            if ( Toolbox::FileExists( tmpFilename ) ) {
                 // Create the texture object this is linked with
                 Engine::GraphicsEngine->CreateTexture( &nrmmapTexture );
-                if ( XR_SUCCESS != nrmmapTexture->Init( normalmap ) ) {
+                if ( XR_SUCCESS != nrmmapTexture->Init( tmpFilename ) ) {
                     SAFE_DELETE( nrmmapTexture );
-                    LogWarn() << "Failed to load normalmap: " << normalmap;
+                    LogWarn() << "Failed to load normalmap: " << tmpFilename;
                 }
                 break; // No need to check the other folders
             }
             j++;
-            replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
+            replacementsFolder.resize( 0 );
+            replacementsFolder.append("system\\GD3D11\\textures\\replacements\\Normalmaps_").append(std::to_string(j));
         }
-        std::string normalmap = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + Engine::GAPI->GetGameName() + "\\" + TextureName + "_normal.dds";
-        if ( !nrmmapTexture && Toolbox::FileExists( normalmap ) ) {
+        tmpFilename.resize( 0 );
+        tmpFilename.append("system\\GD3D11\\textures\\replacements\\Normalmaps_").append(Engine::GAPI->GetGameName()).append("\\").append(TextureName).append("_normal.dds");
+        if ( !nrmmapTexture && Toolbox::FileExists( tmpFilename ) ) {
             // Create the texture object this is linked with
             Engine::GraphicsEngine->CreateTexture( &nrmmapTexture );
-            if ( XR_SUCCESS != nrmmapTexture->Init( normalmap ) ) {
+            if ( XR_SUCCESS != nrmmapTexture->Init( tmpFilename ) ) {
                 SAFE_DELETE( nrmmapTexture );
-                LogWarn() << "Failed to load normalmap: " << normalmap;
+                LogWarn() << "Failed to load normalmap: " << tmpFilename;
             }
         }
     }
 
     if ( !fxMapTexture ) {
         j = 0;
-        replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
+        replacementsFolder.resize( 0 );
+        replacementsFolder.append("system\\GD3D11\\textures\\replacements\\Normalmaps_").append(std::to_string(j));
         while ( !fxMapTexture && Toolbox::FolderExists( replacementsFolder ) ) {
-            std::string fxMap = replacementsFolder + "\\" + TextureName + "_fx.dds";
-            if ( Toolbox::FileExists( fxMap ) ) {
+            tmpFilename.resize( 0 );
+            tmpFilename.append(replacementsFolder).append("\\").append(TextureName).append("_fx.dds");
+            if ( Toolbox::FileExists( tmpFilename ) ) {
                 // Create the texture object this is linked with
                 Engine::GraphicsEngine->CreateTexture( &fxMapTexture );
-                if ( XR_SUCCESS != fxMapTexture->Init( fxMap ) ) {
+                if ( XR_SUCCESS != fxMapTexture->Init( tmpFilename ) ) {
                     SAFE_DELETE( fxMapTexture );
-                    LogWarn() << "Failed to load fxMap: " << fxMap;
+                    LogWarn() << "Failed to load fxMap: " << tmpFilename;
                 }
                 break; // No need to check the other folders
             }
             j++;
-            replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
+            replacementsFolder.resize( 0 );
+            replacementsFolder.append("system\\GD3D11\\textures\\replacements\\Normalmaps_").append(std::to_string(j));
         }
-        std::string fxMap = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + Engine::GAPI->GetGameName() + "\\" + TextureName + "_fx.dds";
-        if ( !fxMapTexture && Toolbox::FileExists( fxMap ) ) {
+        tmpFilename.resize( 0 );
+        tmpFilename.append("system\\GD3D11\\textures\\replacements\\Normalmaps_").append(Engine::GAPI->GetGameName()).append("\\").append(TextureName).append("_fx.dds");
+        if ( !fxMapTexture && Toolbox::FileExists( tmpFilename ) ) {
             // Create the texture object this is linked with
             Engine::GraphicsEngine->CreateTexture( &fxMapTexture );
-            if ( XR_SUCCESS != fxMapTexture->Init( fxMap ) ) {
+            if ( XR_SUCCESS != fxMapTexture->Init( tmpFilename ) ) {
                 SAFE_DELETE( fxMapTexture );
-                LogWarn() << "Failed to load fxMap: " << fxMap;
+                LogWarn() << "Failed to load fxMap: " << tmpFilename;
             }
         }
     }

--- a/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
+++ b/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
@@ -135,7 +135,7 @@ void MyDirectDrawSurface7::LoadAdditionalResources( zCTexture* ownedTexture ) {
     }
     file.reset();
 
-    file = zFILE_VDFS::Create( (R"(\_WORK\DATA\TEXTURES\REPLACEMENTS\)" + TextureName + "_ORM.DDS").c_str() );
+    file = zFILE_VDFS::Create( (R"(\_WORK\DATA\TEXTURES\REPLACEMENTS\)" + TextureName + "_FX.DDS").c_str() );
     if ( file->Exists() ) {
         auto retOpen = file->Open( false );
         if ( retOpen == 0 ) {
@@ -144,10 +144,10 @@ void MyDirectDrawSurface7::LoadAdditionalResources( zCTexture* ownedTexture ) {
             std::vector<uint8_t> storage( size );
             // assume single op file read.
             auto numRead = file->Read( storage.data(), size );
-            Engine::GraphicsEngine->CreateTexture( &ormMapTexture );
-            if ( XR_SUCCESS != ormMapTexture->Init( storage.data(), size, TextureName + "_ORM.DDS" ) ) {
-                SAFE_DELETE( ormMapTexture );
-                LogWarn() << "Failed to load ORM map: " << TextureName;
+            Engine::GraphicsEngine->CreateTexture( &fxMapTexture );
+            if ( XR_SUCCESS != fxMapTexture->Init( storage.data(), size, TextureName + "_FX.DDS" ) ) {
+                SAFE_DELETE( fxMapTexture );
+                LogWarn() << "Failed to load FX map: " << TextureName;
             }
 
             auto retClose = file->Close();
@@ -157,54 +157,58 @@ void MyDirectDrawSurface7::LoadAdditionalResources( zCTexture* ownedTexture ) {
 
     // Check for normalmap in our mods folder first, then in the original games
     int j = 0;
-    std::string replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
-    while ( !nrmmapTexture && Toolbox::FolderExists( replacementsFolder ) ) {
-        std::string normalmap = replacementsFolder + "\\" + TextureName + "_normal.dds";
-        if ( Toolbox::FileExists( normalmap ) ) {
+    if ( !nrmmapTexture ) {
+        std::string replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
+        while ( !nrmmapTexture && Toolbox::FolderExists( replacementsFolder ) ) {
+            std::string normalmap = replacementsFolder + "\\" + TextureName + "_normal.dds";
+            if ( Toolbox::FileExists( normalmap ) ) {
+                // Create the texture object this is linked with
+                Engine::GraphicsEngine->CreateTexture( &nrmmapTexture );
+                if ( XR_SUCCESS != nrmmapTexture->Init( normalmap ) ) {
+                    SAFE_DELETE( nrmmapTexture );
+                    LogWarn() << "Failed to load normalmap: " << normalmap;
+                }
+                break; // No need to check the other folders
+            }
+            j++;
+            replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
+        }
+        std::string normalmap = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + Engine::GAPI->GetGameName() + "\\" + TextureName + "_normal.dds";
+        if ( !nrmmapTexture && Toolbox::FileExists( normalmap ) ) {
             // Create the texture object this is linked with
             Engine::GraphicsEngine->CreateTexture( &nrmmapTexture );
             if ( XR_SUCCESS != nrmmapTexture->Init( normalmap ) ) {
                 SAFE_DELETE( nrmmapTexture );
                 LogWarn() << "Failed to load normalmap: " << normalmap;
             }
-            break; // No need to check the other folders
-        }
-        j++;
-        replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
-    }
-    std::string normalmap = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + Engine::GAPI->GetGameName() + "\\" + TextureName + "_normal.dds";
-    if ( !nrmmapTexture && Toolbox::FileExists( normalmap ) ) {
-        // Create the texture object this is linked with
-        Engine::GraphicsEngine->CreateTexture( &nrmmapTexture );
-        if ( XR_SUCCESS != nrmmapTexture->Init( normalmap ) ) {
-            SAFE_DELETE( nrmmapTexture );
-            LogWarn() << "Failed to load normalmap: " << normalmap;
         }
     }
 
-    j = 0;
-    replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
-    while ( Toolbox::FolderExists( replacementsFolder ) ) {
-        std::string fxMap = replacementsFolder + "\\" + TextureName + "_fx.dds";
-        if ( Toolbox::FileExists( fxMap ) ) {
+    if ( !fxMapTexture ) {
+        j = 0;
+        replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
+        while ( !fxMapTexture && Toolbox::FolderExists( replacementsFolder ) ) {
+            std::string fxMap = replacementsFolder + "\\" + TextureName + "_fx.dds";
+            if ( Toolbox::FileExists( fxMap ) ) {
+                // Create the texture object this is linked with
+                Engine::GraphicsEngine->CreateTexture( &fxMapTexture );
+                if ( XR_SUCCESS != fxMapTexture->Init( fxMap ) ) {
+                    SAFE_DELETE( fxMapTexture );
+                    LogWarn() << "Failed to load fxMap: " << fxMap;
+                }
+                break; // No need to check the other folders
+            }
+            j++;
+            replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
+        }
+        std::string fxMap = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + Engine::GAPI->GetGameName() + "\\" + TextureName + "_fx.dds";
+        if ( !fxMapTexture && Toolbox::FileExists( fxMap ) ) {
             // Create the texture object this is linked with
             Engine::GraphicsEngine->CreateTexture( &fxMapTexture );
             if ( XR_SUCCESS != fxMapTexture->Init( fxMap ) ) {
                 SAFE_DELETE( fxMapTexture );
                 LogWarn() << "Failed to load fxMap: " << fxMap;
             }
-            break; // No need to check the other folders
-        }
-        j++;
-        replacementsFolder = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + std::to_string( j );
-    }
-    std::string fxMap = "system\\GD3D11\\textures\\replacements\\Normalmaps_" + Engine::GAPI->GetGameName() + "\\" + TextureName + "_fx.dds";
-    if ( !fxMapTexture && Toolbox::FileExists( fxMap ) ) {
-        // Create the texture object this is linked with
-        Engine::GraphicsEngine->CreateTexture( &fxMapTexture );
-        if ( XR_SUCCESS != fxMapTexture->Init( fxMap ) ) {
-            SAFE_DELETE( fxMapTexture );
-            LogWarn() << "Failed to load fxMap: " << fxMap;
         }
     }
 

--- a/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
+++ b/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
@@ -83,7 +83,7 @@ void MyDirectDrawSurface7::BindToSlot( int slot ) {
 void MyDirectDrawSurface7::LoadAdditionalResources( zCTexture* ownedTexture ) {
     if ( !GothicTexture ) {
         GothicTexture = ownedTexture;
-        TextureName = GothicTexture->GetNameWithoutExt();
+        TextureName = GothicTexture->GetNameWithoutExtView();
 
         // Find texture type
         if ( Toolbox::StringContainsOneOf( TextureName, LEAF_SUBSTR, std::size( LEAF_SUBSTR ) ) ) {

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4782,8 +4782,8 @@ MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex ) {
         MaterialInfos.emplace(tex, std::move(info));
         mi = MaterialInfos[tex].get();
         if ( tex ) {
-            mi->LoadFromFile( tex->GetNameWithoutExt() );
-            if ( std::string_view{ tex->__GetName().ToChar() } == "NW_MISC_FULLALPHA_01.TGA" ) {
+            mi->LoadFromFile( tex->GetNameWithoutExtView() );
+            if ( tex->GetNameView() == "NW_MISC_FULLALPHA_01.TGA" ) {
                 mi->MaterialType = MaterialInfo::MT_FullAlpha;
             }
         }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1835,7 +1835,6 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
                 if ( str.empty() ) { // Happens when the model has no skeletal-mesh
                     zSTRING mds = zmodel->GetModelName();
                     str = mds.ToChar();
-                    mds.Delete();
                 }
 
                 auto it = SkeletalMeshVisuals.find( str );

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -659,4 +659,27 @@ struct GothicMemoryLocations {
     protected:
         VobTypes() {}
     };
+    
+    
+    struct zFILE_VDFS
+    {
+        static const unsigned int StructSize = 0x2a24;
+
+        static const unsigned int Constructor2 = 0x004468c0;
+        static const unsigned int Destructor = 0x00444d90;
+        static const unsigned int Exists = 0x00444f90;
+        static const unsigned int Open = 0x00445090;
+        static const unsigned int Close = 0x00445310;
+        static const unsigned int Read = 0x004468c0;
+        static const unsigned int Size = 0x00445380;
+        static const unsigned int SetPath = 0x00441670;
+        static const unsigned int zCObjectFactory__CreateZFile = 0x0058bd60;
+    };
+    
+#define zALLOCATOR_SUPPORTED
+    struct zAllocator
+    {
+        static const unsigned int Malloc = 0x007d02f8;
+        static const unsigned int Free = 0x007d02ec;
+    };
 };

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -665,8 +665,8 @@ struct GothicMemoryLocations {
     {
         static const unsigned int StructSize = 0x2a24;
 
-        static const unsigned int Constructor2 = 0x004468c0;
-        static const unsigned int Destructor = 0x00444d90;
+        static const unsigned int Constructor2 = 0x00444d90;
+        static const unsigned int Destructor = 0x00444e40;
         static const unsigned int Exists = 0x00444f90;
         static const unsigned int Open = 0x00445090;
         static const unsigned int Close = 0x00445310;
@@ -679,7 +679,7 @@ struct GothicMemoryLocations {
 #define zALLOCATOR_SUPPORTED
     struct zAllocator
     {
-        static const unsigned int Malloc = 0x007d02f8;
-        static const unsigned int Free = 0x007d02ec;
+        static const unsigned int Malloc = 0x0075ad60;
+        static const unsigned int Free = 0x0075ad6f;
     };
 };

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -568,4 +568,25 @@ struct GothicMemoryLocations {
     protected:
         VobTypes() {}
     };
+    
+    struct zFILE_VDFS
+    {
+        static const unsigned int StructSize = 0x2a24;
+
+        static const unsigned int Constructor2 = 0;
+        static const unsigned int Destructor = 0;
+        static const unsigned int Exists = 0;
+        static const unsigned int Open = 0;
+        static const unsigned int Close = 0;
+        static const unsigned int Read = 0;
+        static const unsigned int Size = 0;
+        static const unsigned int SetPath = 0;
+        static const unsigned int zCObjectFactory__CreateZFile = 0;
+    };
+
+    struct zAllocator
+    {
+        static const unsigned int Malloc = 0;
+        static const unsigned int Free = 0;
+    };
 };

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -735,4 +735,10 @@ struct GothicMemoryLocations {
         static const unsigned int SetPath = 0x004455d0;
         static const unsigned int zCObjectFactory__CreateZFile = 0x005ab940;
     };
+
+    struct zAllocator
+    {
+        static const unsigned int Malloc = 0x0082e30c;
+        static const unsigned int Free = 0x0082e308;
+    };
 };

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -739,7 +739,7 @@ struct GothicMemoryLocations {
 #define zALLOCATOR_SUPPORTED
     struct zAllocator
     {
-        static const unsigned int Malloc = 0x0082e30c;
-        static const unsigned int Free = 0x0082e308;
+        static const unsigned int Malloc = 0x007b4460;
+        static const unsigned int Free = 0x007b446f;
     };
 };

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -732,6 +732,7 @@ struct GothicMemoryLocations {
         static const unsigned int Close = 0x004493a0;
         static const unsigned int Read = 0x0044abf0;
         static const unsigned int Size = 0x00449410;
+        static const unsigned int SetPath = 0x004455d0;
         static const unsigned int zCObjectFactory__CreateZFile = 0x005ab940;
     };
 };

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -736,6 +736,7 @@ struct GothicMemoryLocations {
         static const unsigned int zCObjectFactory__CreateZFile = 0x005ab940;
     };
 
+#define zALLOCATOR_SUPPORTED
     struct zAllocator
     {
         static const unsigned int Malloc = 0x0082e30c;

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -719,4 +719,19 @@ struct GothicMemoryLocations {
     protected:
         VobTypes() {}
     };
+
+
+    struct zFILE_VDFS
+    {
+        static const unsigned int StructSize = 0x2a24;
+
+        static const unsigned int Constructor2 = 0x00448e20;
+        static const unsigned int Destructor = 0x00448ed0;
+        static const unsigned int Exists = 0x00449020;
+        static const unsigned int Open = 0x00449120;
+        static const unsigned int Close = 0x004493a0;
+        static const unsigned int Read = 0x0044abf0;
+        static const unsigned int Size = 0x00449410;
+        static const unsigned int zCObjectFactory__CreateZFile = 0x005ab940;
+    };
 };

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -475,4 +475,26 @@ struct GothicMemoryLocations {
     struct oCItemContainer {
         static const unsigned int s_Container_Draw = 0;
     };
+    
+    
+    struct zFILE_VDFS
+    {
+        static const unsigned int StructSize = 0x2a24;
+
+        static const unsigned int Constructor2 = 0;
+        static const unsigned int Destructor = 0;
+        static const unsigned int Exists = 0;
+        static const unsigned int Open = 0;
+        static const unsigned int Close = 0;
+        static const unsigned int Read = 0;
+        static const unsigned int Size = 0;
+        static const unsigned int SetPath = 0;
+        static const unsigned int zCObjectFactory__CreateZFile = 0;
+    };
+
+    struct zAllocator
+    {
+        static const unsigned int Malloc = 0;
+        static const unsigned int Free = 0;
+    };
 };

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -143,13 +143,15 @@ void ImGuiShim::RenderLoop()
 
     ImGui::GetIO().MouseDrawCursor = GetIsActive() && INT2( ImGui::GetMainViewport()->Size.x, ImGui::GetMainViewport()->Size.y ) != Engine::GraphicsEngine->GetResolution();
 
-    static int beginFrameFn = zCParser::GetParser()->GetIndex( "GDX_IMGUI_BEGINFRAME" );
-    static int endFrameFn = zCParser::GetParser()->GetIndex( "GDX_IMGUI_ENDFRAME" );
+    static zSTRING GDX_IMGUI_BEGINFRAME = "GDX_IMGUI_BEGINFRAME";
+    static zSTRING GDX_IMGUI_ENDFRAME = "GDX_IMGUI_ENDFRAME";
+    static int beginFrameFn = zCParser::GetParser()->GetIndex( GDX_IMGUI_BEGINFRAME );
+    static int endFrameFn = zCParser::GetParser()->GetIndex( GDX_IMGUI_ENDFRAME );
 
     static int retryFindFuncs = 0;
     if ( retryFindFuncs > 120 ) {
-        if ( beginFrameFn == -1 ) { beginFrameFn = zCParser::GetParser()->GetIndex( "GDX_IMGUI_BEGINFRAME" ); }
-        if ( endFrameFn == -1 ) { endFrameFn = zCParser::GetParser()->GetIndex( "GDX_IMGUI_ENDFRAME" ); }
+        if ( beginFrameFn == -1 ) { beginFrameFn = zCParser::GetParser()->GetIndex( GDX_IMGUI_BEGINFRAME ); }
+        if ( endFrameFn == -1 ) { endFrameFn = zCParser::GetParser()->GetIndex( GDX_IMGUI_ENDFRAME ); }
         retryFindFuncs = 0;
     }
 

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -412,7 +412,7 @@ XRESULT WorldConverter::LoadWorldMeshFromFile( const std::string& file, std::map
 
 static bool findStringIC( const std::string_view strHaystack, const std::string_view strNeedle )
 {
-    auto it = std::search(
+    const auto it = std::search(
       strHaystack.begin(), strHaystack.end(),
       strNeedle.begin(), strNeedle.end(),
       []( unsigned char ch1, unsigned char ch2 ) { return std::toupper( ch1 ) == std::toupper( ch2 ); }
@@ -427,8 +427,11 @@ bool AdditionalCheckWaterFall(zCTexture* texture)
     }
     const std::string_view textureName = texture->GetNameView();
 #ifdef BUILD_GOTHIC_2_6_fix
-    if ( findStringIC( textureName, "FALL" ) && !findStringIC( textureName, "SURFACE" ) && !findStringIC( textureName, "STONE" )
-        && findStringIC( textureName, "A0" ) ) {
+    if ( findStringIC( textureName, "FALL" )
+        && findStringIC( textureName, "A0" ) 
+        && !findStringIC( textureName, "SURFACE" )
+        && !findStringIC( textureName, "STONE" )
+    ) {
 #else
     if ( findStringIC( textureName, "FALL" ) && (findStringIC( textureName, "SURFACE" ) || findStringIC( textureName, "STONE" )) ) {
 #endif

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -410,19 +410,27 @@ XRESULT WorldConverter::LoadWorldMeshFromFile( const std::string& file, std::map
     return XR_SUCCESS;
 }
 
+static bool findStringIC( const std::string_view strHaystack, const std::string_view strNeedle )
+{
+    auto it = std::search(
+      strHaystack.begin(), strHaystack.end(),
+      strNeedle.begin(), strNeedle.end(),
+      []( unsigned char ch1, unsigned char ch2 ) { return std::toupper( ch1 ) == std::toupper( ch2 ); }
+    );
+    return (it != strHaystack.end());
+}
+
 bool AdditionalCheckWaterFall(zCTexture* texture)
 {
     if ( !texture ) {
         return false;
     }
-
-    std::string textureName = texture->GetName();
-    std::transform( textureName.begin(), textureName.end(), textureName.begin(), toupper );
+    const std::string_view textureName = texture->GetNameView();
 #ifdef BUILD_GOTHIC_2_6_fix
-    if ( textureName.find( "FALL" ) != std::string::npos && textureName.find( "SURFACE" ) == std::string::npos && textureName.find( "STONE" ) == std::string::npos
-        && textureName.find( "A0" ) != std::string::npos ) {
+    if ( findStringIC( textureName, "FALL" ) && !findStringIC( textureName, "SURFACE" ) && !findStringIC( textureName, "STONE" )
+        && findStringIC( textureName, "A0" ) ) {
 #else
-    if ( textureName.find( "FALL" ) != std::string::npos && (textureName.find( "SURFACE" ) != std::string::npos || textureName.find( "STONE" ) != std::string::npos) ) {
+    if ( findStringIC( textureName, "FALL" ) && (findStringIC( textureName, "SURFACE" ) || findStringIC( textureName, "STONE" )) ) {
 #endif
         // Let's make it work at least with og waterfall foam
         return true;

--- a/D3D11Engine/include/tracy/public/TracyClient.cpp
+++ b/D3D11Engine/include/tracy/public/TracyClient.cpp
@@ -49,14 +49,18 @@
 
 #include <tracy/public/tracy/Tracy.hpp>
 
+#include "../../../zAllocator.h"
+
 void* operator new(std::size_t count)
 {
-    auto ptr = malloc( count );
+    auto ptr = zAllocator::zNew( count );
+    // auto ptr = malloc( count );
     TracyAlloc( ptr, count );
     return ptr;
 }
 void operator delete(void* ptr) noexcept
 {
     TracyFree( ptr );
-    free( ptr );
+    // free(ptr);
+    zAllocator::zFree( ptr );
 }

--- a/D3D11Engine/zAllocator.h
+++ b/D3D11Engine/zAllocator.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "GothicMemoryLocations.h"
+
+struct zAllocator {
+    zAllocator() = delete;
+    ~zAllocator() = delete;
+
+    static void* zNew( size_t size ) {
+        typedef void* (__cdecl* zMallocFunc)(size_t size);
+        return (*reinterpret_cast<zMallocFunc*>(GothicMemoryLocations::zAllocator::Malloc))(size);
+    }
+    static void zFree( void* ptr ) {
+        typedef void (__cdecl* zFreeFunc)(void* ptr);
+        return (*reinterpret_cast<zFreeFunc*>(GothicMemoryLocations::zAllocator::Free))(ptr);
+    }
+};

--- a/D3D11Engine/zAllocator.h
+++ b/D3D11Engine/zAllocator.h
@@ -10,7 +10,7 @@ struct zAllocator {
     static void* zNew( size_t size ) {
 #ifdef zALLOCATOR_SUPPORTED
         typedef void* (__cdecl* zMallocFunc)(size_t size);
-        return (*reinterpret_cast<zMallocFunc*>(GothicMemoryLocations::zAllocator::Malloc))(size);
+        return reinterpret_cast<zMallocFunc>(GothicMemoryLocations::zAllocator::Malloc)(size);
 #else
         return std::malloc(size);
 #endif
@@ -18,7 +18,7 @@ struct zAllocator {
     static void zFree( void* ptr ) {
 #ifdef zALLOCATOR_SUPPORTED
         typedef void (__cdecl* zFreeFunc)(void* ptr);
-        (*reinterpret_cast<zFreeFunc*>(GothicMemoryLocations::zAllocator::Free))(ptr);
+        reinterpret_cast<zFreeFunc>(GothicMemoryLocations::zAllocator::Free)(ptr);
 #else
         std::free(ptr);
 #endif

--- a/D3D11Engine/zAllocator.h
+++ b/D3D11Engine/zAllocator.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdlib>
 #include "GothicMemoryLocations.h"
 
 struct zAllocator {
@@ -7,11 +8,19 @@ struct zAllocator {
     ~zAllocator() = delete;
 
     static void* zNew( size_t size ) {
+#ifdef zALLOCATOR_SUPPORTED
         typedef void* (__cdecl* zMallocFunc)(size_t size);
         return (*reinterpret_cast<zMallocFunc*>(GothicMemoryLocations::zAllocator::Malloc))(size);
+#else
+        return std::malloc(size);
+#endif
     }
     static void zFree( void* ptr ) {
+#ifdef zALLOCATOR_SUPPORTED
         typedef void (__cdecl* zFreeFunc)(void* ptr);
-        return (*reinterpret_cast<zFreeFunc*>(GothicMemoryLocations::zAllocator::Free))(ptr);
+        (*reinterpret_cast<zFreeFunc*>(GothicMemoryLocations::zAllocator::Free))(ptr);
+#else
+        std::free(ptr);
+#endif
     }
 };

--- a/D3D11Engine/zCTexture.h
+++ b/D3D11Engine/zCTexture.h
@@ -46,18 +46,35 @@ public:
     }
     */
 
-    std::string GetName() {
+    std::string GetName() const {
         const zSTRING& str = __GetName();
         return std::string( str.ToChar(), static_cast<size_t>( str.Length() ) );
     }
 
-    std::string GetNameWithoutExt() {
+    std::string GetNameWithoutExt() const {
         std::string n = GetName();
 
-        int p = n.find_last_of( '.' );
+        auto p = n.find_last_of( '.' );
 
         if ( p != std::string::npos )
             n.resize( p );
+
+        return n;
+    }
+
+    std::string_view GetNameView() const {
+        const zSTRING& str = __GetName();
+        std::string_view n = std::string_view( str.ToChar(), str.Length() );
+        return n;
+    }
+
+    std::string_view GetNameWithoutExtView() const {
+        std::string_view n = GetNameView();
+
+        auto p = n.find_last_of( '.' );
+
+        if ( p != std::string::npos )
+            return n.substr( 0, p );
 
         return n;
     }

--- a/D3D11Engine/zFILE_VDFS.h
+++ b/D3D11Engine/zFILE_VDFS.h
@@ -5,17 +5,30 @@
 typedef int zERROR_ID;
 
 class zFILE_VDFS {
-public:
-
-    zFILE_VDFS( const zSTRING& fileName ) {
-        reinterpret_cast<void( __thiscall* )(zFILE_VDFS*, const zSTRING&)>(GothicMemoryLocations::zFILE_VDFS::Constructor2)(this, fileName);
-    }
+private:
     ~zFILE_VDFS() {
         reinterpret_cast<void( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Destructor)(this);
     }
+public:
+    zFILE_VDFS( const zSTRING& fileName ) {
+        reinterpret_cast<void( __thiscall* )(zFILE_VDFS*, const zSTRING&)>(GothicMemoryLocations::zFILE_VDFS::Constructor2)(this, fileName);
+    }
 
-    static std::unique_ptr<zFILE_VDFS> Create( const zSTRING& fileName ) {
-        return std::make_unique<zFILE_VDFS>( fileName );
+    struct Deleter {
+        void operator()( zFILE_VDFS* file ) const {
+            if ( file ) {
+                delete file;
+            }
+        }
+    };
+
+    using Ptr = std::unique_ptr<zFILE_VDFS, Deleter>;
+
+    static Ptr Create( const zSTRING& fileName ) {
+
+        auto ptr = new zFILE_VDFS( fileName );
+
+        return Ptr( ptr );
     }
 
     static void* operator new(std::size_t count) {

--- a/D3D11Engine/zFILE_VDFS.h
+++ b/D3D11Engine/zFILE_VDFS.h
@@ -1,32 +1,29 @@
 #pragma once
 #include "zSTRING.h"
+#include "zAllocator.h"
 
 typedef int zERROR_ID;
 
 class zFILE_VDFS {
 public:
-    zFILE_VDFS() = delete;
-    ~zFILE_VDFS() = delete;
 
-    // --- Lifetime Management ---
-    // Returns a managed unique_ptr with a custom deleter to prevent memory leaks
-    struct Deleter {
-        void operator()( zFILE_VDFS* file ) const {
-            if ( file ) {
-                reinterpret_cast<void( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Destructor)(file);
-                std::free( file );
-            }
-        }
-    };
-    using Ptr = std::unique_ptr<zFILE_VDFS, Deleter>;
+    zFILE_VDFS( const zSTRING& fileName ) {
+        reinterpret_cast<void( __thiscall* )(zFILE_VDFS*, const zSTRING&)>(GothicMemoryLocations::zFILE_VDFS::Constructor2)(this, fileName);
+    }
+    ~zFILE_VDFS() {
+        reinterpret_cast<void( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Destructor)(this);
+    }
 
-    static Ptr Create( const zSTRING& fileName ) {
-        auto* memory = std::malloc( GothicMemoryLocations::zFILE_VDFS::StructSize );
-        if ( !memory ) return nullptr;
+    static std::unique_ptr<zFILE_VDFS> Create( const zSTRING& fileName ) {
+        return std::make_unique<zFILE_VDFS>( fileName );
+    }
 
-        auto* file = reinterpret_cast<zFILE_VDFS*>(memory);
-        reinterpret_cast<void( __thiscall* )(zFILE_VDFS*, const zSTRING&)>(GothicMemoryLocations::zFILE_VDFS::Constructor2)(file, fileName);
-        return Ptr( file );
+    static void* operator new(std::size_t count) {
+        return zAllocator::zNew( std::max( count, GothicMemoryLocations::zFILE_VDFS::StructSize ) );
+    }
+
+    static void operator delete(void* ptr) {
+        zAllocator::zFree( ptr );
     }
 
     bool Exists() {

--- a/D3D11Engine/zFILE_VDFS.h
+++ b/D3D11Engine/zFILE_VDFS.h
@@ -5,18 +5,28 @@ typedef int zERROR_ID;
 
 class zFILE_VDFS {
 public:
+    zFILE_VDFS() = delete;
+    ~zFILE_VDFS() = delete;
 
-    static zFILE_VDFS* Create( const zSTRING& fileName ) {
-        auto file = (zFILE_VDFS*)malloc( GothicMemoryLocations::zFILE_VDFS::StructSize );
-        if ( file ) {
-            reinterpret_cast<void( __thiscall* )(zFILE_VDFS*, const zSTRING&)>(GothicMemoryLocations::zFILE_VDFS::Constructor2)(file, fileName);
+    // --- Lifetime Management ---
+    // Returns a managed unique_ptr with a custom deleter to prevent memory leaks
+    struct Deleter {
+        void operator()( zFILE_VDFS* file ) const {
+            if ( file ) {
+                reinterpret_cast<void( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Destructor)(file);
+                std::free( file );
+            }
         }
-        return file;
-    }
+    };
+    using Ptr = std::unique_ptr<zFILE_VDFS, Deleter>;
 
-    static void Delete( zFILE_VDFS* _this ) {
-        reinterpret_cast<void( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Destructor)(_this);
-        free( _this );
+    static Ptr Create( const zSTRING& fileName ) {
+        auto* memory = std::malloc( GothicMemoryLocations::zFILE_VDFS::StructSize );
+        if ( !memory ) return nullptr;
+
+        auto* file = reinterpret_cast<zFILE_VDFS*>(memory);
+        reinterpret_cast<void( __thiscall* )(zFILE_VDFS*, const zSTRING&)>(GothicMemoryLocations::zFILE_VDFS::Constructor2)(file, fileName);
+        return Ptr( file );
     }
 
     bool Exists() {

--- a/D3D11Engine/zFILE_VDFS.h
+++ b/D3D11Engine/zFILE_VDFS.h
@@ -1,0 +1,40 @@
+#pragma once
+#include "zSTRING.h"
+
+typedef int zERROR_ID;
+
+class zFILE_VDFS {
+public:
+
+    static zFILE_VDFS* Create( const zSTRING& fileName ) {
+        auto file = (zFILE_VDFS*)malloc( GothicMemoryLocations::zFILE_VDFS::StructSize );
+        if ( file ) {
+            reinterpret_cast<void( __thiscall* )(zFILE_VDFS*, const zSTRING&)>(GothicMemoryLocations::zFILE_VDFS::Constructor2)(file, fileName);
+        }
+        return file;
+    }
+
+    static void Delete( zFILE_VDFS* _this ) {
+        reinterpret_cast<void( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Destructor)(_this);
+        free( _this );
+    }
+
+    bool Exists() {
+        return reinterpret_cast<bool( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Exists)(this);
+    }
+
+    zERROR_ID Open( bool writeMode ) {
+        return reinterpret_cast<zERROR_ID( __thiscall* )(zFILE_VDFS*, bool)>(GothicMemoryLocations::zFILE_VDFS::Open)(this, writeMode);
+    }
+    zERROR_ID Close() {
+        return reinterpret_cast<zERROR_ID( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Close)(this);
+    }
+
+    long Read( void* scr, long bytes ) {
+        return reinterpret_cast<long( __thiscall* )(zFILE_VDFS*, void*, long)>(GothicMemoryLocations::zFILE_VDFS::Read)(this, scr, bytes);
+    }
+
+    long Size() {
+        return reinterpret_cast<long( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Size)(this);
+    }
+};

--- a/D3D11Engine/zSTRING.h
+++ b/D3D11Engine/zSTRING.h
@@ -8,7 +8,19 @@ public:
         reinterpret_cast<void( __fastcall* )( zSTRING* )>( GothicMemoryLocations::zSTRING::ConstructorEmptyPtr )( this );
     }
     zSTRING( const char* str ) {
-        reinterpret_cast<void( __fastcall* )( zSTRING*, int, const char* )>( GothicMemoryLocations::zSTRING::ConstructorCharPtr )( this, 0, str );
+        reinterpret_cast<void( __fastcall* )(zSTRING*, int, const char*)>(GothicMemoryLocations::zSTRING::ConstructorCharPtr)(this, 0, str);
+    }
+
+    ~zSTRING() {
+        reinterpret_cast<void( __fastcall* )(zSTRING*)>(GothicMemoryLocations::zSTRING::DestructorCharPtr)(this);
+    }
+
+    static void* operator new(std::size_t count) {
+        return malloc( std::max( count, sizeof( zSTRING ) ) );
+    }
+
+    static void operator delete(void* ptr) {
+        free(ptr);
     }
 
     void Delete() {

--- a/D3D11Engine/zSTRING.h
+++ b/D3D11Engine/zSTRING.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "pch.h"
 #include "GothicMemoryLocations.h"
+#include "zAllocator.h"
 
 class zSTRING {
 public:
@@ -16,15 +17,16 @@ public:
     }
 
     static void* operator new(std::size_t count) {
-        return malloc( std::max( count, sizeof( zSTRING ) ) );
+        return zAllocator::zNew( std::max( count, sizeof( zSTRING ) ) );
     }
 
     static void operator delete(void* ptr) {
-        free(ptr);
+        zAllocator::zFree(ptr);
     }
 
     void Delete() {
-        reinterpret_cast<void( __fastcall* )( zSTRING* )>( GothicMemoryLocations::zSTRING::DestructorCharPtr )( this );
+        // no-op, as we have a proper destructor now.
+        // reinterpret_cast<void( __fastcall* )( zSTRING* )>( GothicMemoryLocations::zSTRING::DestructorCharPtr )( this );
     }
 
     const char* ToChar() const {

--- a/D3D11Engine/zSTRING.h
+++ b/D3D11Engine/zSTRING.h
@@ -16,14 +16,19 @@ public:
     }
 
     const char* ToChar() const {
-        const char* str = *reinterpret_cast<const char**>(reinterpret_cast<DWORD>(this) + GothicMemoryLocations::zSTRING::ToChar);
-        return (str ? str : "");
+        return _dataPtr ? _dataPtr : "";
     }
 
-    int Length() const
+    size_t Length() const
     {
-        return *reinterpret_cast<int*>(reinterpret_cast<DWORD>(this) + 0x0C);
+        return length;
     }
 
-    char data[20];
+private:
+    void* _vtblString;
+    void* _unknwn;
+    //---
+    char* _dataPtr;
+    size_t length;
+    size_t reserved;
 };


### PR DESCRIPTION
- reduce std::string allocations by using std::string_view where possible
  - define `zSTRING` layout to skip calls to ToChar and instantly get to the actual string data and length
  - WoldConverter waterfall checks now use insensitive comparison and string_view
- implement `zFILE_VDFS` support
  - a few Resources can now be loaded from *.vdf/*.mod files, making distributing them easier:
    - Normalmaps: `_WORK\DATA\TEXTURES\REPLACEMENTS\TEXTURENAME_NORMAL.DDS`
    - Specular/FX: `_WORK\DATA\TEXTURES\REPLACEMENTS\TEXTURENAME_FX.DDS`
    - Raindrops: `_work\Data\Textures\GD3D11\Raindrops\cv0_vPositive_0000.dds` through `cv0_vPositive_0369.dds` 
    - Snowflakes: `_work\Data\Textures\GD3D11\Raindrops\Snow_0000.DDS` through `Snow_0255.DDS`
- use Gothic Memory allocator for malloc/free
  - properly construct and free `zSTRING` as well as `zFILE_VDFS`
- fix bug where default `MaterialInfo` was bound incorrectly. (even if it wasn't used)


I ran around in G1 and Chronicles of Myrtana, no memory leaks were observed, when doing nothing memory usage was constant and unchanged. Also game did not crash otherwise when changing maps or going large distances or just playing.