### PR TITLE
feat: Interactive focus highlight

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -274,6 +274,7 @@ struct VS_ExConstantBuffer_PerInstanceSkeletal {
     XMFLOAT4X4 PrevWorld; // Added for motion vectors
     float4 PI_ModelColor;
     float PI_ModelFatness;
+    // Pad1.x holds flag if this is a focused vob
     float3 PI_Pad1;
 };
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2996,8 +2996,11 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         }
     };
 
-    const int interactiveFocusEnabled = distance > 100000 // only MOBs, not NPCs
-        && oCGame::GetHighlightInteractFocus();
+    const int interactiveFocusEnabled = (
+        // NPCs are only lit if combat focus is set to highlight and Npcfocus is active (whatever that means...)
+        (oCGame::GetHighlightMeleeFocus() >= 2 && oCGame::GetNpcFocusIsHighlightActive())
+        || distance > 100000 /*MOBs have FLT_MAX distance*/ 
+        ) && oCGame::GetHighlightInteractFocus();
     const zCVob* playerFocusVob = interactiveFocusEnabled && oCGame::GetPlayer() ? oCGame::GetPlayer()->GetFocusVob() : nullptr;
 
     {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2999,7 +2999,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
     const int interactiveFocusEnabled = (
         // NPCs are only lit if combat focus is set to highlight and Npcfocus is active (whatever that means...)
         (oCGame::GetHighlightMeleeFocus() >= 2 && oCGame::GetNpcFocusIsHighlightActive())
-        || distance > 100000 /*MOBs have FLT_MAX distance*/ 
+        || distance > 3.4028235E+37 /*MOBs have FLT_MAX distance + some floating point buffer */
         ) && oCGame::GetHighlightInteractFocus();
     const zCVob* playerFocusVob = interactiveFocusEnabled && oCGame::GetPlayer() ? oCGame::GetPlayer()->GetFocusVob() : nullptr;
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2996,12 +2996,20 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         }
     };
 
-    const int interactiveFocusEnabled = (
-        // NPCs are only lit if combat focus is set to highlight and Npcfocus is active (whatever that means...)
-        (oCGame::GetHighlightMeleeFocus() >= 2 && oCGame::GetNpcFocusIsHighlightActive())
-        || distance > 3.4028235E+37 /*MOBs have FLT_MAX distance + some floating point buffer */
-        ) && oCGame::GetHighlightInteractFocus();
-    const zCVob* playerFocusVob = interactiveFocusEnabled && oCGame::GetPlayer() ? oCGame::GetPlayer()->GetFocusVob() : nullptr;
+    const float focusedColorSentinel = 2.0f;
+    const float interactiveFocusColor = oCGame::GetHighlightInteractFocus() ? focusedColorSentinel : 0.0f;
+    const float meleeFocusColor = oCGame::GetHighlightMeleeFocus() >= 2 && oCGame::GetNpcFocusIsHighlightActive() ? focusedColorSentinel : 0.0f;
+    const zCVob* playerFocusVob = oCGame::GetPlayer() ? oCGame::GetPlayer()->GetFocusVob() : nullptr;
+
+    static auto getFocusColor = []( zCVob* vob, const zCVob* playerFocusVob, float interactiveFocusColor, float meleeFocusColor ) -> float {
+        if ( vob == playerFocusVob ) {
+            if ( vob->As<oCNPC>() ) {
+                return meleeFocusColor;
+            }
+            return interactiveFocusColor;
+        }
+        return 0.0f;
+    };
 
     {
         auto _scopeBaseMeshes = RecordGraphicsEvent( GE_NAME( "DrawSkeletalMeshVobs::BaseMeshes" ) );
@@ -3080,7 +3088,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                     cb2.PI_ModelFatness = fatness;
                     // Set PrevWorld for motion vectors (use current world if no previous is available)
                     cb2.PrevWorld = vi->HasValidPrevTransforms ? vi->PrevWorldMatrix : world;
-                    cb2.PI_Pad1.x = vi->Vob == playerFocusVob ? 2.0f /*2.0f is a special sentinel for focused vobs*/ : 0.0f;
+                    cb2.PI_Pad1.x = getFocusColor(vi->Vob, playerFocusVob, interactiveFocusColor, meleeFocusColor);
 
                     perInstanceCb.Update( &cb2 );
 
@@ -3317,7 +3325,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
                         VS_ExConstantBuffer_PerInstanceNode instanceInfo;
                         instanceInfo.Color = modelColor;
-                        instanceInfo.Color.w = vi->Vob == playerFocusVob ? 2.0f : 0.0f; 
+                        instanceInfo.Color.w = getFocusColor( vi->Vob, playerFocusVob, interactiveFocusColor, meleeFocusColor );
                         instanceInfo.Fatness = std::max<float>( 0.f, fatness * 0.35f );
                         instanceInfo.Scaling = fatness * 0.02f + 1.f;
                         instanceInfo.World = finalWorld;
@@ -3382,7 +3390,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                     instData.World = finalWorld;
                     instData.PrevWorld = finalPrevWorld;
                     instData.Color = modelColor;
-                    instData.Color.w = vi->Vob == playerFocusVob ? 2.0f : 0.0f;
+                    instData.Color.w = getFocusColor( vi->Vob, playerFocusVob, interactiveFocusColor, meleeFocusColor );
 
                     for ( auto const& itm : mvi->Meshes ) {
                         zCTexture* texture = nullptr;

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2996,6 +2996,9 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         }
     };
 
+    const int interactiveFocusEnabled = oCGame::GetHighlightInteractFocus();
+    const zCVob* playerFocusVob = interactiveFocusEnabled && oCGame::GetPlayer() ? oCGame::GetPlayer()->GetFocusVob() : nullptr;
+
     {
         auto _scopeBaseMeshes = RecordGraphicsEvent( GE_NAME( "DrawSkeletalMeshVobs::BaseMeshes" ) );
         TracyD3D11ZoneCGX( "DrawSkeletalMeshVobs::BaseMeshes" );
@@ -3073,6 +3076,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                     cb2.PI_ModelFatness = fatness;
                     // Set PrevWorld for motion vectors (use current world if no previous is available)
                     cb2.PrevWorld = vi->HasValidPrevTransforms ? vi->PrevWorldMatrix : world;
+                    cb2.PI_Pad1.x = vi->Vob == playerFocusVob ? 2.0f /*2.0f is a special sentinel for focused vobs*/ : 0.0f;
 
                     perInstanceCb.Update( &cb2 );
 
@@ -3309,6 +3313,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
                         VS_ExConstantBuffer_PerInstanceNode instanceInfo;
                         instanceInfo.Color = modelColor;
+                        instanceInfo.Color.w = vi->Vob == playerFocusVob ? 2.0f : 0.0f; 
                         instanceInfo.Fatness = std::max<float>( 0.f, fatness * 0.35f );
                         instanceInfo.Scaling = fatness * 0.02f + 1.f;
                         instanceInfo.World = finalWorld;
@@ -3373,6 +3378,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                     instData.World = finalWorld;
                     instData.PrevWorld = finalPrevWorld;
                     instData.Color = modelColor;
+                    instData.Color.w = vi->Vob == playerFocusVob ? 2.0f : 0.0f;
 
                     for ( auto const& itm : mvi->Meshes ) {
                         zCTexture* texture = nullptr;

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -6762,7 +6762,7 @@ bool D3D11GraphicsEngine::PrepareAndBindWindMetadata( const std::vector<MeshVisu
         m_WindMetadataStaging.push_back( metadata );
 
         for ( auto& instance : visual->Instances ) {
-            instance.GP_Slot = metadataIndex;
+            instance.GP_Slot |= metadataIndex & 0x7FFFFFFF;
         }
     }
 
@@ -7439,7 +7439,7 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
             }
 
             for ( auto& instance : alphaData.instances ) {
-                instance.GP_Slot = it->second;
+                instance.GP_Slot |= it->second & 0x7FFFFFFF;
             }
         }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2996,7 +2996,8 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         }
     };
 
-    const int interactiveFocusEnabled = oCGame::GetHighlightInteractFocus();
+    const int interactiveFocusEnabled = distance > 100000 // only MOBs, not NPCs
+        && oCGame::GetHighlightInteractFocus();
     const zCVob* playerFocusVob = interactiveFocusEnabled && oCGame::GetPlayer() ? oCGame::GetPlayer()->GetFocusVob() : nullptr;
 
     {

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5196,7 +5196,10 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "General", "AnimateStaticVobs", std::to_string( s.AnimateStaticVobs ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "DrawWorldSectionIntersections", std::to_string( s.DrawSectionIntersections ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "SunLightStrength", std::to_string( s.SunLightStrength ).c_str(), ini.c_str() );
+#ifdef BUILD_GOTHIC_1_08k
     WritePrivateProfileStringA( "General", "DrawG1ForestPortals", std::to_string( s.DrawG1ForestPortals ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "G1HighlightInteractiveFocus", std::to_string( s.G1HighlightInteractiveFocus ? TRUE : FALSE ).c_str(), ini.c_str() );
+#endif
     WritePrivateProfileStringA( "General", "DrawRainThroughTransformFeedback", std::to_string( s.DrawRainThroughTransformFeedback ? TRUE : FALSE ).c_str(), ini.c_str() );
 
     /*
@@ -5322,7 +5325,10 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.AnimateStaticVobs = GetPrivateProfileBoolA( "General", "AnimateStaticVobs", ds.AnimateStaticVobs, ini );
         s.DrawSectionIntersections = GetPrivateProfileBoolA( "General", "DrawWorldSectionIntersections", ds.DrawSectionIntersections, ini );
         s.SunLightStrength = GetPrivateProfileFloatA( "General", "SunLightStrength", ds.SunLightStrength, ini );
+#ifdef BUILD_GOTHIC_1_08k
         s.DrawG1ForestPortals = GetPrivateProfileBoolA( "General", "DrawG1ForestPortals", ds.DrawG1ForestPortals, ini );
+        s.G1HighlightInteractiveFocus = GetPrivateProfileBoolA( "General", "G1HighlightInteractiveFocus", ds.G1HighlightInteractiveFocus, ini );
+#endif
         s.DrawRainThroughTransformFeedback = GetPrivateProfileBoolA( "General", "DrawRainThroughTransformFeedback", ds.DrawRainThroughTransformFeedback, ini );
 
         /*

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1912,7 +1912,7 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
     if ( list.size() > 0 ) {
 #ifndef PUBLIC_RELEASE
         if ( RendererState.RendererSettings.EnableDebugLog )
-            LogInfo() << std::string( className ) << " had " + std::to_string( list.size() ) << " vobs";
+            LogInfo() << className << " had " << list.size() << " vobs";
 #endif
 
         VobsByVisual[visual].clear();
@@ -4028,6 +4028,9 @@ void GothicAPI::CollectVisibleVobs(
     // they should be unique at this point.
 
     if ( collectFlags & COLLECT_MUTATE ) {
+        const int interactiveFocusEnabled = oCGame::GetHighlightInteractFocus();
+        const zCVob* playerFocusVob = interactiveFocusEnabled && oCGame::GetPlayer() ? oCGame::GetPlayer()->GetFocusVob() : nullptr;
+
         for ( auto it : renderQueue.vobs ) {
             VobInstanceInfo vii = {};
             vii.world = it->WorldMatrix;
@@ -4035,6 +4038,7 @@ void GothicAPI::CollectVisibleVobs(
             vii.color = it->GroundColor;
             vii.windStrenth = 0.0f;
             vii.canBeAffectedByPlayer = 0;
+            vii.GP_Slot |= playerFocusVob == it->Vob ? 1 << 31 : 0;
 
             zTAnimationMode aniMode = it->Vob->GetVisualAniMode();
             if ( aniMode != zVISUAL_ANIMODE_NONE ) {

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4786,6 +4786,7 @@ void GothicAPI::ResetMaterialInfo() {
 
 static void FixUpMaterial( MaterialInfo::Buffer& buffer ) {
     if ( buffer.SpecularIntensity < 0.0f ) {
+        // we abuse negative specular intensity to mark a pixel as "focused", thus materials must never have negative specular intensity.
         buffer.SpecularIntensity = 0.0f;
     }
 }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4784,6 +4784,12 @@ void GothicAPI::ResetMaterialInfo() {
     MaterialInfos.clear();
 }
 
+static void FixUpMaterial( MaterialInfo::Buffer& buffer ) {
+    if ( buffer.SpecularIntensity < 0.0f ) {
+        buffer.SpecularIntensity = 0.0f;
+    }
+}
+
 /** Returns the material info associated with the given material */
 MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex ) {
     auto it = MaterialInfos.find( tex );
@@ -4804,6 +4810,8 @@ MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex ) {
         mi = it->second.get();
     }
 
+    FixUpMaterial( mi->buffer );
+
     return mi;
 }
 
@@ -4823,6 +4831,8 @@ MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex, const std::string_
         } else {
             mi = it->second.get();
         }
+
+        FixUpMaterial( mi->buffer );
 
         return mi;
 }

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -646,6 +646,7 @@ struct GothicRendererSettings {
 
         DrawG1ForestPortals = false;    //enables the textures around forests and some doors to darken them
                                         //these are only applicable to G1, they don't appear to have been used in G2
+        G1HighlightInteractiveFocus = true; // G1 only: toggles the interactive focus which brightens up focus vobs/mobs
         DrawRainThroughTransformFeedback = false; // Default to compute shaders
 
         FastShadows = false;
@@ -908,6 +909,7 @@ struct GothicRendererSettings {
     int WindQuality;
     bool HeroAffectsObjects;
     bool DrawG1ForestPortals;
+    bool G1HighlightInteractiveFocus;
     bool DrawRainThroughTransformFeedback;
     bool EnableHDR;
     E_HDRToneMap HDRToneMap;

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -504,6 +504,7 @@ struct GothicMemoryLocations {
         static const unsigned int IsAPlayer = 0x0069E9D0;
         static const unsigned int GetName = 0x0068D0B0;
         static const unsigned int HasFlag = 0x0068E150;
+        static const unsigned int Offset_focus_vob = 0x9e4;
     };
 
     struct oCGame {

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -156,12 +156,14 @@ struct GothicMemoryLocations {
         static const unsigned int EnterWorld = 0x006C96F0;
         static const unsigned int TestKeys = 0x006FD560;
         static const unsigned int Var_Player = 0x00AB2684;
+        static const unsigned int Var_InteractiveFocusEnabled = 0x008b20f4;
         static const unsigned int Offset_GameView = 0x30;
         static const unsigned int Offset_SingleStep = 0x11C;
         static const unsigned int DefineExternals_Ulfi = 0x006D4780;
     };
 
     struct oCNPC {
+        static const unsigned int Offset_focus_vob = 0x9ac;
         static const unsigned int ResetPos = 0x006824D0;
         static const unsigned int InitModel = 0x00738480;
         static const unsigned int Enable = 0x00745D40;

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -157,6 +157,8 @@ struct GothicMemoryLocations {
         static const unsigned int TestKeys = 0x006FD560;
         static const unsigned int Var_Player = 0x00AB2684;
         static const unsigned int Var_InteractiveFocusEnabled = 0x008b20f4;
+        static const unsigned int Var_NpcFocusIsHighlightActive = 0x00ab0744;
+        static const unsigned int Var_HighlightMeleeFocus = 0x00ab073c;
         static const unsigned int Offset_GameView = 0x30;
         static const unsigned int Offset_SingleStep = 0x11C;
         static const unsigned int DefineExternals_Ulfi = 0x006D4780;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1191,6 +1191,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         ImGui::Checkbox( "ForceFOV", &settings.ForceFOV );
 #ifdef BUILD_GOTHIC_1_08k
         ImGui::Checkbox( "DrawForestPortals", &settings.DrawG1ForestPortals );
+        ImGui::Checkbox( "Highlight interactive focus", &settings.G1HighlightInteractiveFocus );
 #endif
 
         ImGui::SeparatorText("Debugging");

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -365,7 +365,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	
 	//return float4(sun.rgb, 1);
 	//return float4(vertLighting.rrr, 1);
-	float focusBrightness = 1.0f + (focused ? 2.0f : 0.0f);
+	float focusBrightness = 1.0f + (focused ? 1.0f : 0.0f);
     return float4(litPixel.rgb * focusBrightness, 1);
 	//return float4(pow(spec, specPower) * specIntensity.xxx * diffuse.rgb * SQ_LightColor.rgb,1);
 	

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -259,7 +259,9 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	
 	// Get specular parameters
     float4 gb3 = TX_SI_SP.Sample(SS_Linear, uv);
-    float specIntensity = gb3.x;
+	// Negative specIntensity signals a focused VOB (encoded in PS_Diffuse GBuffer fill).
+	bool focused = gb3.x < 0.0f;
+    float specIntensity = focused ? (-gb3.x - 0.001f) : gb3.x;
     float specPower = gb3.y;
 	
 	// Reconstruct VS World Position from depth
@@ -272,7 +274,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	// CSM: Use soft cascaded shadow map with configurable softness
     float3 wsNormal = normalize(mul(float4(normal, 0.0f), SQ_InvView).xyz);
 
-    if(AC_LightPos.y > 0) // only get shadow value if it isn't night-time
+    if(AC_LightPos.y > 0 && !focused) // only get shadow value if it isn't night-time
 	{
         float3 wsLightDirection = normalize(mul(float4(SQ_LightDirectionVS, 0.0f), SQ_InvView).xyz);
 
@@ -288,7 +290,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 
         // Use screen position for per-pixel rotation (TAA-friendly)
         shadow = ComputeCascadedShadowValueSoft(biasedWsPosition, vsPosition.z, vertLighting, 0.0f, Input.vPosition.xy);
-	} else {
+	} else if (!focused) {
         // Night-time sky ambient:
         // saturate(wsNormal.y) restricts the value to [0, 1].
         // Facing up = 1, Facing sides/down = 0.
@@ -363,7 +365,8 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	
 	//return float4(sun.rgb, 1);
 	//return float4(vertLighting.rrr, 1);
-    return float4(litPixel.rgb, 1);
+	float focusBrightness = 1.0f + (focused ? 4.0f : 0.0f);
+    return float4(litPixel.rgb * focusBrightness, 1);
 	//return float4(pow(spec, specPower) * specIntensity.xxx * diffuse.rgb * SQ_LightColor.rgb,1);
 	
 }

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -365,7 +365,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	
 	//return float4(sun.rgb, 1);
 	//return float4(vertLighting.rrr, 1);
-	float focusBrightness = 1.0f + (focused ? 4.0f : 0.0f);
+	float focusBrightness = 1.0f + (focused ? 2.5f : 0.0f);
     return float4(litPixel.rgb * focusBrightness, 1);
 	//return float4(pow(spec, specPower) * specIntensity.xxx * diffuse.rgb * SQ_LightColor.rgb,1);
 	

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -274,7 +274,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	// CSM: Use soft cascaded shadow map with configurable softness
     float3 wsNormal = normalize(mul(float4(normal, 0.0f), SQ_InvView).xyz);
 
-    if(AC_LightPos.y > 0 && !focused) // only get shadow value if it isn't night-time
+    if(AC_LightPos.y > 0) // only get shadow value if it isn't night-time
 	{
         float3 wsLightDirection = normalize(mul(float4(SQ_LightDirectionVS, 0.0f), SQ_InvView).xyz);
 
@@ -290,7 +290,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 
         // Use screen position for per-pixel rotation (TAA-friendly)
         shadow = ComputeCascadedShadowValueSoft(biasedWsPosition, vsPosition.z, vertLighting, 0.0f, Input.vPosition.xy);
-	} else if (!focused) {
+	} else {
         // Night-time sky ambient:
         // saturate(wsNormal.y) restricts the value to [0, 1].
         // Facing up = 1, Facing sides/down = 0.
@@ -365,7 +365,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	
 	//return float4(sun.rgb, 1);
 	//return float4(vertLighting.rrr, 1);
-	float focusBrightness = 1.0f + (focused ? 2.5f : 0.0f);
+	float focusBrightness = 1.0f + (focused ? 2.0f : 0.0f);
     return float4(litPixel.rgb * focusBrightness, 1);
 	//return float4(pow(spec, specPower) * specIntensity.xxx * diffuse.rgb * SQ_LightColor.rgb,1);
 	

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -164,7 +164,7 @@ FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 		litPixel += FP_ComputePointLighting(wsPosition, vsPosition, nrm, color.rgb, specIntensity, specPower, Input.vPosition.xy);
 	}
 
-	float focusBrightness = 1.0f + step(1.5f, Input.vDiffuse.w) * 2.0f;
+	float focusBrightness = 1.0f + step(1.5f, Input.vDiffuse.w) * 1.0f;
 	output.vColor = float4(litPixel * focusBrightness, 1);
 	output.vNrm = EncodeNormalGBuffer(nrm);
 	output.vSI_SP = float2(specIntensity, specPower);

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -224,14 +224,17 @@ DEFERRED_PS_OUTPUT PSMain( PS_INPUT Input ) : SV_TARGET
 	fx = 1.0f;
 #endif
 	
-	float focusBrightness = 1.0f + step(1.5f, Input.vDiffuse.w) * 0.85f;
-	output.vDiffuse = float4(color.rgb * focusBrightness, Input.vDiffuse.y);
+	output.vDiffuse = float4(color.rgb, Input.vDiffuse.y);
 	//output.vDiffuse = float4(Input.vTexcoord2, 0, 1);
 	//output.vDiffuse = float4(Input.vNormalVS, 1);
-	
+
 	output.vNrm = EncodeNormalGBuffer(nrm);
-	
-	output.vSI_SP.x = MI_SpecularIntensity * fx.r;
+
+	// Encode focused flag as negative specIntensity so it survives into the deferred lighting pass.
+	// PS_DS_AtmosphericScattering decodes it and applies the brightness boost post-lighting.
+	float rawSpecIntensity = abs(MI_SpecularIntensity) * fx.r; // fix negative specular intensity here.
+	bool focused = Input.vDiffuse.w > 1.5f;
+	output.vSI_SP.x = focused ? -(rawSpecIntensity + 0.001f) : rawSpecIntensity;
 	output.vSI_SP.y = MI_SpecularPower * fx.g;
 	
 	// Calculate velocity for motion vectors

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -232,7 +232,7 @@ DEFERRED_PS_OUTPUT PSMain( PS_INPUT Input ) : SV_TARGET
 
 	// Encode focused flag as negative specIntensity so it survives into the deferred lighting pass.
 	// PS_DS_AtmosphericScattering decodes it and applies the brightness boost post-lighting.
-	float rawSpecIntensity = abs(MI_SpecularIntensity) * fx.r; // fix negative specular intensity here.
+	float rawSpecIntensity = MI_SpecularIntensity * fx.r; // fix negative specular intensity here.
 	bool focused = Input.vDiffuse.w > 1.5f;
 	output.vSI_SP.x = focused ? -(rawSpecIntensity + 0.001f) : rawSpecIntensity;
 	output.vSI_SP.y = MI_SpecularPower * fx.g;

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -164,7 +164,8 @@ FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 		litPixel += FP_ComputePointLighting(wsPosition, vsPosition, nrm, color.rgb, specIntensity, specPower, Input.vPosition.xy);
 	}
 
-	output.vColor = float4(litPixel, 1);
+	float focusBrightness = 1.0f + step(1.5f, Input.vDiffuse.w) * 0.35f;
+	output.vColor = float4(litPixel * focusBrightness, 1);
 	output.vNrm = EncodeNormalGBuffer(nrm);
 	output.vSI_SP = float2(specIntensity, specPower);
 	output.vVelocity = CalculateVelocity(Input.vCurrClipPos, Input.vPrevClipPos);
@@ -223,7 +224,8 @@ DEFERRED_PS_OUTPUT PSMain( PS_INPUT Input ) : SV_TARGET
 	fx = 1.0f;
 #endif
 	
-	output.vDiffuse = float4(color.rgb, Input.vDiffuse.y);
+	float focusBrightness = 1.0f + step(1.5f, Input.vDiffuse.w) * 0.85f;
+	output.vDiffuse = float4(color.rgb * focusBrightness, Input.vDiffuse.y);
 	//output.vDiffuse = float4(Input.vTexcoord2, 0, 1);
 	//output.vDiffuse = float4(Input.vNormalVS, 1);
 	

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -164,7 +164,7 @@ FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 		litPixel += FP_ComputePointLighting(wsPosition, vsPosition, nrm, color.rgb, specIntensity, specPower, Input.vPosition.xy);
 	}
 
-	float focusBrightness = 1.0f + step(1.5f, Input.vDiffuse.w) * 0.35f;
+	float focusBrightness = 1.0f + step(1.5f, Input.vDiffuse.w) * 2.0f;
 	output.vColor = float4(litPixel * focusBrightness, 1);
 	output.vNrm = EncodeNormalGBuffer(nrm);
 	output.vSI_SP = float2(specIntensity, specPower);

--- a/D3D11Engine/Shaders/VS_ExInstancedObj.hlsl
+++ b/D3D11Engine/Shaders/VS_ExInstancedObj.hlsl
@@ -49,7 +49,7 @@ struct VS_INPUT
     float4x4 InstancePrevWorldMatrix : INSTANCE_PREV_WORLD_MATRIX;
     float4 InstanceColor : INSTANCE_COLOR;
     float2 InstanceWind : INSTANCE_WINDFLUENCE;
-    uint InstanceWindMetaIndex : INSTANCE_WIND_META_INDEX;
+    uint InstanceWindMetaIndex : INSTANCE_WIND_META_INDEX; // first 31 bits are index into structure buffer, 32 bit is flag if its "focused"
 };
 
 struct VS_OUTPUT
@@ -170,7 +170,7 @@ VS_OUTPUT VSMain( VS_INPUT Input )
     float localMinHeight = minHeight;
     float localMaxHeight = maxHeight;
 #if WIND_META_SRV
-    WindMetaDataEntry meta = WindMetaData[Input.InstanceWindMetaIndex];
+    WindMetaDataEntry meta = WindMetaData[Input.InstanceWindMetaIndex & 0x7FFFFFFF];
     localMinHeight = meta.minHeight;
     localMaxHeight = meta.maxHeight;
 #endif
@@ -216,6 +216,9 @@ VS_OUTPUT VSMain( VS_INPUT Input )
     Output.vTexcoord = Input.vTex1;
     Output.vTexcoord2 = Input.vTex2;
     Output.vDiffuse = Input.InstanceColor;
+    // 2.0 = focused, 0.0 = not focused. Value >1.0 is impossible from UNORM hardware inputs,
+    // so step(1.5) in the PS can distinguish this from other shaders that output alpha=1.0.
+    Output.vDiffuse.w = (Input.InstanceWindMetaIndex >> 31u) ? 2.0f : 0.0f;
     Output.vNormalVS = mul(Input.vNormal, mul((float3x3)Input.InstanceWorldMatrix, (float3x3)frame.M_View));
     Output.vViewPosition = mul(float4(worldPos, 1.0), frame.M_View);
     

--- a/D3D11Engine/Shaders/VS_ExSkeletal.hlsl
+++ b/D3D11Engine/Shaders/VS_ExSkeletal.hlsl
@@ -13,11 +13,7 @@ cbuffer Matrices_PerFrame : register( b0 )
 
 cbuffer Matrices_PerInstances : register( b1 )
 {
-	matrix M_World;
-	matrix M_PrevWorld; // Helper for rigid motion of skeletal mesh
-	float4 PI_ModelColor;
-	float PI_ModelFatness;
-	float3 PI_Pad1;
+	VS_ExConstantBuffer_PerInstanceSkeletal cbInstance;
 };
 
 #if SKINNING_STRUCTURED
@@ -135,15 +131,16 @@ VS_OUTPUT VSMain( VS_INPUT Input )
 	ApplySkinningPrevious( Input.vPosition, Input.vNormal, Input.BoneIndices, Input.Weights, prevPosition, prevNormal );
 
     // 3. Apply fatness and world transforms
-    float3 positionWorld = mul(float4(position + PI_ModelFatness * normal, 1), M_World).xyz;
-    float3 prevPositionWorld = mul(float4(prevPosition + PI_ModelFatness * prevNormal, 1), M_PrevWorld).xyz;
+    float3 positionWorld = mul(float4(position + cbInstance.PI_ModelFatness * normal, 1), cbInstance.M_World).xyz;
+    float3 prevPositionWorld = mul(float4(prevPosition + cbInstance.PI_ModelFatness * prevNormal, 1), cbInstance.M_PrevWorld).xyz;
 	
 	//Output.vPosition = float4(Input.vPosition, 1);
 	Output.vPosition = mul(float4(positionWorld,1), frame.M_ViewProj);
 	Output.vTexcoord2 = Input.vTex1;
 	Output.vTexcoord = Input.vTex1;
-	Output.vDiffuse  = PI_ModelColor;
-	Output.vNormalVS = mul(Input.vBindPoseNormal, (float3x3)mul(M_World, frame.M_View));
+	Output.vDiffuse  = cbInstance.PI_ModelColor;
+	Output.vDiffuse.w  = cbInstance.PI_Pad1.x;
+	Output.vNormalVS = mul(Input.vBindPoseNormal, (float3x3)mul(cbInstance.M_World, frame.M_View));
 	Output.vViewPosition = mul(float4(positionWorld,1), frame.M_View).xyz;
 
 	// Motion Vectors - use UNJITTERED matrices for correct velocity

--- a/D3D11Engine/oCGame.h
+++ b/D3D11Engine/oCGame.h
@@ -63,6 +63,8 @@ public:
     static bool GetHighlightInteractFocus() {
 #if defined(BUILD_GOTHIC_2_6_fix)
         return *reinterpret_cast<int*>(GothicMemoryLocations::oCGame::Var_InteractiveFocusEnabled) != 0;
+#elif (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
+        return Engine::GAPI->GetRendererState().RendererSettings.G1HighlightInteractiveFocus;
 #else
         return false;
 #endif
@@ -72,7 +74,7 @@ public:
 #if defined(BUILD_GOTHIC_2_6_fix)
         return *reinterpret_cast<int*>(GothicMemoryLocations::oCGame::Var_HighlightMeleeFocus);
 #else
-        return 0;
+        return 2; // force npc highlight when focused
 #endif
     }
 
@@ -80,7 +82,7 @@ public:
 #if defined(BUILD_GOTHIC_2_6_fix)
         return *reinterpret_cast<int*>(GothicMemoryLocations::oCGame::Var_NpcFocusIsHighlightActive) != 0;
 #else
-        return false;
+        return GetHighlightInteractFocus();
 #endif
     }
 

--- a/D3D11Engine/oCGame.h
+++ b/D3D11Engine/oCGame.h
@@ -60,6 +60,10 @@ public:
         return *reinterpret_cast<oCNPC**>(GothicMemoryLocations::oCGame::Var_Player);
     }
 
+    static bool GetHighlightInteractFocus() {
+        return *reinterpret_cast<int*>(GothicMemoryLocations::oCGame::Var_InteractiveFocusEnabled) != 0;
+    }
+
     zCView* GetGameView() {
         return *reinterpret_cast<zCView**>(THISPTR_OFFSET( GothicMemoryLocations::oCGame::Offset_GameView ));
     }

--- a/D3D11Engine/oCGame.h
+++ b/D3D11Engine/oCGame.h
@@ -61,7 +61,27 @@ public:
     }
 
     static bool GetHighlightInteractFocus() {
+#if defined(BUILD_GOTHIC_2_6_fix)
         return *reinterpret_cast<int*>(GothicMemoryLocations::oCGame::Var_InteractiveFocusEnabled) != 0;
+#else
+        return false;
+#endif
+    }
+
+    static int GetHighlightMeleeFocus() {
+#if defined(BUILD_GOTHIC_2_6_fix)
+        return *reinterpret_cast<int*>(GothicMemoryLocations::oCGame::Var_HighlightMeleeFocus);
+#else
+        return 0;
+#endif
+    }
+
+    static bool GetNpcFocusIsHighlightActive() {
+#if defined(BUILD_GOTHIC_2_6_fix)
+        return *reinterpret_cast<int*>(GothicMemoryLocations::oCGame::Var_NpcFocusIsHighlightActive) != 0;
+#else
+        return false;
+#endif
     }
 
     zCView* GetGameView() {

--- a/D3D11Engine/oCNPC.h
+++ b/D3D11Engine/oCNPC.h
@@ -67,7 +67,11 @@ public:
     }
 
     zCVob* GetFocusVob() const {
+#if defined(BUILD_GOTHIC_2_6_fix)
         return *reinterpret_cast<zCVob**>(THISPTR_OFFSET( GothicMemoryLocations::oCNPC::Offset_focus_vob ));
+#else
+        return nullptr;
+#endif
     }
 
     void ResetPos( const XMFLOAT3& pos ) {

--- a/D3D11Engine/oCNPC.h
+++ b/D3D11Engine/oCNPC.h
@@ -67,7 +67,7 @@ public:
     }
 
     zCVob* GetFocusVob() const {
-#if defined(BUILD_GOTHIC_2_6_fix)
+#if defined(BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
         return *reinterpret_cast<zCVob**>(THISPTR_OFFSET( GothicMemoryLocations::oCNPC::Offset_focus_vob ));
 #else
         return nullptr;

--- a/D3D11Engine/oCNPC.h
+++ b/D3D11Engine/oCNPC.h
@@ -66,6 +66,10 @@ public:
         HookedFunctions::OriginalFunctions.original_oCNPCDisable( thisptr );
     }
 
+    zCVob* GetFocusVob() const {
+        return *reinterpret_cast<zCVob**>(THISPTR_OFFSET( GothicMemoryLocations::oCNPC::Offset_focus_vob ));
+    }
+
     void ResetPos( const XMFLOAT3& pos ) {
         reinterpret_cast<void( __fastcall* )( oCNPC*, int, const XMFLOAT3& )>( GothicMemoryLocations::oCNPC::ResetPos )( this, 0, pos );
     }

--- a/D3D11Engine/zCVob.h
+++ b/D3D11Engine/zCVob.h
@@ -253,7 +253,7 @@ public:
 
 #if BUILD_SPACER_NET
     /** Return whether all vobs are currently rendered or not */
-    static bool GetDrawVobs() const
+    static bool GetDrawVobs()
     {
         bool showHelpers = *reinterpret_cast<int*>(GothicMemoryLocations::zCVob::s_renderVobs) != 0;
         return showHelpers;

--- a/D3D11Engine/zCVob.h
+++ b/D3D11Engine/zCVob.h
@@ -132,7 +132,7 @@ public:
     }
 #else
     /** Returns the visual saved in this vob */
-    zCVisual* GetVisual() {
+    zCVisual* GetVisual() const {
         return GetMainVisual();
     }
 #endif
@@ -151,12 +151,12 @@ public:
     }
 
     /** Returns the visual saved in this vob */
-    zCVisual* GetMainVisual() {
-        return reinterpret_cast<zCVisual*( __fastcall* )( zCVob* )>( GothicMemoryLocations::zCVob::GetVisual )( this );
+    zCVisual* GetMainVisual() const {
+        return reinterpret_cast<zCVisual*( __fastcall* )( const zCVob* )>( GothicMemoryLocations::zCVob::GetVisual )( this );
     }
 
     /** Returns the name of this vob */
-    std::string GetName() {
+    std::string GetName() const {
         return __GetObjectName().ToChar();
     }
 
@@ -220,17 +220,17 @@ public:
     }
 
     /** Returns a copy of the world matrix */
-    XMMATRIX GetWorldMatrixXM() {
+    XMMATRIX GetWorldMatrixXM() const {
         return XMLoadFloat4x4( reinterpret_cast<XMFLOAT4X4*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_WorldMatrixPtr )) );
     }
 
     /** Returns the world-polygon right under this vob */
-    zCPolygon* GetGroundPoly() {
+    zCPolygon* GetGroundPoly() const {
         return *reinterpret_cast<zCPolygon**>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_GroundPoly ));
     }
 
     /** Returns whether this vob is currently in an indoor-location or not */
-    bool IsIndoorVob() {
+    bool IsIndoorVob() const {
         if ( !GetGroundPoly() )
             return false;
 
@@ -238,12 +238,12 @@ public:
     }
 
     /** Returns the world this vob resists in */
-    zCWorld* GetHomeWorld() {
+    zCWorld* GetHomeWorld() const {
         return *reinterpret_cast<zCWorld**>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_HomeWorld ));
     }
 
     /** Returns whether this vob is currently in sleeping state or not. Sleeping state is something like a waiting (cached out) NPC */
-    int GetSleepingMode() {
+    int GetSleepingMode() const {
         unsigned int flags = *reinterpret_cast<unsigned int*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_SleepingMode ));
         return (flags & GothicMemoryLocations::zCVob::MASK_SkeepingMode);
     }
@@ -253,7 +253,7 @@ public:
 
 #if BUILD_SPACER_NET
     /** Return whether all vobs are currently rendered or not */
-    static bool GetDrawVobs()
+    static bool GetDrawVobs() const
     {
         bool showHelpers = *reinterpret_cast<int*>(GothicMemoryLocations::zCVob::s_renderVobs) != 0;
         return showHelpers;
@@ -262,7 +262,7 @@ public:
 
 #ifndef BUILD_SPACER_NET
     /** Returns whether the visual of this vob is visible */
-    bool GetShowVisual() {
+    bool GetShowVisual() const {
 #ifndef BUILD_SPACER
         return GetShowMainVisual();
 #else
@@ -291,35 +291,35 @@ public:
 #endif
 
     /** Returns whether to show the main visual or not. Only used for the spacer */
-    bool GetShowMainVisual() {
+    bool GetShowMainVisual() const {
         unsigned int flags = *reinterpret_cast<unsigned int*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_Flags ));
         return (flags & GothicMemoryLocations::zCVob::MASK_ShowVisual);
     }
 
     /** Returns whether vob is transparent */
-    bool GetVisualAlpha() {
+    bool GetVisualAlpha() const {
         unsigned int flags = *reinterpret_cast<unsigned int*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_Flags ));
         return (flags & GothicMemoryLocations::zCVob::MASK_VisualAlpha);
     }
 
     /** Returns dynamic collision of the vob */
-    bool GetDynColl() {
+    bool GetDynColl() const {
         unsigned int flags = *reinterpret_cast<unsigned int*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_Flags ));
         return (flags & GothicMemoryLocations::zCVob::MASK_DynColl);
     }
 
     /** Vob transparency */
-    float GetVobTransparency() {
+    float GetVobTransparency() const {
         return *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_VobAlpha ));
     }
 
     /** Vob type */
-    EVobType GetVobType() {
+    EVobType GetVobType() const {
         return *reinterpret_cast<EVobType*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_Type ));
     }
 
     /** Vob parent */
-    zCVob* GetVobParent() {
+    zCVob* GetVobParent() const {
         if ( DWORD vobTree = *reinterpret_cast<DWORD*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_VobTree )) ) {
             if ( ( vobTree = *reinterpret_cast<DWORD*>(vobTree + 0x00) ) != 0 ) { // Read parent from vobtree
                 return *reinterpret_cast<zCVob**>(vobTree + 0x10);
@@ -329,7 +329,7 @@ public:
     }
 
     /** Alignemt to the camera */
-    EVisualCamAlignType GetAlignment() {
+    EVisualCamAlignType GetAlignment() const {
         unsigned int flags = *reinterpret_cast<unsigned int*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_CameraAlignment ));
 
         //.text:00601652                 shl     eax, 1Eh
@@ -341,7 +341,7 @@ public:
         return static_cast<EVisualCamAlignType>(flags);
     }
 
-    zTAnimationMode GetVisualAniMode() {
+    zTAnimationMode GetVisualAniMode() const {
 #ifdef BUILD_GOTHIC_1_08k
 #ifdef BUILD_1_12F
         return zVISUAL_ANIMODE_NONE;
@@ -386,7 +386,7 @@ protected:
         return false;
     }
 
-    zSTRING& __GetObjectName() {
-        return reinterpret_cast<zSTRING&( __fastcall* )( zCVob* )>( GothicMemoryLocations::zCObject::GetObjectName )( this );
+    zSTRING& __GetObjectName() const {
+        return reinterpret_cast<zSTRING&( __fastcall* )( const zCVob* )>( GothicMemoryLocations::zCObject::GetObjectName )( this );
     }
 };


### PR DESCRIPTION
- G2: depending on game settings
  - Brighten up MOBs when focused
  - Brighten up VOBs when focused
  - Brighten up NPCs if Fight-Focus is set to "Brighten"/"Both" and player is using weapon against the NPC  
<img width="300" alt="unfocused-door" src="https://github.com/user-attachments/assets/91533c40-fafa-40ce-8a74-80680e08828d" />
<img width="300" alt="focused-door" src="https://github.com/user-attachments/assets/044e5da3-5144-441f-a8c4-79f1d0a2b65e" />
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/373325b5-8c7a-49a4-b6a8-39f9a7905c8d" />
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/de491f00-3973-4f04-8320-76f74f78b121" />

- G1: Added additional setting into "CTRL+F11"->"General": `Highlight interactive focus` (default: enabled)
  - When set, NPCs and VOBs/MOBs are brightened when focused.