### PR TITLE
fix: remove per Vob/Mesh constantbuffers, large memory usage reduction.

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2775,6 +2775,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
             if ( !model || !vi->VisualInfo || !vi->Vob->GetShowVisual() ) {
                 continue;
             }
+            vi->UpdateState();
 
             const int currentBegin = static_cast<int>(BoneTransformCache.size());
             model->GetBoneTransforms( &BoneTransformCache );
@@ -3181,7 +3182,6 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         }
 
         for ( auto& data : tempVobList ) {
-
             auto vi = data.VobInfo;
             auto model = data.Model;
             auto modelColor = data.ModelColor;
@@ -3189,10 +3189,6 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
             auto fatness = data.Fatness;
             auto& world = data.World;
             auto& prevWorld = data.PrevWorld;
-
-            // Init the constantbuffer if not already done
-            if ( !vi->VobConstantBuffer )
-                vi->UpdateVobConstantBuffer();
 
             auto& nodeAttachments = vi->NodeAttachments;
             for ( unsigned int i = 0; i < transforms.size(); i++ ) {
@@ -5504,9 +5500,13 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
         // At this point either renderedVobs or rndVob is filled with something
         D3D11Texture* lastBoundTexture = nullptr;
         std::list<VobInfo*>& rl = renderedVobs != nullptr ? *renderedVobs : rndVob;
+        VS_ExConstantBuffer_PerInstance cb;
+        
+        auto buffer = GetActiveVS()->GetBuffer(1).Bind();
         for ( auto const& vobInfo : rl ) {
             // Bind per-instance buffer
-            vobInfo->VobConstantBuffer->BindToVertexShader( 1 );
+            vobInfo->UpdateVobConstantBuffer(cb);
+            buffer.Update(&cb, sizeof(cb));
 
             // Draw the vob
             for ( auto const& materialMesh : vobInfo->VisualInfo->Meshes ) {
@@ -5850,10 +5850,14 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
         std::list<VobInfo*>& rl = renderedVobs != nullptr ? *renderedVobs : rndVob;
         auto _ = Engine::GraphicsEngine->RecordGraphicsEvent( GE_NAME( "Draw vobs (layered)" ) );
 
+        VS_ExConstantBuffer_PerInstance cb;
+        auto buffer = GetActiveVS()->GetBuffer(1).Bind();
+
         D3D11Texture* lastBoundTexture = nullptr;
         for ( auto const& vobInfo : rl ) {
             // Bind per-instance buffer
-            vobInfo->VobConstantBuffer->BindToVertexShader( 1 );
+            vobInfo->UpdateVobConstantBuffer(cb);
+            buffer.Update(&cb, sizeof(cb));
 
             // Draw the vob1
             for ( auto const& materialMesh : vobInfo->VisualInfo->Meshes ) {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2277,18 +2277,18 @@ bool D3D11GraphicsEngine::BindTextureNRFX( zCTexture* tex, bool bindShader, bool
         nullptr,
     };
 
+    // Select shader
+    if ( bindShader ) {
+        BindShaderForTexture( tex );
+    }
+
     MaterialInfo* info = nullptr;
     if ( updateMaterialInfo ) {
         info = Engine::GAPI->GetMaterialInfoFrom( tex );
-        if ( !info->Constantbuffer )
-            info->UpdateConstantbuffer();
 
         if ( info->buffer.SpecularIntensity != 0.05f ) {
             info->buffer.SpecularIntensity = 0.05f;
-            info->UpdateConstantbuffer();
         }
-
-        info->Constantbuffer->BindToPixelShader( 2 );
     }
 
     // Bind a default normalmap in case the scene is wet and we currently have none
@@ -2299,9 +2299,12 @@ bool D3D11GraphicsEngine::BindTextureNRFX( zCTexture* tex, bool bindShader, bool
         if ( info &&
             info->buffer.NormalmapStrength != DEFAULT_NORMALMAP_STRENGTH ) {
             info->buffer.NormalmapStrength = DEFAULT_NORMALMAP_STRENGTH;
-            info->UpdateConstantbuffer();
         }
         srvs[1] = DistortionTexture->GetShaderResourceView().Get();
+    }
+
+    if ( info ) {
+        GetActivePS()->GetBuffer( 2 ).Update( &info->buffer, sizeof( info->buffer ) ).Bind();
     }
 
     if ( D3D11Texture* fxmap = tex->GetSurface()->GetFxMap() ) {
@@ -2311,10 +2314,7 @@ bool D3D11GraphicsEngine::BindTextureNRFX( zCTexture* tex, bool bindShader, bool
 
     GetContext()->PSSetShaderResources( 0, 3, srvs );
 
-    // Select shader
-    if ( bindShader ) {
-        BindShaderForTexture( tex );
-    }
+    
     return true;
 }
 
@@ -4718,14 +4718,13 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
                 .Update( &ffdata )
                 .Bind();
 
-            MaterialInfo* info = meshKey.Info;
+            // TODO: Do we even need/use material-info for transparent meshes?
+            /*MaterialInfo* info = meshKey.Info;
             if (info != lastInfo) {
                 if (!lastInfo || !lastInfo->IsSame(info)) {
-                    if ( !info->Constantbuffer ) info->UpdateConstantbuffer();
-                    info->Constantbuffer->BindToPixelShader( 2 );
                     lastInfo = info;
                 }
-            }
+            }*/
 
             // Draw the section-part
             DrawVertexBufferIndexedUINT( nullptr, nullptr, meshInfo->Indices.size(),
@@ -5017,6 +5016,11 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
     SetActivePixelShader( defaultShader );
     ActivePS->Apply();
 
+    MaterialInfo defInfo = {};
+    auto materialInfoBuffer = ActivePS->GetBuffer( "MI_MaterialInfo" )
+        .Update( &defInfo.buffer, sizeof(defInfo.buffer) )
+        .Bind();
+
     // Now draw the actual pixels
     zCTexture* bound = nullptr;
     MaterialInfo* boundInfo = nullptr;
@@ -5046,7 +5050,6 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                     // Modify the strength of that default normalmap for the material info
                     if ( info && info->buffer.NormalmapStrength != DEFAULT_NORMALMAP_STRENGTH ) {
                         info->buffer.NormalmapStrength = DEFAULT_NORMALMAP_STRENGTH;
-                        info->UpdateConstantbuffer();
                     }
                     srv[1] = DistortionTexture->GetShaderResourceView().Get();
                 }
@@ -5062,9 +5065,7 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                 }
 
                 if ( info && !info->IsSame( boundInfo) ) {
-                    if ( !info->Constantbuffer ) info->UpdateConstantbuffer();
-
-                    info->Constantbuffer->BindToPixelShader( 2 );
+                    materialInfoBuffer.Update( &info->buffer, sizeof( info->buffer ) );
 
                     // Don't let the game unload the texture after some time
                     //mesh.first.Texture->CacheIn( 0.6f );
@@ -6823,8 +6824,8 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
 
         // Use default material info for now
         MaterialInfo defInfo = {};
-        ActivePS->GetBuffer( "MI_MaterialInfo" )
-            .Update( &defInfo.buffer )
+        auto materialInfoBuffer = ActivePS->GetBuffer( "MI_MaterialInfo" )
+            .Update( &defInfo.buffer, sizeof(defInfo.buffer) )
             .Bind();
 
         XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
@@ -6845,7 +6846,6 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
             windBuffer.Bind();
         }
 
-        auto materialInfoSlot = ActivePS->GetInputIndex( "MI_MaterialInfo" );
         auto DIST_DistanceSlot = ActivePS->GetInputIndex( "DIST_Distance" );
 
         bool isZPrepass = RenderingStage == D3D11ENGINE_RENDER_STAGE::DES_Z_PRE_PASS;
@@ -7214,7 +7214,6 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                                 != DEFAULT_NORMALMAP_STRENGTH ) {
                                 // update values for distortion texture
                                 info->buffer.NormalmapStrength = DEFAULT_NORMALMAP_STRENGTH;
-                                info->UpdateConstantbuffer();
                                 lastMatInfo = info;
                             }
                             srv[1] = DistortionTexture->GetShaderResourceView().Get();
@@ -7244,8 +7243,7 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                                 }
 
                                 if ( info && !info->IsSame( lastMatInfo ) ) {
-                                    if ( !info->Constantbuffer ) info->UpdateConstantbuffer();
-                                    info->Constantbuffer->BindToPixelShader( materialInfoSlot );
+                                    materialInfoBuffer.Update( &info->buffer, sizeof( info->buffer ) );
                                     lastMatInfo = info;
                                 }
                             }
@@ -7463,8 +7461,7 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
                 UpdateRenderStates();
             }
 
-            MaterialInfo* info = mk.Info;
-            if ( !info->Constantbuffer ) info->UpdateConstantbuffer();
+            // TODO: apply MaterialInfoBuffer.Update(&mk.Info->buffer) ?
 
             g_windBuffer.minHeight = vi->BBox.Min.y;
             g_windBuffer.maxHeight = vi->BBox.Max.y;
@@ -7534,8 +7531,8 @@ XRESULT D3D11GraphicsEngine::DrawPolyStrips( bool noTextures ) {
 
     // Use default material info for now
     MaterialInfo defInfo{};
-    ActivePS->GetBuffer( "MI_MaterialInfo" )
-        .Update( &defInfo.buffer )
+    auto materialInfoBuffer = ActivePS->GetBuffer( "MI_MaterialInfo" )
+        .Update( &defInfo.buffer, sizeof(defInfo.buffer) )
         .Bind();
 
     auto vsBufMPI = ActiveVS->GetBuffer( "Matrices_PerInstances" );
@@ -7594,10 +7591,7 @@ XRESULT D3D11GraphicsEngine::DrawPolyStrips( bool noTextures ) {
             }
 
             MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom( tx );
-            if ( !info->Constantbuffer )
-                info->UpdateConstantbuffer();
-
-            info->Constantbuffer->BindToPixelShader( 2 );
+            materialInfoBuffer.Update( &info->buffer, sizeof( info->buffer ) );
 
         } else {
             //Don't draw if texture is not yet cached (I have no idea how can I preload it in advance)

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -240,6 +240,38 @@ namespace
     }
 }
 
+void ConstantBufferPool::BeginFrame( ID3D11DeviceContext* context ) {
+    D3D11_MAPPED_SUBRESOURCE mappedResource;
+    context->Map( m_poolBuffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResource );
+    m_pMappedData = static_cast<uint8_t*>(mappedResource.pData);
+    m_currentOffset = 0;
+}
+
+ConstantBufferAllocation ConstantBufferPool::Allocate( const void* pData, uint32_t sizeInBytes ) {
+    uint32_t alignedSize = (sizeInBytes + 255) & ~255;
+
+    if ( m_currentOffset + alignedSize > m_bufferSize ) {
+        return { m_poolBuffer.Get(), 0, alignedSize }; // Out of memory in the pool
+    }
+
+    memcpy( m_pMappedData + m_currentOffset, pData, sizeInBytes );
+
+    ConstantBufferAllocation alloc;
+    alloc.pBuffer = m_poolBuffer.Get();
+    alloc.offsetInBytes = m_currentOffset;
+    alloc.sizeInBytes = alignedSize;
+
+    // 4. Advance the offset for the next allocation
+    m_currentOffset += alignedSize;
+
+    return alloc;
+}
+
+void ConstantBufferPool::EndFrame( ID3D11DeviceContext* context ) {
+    context->Unmap( m_poolBuffer.Get(), 0 );
+    m_pMappedData = nullptr;
+}
+
 D3D11GraphicsEngine::D3D11GraphicsEngine() :
     DebugPointlight(nullptr),
     m_LastFrameLimit(0),
@@ -823,6 +855,9 @@ XRESULT D3D11GraphicsEngine::Init() {
     InfiniteRangeConstantBuffer.reset( infiniteRangeConstantBuffer );
     OutdoorSmallVobsConstantBuffer.reset( outdoorSmallVobsConstantBuffer );
     OutdoorVobsConstantBuffer.reset(outdoorVobsConstantBuffer);
+
+    PerObjectMaterialInfoPooledBuffer = std::make_unique<ConstantBufferPool>();
+    PerObjectMaterialInfoPooledBuffer->Initialize( GetDevice().Get() );
 
     // Init inf-buffer now
     static const float4 infiniteRange( FLT_MAX, 0, 0, 0 );
@@ -2303,7 +2338,7 @@ bool D3D11GraphicsEngine::BindTextureNRFX( zCTexture* tex, bool bindShader, bool
         srvs[1] = DistortionTexture->GetShaderResourceView().Get();
     }
 
-    if ( info ) {
+    if ( info && GetActivePS() ) {
         GetActivePS()->GetBuffer( 2 ).Update( &info->buffer, sizeof( info->buffer ) ).Bind();
     }
 
@@ -5023,11 +5058,47 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
 
     // Now draw the actual pixels
     zCTexture* bound = nullptr;
-    MaterialInfo* boundInfo = nullptr;
     if ( !meshList.empty() ) {
         ZoneScopedN( "DrawWorldMesh::OpaqueSubmission" );
         auto _scopeOpaqueSubmission = RecordGraphicsEvent( GE_NAME( "DrawWorldMesh::OpaqueSubmission" ) );
-        for ( auto const& mesh : meshList ) {
+
+        const size_t numMeshes = meshList.size();
+        std::vector<UINT> materialInfoCbOffsets( numMeshes );
+        PerObjectMaterialInfoPooledBuffer->BeginFrame(GetContext().Get());
+
+        MaterialInfo* lastInfo = nullptr;
+        UINT INVALID_OFFSET = PerObjectMaterialInfoPooledBuffer->Allocate( &defInfo.buffer, sizeof( defInfo.buffer ) ).offsetInBytes;
+        for ( size_t i = 0; i < numMeshes; i++ ) {
+            auto needDefaultNormalsStrength = meshList[i].first.Texture->GetSurface()->GetNormalmap() == nullptr;
+            MaterialInfo* info = meshList[i].first.Info;
+
+            if ( info && 
+                needDefaultNormalsStrength &&
+                info->buffer.NormalmapStrength != DEFAULT_NORMALMAP_STRENGTH ) {
+                info->buffer.NormalmapStrength = DEFAULT_NORMALMAP_STRENGTH;
+                // Value override for non-normalmapped textures in case of rain
+            }
+
+            if ( info ) {
+                if ( info->IsSame( lastInfo ) ) {
+                    materialInfoCbOffsets[i] = materialInfoCbOffsets[i - 1];
+                } else {
+                    materialInfoCbOffsets[i] = PerObjectMaterialInfoPooledBuffer->Allocate( &info->buffer, sizeof( info->buffer ) ).offsetInBytes;
+                    lastInfo = info;
+                }
+            } else {
+                materialInfoCbOffsets[i] = INVALID_OFFSET;
+            }
+        }
+        PerObjectMaterialInfoPooledBuffer->EndFrame( GetContext().Get() );
+
+        auto materialInfoPoolBuffer = PerObjectMaterialInfoPooledBuffer->GetBuffer();
+        UINT lastOffsetId = -1;
+        for ( size_t i = 0; i < numMeshes; i++ ) {
+            auto const& mesh = meshList[i];
+            auto materialInfoOffset = materialInfoCbOffsets[i];
+            UINT firstConstant = materialInfoOffset / 16;
+            UINT numConstants = 256 / 16; // aligned size
 
             if ( mesh.first.Texture != bound &&
                 Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh > 1 ) {
@@ -5047,10 +5118,6 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                 // Bind a default normalmap in case the scene is wet and we currently have
                 // none
                 if ( !srv[1] ) {
-                    // Modify the strength of that default normalmap for the material info
-                    if ( info && info->buffer.NormalmapStrength != DEFAULT_NORMALMAP_STRENGTH ) {
-                        info->buffer.NormalmapStrength = DEFAULT_NORMALMAP_STRENGTH;
-                    }
                     srv[1] = DistortionTexture->GetShaderResourceView().Get();
                 }
 
@@ -5064,12 +5131,9 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                     updatePSBuffers();
                 }
 
-                if ( info && !info->IsSame( boundInfo) ) {
-                    materialInfoBuffer.Update( &info->buffer, sizeof( info->buffer ) );
-
-                    // Don't let the game unload the texture after some time
-                    //mesh.first.Texture->CacheIn( 0.6f );
-                    boundInfo = info;
+                if ( lastOffsetId != materialInfoOffset ) {
+                    GetContext()->PSSetConstantBuffers1( materialInfoBuffer.GetSlot(), 1, &materialInfoPoolBuffer, &firstConstant, &numConstants );
+                    lastOffsetId = materialInfoOffset;
                 }
                 bound = mesh.first.Texture;
             }

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -42,6 +42,43 @@ const unsigned int HUD_BUFFER_SIZE = 6 * sizeof( ExVertexStruct );
 const int NUM_MAX_BONES = 96;
 const int unsigned INSTANCING_BUFFER_SIZE = sizeof( VobInstanceInfo ) * 2048;
 
+struct ConstantBufferAllocation {
+    ID3D11Buffer* pBuffer;
+    uint32_t offsetInBytes;
+    uint32_t sizeInBytes;
+};
+
+class ConstantBufferPool {
+private:
+    Microsoft::WRL::ComPtr<ID3D11Buffer> m_poolBuffer;
+    uint32_t m_bufferSize;
+    uint32_t m_currentOffset;
+    uint8_t* m_pMappedData; // CPU pointer when mapped
+
+public:
+    void Initialize( ID3D11Device* device, uint32_t totalSizeInBytes = 4 * 1024 * 1024 ) {
+        m_bufferSize = totalSizeInBytes;
+        m_currentOffset = 0;
+        m_pMappedData = nullptr;
+
+        D3D11_BUFFER_DESC desc = {};
+        desc.ByteWidth = m_bufferSize;
+        desc.Usage = D3D11_USAGE_DYNAMIC;
+        desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+        desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+
+        device->CreateBuffer( &desc, nullptr, &m_poolBuffer );
+#ifdef DEBUG_D3D11
+        SetDebugName( m_poolBuffer.Get(), std::string( "ConstantBufferPool (size:" ) + std::to_string( totalSizeInBytes )+")");
+#endif
+    }
+
+    void BeginFrame( ID3D11DeviceContext* context );
+    ConstantBufferAllocation Allocate( const void* pData, uint32_t sizeInBytes );
+    void EndFrame( ID3D11DeviceContext* context );
+
+    ID3D11Buffer* GetBuffer() const { return m_poolBuffer.Get(); }
+};
 
 class D3D11PointLight;
 class D3D11VShader;
@@ -618,6 +655,7 @@ private:
     std::unique_ptr<D3D11ConstantBuffer> InfiniteRangeConstantBuffer;
     std::unique_ptr<D3D11ConstantBuffer> OutdoorSmallVobsConstantBuffer;
     std::unique_ptr<D3D11ConstantBuffer> OutdoorVobsConstantBuffer;
+    std::unique_ptr<ConstantBufferPool> PerObjectMaterialInfoPooledBuffer;
 
     /** Quads for decals/particles */
     D3D11VertexBuffer* QuadVertexBuffer;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -6388,8 +6388,6 @@ void GothicAPI::CollectVisibleVobs( const RndCullContext& ctx ) {
     bool collectIndoor = ctx.stage != RenderStage::STAGE_DRAW_SHADOWS;
     auto cullingEnabled = RendererState.RendererSettings.DebugSettings.Culling.CullVobs;
 
-    std::list<VobInfo*> removeList; // TODO: This should not be needed!
-
     // Add visible dynamically added vobs
     if ( RendererState.RendererSettings.DrawVOBs ) {
         float dist;
@@ -6407,13 +6405,7 @@ void GothicAPI::CollectVisibleVobs( const RndCullContext& ctx ) {
                     )
                     )
                 ) ) {
-#ifdef BUILD_GOTHIC_1_08k
-                // TODO: This is sometimes nullptr, suggesting that the Vob is invalid. Why does this happen?
-                if ( !it->VobConstantBuffer ) {
-                    removeList.push_back( it );
-                    continue;
-                }
-#endif
+
                 if ( !it->Vob->GetShowVisual() ) {
                     continue;
                 }
@@ -6433,12 +6425,4 @@ void GothicAPI::CollectVisibleVobs( const RndCullContext& ctx ) {
     }
 
     bspVobVisitor.ClearForReuse();
-
-#ifdef BUILD_GOTHIC_1_08k
-    // TODO: See above for info on this
-    for ( VobInfo* vi : removeList ) {
-        RegisteredVobs.insert( vi->Vob ); // This vob isn't in this set anymore, but still in DynamicallyAddedVobs??
-        OnRemovedVob( vi->Vob, oCGame::GetGame()->_zCSession_world );
-    }
-#endif
 }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1748,7 +1748,7 @@ void GothicAPI::OnVobMoved( zCVob* vob ) {
             MoveVobFromBspToDynamic( vi );
         }
 
-        vi->UpdateVobConstantBuffer();
+        vi->UpdateState();
         Engine::GAPI->GetRendererState().RendererInfo.FrameVobUpdates++;
     } else {
         auto sit = SkeletalVobMap.find( vob );
@@ -1760,6 +1760,7 @@ void GothicAPI::OnVobMoved( zCVob* vob ) {
             }
             // This is a mob, remove it from the bsp-cache and add to dynamic list
             MoveVobFromBspToDynamic( vi );
+            vi->UpdateState();
         }
     }
 }
@@ -2225,15 +2226,7 @@ void GothicAPI::OnAddVob( zCVob* vob, zCWorld* world ) {
 
                 vi->VobSection = &WorldSections[section.x][section.y];
                 vi->VobSection->Vobs.push_back( vi );
-
-                // Create this constantbuffer only for non-inventory vobs because it would be recreated for each vob every frame
-                D3D11ConstantBuffer* cb;
-                Engine::GraphicsEngine->CreateConstantBuffer( &cb, nullptr, sizeof( VS_ExConstantBuffer_PerInstance ) );
-#ifdef DEBUG_D3D11
-                SetDebugName( cb->Get().Get(), "VS_ExConstantBuffer_PerInstance::"+vob->GetName());
-#endif
-                vi->VobConstantBuffer.reset(cb);
-                vi->UpdateVobConstantBuffer();
+                vi->UpdateState(); 
 
                 if ( !BspLeafVobLists.empty() ) { // Check if this is the initial loading
                     // It's not, chose this as a dynamically added vob
@@ -2555,10 +2548,6 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
     VS_ExConstantBuffer_PerInstanceNode instanceInfo;
     instanceInfo.Color = modelColor;
 
-    // Init the constantbuffer if not already done
-    if ( !vi->VobConstantBuffer )
-        vi->UpdateVobConstantBuffer();
-
     g->SetupVS_ExMeshDrawCall();
     g->SetupVS_ExConstantBuffer();
 
@@ -2572,6 +2561,7 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
     gtl::flat_hash_map<int, std::vector<MeshVisualInfo*>>& nodeAttachments = vi->NodeAttachments;
     auto vsBufMPI = g->GetActiveVS()->GetBuffer( "Matrices_PerInstances" );
     vsBufMPI.Bind();
+
     for ( unsigned int i = 0; i < transforms.size(); i++ ) {
         // Check for new visual
         zCModel* mvis = static_cast<zCModel*>( vi->Vob->GetVisual() );
@@ -2795,10 +2785,6 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
     VS_ExConstantBuffer_PerInstanceNode instanceInfo;
     instanceInfo.Color = modelColor;
 
-    // Init the constantbuffer if not already done
-    if ( !vi->VobConstantBuffer )
-        vi->UpdateVobConstantBuffer();
-
     g->SetupVS_ExMeshDrawCall();
     g->SetupVS_ExConstantBuffer();
 
@@ -2959,6 +2945,9 @@ void GothicAPI::DrawTransparencyVobs() {
     }
 
     auto psBufGAI = g->GetShaderManager().GetPShader( PShaderID::PS_Transparency )->GetBuffer( "GhostAlphaInfo" );
+
+
+    VS_ExConstantBuffer_PerInstance cbPerInstance;
     while ( !TransparencyVobs.empty() ) {
         auto const& TransVobInfo = TransparencyVobs.front();
 
@@ -2982,7 +2971,9 @@ void GothicAPI::DrawTransparencyVobs() {
         } else if ( TransVobInfo.normalVob ) {
             g->SetActiveVertexShader( VShaderID::VS_Ex );
             g->SetupVS_ExMeshDrawCall();
-            TransVobInfo.normalVob->VobConstantBuffer->BindToVertexShader( 1 );
+            
+            TransVobInfo.normalVob->UpdateVobConstantBuffer( cbPerInstance );
+            g->GetActiveVS()->GetBuffer( 1 ).Update(&cbPerInstance, sizeof(cbPerInstance)).Bind();
 
             // We need to do Z-prepass first
             g->UnbindActivePS();

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -115,23 +115,6 @@ void MaterialInfo::LoadFromFile( const std::string_view name ) {
     fclose( f );
 
     buffer.Color = float4( 1, 1, 1, 1 );
-
-    UpdateConstantbuffer();
-}
-
-/** creates/updates the constantbuffer */
-void MaterialInfo::UpdateConstantbuffer() {
-    if ( Constantbuffer ) {
-        Constantbuffer->UpdateBuffer( &buffer );
-    } else {
-        D3D11ConstantBuffer* cb = nullptr;
-        Engine::GraphicsEngine->CreateConstantBuffer( &cb, &buffer, sizeof( buffer ) );
-#ifdef DEBUG_D3D11
-        SetDebugName( cb->Get().Get(), "ConstantBuffer::MaterialInfo" );
-#endif
-
-        Constantbuffer.reset(cb);
-    }
 }
 
 GothicAPI::GothicAPI() {

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -190,7 +190,6 @@ struct MaterialInfo {
 
     MaterialInfo() :
         PixelShader(static_cast<PShaderID>(0)),
-        Constantbuffer(nullptr),
         MaterialType(MT_None)
     {
         buffer.SpecularIntensity = 0.1f;
@@ -229,11 +228,6 @@ struct MaterialInfo {
                 Color == other.Color;
         }
     };
-
-    /** creates/updates the constantbuffer */
-    void UpdateConstantbuffer();
-
-    std::unique_ptr<D3D11ConstantBuffer> Constantbuffer;
 
     PShaderID PixelShader;
     EMaterialType MaterialType;

--- a/D3D11Engine/ImGuiEditorView.cpp
+++ b/D3D11Engine/ImGuiEditorView.cpp
@@ -256,7 +256,6 @@ void ImGuiEditorView::RenderTextureSelectionPanel() {
             MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom(Selection.SelectedMaterial->GetTexture());
             if (info) {
                 info->buffer.NormalmapStrength = SelectedTexNrmStr;
-                info->UpdateConstantbuffer();
                 info->WriteToFile(Selection.SelectedMaterial->GetTexture()->GetNameWithoutExt());
             }
         }
@@ -269,7 +268,6 @@ void ImGuiEditorView::RenderTextureSelectionPanel() {
             MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom(Selection.SelectedMaterial->GetTexture());
             if (info) {
                 info->buffer.SpecularIntensity = SelectedTexSpecIntens;
-                info->UpdateConstantbuffer();
                 info->WriteToFile(Selection.SelectedMaterial->GetTexture()->GetNameWithoutExt());
             }
         }
@@ -282,7 +280,6 @@ void ImGuiEditorView::RenderTextureSelectionPanel() {
             MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom(Selection.SelectedMaterial->GetTexture());
             if (info) {
                 info->buffer.SpecularPower = SelectedTexSpecPower;
-                info->UpdateConstantbuffer();
                 info->WriteToFile(Selection.SelectedMaterial->GetTexture()->GetNameWithoutExt());
             }
         }

--- a/D3D11Engine/Types.h
+++ b/D3D11Engine/Types.h
@@ -138,10 +138,10 @@ struct float3 {
 
 struct float4 {
     float4( const DWORD& color ) {
-        x = ((color >> 16) & 0xFF) / 255.0f;
-        y = ((color >> 8) & 0xFF) / 255.0f;
-        z = (color & 0xFF) / 255.0f;
-        w = (color >> 24) / 255.0f;
+        x = static_cast<float>((color >> 16) & 0xFF) / 255.0f;
+        y = static_cast<float>((color >> 8) & 0xFF) / 255.0f;
+        z = static_cast<float>(color & 0xFF) / 255.0f;
+        w = static_cast<float>(color >> 24) / 255.0f;
     }
 
     float4( float x, float y, float z, float w ) {

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -9,14 +9,15 @@
 #include "D3D11_Helpers.h"
 
 /** Updates the vobs constantbuffer */
-void VobInfo::UpdateVobConstantBuffer() {
-    VS_ExConstantBuffer_PerInstance cb;
-    XMStoreFloat4x4( &cb.World, Vob->GetWorldMatrixXM() );
+void VobInfo::UpdateVobConstantBuffer(VS_ExConstantBuffer_PerInstance& cb) {
+    UpdateState();
+    cb.World = WorldMatrix;
+    cb.Color = {0.0f, 0.0f, 0.0f, 1.0f};
+}
 
-    VobConstantBuffer->UpdateBuffer( &cb );
-
-    XMStoreFloat3( &LastRenderPosition, Vob->GetPositionWorldXM() );
-    WorldMatrix = cb.World;
+void VobInfo::UpdateState() {
+    WorldMatrix = *Vob->GetWorldMatrixPtr();
+    LastRenderPosition = Vob->GetPositionWorld();
 
     // Colorize the vob according to the underlaying polygon
     if ( IsIndoorVob ) {
@@ -26,27 +27,17 @@ void VobInfo::UpdateVobConstantBuffer() {
         // Get the color of the first found feature of the ground poly
         GroundColor = Vob->GetGroundPoly() ? Vob->GetGroundPoly()->getFeatures()[0]->lightStatic : 0xFFFFFFFF;
     }
-
-    //&WorldMatrix = XMMatrixTranspose(XMLoadFloat4x4(&cb.World));
 }
 
 /** Updates the vobs constantbuffer */
-void SkeletalVobInfo::UpdateVobConstantBuffer() {
-    VS_ExConstantBuffer_PerInstance cb;
-    XMStoreFloat4x4( &cb.World, Vob->GetWorldMatrixXM() );
+void SkeletalVobInfo::UpdateVobConstantBuffer(VS_ExConstantBuffer_PerInstance& cb) {
+    UpdateState();
+    cb.World = WorldMatrix;
+    cb.Color = {0.0f, 0.0f, 0.0f, 1.0f};
+}
 
-    WorldMatrix = cb.World;
-
-    if ( !VobConstantBuffer ) {
-        D3D11ConstantBuffer* d3dcb;
-        Engine::GraphicsEngine->CreateConstantBuffer( &d3dcb, &cb, sizeof( cb ) );
-        VobConstantBuffer.reset(d3dcb);
-#ifdef DEBUG_D3D11
-        SetDebugName( VobConstantBuffer->Get().Get(), "VS_ExConstantBuffer_PerInstance::"+Vob->GetName());
-#endif
-    } else {
-        VobConstantBuffer->UpdateBuffer( &cb );
-    }
+void SkeletalVobInfo::UpdateState() {
+    WorldMatrix = *Vob->GetWorldMatrixPtr();
 }
 
 SectionInstanceCache::~SectionInstanceCache() {

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -312,10 +312,8 @@ struct VobInfo : public BaseVobInfo {
     ~VobInfo() override = default;
 
     /** Updates the vobs constantbuffer */
-    void UpdateVobConstantBuffer();
-
-    /** Constantbuffer which holds this vobs world matrix */
-    std::unique_ptr<D3D11ConstantBuffer> VobConstantBuffer;
+    void UpdateVobConstantBuffer(VS_ExConstantBuffer_PerInstance& cb);
+    void UpdateState();
 
     /** Position the vob was at while being rendered last time */
     XMFLOAT3 LastRenderPosition;
@@ -420,8 +418,9 @@ struct SkeletalVobInfo : public BaseVobInfo {
     }
 
     /** Updates the vobs constantbuffer */
-    void UpdateVobConstantBuffer();
-
+    void UpdateVobConstantBuffer(VS_ExConstantBuffer_PerInstance& cb);
+    void UpdateState();
+    
     void StorePreviousTransforms( const std::vector<XMFLOAT4X4>& currentTransforms ) {
         PrevBoneTransforms = currentTransforms;
         // PrevWorldMatrix = WorldMatrix; // can't be trusted yet, as Instanced drawing doesn't set it.


### PR DESCRIPTION
- Removes per Vob / Skeletalvob constant buffers
  - Main code did not use for skeletal vob anyways, now also no longer used for VobInfo
- Introduce VobInfo/SkelVobInfo->UpdateState() for usage with OnVobAdded/Moved instead of updating constant buffer
- remove per-texture MaterialInfo ConstantBuffer. Instead use by-shader buffer / pooled buffer (dx11.1)


These changes improve memory usage a lot.
Gothic 2 New Balance for example no longer shows out of memory warning right at game start.
Memory went down from ~2.7GiB to around ~1.5 GiB depending on location (tested khorinis city center)

**WITH CHANGES:**
<img width="2559" height="1437" alt="image" src="https://github.com/user-attachments/assets/4dea439a-ad06-4b93-aaa4-83ec1dcceaef" />

**WITHOUT CHANGES:**
<img width="2553" height="1437" alt="image" src="https://github.com/user-attachments/assets/8524cd43-af54-4ddb-a520-6cfd7dd023f8" />
