### PR TITLE
Add some missing motion vectors, fix depth position reconstruction with TAA, fix disabling interactive focus for MOBs

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -93,7 +93,7 @@ struct HeightfogConstantBuffer {
     float HF_pad2;
 
     float2 HF_ProjAB;
-    float2 HF_Pad3;
+    float2 HF_JitterOffset;
 };
 
 struct LumAdaptConstantBuffer {
@@ -164,7 +164,7 @@ struct DS_PointLightConstantBuffer {
     float3 Pl_PositionView;
 
     float2 PL_ViewportSize;
-    float2 PL_Pad2;
+    float2 PL_JitterOffset;
 
     float4 PL_ProjParams; // x = 1/P._11, y = 1/P._22, z = P._43, w = P._33
     XMFLOAT4X4 PL_InvView;
@@ -196,7 +196,7 @@ struct DS_ScreenQuadConstantBuffer {
     float SQ_ShadowSoftness;
     uint32_t SQ_FrameIndex;
     float SQ_LightSize;
-    float2 SQ_Pad;
+    float2 SQ_JitterOffset;
 
     // Shadow atlas: per-cascade UV rect (xy = offset, zw = scale)
     // Used when SHADOW_ATLAS is enabled (Feature Level 10 path)
@@ -414,7 +414,7 @@ struct LightCullingConstantBuffer {
 
 struct TiledShadingConstantBuffer {
     float2 ViewportSize;
-    float2 Pad0;
+    float2 JitterOffset;
     float4 ProjParams; // x = 1/P._11, y = 1/P._22, z = P._43, w = P._33
     uint32_t LimitLightIntensity;
     uint32_t NumTilesX;

--- a/D3D11Engine/D3D11DeferredRenderer.cpp
+++ b/D3D11Engine/D3D11DeferredRenderer.cpp
@@ -75,7 +75,6 @@ void D3D11DeferredRenderer::AddGeometryPasses( RenderGraph& graph,
                 if ( rtvs[i] )
                     context->ClearRenderTargetView( rtvs[i], black );
             }
-            rtvs[4] = nullptr; // don't populate the reactive mask. Just prevent FSR3 from creating one internally.
             context->OMSetRenderTargets( 5, rtvs, engine.GetDepthBuffer()->GetDepthStencilView().Get() );
 
             Engine::GAPI->DrawWorldMeshNaive();

--- a/D3D11Engine/D3D11DeferredRenderer.cpp
+++ b/D3D11Engine/D3D11DeferredRenderer.cpp
@@ -37,10 +37,9 @@ void D3D11DeferredRenderer::AddGeometryPasses( RenderGraph& graph,
         builder.Write( normalsResource );
         builder.Write( specularResource );
         builder.Write( velocityBufferHandle );
-        builder.Write( reactiveMaskResource );
         builder.Write( backBufferHandle );
 
-        pass.m_executeCallback = [&engine, colorResource, normalsResource, specularResource, reactiveMaskResource, velocityBufferHandle]( const RenderGraph& graph ) -> void {
+        pass.m_executeCallback = [&engine, colorResource, normalsResource, specularResource, velocityBufferHandle]( const RenderGraph& graph ) -> void {
             TracyD3D11ZoneCGX( "D3D11DeferredRenderer::G-Buffer Pass" );
             const auto& context = engine.GetContext();
             context->VSSetShaderResources( 0, 8, s_nullSRVs );
@@ -51,7 +50,6 @@ void D3D11DeferredRenderer::AddGeometryPasses( RenderGraph& graph,
 
             auto normals = graph.GetPhysicalTexture( normalsResource );
             auto specular = graph.GetPhysicalTexture( specularResource );
-            auto reactiveMask = graph.GetPhysicalTexture( reactiveMaskResource );
             auto velocityBuffer = graph.GetPhysicalTexture( velocityBufferHandle );
 
             const auto aaMode = Engine::GAPI->GetRendererState().RendererSettings.AntiAliasingMode;
@@ -66,7 +64,6 @@ void D3D11DeferredRenderer::AddGeometryPasses( RenderGraph& graph,
                 normals ? normals->GetRenderTargetView().Get() : nullptr,
                 specular ? specular->GetRenderTargetView().Get() : nullptr,
                 velocityBuffer ? velocityBuffer->GetRenderTargetView().Get() : nullptr,
-                reactiveMask ? reactiveMask->GetRenderTargetView().Get() : nullptr,
             };
 
             constexpr float black[] { 0.f, 0.f, 0.f, 0.f };
@@ -75,7 +72,7 @@ void D3D11DeferredRenderer::AddGeometryPasses( RenderGraph& graph,
                 if ( rtvs[i] )
                     context->ClearRenderTargetView( rtvs[i], black );
             }
-            context->OMSetRenderTargets( 5, rtvs, engine.GetDepthBuffer()->GetDepthStencilView().Get() );
+            context->OMSetRenderTargets( std::size( rtvs ), rtvs, engine.GetDepthBuffer()->GetDepthStencilView().Get());
 
             Engine::GAPI->DrawWorldMeshNaive();
 

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -340,7 +340,7 @@
       </AssemblyDebug>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G2_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>
@@ -390,7 +390,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G2_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>
@@ -437,7 +437,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G2_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>
@@ -488,7 +488,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       </AssemblyDebug>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G2_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>
@@ -580,7 +580,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       </AdditionalLibraryDirectories>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G1_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G1_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G1_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>
@@ -621,7 +621,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       </AdditionalLibraryDirectories>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G1_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G1_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G1_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>
@@ -663,7 +663,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <StripPrivateSymbols>$(OutDir)$(TargetName)-stripped.pdb</StripPrivateSymbols>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G1_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G1_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G1_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>
@@ -705,7 +705,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <StripPrivateSymbols>$(OutDir)$(TargetName)-stripped.pdb</StripPrivateSymbols>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G1_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G1_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G1_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>
@@ -781,7 +781,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <EnableCOMDATFolding>false</EnableCOMDATFolding>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G2_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>
@@ -816,7 +816,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       </DelayLoadDLLs>
     </Link>
     <CustomBuildStep>
-      <Command>copy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders\"
+      <Command>Xcopy "shaders\*" "$(G2_SYSTEM_PATH)\GD3D11\shaders" /y /s
 copy "$(OutDir)$(TargetName)$(TargetExt)" "$(G2_SYSTEM_PATH)\ddraw.dll"
 copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Outputs>xxx</Outputs>

--- a/D3D11Engine/D3D11ForwardPlusRenderer.cpp
+++ b/D3D11Engine/D3D11ForwardPlusRenderer.cpp
@@ -229,7 +229,6 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
                 if ( rtvs[i] )
                     context->ClearRenderTargetView( rtvs[i], black );
             }
-            rtvs[4] = nullptr; // don't populate the reactive mask. Just prevent FSR3 from creating one internally.
 
             context->OMSetRenderTargets( 5, rtvs, engine.GetDepthBuffer()->GetDepthStencilView().Get() );
 

--- a/D3D11Engine/D3D11ForwardPlusRenderer.cpp
+++ b/D3D11Engine/D3D11ForwardPlusRenderer.cpp
@@ -186,7 +186,6 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
         normalsResource = builder.CreateTexture( { static_cast<uint32_t>( size.x ), static_cast<uint32_t>( size.y ), DXGI_FORMAT_R16G16_FLOAT, L"GBufferNormals" } );
         specularResource = builder.CreateTexture( { static_cast<uint32_t>( size.x ), static_cast<uint32_t>( size.y ), DXGI_FORMAT_R16G16_FLOAT, L"GBufferSpecular" } );
         reactiveMaskResource = builder.CreateTexture( { static_cast<uint32_t>( size.x ), static_cast<uint32_t>( size.y ), DXGI_FORMAT_R8_UNORM, L"ReactiveMask" } );
-        builder.Write( reactiveMaskResource );
         builder.Write( velocityBufferHandle );
         builder.Write( colorResource );
         builder.Write( normalsResource );
@@ -196,14 +195,13 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
             builder.Read( shadowMaskResource );
         }
 
-        pass.m_executeCallback = [this, &engine, colorResource, normalsResource, specularResource, reactiveMaskResource, velocityBufferHandle, shadowMaskResource, useScreenSpaceShadowMask]( const RenderGraph& graph ) -> void {
+        pass.m_executeCallback = [this, &engine, colorResource, normalsResource, specularResource, velocityBufferHandle, shadowMaskResource, useScreenSpaceShadowMask]( const RenderGraph& graph ) -> void {
             TracyD3D11ZoneCGX( "D3D11ForwardPlusRenderer::Lit Geometry" );
             auto& context = engine.GetContext();
             auto* shadowMaps = engine.GetShadowMaps();
 
             auto normals = graph.GetPhysicalTexture( normalsResource );
             auto specular = graph.GetPhysicalTexture( specularResource );
-            auto reactiveMask = graph.GetPhysicalTexture( reactiveMaskResource );
             auto velocityBuffer = graph.GetPhysicalTexture( velocityBufferHandle );
             auto* shadowMask = ( useScreenSpaceShadowMask && shadowMaskResource != RG_INVALID_HANDLE )
                 ? graph.GetPhysicalTexture( shadowMaskResource )
@@ -220,7 +218,6 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
                 normals ? normals->GetRenderTargetView().Get() : nullptr,
                 specular ? specular->GetRenderTargetView().Get() : nullptr,
                 velocityBuffer ? velocityBuffer->GetRenderTargetView().Get() : nullptr,
-                reactiveMask ? reactiveMask->GetRenderTargetView().Get() : nullptr,
             };
 
             constexpr float black[] { 0.f, 0.f, 0.f, 0.f };
@@ -230,7 +227,7 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
                     context->ClearRenderTargetView( rtvs[i], black );
             }
 
-            context->OMSetRenderTargets( 5, rtvs, engine.GetDepthBuffer()->GetDepthStencilView().Get() );
+            context->OMSetRenderTargets( std::size( rtvs ), rtvs, engine.GetDepthBuffer()->GetDepthStencilView().Get() );
 
             // Use LESS_EQUAL depth test to leverage the depth prepass
             auto& depthState = Engine::GAPI->GetRendererState().DepthState;

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4048,12 +4048,23 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
             //RGTextureDesc albedoDesc{ 1920, 1080, 28 /* DXGI_FORMAT_R8G8B8A8_UNORM */, "Albedo" };
             //albedoTarget = builder.CreateTexture( albedoDesc );
             builder.Write( backBufferHandle );
+            builder.Write( velocityBufferHandle );
+            builder.Write( reactiveMaskResource );
 
-            pass.m_executeCallback = [this, backBufferHandle]( const RenderGraph& graph )->void {
+            pass.m_executeCallback = [this, backBufferHandle, reactiveMaskResource, velocityBufferHandle]( const RenderGraph& graph )->void {
                 TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw Sky" );
                 // Draw back of the sky if outdoor
-                GetContext()->OMSetRenderTargets( 1, graph.GetPhysicalTexture( backBufferHandle )->GetRenderTargetView().GetAddressOf(), GetDepthBuffer()->GetDepthStencilView().Get() );
 
+                auto reactiveMask = graph.GetPhysicalTexture( reactiveMaskResource );
+                auto velocityBuffer = graph.GetPhysicalTexture( velocityBufferHandle );
+                ID3D11RenderTargetView* rtvs[] = {
+                    graph.GetPhysicalTexture(backBufferHandle)->GetRenderTargetView().Get(),
+                    velocityBuffer ? velocityBuffer->GetRenderTargetView().Get() : nullptr,
+                    reactiveMask ? reactiveMask->GetRenderTargetView().Get() : nullptr,
+                };
+                GetContext()->OMSetRenderTargets(std::size(rtvs), rtvs, GetDepthBuffer()->GetDepthStencilView().Get());
+
+                SetupVS_ExConstantBuffer(); // required for motion vectors
                 DrawSky();
             };
         } );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2996,8 +2996,8 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
         }
     };
 
-    const float focusedColorSentinel = 2.0f;
-    const float interactiveFocusColor = oCGame::GetHighlightInteractFocus() ? focusedColorSentinel : 0.0f;
+    static const float focusedColorSentinel = 2.0f;
+    const float interactiveFocusEnabled = oCGame::GetHighlightInteractFocus();
     const float meleeFocusEnabled = oCGame::GetHighlightMeleeFocus() >= 2 && oCGame::GetNpcFocusIsHighlightActive();
     zCVob* playerFocusVob = oCGame::GetPlayer() ? oCGame::GetPlayer()->GetFocusVob() : nullptr;
     if ( playerFocusVob ) {
@@ -3005,23 +3005,26 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
             if ( !meleeFocusEnabled ) {
                 playerFocusVob = nullptr;
             }
-        } else if ( oCMobInter* mobInter = playerFocusVob->As<oCMobInter>() ) {
-            // TODO: Also disable if this MOB has no "Name"
-            // TODO: Figure out how to properly call oCMob::GetName which populates a string on the stack.
-            if ( mobInter->IsInteractingWith( oCGame::GetPlayer()) || !mobInter->HasName() ) {
-                // disable focus if player is interacting with the mob.
-                playerFocusVob = nullptr;
-            }
-        } else if ( oCMob* mob = playerFocusVob->As<oCMob>() ) {
-            if ( !mob->HasName() ) {
-                playerFocusVob = nullptr; // disable highlight for unnamed MOBs
+        } 
+        else if ( !interactiveFocusEnabled ) {
+            playerFocusVob = nullptr;
+        } else {
+            if ( oCMobInter* mobInter = playerFocusVob->As<oCMobInter>() ) {
+                if ( mobInter->IsInteractingWith( oCGame::GetPlayer() ) || !mobInter->HasName() ) {
+                    // disable focus if player is interacting with the mob.
+                    playerFocusVob = nullptr;
+                }
+            } else if ( oCMob* mob = playerFocusVob->As<oCMob>() ) {
+                if ( !mob->HasName() ) {
+                    playerFocusVob = nullptr; // disable highlight for unnamed MOBs
+                }
             }
         }
     }
 
     static auto getFocusColor = []( zCVob* vob, const zCVob* playerFocusVob ) -> float {
         if ( vob == playerFocusVob ) {
-            return 2.0f;
+            return focusedColorSentinel;
         }
         return 0.0f;
     };

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4044,23 +4044,17 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
 
     if ( rendererState.RendererSettings.DrawSky ) {
         graph.AddPass( RG_PASS_NAME( "Draw Sky" ), [&]( RGBuilder& builder, RenderPass& pass ) {
-            //// Setup / Declare
-            //RGTextureDesc albedoDesc{ 1920, 1080, 28 /* DXGI_FORMAT_R8G8B8A8_UNORM */, "Albedo" };
-            //albedoTarget = builder.CreateTexture( albedoDesc );
             builder.Write( backBufferHandle );
             builder.Write( velocityBufferHandle );
-            builder.Write( reactiveMaskResource );
 
-            pass.m_executeCallback = [this, backBufferHandle, reactiveMaskResource, velocityBufferHandle]( const RenderGraph& graph )->void {
+            pass.m_executeCallback = [this, backBufferHandle, velocityBufferHandle]( const RenderGraph& graph )->void {
                 TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw Sky" );
                 // Draw back of the sky if outdoor
 
-                auto reactiveMask = graph.GetPhysicalTexture( reactiveMaskResource );
                 auto velocityBuffer = graph.GetPhysicalTexture( velocityBufferHandle );
                 ID3D11RenderTargetView* rtvs[] = {
                     graph.GetPhysicalTexture(backBufferHandle)->GetRenderTargetView().Get(),
                     velocityBuffer ? velocityBuffer->GetRenderTargetView().Get() : nullptr,
-                    reactiveMask ? reactiveMask->GetRenderTargetView().Get() : nullptr,
                 };
                 GetContext()->OMSetRenderTargets(std::size(rtvs), rtvs, GetDepthBuffer()->GetDepthStencilView().Get());
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3701,7 +3701,8 @@ XRESULT D3D11GraphicsEngine::UpdateRenderStates() {
         FFBlendStateHash = blendState.Hash;
 
         blendState.StateDirty = false;
-        GetContext()->OMSetBlendState( FFBlendState.Get(), float4( 0, 0, 0, 0 ).toPtr(),
+        const FLOAT blendFactor[4] = {0,0,0,0};
+        GetContext()->OMSetBlendState( FFBlendState.Get(), blendFactor,
             0xFFFFFFFF );
     }
 
@@ -4160,20 +4161,36 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         if ( FeatureLevel10Compatibility || Engine::GAPI->GetRendererState().RendererSettings.DrawRainThroughTransformFeedback ) {
             graph.AddPass( RG_PASS_NAME("Draw Rain"), [&]( RGBuilder& builder, RenderPass& pass ) {
                 builder.Read( backBufferHandle );
+                builder.Write( reactiveMaskResource );
                 builder.Write( backBufferHandle );
 
-                pass.m_executeCallback = [this](const RenderGraph&) {
+                pass.m_executeCallback = [this, backBufferHandle, reactiveMaskResource](const RenderGraph& g) {
                     TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw Rain" );
+                    
+                    auto reactiveMask = g.GetPhysicalTexture(reactiveMaskResource);
+                    ID3D11RenderTargetView* rtvs[] = {
+                        g.GetPhysicalTexture(backBufferHandle)->GetRenderTargetView().Get(),
+                        reactiveMask ? reactiveMask->GetRenderTargetView().Get() : nullptr,
+                    };
+                    Context->OMSetRenderTargets(std::size(rtvs), rtvs, nullptr);
+
                     Effects->DrawRain();
                 };
             });
         } else {
             graph.AddPass( RG_PASS_NAME("Draw Rain CS"), [&]( RGBuilder& builder, RenderPass& pass ) {
                 builder.Read( backBufferHandle );
+                builder.Write( reactiveMaskResource );
                 builder.Write( backBufferHandle );
 
-                pass.m_executeCallback = [this](const RenderGraph&) {
+                pass.m_executeCallback = [this, backBufferHandle, reactiveMaskResource](const RenderGraph& g) {
                     TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw Rain (CS)" );
+                    auto reactiveMask = g.GetPhysicalTexture( reactiveMaskResource );
+                    ID3D11RenderTargetView* rtvs[] = {
+                        g.GetPhysicalTexture(backBufferHandle)->GetRenderTargetView().Get(),
+                        reactiveMask ? reactiveMask->GetRenderTargetView().Get() : nullptr,
+                    };
+                    Context->OMSetRenderTargets(std::size(rtvs), rtvs, nullptr);
                     Effects->DrawRain_CS();
                 };
             });

--- a/D3D11Engine/D3D11LegacyDeferredShading.cpp
+++ b/D3D11Engine/D3D11LegacyDeferredShading.cpp
@@ -55,6 +55,8 @@ XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
     {
         auto& proj = Engine::GAPI->GetProjectionMatrix();
         plcb.PL_ProjParams = float4( 1.0f / proj._11, 1.0f / proj._22, proj._43, proj._33 );
+        // Camera jitter (TAA/FSR) in UV space, subtracted before depth->world reconstruction.
+        plcb.PL_JitterOffset = float2( proj._13 * 0.5f, -proj._23 * 0.5f );
     }
     XMStoreFloat4x4( &plcb.PL_InvView, XMMatrixInverse( nullptr, XMLoadFloat4x4( &Engine::GAPI->GetRendererState().TransformState.TransformView ) ) );
 

--- a/D3D11Engine/D3D11PFX_HeightFog.cpp
+++ b/D3D11Engine/D3D11PFX_HeightFog.cpp
@@ -31,6 +31,7 @@ XRESULT D3D11PFX_HeightFog::Render( RenderToTextureBuffer* fxbuffer ) {
 	{
 		auto& proj = Engine::GAPI->GetProjectionMatrix();
 		cb.HF_ProjParams = float4( 1.0f / proj._11, 1.0f / proj._22, proj._43, proj._33 );
+		cb.HF_JitterOffset = float2( proj._13 * 0.5f, -proj._23 * 0.5f );
 	}
 
 	XMStoreFloat4x4( &cb.InvView, XMMatrixInverse( nullptr, Engine::GAPI->GetViewMatrixXM() ) );

--- a/D3D11Engine/D3D11PfxRenderer.cpp
+++ b/D3D11Engine/D3D11PfxRenderer.cpp
@@ -292,6 +292,7 @@ XRESULT D3D11PfxRenderer::RenderPostFXComposition(
         {
             auto& proj = Engine::GAPI->GetProjectionMatrix();
             cb.HF_ProjParams = float4( 1.0f / proj._11, 1.0f / proj._22, proj._43, proj._33 );
+            cb.HF_JitterOffset = float2( proj._13 * 0.5f, -proj._23 * 0.5f );
         }
         XMStoreFloat4x4( &cb.InvView, XMMatrixInverse( nullptr, Engine::GAPI->GetViewMatrixXM() ) );
         cb.CameraPosition = Engine::GAPI->GetCameraPosition();

--- a/D3D11Engine/D3D11PipelineStates.h
+++ b/D3D11Engine/D3D11PipelineStates.h
@@ -57,7 +57,7 @@ public:
         D3D11_BLEND_DESC blendDesc;
         // Set to default
         blendDesc.AlphaToCoverageEnable = bs.AlphaToCoverage;
-        blendDesc.IndependentBlendEnable = FALSE;
+        blendDesc.IndependentBlendEnable = TRUE;
 
         blendDesc.RenderTarget[0].RenderTargetWriteMask = bs.ColorWritesEnabled ? (D3D11_COLOR_WRITE_ENABLE_RED |
             D3D11_COLOR_WRITE_ENABLE_BLUE |
@@ -71,6 +71,14 @@ public:
         blendDesc.RenderTarget[0].DestBlendAlpha = static_cast<D3D11_BLEND>(bs.DestBlendAlpha);
         blendDesc.RenderTarget[0].BlendOpAlpha = static_cast<D3D11_BLEND_OP>(bs.BlendOpAlpha);
         blendDesc.RenderTarget[0].BlendEnable = bs.BlendEnabled;
+
+        for (int i = 1; i < std::size(blendDesc.RenderTarget); ++i) {
+            blendDesc.RenderTarget[i].BlendEnable = FALSE;
+            blendDesc.RenderTarget[i].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_RED |
+                D3D11_COLOR_WRITE_ENABLE_BLUE |
+                D3D11_COLOR_WRITE_ENABLE_GREEN |
+                D3D11_COLOR_WRITE_ENABLE_ALPHA;
+        }
 
         reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine)->GetDevice()->CreateBlendState( &blendDesc, State.ReleaseAndGetAddressOf() );
     }

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1354,6 +1354,10 @@ DS_ScreenQuadConstantBuffer D3D11ShadowMap::FillSunCSMConstantBuffer() const {
         scb.SQ_FrameIndex = frameCounter++;
     }
 
+    // Camera jitter (TAA/FSR) baked into the projection, in UV space. Subtracted in the
+    // shader before depth->world reconstruction so shadows don't crawl/flicker each frame.
+    scb.SQ_JitterOffset = float2( proj._13 * 0.5f, -proj._23 * 0.5f );
+
     XMStoreFloat3( scb.SQ_LightDirectionVS.toXMFLOAT3(),
         XMVector3TransformNormal( XMLoadFloat3( sky->GetAtmosphereCB().AC_LightPos.toXMFLOAT3() ), view ) );
 
@@ -1482,6 +1486,10 @@ XRESULT D3D11ShadowMap::DrawWorldLights()
         // only when we have jitter in the frame
         scb.SQ_FrameIndex = frameCounter++;
     }
+
+    // Camera jitter (TAA/FSR) baked into the projection, in UV space. Subtracted in the
+    // shader before depth->world reconstruction so shadows don't crawl/flicker each frame.
+    scb.SQ_JitterOffset = float2( proj._13 * 0.5f, -proj._23 * 0.5f );
 
     XMStoreFloat3( scb.SQ_LightDirectionVS.toXMFLOAT3(),
         XMVector3TransformNormal( XMLoadFloat3( sky->GetAtmosphereCB().AC_LightPos.toXMFLOAT3() ), view ) );

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -243,6 +243,7 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
         {
             auto& proj = Engine::GAPI->GetProjectionMatrix();
             shadeCB.ProjParams = float4( 1.0f / proj._11, 1.0f / proj._22, proj._43, proj._33 );
+            shadeCB.JitterOffset = float2( proj._13 * 0.5f, -proj._23 * 0.5f );
         }
         shadeCB.LimitLightIntensity = settings.LimitLightIntesity ? 1 : 0;
         shadeCB.NumTilesX = numTilesX;

--- a/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
+++ b/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
@@ -31,8 +31,6 @@ MyDirectDrawSurface7::MyDirectDrawSurface7() {
 }
 
 MyDirectDrawSurface7::~MyDirectDrawSurface7() {
-    Engine::GAPI->RemoveSurface( this );
-
     // Release mip-map chain first
     for ( LPDIRECTDRAWSURFACE7 mipmap : attachedSurfaces ) {
         mipmap->Release();
@@ -90,8 +88,6 @@ void MyDirectDrawSurface7::LoadAdditionalResources( zCTexture* ownedTexture ) {
         if ( Toolbox::StringContainsOneOf( TextureName, LEAF_SUBSTR, std::size( LEAF_SUBSTR ) ) ) {
             TextureType = ETextureType::TX_LEAF;
         }
-
-        Engine::GAPI->AddSurface( TextureName, this );
 
         // Set texture name
         if ( EngineTexture ) {

--- a/D3D11Engine/GVegetationBox.cpp
+++ b/D3D11Engine/GVegetationBox.cpp
@@ -126,6 +126,8 @@ XRESULT GVegetationBox::InitVegetationBox( const XMFLOAT3& min,
         zCMaterial* m = Engine::GAPI->GetMaterialByTextureName( restrictByTexture );
         MeshTexture = m ? m->GetTexture() : nullptr;
     }
+    
+    std::string_view restrictByTextureView = restrictByTexture;
 
     BoxMax = max;
     BoxMin = min;
@@ -150,14 +152,14 @@ XRESULT GVegetationBox::InitVegetationBox( const XMFLOAT3& min,
 
                 if ( PositionInsideBox( *p[i]->getVertices()[v]->Position.toXMFLOAT3() ) ) {
                     // Restrict by texture
-                    if ( restrictByTexture.length() &&
+                    if (!restrictByTextureView.empty() &&
                         p[i]->GetMaterial() &&
                         p[i]->GetMaterial()->GetTexture() &&
-                        p[i]->GetMaterial()->GetTexture()->GetNameWithoutExt() == restrictByTexture ) {
+                        p[i]->GetMaterial()->GetTexture()->GetNameWithoutExtView() == restrictByTextureView ) {
                         polysInside.push_back( tri[0] );
                         polysInside.push_back( tri[1] );
                         polysInside.push_back( tri[2] );
-                    } else if ( !restrictByTexture.length() ) {
+                    } else if (restrictByTextureView.empty()) {
                         polysInside.push_back( tri[0] );
                         polysInside.push_back( tri[1] );
                         polysInside.push_back( tri[2] );
@@ -177,14 +179,14 @@ XRESULT GVegetationBox::InitVegetationBox( const XMFLOAT3& min,
                                         *p[i]->getVertices()[2]->Position.toXMFLOAT3() };
 
                 // Restrict by texture
-                if ( restrictByTexture.length() &&
+                if (!restrictByTextureView.empty() &&
                     p[i]->GetMaterial() &&
                     p[i]->GetMaterial()->GetTexture() &&
-                    p[i]->GetMaterial()->GetTexture()->GetNameWithoutExt() == restrictByTexture ) {
+                    p[i]->GetMaterial()->GetTexture()->GetNameWithoutExtView() == restrictByTextureView ) {
                     polysInside.push_back( tri[0] );
                     polysInside.push_back( tri[1] );
                     polysInside.push_back( tri[2] );
-                } else if ( !restrictByTexture.length() ) {
+                } else if (restrictByTextureView.empty()) {
                     polysInside.push_back( tri[0] );
                     polysInside.push_back( tri[1] );
                     polysInside.push_back( tri[2] );

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4854,21 +4854,6 @@ MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex, const std::string_
         return mi;
 }
 
-/** Adds a surface */
-void GothicAPI::AddSurface( const std::string& name, MyDirectDrawSurface7* surface ) {
-    SurfacesByName[name] = surface;
-}
-
-/** Gets a surface by texturename */
-MyDirectDrawSurface7* GothicAPI::GetSurface( const std::string& name ) {
-    return SurfacesByName[name];
-}
-
-/** Removes a surface */
-void GothicAPI::RemoveSurface( MyDirectDrawSurface7* surface ) {
-    SurfacesByName.erase( surface->GetTextureName() );
-}
-
 /** Returns the loaded skeletal mesh vobs */
 std::vector<SkeletalVobInfo*>& GothicAPI::GetSkeletalMeshVobs() {
     return SkeletalMeshVobs;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -73,10 +73,17 @@ extern float vobAnimation_WindStrength;
 
 /** Writes this info to a file */
 void MaterialInfo::WriteToFile( const std::string& name ) {
-    FILE* f = fopen( ("system\\GD3D11\\textures\\infos\\" + name + ".mi").c_str(), "wb" );
+    thread_local std::string infoPath{};
+    infoPath.reserve( 255 );
+    infoPath.clear();
+
+    infoPath.append(R"(system\GD3D11\textures\infos\)");
+    infoPath.append(name);
+    infoPath.append(".mi");
+    FILE* f = fopen( infoPath.c_str(), "wb" );
 
     if ( !f ) {
-        LogError() << "Failed to open file '" << ("system\\GD3D11\\textures\\infos\\" + name + ".mi") << "' for writing! Make sure the game runs in Admin mode "
+        LogError() << "Failed to open file '" << infoPath << "' for writing! Make sure the game runs in Admin mode "
             " to get the rights to write to that directory!";
 
         return;
@@ -96,9 +103,13 @@ void MaterialInfo::LoadFromFile( const std::string_view name ) {
     bool foundFile = false;
     char ReadBuffer[sizeof( int ) + sizeof( MaterialInfo::Buffer )];
     
-    std::string filePath = R"(\system\GD3D11\textures\infos\)";
-    filePath = filePath.append( name.data(), name.size() );
-    filePath = filePath.append( ".mi" );
+    thread_local std::string filePath{};
+    filePath.reserve( 255 );
+    filePath.clear();
+
+    filePath.append(R"(\system\GD3D11\textures\infos\)");
+    filePath.append( name.data(), name.size() );
+    filePath.append( ".mi" );
     {
         auto vdfsFile = zFILE_VDFS::Create(filePath.c_str());
         if ( vdfsFile->Exists()
@@ -5808,7 +5819,7 @@ bool GothicAPI::CheckNormalmapFilesOld() {
         the directory itself (".") and FindNextFile() will fail with ERROR_FILE_NOT_FOUND. **/
 
     WIN32_FIND_DATAA data;
-    HANDLE f = FindFirstFile( "system\\GD3D11\\Textures\\Replacements\\*.dds", &data );
+    HANDLE f = FindFirstFile(R"(system\GD3D11\Textures\Replacements\*.dds)", &data );
     if ( !FindNextFile( f, &data ) ) {
         /*
                 // Inform the user that he is missing normalmaps
@@ -5834,8 +5845,8 @@ bool GothicAPI::CheckNormalmapFilesOld() {
         "The old normalmaps will be moved to the new location. You should however go and delete everything in the replacements-folder"
         " if you have installed normalmaps for any Mod (Like L'Hiver) and let GD3D11 download them again for you.", "Something has changed...", MB_OK | MB_TOPMOST );
 
-    system( "mkdir system\\GD3D11\\Textures\\Replacements\\Normalmaps_Original" );
-    system( "move /Y system\\GD3D11\\Textures\\Replacements\\*.dds system\\GD3D11\\Textures\\Replacements\\Normalmaps_Original" );
+    system(R"(mkdir system\GD3D11\Textures\Replacements\Normalmaps_Original)");
+    system(R"(move /Y system\GD3D11\Textures\Replacements\*.dds system\GD3D11\Textures\Replacements\Normalmaps_Original)");
 
     return true;
 }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4745,10 +4745,11 @@ float GothicAPI::GetNearPlane() {
 
 /** Get material by texture name */
 zCMaterial* GothicAPI::GetMaterialByTextureName( const std::string& name ) {
+    const std::string_view nameView = name;
     for ( auto const& it : LoadedMaterials ) {
         if ( it->GetTexture() ) {
-            std::string tn = it->GetTexture()->GetNameWithoutExt();
-            if ( _strnicmp( name.c_str(), tn.c_str(), 255 ) == 0 )
+            const std::string_view tn = it->GetTexture()->GetNameWithoutExtView();
+            if ( Toolbox::EqualsIgnoreCase(nameView, tn ) )
                 return it;
         }
     }
@@ -4757,10 +4758,11 @@ zCMaterial* GothicAPI::GetMaterialByTextureName( const std::string& name ) {
 }
 
 void GothicAPI::GetMaterialListByTextureName( const std::string& name, std::list<zCMaterial*>& list ) {
+    const std::string_view nameView = name;
     for ( auto const& it : LoadedMaterials ) {
         if ( it->GetTexture() ) {
-            std::string tn = it->GetTexture()->GetNameWithoutExt();
-            if ( _strnicmp( name.c_str(), tn.c_str(), 255 ) == 0 )
+            const std::string_view tn = it->GetTexture()->GetNameWithoutExtView();
+            if ( Toolbox::EqualsIgnoreCase(nameView, tn ) )
                 list.push_back( it );
         }
     }
@@ -4970,14 +4972,19 @@ void GothicAPI::ApplySuppressedSectionTextures() {
         // Look into each mesh of this section and find the texture
         for ( auto mit = section->WorldMeshes.begin(); mit != section->WorldMeshes.end(); ) {
             bool movedToSuppressed = false;
-            for ( unsigned int i = 0; i < it.second.size(); i++ ) {
-                // Is this the texture we are looking for?
-                if ( (*mit).first.Material && (*mit).first.Material->GetTexture() && (*mit).first.Material->GetTexture()->GetNameWithoutExt() == it.second[i] ) {
-                    // Yes, move it to the suppressed map
-                    section->SuppressedMeshes[(*mit).first] = (*mit).second;
-                    mit = section->WorldMeshes.erase( mit );
-                    movedToSuppressed = true;
-                    break;
+            if (auto mat = mit->first.Material ) {
+                if ( auto tx = mat->GetTexture()) {
+                    auto txName = tx->GetNameWithoutExtView();
+                    for ( unsigned int i = 0; i < it.second.size(); i++ ) {
+                        // Is this the texture we are looking for?
+                        if ( txName == it.second[i] ) {
+                            // Yes, move it to the suppressed map
+                            section->SuppressedMeshes[mit->first] = mit->second;
+                            mit = section->WorldMeshes.erase( mit );
+                            movedToSuppressed = true;
+                            break;
+                        }
+                    }
                 }
             }
 

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -686,15 +686,6 @@ public:
     MaterialInfo* GetMaterialInfoFrom( zCTexture* tex );
     MaterialInfo* GetMaterialInfoFrom( zCTexture* tex, const std::string_view textureName );
 
-    /** Adds a surface */
-    void AddSurface( const std::string& name, MyDirectDrawSurface7* surface );
-
-    /** Gets a surface by texturename */
-    MyDirectDrawSurface7* GetSurface( const std::string& name );
-
-    /** Removes a surface */
-    void RemoveSurface( MyDirectDrawSurface7* surface );
-
     /** Returns a texture from the given surface */
     zCTexture* GetTextureBySurface( MyDirectDrawSurface7* surface );
 

--- a/D3D11Engine/ImGuiEditorView.cpp
+++ b/D3D11Engine/ImGuiEditorView.cpp
@@ -756,13 +756,13 @@ void ImGuiEditorView::OnMouseClick(int button) {
 void ImGuiEditorView::UpdateSelectionPanel() {
     // Update selection panel
     if (Selection.SelectedMaterial && Selection.SelectedMaterial->GetTexture()) {
+        auto tx = Selection.SelectedMaterial->GetTexture();
         // Select preferred texture for the texture settings
-        // Engine::AntTweakBar->SetPreferredTextureForSettings(Selection.SelectedMaterial->GetTexture()->GetNameWithoutExt());
+        // Engine::AntTweakBar->SetPreferredTextureForSettings(tx->GetNameWithoutExt());
 
         // Update thumbnail
-        MyDirectDrawSurface7* surface = Engine::GAPI->GetSurface(Selection.SelectedMaterial->GetTexture()->GetNameWithoutExt());
 
-        if (surface) {
+        if (MyDirectDrawSurface7* surface = tx->GetSurface()) {
             auto& thumb = surface->GetEngineTexture()->GetThumbnailSRV();
             if (!thumb.Get()) {
                 XLE((surface->GetEngineTexture())->CreateThumbnail());
@@ -777,7 +777,7 @@ void ImGuiEditorView::UpdateSelectionPanel() {
         }
 
         // Load texture settings
-        MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom(Selection.SelectedMaterial->GetTexture());
+        MaterialInfo* info = Engine::GAPI->GetMaterialInfoFrom(tx);
         if (info) {
             SelectedTexNrmStr = info->buffer.NormalmapStrength;
             SelectedTexSpecIntens = info->buffer.SpecularIntensity;

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -19,7 +19,7 @@ struct LightGrid {
 
 cbuffer TiledShadingConstantBuffer : register( b0 ) {
     float2 ViewportSize;
-    float2 Pad0;
+    float2 JitterOffset;
     float4 ProjParams; // x = 1/P._11, y = 1/P._22, z = P._43, w = P._33
     uint LimitLightIntensity;
     uint NumTilesX;
@@ -42,7 +42,9 @@ TextureCubeArray TX_ShadowCubeArray : register( t11 );
 RWTexture2D<float4> RW_HDR : register( u0 );
 
 float3 VSPositionFromDepth( float depth, uint2 pixelCoord ) {
-    return ReconstructVSPositionFromDepthReverseZInfinite( depth, pixelCoord, ViewportSize, ProjParams.xy );
+    // Remove camera jitter (TAA/FSR) baked into the depth buffer's projection.
+    float2 texcoord = (float2( pixelCoord ) + 0.5f) / ViewportSize - JitterOffset;
+    return ReconstructVSPositionFromDepthReverseZInfinite( depth, texcoord, ProjParams.xy );
 }
 
 [numthreads( TILE_SIZE, TILE_SIZE, 1 )]

--- a/D3D11Engine/Shaders/DS_Defines.h
+++ b/D3D11Engine/Shaders/DS_Defines.h
@@ -4,7 +4,6 @@ struct DEFERRED_PS_OUTPUT
 	float2 vNrm : SV_TARGET1; 
 	float2 vSI_SP : SV_TARGET2;
 	float2 vVelocity : SV_TARGET3;  // Screen-space velocity for motion vectors
-	float vReactiveMask : SV_TARGET4;  // Screen-space velocity for motion vectors
 };
 
 struct DEFERRED_PS_OUTPUT_ALPHA_TO_COVERAGE
@@ -20,7 +19,6 @@ struct FORWARD_PLUS_PS_OUTPUT
 	float2 vNrm : SV_TARGET1;
 	float2 vSI_SP : SV_TARGET2;
 	float2 vVelocity : SV_TARGET3;
-	float vReactiveMask : SV_TARGET4;
 };
 
 

--- a/D3D11Engine/Shaders/PS_Atmosphere.hlsl
+++ b/D3D11Engine/Shaders/PS_Atmosphere.hlsl
@@ -4,6 +4,14 @@
 
 #include <AtmosphericScattering.h>
 
+cbuffer cbPerFrame : register( b0 )
+{
+	matrix Frame_View;
+	matrix Frame_Projection;
+	matrix Frame_ViewProj;
+	matrix Frame_PrevViewProj;
+	matrix Frame_UnjitteredViewProj;
+};
 
 //--------------------------------------------------------------------------------------
 // Textures and Samplers
@@ -27,10 +35,38 @@ struct PS_INPUT
 	float4 vPosition		: SV_POSITION;
 };
 
+struct PS_OUTPUT
+{
+	float4 Color : SV_TARGET0;
+	float2 MotionVectors : SV_TARGET1;  // motion vectors
+	float ReactiveMask : SV_TARGET2;  // reactive mask for FSR
+};
+
+float2 CalculateVelocity(float4 currClipPos, float4 prevClipPos)
+{
+	// Handle edge case where clip positions are invalid (w == 0)
+	if (currClipPos.w == 0.0 || prevClipPos.w == 0.0)
+		return float2(0, 0);
+	
+	// Perspective divide to get NDC [-1,1]
+	float2 currNDC = currClipPos.xy / currClipPos.w;
+	float2 prevNDC = prevClipPos.xy / prevClipPos.w;
+	
+	// Convert NDC to UV space [0,1]
+	// Note: Y is flipped between NDC (Y+ up) and UV (Y+ down)
+	float2 currUV = float2(currNDC.x * 0.5 + 0.5, 1.0 - (currNDC.y * 0.5 + 0.5));
+	float2 prevUV = float2(prevNDC.x * 0.5 + 0.5, 1.0 - (prevNDC.y * 0.5 + 0.5));
+	
+	// Velocity = current - previous (where the pixel came from)
+	float2 velocity = prevUV - currUV;
+	
+	return velocity;
+}
+
 //--------------------------------------------------------------------------------------
 // Pixel Shader
 //--------------------------------------------------------------------------------------
-float4 PSMain( PS_INPUT Input ) : SV_TARGET
+PS_OUTPUT PSMain( PS_INPUT Input )
 {
 	float3 atmoColor = ApplyAtmosphericScatteringSky(Input.vWorldPosition) * 2.0f;
 	
@@ -47,7 +83,17 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	
 	// Apply stars
 	atmoColor += night * 0.4f;
+
+
+	float4 viewDir = float4(normalize(Input.vWorldPosition), 0.0f);
+	float4 curPosClip = mul(viewDir, Frame_UnjitteredViewProj);
+	float4 prevPosClip = mul(viewDir, Frame_PrevViewProj);
 	
-	return float4(atmoColor,1);
+	PS_OUTPUT output;
+	output.Color = float4(atmoColor,1);
+	output.MotionVectors = CalculateVelocity(curPosClip, prevPosClip);
+	output.ReactiveMask = 1.0f;
+
+	return output;
 }
 

--- a/D3D11Engine/Shaders/PS_Atmosphere.hlsl
+++ b/D3D11Engine/Shaders/PS_Atmosphere.hlsl
@@ -39,7 +39,6 @@ struct PS_OUTPUT
 {
 	float4 Color : SV_TARGET0;
 	float2 MotionVectors : SV_TARGET1;  // motion vectors
-	float ReactiveMask : SV_TARGET2;  // reactive mask for FSR
 };
 
 float2 CalculateVelocity(float4 currClipPos, float4 prevClipPos)
@@ -92,7 +91,6 @@ PS_OUTPUT PSMain( PS_INPUT Input )
 	PS_OUTPUT output;
 	output.Color = float4(atmoColor,1);
 	output.MotionVectors = CalculateVelocity(curPosClip, prevPosClip);
-	output.ReactiveMask = 1.0f;
 
 	return output;
 }

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -31,7 +31,7 @@ cbuffer DS_ScreenQuadConstantBuffer : register(b0)
     
     uint SQ_FrameIndex;
     float SQ_LightSize;
-    float2 SQ_Pad;
+    float2 SQ_JitterOffset;
 
     // Shadow atlas: per-cascade UV rect (xy = offset, zw = scale)
     float4 SQ_CascadeAtlasRect[MAX_CSM_CASCADES];
@@ -75,7 +75,9 @@ struct PS_INPUT
 
 float3 VSPositionFromDepth(float depth, float2 vTexCoord)
 {
-    return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord, SQ_ProjParams.xy );
+    // Remove the camera jitter (TAA/FSR) that was baked into the depth buffer's
+    // projection, so the reconstructed world position is stable across frames.
+    return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord - SQ_JitterOffset, SQ_ProjParams.xy );
 }
 
 //--------------------------------------------------------------------------------------

--- a/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
@@ -16,7 +16,7 @@ cbuffer DS_PointLightConstantBuffer : register( b0 )
 	float3 Pl_PositionView;
 	
 	float2 PL_ViewportSize;
-	float2 PL_Pad2;
+	float2 PL_JitterOffset;
 	
 	float4 PL_ProjParams; // x = 1/P._11, y = 1/P._22, z = P._43, w = P._33
 	matrix PL_InvView; // Optimize out!
@@ -45,7 +45,7 @@ struct PS_INPUT
 
 float3 VSPositionFromDepth(float depth, float2 vTexCoord)
 {
-	return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord, PL_ProjParams.xy );
+	return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord - PL_JitterOffset, PL_ProjParams.xy );
 }
 
 //--------------------------------------------------------------------------------------

--- a/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
@@ -16,7 +16,7 @@ cbuffer DS_PointLightConstantBuffer : register( b0 )
 	float3 Pl_PositionView;
 	
 	float2 PL_ViewportSize;
-	float2 PL_Pad2;
+	float2 PL_JitterOffset;
 	
 	float4 PL_ProjParams; // x = 1/P._11, y = 1/P._22, z = P._43, w = P._33
 	matrix PL_InvView; // Optimize out!
@@ -47,7 +47,7 @@ struct PS_INPUT
 
 float3 VSPositionFromDepth(float depth, float2 vTexCoord)
 {
-	return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord, PL_ProjParams.xy );
+	return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord - PL_JitterOffset, PL_ProjParams.xy );
 }
 
 //--------------------------------------------------------------------------------------

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -85,7 +85,6 @@ float2 CalculateVelocity(float4 currClipPos, float4 prevClipPos)
 FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 {
 	FORWARD_PLUS_PS_OUTPUT output;
-	output.vReactiveMask = 0.0f;
 
 	float4 color = TX_Texture0.Sample(SS_Linear, Input.vTexcoord);
 
@@ -94,7 +93,6 @@ FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 
 #if ALPHATEST == 1
 	DoAlphaTest(color.a);
-	output.vReactiveMask = 0.04f;
 #endif
 
 #if NORMALMAPPING == 1
@@ -199,7 +197,6 @@ DEFERRED_PS_OUTPUT PSMain( PS_INPUT Input ) : SV_TARGET
 #endif
 {
 	DEFERRED_PS_OUTPUT output;
-	output.vReactiveMask = 0.0f;
 
 	float4 color = TX_Texture0.Sample(SS_Linear, Input.vTexcoord);
 	
@@ -210,7 +207,6 @@ DEFERRED_PS_OUTPUT PSMain( PS_INPUT Input ) : SV_TARGET
 	
 	// WorldMesh can always do the alphatest
 	DoAlphaTest(color.a);
-	output.vReactiveMask = 0.04f; // 0.1f still causes a bit of flickering shadows, 0.04 reduced it noticibly
 #endif
 	
 	// Apply normalmapping if wanted

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -94,7 +94,7 @@ FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 
 #if ALPHATEST == 1
 	DoAlphaTest(color.a);
-	output.vReactiveMask = 0.1f;
+	output.vReactiveMask = 0.04f;
 #endif
 
 #if NORMALMAPPING == 1
@@ -210,7 +210,7 @@ DEFERRED_PS_OUTPUT PSMain( PS_INPUT Input ) : SV_TARGET
 	
 	// WorldMesh can always do the alphatest
 	DoAlphaTest(color.a);
-	output.vReactiveMask = 0.1f; // 0.1f seemed fine, no blur and just tiiiiiny bit of flickering
+	output.vReactiveMask = 0.04f; // 0.1f still causes a bit of flickering shadows, 0.04 reduced it noticibly
 #endif
 	
 	// Apply normalmapping if wanted

--- a/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
+++ b/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
@@ -36,7 +36,7 @@ cbuffer DS_ScreenQuadConstantBuffer : register( b0 )
 
     uint   SQ_FrameIndex;
     float  SQ_LightSize;
-    float2 SQ_Pad;
+    float2 SQ_JitterOffset;
 
     // Shadow atlas: per-cascade UV rect (xy = offset, zw = scale)
     float4 SQ_CascadeAtlasRect[MAX_CSM_CASCADES];
@@ -79,7 +79,7 @@ struct PS_INPUT
 //--------------------------------------------------------------------------------------
 float3 VSPositionFromDepth( float depth, float2 vTexCoord )
 {
-    return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord, SQ_ProjParams.xy );
+    return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord - SQ_JitterOffset, SQ_ProjParams.xy );
 }
 
 //--------------------------------------------------------------------------------------

--- a/D3D11Engine/Shaders/PS_PFX_Composition.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_Composition.hlsl
@@ -29,7 +29,7 @@ cbuffer PFXBuffer : register( b0 )
     float HF_pad2;
 
     float2 HF_ProjAB;
-    float2 HF_Pad3;
+    float2 HF_JitterOffset;
 };
 #endif
 
@@ -58,7 +58,7 @@ Texture2D TX_Depth : register( t3 );
 #if COMPOSE_HEIGHTFOG
 float3 VSPositionFromDepth( float depth, float2 vTexCoord )
 {
-    return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord, HF_ProjParams.xy );
+    return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord - HF_JitterOffset, HF_ProjParams.xy );
 }
 
 float ComputeVolumetricFog( float3 cameraToWorldPos, float3 posOriginal )

--- a/D3D11Engine/Shaders/PS_PFX_Heightfog.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_Heightfog.hlsl
@@ -21,7 +21,7 @@ cbuffer PFXBuffer : register( b0 )
 	float HF_pad2;
 
 	float2 HF_ProjAB;
-	float2 HF_Pad3;
+	float2 HF_JitterOffset;
 };
 
 //--------------------------------------------------------------------------------------
@@ -34,7 +34,7 @@ Texture2D	TX_Depth : register( t1 );
 
 float3 VSPositionFromDepth(float depth, float2 vTexCoord)
 {
-	return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord, HF_ProjParams.xy );
+	return ReconstructVSPositionFromDepthReverseZInfinite( depth, vTexCoord - HF_JitterOffset, HF_ProjParams.xy );
 }
 
 float ComputeVolumetricFog(float3 cameraToWorldPos, float3 posOriginal)

--- a/D3D11Engine/Shaders/PS_Rain.hlsl
+++ b/D3D11Engine/Shaders/PS_Rain.hlsl
@@ -25,6 +25,12 @@ struct PS_INPUT
 	float4 vPosition		: SV_POSITION;
 };
 
+struct PS_OUTPUT
+{
+	float4 Color : SV_TARGET0;
+	float ReactiveMask : SV_TARGET1;  // reactive mask for FSR
+};
+
 cbuffer AdvanceRainConstantBuffer : register( b1 )
 {
 	float3 AR_LightPosition;
@@ -236,21 +242,14 @@ void rainResponse(PS_INPUT input, float3 lightVector, float lightIntensity, floa
 //--------------------------------------------------------------------------------------
 // Pixel Shader
 //--------------------------------------------------------------------------------------
-float4 PSMain( PS_INPUT Input ) : SV_TARGET
+PS_OUTPUT PSMain( PS_INPUT Input ) 
 {
-	//float4 color = pow(TX_Texture0.Sample(SS_Linear, Input.vTexcoord), 1.0f);
-	float4 color = float4(1,1,1, 0.2f);
-	
-	//float dirLightIntensity = 0.5f * max(0.5f, pow(AR_LightDirection.y, 1/4.0f));
-	
 	float globalLighting = 1.0f;//lerp(0.2f, 1.0f, saturate(pow(abs(AR_LightDirection.y), 1/1.5f)));
 	
 	float4 directionalLight;
 	float3 lightPos = normalize(float3(0.333f,0.433f,0.333f)) * 10000.0f;
     rainResponse(Input, lightPos, globalLighting * Input.vDiffuse.a, float3(1.0,1.0,1.0), AR_CameraPosition - Input.vWorldPosition, false, directionalLight);
-	
-	//float tx = TX_RainTextureArray.Sample(SS_Anisotropic, float3(Input.vTexcoord, 0)).r;
-	
+
 	// if snow, then white-ish
 #ifdef SNOW_FEATURE
 	directionalLight = float4(
@@ -259,31 +258,9 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 		1.0-(1.0/250.0),
 		directionalLight.w);
 #endif	
-	return directionalLight;
+
+    PS_OUTPUT output;
+    output.Color = directionalLight;
+    output.ReactiveMask = 1.0f;
+	return output;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
+++ b/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
@@ -57,7 +57,7 @@ cbuffer FP_ScreenQuadConstantBuffer : register( b4 )
     float SQ_ShadowSoftness;
     uint SQ_FrameIndex;
     float SQ_LightSize;
-    float2 SQ_Pad;
+    float2 SQ_JitterOffset; // unused here (forward+ uses interpolated world pos), kept for layout parity
     float4 SQ_CascadeAtlasRect[MAX_CSM_CASCADES];
 
     // World-space units per texel, precomputed on CPU (x=cascade0 ... w=cascade3).

--- a/D3D11Engine/Toolbox.h
+++ b/D3D11Engine/Toolbox.h
@@ -12,8 +12,19 @@
 struct zTBBox3D;
 struct zTPlane;
 
+static bool ichar_equals(char a, char b)
+{
+    return std::tolower(static_cast<unsigned char>(a)) ==
+           std::tolower(static_cast<unsigned char>(b));
+}
+
 namespace Toolbox {
-    FORCEINLINE float GetRecommendedWorldShadowRangeScaleForSize( int size ) {
+    
+    inline bool EqualsIgnoreCase(std::string_view a, std::string_view b) {
+        return std::ranges::equal(a, b, ichar_equals);
+    }
+    
+    inline FORCEINLINE float GetRecommendedWorldShadowRangeScaleForSize( int size ) {
         constexpr int MAX_SHADOWMAP_SIZE = 16384;
         return static_cast<float>(MAX_SHADOWMAP_SIZE / size);
 


### PR DESCRIPTION
- infra: builds now always copy all shaders to output path
- fix: populate reactive mask for rain/snow
- fix: populate motion vectors for atmospheric scattering sky (Gothic engine fixed-function sky is still broken with TAA/FSR)
- fix: interactive focus highlight being always active for MOBs
- fix: incorrect depth-worldspace reconstruction when jittered projection is used causing flickering shadows with TAA/FSR