### PR TITLE
feat: load some textures as immutable, Fix some more vegetation placement stuff, more VDF support for renderer resources

### DIFF
--- a/D3D11Engine/D3D11DeferredRenderer.cpp
+++ b/D3D11Engine/D3D11DeferredRenderer.cpp
@@ -155,14 +155,18 @@ bool D3D11DeferredRenderer::BindShaderForTexture( D3D11ShaderManager& shaderMana
     } else if ( texture->HasAlphaChannel() || forceAlphaTest ) {
         if ( texture->GetSurface()->GetFxMap() ) {
             newShader = shaderManager.GetPShader( resolvedDiffuseNormalmappedAlphatestFxMap );
+        } else if ( texture->GetSurface()->GetNormalmap() || Engine::GAPI->GetSceneWetness() > 1e-6 ) {
+            newShader = shaderManager.GetPShader( resolvedDiffuseNormalmappedAlphatest ); 
         } else {
-            newShader = shaderManager.GetPShader( resolvedDiffuseNormalmappedAlphatest );
+            newShader = shaderManager.GetPShader( PShaderID::PS_DiffuseAlphaTest );
         }
     } else {
         if ( texture->GetSurface()->GetFxMap() ) {
             newShader = shaderManager.GetPShader( resolvedDiffuseNormalmappedFxMap );
-        } else {
+        } else if ( texture->GetSurface()->GetNormalmap() || Engine::GAPI->GetSceneWetness() > 1e-6 ) {
             newShader = shaderManager.GetPShader( resolvedDiffuseNormalmapped );
+        } else {
+            newShader = shaderManager.GetPShader( PShaderID::PS_Diffuse );
         }
     }
 

--- a/D3D11Engine/D3D11ForwardPlusRenderer.cpp
+++ b/D3D11Engine/D3D11ForwardPlusRenderer.cpp
@@ -367,14 +367,18 @@ bool D3D11ForwardPlusRenderer::BindShaderForTexture(
     if ( texture->HasAlphaChannel() || forceAlphaTest ) {
         if ( texture->GetSurface()->GetFxMap() ) {
             newShader = shaderManager.GetPShader( PShaderID::PS_FP_DiffuseNormalmappedAlphaTestFxMap );
-        } else {
+        } else if ( texture->GetSurface()->GetNormalmap() || Engine::GAPI->GetSceneWetness() > 1e-6 ) {
             newShader = shaderManager.GetPShader( PShaderID::PS_FP_DiffuseNormalmappedAlphaTest );
+        } else {
+            newShader = shaderManager.GetPShader( PShaderID::PS_FP_DiffuseAlphaTest );
         }
     } else {
         if ( texture->GetSurface()->GetFxMap() ) {
             newShader = shaderManager.GetPShader( PShaderID::PS_FP_DiffuseNormalmappedFxMap );
-        } else {
+        } else if ( texture->GetSurface()->GetNormalmap() || Engine::GAPI->GetSceneWetness() > 1e-6 ) {
             newShader = shaderManager.GetPShader( PShaderID::PS_FP_DiffuseNormalmapped );
+        } else {
+            newShader = shaderManager.GetPShader( PShaderID::PS_FP_Diffuse );
         }
     }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -843,8 +843,7 @@ XRESULT D3D11GraphicsEngine::Init() {
 
     WhiteTexture = std::make_unique<D3D11Texture>();
     uint32_t whitePixel = 0xFFFFFFFF;
-    WhiteTexture->Init( {1,1}, D3D11Texture::ETextureFormat::TF_B8G8R8A8, 1, nullptr, "FULL_WHITE_ALPHA_OPAQUE.static-memory");
-    WhiteTexture->UpdateData( &whitePixel, 0 );
+    WhiteTexture->Init( {1,1}, D3D11Texture::ETextureFormat::TF_B8G8R8A8, 1, &whitePixel, "FULL_WHITE_ALPHA_OPAQUE.static-memory");
 
     InverseUnitSphereMesh = new GMesh;
     InverseUnitSphereMesh->LoadMesh( "system\\GD3D11\\meshes\\icoSphere.obj" );

--- a/D3D11Engine/D3D11Texture.cpp
+++ b/D3D11Engine/D3D11Texture.cpp
@@ -7,6 +7,7 @@
 #include "RenderToTextureBuffer.h"
 #include "D3D11_Helpers.h"
 #include "TextureConversions.h"
+#include "zFILE_VDFS.h"
 
 extern bool NativeSupport16BitTextures;
 static unsigned char* ConvertedData = nullptr;
@@ -85,19 +86,50 @@ XRESULT D3D11Texture::Init( const std::string& file ) {
     D3D11GraphicsEngineBase* engine = reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine);
 
     //LogInfo() << "Loading Engine-Texture: " << file;
-
     Microsoft::WRL::ComPtr<ID3D11Texture2D> res;
-    LE( CreateDDSTextureFromFileEx(
-        engine->GetDevice().Get(),
-        Toolbox::ToWideChar( file.c_str() ).c_str(),
-        0,  // maxsize (0 means no limit)
-        D3D11_USAGE_IMMUTABLE,
-        D3D11_BIND_SHADER_RESOURCE,
-        0, // cpuAccessFlags (0 for immutable)
-        0, // miscFlags
-        DirectX::DDS_LOADER_DEFAULT,
-        reinterpret_cast<ID3D11Resource**>(res.ReleaseAndGetAddressOf()),
-        ShaderResourceView.GetAddressOf()) );
+    if ( std::filesystem::path( file ).is_absolute() ) {
+        LE( CreateDDSTextureFromFileEx(
+            engine->GetDevice().Get(),
+            Toolbox::ToWideChar( file.c_str() ).c_str(),
+            0,  // maxsize (0 means no limit)
+            D3D11_USAGE_IMMUTABLE,
+            D3D11_BIND_SHADER_RESOURCE,
+            0, // cpuAccessFlags (0 for immutable)
+            0, // miscFlags
+            DirectX::DDS_LOADER_DEFAULT,
+            reinterpret_cast<ID3D11Resource**>(res.ReleaseAndGetAddressOf()),
+            ShaderResourceView.GetAddressOf()) );
+    } else {
+        std::vector<uint8_t> fileData;
+        
+        zFILE_VDFS::Ptr vdfsFile;
+        if ( !file.empty() && file[0] != '\\' ) {
+            vdfsFile = zFILE_VDFS::Create( ("\\" + file).c_str());
+        } else {
+            vdfsFile = zFILE_VDFS::Create( file.c_str() );
+        }
+        if ( !vdfsFile || !vdfsFile->Exists() || vdfsFile->Open(false) != zERROR_NONE ) {
+            LogError() << "Failed to load texture from VDFS: " << file;
+            return XR_FAILED;
+        }
+        fileData.resize( vdfsFile->Size() );
+        vdfsFile->Read( fileData.data(), fileData.size() );
+        vdfsFile->Close();
+
+        LE( CreateDDSTextureFromMemoryEx(
+            engine->GetDevice().Get(),
+            fileData.data(),
+            fileData.size(),
+            0,  // maxsize (0 means no limit)
+            D3D11_USAGE_IMMUTABLE,
+            D3D11_BIND_SHADER_RESOURCE,
+            0, // cpuAccessFlags (0 for immutable)
+            0, // miscFlags
+            DirectX::DDS_LOADER_DEFAULT,
+            reinterpret_cast<ID3D11Resource**>(res.ReleaseAndGetAddressOf()),
+            ShaderResourceView.GetAddressOf() ) );
+    }
+
 
     if ( !ShaderResourceView.Get() || !res.Get() )
         return XR_FAILED;

--- a/D3D11Engine/D3D11Texture.cpp
+++ b/D3D11Engine/D3D11Texture.cpp
@@ -57,9 +57,15 @@ XRESULT D3D11Texture::Init( INT2 size, ETextureFormat format, UINT mipMapCount, 
         size.y,
         1,
         mipMapCount,
-        D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0, 1, 0, 0 );
+        D3D11_BIND_SHADER_RESOURCE, data ? D3D11_USAGE_IMMUTABLE : D3D11_USAGE_DEFAULT, 0, 1, 0, 0 );
 
-    LE( engine->GetDevice()->CreateTexture2D( &textureDesc, nullptr, Texture.ReleaseAndGetAddressOf() ) );
+    D3D11_SUBRESOURCE_DATA initialData = {};
+    initialData.pSysMem = data;
+    if ( format == ETextureFormat::TF_B8G8R8A8 ) {
+        initialData.SysMemPitch = size.x * 4;
+    }
+
+    LE( engine->GetDevice()->CreateTexture2D( &textureDesc, data ? &initialData : nullptr, Texture.ReleaseAndGetAddressOf() ) );
     SetDebugName( Texture.Get(), "D3D11Texture(\"" + fileName + "\")->Texture" );
 
     D3D11_SHADER_RESOURCE_VIEW_DESC descRV = {};
@@ -81,8 +87,17 @@ XRESULT D3D11Texture::Init( const std::string& file ) {
     //LogInfo() << "Loading Engine-Texture: " << file;
 
     Microsoft::WRL::ComPtr<ID3D11Texture2D> res;
-    LE( CreateDDSTextureFromFile( engine->GetDevice().Get(), Toolbox::ToWideChar( file.c_str() ).c_str(),
-        reinterpret_cast<ID3D11Resource**>(res.ReleaseAndGetAddressOf()), ShaderResourceView.GetAddressOf() ) );
+    LE( CreateDDSTextureFromFileEx(
+        engine->GetDevice().Get(),
+        Toolbox::ToWideChar( file.c_str() ).c_str(),
+        0,  // maxsize (0 means no limit)
+        D3D11_USAGE_IMMUTABLE,
+        D3D11_BIND_SHADER_RESOURCE,
+        0, // cpuAccessFlags (0 for immutable)
+        0, // miscFlags
+        DirectX::DDS_LOADER_DEFAULT,
+        reinterpret_cast<ID3D11Resource**>(res.ReleaseAndGetAddressOf()),
+        ShaderResourceView.GetAddressOf()) );
 
     if ( !ShaderResourceView.Get() || !res.Get() )
         return XR_FAILED;

--- a/D3D11Engine/GVegetationBox.cpp
+++ b/D3D11Engine/GVegetationBox.cpp
@@ -375,15 +375,14 @@ void GVegetationBox::VisualizeGrass( const XMFLOAT4& color ) {
             continue; // Only render every 10th grassmesh
 
         XMFLOAT3 spot = XMFLOAT3( VegetationSpots[i]._14, VegetationSpots[i]._24, VegetationSpots[i]._34 );
-        XMFLOAT3 scale;
 
-        // Compute scale
-        //XMStoreFloat(&scale.x, XMVector3Length( XMVectorSet(VegetationSpots[i]._11, VegetationSpots[i]._21, VegetationSpots[i]._31, 0) ));
-        XMStoreFloat( &scale.y, XMVector3Length( XMVectorSet( VegetationSpots[i]._12, VegetationSpots[i]._22, VegetationSpots[i]._32, 0 ) ) );
-        //XMStoreFloat(&scale.z, XMVector3Length( XMVectorSet(VegetationSpots[i]._13, VegetationSpots[i]._23, VegetationSpots[i]._33, 0) ));
+        // Compute scale along the up-axis only. x/z are intentionally not used;
+        // they must not be left uninitialized since spot_scale is built from them.
+        float scaleY;
+        XMStoreFloat( &scaleY, XMVector3Length( XMVectorSet( VegetationSpots[i]._12, VegetationSpots[i]._22, VegetationSpots[i]._32, 0 ) ) );
 
-        XMFLOAT3 spot_scale;
-        XMStoreFloat3( &spot_scale, XMLoadFloat3( &spot ) + XMLoadFloat3( &scale ) * 2.0f );
+        // Draw a vertical tick from the spot upwards
+        XMFLOAT3 spot_scale = XMFLOAT3( spot.x, spot.y + scaleY * 2.0f, spot.z );
         Engine::GraphicsEngine->GetLineRenderer()->AddLine( LineVertex( spot, color ), LineVertex( spot_scale, color ) );
     }
 }

--- a/D3D11Engine/GVegetationBox.cpp
+++ b/D3D11Engine/GVegetationBox.cpp
@@ -93,7 +93,7 @@ XRESULT GVegetationBox::InitVegetationBox( MeshInfo* mesh,
         trisInside.push_back( tri[2] );
     }
 
-    InitSpotsRandom( trisInside );
+    InitSpotsRandom( trisInside, S_None, density );
     TrisInside = trisInside;
 
     return XR_SUCCESS;
@@ -200,7 +200,7 @@ XRESULT GVegetationBox::InitVegetationBox( const XMFLOAT3& min,
     }
 
 
-    InitSpotsRandom( polysInside, shape );
+    InitSpotsRandom( polysInside, shape, density );
     TrisInside = polysInside;
 
     return XR_SUCCESS;
@@ -460,6 +460,26 @@ void GVegetationBox::RefitBoundingBox() {
         BoxMax.x = BoxMax.x < spot.x ? spot.x : BoxMax.x;
         BoxMax.y = BoxMax.y < spot.y ? spot.y : BoxMax.y;
         BoxMax.z = BoxMax.z < spot.z ? spot.z : BoxMax.z;
+    }
+}
+
+/** Merges the vegetation of the given box into this one. Call RebuildInstancingBuffer() afterwards. */
+void GVegetationBox::MergeVegetation( GVegetationBox* other ) {
+    VegetationSpots.insert( VegetationSpots.end(), other->VegetationSpots.begin(), other->VegetationSpots.end() );
+    TrisInside.insert( TrisInside.end(), other->TrisInside.begin(), other->TrisInside.end() );
+    Modified = true;
+}
+
+/** Recreates the instancing buffer from the current spots and refits the bounding box. */
+void GVegetationBox::RebuildInstancingBuffer() {
+    delete InstancingBuffer;
+    InstancingBuffer = nullptr;
+
+    RefitBoundingBox();
+
+    if ( !VegetationSpots.empty() ) {
+        Engine::GraphicsEngine->CreateVertexBuffer( &InstancingBuffer );
+        InstancingBuffer->Init( &VegetationSpots[0], VegetationSpots.size() * sizeof( XMFLOAT4X4 ) );
     }
 }
 

--- a/D3D11Engine/GVegetationBox.cpp
+++ b/D3D11Engine/GVegetationBox.cpp
@@ -10,7 +10,6 @@
 #include "D3D11Texture.h"
 #include "D3D11GraphicsEngine.h"
 #include "zCMaterial.h"
-
 GVegetationBox::GVegetationBox() {
     VegetationMesh = nullptr;
     VegetationTexture = nullptr;
@@ -513,14 +512,14 @@ void GVegetationBox::SaveToFILE( FILE* f, int version ) {
 }
 
 /** Loads this box from the given FILE* */
-void GVegetationBox::LoadFromFILE( FILE* f, int version ) {
+void GVegetationBox::LoadFromFILE( zFILE_VDFS* f, int version ) {
     // Save size of vegetation array
     int vsize;
-    fread( &vsize, sizeof( vsize ), 1, f );
+    f->Read( &vsize, sizeof( vsize ) );
 
     std::vector<XMFLOAT4> spots;
     spots.resize( vsize );
-    fread( &spots[0], sizeof( XMFLOAT4 ) * vsize, 1, f );
+    f->Read( &spots[0], sizeof( XMFLOAT4 ) * vsize );
 
     // Reconstruct spots
     for ( unsigned int i = 0; i < spots.size(); i++ ) {
@@ -536,13 +535,13 @@ void GVegetationBox::LoadFromFILE( FILE* f, int version ) {
 
     // Load tris inside
     int tsize;
-    fread( &tsize, sizeof( tsize ), 1, f );
+    f->Read( &tsize, sizeof( tsize ) );
     TrisInside.resize( tsize );
-    fread( &TrisInside[0], sizeof( XMFLOAT3 ) * tsize, 1, f );
+    f->Read( &TrisInside[0], sizeof( XMFLOAT3 ) * tsize );
 
     // Save wether this was using a mesh info or not
     bool hasMeshInfo = MeshPart != nullptr;
-    fread( &hasMeshInfo, sizeof( hasMeshInfo ), 1, f );
+    f->Read( &hasMeshInfo, sizeof( hasMeshInfo ) );
 
     MeshInfo* hitMesh = nullptr;
     zCMaterial* hitMaterial = nullptr;

--- a/D3D11Engine/GVegetationBox.h
+++ b/D3D11Engine/GVegetationBox.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "pch.h"
+#include "zFILE_VDFS.h"
 
 class GMeshSimple;
 class D3D11Texture;
@@ -72,7 +73,7 @@ public:
     void SaveToFILE( FILE* f, int version );
 
     /** Loads this box from the given FILE* */
-    void LoadFromFILE( FILE* f, int version );
+    void LoadFromFILE( zFILE_VDFS* f, int version );
 
     /** Returns whether this has been modified or not */
     bool HasBeenModified();

--- a/D3D11Engine/GVegetationBox.h
+++ b/D3D11Engine/GVegetationBox.h
@@ -60,6 +60,12 @@ public:
     /** Refits the bounding-box around the grass-meshes. If there are none, the box will be set to 0. */
     void RefitBoundingBox();
 
+    /** Merges the vegetation of the given box into this one. Call RebuildInstancingBuffer() afterwards. */
+    void MergeVegetation( GVegetationBox* other );
+
+    /** Recreates the instancing buffer from the current spots and refits the bounding box. */
+    void RebuildInstancingBuffer();
+
     /** Re-sets the grass with the given density */
     void ResetVegetationWithDensity( float density );
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -50,12 +50,18 @@
 #include "D3D11GraphicsEngine.h"
 #include "MeshManager.h"
 #include "ThreadPool.h"
+#include "zFILE.h"
+#include "zFILE_VDFS.h"
 
 #ifndef PUBLIC_RELEASE
 #define OPT_DBG_NOINLINE __declspec(noinline)
 #else
 #define OPT_DBG_NOINLINE
 #endif
+
+struct file_deleter {
+    void operator()( std::FILE* fp ) { std::fclose( fp ); }
+};
 
 // Duration how long the scene will stay wet, in MS
 const DWORD SCENE_WETNESS_DURATION_MS = 20 * 1000;
@@ -86,18 +92,27 @@ void MaterialInfo::WriteToFile( const std::string& name ) {
 
 /** Loads this info from a file */
 void MaterialInfo::LoadFromFile( const std::string_view name ) {
-    char filePath[MAX_PATH]{};
-    if (snprintf( filePath, MAX_PATH, R"(system\GD3D11\textures\infos\%.*s.mi)", static_cast<int>(name.size()), name.data() ) >= MAX_PATH) {
+    
+    bool foundFile = false;
+    char ReadBuffer[sizeof( int ) + sizeof( MaterialInfo::Buffer )];
+    
+    std::string filePath = R"(\system\GD3D11\textures\infos\)";
+    filePath = filePath.append( name.data(), name.size() );
+    filePath = filePath.append( ".mi" );
+    {
+        auto vdfsFile = zFILE_VDFS::Create(filePath.c_str());
+        if ( vdfsFile->Exists()
+            && vdfsFile->Open(false) == zERROR_NONE )
+        {
+            vdfsFile->Read(ReadBuffer, sizeof(ReadBuffer));
+            vdfsFile->Close();
+            foundFile = true;
+        }
+    }
+    
+    if (!foundFile) {
         return;
     }
-    FILE* f = fopen( filePath, "rb" );
-
-    if ( !f )
-        return;
-
-    char ReadBuffer[sizeof( int ) + sizeof( MaterialInfo::Buffer )];
-    fread( ReadBuffer, 1, sizeof( ReadBuffer ), f );
-
     // Write the version first
     int version;
     memcpy( &version, ReadBuffer, sizeof( int ) );
@@ -111,8 +126,6 @@ void MaterialInfo::LoadFromFile( const std::string_view name ) {
             buffer.DisplacementFactor = 0.7f;
         }
     }
-
-    fclose( f );
 
     buffer.Color = float4( 1, 1, 1, 1 );
 }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5114,30 +5114,38 @@ XRESULT GothicAPI::SaveVegetation( const std::string& file ) {
 
 /** Saves vegetation to a file */
 XRESULT GothicAPI::LoadVegetation( const std::string& file ) {
-    FILE* f = fopen( file.c_str(), "rb" );
-
     LogInfo() << "Loading vegetation";
 
     // Reset first
     ResetVegetation();
 
-    if ( !f )
+    zFILE_VDFS::Ptr vdfsFile;
+    if ( std::filesystem::path( file ).is_absolute() ) {
+        vdfsFile = zFILE_VDFS::Create( file.c_str() );
+    } else if ( !file.empty() && file[0] != '\\' ) {
+        vdfsFile = zFILE_VDFS::Create( ("\\"+ file).c_str());
+    } else {
+        vdfsFile = zFILE_VDFS::Create( file.c_str() );
+    }
+
+    if ( !vdfsFile->Exists() || !vdfsFile->Open( false ) ) {
         return XR_FAILED;
+    }
 
     int version;
-    fread( &version, sizeof( version ), 1, f );
+    vdfsFile->Read( &version, sizeof( version ) );
 
     size_t num = VegetationBoxes.size();
-    fread( &num, sizeof( num ), 1, f );
+    vdfsFile->Read( &num, sizeof( num ) );
 
     for ( size_t i = 0; i < num; i++ ) {
         GVegetationBox* b = new GVegetationBox;
-        b->LoadFromFILE( f, version );
+        b->LoadFromFILE( vdfsFile.get(), version );
 
         AddVegetationBox( b );
     }
 
-    fclose( f );
+    vdfsFile->Close();
 
     return XR_SUCCESS;
 }

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -667,12 +667,6 @@ struct GothicMemoryLocations {
 
         static const unsigned int Constructor2 = 0x00444d90;
         static const unsigned int Destructor = 0x00444e40;
-        static const unsigned int Exists = 0x00444f90;
-        static const unsigned int Open = 0x00445090;
-        static const unsigned int Close = 0x00445310;
-        static const unsigned int Read = 0x004468c0;
-        static const unsigned int Size = 0x00445380;
-        static const unsigned int SetPath = 0x00441670;
         static const unsigned int zCObjectFactory__CreateZFile = 0x0058bd60;
     };
     

--- a/D3D11Engine/ImGuiEditorView.cpp
+++ b/D3D11Engine/ImGuiEditorView.cpp
@@ -314,7 +314,7 @@ void ImGuiEditorView::RenderVegetationSelectionPanel() {
     }
 
     ImGui::Text("Vegetation density:");
-    if (ImGui::SliderFloat("##VegAmount", &SelectedVegAmount, 0.0f, 3.0f, "%.2f")) {
+    if (ImGui::SliderFloat("##VegAmount", &SelectedVegAmount, 0.0f, 20.0f, "%.2f")) {
         if (Selection.SelectedVegetationBox) {
             XMFLOAT3 min, max;
             Selection.SelectedVegetationBox->GetBoundingBox(&min, &max);

--- a/D3D11Engine/ImGuiEditorView.cpp
+++ b/D3D11Engine/ImGuiEditorView.cpp
@@ -60,6 +60,7 @@ ImGuiEditorView::ImGuiEditorView() {
     // Vegetation settings
     VegRestrictByTexture = false;
     VegCircularShape = false;
+    VegBrushActive = false;
     SelectTrianglesOnly = false;
 
     // Slider defaults
@@ -180,7 +181,11 @@ void ImGuiEditorView::RenderMainPanel() {
 }
 
 void ImGuiEditorView::RenderVegetationTab() {
-    if (ImGui::Button("Place Volume", ImVec2(125, 30))) {
+    if (Mode == EM_PLACE_VEGETATION) {
+        if (ImGui::Button("Stop Painting", ImVec2(125, 30))) {
+            SetEditorMode(EM_IDLE);
+        }
+    } else if (ImGui::Button("Paint Vegetation", ImVec2(125, 30))) {
         MMWDelta = 0;
         SetEditorMode(EM_PLACE_VEGETATION);
     }
@@ -371,10 +376,13 @@ void ImGuiEditorView::Update(float deltaTime) {
     bool ctrlHeld = io.KeyCtrl;
 
     // Handle selection and placement modes
-    if (!MMovedAfterClick) {
-        if (Mode == EM_PLACE_VEGETATION) {
-            DoVegetationPlacement();
-        } else if (Mode == EM_SELECT_POLY || Mode == EM_IDLE) {
+    if (Mode == EM_PLACE_VEGETATION) {
+        // Acts like a paint brush: visualizes the brush and paints while LMB is
+        // held. Runs even while the mouse is moving (so dragging paints instead
+        // of moving the camera).
+        DoVegetationPlacement();
+    } else if (!MMovedAfterClick) {
+        if (Mode == EM_SELECT_POLY || Mode == EM_IDLE) {
             DoSelection();
         }
     } else if (Mode == EM_REMOVE_VEGETATION) {
@@ -434,17 +442,43 @@ void ImGuiEditorView::DoVegetationPlacement() {
     if (VegRestrictByTexture)
         rtp = &TracedTexture;
 
+    ImGuiIO& io = ImGui::GetIO();
+    bool leftDown = io.MouseDown[0];
+
     // Trace the worldmesh from the cursor
     if (Engine::GAPI->TraceWorldMesh(GetCameraPosition(), wDir, hit, rtp, hitTri)) {
         // Update the position if successful
         DraggedBoxCenter = hit;
 
-        // Visualize box
+        // Compute the brush footprint
         XMFLOAT3 minAABB;
         XMFLOAT3 maxAABB;
         XMStoreFloat3(&minAABB, XMLoadFloat3(&DraggedBoxCenter) + XMLoadFloat3(&DraggedBoxMinLocal) * (1 + MMWDelta * 0.01f));
         XMStoreFloat3(&maxAABB, XMLoadFloat3(&DraggedBoxCenter) + XMLoadFloat3(&DraggedBoxMaxLocal) * (1 + MMWDelta * 0.01f));
-        Engine::GraphicsEngine->GetLineRenderer()->AddAABBMinMax(minAABB, maxAABB);
+
+        // Paint while the left mouse button is held, but only where there is no
+        // vegetation yet so we don't over-draw existing regions.
+        XMFLOAT4 brushColor(1, 1, 1, 1);
+        if (leftDown) {
+            // Lock onto the texture under the cursor at the start of the stroke.
+            // When "texture aware" is enabled we only paint where the traced
+            // texture matches it, ignoring all others.
+            if (!VegBrushActive) {
+                VegBrushActive = true;
+                VegBrushTexture = TracedTexture;
+            }
+
+            bool textureMismatch = VegRestrictByTexture && TracedTexture != VegBrushTexture;
+
+            if (VegetationCoversPosition(hit) || textureMismatch) {
+                // Already covered or wrong texture - show red, don't paint here
+                brushColor = XMFLOAT4(1, 0, 0, 1);
+            } else {
+                PlaceVegetationBox(minAABB, maxAABB);
+                brushColor = XMFLOAT4(0, 1, 0, 1);
+            }
+        }
+        Engine::GraphicsEngine->GetLineRenderer()->AddAABBMinMax(minAABB, maxAABB, brushColor);
 
         // Visualize triangle
         FXMVECTOR nrm = Toolbox::ComputeNormal(hitTri[0], hitTri[1], hitTri[2]);
@@ -626,8 +660,8 @@ void ImGuiEditorView::OnMouseClick(int button) {
                 Engine::GAPI->SetPlayerPosition(pos);
             }
         } else if (Mode == EM_PLACE_VEGETATION) {
-            // Place the currently dragged vegetationbox
-            PlaceDraggedVegetationBox();
+            // Painting is handled continuously in DoVegetationPlacement while
+            // the left mouse button is held, so nothing to do on click release.
         } else if (Mode == EM_SELECT_POLY || Mode == EM_IDLE) {
             // Reset selection and apply what ever has the most priority
             MMWDelta = 0;
@@ -850,26 +884,28 @@ bool ImGuiEditorView::IsMouseInsideEditorWindow() {
     return io.WantCaptureMouse;
 }
 
-GVegetationBox* ImGuiEditorView::PlaceDraggedVegetationBox() {
-    SetEditorMode(EM_IDLE);
+bool ImGuiEditorView::VegetationCoversPosition(const XMFLOAT3& p) {
+    for (GVegetationBox* vegetationBox : Engine::GAPI->GetVegetationBoxes()) {
+        if (vegetationBox->PositionInsideBox(p))
+            return true;
+    }
 
+    return false;
+}
+
+GVegetationBox* ImGuiEditorView::PlaceVegetationBox(const XMFLOAT3& minp, const XMFLOAT3& maxp) {
     GVegetationBox::EShape shape = GVegetationBox::S_Box;
     if (VegCircularShape)
         shape = GVegetationBox::S_Circle;
 
     GVegetationBox* box = new GVegetationBox;
-    XMFLOAT3 minp;
-    XMFLOAT3 maxp;
-    XMStoreFloat3(&minp, XMLoadFloat3(&DraggedBoxCenter) + XMLoadFloat3(&DraggedBoxMinLocal) * (1 + MMWDelta));
-    XMStoreFloat3(&maxp, XMLoadFloat3(&DraggedBoxCenter) + XMLoadFloat3(&DraggedBoxMaxLocal) * (1 + MMWDelta));
     if (XR_SUCCESS == box->InitVegetationBox(minp, maxp, "", 1.0f, 1.0f, TracedTexture, shape)) {
         Engine::GAPI->AddVegetationBox(box);
-    } else {
-        SAFE_DELETE(box);
+        return box;
     }
 
-    Selection.SelectedVegetationBox = box;
-    return box;
+    SAFE_DELETE(box);
+    return nullptr;
 }
 
 bool ImGuiEditorView::OnWindowMessage(HWND hWnd, unsigned int msg, WPARAM wParam, LPARAM lParam) {
@@ -920,6 +956,7 @@ bool ImGuiEditorView::OnWindowMessage(HWND hWnd, unsigned int msg, WPARAM wParam
             OnMouseClick(0);
         }
         MMovedAfterClick = false;
+        VegBrushActive = false; // End the current paint stroke
         break;
 
     case WM_RBUTTONDOWN:

--- a/D3D11Engine/ImGuiEditorView.cpp
+++ b/D3D11Engine/ImGuiEditorView.cpp
@@ -310,25 +310,39 @@ void ImGuiEditorView::RenderTextureSelectionPanel() {
 }
 
 void ImGuiEditorView::RenderVegetationSelectionPanel() {
+    const size_t selCount = Selection.SelectedVegetationBoxes.size();
+
+    if (selCount > 1) {
+        ImGui::Text("%zu patches selected", selCount);
+    }
+    ImGui::TextWrapped("Ctrl+Click a patch to add/remove it from the selection.");
+    ImGui::Spacing();
+
     ImGui::Text("Vegetation size:");
     if (ImGui::SliderFloat("##VegSize", &SelectedVegSize, 0.0f, 3.0f, "%.2f")) {
-        if (Selection.SelectedVegetationBox) {
-            Selection.SelectedVegetationBox->ApplyUniformScaling(1 + (SelectedVegSize - VegLastUniformScale));
+        if (!Selection.SelectedVegetationBoxes.empty()) {
+            float factor = 1 + (SelectedVegSize - VegLastUniformScale);
+            for (GVegetationBox* box : Selection.SelectedVegetationBoxes)
+                box->ApplyUniformScaling(factor);
             VegLastUniformScale = SelectedVegSize;
         }
     }
 
     ImGui::Text("Vegetation density:");
     if (ImGui::SliderFloat("##VegAmount", &SelectedVegAmount, 0.0f, 20.0f, "%.2f")) {
-        if (Selection.SelectedVegetationBox) {
+        for (GVegetationBox* box : Selection.SelectedVegetationBoxes) {
             XMFLOAT3 min, max;
-            Selection.SelectedVegetationBox->GetBoundingBox(&min, &max);
-            Selection.SelectedVegetationBox->ResetVegetationWithDensity(SelectedVegAmount);
-            Selection.SelectedVegetationBox->SetBoundingBox(min, max);
+            box->GetBoundingBox(&min, &max);
+            box->ResetVegetationWithDensity(SelectedVegAmount);
+            box->SetBoundingBox(min, max);
         }
     }
 
-    if (Selection.SelectedVegetationBox && Selection.SelectedVegetationBox->HasBeenModified()) {
+    bool anyModified = false;
+    for (GVegetationBox* box : Selection.SelectedVegetationBoxes) {
+        if (box->HasBeenModified()) { anyModified = true; break; }
+    }
+    if (anyModified) {
         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1, 0, 0, 1));
         ImGui::TextWrapped("You may lose changes made to the volume after changing its density!");
         ImGui::PopStyleColor();
@@ -363,8 +377,11 @@ void ImGuiEditorView::Update(float deltaTime) {
         VisualizeMeshInfo(Selection.SelectedMesh, XMFLOAT4(1, 0, 0, 1));
     }
 
-    if (Selection.SelectedVegetationBox) {
-        Selection.SelectedVegetationBox->VisualizeGrass(XMFLOAT4(1, 0, 0, 1));
+    for (GVegetationBox* box : Selection.SelectedVegetationBoxes) {
+        // Highlight the primary box in red, the rest in orange so the user can
+        // tell which one drives the displayed slider values.
+        XMFLOAT4 c = (box == Selection.SelectedVegetationBox) ? XMFLOAT4(1, 0, 0, 1) : XMFLOAT4(1, 0.5f, 0, 1);
+        box->VisualizeGrass(c);
     }
 
     // Check if ImGui wants the mouse
@@ -415,8 +432,9 @@ void ImGuiEditorView::DoVegetationRemove() {
 
                 // Delete if empty
                 if (Selection.SelectedVegetationBox->IsEmpty()) {
-                    Engine::GAPI->RemoveVegetationBox(Selection.SelectedVegetationBox);
-                    Selection.SelectedVegetationBox = nullptr;
+                    GVegetationBox* removed = Selection.SelectedVegetationBox;
+                    Engine::GAPI->RemoveVegetationBox(removed);
+                    Selection.RemoveVegetationBox(removed);
                     DoSelection();
                 }
 
@@ -474,7 +492,8 @@ void ImGuiEditorView::DoVegetationPlacement() {
                 // Already covered or wrong texture - show red, don't paint here
                 brushColor = XMFLOAT4(1, 0, 0, 1);
             } else {
-                PlaceVegetationBox(minAABB, maxAABB);
+                if (GVegetationBox* placed = PlaceVegetationBox(minAABB, maxAABB))
+                    StrokeBoxes.push_back(placed);
                 brushColor = XMFLOAT4(0, 1, 0, 1);
             }
         }
@@ -663,15 +682,32 @@ void ImGuiEditorView::OnMouseClick(int button) {
             // Painting is handled continuously in DoVegetationPlacement while
             // the left mouse button is held, so nothing to do on click release.
         } else if (Mode == EM_SELECT_POLY || Mode == EM_IDLE) {
-            // Reset selection and apply what ever has the most priority
-            MMWDelta = 0;
-            Selection.Reset();
+            // Ctrl+Click on a vegetation box adds/removes it from the current
+            // multi-selection instead of replacing the whole selection.
+            bool multiSelectVeg = io.KeyCtrl && TracedVegetationBox;
 
-            VegLastUniformScale = 1.0f;
-            SelectedVegAmount = 1.0f;
-            SelectedVegSize = 1.0f;
+            if (!multiSelectVeg) {
+                // Reset selection and apply what ever has the most priority
+                MMWDelta = 0;
+                Selection.Reset();
 
-            if (TracedVobInfo) {
+                // VegLastUniformScale = 1.0f;
+                // SelectedVegAmount = 1.0f;
+                // SelectedVegSize = 1.0f;
+            }
+
+            if (multiSelectVeg) {
+                Selection.ToggleVegetationBox(TracedVegetationBox);
+
+                SelectionTabIndex = 1; // Vegetation tab
+
+                // Reflect the (new) primary box on the sliders. Scaling is
+                // relative, so reset its baseline; this does not modify the box.
+                VegLastUniformScale = 1.0f;
+                SelectedVegSize = 1.0f;
+                if (Selection.SelectedVegetationBox)
+                    SelectedVegAmount = Selection.SelectedVegetationBox->GetDensity();
+            } else if (TracedVobInfo) {
                 Selection.SelectedVobInfo = TracedVobInfo;
                 Selection.SelectedMaterial = TracedMaterial;
 
@@ -691,15 +727,12 @@ void ImGuiEditorView::OnMouseClick(int button) {
                 Widgets->ClearSelection();
                 Widgets->AddSelection(TracedSkeletalVobInfo);
             } else if (TracedVegetationBox) {
-                Selection.SelectedVegetationBox = TracedVegetationBox;
+                Selection.AddVegetationBox(TracedVegetationBox);
 
                 SelectionTabIndex = 1; // Vegetation tab
 
-                // Trick the slider into not updating the just selected volume
-                float d = Selection.SelectedVegetationBox->GetDensity();
-                Selection.SelectedVegetationBox = nullptr;
-                SelectedVegAmount = d;
-                Selection.SelectedVegetationBox = TracedVegetationBox;
+                // Show the selected volume's density on the slider
+                SelectedVegAmount = TracedVegetationBox->GetDensity();
             } else {
                 // Vegetation has priority over mesh
                 Selection.SelectedMesh = TracedMesh;
@@ -899,13 +932,31 @@ GVegetationBox* ImGuiEditorView::PlaceVegetationBox(const XMFLOAT3& minp, const 
         shape = GVegetationBox::S_Circle;
 
     GVegetationBox* box = new GVegetationBox;
-    if (XR_SUCCESS == box->InitVegetationBox(minp, maxp, "", 1.0f, 1.0f, TracedTexture, shape)) {
+    if (XR_SUCCESS == box->InitVegetationBox(minp, maxp, "", SelectedVegAmount, 1.0f, TracedTexture, shape)) {
+        // Apply the size set on the slider (the per-instance scale baseline is 1.0)
+        if (SelectedVegSize != 1.0f)
+            box->ApplyUniformScaling(SelectedVegSize);
         Engine::GAPI->AddVegetationBox(box);
         return box;
     }
 
     SAFE_DELETE(box);
     return nullptr;
+}
+
+void ImGuiEditorView::ConsolidateStrokeBoxes() {
+    // Merge every box painted during the stroke into the first one so a long
+    // stroke ends up as a single vegetation box instead of dozens of small ones.
+    if (StrokeBoxes.size() > 1) {
+        GVegetationBox* target = StrokeBoxes.front();
+        for (size_t i = 1; i < StrokeBoxes.size(); i++) {
+            target->MergeVegetation(StrokeBoxes[i]);
+            Engine::GAPI->RemoveVegetationBox(StrokeBoxes[i]); // removes from the world and deletes it
+        }
+        target->RebuildInstancingBuffer();
+    }
+
+    StrokeBoxes.clear();
 }
 
 bool ImGuiEditorView::OnWindowMessage(HWND hWnd, unsigned int msg, WPARAM wParam, LPARAM lParam) {
@@ -957,6 +1008,7 @@ bool ImGuiEditorView::OnWindowMessage(HWND hWnd, unsigned int msg, WPARAM wParam
         }
         MMovedAfterClick = false;
         VegBrushActive = false; // End the current paint stroke
+        ConsolidateStrokeBoxes();
         break;
 
     case WM_RBUTTONDOWN:
@@ -1007,7 +1059,8 @@ bool ImGuiEditorView::OnWindowMessage(HWND hWnd, unsigned int msg, WPARAM wParam
             if (Selection.SelectedVegetationBox) {
                 // Adjust size of grassblades if not in removing-mode
                 if (Mode == EM_IDLE) {
-                    Selection.SelectedVegetationBox->ApplyUniformScaling(delta < 0 ? 0.9f : 1.1f);
+                    for (GVegetationBox* box : Selection.SelectedVegetationBoxes)
+                        box->ApplyUniformScaling(delta < 0 ? 0.9f : 1.1f);
                 }
             } else if (!io.KeyCtrl) {
                 // no editor movement if we hold CTRL
@@ -1064,9 +1117,11 @@ void ImGuiEditorView::SetEditorMode(EditorMode mode) {
 void ImGuiEditorView::OnDelete() {
     // Find out what we have selected
     if (Selection.SelectedVegetationBox) {
-        // Delete all attachments to this mesh
-        Engine::GAPI->RemoveVegetationBox(Selection.SelectedVegetationBox);
+        // Delete all selected boxes and their attachments
+        for (GVegetationBox* box : Selection.SelectedVegetationBoxes)
+            Engine::GAPI->RemoveVegetationBox(box);
 
+        Selection.SelectedVegetationBoxes.clear();
         Selection.SelectedVegetationBox = nullptr;
         return;
     }

--- a/D3D11Engine/ImGuiEditorView.h
+++ b/D3D11Engine/ImGuiEditorView.h
@@ -118,8 +118,11 @@ protected:
     /** Returns if the mouse is inside the editor window */
     bool IsMouseInsideEditorWindow();
 
-    /** Places the currently dragged vegetation box */
-    GVegetationBox* PlaceDraggedVegetationBox();
+    /** Places a vegetation box spanning the given world-space bounds */
+    GVegetationBox* PlaceVegetationBox(const XMFLOAT3& minp, const XMFLOAT3& maxp);
+
+    /** Returns true if any existing vegetation box already covers the position */
+    bool VegetationCoversPosition(const XMFLOAT3& p);
 
     /** Traces the set of placed vegetation boxes */
     GVegetationBox* TraceVegetationBoxes(const XMFLOAT3& wPos, const XMFLOAT3& wDir);
@@ -154,6 +157,10 @@ protected:
     /** Vegetation settings checkboxes */
     bool VegRestrictByTexture;
     bool VegCircularShape;
+
+    /** Paint-brush stroke state for EM_PLACE_VEGETATION */
+    bool VegBrushActive;        // true while the left button is held during a paint stroke
+    std::string VegBrushTexture; // texture locked at stroke start (used when "texture aware")
 
     /** Selection specific values */
     bool SelectTrianglesOnly;

--- a/D3D11Engine/ImGuiEditorView.h
+++ b/D3D11Engine/ImGuiEditorView.h
@@ -23,15 +23,51 @@ struct ImGuiSelectionInfo {
         SelectedMesh = nullptr;
         SelectedMaterial = nullptr;
         SelectedVegetationBox = nullptr;
+        SelectedVegetationBoxes.clear();
         SelectedVobInfo = nullptr;
         SelectedSkeletalVob = nullptr;
+    }
+
+    /** Returns true if the given box is part of the current selection */
+    bool IsVegetationSelected(GVegetationBox* b) const {
+        for (GVegetationBox* v : SelectedVegetationBoxes)
+            if (v == b) return true;
+        return false;
+    }
+
+    /** Adds a box to the selection and makes it the primary */
+    void AddVegetationBox(GVegetationBox* b) {
+        if (!b || IsVegetationSelected(b)) return;
+        SelectedVegetationBoxes.push_back(b);
+        SelectedVegetationBox = b;
+    }
+
+    /** Removes a box from the selection, updating the primary if needed */
+    void RemoveVegetationBox(GVegetationBox* b) {
+        for (size_t i = 0; i < SelectedVegetationBoxes.size(); ++i) {
+            if (SelectedVegetationBoxes[i] == b) {
+                SelectedVegetationBoxes.erase(SelectedVegetationBoxes.begin() + i);
+                break;
+            }
+        }
+        if (SelectedVegetationBox == b)
+            SelectedVegetationBox = SelectedVegetationBoxes.empty() ? nullptr : SelectedVegetationBoxes.back();
+    }
+
+    /** Adds the box if not selected, otherwise removes it */
+    void ToggleVegetationBox(GVegetationBox* b) {
+        if (IsVegetationSelected(b)) RemoveVegetationBox(b);
+        else AddVegetationBox(b);
     }
 
     MeshInfo* SelectedMesh;
     zCMaterial* SelectedMaterial;
     VobInfo* SelectedVobInfo;
     SkeletalVobInfo* SelectedSkeletalVob;
+    /** Primary (most recently picked) selected box, or nullptr. Mirrors the back of SelectedVegetationBoxes. */
     GVegetationBox* SelectedVegetationBox;
+    /** All currently selected vegetation boxes (multi-selection) */
+    std::vector<GVegetationBox*> SelectedVegetationBoxes;
 };
 
 class ImGuiEditorView {
@@ -121,6 +157,9 @@ protected:
     /** Places a vegetation box spanning the given world-space bounds */
     GVegetationBox* PlaceVegetationBox(const XMFLOAT3& minp, const XMFLOAT3& maxp);
 
+    /** Consolidates all boxes painted during the current stroke into a single box */
+    void ConsolidateStrokeBoxes();
+
     /** Returns true if any existing vegetation box already covers the position */
     bool VegetationCoversPosition(const XMFLOAT3& p);
 
@@ -161,6 +200,7 @@ protected:
     /** Paint-brush stroke state for EM_PLACE_VEGETATION */
     bool VegBrushActive;        // true while the left button is held during a paint stroke
     std::string VegBrushTexture; // texture locked at stroke start (used when "texture aware")
+    std::vector<GVegetationBox*> StrokeBoxes; // boxes placed during the current stroke, consolidated on release
 
     /** Selection specific values */
     bool SelectTrianglesOnly;

--- a/D3D11Engine/zFILE_VDFS.h
+++ b/D3D11Engine/zFILE_VDFS.h
@@ -4,8 +4,73 @@
 
 typedef int zERROR_ID;
 
+enum zERRORS {
+    zERROR_NONE = 0,
+};
+
 class zFILE_VDFS {
 private:
+    struct {
+        void* _Destructor;
+        void* SetMode;
+        void* GetMode;
+        void* SetPath;
+        void* SetDrive;
+        void* SetDir;
+        void* SetFile;
+        void* SetFilename;
+        void* SetExt;
+        void* GetFileHandle; // 10
+        void* GetFullPath;
+        void* GetPath;
+        void* GetDirectoryPath;
+        void* GetDrive;
+        void* GetDir;
+        void* GetFile;
+        void* GetFilename;
+        void* GetExt;
+        void* SetCurrentDir;
+        void* ChangeDir; // 20
+        void* SearchFile;
+        void* FindFirst;
+        void* FindNext;
+        void* DirCreate;
+        void* DirRemove;
+        void* DirExists;
+        void* FileMove;
+        void* FileCopy;
+        void* FileMove2;
+        void* FileCopy2;  // 30
+        void* FileDelete;
+        void* IsOpened;
+        void* Create;
+        void* Create2; // const zSTRING& s
+        void* Open2; // const zSTRING& s, bool writeMode = false
+        zERROR_ID( __thiscall* Open )(zFILE_VDFS*, bool);
+        void* Exists2; // const zSTRING& s
+        bool( __thiscall* Exists )(zFILE_VDFS*);
+        zERROR_ID( __thiscall* Close )(zFILE_VDFS*);
+        void* Reset;
+        void* Append;
+        long( __thiscall* Size )(zFILE_VDFS*);
+        void* Pos;
+        void* Seek;
+        void* Eof;
+        void* GetStats;
+        void* Write;
+        void* Write2;
+        void* Write3;
+        void* Read2;
+        void* Read3;
+        long( __thiscall* Read )(zFILE_VDFS*, void*, long);
+        void* ReadChar;
+        void* SeekText;
+        void* ReadBlock;
+        void* UpdateBlock;
+        void* GetFreeDiskSpace;
+        void* FlushBuffer;
+    } *vftable;
+
     ~zFILE_VDFS() {
         reinterpret_cast<void( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Destructor)(this);
     }
@@ -40,21 +105,21 @@ public:
     }
 
     bool Exists() {
-        return reinterpret_cast<bool( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Exists)(this);
+        return vftable->Exists( this );
     }
 
-    zERROR_ID Open( bool writeMode ) {
-        return reinterpret_cast<zERROR_ID( __thiscall* )(zFILE_VDFS*, bool)>(GothicMemoryLocations::zFILE_VDFS::Open)(this, writeMode);
+    zERROR_ID Open( bool openWrite ) {
+        return vftable->Open( this, openWrite );
     }
     zERROR_ID Close() {
-        return reinterpret_cast<zERROR_ID( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Close)(this);
+        return vftable->Close( this );
     }
 
     long Read( void* scr, long bytes ) {
-        return reinterpret_cast<long( __thiscall* )(zFILE_VDFS*, void*, long)>(GothicMemoryLocations::zFILE_VDFS::Read)(this, scr, bytes);
+        return vftable->Read( this, scr, bytes );
     }
 
     long Size() {
-        return reinterpret_cast<long( __thiscall* )(zFILE_VDFS*)>(GothicMemoryLocations::zFILE_VDFS::Size)(this);
+        return vftable->Size( this );
     }
 };


### PR DESCRIPTION
- load our static textures as immutable textures.
- Vegetation placement:
  - allow painting multiple patches of grass while holding down LMOUSE
  - Allow selecting multiple patches of grass for modification using CTRL+Click
  - fix issue with hover effect on vegetation.
- use `zFILE_VDFS` for more resources. allowing modders to deploy their own resources, for example world vegetation data and material infos 
  - For material infos they need to be in a VDF at the location `system\GD3D11\textures\infos\SOMETEX.mi`
  - For vegetation it needs to be:
    - Unmodded game `system\GD3D11\ZENResources\ZENNAME.veg`
    - modded game `system\GD3D11\ZENResources\MOD-INI-NAME\ZENNAME.veg`
      - for example `system\GD3D11\ZENResources\NostalgicEdition\NEWWORLD.veg`
- `zFILE_VDFS` now uses vtable instead of offsets into memory for their methods.
- Fix issue with normal maps enabled but no normal maps available for certain textures.