### PR TITLE
increase shadowmap resolution 16 bit -> 32 bit. Ensure only number of…

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -201,6 +201,11 @@ struct DS_ScreenQuadConstantBuffer {
     // Shadow atlas: per-cascade UV rect (xy = offset, zw = scale)
     // Used when SHADOW_ATLAS is enabled (Feature Level 10 path)
     float4 SQ_CascadeAtlasRect[MAX_CSM_CASCADES];
+
+    // World-space units per texel for each cascade, precomputed on CPU.
+    // Packed into a float4 (x=cascade0 ... w=cascade3) to avoid cbuffer array padding.
+    // Replaces per-fragment GetCascadeWorldTexelSize() matrix math in shaders.
+    float4 SQ_CascadeTexelSize;
 };
 
 struct CloudConstantBuffer {

--- a/D3D11Engine/D3D11CascadedShadowMapBuffer.cpp
+++ b/D3D11Engine/D3D11CascadedShadowMapBuffer.cpp
@@ -17,6 +17,8 @@ void D3D11CascadedShadowMapBuffer::Release() {
     }
     m_srv.Reset();
     m_texture.Reset();
+    m_size = 0;
+    m_numCascades = 0;
 }
 
 HRESULT D3D11CascadedShadowMapBuffer::Init(
@@ -25,10 +27,12 @@ HRESULT D3D11CascadedShadowMapBuffer::Init(
     UINT numCascades ) {
 
     m_device = device;
-    m_numCascades = std::min<UINT>( numCascades, MAX_CSM_CASCADES );
-    m_numCascades = std::max<UINT>( m_numCascades, 1 );
+    m_numCascades = std::clamp<UINT>( numCascades, 1, MAX_CSM_CASCADES );
 
-    return Resize( size );
+    if ( m_size != size || m_numCascades != numCascades ) {
+        return Resize( size );
+    }
+    return S_OK;
 }
 
 HRESULT D3D11CascadedShadowMapBuffer::Resize( UINT size ) {
@@ -40,7 +44,6 @@ HRESULT D3D11CascadedShadowMapBuffer::Resize( UINT size ) {
     // Clamp size to valid range
     m_size = std::max<UINT>( size, 512 );
 
-    Release();
 
     HRESULT hr = S_OK;
 
@@ -50,13 +53,17 @@ HRESULT D3D11CascadedShadowMapBuffer::Resize( UINT size ) {
     texDesc.Height = m_size;
     texDesc.MipLevels = 1;
     texDesc.ArraySize = m_numCascades;
-    texDesc.Format = DXGI_FORMAT_R16_TYPELESS;
+    texDesc.Format = DXGI_FORMAT_R32_TYPELESS;
     texDesc.SampleDesc.Count = 1;
     texDesc.SampleDesc.Quality = 0;
     texDesc.Usage = D3D11_USAGE_DEFAULT;
     texDesc.BindFlags = D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE;
     texDesc.CPUAccessFlags = 0;
     texDesc.MiscFlags = 0;
+
+    Release();
+    m_size = texDesc.Width;
+    m_numCascades = texDesc.ArraySize;
 
     LE( m_device->CreateTexture2D( &texDesc, nullptr, m_texture.GetAddressOf() ) );
     if ( FAILED( hr ) || !m_texture ) {
@@ -68,7 +75,7 @@ HRESULT D3D11CascadedShadowMapBuffer::Resize( UINT size ) {
     // Create per-slice depth stencil views
     for ( UINT i = 0; i < m_numCascades; ++i ) {
         D3D11_DEPTH_STENCIL_VIEW_DESC dsvDesc = {};
-        dsvDesc.Format = DXGI_FORMAT_D16_UNORM;
+        dsvDesc.Format = DXGI_FORMAT_D32_FLOAT;
         dsvDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
         dsvDesc.Texture2DArray.MipSlice = 0;
         dsvDesc.Texture2DArray.FirstArraySlice = i;
@@ -85,7 +92,7 @@ HRESULT D3D11CascadedShadowMapBuffer::Resize( UINT size ) {
 
     // Create shader resource view for the entire array
     D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-    srvDesc.Format = DXGI_FORMAT_R16_UNORM;
+    srvDesc.Format = DXGI_FORMAT_R32_FLOAT;
     srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
     srvDesc.Texture2DArray.MostDetailedMip = 0;
     srvDesc.Texture2DArray.MipLevels = 1;

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1248,6 +1248,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="GMeshSimple.cpp" />
     <ClCompile Include="GothicAPI.cpp" />
     <ClCompile Include="GothicExternals.cpp" />
+    <ClCompile Include="GothicGraphicsState.cpp" />
     <ClCompile Include="GraphicsShader.cpp" />
     <ClCompile Include="GSky.cpp" />
     <ClCompile Include="GSpriteCloud.cpp" />

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -1156,6 +1156,9 @@
     <ClCompile Include="include\ImGuizmo\src\ImGradient.cpp" />
     <ClCompile Include="include\ImGuizmo\src\ImGuizmo.cpp" />
     <ClCompile Include="include\ImGuizmo\src\ImSequencer.cpp" />
+    <ClCompile Include="GothicGraphicsState.cpp">
+      <Filter>Engine</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="ddraw.def">

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -6298,6 +6298,10 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
         GothicRasterizerStateInfo::CM_CULL_NONE;
 
     Engine::GAPI->GetRendererState().RasterizerState.DepthClipEnable = true;
+    // Slope-scaled depth bias pushes caster depth away from the light along sloped
+    // surfaces, removing shadow acne/stepping on thin geometry and in crevices.
+    Engine::GAPI->GetRendererState().RasterizerState.SlopeScaledDepthBias =
+        Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.ShadowCascades.ShadowDepthSlopeBias;
     Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
 
     Engine::GAPI->GetRendererState().DepthState.SetDefault();

--- a/D3D11Engine/D3D11PipelineStates.h
+++ b/D3D11Engine/D3D11PipelineStates.h
@@ -98,7 +98,7 @@ public:
         rasterizerDesc.FrontCounterClockwise = rs.FrontCounterClockwise;
         rasterizerDesc.DepthBias = rs.ZBias;
         rasterizerDesc.DepthBiasClamp = 0;
-        rasterizerDesc.SlopeScaledDepthBias = 0;
+        rasterizerDesc.SlopeScaledDepthBias = rs.SlopeScaledDepthBias;
         rasterizerDesc.DepthClipEnable = rs.DepthClipEnable;
         rasterizerDesc.ScissorEnable = false;
         rasterizerDesc.MultisampleEnable = false;

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1378,6 +1378,26 @@ DS_ScreenQuadConstantBuffer D3D11ShadowMap::FillSunCSMConstantBuffer() const {
         }
     }
 
+    // Precompute world-space units-per-texel for each cascade so shaders can read
+    // SQ_CascadeTexelSize[i] instead of running per-fragment matrix math.
+    {
+        const float mapSize = static_cast<float>( this->GetSizeX() );
+        float* ts = scb.SQ_CascadeTexelSize.toPtr();
+        for ( size_t i = 0; i < MAX_CSM_CASCADES; ++i ) {
+            const XMFLOAT4X4& m = scb.SQ_ShadowViewProj[i];
+            const float sx = sqrtf( m._11 * m._11 + m._21 * m._21 + m._31 * m._31 );
+            const float sy = sqrtf( m._12 * m._12 + m._22 * m._22 + m._32 * m._32 );
+            const float wx = ( sx > 1e-6f ) ? ( 2.0f / sx ) : 0.0f;
+            const float wy = ( sy > 1e-6f ) ? ( 2.0f / sy ) : 0.0f;
+            float res = mapSize;
+            if ( m_useAtlas && m_shadowAtlas ) {
+                const float4& r = scb.SQ_CascadeAtlasRect[i];
+                res *= std::max( r.z, r.w );
+            }
+            ts[i] = 0.5f * ( wx + wy ) / std::max( res, 1.0f );
+        }
+    }
+
     XMStoreFloat4x4( &scb.SQ_RainViewProj,
         XMLoadFloat4x4( &reinterpret_cast<D3D11GraphicsEngine*>( Engine::GraphicsEngine )->Effects->GetRainShadowmapCameraRepl().ProjectionReplacement ) *
         XMLoadFloat4x4( &reinterpret_cast<D3D11GraphicsEngine*>( Engine::GraphicsEngine )->Effects->GetRainShadowmapCameraRepl().ViewReplacement ) );
@@ -1492,6 +1512,26 @@ XRESULT D3D11ShadowMap::DrawWorldLights()
     if ( m_useAtlas && m_shadowAtlas ) {
         for ( size_t i = 0; i < MAX_CSM_CASCADES; ++i ) {
             scb.SQ_CascadeAtlasRect[i] = m_shadowAtlas->GetCascadeUVRect( static_cast<UINT>( i ) );
+        }
+    }
+
+    // Precompute world-space units-per-texel for each cascade so shaders can read
+    // SQ_CascadeTexelSize[i] instead of running per-fragment matrix math.
+    {
+        const float mapSize = static_cast<float>( this->GetSizeX() );
+        float* ts = scb.SQ_CascadeTexelSize.toPtr();
+        for ( size_t i = 0; i < MAX_CSM_CASCADES; ++i ) {
+            const XMFLOAT4X4& m = scb.SQ_ShadowViewProj[i];
+            const float sx = sqrtf( m._11 * m._11 + m._21 * m._21 + m._31 * m._31 );
+            const float sy = sqrtf( m._12 * m._12 + m._22 * m._22 + m._32 * m._32 );
+            const float wx = ( sx > 1e-6f ) ? ( 2.0f / sx ) : 0.0f;
+            const float wy = ( sy > 1e-6f ) ? ( 2.0f / sy ) : 0.0f;
+            float res = mapSize;
+            if ( m_useAtlas && m_shadowAtlas ) {
+                const float4& r = scb.SQ_CascadeAtlasRect[i];
+                res *= std::max( r.z, r.w );
+            }
+            ts[i] = 0.5f * ( wx + wy ) / std::max( res, 1.0f );
         }
     }
 

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -293,7 +293,7 @@ void D3D11ShadowMap::EnsureShadowMapBackend( int size ) {
         } else {
             m_shadowAtlas.reset();
             m_cascadedShadowMap = std::make_unique<D3D11CascadedShadowMapBuffer>();
-            m_cascadedShadowMap->Init( m_device, clampedSize, MAX_CSM_CASCADES );
+            m_cascadedShadowMap->Init( m_device, clampedSize, atlasNumCascades );
         }
 
         // Sampler addressing depends on atlas/array path.
@@ -316,9 +316,11 @@ void D3D11ShadowMap::EnsureShadowMapBackend( int size ) {
         const int maxAtlasCascade0Size = (atlasNumCascades <= 1) ? clampedSize : (clampedSize / 4);
         int atlasCascade0Size = std::min<int>( clampedSize, maxAtlasCascade0Size );
         m_shadowAtlas->Resize( atlasCascade0Size, atlasNumCascades );
-    } else if ( !m_useAtlas && !m_cascadedShadowMap ) {
-        m_cascadedShadowMap = std::make_unique<D3D11CascadedShadowMapBuffer>();
-        m_cascadedShadowMap->Init( m_device, clampedSize, MAX_CSM_CASCADES );
+    } else if ( !m_useAtlas ) {
+        if ( !m_cascadedShadowMap ) {
+            m_cascadedShadowMap = std::make_unique<D3D11CascadedShadowMapBuffer>();
+        }
+        m_cascadedShadowMap->Init( m_device, clampedSize, atlasNumCascades );
     }
 }
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5246,6 +5246,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "Shadows", "ShadowSoftness", std::to_string( s.ShadowSoftness ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "ShadowAOStrength", std::to_string( s.ShadowAOStrength ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "WorldAOStrength", std::to_string( s.WorldAOStrength ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "ShadowDepthSlopeBias", std::to_string( s.DebugSettings.ShadowCascades.ShadowDepthSlopeBias ).c_str(), ini.c_str() );
 
     // WritePrivateProfileStringA( "SMAA", "Enabled", std::to_string( s.EnableSMAA ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "AntiAliasing", std::to_string( (int)s.AntiAliasingMode ).c_str(), ini.c_str() );
@@ -5353,6 +5354,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.ShadowSoftness = GetPrivateProfileFloatA( "Shadows", "ShadowSoftness", ds.ShadowSoftness, ini );
         s.ShadowAOStrength = GetPrivateProfileFloatA( "Shadows", "ShadowAOStrength", ds.ShadowAOStrength, ini );
         s.WorldAOStrength = GetPrivateProfileFloatA( "Shadows", "WorldAOStrength", ds.WorldAOStrength, ini );
+        s.DebugSettings.ShadowCascades.ShadowDepthSlopeBias = GetPrivateProfileFloatA( "Shadows", "ShadowDepthSlopeBias", ds.DebugSettings.ShadowCascades.ShadowDepthSlopeBias, ini );
 
         INT2 res = {};
         RECT desktopRect;

--- a/D3D11Engine/GothicGraphicsState.cpp
+++ b/D3D11Engine/GothicGraphicsState.cpp
@@ -31,10 +31,10 @@ static void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.DebugSettings.FeatureSet.UseShadowAtlas = true;
         s.ShadowMapSize = 1024;
         s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_AGGRESSIVE;
-        s.ShadowSoftness = 0.85f;
+        s.ShadowSoftness = 2.00f;
         s.SmoothShadowCameraUpdate = true;
         s.SmoothShadowFrequency = 500;
-        s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_DISABLED;
+        s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_SIMPLE;
 
         s.EnableDynamicLighting = false;
         s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_DISABLED;
@@ -66,7 +66,7 @@ static void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.DebugSettings.FeatureSet.UseShadowAtlas = true;
         s.ShadowMapSize = 2048;
         s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_CONSERVATIVE;
-        s.ShadowSoftness = 0.85f;
+        s.ShadowSoftness = 2.00f;
         s.SmoothShadowCameraUpdate = true;
         s.SmoothShadowFrequency = 1000;
         s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_SIMPLE;
@@ -74,7 +74,8 @@ static void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.EnableDynamicLighting = true;
         s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY;
 
-        s.AoMode = AOMode::AO_NONE;
+        s.AoMode = AOMode::AO_ASSAO;
+        s.ApplyAssaoPreset( 0 );
 
         s.textureMaxSize = static_cast<int>(GothicRendererSettings::TX_QUALITY::Medium);
 
@@ -100,7 +101,7 @@ static void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.NumShadowCascades = 3;
         s.ShadowMapSize = 4096;
         s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_CONSERVATIVE;
-        s.ShadowSoftness = 1.0f;
+        s.ShadowSoftness = 2.0f;
         s.SmoothShadowCameraUpdate = false;
         s.SmoothShadowFrequency = 1000;
         s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_SIMPLE;
@@ -108,9 +109,8 @@ static void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.EnableDynamicLighting = true;
         s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_UPDATE_DYNAMIC;
 
-        s.AoMode = AOMode::AO_HBAO;
-        s.HbaoSettings.SsaoStepCount = 4;
-        s.HbaoSettings.SsaoBlurRadius = 4;
+        s.AoMode = AOMode::AO_ASSAO;
+        s.ApplyAssaoPreset( 1 );
 
         s.textureMaxSize = static_cast<int>(GothicRendererSettings::TX_QUALITY::High);
 
@@ -144,9 +144,8 @@ static void ApplyGraphicsPresets( GothicRendererSettings& s ) {
         s.EnableDynamicLighting = true;
         s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_UPDATE_DYNAMIC;
 
-        s.AoMode = AOMode::AO_HBAO;
-        s.HbaoSettings.SsaoStepCount = 8;
-        s.HbaoSettings.SsaoBlurRadius = 4;
+        s.AoMode = AOMode::AO_ASSAO;
+        s.ApplyAssaoPreset( 1 );
 
         s.textureMaxSize = static_cast<int>(GothicRendererSettings::TX_QUALITY::VeryHigh);
 

--- a/D3D11Engine/GothicGraphicsState.cpp
+++ b/D3D11Engine/GothicGraphicsState.cpp
@@ -1,0 +1,187 @@
+#include "GothicGraphicsState.h"
+#include "Engine.h"
+#include "GothicAPI.h"
+#include "D3D11ShadowMap.h"
+#include "BaseGraphicsEngine.h"
+
+static void ApplyFeatureLevel10Downgrades( GothicRendererSettings& s ) {
+    // one 4k texture, 1/2 2k textures max.
+    s.NumShadowCascades = std::min( s.NumShadowCascades, MAX_CSM_CASCADES );
+
+    if ( s.NumShadowCascades >= 2 ) {
+        s.DebugSettings.ShadowCascades.Lambda = D3D11ShadowMap::lambdaBiasTable[s.NumShadowCascades].lambda;
+        s.DebugSettings.ShadowCascades.Bias = D3D11ShadowMap::lambdaBiasTable[s.NumShadowCascades].bias;
+    }
+}
+
+static void ApplyGraphicsPresets( GothicRendererSettings& s ) {
+    const auto preset = s.GraphicsPreset;
+    if ( preset == GothicRendererSettings::E_GraphicsPreset::GRAPHICS_CUSTOM ) {
+        return;
+    }
+
+    switch ( preset ) {
+    case GothicRendererSettings::GRAPHICS_LOW:
+    {
+        s.ChangeWindowPreset = WINDOW_MODE_FULLSCREEN_BORDERLESS;
+
+        s.CompressBackBuffer = true;
+        s.WorldShadowRangeScale = 1.0f;
+        s.NumShadowCascades = 2;
+        s.DebugSettings.FeatureSet.UseShadowAtlas = true;
+        s.ShadowMapSize = 1024;
+        s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_AGGRESSIVE;
+        s.ShadowSoftness = 0.85f;
+        s.SmoothShadowCameraUpdate = true;
+        s.SmoothShadowFrequency = 500;
+        s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_DISABLED;
+
+        s.EnableDynamicLighting = false;
+        s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_DISABLED;
+
+        s.AoMode = AOMode::AO_NONE;
+
+        s.textureMaxSize = static_cast<int>(GothicRendererSettings::TX_QUALITY::Medium);
+
+        s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_NONE;
+        s.SectionDrawRadius = 2;
+        s.VisualFXDrawRadius = 5'000;
+        s.OutdoorVobDrawRadius = 30'000;
+        s.OutdoorSmallVobDrawRadius = 10'000;
+        s.IndoorVobDrawRadius = 10'000;
+
+        s.WindQuality = GothicRendererSettings::EWindQuality::WIND_QUALITY_NONE;
+        s.HeroAffectsObjects = 0;
+
+        s.EnableGodRays = false;
+    }
+    break;
+    case GothicRendererSettings::GRAPHICS_MEDIUM:
+    {
+        s.ChangeWindowPreset = WINDOW_MODE_FULLSCREEN_BORDERLESS;
+
+        s.CompressBackBuffer = true;
+        s.WorldShadowRangeScale = 1.0f;
+        s.NumShadowCascades = 3;
+        s.DebugSettings.FeatureSet.UseShadowAtlas = true;
+        s.ShadowMapSize = 2048;
+        s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_CONSERVATIVE;
+        s.ShadowSoftness = 0.85f;
+        s.SmoothShadowCameraUpdate = true;
+        s.SmoothShadowFrequency = 1000;
+        s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_SIMPLE;
+
+        s.EnableDynamicLighting = true;
+        s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY;
+
+        s.AoMode = AOMode::AO_NONE;
+
+        s.textureMaxSize = static_cast<int>(GothicRendererSettings::TX_QUALITY::Medium);
+
+        s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_SMAA;
+        s.SectionDrawRadius = 4;
+        s.VisualFXDrawRadius = 6'000;
+        s.OutdoorVobDrawRadius = 30'000;
+        s.OutdoorSmallVobDrawRadius = 15'000;
+        s.IndoorVobDrawRadius = 15'000;
+
+        s.WindQuality = GothicRendererSettings::EWindQuality::WIND_QUALITY_NONE;
+        s.HeroAffectsObjects = 1;
+
+        s.EnableGodRays = true;
+    }
+    break;
+    case GothicRendererSettings::GRAPHICS_HIGH:
+    {
+        s.ChangeWindowPreset = WINDOW_MODE_FULLSCREEN_BORDERLESS;
+
+        s.CompressBackBuffer = false;
+        s.WorldShadowRangeScale = 1.0f;
+        s.NumShadowCascades = 3;
+        s.ShadowMapSize = 4096;
+        s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_CONSERVATIVE;
+        s.ShadowSoftness = 1.0f;
+        s.SmoothShadowCameraUpdate = false;
+        s.SmoothShadowFrequency = 1000;
+        s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_SIMPLE;
+
+        s.EnableDynamicLighting = true;
+        s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_UPDATE_DYNAMIC;
+
+        s.AoMode = AOMode::AO_HBAO;
+        s.HbaoSettings.SsaoStepCount = 4;
+        s.HbaoSettings.SsaoBlurRadius = 4;
+
+        s.textureMaxSize = static_cast<int>(GothicRendererSettings::TX_QUALITY::High);
+
+        s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_SMAA;
+        s.SectionDrawRadius = 4;
+        s.VisualFXDrawRadius = 8'000;
+        s.OutdoorVobDrawRadius = 40'000;
+        s.OutdoorSmallVobDrawRadius = 25'000;
+        s.IndoorVobDrawRadius = 20'000;
+
+        s.WindQuality = GothicRendererSettings::EWindQuality::WIND_QUALITY_ADVANCED;
+        s.HeroAffectsObjects = 1;
+
+        s.EnableGodRays = true;
+    }
+    break;
+    case GothicRendererSettings::GRAPHICS_VERY_HIGH:
+    {
+        s.ChangeWindowPreset = WINDOW_MODE_FULLSCREEN_BORDERLESS;
+
+        s.CompressBackBuffer = false;
+        s.WorldShadowRangeScale = 1.0f;
+        s.NumShadowCascades = 4;
+        s.ShadowMapSize = 4096;
+        s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_CONSERVATIVE;
+        s.ShadowSoftness = 1.0f;
+        s.SmoothShadowCameraUpdate = false;
+        s.SmoothShadowFrequency = 1000;
+        s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_PCSS;
+
+        s.EnableDynamicLighting = true;
+        s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_UPDATE_DYNAMIC;
+
+        s.AoMode = AOMode::AO_HBAO;
+        s.HbaoSettings.SsaoStepCount = 8;
+        s.HbaoSettings.SsaoBlurRadius = 4;
+
+        s.textureMaxSize = static_cast<int>(GothicRendererSettings::TX_QUALITY::VeryHigh);
+
+        s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_SMAA;
+        s.SectionDrawRadius = 5;
+        s.VisualFXDrawRadius = 10'000;
+        s.OutdoorVobDrawRadius = 40'000;
+        s.OutdoorSmallVobDrawRadius = 25'000;
+        s.IndoorVobDrawRadius = 20'000;
+
+        s.WindQuality = GothicRendererSettings::EWindQuality::WIND_QUALITY_ADVANCED;
+        s.HeroAffectsObjects = 1;
+
+        s.EnableGodRays = true;
+    }
+    break;
+    default:
+        return;
+    }
+
+    if ( FeatureLevel10Compatibility ) {
+        s.ApplyFeatureLevel10Downgrades();
+    }
+
+    Engine::GAPI->UpdateTextureMaxSize();
+    Engine::GraphicsEngine->ReloadShaders();
+    Engine::GAPI->UpdateCompressBackBuffer();
+}
+
+void GothicRendererSettings::ApplyGraphicsPreset()
+{
+    ::ApplyGraphicsPresets( *this );
+}
+
+void GothicRendererSettings::ApplyFeatureLevel10Downgrades()
+{
+    ::ApplyFeatureLevel10Downgrades( *this );
+}

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -420,6 +420,7 @@ struct GothicRasterizerStateInfo : public GothicPipelineState {
     void SetDefault() {
         CullMode = CM_CULL_BACK;
         ZBias = 0;
+        SlopeScaledDepthBias = 0.0f;
         FrontCounterClockwise = false;
         Wireframe = false;
         DepthClipEnable = false;
@@ -431,6 +432,7 @@ struct GothicRasterizerStateInfo : public GothicPipelineState {
     bool Wireframe;
     bool Padding;
     int ZBias;
+    float SlopeScaledDepthBias;
 
     /** Deletes all cached states */
     static void DeleteCachedObjects() {
@@ -849,6 +851,7 @@ struct GothicRendererSettings {
         DebugSettings.Culling.CullBspSections = true;
         DebugSettings.Culling.CullVobs = true;
         DebugSettings.ShadowCascades.LazyCascadeUpdate = true;
+        DebugSettings.ShadowCascades.ShadowDepthSlopeBias = 0.0f;
         DebugSettings.FeatureSet.EnableDriverExtensions = true;
         DebugSettings.FeatureSet.UseWorldSectionBVH = true;
         DebugSettings.FeatureSet.UseScreenSpaceShadowMask = false;
@@ -1047,6 +1050,7 @@ struct GothicRendererSettings {
             float ExtendSide;
             float Lambda;
             float Bias;
+            float ShadowDepthSlopeBias;
         } ShadowCascades;
         struct {
             bool CullVobs;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -612,6 +612,15 @@ struct GothicRendererSettings {
         RM_ForwardPlus = 1,
     };
 
+    enum class TX_QUALITY : uint16_t {
+        VeryLow = 128,
+        Low = 256,
+        Medium = 512,
+        High = 1024,
+        VeryHigh = 2048,
+        MAX = 16384,
+    };
+
     /** Sets the default values for this struct */
     void SetDefault() {
         SectionDrawRadius = 4;
@@ -808,6 +817,9 @@ struct GothicRendererSettings {
 
         ResetDebugSettings();
     }
+
+    void ApplyGraphicsPreset();
+    void ApplyFeatureLevel10Downgrades();
 
     void ApplyAssaoPreset( int preset ) {
         AssaoSettings = ASSAO_Settings();

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -30,15 +30,6 @@ extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler( HWND hWnd, UINT ms
 extern float* ShadowMapLambda;
 extern float* ShadowMapBias;
 
-enum class TX_QUALITY : uint16_t {
-    VeryLow = 128,
-    Low = 256,
-    Medium = 512,
-    High = 1024,
-    VeryHigh = 2048,
-    MAX = 16384,
-};
-
 int GetDpi( HWND hWnd )
 {
     bool v81 = IsWindows8Point1OrGreater();
@@ -72,8 +63,6 @@ int GetDpi( HWND hWnd )
 
     return ydpi;
 }
-
-void ApplyFeatureLevel10Downgrades(GothicRendererSettings& s);
 
 void ImGuiShim::Init(
     HWND Window,
@@ -180,7 +169,7 @@ void ImGuiShim::RenderLoop()
             Engine::GAPI->GetRendererState().RendererSettings.GraphicsPreset = GothicRendererSettings::E_GraphicsPreset::GRAPHICS_CUSTOM;
         }
         if ( FeatureLevel10Compatibility ) {
-            ApplyFeatureLevel10Downgrades( Engine::GAPI->GetRendererState().RendererSettings );
+            Engine::GAPI->GetRendererState().RendererSettings.ApplyFeatureLevel10Downgrades();
         }
     }
     //if ( DemoVisible )
@@ -408,177 +397,6 @@ bool ImGuizmoDirectionEdit( const char* label, XMFLOAT3& direction, float widget
     return modified;
 }
 
-void ApplyFeatureLevel10Downgrades(GothicRendererSettings& s) {
-    // one 4k texture, 1/2 2k textures max.
-    s.NumShadowCascades = std::min(s.NumShadowCascades, MAX_CSM_CASCADES);
-
-    if (s.NumShadowCascades >= 2) {
-        s.DebugSettings.ShadowCascades.Lambda = D3D11ShadowMap::lambdaBiasTable[s.NumShadowCascades].lambda;
-        s.DebugSettings.ShadowCascades.Bias = D3D11ShadowMap::lambdaBiasTable[s.NumShadowCascades].bias;
-    }
-}
-
-void ApplyGraphicsPresets( GothicRendererSettings& s ) {
-    const auto preset = s.GraphicsPreset;
-    if ( preset == GothicRendererSettings::E_GraphicsPreset::GRAPHICS_CUSTOM ) {
-        return;
-    }
-
-    switch ( preset ) {
-    case GothicRendererSettings::GRAPHICS_LOW:
-    {
-        s.ChangeWindowPreset = WINDOW_MODE_FULLSCREEN_BORDERLESS;
-
-        s.CompressBackBuffer = true;
-        s.WorldShadowRangeScale = 1.0f;
-        s.NumShadowCascades = 2;
-        s.DebugSettings.FeatureSet.UseShadowAtlas = true;
-        s.ShadowMapSize = 1024;
-        s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_AGGRESSIVE;
-        s.ShadowSoftness = 0.85f;
-        s.SmoothShadowCameraUpdate = true;
-        s.SmoothShadowFrequency = 500;
-        s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_DISABLED;
-
-        s.EnableDynamicLighting = false;
-        s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_DISABLED;
-
-        s.AoMode = AOMode::AO_NONE;
-
-        s.textureMaxSize = static_cast<int>(TX_QUALITY::Medium);
-
-        s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_NONE;
-        s.SectionDrawRadius = 2;
-        s.VisualFXDrawRadius = 5'000;
-        s.OutdoorVobDrawRadius = 30'000;
-        s.OutdoorSmallVobDrawRadius = 10'000;
-        s.IndoorVobDrawRadius = 10'000;
-        
-        s.WindQuality = GothicRendererSettings::EWindQuality::WIND_QUALITY_NONE;
-        s.HeroAffectsObjects = 0;
-
-        s.EnableGodRays = false;
-    }
-    break;
-    case GothicRendererSettings::GRAPHICS_MEDIUM:
-    {
-        s.ChangeWindowPreset = WINDOW_MODE_FULLSCREEN_BORDERLESS;
-
-        s.CompressBackBuffer = true;
-        s.WorldShadowRangeScale = 1.0f;
-        s.NumShadowCascades = 3;
-        s.DebugSettings.FeatureSet.UseShadowAtlas = true;
-        s.ShadowMapSize = 2048;
-        s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_CONSERVATIVE;
-        s.ShadowSoftness = 0.85f;
-        s.SmoothShadowCameraUpdate = true;
-        s.SmoothShadowFrequency = 1000;
-        s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_SIMPLE;
-            
-        s.EnableDynamicLighting = true;
-        s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY;
-
-        s.AoMode = AOMode::AO_NONE;
-
-        s.textureMaxSize = static_cast<int>(TX_QUALITY::Medium);
-
-        s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_SMAA;
-        s.SectionDrawRadius = 4;
-        s.VisualFXDrawRadius = 6'000;
-        s.OutdoorVobDrawRadius = 30'000;
-        s.OutdoorSmallVobDrawRadius = 15'000;
-        s.IndoorVobDrawRadius = 15'000;
-
-        s.WindQuality = GothicRendererSettings::EWindQuality::WIND_QUALITY_NONE;
-        s.HeroAffectsObjects = 1;
-
-        s.EnableGodRays = true;
-    }
-    break;
-    case GothicRendererSettings::GRAPHICS_HIGH:
-    {
-        s.ChangeWindowPreset = WINDOW_MODE_FULLSCREEN_BORDERLESS;
-
-        s.CompressBackBuffer = false;
-        s.WorldShadowRangeScale = 1.0f;
-        s.NumShadowCascades = 3;
-        s.ShadowMapSize = 4096;
-        s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_CONSERVATIVE;
-        s.ShadowSoftness = 1.0f;
-        s.SmoothShadowCameraUpdate = false;
-        s.SmoothShadowFrequency = 1000;
-        s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_SIMPLE;
-
-        s.EnableDynamicLighting = true;
-        s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_UPDATE_DYNAMIC;
-
-        s.AoMode = AOMode::AO_HBAO;
-        s.HbaoSettings.SsaoStepCount = 4;
-        s.HbaoSettings.SsaoBlurRadius = 4;
-
-        s.textureMaxSize = static_cast<int>(TX_QUALITY::High);
-
-        s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_SMAA;
-        s.SectionDrawRadius = 4;
-        s.VisualFXDrawRadius = 8'000;
-        s.OutdoorVobDrawRadius = 40'000;
-        s.OutdoorSmallVobDrawRadius = 25'000;
-        s.IndoorVobDrawRadius = 20'000;
-
-        s.WindQuality = GothicRendererSettings::EWindQuality::WIND_QUALITY_ADVANCED;
-        s.HeroAffectsObjects = 1;
-
-        s.EnableGodRays = true;
-    }
-    break;
-    case GothicRendererSettings::GRAPHICS_VERY_HIGH:
-    {
-        s.ChangeWindowPreset = WINDOW_MODE_FULLSCREEN_BORDERLESS;
-
-        s.CompressBackBuffer = false;
-        s.WorldShadowRangeScale = 1.0f;
-        s.NumShadowCascades = 4;
-        s.ShadowMapSize = 4096;
-        s.ShadowFrustumCullingMode = GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_CONSERVATIVE;
-        s.ShadowSoftness = 1.0f;
-        s.SmoothShadowCameraUpdate = false;
-        s.SmoothShadowFrequency = 1000;
-        s.ShadowFilterMode = GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_PCSS;
-
-        s.EnableDynamicLighting = true;
-        s.EnablePointlightShadows = GothicRendererSettings::EPointLightShadowMode::PLS_UPDATE_DYNAMIC;
-
-        s.AoMode = AOMode::AO_HBAO;
-        s.HbaoSettings.SsaoStepCount = 8;
-        s.HbaoSettings.SsaoBlurRadius = 4;
-
-        s.textureMaxSize = static_cast<int>(TX_QUALITY::VeryHigh);
-
-        s.AntiAliasingMode = GothicRendererSettings::E_AntiAliasingMode::AA_SMAA;
-        s.SectionDrawRadius = 5;
-        s.VisualFXDrawRadius = 10'000;
-        s.OutdoorVobDrawRadius = 40'000;
-        s.OutdoorSmallVobDrawRadius = 25'000;
-        s.IndoorVobDrawRadius = 20'000;
-
-        s.WindQuality = GothicRendererSettings::EWindQuality::WIND_QUALITY_ADVANCED;
-        s.HeroAffectsObjects = 1;
-
-        s.EnableGodRays = true;
-    }
-    break;
-    default:
-        return;
-    }
-
-    if (FeatureLevel10Compatibility) {
-        ApplyFeatureLevel10Downgrades(s);
-    }
-    
-    Engine::GAPI->UpdateTextureMaxSize();
-    Engine::GraphicsEngine->ReloadShaders();
-    Engine::GAPI->UpdateCompressBackBuffer();
-}
 
 namespace
 {
@@ -642,7 +460,7 @@ void ImGuiShim::RenderSettingsWindow()
         
         ImGui::PushItemWidth( 250 );
         if ( ImComboBoxC( "##GraphicsPreset", graphicsPresets, (int*)&settings.GraphicsPreset, [&settings]() {
-            ApplyGraphicsPresets( settings );
+            settings.ApplyGraphicsPreset();
             } ) ) {
             ImGui::EndCombo();
         }
@@ -864,12 +682,12 @@ void ImGuiShim::RenderSettingsWindow()
 
             ImText( "Texture Quality", buttonWidth ); ImGui::SameLine();
             static std::vector<std::pair<const char*, int>> QualityOptions = {
-                { "Very Low", static_cast<int>(TX_QUALITY::VeryLow) },
-                { "Low", static_cast<int>(TX_QUALITY::Low) },
-                { "Medium", static_cast<int>(TX_QUALITY::Medium) },
-                { "High", static_cast<int>(TX_QUALITY::High) },
-                { "Very High", static_cast<int>(TX_QUALITY::VeryHigh) },
-                { "Extreme", static_cast<int>(TX_QUALITY::MAX) }, // TODO: this should depend on the GPU capabilities like in the original game
+                { "Very Low", static_cast<int>(GothicRendererSettings::TX_QUALITY::VeryLow) },
+                { "Low", static_cast<int>(GothicRendererSettings::TX_QUALITY::Low) },
+                { "Medium", static_cast<int>(GothicRendererSettings::TX_QUALITY::Medium) },
+                { "High", static_cast<int>(GothicRendererSettings::TX_QUALITY::High) },
+                { "Very High", static_cast<int>(GothicRendererSettings::TX_QUALITY::VeryHigh) },
+                { "Extreme", static_cast<int>(GothicRendererSettings::TX_QUALITY::MAX) }, // TODO: this should depend on the GPU capabilities like in the original game
             };
             
             if (settings.textureMaxSize > QualityOptions.back().second) {
@@ -1277,7 +1095,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 settings.NumShadowCascades = std::clamp( settings.NumShadowCascades, 1, max_cascaded_supported );
                 settings.DebugSettings.ShadowCascades.Lambda = D3D11ShadowMap::lambdaBiasTable[settings.NumShadowCascades].lambda;
                 settings.DebugSettings.ShadowCascades.Bias = D3D11ShadowMap::lambdaBiasTable[settings.NumShadowCascades].bias;
-                ApplyFeatureLevel10Downgrades(settings);
+                settings.ApplyFeatureLevel10Downgrades();
                 Engine::GraphicsEngine->ReloadShaders( ShaderCategory::LightsAndShadows );
             }
             ImGui::SetItemTooltip( "Changing this will reload shaders." );
@@ -1435,7 +1253,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                     ImGui::SetItemTooltip( "Uses compute shader light culling for point lights. Reduces draw calls and overdraw." );
                 }
                 if ( ImGui::Checkbox( "Use Shadow Atlas", &settings.DebugSettings.FeatureSet.UseShadowAtlas ) ) {
-                    ApplyFeatureLevel10Downgrades( settings );
+                    settings.ApplyFeatureLevel10Downgrades();
                 }
                 ImGui::SetItemTooltip("Enables a less intensive but lower quality shadow solution.");
                 if ( ImGui::Checkbox( "Use Screen-Space Shadow Mask", &settings.DebugSettings.FeatureSet.UseScreenSpaceShadowMask ) ) {

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1401,7 +1401,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 ImGui::SliderFloat("Extend Side", &settings.DebugSettings.ShadowCascades.ExtendSide, -10000, 20000, "%.0f");
                 ImGui::SliderFloat("Split Lambda", &settings.DebugSettings.ShadowCascades.Lambda, 0.0f, 1.00f, "%.2f");
                 ImGui::SliderFloat("Split Bias", &settings.DebugSettings.ShadowCascades.Bias, 0.0f, 10.0f, "%.1f");
-                ImGui::SliderFloat("Depth Slope Bias", &settings.DebugSettings.ShadowCascades.ShadowDepthSlopeBias, 0.0f, 8.0f, "%.2f");
+                ImGui::SliderFloat("Depth Slope Bias", &settings.DebugSettings.ShadowCascades.ShadowDepthSlopeBias, 0.0f, 8.0f, "%.6f");
                 ImGui::SetItemTooltip("Slope-scaled depth bias for the shadow caster pass. Higher removes shadow acne/stepping on thin geometry; too high detaches contact shadows (peter-panning)");
                 ImGui::EndTabItem();
             }

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1401,6 +1401,8 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 ImGui::SliderFloat("Extend Side", &settings.DebugSettings.ShadowCascades.ExtendSide, -10000, 20000, "%.0f");
                 ImGui::SliderFloat("Split Lambda", &settings.DebugSettings.ShadowCascades.Lambda, 0.0f, 1.00f, "%.2f");
                 ImGui::SliderFloat("Split Bias", &settings.DebugSettings.ShadowCascades.Bias, 0.0f, 10.0f, "%.1f");
+                ImGui::SliderFloat("Depth Slope Bias", &settings.DebugSettings.ShadowCascades.ShadowDepthSlopeBias, 0.0f, 8.0f, "%.2f");
+                ImGui::SetItemTooltip("Slope-scaled depth bias for the shadow caster pass. Higher removes shadow acne/stepping on thin geometry; too high detaches contact shadows (peter-panning)");
                 ImGui::EndTabItem();
             }
             

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -35,6 +35,9 @@ cbuffer DS_ScreenQuadConstantBuffer : register(b0)
 
     // Shadow atlas: per-cascade UV rect (xy = offset, zw = scale)
     float4 SQ_CascadeAtlasRect[MAX_CSM_CASCADES];
+
+    // World-space units per texel, precomputed on CPU (x=cascade0 ... w=cascade3).
+    float4 SQ_CascadeTexelSize;
 };
 
 //--------------------------------------------------------------------------------------
@@ -277,7 +280,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
         float slopeScale = sqrt(saturate(1.0f - NoL * NoL));
 
         int cascadeIndex = GetPrimaryCascadeIndex(wsPosition);
-        float texelWorldSize = GetCascadeWorldTexelSize(cascadeIndex);
+        float texelWorldSize = SQ_CascadeTexelSize[cascadeIndex];
 
         const float normalBiasMultiplier = 1.5f;
 

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -135,7 +135,7 @@ FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 			float slopeScale = sqrt(saturate(1.0f - NoL * NoL));
 
 			int cascadeIndex = GetPrimaryCascadeIndex(wsPosition);
-			float texelWorldSize = GetCascadeWorldTexelSize(cascadeIndex);
+			float texelWorldSize = SQ_CascadeTexelSize[cascadeIndex];
 
 			const float normalBiasMultiplier = 1.5f;
 

--- a/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
+++ b/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
@@ -40,6 +40,9 @@ cbuffer DS_ScreenQuadConstantBuffer : register( b0 )
 
     // Shadow atlas: per-cascade UV rect (xy = offset, zw = scale)
     float4 SQ_CascadeAtlasRect[MAX_CSM_CASCADES];
+
+    // World-space units per texel, precomputed on CPU (x=cascade0 ... w=cascade3).
+    float4 SQ_CascadeTexelSize;
 };
 
 //--------------------------------------------------------------------------------------
@@ -105,7 +108,7 @@ float PSMain( PS_INPUT Input ) : SV_TARGET
     float slopeScale = sqrt( saturate( 1.0f - NoL * NoL ) );
 
     int cascadeIndex = GetPrimaryCascadeIndex( wsPosition );
-    float texelWorldSize = GetCascadeWorldTexelSize( cascadeIndex );
+    float texelWorldSize = SQ_CascadeTexelSize[cascadeIndex];
 
     const float normalBiasMultiplier = 1.5f;
 

--- a/D3D11Engine/Shaders/ShadowSampling.h
+++ b/D3D11Engine/Shaders/ShadowSampling.h
@@ -95,29 +95,12 @@ float SampleShadowMapLevel(float2 cascadeUV, int cascadeIndex)
 #endif
 
 //--------------------------------------------------------------------------------------
-// High-quality Poisson disk for shadow sampling
-// Rotated per-pixel for better TAA integration and reduced banding
+// Single 32-tap Poisson disk used for all sampling quality levels.
+// Near-cascade PCF/PCSS: full 32 taps (mask & 31).
+// Mid-quality:           first 16 entries  (mask & 15).
+// Distant cascades:      first 8 entries   (mask & 7).
+// The first 8 and 16 entries form valid sub-distributions on their own.
 //--------------------------------------------------------------------------------------
-static const float2 g_PoissonDisk16[16] = {
-    float2(-0.94201624f, -0.39906216f),
-    float2( 0.94558609f, -0.76890725f),
-    float2(-0.09418410f, -0.92938870f),
-    float2( 0.34495938f,  0.29387760f),
-    float2(-0.91588581f,  0.45771432f),
-    float2(-0.81544232f, -0.87912464f),
-    float2(-0.38277543f,  0.27676845f),
-    float2( 0.97484398f,  0.75648379f),
-    float2( 0.44323325f, -0.97511554f),
-    float2( 0.53742981f, -0.47373420f),
-    float2(-0.26496911f, -0.41893023f),
-    float2( 0.79197514f,  0.19090188f),
-    float2(-0.24188840f,  0.99706507f),
-    float2(-0.81409955f,  0.91437590f),
-    float2( 0.19984126f,  0.78641367f),
-    float2( 0.14383161f, -0.14100790f)
-};
-
-// 32-tap Poisson disk for high quality PCSS
 static const float2 g_PoissonDisk32[32] = {
     float2(-0.94201624f, -0.39906216f),
     float2( 0.94558609f, -0.76890725f),
@@ -153,18 +136,6 @@ static const float2 g_PoissonDisk32[32] = {
     float2(-0.04244530f,  0.71893100f)
 };
 
-// 8-tap Poisson disk for medium quality / distant cascades
-static const float2 g_PoissonDisk8[8] = {
-    float2(-0.7071f,  0.7071f),
-    float2(-0.0000f, -0.8750f),
-    float2( 0.5303f,  0.5303f),
-    float2(-0.6250f, -0.3310f),
-    float2( 0.8750f,  0.0000f),
-    float2(-0.3310f,  0.6250f),
-    float2( 0.3310f, -0.6250f),
-    float2( 0.0000f,  0.0000f)
-};
-
 float GetShadowBlueNoise(float2 screenPos, int cascadeIndex, int sampleOffset)
 {
 #if SHD_BLUE_NOISE
@@ -190,53 +161,62 @@ float GetShadowBlueNoise(float2 screenPos, int cascadeIndex, int sampleOffset)
 #endif
 }
 
+// patternSize MUST be a power of two (8, 16, or 32).
 int GetBlueNoiseStartIndex(float2 screenPos, int cascadeIndex, int patternSize, int sampleOffset)
 {
     int size = max(patternSize, 1);
-    return (int)(GetShadowBlueNoise(screenPos, cascadeIndex, sampleOffset) * (float)size) % size;
+    return (int)(GetShadowBlueNoise(screenPos, cascadeIndex, sampleOffset) * (float)size) & (size - 1);
 }
 
-float2x2 RotationMatrixFromNoise(float rawNoise)
+//--------------------------------------------------------------------------------------
+// Rotation helpers.
+// Rotation state is stored as float2(cos, sin) to halve register cost vs float2x2.
+// All Poisson offsets are rotated with RotatePoisson() rather than mul().
+//--------------------------------------------------------------------------------------
+float2 RotatePoisson(float2 v, float2 rotSC)
+{
+    return float2(rotSC.x * v.x - rotSC.y * v.y,
+                  rotSC.y * v.x + rotSC.x * v.y);
+}
+
+// Returns float2(cos(angle), sin(angle)) derived from a [0,1] noise value.
+float2 RotationSCFromNoise(float rawNoise)
 {
     float angle = rawNoise * 6.283185307f;
-
     float s, c;
     sincos(angle, s, c);
-    return float2x2(c, -s, s, c);
+    return float2(c, s);
 }
 
-float2x2 GetPoissonRotationMatrixForCascade(float2 screenPos, int cascadeIndex)
+float2 GetPoissonRotationSCForCascade(float2 screenPos, int cascadeIndex)
 {
-	// If TAA is disabled return an identity matrix to get standard PCF instead of noise.
+    // If TAA is disabled return identity (standard unrotated PCF, no noise).
     if (SQ_FrameIndex == 0)
-	{
-			return float2x2(1.0f, 0.0f, 0.0f, 1.0f);
-	}
+        return float2(1.0f, 0.0f);
 
-    return RotationMatrixFromNoise(GetShadowBlueNoise(screenPos, cascadeIndex, 0));
+    return RotationSCFromNoise(GetShadowBlueNoise(screenPos, cascadeIndex, 0));
 }
 
-float2x2 GetPoissonRotationMatrix(float2 screenPos)
+float2 GetPoissonRotationSC(float2 screenPos)
 {
-    return GetPoissonRotationMatrixForCascade(screenPos, 0);
+    return GetPoissonRotationSCForCascade(screenPos, 0);
 }
 
-float2x2 GetPoissonRotationMatrixRForCascade(float2 screenPos, int cascadeIndex, out float rawNoise)
+float2 GetPoissonRotationSCRForCascade(float2 screenPos, int cascadeIndex, out float rawNoise)
 {
-    // If TAA is disabled return an identity matrix to get standard PCF instead of noise.
     if (SQ_FrameIndex == 0)
-	{
+    {
         rawNoise = 0.5f;
-        return float2x2(1.0f, 0.0f, 0.0f, 1.0f);
-	}
+        return float2(1.0f, 0.0f);
+    }
 
     rawNoise = GetShadowBlueNoise(screenPos, cascadeIndex, 0);
-    return RotationMatrixFromNoise(rawNoise);
+    return RotationSCFromNoise(rawNoise);
 }
 
-float2x2 GetPoissonRotationMatrixR(float2 screenPos, out float rawNoise)
+float2 GetPoissonRotationSCR(float2 screenPos, out float rawNoise)
 {
-    return GetPoissonRotationMatrixRForCascade(screenPos, 0, rawNoise);
+    return GetPoissonRotationSCRForCascade(screenPos, 0, rawNoise);
 }
 
 //--------------------------------------------------------------------------------------
@@ -246,7 +226,7 @@ float2x2 GetPoissonRotationMatrixR(float2 screenPos, out float rawNoise)
 #if SHD_FILTER_PCSS
 void FindBlockers(out float avgBlockerDepth, out float numBlockers,
                   float2 uv, float zReceiver, float searchRadius,
-                  int cascadeIndex, float2x2 rotMat, float2 screenPos)
+                  int cascadeIndex, float2 rotSC, float2 screenPos)
 {
     float blockerSum = 0.0f;
     numBlockers = 0.0f;
@@ -256,34 +236,34 @@ void FindBlockers(out float avgBlockerDepth, out float numBlockers,
     for (int i = 0; i < PCSS_BLOCKER_TAPS; ++i)
     {
         int sampleIdx = (startIdx + i * 5) & 15;
-        float2 offset = mul(rotMat, g_PoissonDisk16[sampleIdx]) * searchRadius;
+        float2 offset = RotatePoisson(g_PoissonDisk32[sampleIdx], rotSC) * searchRadius;
         float shadowMapDepth = SampleShadowMapLevel(uv + offset, cascadeIndex);
 
-        if (shadowMapDepth < zReceiver)
-        {
-            blockerSum += shadowMapDepth;
-            numBlockers += 1.0f;
-        }
+        // Branchless: isBlocker=1 when depth is strictly shallower than receiver.
+        // The 1e-5 margin avoids self-blocking at grazing contacts.
+        float isBlocker = step(shadowMapDepth + 1e-5f, zReceiver);
+        blockerSum += shadowMapDepth * isBlocker;
+        numBlockers += isBlocker;
     }
     avgBlockerDepth = blockerSum / max(numBlockers, 1.0f);
 }
 
 // PCSS: Estimate penumbra width and return filter radius
 float EstimatePCSSFilterRadius(float2 uv, float zReceiver, int cascadeIndex,
-                               float lightSize, float2x2 rotMat, float texelSize, float2 screenPos)
+                               float lightSize, float2 rotSC, float texelSize, float2 screenPos)
 {
     // Cap search radius in texel units to keep blocker search cost predictable.
     float searchRadius = min(lightSize, texelSize * PCSS_BLOCKER_SEARCH_TEXEL_CAP);
-    
+
     float avgBlockerDepth = 0.0f;
     float numBlockers = 0.0f;
-    FindBlockers(avgBlockerDepth, numBlockers, uv, zReceiver, searchRadius, cascadeIndex, rotMat, screenPos);
+    FindBlockers(avgBlockerDepth, numBlockers, uv, zReceiver, searchRadius, cascadeIndex, rotSC, screenPos);
 
     if (numBlockers < 1.0f)
         return -1.0f; // No blockers found - fully lit
 
     float penumbraWidth = (zReceiver - avgBlockerDepth) * lightSize;
-    
+
     return clamp(penumbraWidth, texelSize * 0.5f, texelSize * 32.0f);
 }
 #endif
@@ -293,7 +273,7 @@ float IsInShadow(float3 wsPosition, Texture2D shadowmapAtlas, SamplerComparisonS
 {
     float4 vShadowSamplingPos = mul(float4(wsPosition, 1), SQ_ShadowViewProj[0]);
     // vShadowSamplingPos.xyz /= vShadowSamplingPos.www; // no need for perspective divide, as this is an orthographic sun light
-	
+
     float2 projectedTexCoords = vShadowSamplingPos.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
     return SampleShadowMapCmp(projectedTexCoords.xy, 0, vShadowSamplingPos.z);
 }
@@ -302,7 +282,7 @@ float IsInShadow(float3 wsPosition, Texture2DArray shadowmapArray, SamplerCompar
 {
     float4 vShadowSamplingPos = mul(float4(wsPosition, 1), SQ_ShadowViewProj[0]);
     // vShadowSamplingPos.xyz /= vShadowSamplingPos.www; // no need for perspective divide, as this is an orthographic sun light
-	
+
     float2 projectedTexCoords = vShadowSamplingPos.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
     return shadowmapArray.SampleCmpLevelZero(samplerState, float3(projectedTexCoords.xy, 0), vShadowSamplingPos.z);
 }
@@ -312,7 +292,7 @@ float IsWet(float3 wsPosition, Texture2D shadowmap, SamplerComparisonState sampl
 {
     float4 vShadowSamplingPos = mul(float4(wsPosition, 1), SQ_RainViewProj);
     vShadowSamplingPos.xyz /= vShadowSamplingPos.www;
-	
+
     float2 projectedTexCoords = vShadowSamplingPos.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
     float bias = 0.001f;
     return shadowmap.SampleCmpLevelZero(samplerState, projectedTexCoords.xy, vShadowSamplingPos.z - bias);
@@ -322,22 +302,22 @@ float IsWet(float3 wsPosition, Texture2D shadowmap, SamplerComparisonState sampl
 // Helper: Get shadow map UV and check if position is within cascade bounds
 // Returns: projectedTexCoords in xy, isInBounds as 0 or 1 in z, blend factor in w
 //--------------------------------------------------------------------------------------
-void GetCascadeUVAndBounds(float3 wsPosition, int cascadeIndex, 
-                           out float4 vShadowSamplingPos, out float2 projectedTexCoords, 
+void GetCascadeUVAndBounds(float3 wsPosition, int cascadeIndex,
+                           out float4 vShadowSamplingPos, out float2 projectedTexCoords,
                            out float inBounds, out float blendFactor)
 {
     matrix viewProj = SQ_ShadowViewProj[cascadeIndex];
-    
+
     // Calculate once and pass out
     vShadowSamplingPos = mul(float4(wsPosition, 1), viewProj);
     projectedTexCoords = vShadowSamplingPos.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
-    
+
     // Check if within bounds (with margin for blend zone)
     const float margin = 0.02f;
     bool isInBounds = projectedTexCoords.x > margin && projectedTexCoords.x < (1.0f - margin) &&
                       projectedTexCoords.y > margin && projectedTexCoords.y < (1.0f - margin);
     inBounds = isInBounds ? 1.0f : 0.0f;
-    
+
     // Calculate blend factor based on distance to edge
     // Wide blend zone (30%) with smoothstep for gradual cascade transitions
     const float blendZoneStart = 0.30f;
@@ -368,35 +348,10 @@ int GetPrimaryCascadeIndex(float3 wsPosition)
 }
 
 //--------------------------------------------------------------------------------------
-// Estimates current-cascade world-space texel size from the orthographic shadow matrix.
-//--------------------------------------------------------------------------------------
-float GetCascadeWorldTexelSize(int cascadeIndex)
-{
-    if (cascadeIndex < 0)
-        return 0.0f;
-
-    matrix shadowViewProj = SQ_ShadowViewProj[cascadeIndex];
-
-    float shadowScaleX = length(float3(shadowViewProj[0][0], shadowViewProj[1][0], shadowViewProj[2][0]));
-    float shadowScaleY = length(float3(shadowViewProj[0][1], shadowViewProj[1][1], shadowViewProj[2][1]));
-
-    float worldSpanX = (shadowScaleX > 1e-6f) ? (2.0f / shadowScaleX) : 0.0f;
-    float worldSpanY = (shadowScaleY > 1e-6f) ? (2.0f / shadowScaleY) : 0.0f;
-
-    float cascadeResolution = SQ_ShadowmapSize;
-#if SHADOW_ATLAS
-    float4 atlasRect = SQ_CascadeAtlasRect[cascadeIndex];
-    cascadeResolution *= max(atlasRect.z, atlasRect.w);
-#endif
-
-    return 0.5f * (worldSpanX + worldSpanY) / max(cascadeResolution, 1.0f);
-}
-
-//--------------------------------------------------------------------------------------
 // High-quality shadow sampling with configurable softness
 // Uses rotated Poisson disk for TAA-friendly results
 //--------------------------------------------------------------------------------------
-float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoords, 
+float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoords,
                               int cascadeIndex, float bias, float2 screenPos, float softness)
 {
     if (projectedTexCoords.x < 0.0f || projectedTexCoords.x > 1.0f ||
@@ -404,10 +359,10 @@ float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoor
     {
         return 1.0f;
     }
-    
+
     float shadow = 1.0f;
     float texelSize = 1.0f / SQ_ShadowmapSize;
-    
+
     // Scale the filter radius based on softness setting
     // softness of 1.0 = default, < 1.0 = sharper, > 1.0 = softer
     float filterRadius = texelSize * softness;
@@ -419,11 +374,11 @@ float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoor
     // PCSS inherently handles distance-based penumbra via the blocker depth difference.
     {
         float noiseVal;
-        float2x2 rotMat = GetPoissonRotationMatrixRForCascade(screenPos, cascadeIndex, noiseVal);
+        float2 rotSC = GetPoissonRotationSCRForCascade(screenPos, cascadeIndex, noiseVal);
         float zReceiver = vShadowSamplingPos.z - bias;
-        
+
         float pcssRadius = EstimatePCSSFilterRadius(projectedTexCoords.xy, zReceiver,
-            cascadeIndex, SQ_LightSize, rotMat, texelSize, screenPos);
+            cascadeIndex, SQ_LightSize, rotSC, texelSize, screenPos);
         pcssRadius *= SQ_ShadowSoftness;
 
         if (pcssRadius < 0.0f)
@@ -439,13 +394,13 @@ float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoor
                 float radiusJitter = lerp(0.85f, 1.15f, noiseVal);
                 float finalRadius = pcssRadius * radiusJitter;
                 int startIdx = GetBlueNoiseStartIndex(screenPos, cascadeIndex, 32, 11);
-                
+
                 [unroll]
                 for (int i = 0; i < PCSS_FILTER_TAPS_NEAR; i++)
                 {
                     int sampleIdx = (startIdx + i * 9) & 31;
-                    float2 offset = mul(rotMat, g_PoissonDisk32[sampleIdx]) * finalRadius;
-                    
+                    float2 offset = RotatePoisson(g_PoissonDisk32[sampleIdx], rotSC) * finalRadius;
+
                     sum += SampleShadowMapCmp(
                         projectedTexCoords.xy + offset, cascadeIndex,
                         zReceiver);
@@ -455,12 +410,12 @@ float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoor
                 float radiusJitter = lerp(0.95f, 1.05f, noiseVal);
                 float finalRadius = pcssRadius * radiusJitter;
                 int startIdx = GetBlueNoiseStartIndex(screenPos, cascadeIndex, 16, 17);
-                
+
                 [unroll]
                 for (int i = 0; i < PCSS_FILTER_TAPS_FAR; i++)
                 {
                     int sampleIdx = (startIdx + i * 5) & 15;
-                    float2 offset = mul(rotMat, g_PoissonDisk16[sampleIdx]) * finalRadius;
+                    float2 offset = RotatePoisson(g_PoissonDisk32[sampleIdx], rotSC) * finalRadius;
                     sum += SampleShadowMapCmp(
                         projectedTexCoords.xy + offset, cascadeIndex,
                         zReceiver);
@@ -472,15 +427,15 @@ float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoor
 #elif SHD_FILTER_16TAP_PCF
 #if NUM_CSM_CASCADES <= 1
     // Single cascade - use near cascade quality profile.
-    float2x2 rotMat = GetPoissonRotationMatrixForCascade(screenPos, cascadeIndex);
+    float2 rotSC = GetPoissonRotationSCForCascade(screenPos, cascadeIndex);
     float sum = 0.0f;
     int startIdx = GetBlueNoiseStartIndex(screenPos, cascadeIndex, 16, 23);
-    
+
     [unroll]
     for (int i = 0; i < PCF_FILTER_TAPS_NEAR; i++)
     {
         int sampleIdx = (startIdx + i * 5) & 15;
-        float2 offset = mul(rotMat, g_PoissonDisk16[sampleIdx]) * filterRadius;
+        float2 offset = RotatePoisson(g_PoissonDisk32[sampleIdx], rotSC) * filterRadius;
         sum += SampleShadowMapCmp(
             projectedTexCoords.xy + offset, cascadeIndex,
             vShadowSamplingPos.z - bias);
@@ -488,36 +443,36 @@ float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoor
     shadow = sum / (float)max(PCF_FILTER_TAPS_NEAR, 1);
 #else
     // Multiple cascades - use quality based on cascade index
-    if (cascadeIndex < CSM_PCF_LIMIT) 
+    if (cascadeIndex < CSM_PCF_LIMIT)
     {
         // High quality for close cascades.
-        float2x2 rotMat = GetPoissonRotationMatrixForCascade(screenPos, cascadeIndex);
+        float2 rotSC = GetPoissonRotationSCForCascade(screenPos, cascadeIndex);
         float sum = 0.0f;
         int startIdx = GetBlueNoiseStartIndex(screenPos, cascadeIndex, 16, 29);
-        
+
         [unroll]
         for (int i = 0; i < PCF_FILTER_TAPS_NEAR; i++)
         {
             int sampleIdx = (startIdx + i * 5) & 15;
-            float2 offset = mul(rotMat, g_PoissonDisk16[sampleIdx]) * filterRadius;
+            float2 offset = RotatePoisson(g_PoissonDisk32[sampleIdx], rotSC) * filterRadius;
             sum += SampleShadowMapCmp(
                 projectedTexCoords.xy + offset, cascadeIndex,
                 vShadowSamplingPos.z - bias);
         }
         shadow = sum / (float)max(PCF_FILTER_TAPS_NEAR, 1);
-    } 
-    else 
+    }
+    else
     {
         // Reduced quality profile for distant cascades.
-        float2x2 rotMat = GetPoissonRotationMatrixForCascade(screenPos, cascadeIndex);
+        float2 rotSC = GetPoissonRotationSCForCascade(screenPos, cascadeIndex);
         float sum = 0.0f;
         int startIdx = GetBlueNoiseStartIndex(screenPos, cascadeIndex, 8, 31);
-        
+
         [unroll]
         for (int i = 0; i < PCF_FILTER_TAPS_FAR; i++)
         {
             int sampleIdx = (startIdx + i * 3) & 7;
-            float2 offset = mul(rotMat, g_PoissonDisk8[sampleIdx]) * filterRadius;
+            float2 offset = RotatePoisson(g_PoissonDisk32[sampleIdx], rotSC) * filterRadius;
             sum += SampleShadowMapCmp(
                 projectedTexCoords.xy + offset, cascadeIndex,
                 vShadowSamplingPos.z - bias);
@@ -531,7 +486,7 @@ float SampleCascadeShadowSoft(float4 vShadowSamplingPos, float2 projectedTexCoor
         projectedTexCoords.xy, cascadeIndex,
         vShadowSamplingPos.z - bias);
 #endif
-    
+
     return saturate(shadow);
 }
 
@@ -545,10 +500,10 @@ float ComputeShadowValueDirect(float3 wsPosition, Texture2D shadowmap, SamplerCo
 	// Reconstruct VS World ShadowViewPosition from depth
     float4 vShadowSamplingPos = mul(float4(wsPosition, 1), viewProj);
     // vShadowSamplingPos.xyz /= vShadowSamplingPos.www; // no need for perspective divide, as this is an orthographic sun light
-	
+
     float2 projectedTexCoords = vShadowSamplingPos.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
     float shadow = 1.0f;
-    
+
     // Sample shadow map if within valid bounds
     if (projectedTexCoords.x >= 0.0f && projectedTexCoords.x <= 1.0f &&
         projectedTexCoords.y >= 0.0f && projectedTexCoords.y <= 1.0f)
@@ -556,9 +511,9 @@ float ComputeShadowValueDirect(float3 wsPosition, Texture2D shadowmap, SamplerCo
 #if SHD_FILTER_16TAP_PCF
 		float sum = 0;
 		float x, y;
-		
+
 		float scale = softnessScale;
-		
+
 		//perform PCF filtering on a 4 x 4 texel neighborhood
 		[unroll] for (y = -1.5; y <= 1.5; y += 1.0)
 		{
@@ -567,15 +522,15 @@ float ComputeShadowValueDirect(float3 wsPosition, Texture2D shadowmap, SamplerCo
 				sum += shadowmap.SampleCmpLevelZero( samplerState, projectedTexCoords.xy + TexOffset(x,y) * scale, vShadowSamplingPos.z - bias);
 			}
 		}
-	 
+
 		float shadowFactor = sum / 16.0;
-	
+
 		shadow *= shadowFactor;
 #else
         shadow = shadowmap.SampleCmpLevelZero(samplerState, projectedTexCoords.xy, vShadowSamplingPos.z - bias);
 #endif
     }
-	
+
     return saturate(shadow);
 }
 
@@ -591,10 +546,6 @@ float ComputeShadowValue(float2 uv, float3 wsPosition, Texture2D shadowmap, Samp
 float ComputeCascadedShadowValueSoft(float3 wsPosition, float viewSpaceZ, float vertLighting, float bias, float2 screenPos)
 {
     float shadow = vertLighting;
-    // Apply distance-based softness scaling
-    // Shadows get slightly softer with distance (simulating penumbra growth)
-    float distanceFactor = saturate(abs(viewSpaceZ) / 5000.0f);
-    float softness = SQ_ShadowSoftness * (1.0f + distanceFactor * 0.5f);
 
     int selectedCascade = -1;
     float4 vShadowPos;
@@ -606,8 +557,8 @@ float ComputeCascadedShadowValueSoft(float3 wsPosition, float viewSpaceZ, float 
     {
         float inBounds;
         GetCascadeUVAndBounds(wsPosition, c, vShadowPos, projCoords, inBounds, blendFactor);
-        
-        if (inBounds > 0.5f) 
+
+        if (inBounds > 0.5f)
         {
             selectedCascade = c;
             break; // Standard break without [unroll] is safe and highly efficient
@@ -617,8 +568,13 @@ float ComputeCascadedShadowValueSoft(float3 wsPosition, float viewSpaceZ, float 
     // 2. Only sample textures if a valid cascade was found
     if (selectedCascade >= 0)
     {
+        // Compute distance-based softness only on the hit path to avoid wasted ALU
+        // when the fragment falls outside all cascades.
+        float distanceFactor = saturate(abs(viewSpaceZ) / 5000.0f);
+        float softness = SQ_ShadowSoftness * (1.0f + distanceFactor * 0.5f);
+
         shadow = SampleCascadeShadowSoft(vShadowPos, projCoords, selectedCascade, bias, screenPos, softness);
-        
+
         // 3. Check if we need to blend with the next cascade
         if (selectedCascade < NUM_CSM_CASCADES - 1 && blendFactor > 0.0f)
         {
@@ -626,9 +582,9 @@ float ComputeCascadedShadowValueSoft(float3 wsPosition, float viewSpaceZ, float 
             float2 nextProjCoords;
             float nextInBounds;
             float nextBlendFactor;
-            
+
             GetCascadeUVAndBounds(wsPosition, selectedCascade + 1, nextShadowPos, nextProjCoords, nextInBounds, nextBlendFactor);
-            
+
             if (nextInBounds > 0.5f)
             {
                 float shadowNext = SampleCascadeShadowSoft(nextShadowPos, nextProjCoords, selectedCascade + 1, bias, screenPos, softness);
@@ -636,10 +592,9 @@ float ComputeCascadedShadowValueSoft(float3 wsPosition, float viewSpaceZ, float 
             }
         }
     }
-    
+
     return shadow;
 }
-
 
 
 #endif

--- a/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
+++ b/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
@@ -59,6 +59,9 @@ cbuffer FP_ScreenQuadConstantBuffer : register( b4 )
     float SQ_LightSize;
     float2 SQ_Pad;
     float4 SQ_CascadeAtlasRect[MAX_CSM_CASCADES];
+
+    // World-space units per texel, precomputed on CPU (x=cascade0 ... w=cascade3).
+    float4 SQ_CascadeTexelSize;
 };
 
 // Forward+ tile data


### PR DESCRIPTION
… cascades used is actually allocated in texture. Allow configuring raster SlopeScaledDepthBias

The higher bit depth reduces the amount of artifacts that occur for things like heros ponytail, or necks of NPCs, but uses 4x more VRAM.

Further, up until now, the depth buffer for shadowmaps always allocated all four cascades (array of 4 textures). Now it only allocates a Texture2DArray of the actual required numCascades

- reduce computation in shadow shader by pre-computing texelsize once in constant buffer.
- move graphics preset code from `ImGuiShim.cpp` to `GothicGraphicsState.cpp`
- update graphics presets 
  - set shadow softness to 2 on low/medium/high
  - replace HBAO+ with ASSAO in presets.