### PR TITLE
chore: Table driven additional resource loading. Allow CTRL+F11 for Strafkolonie-Online/GMP

### DIFF
--- a/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
+++ b/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
@@ -78,6 +78,40 @@ void MyDirectDrawSurface7::BindToSlot( int slot ) {
     }
 }
 
+static bool LoadResource(
+    const std::string& path,
+    const std::string& name,
+    std::vector<uint8_t>& storage,
+    D3D11Texture** ppTexture) {
+    auto file = zFILE_VDFS::Create( path );
+    if ( !file->Exists() ) {
+        return false;
+    }
+    auto retOpen = file->Open( false );
+    if ( retOpen != 0 ) {
+        return false;
+    }
+    auto size = file->Size();
+    storage.resize(size);
+
+    // assume single op file read.
+    auto numRead = file->Read( storage.data(), size );
+    (void)file->Close();
+
+    if (numRead != size) {
+        LogWarn() << "Failed to load " << name << ": short read";
+        return false;
+    }
+
+    Engine::GraphicsEngine->CreateTexture( ppTexture );
+    if ( XR_SUCCESS != (*ppTexture)->Init( storage.data(), size, name ) ) {
+        SAFE_DELETE( *ppTexture );
+        LogWarn() << "Failed to load " << name << ": init failed";
+        return false;
+    }
+    return true;
+}
+
 /** Loads additional resources if possible */
 void MyDirectDrawSurface7::LoadAdditionalResources( zCTexture* ownedTexture ) {
     if ( !GothicTexture ) {
@@ -111,111 +145,32 @@ void MyDirectDrawSurface7::LoadAdditionalResources( zCTexture* ownedTexture ) {
     D3D11Texture* fxMapTexture = nullptr;
     D3D11Texture* nrmmapTexture = nullptr;
 
-    auto file = zFILE_VDFS::Create( (R"(\_WORK\DATA\TEXTURES\REPLACEMENTS\)" + TextureName + "_NORMAL.DDS").c_str() );
-    if ( file->Exists() ) {
-        auto retOpen = file->Open( false );
-        if ( retOpen == 0 ) {
-            auto size = file->Size();
+    static constexpr char vdfsWorkPath[] { R"(\_WORK\DATA\TEXTURES\REPLACEMENTS\)" };
+    static constexpr char systemWorkPath[] {R"(\SYSTEM\GD3D11\TEXTURES\REPLACEMENTS\)"};
+    std::string currentResource(255, ' ');
+    std::string textureName(255, ' ');
+    std::vector<uint8_t> storage;
 
-            std::vector<uint8_t> storage( size );
-            // assume single op file read.
-            auto numRead = file->Read( storage.data(), size );
-            Engine::GraphicsEngine->CreateTexture( &nrmmapTexture );
-            if ( XR_SUCCESS != nrmmapTexture->Init( storage.data(), size, TextureName + "_NORMAL.DDS" ) ) {
-                SAFE_DELETE( nrmmapTexture );
-                LogWarn() << "Failed to load normalmap: " << TextureName;
-            }
+    const auto& gameName = Engine::GAPI->GetGameName();
+    
+    const std::pair<const char*, D3D11Texture** const> resourcesToLoad[] = {
+        {"_NORMAL.DDS", &nrmmapTexture},
+        {"_FX.DDS", &fxMapTexture},
+    };
 
-            auto retClose = file->Close();
+    for (const auto [suffix, texture] : resourcesToLoad) {
+        textureName.clear();
+        textureName.append(TextureName).append(suffix);
+
+        currentResource.clear();
+        currentResource.append(vdfsWorkPath).append(textureName);
+        if (LoadResource(currentResource, textureName, storage, texture)) {
+            continue;
         }
-    }
-    file.reset();
-
-    file = zFILE_VDFS::Create( (R"(\_WORK\DATA\TEXTURES\REPLACEMENTS\)" + TextureName + "_FX.DDS").c_str() );
-    if ( file->Exists() ) {
-        auto retOpen = file->Open( false );
-        if ( retOpen == 0 ) {
-            auto size = file->Size();
-
-            std::vector<uint8_t> storage( size );
-            // assume single op file read.
-            auto numRead = file->Read( storage.data(), size );
-            Engine::GraphicsEngine->CreateTexture( &fxMapTexture );
-            if ( XR_SUCCESS != fxMapTexture->Init( storage.data(), size, TextureName + "_FX.DDS" ) ) {
-                SAFE_DELETE( fxMapTexture );
-                LogWarn() << "Failed to load FX map: " << TextureName;
-            }
-
-            auto retClose = file->Close();
-        }
-    }
-    file.reset();
-
-    // Check for normalmap in our mods folder first, then in the original games
-    int j = 0;
-    thread_local std::string replacementsFolder;
-    thread_local std::string tmpFilename;
-    if ( !nrmmapTexture ) {
-        replacementsFolder.resize( 0 );
-        replacementsFolder.append("system\\GD3D11\\textures\\replacements\\Normalmaps_").append(std::to_string(j));
-        while ( !nrmmapTexture && Toolbox::FolderExists( replacementsFolder ) ) {
-            tmpFilename.resize( 0 );
-            tmpFilename.append(replacementsFolder).append("\\").append(TextureName).append("_normal.dds");
-            if ( Toolbox::FileExists( tmpFilename ) ) {
-                // Create the texture object this is linked with
-                Engine::GraphicsEngine->CreateTexture( &nrmmapTexture );
-                if ( XR_SUCCESS != nrmmapTexture->Init( tmpFilename ) ) {
-                    SAFE_DELETE( nrmmapTexture );
-                    LogWarn() << "Failed to load normalmap: " << tmpFilename;
-                }
-                break; // No need to check the other folders
-            }
-            j++;
-            replacementsFolder.resize( 0 );
-            replacementsFolder.append("system\\GD3D11\\textures\\replacements\\Normalmaps_").append(std::to_string(j));
-        }
-        tmpFilename.resize( 0 );
-        tmpFilename.append("system\\GD3D11\\textures\\replacements\\Normalmaps_").append(Engine::GAPI->GetGameName()).append("\\").append(TextureName).append("_normal.dds");
-        if ( !nrmmapTexture && Toolbox::FileExists( tmpFilename ) ) {
-            // Create the texture object this is linked with
-            Engine::GraphicsEngine->CreateTexture( &nrmmapTexture );
-            if ( XR_SUCCESS != nrmmapTexture->Init( tmpFilename ) ) {
-                SAFE_DELETE( nrmmapTexture );
-                LogWarn() << "Failed to load normalmap: " << tmpFilename;
-            }
-        }
-    }
-
-    if ( !fxMapTexture ) {
-        j = 0;
-        replacementsFolder.resize( 0 );
-        replacementsFolder.append("system\\GD3D11\\textures\\replacements\\Normalmaps_").append(std::to_string(j));
-        while ( !fxMapTexture && Toolbox::FolderExists( replacementsFolder ) ) {
-            tmpFilename.resize( 0 );
-            tmpFilename.append(replacementsFolder).append("\\").append(TextureName).append("_fx.dds");
-            if ( Toolbox::FileExists( tmpFilename ) ) {
-                // Create the texture object this is linked with
-                Engine::GraphicsEngine->CreateTexture( &fxMapTexture );
-                if ( XR_SUCCESS != fxMapTexture->Init( tmpFilename ) ) {
-                    SAFE_DELETE( fxMapTexture );
-                    LogWarn() << "Failed to load fxMap: " << tmpFilename;
-                }
-                break; // No need to check the other folders
-            }
-            j++;
-            replacementsFolder.resize( 0 );
-            replacementsFolder.append("system\\GD3D11\\textures\\replacements\\Normalmaps_").append(std::to_string(j));
-        }
-        tmpFilename.resize( 0 );
-        tmpFilename.append("system\\GD3D11\\textures\\replacements\\Normalmaps_").append(Engine::GAPI->GetGameName()).append("\\").append(TextureName).append("_fx.dds");
-        if ( !fxMapTexture && Toolbox::FileExists( tmpFilename ) ) {
-            // Create the texture object this is linked with
-            Engine::GraphicsEngine->CreateTexture( &fxMapTexture );
-            if ( XR_SUCCESS != fxMapTexture->Init( tmpFilename ) ) {
-                SAFE_DELETE( fxMapTexture );
-                LogWarn() << "Failed to load fxMap: " << tmpFilename;
-            }
-        }
+    
+        currentResource.clear();
+        currentResource.append(systemWorkPath).append(gameName).append("\\").append(textureName);
+        LoadResource(currentResource, textureName, storage, texture);
     }
 
     Normalmap = nrmmapTexture;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1039,7 +1039,7 @@ void GothicAPI::LoadRendererWorldSettings( GothicRendererSettings& s, const char
     GetPrivateProfileRGB("Atmoshpere", "FogColorMod", s.FogColorMod, ini);
 
 	s.GraphicsPreset = (GothicRendererSettings::E_GraphicsPreset)GetPrivateProfileIntA( "General", "GraphicsPreset", s.GraphicsPreset, ini.c_str() );
-    if ( !GMPModeActive ) {
+    if ( true ) {
 	    s.VisualFXDrawRadius = GetPrivateProfileFloatA( "General", "VisualFXDrawRadius", s.VisualFXDrawRadius, ini );
 	    s.OutdoorVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorVobDrawRadius", s.OutdoorVobDrawRadius, ini );
         s.OutdoorSmallVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorSmallVobDrawRadius", s.OutdoorSmallVobDrawRadius, ini );
@@ -3807,7 +3807,7 @@ LRESULT GothicAPI::OnWindowMessage( HWND hWnd, UINT msg, WPARAM wParam, LPARAM l
        
 #endif
         case VK_F11:
-            if ( ( GetAsyncKeyState( VK_CONTROL ) & 0x8000 ) && !GMPModeActive ) {
+            if ( ( GetAsyncKeyState( VK_CONTROL ) & 0x8000 ) ) {
                 Engine::GraphicsEngine->OnUIEvent( BaseGraphicsEngine::EUIEvent::UI_ToggleAdvancedSettings );
             } else {
                 Engine::GraphicsEngine->OnUIEvent( BaseGraphicsEngine::EUIEvent::UI_OpenSettings );
@@ -5375,7 +5375,6 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
             s.OutdoorVobDrawRadius = std::max( 20000.f, s.OutdoorVobDrawRadius );
             s.OutdoorSmallVobDrawRadius = std::max( 20000.f, s.OutdoorSmallVobDrawRadius );
             s.SectionDrawRadius = std::max( 3, s.SectionDrawRadius );
-            s.EnableHDR = false;
         }
 
         static XMFLOAT3 defaultLightDirection = XMFLOAT3( 1, 1, 1 );

--- a/D3D11Engine/zFILE_VDFS.h
+++ b/D3D11Engine/zFILE_VDFS.h
@@ -80,20 +80,24 @@ public:
     }
 
     struct Deleter {
-        void operator()( zFILE_VDFS* file ) const {
-            if ( file ) {
-                delete file;
-            }
+        void operator()(const zFILE_VDFS* file ) const {
+            delete file;
         }
     };
 
     using Ptr = std::unique_ptr<zFILE_VDFS, Deleter>;
 
     static Ptr Create( const zSTRING& fileName ) {
-
         auto ptr = new zFILE_VDFS( fileName );
-
         return Ptr( ptr );
+    }
+    
+    static Ptr Create( const std::string& fileName ) {
+        return Create( zSTRING(fileName.c_str()) );
+    }
+
+    static Ptr Create( const char* fileName ) {
+        return Create( zSTRING( fileName ) );
     }
 
     static void* operator new(std::size_t count) {


### PR DESCRIPTION
- reduce code clutter when loading additional resources
- Allow using CTRL+F11 Menu in GMP. The people over there even recommended older versions to get it back working. 
  > source: https://strafkolonie-online.net/forum/board/thread/922-der-ultimative-sko-grafik-und-performance-guide-plus-technik-faq/
  > 
  > Ich vermisse das STRG-F11 Renderer Menü
  > 
  > > Ältere Renderer-Version verwenden https://github.com/Kirides/GD3D11/releases/tag/v17.7-dev8

