### PR TITLE
fix #373 - always update particleFX if close to player, fix pointlight memory leak

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -5345,7 +5345,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
     FXMVECTOR position, float range, bool cullFront, bool indoor,
     bool noNPCs, std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
-    std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache,
+    std::vector<std::pair<MeshKey, MeshInfo*>>* worldMeshCache,
     unsigned int casterMask ) {
 
     // Setup renderstates
@@ -5690,7 +5690,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
     FXMVECTOR position, float range, bool cullFront, bool indoor,
     bool noNPCs, std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
-    std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache,
+    std::vector<std::pair<MeshKey, MeshInfo*>>* worldMeshCache,
     unsigned int casterMask ) {
 
     // Setup renderstates
@@ -7883,7 +7883,7 @@ void XM_CALLCONV D3D11GraphicsEngine::RenderShadowCube(
     Microsoft::WRL::ComPtr<ID3D11RenderTargetView> debugRTV, bool cullFront, bool indoor, bool noNPCs,
     std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
-    std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache,
+    std::vector<std::pair<MeshKey, MeshInfo*>>* worldMeshCache,
     bool clearDepth,
     unsigned int casterMask ) {
     

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -284,14 +284,14 @@ public:
         bool cullFront = true,
         bool indoor = false,
         bool noNPCs = false,
-        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache = nullptr,
+        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::vector<std::pair<MeshKey, MeshInfo*>>* worldMeshCache = nullptr,
         unsigned int casterMask = SHADOW_CASTER_ALL );
     void XM_CALLCONV DrawWorldAround_Layered( FXMVECTOR position,
         float range,
         bool cullFront = true,
         bool indoor = false,
         bool noNPCs = false,
-        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache = nullptr,
+        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::vector<std::pair<MeshKey, MeshInfo*>>* worldMeshCache = nullptr,
         unsigned int casterMask = SHADOW_CASTER_ALL );
 
     /** Update morph mesh visual */
@@ -322,7 +322,7 @@ public:
         bool cullFront = true,
         bool indoor = false,
         bool noNPCs = false,
-        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache = nullptr,
+        std::list<VobInfo*>* renderedVobs = nullptr, std::list<SkeletalVobInfo*>* renderedMobs = nullptr, std::vector<std::pair<MeshKey, MeshInfo*>>* worldMeshCache = nullptr,
         bool clearDepth = true,
         unsigned int casterMask = SHADOW_CASTER_ALL );
 

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -195,7 +195,7 @@ void D3D11PointLight::RenderStaticShadowPass( RenderToDepthStencilBuffer& target
     D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
     const float range = LightInfo->Vob->GetLightRange();
 
-    std::map<MeshKey, MeshInfo*, cmpMeshKey>* wc = &WorldMeshCache;
+    auto wc = &WorldMeshCache;
     if ( WorldCacheInvalid ) {
         wc = nullptr;
     }
@@ -233,6 +233,9 @@ void D3D11PointLight::InitResources() {
     // Generate worldmesh cache if we aren't a dynamically added light
     if ( !DynamicLight ) {
         WorldConverter::WorldMeshCollectPolyRange( LightInfo->Vob->GetPositionWorld(), LightInfo->Vob->GetLightRange(), Engine::GAPI->GetWorldSections(), WorldMeshCache );
+        std::ranges::sort(WorldMeshCache, []( const auto& a, const auto& b ) {
+            return std::tie(a.first.Material, a.first.Texture) < std::tie(b.first.Material, b.first.Texture);
+        });
         WorldCacheInvalid = false;
     } else {
         WorldCacheInvalid = true;
@@ -438,7 +441,7 @@ void D3D11PointLight::RenderFullCubemap() {
         return;
     }
 
-    std::map<MeshKey, MeshInfo*, cmpMeshKey>* wc = &WorldMeshCache;
+    auto wc = &WorldMeshCache;
     if ( WorldCacheInvalid ) {
         wc = nullptr;
     }

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -91,7 +91,7 @@ protected:
 
     std::list<VobInfo*> VobCache;
     std::list<SkeletalVobInfo*> SkeletalVobCache;
-    std::map<MeshKey, MeshInfo*, cmpMeshKey> WorldMeshCache;
+    std::vector<std::pair<MeshKey, MeshInfo*>> WorldMeshCache;
     bool WorldCacheInvalid;
 
     VobLightInfo* LightInfo;

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1560,7 +1560,7 @@ void XM_CALLCONV D3D11ShadowMap::RenderShadowCube(
     Microsoft::WRL::ComPtr<ID3D11RenderTargetView> debugRTV, bool cullFront, bool indoor, bool noNPCs,
     std::list<VobInfo*>* renderedVobs,
     std::list<SkeletalVobInfo*>* renderedMobs,
-    std::map<MeshKey, MeshInfo*, cmpMeshKey>* worldMeshCache,
+    std::vector<std::pair<MeshKey, MeshInfo*>>* worldMeshCache,
     bool clearDepth,
     unsigned int casterMask ) {
 

--- a/D3D11Engine/D3D11ShadowMap.h
+++ b/D3D11Engine/D3D11ShadowMap.h
@@ -160,9 +160,7 @@ public:
         bool noNPCs = false,
         std::list<VobInfo*>* renderedVobs = nullptr, 
         std::list<SkeletalVobInfo*>* renderedMobs = nullptr,
-        std::map<MeshKey,
-        MeshInfo*,
-        cmpMeshKey>* worldMeshCache = nullptr,
+        std::vector<std::pair<MeshKey, MeshInfo*>>* worldMeshCache = nullptr,
         bool clearDepth = true,
         unsigned int casterMask = 0xFFFFFFFFu );
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1377,7 +1377,6 @@ void GothicAPI::DrawParticlesSimple(
 
     if ( RendererState.RendererSettings.DrawParticleEffects ) {
         std::vector<zCVob*> renderedParticleFXs;
-        zCCamera::GetCamera()->Activate();
         GetVisibleParticleEffectsList( renderedParticleFXs );
 
         // now it is save to render
@@ -1606,14 +1605,26 @@ void GothicAPI::GetVisibleParticleEffectsList( std::vector<zCVob*>& pfxList ) {
     if ( RendererState.RendererSettings.DrawParticleEffects ) {
         FXMVECTOR camPos = GetCameraPositionXM();
 
-        // now it is save to render
-        float dist;
-        for ( auto const& it : ParticleEffectVobs ) {
-            XMStoreFloat( &dist, XMVector3Length( it->GetPositionWorldXM() - camPos ) );
-            if ( dist > RendererState.RendererSettings.VisualFXDrawRadius )
-                continue;
+        auto sceneCam = reinterpret_cast<zCCamera*>(oCGame::GetGame()->_zCSession_camera);
+        if ( !sceneCam ) {
+            // No camera??
+            return;
+        }
 
-            if ( GetCameraBBox3DInFrustum( it->GetBBox(), EGothicCullFlags::CullSides ) == ZTCAM_CLIPTYPE_OUT ) {
+        const XMVECTOR vVfxRangeSq = XMVectorReplicate( RendererState.RendererSettings.VisualFXDrawRadius * RendererState.RendererSettings.VisualFXDrawRadius );
+
+        for ( auto const& it : ParticleEffectVobs ) {
+            if ( XMVector3Greater( XMVector3LengthSq( it->GetPositionWorldXM() - camPos ), vVfxRangeSq ) ) {
+                // too far? It's ok for particles to not update and restart.
+                continue;
+            }
+
+            INT clipFlags = EGothicCullFlags::CullSides;
+            if ( sceneCam->BBox3DInFrustum( it->GetBBox(), clipFlags ) == ZTCAM_CLIPTYPE_OUT ) {
+                if ( auto vis = it->GetVisual() ) {
+                    // Do update particle state, even if not in frustum, so that if player turns back to it, it doesn't restart.
+                    reinterpret_cast<zCParticleFX*>(vis)->UpdateParticleFX();
+                }
                 continue;
             }
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1623,7 +1623,11 @@ void GothicAPI::GetVisibleParticleEffectsList( std::vector<zCVob*>& pfxList ) {
             if ( sceneCam->BBox3DInFrustum( it->GetBBox(), clipFlags ) == ZTCAM_CLIPTYPE_OUT ) {
                 if ( auto vis = it->GetVisual() ) {
                     // Do update particle state, even if not in frustum, so that if player turns back to it, it doesn't restart.
-                    reinterpret_cast<zCParticleFX*>(vis)->UpdateParticleFX();
+                    auto particleFx = reinterpret_cast<zCParticleFX*>(vis);
+                    particleFx->UpdateParticleFX();
+                    if ( !particleFx->GetVisualDied() ) {
+                        zCParticleFX::GetStaticPFXList()->TouchPfx( particleFx );
+                    }
                 }
                 continue;
             }
@@ -3211,7 +3215,7 @@ void GothicAPI::DrawParticleFX( zCVob* source, zCParticleFX* fx, ParticleFrameDa
             connectedVob->GetHomeWorld()->RemoveVob( connectedVob );
         }
     } else {
-        fx->GetStaticPFXList()->TouchPfx( fx );
+        zCParticleFX::GetStaticPFXList()->TouchPfx( fx );
     }
 }
 

--- a/D3D11Engine/Toolbox.cpp
+++ b/D3D11Engine/Toolbox.cpp
@@ -108,25 +108,6 @@ namespace Toolbox {
         }
     }
 
-    static std::size_t hash_value( float value ) {
-        std::hash<float> hasher;
-        return hasher( value );
-    }
-
-    static std::size_t hash_value( DWORD value ) {
-        std::hash<DWORD> hasher;
-        return hasher( value );
-    }
-
-    static void hash_combine( std::size_t& seed, float value ) {
-        seed ^= hash_value( value ) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    }
-
-    /** Hashes the given DWORD value */
-    void hash_combine( std::size_t& seed, DWORD value ) {
-        seed ^= hash_value( value ) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    }
-
     /** Returns true if the given position is inside the box */
     bool PositionInsideBox( const XMFLOAT3& p, const XMFLOAT3& min, const XMFLOAT3& max ) {
         if ( p.x > min.x &&

--- a/D3D11Engine/Toolbox.h
+++ b/D3D11Engine/Toolbox.h
@@ -123,11 +123,14 @@ namespace Toolbox {
     /** Checks if a folder exists */
     bool FolderExists( const std::string& dirName_in );
 
+    template<typename T>
+    inline size_t hash_value( T value ) { return std::hash<T>()( value ); }
+    
     /** Hashes the given float value */
-    void hash_combine( std::size_t& seed, float value );
-
-    /** Hashes the given DWORD value */
-    void hash_combine( std::size_t& seed, DWORD value );
+    template<typename T>
+    inline void hash_combine( std::size_t& seed, T value ) {
+        seed ^= std::hash<T>()( value ) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    }
 
     /** Returns true if the given position is inside the box */
     bool PositionInsideBox( const XMFLOAT3& p, const XMFLOAT3& min, const XMFLOAT3& max );

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -70,7 +70,8 @@ namespace {
 }
 
 /** Collects all world-polys in the specific range. Drops all materials that have no alphablending */
-void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float range, std::map<int, std::map<int, WorldMeshSectionInfo>>& inSections, std::map<MeshKey, MeshInfo*, cmpMeshKey>& outMeshes ) {
+void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float range, std::map<int, std::map<int, WorldMeshSectionInfo>>& inSections, 
+    std::vector<std::pair<MeshKey, MeshInfo*>>& outMeshes ) {
     ZoneScoped;
 
     INT2 s = GetSectionOfPos( position );
@@ -80,7 +81,7 @@ void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float ra
     opaqueKey.Texture = nullptr;
 
     MeshInfo* opaqueMesh = new MeshInfo;
-    outMeshes[opaqueKey] = opaqueMesh;
+    outMeshes.emplace_back(opaqueKey, opaqueMesh);
 
     FXMVECTOR xmPosition = XMLoadFloat3( position.toXMFLOAT3() );
 
@@ -96,17 +97,27 @@ void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float ra
             if ( len < 2 ) {
                 // Check all polys from all meshes
                 for ( auto const& it : ity.second.WorldMeshes ) {
-                    MeshInfo* m;
+                    MeshInfo* m = nullptr;
 
                     // Create new mesh-part for alphatested surfaces
                     if ( it.first.Texture && it.first.Texture->HasAlphaChannel() ) {
-                        m = new MeshInfo;
-                        outMeshes[it.first] = m;
+                        for (auto [key, msh] : outMeshes) {
+                            if (it.first == key) {
+                                m = msh;
+                                break;
+                            }
+                        }
+                        if ( m == nullptr ) {
+                            m = new MeshInfo;
+                            outMeshes.emplace_back(it.first, m);
+                        }
                     } else {
                         // Just use the same mesh for opaque surfaces
                         m = opaqueMesh;
                     }
 
+                    // reserve required size beforehand to avoid multiple reallocations
+                    m->Vertices.reserve( it.second->Vertices.size() );
                     for ( unsigned int i = 0; i < it.second->Indices.size(); i += 3 ) {
                         // Check if one of them is in range
 
@@ -127,42 +138,48 @@ void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float ra
     }
 
     // Index all meshes
-    for ( auto it = outMeshes.begin(); it != outMeshes.end();) {
-        if ( it->second->Vertices.empty() ) {
-            it = outMeshes.erase( it );
+    for ( size_t i = 0; i < outMeshes.size(); ) {
+        auto it = outMeshes[i];
+
+        if ( it.second->Vertices.empty() ) {
+            delete it.second;
+            if ( i != outMeshes.size() - 1 ) {
+                outMeshes[i] = std::move( outMeshes.back() );
+            }
+            outMeshes.pop_back();
             continue;
         }
 
         std::vector<VERTEX_INDEX> indices;
         std::vector<ExVertexStruct> vertices;
-        IndexVertices( &it->second->Vertices[0], it->second->Vertices.size(), vertices, indices );
+        IndexVertices( &it.second->Vertices[0], it.second->Vertices.size(), vertices, indices );
 
-        it->second->Vertices = std::move( vertices );
-        it->second->Indices = std::move( indices );
+        it.second->Vertices = std::move( vertices );
+        it.second->Indices = std::move( indices );
 
         // Create the buffers
-        Engine::GraphicsEngine->CreateVertexBuffer( &it->second->MeshVertexBuffer );
-        Engine::GraphicsEngine->CreateVertexBuffer( &it->second->MeshIndexBuffer );
+        Engine::GraphicsEngine->CreateVertexBuffer( &it.second->MeshVertexBuffer );
+        Engine::GraphicsEngine->CreateVertexBuffer( &it.second->MeshIndexBuffer );
 
         // Optimize index and vertex locality before uploading immutable buffers.
-        it->second->MeshVertexBuffer->OptimizeFaces( it->second->Indices.data(),
-            reinterpret_cast<byte*>( it->second->Vertices.data() ),
-            it->second->Indices.size(),
-            it->second->Vertices.size(),
+        it.second->MeshVertexBuffer->OptimizeFaces( it.second->Indices.data(),
+            reinterpret_cast<byte*>( it.second->Vertices.data() ),
+            it.second->Indices.size(),
+            it.second->Vertices.size(),
             sizeof( ExVertexStruct ) );
-        it->second->MeshVertexBuffer->OptimizeVertices( it->second->Indices.data(),
-            reinterpret_cast<byte*>( it->second->Vertices.data() ),
-            it->second->Indices.size(),
-            it->second->Vertices.size(),
+        it.second->MeshVertexBuffer->OptimizeVertices( it.second->Indices.data(),
+            reinterpret_cast<byte*>( it.second->Vertices.data() ),
+            it.second->Indices.size(),
+            it.second->Vertices.size(),
             sizeof( ExVertexStruct ),
-            &it->second->ShadowIndices );
+            &it.second->ShadowIndices );
 
         // Init and fill them
-        it->second->MeshVertexBuffer->Init( &it->second->Vertices[0], it->second->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
-        it->second->MeshIndexBuffer->Init( &it->second->Indices[0], it->second->Indices.size() * sizeof( VERTEX_INDEX ), D3D11VertexBuffer::B_INDEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
-        CreateShadowIndexBuffer( it->second );
-
-        ++it;
+        it.second->MeshVertexBuffer->Init( &it.second->Vertices[0], it.second->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
+        it.second->MeshIndexBuffer->Init( &it.second->Indices[0], it.second->Indices.size() * sizeof( VERTEX_INDEX ), D3D11VertexBuffer::B_INDEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
+        CreateShadowIndexBuffer( it.second );
+        
+        ++i;
     }
 }
 
@@ -199,7 +216,7 @@ XRESULT WorldConverter::LoadWorldMeshFromFile( const std::string& file, std::map
     std::vector<MeshInfo*>& meshes = mesh->GetMeshes();
     std::vector<std::string>& textures = mesh->GetTextures();
     std::map<std::string, D3D11Texture*> loadedTextures;
-    std::set<std::string> missingTextures;
+    gtl::flat_hash_set<std::string> missingTextures;
 
     // run through meshes and pack them into sections
     for ( unsigned int m = 0; m < meshes.size(); m++ ) {
@@ -1578,7 +1595,7 @@ void WorldConverter::IndexVertices( ExVertexStruct* input, unsigned int numInput
     int index = 0;
 
     for ( unsigned int i = 0; i < numInputVertices; i++ ) {
-        std::set<std::pair<ExVertexStruct, int>>::iterator it = vertices.find( std::make_pair( input[i], 0/*this value doesn't matter*/ ) );
+        auto it = vertices.find( std::make_pair( input[i], 0/*this value doesn't matter*/ ) );
         if ( it != vertices.end() ) outIndices.emplace_back( it->second );
         else {
             vertices.insert( std::make_pair( input[i], index ) );
@@ -1586,30 +1603,10 @@ void WorldConverter::IndexVertices( ExVertexStruct* input, unsigned int numInput
         }
     }
 
-    // TODO: Remove this and fix it properly!
-    /*for (std::set<std::pair<ExVertexStruct, int>>::iterator it=vertices.begin(); it!=vertices.end(); it++)
-    {
-        if ( static_cast<size_t>(it->second) >= vertices.size() )
-        {
-             // TODO: Investigate!
-            it = vertices.erase(it);
-            continue;
-        }
-    }
-
-    for (std::vector<VERTEX_INDEX>::iterator it=outIndices.begin(); it!=outIndices.end(); it++)
-    {
-        if ( static_cast<size_t>(*it) >= vertices.size() )
-        {
-             // TODO: Investigate!
-            it = outIndices.erase(it);
-            continue;
-        }
-    }*/
-
     // Check for overlaying triangles and throw them out
     // Some mods do that for the worldmesh for example
-    std::set<std::tuple<VERTEX_INDEX, VERTEX_INDEX, VERTEX_INDEX>> triangles;
+    gtl::flat_hash_set<std::tuple<VERTEX_INDEX, VERTEX_INDEX, VERTEX_INDEX>> triangles;
+    triangles.reserve( outIndices.size() / 3 );
     for ( size_t i = 0; i < outIndices.size(); i += 3 ) {
         // Insert every combination of indices here. Duplicates will be ignored
         triangles.insert( std::make_tuple( outIndices[i + 0], outIndices[i + 1], outIndices[i + 2] ) );
@@ -1643,7 +1640,7 @@ void WorldConverter::IndexVertices( ExVertexStruct* input, unsigned int numInput
     unsigned int index = 0;
 
     for ( unsigned int i = 0; i < numInputVertices; i++ ) {
-        std::set<std::pair<ExVertexStruct, int>>::iterator it = vertices.find( std::make_pair( input[i], 0/*this value doesn't matter*/ ) );
+        auto it = vertices.find( std::make_pair( input[i], 0/*this value doesn't matter*/ ) );
         if ( it != vertices.end() ) outIndices.emplace_back( it->second );
         else {
             vertices.insert( std::make_pair( input[i], index ) );

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -28,7 +28,7 @@ public:
     virtual ~WorldConverter();
 
     /** Collects all world-polys in the specific range. Drops all materials that have no alphablending */
-    static void WorldMeshCollectPolyRange( const float3& position, float range, std::map<int, std::map<int, WorldMeshSectionInfo>>& inSections, std::map<MeshKey, MeshInfo*, cmpMeshKey>& outMeshes );
+    static void WorldMeshCollectPolyRange( const float3& position, float range, std::map<int, std::map<int, WorldMeshSectionInfo>>& inSections, std::vector<std::pair<MeshKey, MeshInfo*>>& outMeshes );
 
     /** Converts the worldmesh into a more usable format */
     static HRESULT ConvertWorldMesh( zCPolygon** polys, unsigned int numPolygons, std::map<int, std::map<int, WorldMeshSectionInfo>>* outSections, WorldInfo* info, MeshInfo** outWrappedMesh, bool indoorLocation );

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -54,28 +54,26 @@ struct MeshKey {
     zCMaterial* Material;
     MaterialInfo* Info;
     //zCLightmap* Lightmap;
+    
+    bool operator==( const MeshKey& other ) const {
+        return Material == other.Material
+            && Texture == other.Texture;
+    }
 };
 
 struct cmpMeshKey {
     bool operator()( const MeshKey& a, const MeshKey& b ) const {
-        return (a.Material != b.Material) 
-            ? (a.Material < b.Material)
-            : (a.Texture < b.Texture);
+        return std::tie(a.Material, a.Texture) < std::tie(b.Material, b.Texture);
     }
 };
 
-/*struct MeshKey
-{
-    zCMaterial* Material;
-    zCLightmap* Lightmap;
-};
-
-struct cmpMeshKey {
-    bool operator()(const MeshKey& a, const MeshKey& b) const
-    {
-        return (a.Material<b.Material) || (a.Material == b.Material && a.Lightmap<b.Lightmap);
+struct meshKeyHasher {
+    size_t operator()( const MeshKey& a ) const {
+        size_t seed = reinterpret_cast<size_t>(a.Material);
+        Toolbox::hash_combine(seed, reinterpret_cast<size_t>(a.Texture));
+        return seed;
     }
-};*/
+};
 
 /** Holds information about a mesh, ready to be loaded into the renderer */
 struct MeshInfo {

--- a/D3D11Engine/zCParticleFX.h
+++ b/D3D11Engine/zCParticleFX.h
@@ -242,7 +242,7 @@ public:
         reinterpret_cast<void( __fastcall* )( zCParticleFX* )>( GothicMemoryLocations::zCParticleFX::CheckDependentEmitter )( this );
     }
 
-    zCStaticPfxList* GetStaticPFXList() {
+    static zCStaticPfxList* GetStaticPFXList() {
         return reinterpret_cast<zCStaticPfxList*>(GothicMemoryLocations::zCParticleFX::OBJ_s_pfxList);
     }
 

--- a/D3D11Engine/zCParticleFX.h
+++ b/D3D11Engine/zCParticleFX.h
@@ -234,8 +234,8 @@ public:
         return reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCParticleFX::Offset_PrivateTotalTime ));
     }
 
-    int UpdateParticleFX() {
-        return reinterpret_cast<int( __fastcall* )( zCParticleFX* )>( GothicMemoryLocations::zCParticleFX::UpdateParticleFX )( this );
+    void UpdateParticleFX() {
+        reinterpret_cast<void( __fastcall* )( zCParticleFX* )>( GothicMemoryLocations::zCParticleFX::UpdateParticleFX )( this );
     }
 
     void CheckDependentEmitter() {


### PR DESCRIPTION
- always update particleFX if close to player, even if not inside frustum, but don't draw them.
- fix memory leak in `WorldConverter::WorldMeshCollectPolyRange` when world mesh part has no verticies in range.
- instead of std::map/std::set use contiguous storage where appropriate, like for finding "duplicate" verticies, or for the pointlight world mesh cache.