### PR TITLE
fix shadow cascade isInBounds check by including depth (z), ...

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4968,10 +4968,6 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                         continue;
                     }
 
-                    if ( aniTex->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
-                        continue;
-                    }
-
                     const float distanceSq = ComputeWorldMeshDistanceSqFromCamera( renderItem, worldMesh.second, cameraPosition );
                     const std::pair<MeshKey, MeshInfo*> transparencyMesh = { worldMesh.first, worldMesh.second };
 
@@ -4998,6 +4994,9 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                         continue;
                     } else {
 
+                        if ( aniTex->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
+                            continue;
+                        }
                         int alphaLevel = 0;
                         if ( worldMesh.first.Texture && worldMesh.first.Texture->HasAlphaChannel() ) {
                             alphaLevel = 2;

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -253,15 +253,23 @@ void D3D11ShadowMap::RecreateShadowSampler() {
     // Create sampler
     D3D11_SAMPLER_DESC samplerDesc = {};
     samplerDesc.Filter = D3D11_FILTER_COMPARISON_MIN_MAG_MIP_LINEAR;
-    // Atlas path uses CLAMP to prevent seam bleeding at cascade boundaries.
-    // Texture array path uses WRAP for compatibility with previous behavior.
-    auto addressMode = m_useAtlas ? D3D11_TEXTURE_ADDRESS_CLAMP : D3D11_TEXTURE_ADDRESS_WRAP;
+    // Atlas path uses CLAMP to prevent seam bleeding at cascade boundaries (it also
+    // insets sampling by half a texel per sub-rect).
+    // Texture array path uses BORDER with a white (1.0 = far) border: each cascade is its
+    // own slice with its own [0,1], so PCF/PCSS taps that spill past a cascade edge read
+    // the border depth of 1.0 and compare as "lit" instead of WRAPping to the opposite
+    // side of the slice (which fabricated shadow and produced dark bars between cascades).
+    auto addressMode = m_useAtlas ? D3D11_TEXTURE_ADDRESS_CLAMP : D3D11_TEXTURE_ADDRESS_BORDER;
     samplerDesc.AddressU = addressMode;
     samplerDesc.AddressV = addressMode;
     samplerDesc.AddressW = addressMode;
     samplerDesc.MipLODBias = 0;
     samplerDesc.MaxAnisotropy = 1;
     samplerDesc.ComparisonFunc = D3D11_COMPARISON_LESS_EQUAL;
+    samplerDesc.BorderColor[0] = 1.0f;
+    samplerDesc.BorderColor[1] = 1.0f;
+    samplerDesc.BorderColor[2] = 1.0f;
+    samplerDesc.BorderColor[3] = 1.0f;
     samplerDesc.MinLOD = -FLT_MAX;
     samplerDesc.MaxLOD = FLT_MAX;
 

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -676,22 +676,24 @@ XRESULT D3D11ShadowMap::PrepareRender()
                 }
                 ZoneScoped;
                 ZoneNameF( "Shadow Cascade %zu", idx );
-
+                const auto& rs = Engine::GAPI->GetRendererState().RendererSettings;
+                
+                const float shadowDistance = 8000 + (12000.0f * std::max( 0.1f, rs.WorldShadowRangeScale ));
+                
                 RndCullContext ctx;
                 ctx.queue = _this->m_RenderQueues[idx].get();
                 ctx.frustum = _this->m_CascadeCRs[idx].frustum;
                 ctx.cameraPosition = _this->m_WorldShadowPos;
                 ctx.stage = RenderStage::STAGE_DRAW_SHADOWS;
-                ctx.drawDistances.OutdoorVobs = 20000;
-                ctx.drawDistances.OutdoorVobsSmall = 20000;
-                ctx.drawDistances.IndoorVobs = 20000;
+                ctx.drawDistances.OutdoorVobs = std::max(20000.0f, shadowDistance);
+                ctx.drawDistances.OutdoorVobsSmall = std::max(20000.0f, shadowDistance);
+                ctx.drawDistances.IndoorVobs = std::max(20000.0f, shadowDistance);
                 ctx.drawDistances.VisualFX = 0.0f;
                 ctx.drawDistancesSq.OutdoorVobs = ctx.drawDistances.OutdoorVobs * ctx.drawDistances.OutdoorVobs;
                 ctx.drawDistancesSq.OutdoorVobsSmall = ctx.drawDistances.OutdoorVobsSmall * ctx.drawDistances.OutdoorVobsSmall;
                 ctx.drawDistancesSq.IndoorVobs = ctx.drawDistances.IndoorVobs * ctx.drawDistances.IndoorVobs;
                 ctx.drawDistancesSq.VisualFX = 0.0f;
 
-                const auto& rs = Engine::GAPI->GetRendererState().RendererSettings;
                 ctx.drawFlags.DrawVOBs = rs.DrawVOBs;
                 ctx.drawFlags.DrawMobs = rs.DrawMobs;
                 ctx.drawFlags.EnableDynamicLighting = rs.EnableDynamicLighting;
@@ -767,20 +769,22 @@ XRESULT D3D11ShadowMap::PrepareRender()
         RndCullContext ctx;
         LegacyRenderQueueProxy q(potentialCasters, _1, _2);
 
+        const auto& rs = Engine::GAPI->GetRendererState().RendererSettings;
+        const float shadowDistance = 8000 + (12000.0f * std::max( 0.1f, rs.WorldShadowRangeScale ));
+
         ctx.queue = &q;
         ctx.frustum = frustum;
         ctx.cameraPosition = m_WorldShadowPos;
         ctx.stage = RenderStage::STAGE_DRAW_SHADOWS;
-        ctx.drawDistances.OutdoorVobs = 20000;
-        ctx.drawDistances.OutdoorVobsSmall = 20000;
-        ctx.drawDistances.IndoorVobs = 20000;
+        ctx.drawDistances.OutdoorVobs = std::max(20000.0f, shadowDistance);
+        ctx.drawDistances.OutdoorVobsSmall = std::max(20000.0f, shadowDistance);
+        ctx.drawDistances.IndoorVobs = std::max(20000.0f, shadowDistance);
         ctx.drawDistances.VisualFX = 0.0f;
         ctx.drawDistancesSq.OutdoorVobs = ctx.drawDistances.OutdoorVobs * ctx.drawDistances.OutdoorVobs;
         ctx.drawDistancesSq.OutdoorVobsSmall = ctx.drawDistances.OutdoorVobsSmall * ctx.drawDistances.OutdoorVobsSmall;
         ctx.drawDistancesSq.IndoorVobs = ctx.drawDistances.IndoorVobs * ctx.drawDistances.IndoorVobs;
         ctx.drawDistancesSq.VisualFX = 0.0f;
 
-        const auto& rs = Engine::GAPI->GetRendererState().RendererSettings;
         ctx.drawFlags.DrawVOBs = rs.DrawVOBs;
         ctx.drawFlags.DrawMobs = rs.DrawMobs;
         ctx.drawFlags.EnableDynamicLighting = rs.EnableDynamicLighting;

--- a/D3D11Engine/D3D11Texture.cpp
+++ b/D3D11Engine/D3D11Texture.cpp
@@ -32,12 +32,16 @@ unsigned char* ConvertTextureData( UINT TextureWidth, UINT TextureHeight, DXGI_F
     return ConvertedData;
 }
 
-D3D11Texture::D3D11Texture() {}
+D3D11Texture::D3D11Texture() {
+    TracyAllocN( this, 1, "Textures" );
+}
 
 D3D11Texture::~D3D11Texture() {
     Thumbnail.Reset();
     Texture.Reset();
     ShaderResourceView.Reset();
+
+    TracyFreeN( this, "Textures" );
 }
 
 /** Initializes the texture object */

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -400,6 +400,16 @@ namespace
         ss << std::fixed << std::setprecision(precision) << val;
         return ss.str();
     }
+    
+    zCCamera* GetSceneCamera() {
+        if ( !oCGame::GetGame()->_zCSession_camVob )
+            return zCCamera::GetCamera();
+        
+        if (auto cam = static_cast<zCCamera*>(oCGame::GetGame()->_zCSession_camera); cam) {
+            return cam;
+        }
+        return zCCamera::GetCamera();
+    }
 }
 
 void GothicAPI::ProcessVobAnimation( zCVob* vob, zTAnimationMode aniMode, VobInstanceInfo& vobInstance ) {
@@ -512,11 +522,11 @@ void GothicAPI::OnWorldUpdate() {
     RendererState.RendererInfo.FPS = GetFramesPerSecond();
     RendererState.GraphicsState.FF_Time = GetTimeSeconds();
 
-    if ( zCCamera* camera = zCCamera::GetCamera() ) {
+    if ( zCCamera* camera = GetSceneCamera() ) {
         RendererState.RendererInfo.FarPlane = camera->GetFarPlane();
         RendererState.RendererInfo.NearPlane = camera->GetNearPlane();
 
-        //zCCamera::GetCamera()->Activate();
+        //GetSceneCamera()->Activate();
         SetViewTransform( camera->GetTransformDX( zCCamera::ETransformType::TT_VIEW ), false );
     }
 
@@ -1255,7 +1265,7 @@ static bool GetShouldRenderAsMorphMesh(SkeletalVobInfo* vi, zCModel* model) {
 /** Draws the world-mesh */
 void GothicAPI::DrawWorldMeshNaive() {
     ZoneScopedN( "GothicAPI::DrawWorldMeshNaive" );
-    if ( !zCCamera::GetCamera() || !oCGame::GetGame() )
+    if ( !GetSceneCamera() || !oCGame::GetGame() )
         return;
 
     static float setfovH = RendererState.RendererSettings.FOVHoriz;
@@ -1268,15 +1278,15 @@ void GothicAPI::DrawWorldMeshNaive() {
         setfovV = RendererState.RendererSettings.FOVVert;
 
         // Fix camera FOV-Bug
-        zCCamera::GetCamera()->SetFOV( RendererState.RendererSettings.FOVHoriz, (Engine::GraphicsEngine->GetResolution().y / static_cast<float>(Engine::GraphicsEngine->GetResolution().x)) * RendererState.RendererSettings.FOVVert );
+        GetSceneCamera()->SetFOV( RendererState.RendererSettings.FOVHoriz, (Engine::GraphicsEngine->GetResolution().y / static_cast<float>(Engine::GraphicsEngine->GetResolution().x)) * RendererState.RendererSettings.FOVVert );
 
-        CurrentCamera = zCCamera::GetCamera();
+        CurrentCamera = GetSceneCamera();
     }
 #else
 */
 #if defined(BUILD_GOTHIC_1_08k) || defined(BUILD_1_12F) || defined(BUILD_GOTHIC_2_6_fix)
     if ( RendererState.RendererSettings.ForceFOV ) {
-        zCCamera* camera = zCCamera::GetCamera();
+        zCCamera* camera = GetSceneCamera();
         if ( camera )
             camera->GetFOV( setfovH, setfovV );
 
@@ -1325,7 +1335,7 @@ void GothicAPI::DrawWorldMeshNaive() {
         // Set up frustum for the camera
         RendererState.RasterizerState.SetDefault();
         RendererState.RasterizerState.SetDirty();
-        zCCamera::GetCamera()->Activate();
+        GetSceneCamera()->Activate();
 
         auto drawRadius = RendererState.RendererSettings.SkeletalMeshDrawRadius;
 
@@ -1343,7 +1353,7 @@ void GothicAPI::DrawWorldMeshNaive() {
             if ( dist > drawRadius )
                 continue; // Skip out of range
 
-            zCCamera::GetCamera()->SetTransform( zCCamera::ETransformType::TT_WORLD, *vobInfo->Vob->GetWorldMatrixPtr() );
+            GetSceneCamera()->SetTransform( zCCamera::ETransformType::TT_WORLD, *vobInfo->Vob->GetWorldMatrixPtr() );
 
             //Engine::GraphicsEngine->GetLineRenderer()->AddAABBMinMax(bb.Min, bb.Max, XMFLOAT4(1, 1, 1, 1));
 
@@ -3547,7 +3557,7 @@ void XM_CALLCONV GothicAPI::UnprojectXM(float2 p, XMVECTOR& worldPos, XMVECTOR& 
     const auto res = Engine::GraphicsEngine->GetBackbufferResolution();
 
     XMMATRIX proj    = XMMatrixTranspose(XMLoadFloat4x4(&RendererState.TransformState.TransformProj));
-    XMMATRIX invView = XMMatrixTranspose(XMLoadFloat4x4(&zCCamera::GetCamera()->GetTransformDX( zCCamera::ETransformType::TT_VIEW_INV )));
+    XMMATRIX invView = XMMatrixTranspose(XMLoadFloat4x4(&GetSceneCamera()->GetTransformDX( zCCamera::ETransformType::TT_VIEW_INV )));
 
     const float ux = (((2.0f * p.x) / res.x) - 1.0f) / XMVectorGetX(proj.r[0]);
     const float uy = -(((2.0f * p.y) / res.y) - 1.0f) / XMVectorGetY(proj.r[1]);
@@ -3604,7 +3614,7 @@ zTCam_ClipType GothicAPI::GetCameraBBox3DInFrustum( const zTBBox3D& box, int cli
             return zTCam_ClipType::ZTCAM_CLIPTYPE_CROSSING;
         return zTCam_ClipType::ZTCAM_CLIPTYPE_IN;
     }
-    if (auto cam = zCCamera::GetCamera(); cam) {
+    if (auto cam = static_cast<zCCamera*>(oCGame::GetGame()->_zCSession_camera); cam) {
         return cam->BBox3DInFrustum(box, clipFlags);
     }
     
@@ -3616,7 +3626,7 @@ zTCam_ClipType GothicAPI::GetCameraBBox3DInFrustum( const zCVob* vob, int clipFl
         auto box = vob->GetBBox();
         return GetCameraBBox3DInFrustum(box, clipFlags);
     }
-    if (auto cam = zCCamera::GetCamera(); cam) {
+    if (auto cam = GetSceneCamera(); cam) {
         auto box = isLocalCamera ? vob->GetBBoxLocal() : vob->GetBBox();
         return GetCameraBBox3DInFrustum(box, clipFlags);
     }
@@ -3632,7 +3642,7 @@ void GothicAPI::GetViewMatrix( XMFLOAT4X4* view ) {
         return;
     }
 
-    *view = zCCamera::GetCamera()->GetTransformDX( zCCamera::ETransformType::TT_VIEW );
+    *view = GetSceneCamera()->GetTransformDX( zCCamera::ETransformType::TT_VIEW );
 }
 
 /** Returns the view matrix */
@@ -3640,7 +3650,7 @@ XMMATRIX GothicAPI::GetViewMatrixXM() {
     if ( CameraReplacementPtr ) {
         return XMLoadFloat4x4( &CameraReplacementPtr->ViewReplacement );
     }
-    return XMLoadFloat4x4( &zCCamera::GetCamera()->GetTransformDX( zCCamera::ETransformType::TT_VIEW ) );
+    return XMLoadFloat4x4( &GetSceneCamera()->GetTransformDX( zCCamera::ETransformType::TT_VIEW ) );
 }
 
 /** Returns the view matrix */
@@ -3650,7 +3660,7 @@ void GothicAPI::GetInverseViewMatrixXM( XMFLOAT4X4* invView ) {
         return;
     }
 
-    *invView = zCCamera::GetCamera()->GetTransformDX( zCCamera::ETransformType::TT_VIEW_INV );
+    *invView = GetSceneCamera()->GetTransformDX( zCCamera::ETransformType::TT_VIEW_INV );
 }
 
 /** Returns the projection-matrix in Column-Major format, with reversed depth buffer */
@@ -3949,7 +3959,7 @@ void GothicAPI::CollectVisibleVobs(
 
     zCBspBase* rootBsp = tree->GetRootNode();
     Frustum frustum = Frustum::AlwaysContainingFrustum();
-    if ( auto cam = zCCamera::GetCamera() ) {
+    if ( auto cam = GetSceneCamera() ) {
         cam->Activate();
 
         // Row-Major view
@@ -4737,12 +4747,13 @@ BspInfo* GothicAPI::GetNewBspNode( zCBspBase* base ) {
 
 /** Sets/Gets the far-plane */
 void GothicAPI::SetFarPlane( float value ) {
-    zCCamera::GetCamera()->SetFarPlane( value );
-    zCCamera::GetCamera()->Activate();
+    auto cam = GetSceneCamera();    
+    cam->SetFarPlane( value );
+    cam->Activate();
 }
 
 float GothicAPI::GetFarPlane() {
-    return zCCamera::GetCamera()->GetFarPlane();
+    return GetSceneCamera()->GetFarPlane();
 }
 
 /** Sets/Gets the far-plane */
@@ -4751,7 +4762,7 @@ void GothicAPI::SetNearPlane( float value ) {
 }
 
 float GothicAPI::GetNearPlane() {
-    return zCCamera::GetCamera()->GetNearPlane();
+    return GetSceneCamera()->GetNearPlane();
 }
 
 /** Get material by texture name */
@@ -4805,7 +4816,7 @@ bool GothicAPI::IsInTextureTestBindMode( std::string& currentBoundTexture ) {
 
 /** Lets Gothic draw its sky */
 void GothicAPI::DrawSkyGothicOriginal() {
-    HookedFunctions::OriginalFunctions.original_zCWorldRender( oCGame::GetGame()->_zCSession_world, *zCCamera::GetCamera() );
+    HookedFunctions::OriginalFunctions.original_zCWorldRender( oCGame::GetGame()->_zCSession_world, *GetSceneCamera() );
 }
 
 /** Reset's the material info that were previously gathered */

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -282,18 +282,14 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 
 		float rawNoL = dot(wsNormal, wsLightDirection);
 
-		int cascadeIndex = GetPrimaryCascadeIndex(wsPosition);
-		float texelWorldSize = SQ_CascadeTexelSize[cascadeIndex];
-
-		float shadowNoL = saturate(rawNoL); 
+		float shadowNoL = saturate(rawNoL);
 		float slopeScale = sqrt(saturate(1.0f - shadowNoL * shadowNoL));
-		
-		const float normalBiasMultiplier = 1.0f;
-		float3 biasedWsPosition = wsPosition + wsNormal * (slopeScale * texelWorldSize * normalBiasMultiplier);
 
 		float constantDepthBias = 0.000003f;
 
-		shadow = ComputeCascadedShadowValueSoft(biasedWsPosition, vsPosition.z, vertLighting, constantDepthBias, Input.vPosition.xy);
+		// Pass the UN-biased position plus normal/slope; the normal-offset bias is applied
+		// per cascade inside the function so the blended (coarser) cascade isn't under-biased.
+		shadow = ComputeCascadedShadowValueSoft(wsPosition, wsNormal, slopeScale, vsPosition.z, vertLighting, constantDepthBias, Input.vPosition.xy);
 	} else {
         // Night-time sky ambient:
         // saturate(wsNormal.y) restricts the value to [0, 1].

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -131,18 +131,14 @@ FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 
 			float rawNoL = dot(wsNormal, wsLightDirection);
 
-			int cascadeIndex = GetPrimaryCascadeIndex(wsPosition);
-			float texelWorldSize = SQ_CascadeTexelSize[cascadeIndex];
-
-			float shadowNoL = saturate(rawNoL); 
+			float shadowNoL = saturate(rawNoL);
 			float slopeScale = sqrt(saturate(1.0f - shadowNoL * shadowNoL));
-			
-			const float normalBiasMultiplier = 1.0f;
-			float3 biasedWsPosition = wsPosition + wsNormal * (slopeScale * texelWorldSize * normalBiasMultiplier);
 
 			float constantDepthBias = 0.000003f;
 
-			shadow = ComputeCascadedShadowValueSoft(biasedWsPosition, vsPosition.z, vertLighting, constantDepthBias, Input.vPosition.xy);
+			// Pass the UN-biased position plus normal/slope; the normal-offset bias is applied
+			// per cascade inside the function so the blended (coarser) cascade isn't under-biased.
+			shadow = ComputeCascadedShadowValueSoft(wsPosition, wsNormal, slopeScale, vsPosition.z, vertLighting, constantDepthBias, Input.vPosition.xy);
 
 		#endif
 	} else {

--- a/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
+++ b/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
@@ -106,19 +106,15 @@ float PSMain( PS_INPUT Input ) : SV_TARGET
 
 	float rawNoL = dot(wsNormal, wsLightDirection);
 
-	int cascadeIndex = GetPrimaryCascadeIndex(wsPosition);
-	float texelWorldSize = SQ_CascadeTexelSize[cascadeIndex];
-
-	float shadowNoL = saturate(rawNoL); 
+	float shadowNoL = saturate(rawNoL);
 	float slopeScale = sqrt(saturate(1.0f - shadowNoL * shadowNoL));
-	
-	const float normalBiasMultiplier = 1.0f;
-	float3 biasedWsPosition = wsPosition + wsNormal * (slopeScale * texelWorldSize * normalBiasMultiplier);
 
 	float constantDepthBias = 0.000003f;
 
     // ComputeCascadedShadowValueSoft is defined in ShadowSampling.h.
     // Pass 1.0 for vertLighting (the shadow mask carries only the cascade shadow;
     // vertex-AO is applied separately in FP_ComputeSunLighting).
-    return ComputeCascadedShadowValueSoft( biasedWsPosition, vsPosition.z, 1.0f, constantDepthBias, Input.vPosition.xy );
+    // Pass the UN-biased position plus normal/slope; the normal-offset bias is applied
+    // per cascade inside the function so the blended (coarser) cascade isn't under-biased.
+    return ComputeCascadedShadowValueSoft( wsPosition, wsNormal, slopeScale, vsPosition.z, 1.0f, constantDepthBias, Input.vPosition.xy );
 }

--- a/D3D11Engine/Shaders/ShadowSampling.h
+++ b/D3D11Engine/Shaders/ShadowSampling.h
@@ -312,10 +312,19 @@ void GetCascadeUVAndBounds(float3 wsPosition, int cascadeIndex,
     vShadowSamplingPos = mul(float4(wsPosition, 1), viewProj);
     projectedTexCoords = vShadowSamplingPos.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
 
-    // Check if within bounds (with margin for blend zone)
-    const float margin = 0.02f;
+    // XY inset of ~1.5 texels: only reject the literal edge texel (no valid filter
+    // neighbourhood there). Edge taps that spill past [0,1] are handled by the shadow
+    // sampler's BORDER addressing (border = lit), so a wide inset isn't needed.
+    const float margin = 1.5f / SQ_ShadowmapSize;
+    // Depth (Z) bounds matter too: a fragment can land inside this cascade's XY footprint
+    // while being deeper than its far plane (z > 1) -- e.g. terrain plunging away under a
+    // grazing sun when viewed from above. A LESS_EQUAL comparison sampler always fails for
+    // z > stored and would force the fragment fully into shadow. Excluding out-of-depth-
+    // range fragments lets selection fall through to a larger cascade whose far plane
+    // reaches scene-deep, instead of painting a false dark blob.
     bool isInBounds = projectedTexCoords.x > margin && projectedTexCoords.x < (1.0f - margin) &&
-                      projectedTexCoords.y > margin && projectedTexCoords.y < (1.0f - margin);
+                      projectedTexCoords.y > margin && projectedTexCoords.y < (1.0f - margin) &&
+                      vShadowSamplingPos.z >= 0.0f && vShadowSamplingPos.z <= 1.0f;
     inBounds = isInBounds ? 1.0f : 0.0f;
 
     // Calculate blend factor based on distance to edge
@@ -324,27 +333,6 @@ void GetCascadeUVAndBounds(float3 wsPosition, int cascadeIndex,
     float distToEdge = min(min(projectedTexCoords.x, 1.0f - projectedTexCoords.x),
                            min(projectedTexCoords.y, 1.0f - projectedTexCoords.y));
     blendFactor = 1.0f - smoothstep(margin, blendZoneStart, distToEdge);
-}
-
-//--------------------------------------------------------------------------------------
-// Returns the first cascade that contains wsPosition. If no cascade contains the
-// position, returns -1.
-//--------------------------------------------------------------------------------------
-int GetPrimaryCascadeIndex(float3 wsPosition)
-{
-    float4 vShadowPos;
-    float2 projCoords;
-    float inBounds;
-    float blendFactor;
-
-    for (int c = 0; c < NUM_CSM_CASCADES; c++)
-    {
-        GetCascadeUVAndBounds(wsPosition, c, vShadowPos, projCoords, inBounds, blendFactor);
-        if (inBounds > 0.5f)
-            return c;
-    }
-
-    return -1;
 }
 
 //--------------------------------------------------------------------------------------
@@ -542,20 +530,30 @@ float ComputeShadowValue(float2 uv, float3 wsPosition, Texture2D shadowmap, Samp
 //--------------------------------------------------------------------------------------
 // CSM: Shadow-Sampling with soft shadows and cascade blending
 // Uses SQ_ShadowSoftness for configurable shadow edge softness
+//
+// Takes the UN-biased world position plus the world-space normal and slope factor. The
+// normal-offset bias is applied PER CASCADE using that cascade's own world texel size
+// (SQ_CascadeTexelSize[c]). This matters in the blend region: the primary and the next
+// (coarser) cascade need different offsets, and biasing once for the primary leaves the
+// next cascade under-biased -> self-shadowing -> a dark bar exactly at the boundary.
 //--------------------------------------------------------------------------------------
-float ComputeCascadedShadowValueSoft(float3 wsPosition, float viewSpaceZ, float vertLighting, float bias, float2 screenPos)
+float ComputeCascadedShadowValueSoft(float3 wsPosition, float3 wsNormal, float slopeScale,
+                                     float viewSpaceZ, float vertLighting, float bias, float2 screenPos)
 {
+    const float normalBiasMultiplier = 1.0f;
+
     float shadow = vertLighting;
 
     int selectedCascade = -1;
     float4 vShadowPos;
     float2 projCoords;
+    float inBounds;
     float blendFactor = 0.0f;
 
-    // 1. Find the primary cascade WITHOUT sampling textures
+    // 1. Find the primary cascade using the UN-biased position (selection/bounds must be
+    //    consistent across cascades; only the sampled position gets the per-cascade offset).
     for (int c = 0; c < NUM_CSM_CASCADES; c++)
     {
-        float inBounds;
         GetCascadeUVAndBounds(wsPosition, c, vShadowPos, projCoords, inBounds, blendFactor);
 
         if (inBounds > 0.5f)
@@ -573,21 +571,34 @@ float ComputeCascadedShadowValueSoft(float3 wsPosition, float viewSpaceZ, float 
         float distanceFactor = saturate(abs(viewSpaceZ) / 5000.0f);
         float softness = SQ_ShadowSoftness * (1.0f + distanceFactor * 0.5f);
 
-        shadow = SampleCascadeShadowSoft(vShadowPos, projCoords, selectedCascade, bias, screenPos, softness);
+        // Bias matched to the PRIMARY cascade's texel size.
+        float3 biasedPos = wsPosition + wsNormal * (slopeScale * SQ_CascadeTexelSize[selectedCascade] * normalBiasMultiplier);
+        float4 cShadowPos;
+        float2 cProjCoords;
+        float cInBounds;
+        float cBlendFactor;
+        GetCascadeUVAndBounds(biasedPos, selectedCascade, cShadowPos, cProjCoords, cInBounds, cBlendFactor);
+
+        shadow = SampleCascadeShadowSoft(cShadowPos, cProjCoords, selectedCascade, bias, screenPos, softness);
 
         // 3. Check if we need to blend with the next cascade
         if (selectedCascade < NUM_CSM_CASCADES - 1 && blendFactor > 0.0f)
         {
+            int nextCascade = selectedCascade + 1;
+
+            // Bias matched to the NEXT (coarser) cascade's texel size so the blended
+            // sample isn't under-biased.
+            float3 nextBiasedPos = wsPosition + wsNormal * (slopeScale * SQ_CascadeTexelSize[nextCascade] * normalBiasMultiplier);
             float4 nextShadowPos;
             float2 nextProjCoords;
             float nextInBounds;
             float nextBlendFactor;
 
-            GetCascadeUVAndBounds(wsPosition, selectedCascade + 1, nextShadowPos, nextProjCoords, nextInBounds, nextBlendFactor);
+            GetCascadeUVAndBounds(nextBiasedPos, nextCascade, nextShadowPos, nextProjCoords, nextInBounds, nextBlendFactor);
 
             if (nextInBounds > 0.5f)
             {
-                float shadowNext = SampleCascadeShadowSoft(nextShadowPos, nextProjCoords, selectedCascade + 1, bias, screenPos, softness);
+                float shadowNext = SampleCascadeShadowSoft(nextShadowPos, nextProjCoords, nextCascade, bias, screenPos, softness);
                 shadow = lerp(shadow, shadowNext, blendFactor);
             }
         }


### PR DESCRIPTION
- fix shadow cascade isInBounds check by including depth (z)
  - fixes "dark spots" when looking down from a hill, or from the free-look camera.
- collect metrics for allocated textures using tracy
- increasing shadow distance will now also increase shadow vob culling distance, to allow even further shadows
- ensure we always use scene camera for culling and don't rely on the global "active" camera
- fix shadow PCF filtering by changing shadow sampler from WRAP to BORDER which should help preventing over-shadowing and "shadow from nowhere"