### PR TITLE
"static" pointlights (ambient lights?) only draw static world mesh geometry shadows, no vobs, mobs or NPCs

### DIFF
--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -109,7 +109,13 @@ void D3D11PointLight::ClearTiledSlot() {
 }
 
 int D3D11PointLight::GetCurrentShadowMode() const {
-    return static_cast<int>(Engine::GAPI->GetRendererState().RendererSettings.EnablePointlightShadows);
+    auto mode = static_cast<int>(Engine::GAPI->GetRendererState().RendererSettings.EnablePointlightShadows);
+    if ( mode > 1 ) {
+        if ( LightInfo->Vob->GetLightInfoFlags().isStatic ) {
+            return GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY; 
+        }
+    }
+    return mode;
 }
 
 void D3D11PointLight::HandleShadowModeChange( int shadowMode ) {
@@ -200,7 +206,10 @@ void D3D11PointLight::RenderStaticShadowPass( RenderToDepthStencilBuffer& target
         wc = nullptr;
     }
 
-    const unsigned int staticCasterMask = SHADOW_CASTER_WORLD | SHADOW_CASTER_VOBS | SHADOW_CASTER_MOBS;
+    const unsigned int staticCasterMask = LightInfo->Vob->GetLightInfoFlags().isStatic
+        ? SHADOW_CASTER_WORLD // static light? only draw world mesh.
+        : SHADOW_CASTER_WORLD | SHADOW_CASTER_VOBS | SHADOW_CASTER_MOBS;
+
     engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), range, target, nullptr, nullptr, false, LightInfo->IsIndoorVob, false,
         &VobCache, &SkeletalVobCache, wc, clearDepth, staticCasterMask );
 }
@@ -258,7 +267,8 @@ bool D3D11PointLight::NeedsUpdate() {
 
     const int shadowMode = GetCurrentShadowMode();
     if ( shadowMode != m_LastShadowMode ) {
-        return true;
+        m_LastShadowMode = shadowMode;
+        return shadowMode > 0;
     }
 
     FXMVECTOR lastPos = XMLoadFloat3( &LastUpdatePosition );
@@ -281,7 +291,7 @@ bool D3D11PointLight::WantsUpdate() {
         return false;
 
     const int shadowMode = GetCurrentShadowMode();
-    if ( shadowMode == GothicRendererSettings::PLS_STATIC_ONLY ) {
+    if ( shadowMode <= GothicRendererSettings::PLS_STATIC_ONLY ) {
         return false;
     }
 

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -423,10 +423,9 @@ void D3D11PointLight::RenderFullCubemap() {
     }
 
     const int shadowMode = GetCurrentShadowMode();
-    if ( shadowMode == GothicRendererSettings::PLS_STATIC_ONLY ) {
+    if ( shadowMode >= GothicRendererSettings::PLS_STATIC_ONLY ) {
         RenderStaticShadowPass( *activeTarget, true );
         m_StaticShadowReady = true;
-        return;
     }
 
     if ( shadowMode == GothicRendererSettings::PLS_UPDATE_DYNAMIC ) {
@@ -448,16 +447,15 @@ void D3D11PointLight::RenderFullCubemap() {
         }
 
         RenderAnimatedShadowPass( *activeTarget, false );
-        return;
-    }
+    } else if ( shadowMode == GothicRendererSettings::PLS_FULL ) {
+        auto wc = &WorldMeshCache;
+        if ( WorldCacheInvalid ) {
+            wc = nullptr;
+        }
 
-    auto wc = &WorldMeshCache;
-    if ( WorldCacheInvalid ) {
-        wc = nullptr;
+        engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), LightInfo->Vob->GetLightRange(), *activeTarget,
+            nullptr, nullptr, false, LightInfo->IsIndoorVob, false, &VobCache, &SkeletalVobCache, wc, true, SHADOW_CASTER_ALL );
     }
-
-    engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), LightInfo->Vob->GetLightRange(), *activeTarget,
-        nullptr, nullptr, false, LightInfo->IsIndoorVob, false, &VobCache, &SkeletalVobCache, wc, true, SHADOW_CASTER_ALL );
 }
 
 bool D3D11PointLight::IsReady()

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1051,7 +1051,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
 
     // Render the immediate priority lights
     for ( auto const& importantUpdate : importantUpdates ) {
-        static_cast<D3D11PointLight*>(importantUpdate->LightShadowBuffers.get())->RenderCubemap( true, m_PointLightCB.get() );
+        static_cast<D3D11PointLight*>(importantUpdate->LightShadowBuffers.get())->RenderCubemap( importantUpdate->UpdateShadows, m_PointLightCB.get() );
         importantUpdate->UpdateShadows = false;
     }
 
@@ -1074,11 +1074,11 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
             light->UpdateShadows = false;
             continue;
         }
-
+        bool force = light->UpdateShadows;
         light->UpdateShadows = false;
 
         // FORCE the render! It waited in line for its turn, it must draw.
-        l->RenderCubemap( true, m_PointLightCB.get() );
+        l->RenderCubemap( force, m_PointLightCB.get() );
         graphicsEngine->DebugPointlight = l;
 
         updatesDone++;

--- a/D3D11Engine/D3D11TiledDeferredShading.h
+++ b/D3D11Engine/D3D11TiledDeferredShading.h
@@ -11,7 +11,7 @@
 struct RenderToTextureBuffer;
 struct RenderToDepthStencilBuffer;
 
-constexpr uint32_t MAX_TILED_LIGHTS = 1024;
+constexpr uint32_t MAX_TILED_LIGHTS = 400;
 
 constexpr uint32_t MAX_SHADOW_CUBEMAPS = 128;
 constexpr uint32_t SHADOW_CUBE_SIZE = 128; // Must match POINTLIGHT_SHADOWMAP_SIZE

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4060,20 +4060,36 @@ void GothicAPI::CollectVisibleVobs(
 
         float minDynamicUpdateLightRange = Engine::GAPI->GetRendererState().RendererSettings.MinLightShadowUpdateRange;
     
-        for ( auto vi : renderQueue.lights ) {
-            if ( vi->Vob->IsEnabled() /*&& vob->GetShowVisual()*/ ) {
-                vi->VisibleInFrame = true;
 
-                // Update the lights shadows if: Light is dynamic or full shadow-updates are set
-                if ( !vi->IsPFXVobLight ) {
-                    if ( RendererState.RendererSettings.EnablePointlightShadows >= GothicRendererSettings::PLS_FULL
-                        || (RendererState.RendererSettings.EnablePointlightShadows >= GothicRendererSettings::PLS_UPDATE_DYNAMIC && !vi->Vob->IsStatic()) ) {
-                        // Now check for distances, etc
-                        float lightPlayerDist;
-                        XMStoreFloat( &lightPlayerDist, XMVector3Length( playerPosition - vi->Vob->GetPositionWorldXM() ) );
-                        if ( vi->Vob->GetLightRange() > minDynamicUpdateLightRange && lightPlayerDist < vi->Vob->GetLightRange() * 1.5f )
-                            vi->UpdateShadows = true;
-                    }
+        std::vector<std::pair<float, VobLightInfo*>> lightWithDist;
+        lightWithDist.reserve( renderQueue.lights.size() );
+
+        const auto camPos = ctx.cameraPosition;
+        float lightPlayerDist;
+        for ( auto vi : renderQueue.lights ) {
+            if ( vi->Vob->IsEnabled() ) {
+                XMStoreFloat( &lightPlayerDist, XMVector3LengthSq( playerPosition - vi->Vob->GetPositionWorldXM() ) ); 
+                lightWithDist.emplace_back( lightPlayerDist, vi );
+            }
+        }
+
+        std::sort( lightWithDist.begin(), lightWithDist.end(), []( const std::pair<float, VobLightInfo*>& a, const std::pair<float, VobLightInfo*>& b ) {
+            return a.first < b.first;
+        });
+
+        renderQueue.lights.clear();
+
+        const bool lightUpdateEnabled = RendererState.RendererSettings.EnablePointlightShadows >= GothicRendererSettings::PLS_UPDATE_DYNAMIC;
+        for ( auto [distSq, vi] : lightWithDist ) {
+            renderQueue.lights.push_back( vi );
+            vi->VisibleInFrame = true;
+
+            // Update the lights shadows if: Light is dynamic or full shadow-updates are set
+            if ( !vi->IsPFXVobLight ) {
+                if ( lightUpdateEnabled && !vi->Vob->IsStatic() ) {
+                    const float lightRange = vi->Vob->GetLightRange();
+                    if ( lightRange > minDynamicUpdateLightRange && distSq < (lightRange * lightRange) )
+                        vi->UpdateShadows = true;
                 }
             }
         }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5305,6 +5305,8 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "SAO", "BlurSharpness", std::to_string( s.SaoSettings.BlurSharpness ).c_str(), ini.c_str() );
 
     WritePrivateProfileStringA( "FontRendering", "Enable", std::to_string( s.EnableCustomFontRendering ? TRUE : FALSE ).c_str(), ini.c_str() );
+
+    WritePrivateProfileStringA( "Debug", "ThreadedShadowCulling", std::to_string( s.ThreadedShadowCulling ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Debug", "UseShadowAtlas", std::to_string( s.DebugSettings.FeatureSet.UseShadowAtlas ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Debug", "UseScreenSpaceShadowMask", std::to_string( s.DebugSettings.FeatureSet.UseScreenSpaceShadowMask ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Debug", "ForceFeatureLevel10", std::to_string( s.DebugSettings.FeatureSet.ForceFeatureLevel10 ? TRUE : FALSE ).c_str(), ini.c_str() );
@@ -5416,10 +5418,9 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.EnableRainEffects = GetPrivateProfileBoolA( "Display", "RainEffects", ds.EnableRainEffects, ini );
         s.LimitLightIntesity = GetPrivateProfileBoolA( "Display", "LimitLightIntesity", ds.LimitLightIntesity, ini );
 
-        // s.EnableTiledLighting = GetPrivateProfileBoolA( "Display", "TiledLighting", s.EnableTiledLighting, ini );
+        s.EnableTiledLighting = GetPrivateProfileBoolA( "Display", "TiledLighting", s.EnableTiledLighting, ini );
         // s.RendererMode = static_cast<GothicRendererSettings::E_RendererMode>(GetPrivateProfileIntA( "Display", "RendererMode", s.RendererMode, ini.c_str() ) );
-        // Force these two experimental settings OFF
-        s.EnableTiledLighting = false;
+        // Force experimental settings OFF
         s.RendererMode = GothicRendererSettings::E_RendererMode::RM_Deferred;
         // ....
 
@@ -5458,6 +5459,8 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.SaoSettings.BlurSharpness = GetPrivateProfileFloatA( "SAO", "BlurSharpness", defaultSAOSettings.BlurSharpness, ini );
 
         s.EnableCustomFontRendering = GetPrivateProfileBoolA( "FontRendering", "Enable", ds.EnableCustomFontRendering, ini );
+
+        s.ThreadedShadowCulling = GetPrivateProfileBoolA( "Debug", "ThreadedShadowCulling", ds.ThreadedShadowCulling, ini );
         s.DebugSettings.FeatureSet.UseShadowAtlas = GetPrivateProfileBoolA( "Debug", "UseShadowAtlas", ds.DebugSettings.FeatureSet.UseShadowAtlas, ini );
         s.DebugSettings.FeatureSet.UseScreenSpaceShadowMask = GetPrivateProfileBoolA( "Debug", "UseScreenSpaceShadowMask", ds.DebugSettings.FeatureSet.UseScreenSpaceShadowMask, ini );
         s.DebugSettings.FeatureSet.ForceFeatureLevel10 = GetPrivateProfileBoolA( "Debug", "ForceFeatureLevel10", ds.DebugSettings.FeatureSet.ForceFeatureLevel10, ini );

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -163,7 +163,14 @@ struct SkeletalMeshInfo {
 
 class zCVisual;
 struct BaseVisualInfo {
-    BaseVisualInfo() = default;
+    BaseVisualInfo() :
+        Meshes{},
+        MeshSize{},
+        BBox{},
+        MidPoint{},
+        Visual{},
+        VisualName{}
+    {};
     BaseVisualInfo(BaseVisualInfo&& other) = default;
     BaseVisualInfo& operator=( BaseVisualInfo&& ) noexcept = default;
     BaseVisualInfo(const BaseVisualInfo& other) = delete;
@@ -199,15 +206,14 @@ struct BaseVisualInfo {
 class zCProgMeshProto;
 class zCTexture;
 struct MeshVisualInfo : public BaseVisualInfo {
-    MeshVisualInfo() {
-        Visual = nullptr;
-        MorphMeshVisual = nullptr;
-        UnloadedSomething = false;
-        StartInstanceNum = 0;
-        FullMesh = nullptr;
-        LastAniUpdateFrame = 0;
-        NeedsAlphaTesting = false;
-    }
+    MeshVisualInfo(): 
+        StartInstanceNum{},
+        FullMesh{},
+        UnloadedSomething{},
+        MorphMeshVisual{},
+        NeedsAlphaTesting{},
+        LastAniUpdateFrame{}
+    {}
     
     MeshVisualInfo(MeshVisualInfo&& other) = default;
     MeshVisualInfo& operator=( MeshVisualInfo&& ) = default;
@@ -252,7 +258,9 @@ struct MeshVisualInfo : public BaseVisualInfo {
 class zCMeshSoftSkin;
 class zCModel;
 struct SkeletalMeshVisualInfo : public BaseVisualInfo {
-    SkeletalMeshVisualInfo() = default;
+    SkeletalMeshVisualInfo() :
+        SkeletalMeshes{}
+    {};
     SkeletalMeshVisualInfo(SkeletalMeshVisualInfo&& other) = default;
     SkeletalMeshVisualInfo& operator=( SkeletalMeshVisualInfo&& ) = default;
     SkeletalMeshVisualInfo(const SkeletalMeshVisualInfo& other) = delete;
@@ -285,7 +293,10 @@ struct SkeletalMeshVisualInfo : public BaseVisualInfo {
 };
 
 struct BaseVobInfo {
-    BaseVobInfo() = default;
+    BaseVobInfo() : 
+        VisualInfo{},
+        Vob{}
+    {}
     BaseVobInfo(BaseVobInfo&& other) = default;
     BaseVobInfo& operator=( BaseVobInfo&& ) = default;
     BaseVobInfo(const BaseVobInfo& other) = delete;
@@ -301,7 +312,18 @@ struct BaseVobInfo {
 
 struct WorldMeshSectionInfo;
 struct VobInfo : public BaseVobInfo {
-    VobInfo() = default;
+    VobInfo() :
+        LastRenderPosition{},
+        IsIndoorVob{},
+        VisibleInRenderPass{},
+        VobSection{},
+        WorldMatrix{},
+        ParentBSPNodes{},
+        GroundColor{},
+        PrevWorldMatrix{},
+        HasValidPrevMatrix{}
+    {
+    }
     VobInfo(VobInfo&& other) = delete;
     VobInfo& operator=( VobInfo&& ) = delete;
     VobInfo(const VobInfo& other) = delete;
@@ -320,7 +342,7 @@ struct VobInfo : public BaseVobInfo {
     bool IsIndoorVob;
 
     /** Flag to see if this vob was drawn in the current render pass. Used to collect the same vob only once. */
-    std::atomic<size_t> VisibleInRenderPass{};
+    std::atomic<size_t> VisibleInRenderPass;
 
     /** Section this vob is in */
     WorldMeshSectionInfo* VobSection;
@@ -329,7 +351,7 @@ struct VobInfo : public BaseVobInfo {
     XMFLOAT4X4 WorldMatrix;
 
     /** BSP-Node this is stored in */
-    std::vector<BspInfo*> ParentBSPNodes{};
+    std::vector<BspInfo*> ParentBSPNodes;
 
     /** Color the underlaying polygon has */
     DWORD GroundColor;
@@ -346,7 +368,19 @@ struct VobInfo : public BaseVobInfo {
 class zCVobLight;
 class BaseShadowedPointLight;
 struct VobLightInfo {
-    VobLightInfo() = default;
+    VobLightInfo() : 
+        Vob{},
+        VisibleInRenderPass{},
+        IsPFXVobLight{},
+        IsIndoorVob{},
+        ParentBSPNodes{},
+        LightShadowBuffers{},
+        DynamicShadows{},
+        UpdateShadows{},
+        LastRenderedPosition{},
+        VisibleInFrame{}
+    {}
+
     VobLightInfo(VobLightInfo&& other) = delete;
     VobLightInfo& operator=( VobLightInfo&& ) = delete;
     VobLightInfo(const VobLightInfo& other) = delete;
@@ -358,14 +392,14 @@ struct VobLightInfo {
     zCVobLight* Vob;
 
     /** Flag to see if this vob was drawn in the current render pass. Used to collect the same vob only once. Cleared immediately. */
-    std::atomic<size_t> VisibleInRenderPass{};
+    std::atomic<size_t> VisibleInRenderPass;
     bool IsPFXVobLight;
 
     /** True if this is an indoor-vob */
     bool IsIndoorVob;
 
     /** BSP-Node this is stored in */
-    std::vector<BspInfo*> ParentBSPNodes{};
+    std::vector<BspInfo*> ParentBSPNodes;
 
     /** Buffers for doing shadows on this light */
     std::unique_ptr<BaseShadowedPointLight> LightShadowBuffers;
@@ -387,14 +421,17 @@ static auto g_MatIdentity = XMFLOAT4X4(
 );
 /** Holds the converted mesh of a VOB */
 struct SkeletalVobInfo : public BaseVobInfo {
-    SkeletalVobInfo() : WorldMatrix(g_MatIdentity), PrevWorldMatrix(g_MatIdentity)
+    SkeletalVobInfo() : 
+        NodeAttachments{},
+        IndoorVob{},
+        VisibleInRenderPass{},
+        WorldMatrix{},
+        ParentBSPNodes{},
+        PrevBoneTransforms{},
+        PrevWorldMatrix{},
+        HasValidPrevTransforms{},
+        LastAniUpdateFrame{}
     {
-        Vob = nullptr;
-        VisualInfo = nullptr;
-        IndoorVob = false;
-        VobConstantBuffer = nullptr;
-        HasValidPrevTransforms = false;
-        LastAniUpdateFrame = 0;
     }
 
     SkeletalVobInfo(SkeletalVobInfo&& other) = delete;
@@ -404,15 +441,11 @@ struct SkeletalVobInfo : public BaseVobInfo {
 
     ~SkeletalVobInfo() override
     {
-        //delete VisualInfo;
-
         for ( auto& [k, meshes] : NodeAttachments ) {
             for ( MeshVisualInfo* mvi : meshes ) {
                 delete mvi;
             }
         }
-
-        VobConstantBuffer.reset();
     }
 
     /** Updates the vobs constantbuffer */
@@ -425,26 +458,22 @@ struct SkeletalVobInfo : public BaseVobInfo {
         HasValidPrevTransforms = true;
     }
 
-    /** Constantbuffer which holds this vobs world matrix */
-    D3D11ConstantBuffer* GetVobConstantBuffer() const { return VobConstantBuffer.get(); };
-    std::unique_ptr<D3D11ConstantBuffer> VobConstantBuffer;
-
     /** Map of visuals attached to nodes */
-    gtl::flat_hash_map<int, std::vector<MeshVisualInfo*>> NodeAttachments{};
+    gtl::flat_hash_map<int, std::vector<MeshVisualInfo*>> NodeAttachments;
 
     /** Indoor* */
     bool IndoorVob;
 
     /** Flag to see if this vob was drawn in the current render pass. Used to collect the same vob only once. */
-    std::atomic<size_t> VisibleInRenderPass{};
+    std::atomic<size_t> VisibleInRenderPass;
 
     /** Current world transform */
     XMFLOAT4X4 WorldMatrix;
 
     /** BSP-Node this is stored in */
-    std::vector<BspInfo*> ParentBSPNodes{};
+    std::vector<BspInfo*> ParentBSPNodes;
 
-    std::vector<XMFLOAT4X4> PrevBoneTransforms{};
+    std::vector<XMFLOAT4X4> PrevBoneTransforms;
     XMFLOAT4X4 PrevWorldMatrix;
     bool HasValidPrevTransforms;
     size_t LastAniUpdateFrame;
@@ -466,12 +495,15 @@ class D3D11Texture;
 
 /** Describes a world-section for the renderer */
 struct WorldMeshSectionInfo {
-    WorldMeshSectionInfo() {
-        BoundingBox.Min = XMFLOAT3( FLT_MAX, FLT_MAX, FLT_MAX );
-        BoundingBox.Max = XMFLOAT3( -FLT_MAX, -FLT_MAX, -FLT_MAX );
-        FullStaticMesh = nullptr;
+    WorldMeshSectionInfo() : 
+    FullStaticMesh{},
+    BaseIndexLocation{},
+    NumIndices{}
+    {
+        BoundingBox.Min = XMFLOAT3(FLT_MAX, FLT_MAX, FLT_MAX);
+        BoundingBox.Max = XMFLOAT3(-FLT_MAX, -FLT_MAX, -FLT_MAX);
     }
-    
+
     WorldMeshSectionInfo(WorldMeshSectionInfo&& other) = default;
     WorldMeshSectionInfo& operator=( WorldMeshSectionInfo&& ) = default;
     WorldMeshSectionInfo(const WorldMeshSectionInfo& other) = delete;
@@ -530,11 +562,16 @@ struct WorldMeshSectionInfo {
 class zCBspTree;
 class zCWorld;
 struct WorldInfo {
-    WorldInfo() {
-        BspTree = nullptr;
-        CustomWorldLoaded = false;
+    WorldInfo() :
+        MidPoint{},
+        LowestVertex{},
+        HighestVertex{},
+        BspTree{},
+        MainWorld{},
+        CustomWorldLoaded{}
+    {
     }
-    
+
     WorldInfo(WorldInfo&& other) = default;
     WorldInfo& operator=(WorldInfo&& other) = default;
     WorldInfo(const WorldInfo& other) = delete;
@@ -558,6 +595,7 @@ struct TransparencyVobInfo {
     TransparencyVobInfo(TransparencyVobInfo&& other) = default;
     TransparencyVobInfo& operator=( TransparencyVobInfo&& ) = default;
     TransparencyVobInfo(const TransparencyVobInfo& other) = delete;
+    TransparencyVobInfo& operator=(const TransparencyVobInfo& other) = delete;
 
     float distance;
     float alpha;

--- a/D3D11Engine/zCVobLight.h
+++ b/D3D11Engine/zCVobLight.h
@@ -4,15 +4,32 @@
 class zCVobLight : public zCVob {
 public:
 
-    DWORD GetLightColor() {
+    struct LightInfoFlags {
+        uint8_t isStatic : 1;
+        uint8_t rangeAniSmooth : 1;
+        uint8_t rangeAniLoop : 1;
+        uint8_t colorAniSmooth : 1;
+        uint8_t colorAniLoop : 1;
+        uint8_t isTurnedOn : 1;
+        uint8_t lightQuality : 4;
+        uint8_t lightType : 4;
+        uint8_t m_bCanMove : 1;
+    };
+
+    DWORD GetLightColor() const {
         return *reinterpret_cast<DWORD*>(THISPTR_OFFSET( GothicMemoryLocations::zCVobLight::Offset_LightColor ));
     }
 
-    float GetLightRange() {
+    float GetLightRange() const {
         return *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCVobLight::Offset_Range ));
     }
 
-    bool IsEnabled() {
+    LightInfoFlags& GetLightInfoFlags() const {
+        LightInfoFlags& flags = *reinterpret_cast<LightInfoFlags*>(THISPTR_OFFSET( GothicMemoryLocations::zCVobLight::Offset_LightInfo ));
+        return flags;
+    }
+
+    bool IsEnabled() const {
         return *reinterpret_cast<DWORD*>(THISPTR_OFFSET( GothicMemoryLocations::zCVobLight::Offset_LightInfo )) & GothicMemoryLocations::zCVobLight::Mask_LightEnabled;
     }
 
@@ -20,7 +37,7 @@ public:
         reinterpret_cast<void( __fastcall* )( zCVobLight* )>( GothicMemoryLocations::zCVobLight::DoAnimation )( this );
     }
 
-    bool IsStatic() {
+    bool IsStatic() const {
         int flags = *reinterpret_cast<int*>(THISPTR_OFFSET( GothicMemoryLocations::zCVobLight::Offset_LightInfo ));
         return (flags & 1) != 0;
     }


### PR DESCRIPTION
There are many many "static" lights in Gothic to light up some places which would otherwise be too dark.
Those lights don't have a "light source" as in a torch, candle, etc.

But they currently produce shadows for Vobs and NPCs even if they should not.

This PR changes this, such that those lights do not provide shadows except the world mesh, to prevent light bleeding outside of buildings (as much as possible)

these changes prevent random player shadows from a direction where no light source is.
**But** also may cause some houses to look different / weird, due to the game having some ovens and candles with very low range or no "dynLight" at all.

`VobLight->IsStatic()` call was removed in the past accidentally, which was used to prevent drawing NPC shadows for "ambient" light types.