### PR TITLE
fixes: locale independent parsing, std::stop_token, SRV/RTV warnings in Forward+, improve TAA ping-pong, fix FSR1, fix sky motion vectors with atmospheric scattering

### DIFF
--- a/D3D11Engine/D3D11ForwardPlusRenderer.cpp
+++ b/D3D11Engine/D3D11ForwardPlusRenderer.cpp
@@ -34,7 +34,7 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
     RGResourceHandle& outReactiveMaskResource ) {
 
     RGResourceHandle normalsResource = {};
-    RGResourceHandle specularResource = {};
+    RGResourceHandle specularResource = RG_INVALID_HANDLE;
     RGResourceHandle reactiveMaskResource = {};
     RGResourceHandle shadowMaskResource = RG_INVALID_HANDLE;
     const bool useScreenSpaceShadowMask = Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.FeatureSet.UseScreenSpaceShadowMask;
@@ -184,24 +184,21 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
     graph.AddPass( RG_PASS_NAME("FP Lit Geometry"), [&]( RGBuilder& builder, RenderPass& pass ) {
         auto size = engine.GetResolution();
         normalsResource = builder.CreateTexture( { static_cast<uint32_t>( size.x ), static_cast<uint32_t>( size.y ), DXGI_FORMAT_R16G16_FLOAT, L"GBufferNormals" } );
-        specularResource = builder.CreateTexture( { static_cast<uint32_t>( size.x ), static_cast<uint32_t>( size.y ), DXGI_FORMAT_R16G16_FLOAT, L"GBufferSpecular" } );
         reactiveMaskResource = builder.CreateTexture( { static_cast<uint32_t>( size.x ), static_cast<uint32_t>( size.y ), DXGI_FORMAT_R8_UNORM, L"ReactiveMask" } );
         builder.Write( velocityBufferHandle );
         builder.Write( colorResource );
         builder.Write( normalsResource );
-        builder.Write( specularResource );
         builder.Write( backBufferHandle );
         if ( useScreenSpaceShadowMask && shadowMaskResource != RG_INVALID_HANDLE ) {
             builder.Read( shadowMaskResource );
         }
 
-        pass.m_executeCallback = [this, &engine, colorResource, normalsResource, specularResource, velocityBufferHandle, shadowMaskResource, useScreenSpaceShadowMask]( const RenderGraph& graph ) -> void {
+        pass.m_executeCallback = [this, &engine, colorResource, normalsResource, velocityBufferHandle, shadowMaskResource, useScreenSpaceShadowMask]( const RenderGraph& graph ) -> void {
             TracyD3D11ZoneCGX( "D3D11ForwardPlusRenderer::Lit Geometry" );
             auto& context = engine.GetContext();
             auto* shadowMaps = engine.GetShadowMaps();
 
             auto normals = graph.GetPhysicalTexture( normalsResource );
-            auto specular = graph.GetPhysicalTexture( specularResource );
             auto velocityBuffer = graph.GetPhysicalTexture( velocityBufferHandle );
             auto* shadowMask = ( useScreenSpaceShadowMask && shadowMaskResource != RG_INVALID_HANDLE )
                 ? graph.GetPhysicalTexture( shadowMaskResource )
@@ -216,7 +213,6 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
             ID3D11RenderTargetView* rtvs[] = {
                 graph.GetPhysicalTexture( colorResource )->GetRenderTargetView().Get(),
                 normals ? normals->GetRenderTargetView().Get() : nullptr,
-                specular ? specular->GetRenderTargetView().Get() : nullptr,
                 velocityBuffer ? velocityBuffer->GetRenderTargetView().Get() : nullptr,
             };
 

--- a/D3D11Engine/D3D11ForwardPlusRenderer.cpp
+++ b/D3D11Engine/D3D11ForwardPlusRenderer.cpp
@@ -359,7 +359,6 @@ bool D3D11ForwardPlusRenderer::BindShaderForTexture(
 
     auto active = activePS;
     auto newShader = activePS;
-
     if ( texture->HasAlphaChannel() || forceAlphaTest ) {
         if ( texture->GetSurface()->GetFxMap() ) {
             newShader = shaderManager.GetPShader( PShaderID::PS_FP_DiffuseNormalmappedAlphaTestFxMap );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -7209,7 +7209,7 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
 
             if ( isZPrepass ) {
                 // force alpha testing for vobs in prepass.
-                SetActivePixelShader( PShaderID::PS_DiffuseAlphaTestShadows );
+                ActivePS = nullptr;
                 Context->PSSetShader( nullptr, nullptr, 0 );
             }
 
@@ -8240,6 +8240,19 @@ bool D3D11GraphicsEngine::BindShaderForTexture( zCTexture* texture,
     bool forceAlphaTest,
     int zMatAlphaFunc,
     MaterialInfo::EMaterialType materialInfo ) {
+    
+    if (GetRenderingStage() == DES_Z_PRE_PASS) {
+        const auto& active = ActivePS;
+        // in Z_PRE_PASS the only way time someone wants a PS is when alpha testing is needed.
+        auto& newShader = GetShaderManager().GetPShader( PShaderID::PS_DiffuseAlphaTestShadows );
+        
+        if (active != newShader) {
+            SetActivePS(newShader)->Apply();
+            return true;
+        }
+        return false;
+    }
+    
     return ActiveSceneRenderer->BindShaderForTexture( GetShaderManager(), ActivePS,
         texture, forceAlphaTest, zMatAlphaFunc, materialInfo,
         Resolved_DiffuseNormalmapped,

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -426,7 +426,7 @@ void D3D11GraphicsEngine::CreateAndBindDefaultSampler() {
     samplerDesc.MinLOD = -3.402823466e+38F;  // -FLT_MAX
     samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;   // FLT_MAX
     
-    LE( GetDevice()->CreateSamplerState( &samplerDesc, DefaultSamplerState.GetAddressOf() ) );
+    DefaultSamplerState = GetPfxRenderer()->GetSampler(samplerDesc);
     GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
     GetContext()->VSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
     GetContext()->DSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
@@ -727,6 +727,8 @@ XRESULT D3D11GraphicsEngine::Init() {
     ShaderManager = std::make_unique<D3D11ShaderManager>();
     ShaderManager->Init();
     ShaderManager->LoadShaders();
+    
+    PfxRenderer = std::make_unique<D3D11PfxRenderer>();
 
     TempVertexBuffer = std::make_unique<D3D11VertexBuffer>();
     TempVertexBuffer->Init(
@@ -806,7 +808,7 @@ XRESULT D3D11GraphicsEngine::Init() {
     samplerDesc.MinLOD = -3.402823466e+38F;  // -FLT_MAX
     samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;   // FLT_MAX
 
-    LE( GetDevice()->CreateSamplerState( &samplerDesc, LinearSamplerState.GetAddressOf() ) );
+    LinearSamplerState = GetPfxRenderer()->GetSampler(samplerDesc);
     SetDebugName( LinearSamplerState.Get(), "LinearSamplerState" );
 
     samplerDesc.Filter = D3D11_FILTER_COMPARISON_MIN_MAG_MIP_LINEAR;
@@ -819,14 +821,14 @@ XRESULT D3D11GraphicsEngine::Init() {
     samplerDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
     samplerDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
     samplerDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-    GetDevice()->CreateSamplerState( &samplerDesc, ClampSamplerState.GetAddressOf() );
+    ClampSamplerState = GetPfxRenderer()->GetSampler(samplerDesc);
     SetDebugName( ClampSamplerState.Get(), "ClampSamplerState" );
 
     samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
     samplerDesc.AddressU = D3D11_TEXTURE_ADDRESS_WRAP;
     samplerDesc.AddressV = D3D11_TEXTURE_ADDRESS_WRAP;
     samplerDesc.AddressW = D3D11_TEXTURE_ADDRESS_WRAP;
-    GetDevice()->CreateSamplerState( &samplerDesc, CubeSamplerState.GetAddressOf() );
+    CubeSamplerState = GetPfxRenderer()->GetSampler(samplerDesc);
     SetDebugName( CubeSamplerState.Get(), "CubeSamplerState" );
 
     SetActivePixelShader( PShaderID::PS_Simple );
@@ -1109,6 +1111,11 @@ XRESULT D3D11GraphicsEngine::RecreateBuffers() {
     }
     lastRoundedTextureResolution = roundedTextureResolution;
     
+    // Create PFX-Renderer
+    if ( !PfxRenderer ) PfxRenderer = std::make_unique<D3D11PfxRenderer>();
+
+    PfxRenderer->OnResize( roundedTextureResolution );
+    
     // Adjust DefaultSampler with negative LOD bias for upscaling
     CreateAndBindDefaultSampler();
     
@@ -1120,11 +1127,6 @@ XRESULT D3D11GraphicsEngine::RecreateBuffers() {
     DepthStencilBufferCopy = std::make_unique<RenderToTextureBuffer>(
         GetDevice().Get(), roundedTextureResolution.x, roundedTextureResolution.y, DXGI_FORMAT_R32_TYPELESS, nullptr,
         DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_R32_FLOAT );
-
-    // Create PFX-Renderer
-    if ( !PfxRenderer ) PfxRenderer = std::make_unique<D3D11PfxRenderer>();
-
-    PfxRenderer->OnResize( roundedTextureResolution );
 
     VelocityBuffer = std::make_unique<RenderToTextureBuffer>(
         GetDevice().Get(), roundedTextureResolution.x, roundedTextureResolution.y, DXGI_FORMAT_R16G16_FLOAT );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -7859,6 +7859,8 @@ XRESULT D3D11GraphicsEngine::DrawSky() {
 
     SetupVS_ExMeshDrawCall();
     SetupVS_ExConstantBuffer();
+    // PS_Atmosphere uses the same VS_ExConstantBuffer_PerFrame for motion vectors
+    ActiveVS->GetBuffer(0).GetRawBuffer()->BindToPixelShader(0);
 
     ID3D11ShaderResourceView* srvs[2]{};
     // Apply sky texture

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4546,6 +4546,9 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
 
         graph.Compile();
         graph.Execute();
+
+        // Store view-projection matrix only after the rendergraph, or else parts after geometry have wrong motion vectors
+        StorePrevViewProjMatrix();
         
         GetContext()->ClearDepthStencilView( DepthStencilBuffer->GetDepthStencilView().Get(), D3D11_CLEAR_DEPTH, 0, 0 );
         GetContext()->ClearDepthStencilView( m_SwapchainDepthStencilBuffer->GetDepthStencilView().Get(), D3D11_CLEAR_DEPTH, 0, 0 );
@@ -9407,8 +9410,6 @@ void D3D11GraphicsEngine::StoreVobPreviousTransforms() {
     for (auto dynVob : Engine::GAPI->GetDynamicallyAddedVobs()) {
         dynVob->StorePreviousTransform();
     }
-
-    // Store view-projection matrix
-    StorePrevViewProjMatrix();
+    
 }
 

--- a/D3D11Engine/D3D11PFX_FSR1.cpp
+++ b/D3D11Engine/D3D11PFX_FSR1.cpp
@@ -73,6 +73,7 @@ void D3D11PFX_FSR1::SetSharpness( float sharpness ) {
 
 void D3D11PFX_FSR1::ReleaseResources() {
     PointSampler.Reset();
+    Initialized = false;
 }
 
 XRESULT D3D11PFX_FSR1::ApplyEASU(
@@ -97,6 +98,7 @@ XRESULT D3D11PFX_FSR1::ApplyEASU(
         LogError() << "FSR1 EASU shader not found";
         return XR_FAILED;
     }
+    engine->GetShaderManager().GetVShader( VShaderID::VS_PFX )->Apply();
 
     // Setup EASU constants
     FSR1EASUConstantBuffer cb = {};

--- a/D3D11Engine/D3D11PFX_FSR1.cpp
+++ b/D3D11Engine/D3D11PFX_FSR1.cpp
@@ -31,9 +31,6 @@ bool D3D11PFX_FSR1::Init() {
         return true;
     }
 
-    D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
-    auto device = engine->GetDevice();
-
     // Create point sampler for Gather operations (FSR1 requires point sampling)
     D3D11_SAMPLER_DESC samplerDesc = {};
     samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
@@ -46,8 +43,8 @@ bool D3D11PFX_FSR1::Init() {
     samplerDesc.MinLOD = 0;
     samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
 
-    HRESULT hr = device->CreateSamplerState( &samplerDesc, PointSampler.GetAddressOf() );
-    if ( FAILED( hr ) ) {
+    PointSampler = Renderer->GetSampler(samplerDesc);
+    if ( !PointSampler ) {
         LogError() << "Failed to create FSR1 point sampler";
         return false;
     }
@@ -72,7 +69,6 @@ void D3D11PFX_FSR1::SetSharpness( float sharpness ) {
 }
 
 void D3D11PFX_FSR1::ReleaseResources() {
-    PointSampler.Reset();
     Initialized = false;
 }
 

--- a/D3D11Engine/D3D11PFX_TAA.cpp
+++ b/D3D11Engine/D3D11PFX_TAA.cpp
@@ -251,7 +251,7 @@ Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> D3D11PFX_TAA::GetVelocityBuffer
 }
 
 void D3D11PFX_TAA::RenderPostFX(
-    const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& currentFrameSRV,
+    RenderToTextureBuffer& renderTarget,
     const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& depthSRV,
     const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& velocitySRV) {
     
@@ -278,7 +278,7 @@ void D3D11PFX_TAA::RenderPostFX(
     auto tempBuffer = FxRenderer->GetTempBuffer();
 
     // update the temp buffer with the latest backbuffer data
-    FxRenderer->CopyTextureToRTV( currentFrameSRV, tempBuffer->GetRenderTargetView(), engine->GetResolution() );
+    FxRenderer->CopyTextureToRTV( renderTarget.GetShaderResView(), tempBuffer->GetRenderTargetView(), engine->GetResolution() );
     
     // Build constant buffer
     TAAConstantBuffer cb;
@@ -310,16 +310,11 @@ void D3D11PFX_TAA::RenderPostFX(
     m_PrevCameraPosition = Engine::GAPI->GetCameraPosition();
 
     // Set render target
-    context->OMSetRenderTargets( 1, tempBuffer->GetRenderTargetView().GetAddressOf(), nullptr );
+    context->OMSetRenderTargets( 1, oldRTV.GetAddressOf(), nullptr );
 
     // Bind shaders
     engine->GetShaderManager().GetVShader( VShaderID::VS_PFX )->Apply();
     auto taaPS = engine->GetShaderManager().GetPShader( PShaderID::PS_PFX_TAA );
-    if (!taaPS) {
-        FxRenderer->CopyTextureToRTV( currentFrameSRV, oldRTV );
-        context->OMSetRenderTargets(1, oldRTV.GetAddressOf(), oldDSV.Get());
-        return;
-    }
     taaPS->Apply();
 
     // Bind textures:
@@ -328,8 +323,8 @@ void D3D11PFX_TAA::RenderPostFX(
     // t2: Depth buffer
     // t3: Velocity buffer
     ID3D11ShaderResourceView* srvs[4] = {
-        currentFrameSRV.Get(),
-        m_FirstFrame ? currentFrameSRV.Get() : m_HistoryBuffer->GetShaderResView().Get(),
+        tempBuffer->GetShaderResView().Get(),
+        m_FirstFrame ? renderTarget.GetShaderResView().Get() : m_HistoryBuffer->GetShaderResView().Get(),
         depthSRV.Get(),
         velocitySRV.Get()
     };
@@ -344,14 +339,11 @@ void D3D11PFX_TAA::RenderPostFX(
     
     // Copy output to history buffer for next frame
     context->CopyResource(m_HistoryBuffer->GetTexture().Get(), 
-                          tempBuffer->GetTexture().Get());
+                          renderTarget.GetTexture().Get());
 
     // Cleanup shader resources
     ID3D11ShaderResourceView* nullSRVs[4] = { nullptr, nullptr, nullptr, nullptr };
     context->PSSetShaderResources( 0, 4, nullSRVs );
-
-    // Copy result back to the original render target
-    FxRenderer->CopyTextureToRTV( tempBuffer->GetShaderResView(), oldRTV );
 
     // Restore original render targets
     context->OMSetRenderTargets(1, oldRTV.GetAddressOf(), oldDSV.Get());

--- a/D3D11Engine/D3D11PFX_TAA.h
+++ b/D3D11Engine/D3D11PFX_TAA.h
@@ -41,7 +41,7 @@ public:
 
     /** Renders the TAA effect */
     void RenderPostFX(
-        const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& currentFrameSRV,
+        RenderToTextureBuffer& renderTarget,
         const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& depthSRV,
         const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& velocitySRV);
 

--- a/D3D11Engine/D3D11PfxRenderer.cpp
+++ b/D3D11Engine/D3D11PfxRenderer.cpp
@@ -28,6 +28,7 @@
 
 D3D11PfxRenderer::D3D11PfxRenderer() {
 
+    m_Samplers = {};
     auto engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
     m_texturePool = std::make_unique<TexturePool>( engine->GetDevice().Get() );
     m_depthStencilPool = std::make_unique<DepthStencilPool>( engine->GetDevice().Get() );
@@ -422,6 +423,39 @@ TextureHandle D3D11PfxRenderer::GetTempBufferDS4()
     auto res = engine->GetResolution();
 
     return m_texturePool->Acquire( TexturePool::Description{ res.x / 4, res.y / 4, bbufferFormat } );
+}
+
+Microsoft::WRL::ComPtr<ID3D11SamplerState>& D3D11PfxRenderer::GetSampler(const D3D11_SAMPLER_DESC& desc) {
+    size_t hash = Toolbox::hash_value(desc.Filter);
+    Toolbox::hash_combine(hash, desc.AddressU);
+    Toolbox::hash_combine(hash, desc.AddressV);
+    Toolbox::hash_combine(hash, desc.AddressW);
+    Toolbox::hash_combine(hash, desc.MipLODBias);
+    Toolbox::hash_combine(hash, desc.MaxAnisotropy);
+    Toolbox::hash_combine(hash, desc.ComparisonFunc);
+    Toolbox::hash_combine(hash, desc.BorderColor[0]);
+    Toolbox::hash_combine(hash, desc.BorderColor[1]);
+    Toolbox::hash_combine(hash, desc.BorderColor[2]);
+    Toolbox::hash_combine(hash, desc.BorderColor[3]);
+    Toolbox::hash_combine(hash, desc.MinLOD);
+    Toolbox::hash_combine(hash, desc.MaxLOD);
+
+    if (auto found = m_Samplers.find(hash); found != m_Samplers.end()) {
+        return found->second;
+    }
+    
+    D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
+    auto device = engine->GetDevice().Get();
+
+    ComPtr<ID3D11SamplerState> sampler;
+    HRESULT hr = device->CreateSamplerState( &desc, sampler.ReleaseAndGetAddressOf() );
+    if ( FAILED( hr ) ) {
+        LogError() << "Failed to create sampler";
+        static ComPtr<ID3D11SamplerState> null{};
+        return null;
+    }
+    
+    return m_Samplers.emplace(hash, sampler).first->second;
 }
 
 void D3D11PfxRenderer::FreeResources()

--- a/D3D11Engine/D3D11PfxRenderer.cpp
+++ b/D3D11Engine/D3D11PfxRenderer.cpp
@@ -118,7 +118,7 @@ XRESULT D3D11PfxRenderer::RenderTAA(const Microsoft::WRL::ComPtr<ID3D11ShaderRes
     
     // Then render TAA using the velocity buffer
     FX_TAA->RenderPostFX(
-        engine->GetHDRBackBuffer().GetShaderResView(),
+        engine->GetHDRBackBuffer(),
         engine->GetDepthBuffer()->GetShaderResView(),
         velocityBuffer.Get() ? velocityBuffer : FX_TAA->GetVelocityBufferSRV()
     );

--- a/D3D11Engine/D3D11PfxRenderer.h
+++ b/D3D11Engine/D3D11PfxRenderer.h
@@ -99,6 +99,7 @@ public:
     TextureHandle GetTempBuffer();
     TextureHandle GetBackbufferTempBuffer();
     TextureHandle GetTempBufferDS4();
+    Microsoft::WRL::ComPtr<ID3D11SamplerState>& GetSampler(const D3D11_SAMPLER_DESC& desc);
 
     D3D11PFX_TAA* GetTAAEffect() { return FX_TAA.get(); }
     D3D11PFX_CAS* GetCAS() { return PFX_CAS.get(); }
@@ -141,5 +142,7 @@ private:
     std::unique_ptr<D3D11PFX_ASSAO> PFX_ASSAO;
     std::unique_ptr<TexturePool> m_texturePool;
     std::unique_ptr<DepthStencilPool> m_depthStencilPool;
+    
+    std::unordered_map<size_t, Microsoft::WRL::ComPtr<ID3D11SamplerState>> m_Samplers;
 };
 

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -483,9 +483,9 @@ void D3D11PointLight::StartReInit() {
 
         // Add to queue
         m_PendingInit.cancel( ); // Cancel any pending init first, we only care about the latest one
-        m_PendingInit = Engine::WorkerThreadPool->enqueue( [this] (const CancellationToken& token)
+        m_PendingInit = Engine::WorkerThreadPool->enqueue( [this] (const std::stop_token& token)
         {
-            if (token.isCancelled()) {
+            if (token.stop_requested()) {
                 InitDone = true;
                 return;
             }

--- a/D3D11Engine/D3D11ShaderManager.h
+++ b/D3D11Engine/D3D11ShaderManager.h
@@ -98,11 +98,11 @@ public:
     void UpdateShaderInfo( ShaderInfo& shader );
 
     /** Return a specific shader */
-    std::shared_ptr<D3D11VShader> GetVShader( VShaderID id ) { return VShaders[static_cast<size_t>(id)]; }
-    std::shared_ptr<D3D11PShader> GetPShader( PShaderID id ) { return PShaders[static_cast<size_t>(id)]; }
-    std::shared_ptr<D3D11HDShader> GetHDShader( HDShaderID id ) { return HDShaders[static_cast<size_t>(id)]; }
-    std::shared_ptr<D3D11GShader> GetGShader( GShaderID id ) { return GShaders[static_cast<size_t>(id)]; }
-    std::shared_ptr<D3D11CShader> GetCShader( CShaderID id ) { return CShaders[static_cast<size_t>(id)]; }
+    std::shared_ptr<D3D11VShader>& GetVShader( VShaderID id ) { return VShaders[static_cast<size_t>(id)]; }
+    std::shared_ptr<D3D11PShader>& GetPShader( PShaderID id ) { return PShaders[static_cast<size_t>(id)]; }
+    std::shared_ptr<D3D11HDShader>& GetHDShader( HDShaderID id ) { return HDShaders[static_cast<size_t>(id)]; }
+    std::shared_ptr<D3D11GShader>& GetGShader( GShaderID id ) { return GShaders[static_cast<size_t>(id)]; }
+    std::shared_ptr<D3D11CShader>& GetCShader( CShaderID id ) { return CShaders[static_cast<size_t>(id)]; }
 
 private:
     XRESULT CompileShader( ShaderInfo& si );

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -678,8 +678,8 @@ XRESULT D3D11ShadowMap::PrepareRender()
                 continue; // Skip culling for this cascade if we're not updating it this frame
             }
 
-            m_ShadowCullingJobs.push_back( Engine::WorkerThreadPool->enqueue( []( const CancellationToken& token, D3D11ShadowMap* _this, size_t idx ) {
-                if ( token.isCancelled() ) {
+            m_ShadowCullingJobs.push_back( Engine::WorkerThreadPool->enqueue( []( const std::stop_token& token, D3D11ShadowMap* _this, size_t idx ) {
+                if ( token.stop_requested() ) {
                     return;
                 }
                 ZoneScoped;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -204,16 +204,30 @@ namespace
         const float nDefault,
         const std::string& lpFileName
     ) {
-        const int float_str_max = 30;
+        constexpr int float_str_max = 30;
         TCHAR nFloat[float_str_max];
         if ( auto count = ::GetPrivateProfileStringA( lpAppName, lpKeyName, nullptr, nFloat, float_str_max, lpFileName.c_str() ) ) {
-            try {
-                return std::stof( std::string( nFloat, count ) );
-            } catch ( const std::exception& ) {
-                return nDefault;
+            float flt;
+            auto dataPtr = &nFloat[0];
+            auto [_, ec] = std::from_chars(dataPtr, dataPtr+count, flt);
+
+            if (ec == std::errc{}) {
+                return flt;
             }
+            return nDefault;
         }
         return nDefault;
+    }
+    
+    template<typename T>
+    std::string to_string_locale_independent(const T value) {
+        std::array<char, 255> buffer;
+        auto [ptr, ec] = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value);
+
+        if (ec == std::errc{}) {
+            return std::string(buffer.data(), ptr);
+        }
+        return "";
     }
 
     // Helper function to trim leading/trailing whitespace
@@ -351,6 +365,7 @@ namespace
         const std::string& lpFileName
     ) {
         std::stringstream ss;
+        ss.imbue(std::locale::classic());
 
         for (size_t i = 0; i < count; i++)
         {
@@ -397,6 +412,8 @@ namespace
     static std::string float_to_string(const float val, int precision = 6)
     {
         std::stringstream ss;
+        ss.imbue(std::locale::classic());
+
         ss << std::fixed << std::setprecision(precision) << val;
         return ss.str();
     }
@@ -553,6 +570,7 @@ void GothicAPI::OnWorldUpdate() {
 
     // Do rain-effects
     zCSkyController_Outdoor* skyController;
+
     if ( world && (skyController = world->GetSkyControllerOutdoor()) != nullptr && _canRain ) {
         bool outdoor = (LoadedWorldInfo->BspTree->GetBspTreeMode() == zBSP_MODE_OUTDOOR);
         if ( RendererState.RendererSettings.AtmosphericScattering && outdoor ) {
@@ -1055,7 +1073,7 @@ void GothicAPI::LoadRendererWorldSettings( GothicRendererSettings& s, const char
         s.OutdoorSmallVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorSmallVobDrawRadius", s.OutdoorSmallVobDrawRadius, ini );
         s.IndoorVobDrawRadius = GetPrivateProfileFloatA( "General", "IndoorVobDrawRadius", s.IndoorVobDrawRadius, ini );
 	    s.SkeletalMeshDrawRadius = GetPrivateProfileFloatA( "General", "SkeletalMeshDrawRadius", s.SkeletalMeshDrawRadius, ini );
-	    s.SectionDrawRadius = GetPrivateProfileFloatA( "General", "SectionDrawRadius", s.SectionDrawRadius, ini );
+	    s.SectionDrawRadius = GetPrivateProfileIntA( "General", "SectionDrawRadius", s.SectionDrawRadius, ini.c_str() );
     }
 
     s.RainRadiusRange = GetPrivateProfileFloatA( "Rain", "RadiusRange", s.RainRadiusRange, ini );
@@ -1110,31 +1128,31 @@ void GothicAPI::SaveRendererWorldSettings( const GothicRendererSettings& s )
 void GothicAPI::SaveRendererWorldSettings( const GothicRendererSettings& s, const char* iniFile ) {
     const std::string ini = iniFile;
 
-    WritePrivateProfileStringA( "Fog", "Height", std::to_string( s.FogHeight ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Fog", "HeightFalloff", std::to_string( s.FogHeightFalloff ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Fog", "GlobalDensity", std::to_string( s.FogGlobalDensity ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Fog", "Height", to_string_locale_independent( s.FogHeight ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Fog", "HeightFalloff", to_string_locale_independent( s.FogHeightFalloff ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Fog", "GlobalDensity", to_string_locale_independent( s.FogGlobalDensity ).c_str(), ini.c_str() );
 
     WritePrivateProfileRGB("Atmoshpere", "SunLightColor", s.SunLightColor, ini);
     WritePrivateProfileRGB("Atmoshpere", "FogColorMod", s.FogColorMod, ini);
 
-    WritePrivateProfileStringA( "General", "GraphicsPreset", std::to_string( (int)s.GraphicsPreset ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "VisualFXDrawRadius", std::to_string( s.VisualFXDrawRadius ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "OutdoorVobDrawRadius", std::to_string( s.OutdoorVobDrawRadius ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "OutdoorSmallVobDrawRadius", std::to_string( s.OutdoorSmallVobDrawRadius ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "IndoorVobDrawRadius", std::to_string( s.IndoorVobDrawRadius ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "SkeletalMeshDrawRadius", std::to_string( s.SkeletalMeshDrawRadius ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "SectionDrawRadius", std::to_string( s.SectionDrawRadius ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "GraphicsPreset", to_string_locale_independent( (int)s.GraphicsPreset ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "VisualFXDrawRadius", to_string_locale_independent( s.VisualFXDrawRadius ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "OutdoorVobDrawRadius", to_string_locale_independent( s.OutdoorVobDrawRadius ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "OutdoorSmallVobDrawRadius", to_string_locale_independent( s.OutdoorSmallVobDrawRadius ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "IndoorVobDrawRadius", to_string_locale_independent( s.IndoorVobDrawRadius ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "SkeletalMeshDrawRadius", to_string_locale_independent( s.SkeletalMeshDrawRadius ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "SectionDrawRadius", to_string_locale_independent( s.SectionDrawRadius ).c_str(), ini.c_str() );
 
-    WritePrivateProfileStringA( "Rain", "RadiusRange", std::to_string( s.RainRadiusRange ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Rain", "HeightRange", std::to_string( s.RainHeightRange ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Rain", "NumParticles", std::to_string( s.RainNumParticles ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Rain", "RadiusRange", to_string_locale_independent( s.RainRadiusRange ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Rain", "HeightRange", to_string_locale_independent( s.RainHeightRange ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Rain", "NumParticles", to_string_locale_independent( s.RainNumParticles ).c_str(), ini.c_str() );
     WritePrivateProfileArray( "Rain", "GlobalVelocity", &s.RainGlobalVelocity.x, 3, ini.c_str() );
-    WritePrivateProfileStringA( "Rain", "SceneWettness", std::to_string( s.RainSceneWettness ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Rain", "SunLightStrength", std::to_string( s.RainSunLightStrength ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Rain", "SceneWettness", to_string_locale_independent( s.RainSceneWettness ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Rain", "SunLightStrength", to_string_locale_independent( s.RainSunLightStrength ).c_str(), ini.c_str() );
     WritePrivateProfileRGB( "Rain", "FogColor", s.RainFogColor, ini );
-    WritePrivateProfileStringA( "Rain", "FogDensity", std::to_string( s.RainFogDensity ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Rain", "FogDensity", to_string_locale_independent( s.RainFogDensity ).c_str(), ini.c_str() );
 
-    WritePrivateProfileStringA( "Atmoshpere", "ReplaceSunDirection", std::to_string( s.ReplaceSunDirection ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Atmoshpere", "ReplaceSunDirection", to_string_locale_independent( s.ReplaceSunDirection ? TRUE : FALSE ).c_str(), ini.c_str() );
 
     AtmosphereSettings& aS = GetSky()->GetAtmoshpereSettings();
 
@@ -1154,9 +1172,9 @@ void GothicAPI::SaveRendererWorldSettings( const GothicRendererSettings& s, cons
     WritePrivateProfileStringA( "Atmoshpere", "LightDirectionY", nullptr, ini.c_str() );
     WritePrivateProfileStringA( "Atmoshpere", "LightDirectionZ", nullptr, ini.c_str() );
 
-    WritePrivateProfileStringA( "GodRays", "GodRayDecay", std::to_string( s.GodRayDecay ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "GodRays", "GodRayDensity", std::to_string( s.GodRayDensity ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "GodRays", "GodRayWeight", std::to_string( s.GodRayWeight ).c_str(), ini.c_str() );    
+    WritePrivateProfileStringA( "GodRays", "GodRayDecay", to_string_locale_independent( s.GodRayDecay ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "GodRays", "GodRayDensity", to_string_locale_independent( s.GodRayDensity ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "GodRays", "GodRayWeight", to_string_locale_independent( s.GodRayWeight ).c_str(), ini.c_str() );    
 }
 
 /** Goes through the given zCTree and registers all found vobs */
@@ -2508,7 +2526,6 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
     D3D11GraphicsEngine* g = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
 
     zCModel* model = static_cast<zCModel*>(vi->Vob->GetVisual());
-    SkeletalMeshVisualInfo* visual = static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo);
 
     if ( !model || !vi->VisualInfo )
         return; // Gothic fortunately sets this to 0 when it throws the model out of the cache
@@ -2686,7 +2703,6 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
                     instanceInfo.Scaling = 1.f;
                 }
 
-                auto& VShader = g->GetActiveVS();
                 if ( distance < 1000 && isMMS ) {
                     zCMorphMesh* mm = reinterpret_cast<zCMorphMesh*>( mvi->Visual );
                     // Only draw this as a morphmesh when rendering the main scene or when rendering as ghost
@@ -2749,7 +2765,6 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
     D3D11GraphicsEngine* g = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
 
     zCModel* model = static_cast<zCModel*>(vi->Vob->GetVisual());
-    SkeletalMeshVisualInfo* visual = static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo);
 
     if ( !model || !vi->VisualInfo )
         return; // Gothic fortunately sets this to 0 when it throws the model out of the cache
@@ -2921,7 +2936,6 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
                 // Update constantbuffer
                 vsBufMPI.Update( &instanceInfo );
 
-                auto& VShader = g->GetActiveVS();
                 if ( distance < 1000 && isMMS ) {
                     zCMorphMesh* mm = reinterpret_cast<zCMorphMesh*>( mvi->Visual );
                     // Only draw this as a morphmesh when rendering the main scene or when rendering as ghost
@@ -4933,18 +4947,18 @@ zCVob* GothicAPI::GetPlayerVob() {
 /** Loads resources created for this .ZEN */
 void GothicAPI::LoadCustomZENResources() {
     auto gameName = GetGameName();
-    std::string zenFolder;
+    std::string zenFolder; zenFolder.reserve(255);
     if ( gameName == "Original" ) {
-        zenFolder = "system\\GD3D11\\ZENResources\\";
+        zenFolder.append("system\\GD3D11\\ZENResources\\");
     } else {
-        zenFolder = "system\\GD3D11\\ZENResources\\" + gameName + "\\";
+        zenFolder.append("system\\GD3D11\\ZENResources\\").append(gameName).append("\\");
     }
     if ( !Toolbox::FolderExists( zenFolder ) ) {
         LogInfo() << "Custom ZEN-Resources. Directory not found: " << zenFolder;
         return;
     }
 
-    std::string zen = zenFolder + LoadedWorldInfo->WorldName;
+    std::string& zen = zenFolder.append(LoadedWorldInfo->WorldName);
 
     LogInfo() << "Loading custom ZEN-Resources from: " << zen;
 
@@ -4958,11 +4972,11 @@ void GothicAPI::LoadCustomZENResources() {
 /** Saves resources created for this .ZEN */
 void GothicAPI::SaveCustomZENResources() {
     auto gameName = GetGameName();
-    std::string zenFolder;
+    std::string zenFolder; zenFolder.reserve(255);
     if ( gameName == "Original" ) {
-        zenFolder = "system\\GD3D11\\ZENResources\\";
+        zenFolder.append(R"(system\GD3D11\ZENResources\)");
     } else {
-        zenFolder = "system\\GD3D11\\ZENResources\\" + gameName + "\\";
+        zenFolder.append(R"(system\GD3D11\ZENResources\)").append(gameName).append("\\");
     }
 
     bool mkDirErr = false;
@@ -4975,7 +4989,7 @@ void GothicAPI::SaveCustomZENResources() {
         return;
     }
 
-    std::string zen = zenFolder + LoadedWorldInfo->WorldName;
+    std::string& zen = zenFolder.append(LoadedWorldInfo->WorldName);
 
     LogInfo() << "Saving custom ZEN-Resources to: " << zen;
 
@@ -5214,117 +5228,117 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     LogInfo() << "Saving menu settings to " << ini;
     GothicRendererSettings& s = RendererState.RendererSettings;
 
-    WritePrivateProfileStringA( "General", "ChangeToMode", std::to_string( s.ChangeWindowPreset ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "AtmosphericScattering", std::to_string( s.AtmosphericScattering ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "EnableFog", std::to_string( s.DrawFog ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "ChangeToMode", to_string_locale_independent( s.ChangeWindowPreset ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "AtmosphericScattering", to_string_locale_independent( s.AtmosphericScattering ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "EnableFog", to_string_locale_independent( s.DrawFog ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "FogRange", float_to_string( s.FogRange , 2).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "EnableHDR", std::to_string( s.EnableHDR ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "HDRToneMap", std::to_string( s.HDRToneMap ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "EnableDebugLog", std::to_string( s.EnableDebugLog ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "EnableAutoupdates", std::to_string( s.EnableAutoupdates ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "EnableGodRays", std::to_string( s.EnableGodRays ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "EnableDoF", std::to_string( s.EnableDoF ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "DoFGaussBlur", std::to_string( s.DoFGaussBlur ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "EnableHDR", to_string_locale_independent( s.EnableHDR ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "HDRToneMap", to_string_locale_independent( s.HDRToneMap ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "EnableDebugLog", to_string_locale_independent( s.EnableDebugLog ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "EnableAutoupdates", to_string_locale_independent( s.EnableAutoupdates ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "EnableGodRays", to_string_locale_independent( s.EnableGodRays ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "EnableDoF", to_string_locale_independent( s.EnableDoF ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "DoFGaussBlur", to_string_locale_independent( s.DoFGaussBlur ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "DoFFocusDistance", float_to_string( s.DoFFocusDistance, 1 ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "DoFFocusRange", float_to_string( s.DoFFocusRange, 1 ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "DoFBokehRadius", float_to_string( s.DoFBokehRadius, 1 ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "DoFMaxBlur", float_to_string( s.DoFMaxBlur, 1 ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "AllowNormalmaps", std::to_string( s.AllowNormalmaps ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "AllowNumpadKeys", std::to_string( s.AllowNumpadKeys ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "EnableInactiveFpsLock", std::to_string( s.EnableInactiveFpsLock ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "MultiThreadResourceManager", std::to_string( s.MTResoureceManager ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "CompressBackBuffer", std::to_string( s.CompressBackBuffer ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "AnimateStaticVobs", std::to_string( s.AnimateStaticVobs ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "DrawWorldSectionIntersections", std::to_string( s.DrawSectionIntersections ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "SunLightStrength", std::to_string( s.SunLightStrength ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "AllowNormalmaps", to_string_locale_independent( s.AllowNormalmaps ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "AllowNumpadKeys", to_string_locale_independent( s.AllowNumpadKeys ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "EnableInactiveFpsLock", to_string_locale_independent( s.EnableInactiveFpsLock ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "MultiThreadResourceManager", to_string_locale_independent( s.MTResoureceManager ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "CompressBackBuffer", to_string_locale_independent( s.CompressBackBuffer ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "AnimateStaticVobs", to_string_locale_independent( s.AnimateStaticVobs ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "DrawWorldSectionIntersections", to_string_locale_independent( s.DrawSectionIntersections ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "SunLightStrength", to_string_locale_independent( s.SunLightStrength ).c_str(), ini.c_str() );
 #ifdef BUILD_GOTHIC_1_08k
-    WritePrivateProfileStringA( "General", "DrawG1ForestPortals", std::to_string( s.DrawG1ForestPortals ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "G1HighlightInteractiveFocus", std::to_string( s.G1HighlightInteractiveFocus ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "DrawG1ForestPortals", to_string_locale_independent( s.DrawG1ForestPortals ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "G1HighlightInteractiveFocus", to_string_locale_independent( s.G1HighlightInteractiveFocus ? TRUE : FALSE ).c_str(), ini.c_str() );
 #endif
-    WritePrivateProfileStringA( "General", "DrawRainThroughTransformFeedback", std::to_string( s.DrawRainThroughTransformFeedback ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "DrawRainThroughTransformFeedback", to_string_locale_independent( s.DrawRainThroughTransformFeedback ? TRUE : FALSE ).c_str(), ini.c_str() );
 
     /*
     * Draw-distance is saved on a per World basis using SaveRendererWorldSettings
     */
 
-    WritePrivateProfileStringA( "General", "EnableOcclusionCulling", std::to_string( s.EnableOcclusionCulling ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "FpsLimit", std::to_string( s.FpsLimit ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "EnableOcclusionCulling", to_string_locale_independent( s.EnableOcclusionCulling ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "FpsLimit", to_string_locale_independent( s.FpsLimit ).c_str(), ini.c_str() );
     
     auto res = Engine::GraphicsEngine->GetBackbufferResolution();
-    WritePrivateProfileStringA( "Display", "TextureQuality", std::to_string( s.textureMaxSize ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "Width", std::to_string( res.x ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "Height", std::to_string( res.y ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "ResolutionScale", std::to_string( s.ResolutionScalePercent ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "Upscaler", std::to_string( static_cast<int>(s.Upscaler) ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "VSync", std::to_string( s.EnableVSync ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "ForceFOV", std::to_string( s.ForceFOV ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "FOVHoriz", std::to_string( static_cast<int>(s.FOVHoriz) ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "FOVVert", std::to_string( static_cast<int>(s.FOVVert) ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "Gamma", std::to_string( s.GammaValue ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "Brightness", std::to_string( s.BrightnessValue ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "DisplayFlip", std::to_string( s.DisplayFlip ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "LowLatency", std::to_string( s.LowLatency ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "HDR_Monitor", std::to_string( s.HDR_Monitor ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "TextureQuality", to_string_locale_independent( s.textureMaxSize ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "Width", to_string_locale_independent( res.x ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "Height", to_string_locale_independent( res.y ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "ResolutionScale", to_string_locale_independent( s.ResolutionScalePercent ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "Upscaler", to_string_locale_independent( static_cast<int>(s.Upscaler) ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "VSync", to_string_locale_independent( s.EnableVSync ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "ForceFOV", to_string_locale_independent( s.ForceFOV ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "FOVHoriz", to_string_locale_independent( static_cast<int>(s.FOVHoriz) ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "FOVVert", to_string_locale_independent( static_cast<int>(s.FOVVert) ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "Gamma", to_string_locale_independent( s.GammaValue ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "Brightness", to_string_locale_independent( s.BrightnessValue ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "DisplayFlip", to_string_locale_independent( s.DisplayFlip ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "LowLatency", to_string_locale_independent( s.LowLatency ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "HDR_Monitor", to_string_locale_independent( s.HDR_Monitor ? TRUE : FALSE ).c_str(), ini.c_str() );
 
-    WritePrivateProfileStringA( "Display", "StretchWindow", std::to_string( s.StretchWindow ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "UIScale", std::to_string( s.GothicUIScale ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "Rain", std::to_string( s.EnableRain ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "RainEffects", std::to_string( s.EnableRainEffects ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "LimitLightIntesity", std::to_string( s.LimitLightIntesity ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "TiledLighting", std::to_string( s.EnableTiledLighting ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "RendererMode", std::to_string( static_cast<int>(s.RendererMode) ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "WindQuality", std::to_string( s.WindQuality ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "WindStrength", std::to_string( s.GlobalWindStrength ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "WaterWaveAnimation", std::to_string( s.EnableWaterAnimation ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "HeroAffectsObjects", std::to_string( s.HeroAffectsObjects ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "StretchWindow", to_string_locale_independent( s.StretchWindow ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "UIScale", to_string_locale_independent( s.GothicUIScale ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "Rain", to_string_locale_independent( s.EnableRain ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "RainEffects", to_string_locale_independent( s.EnableRainEffects ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "LimitLightIntesity", to_string_locale_independent( s.LimitLightIntesity ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "TiledLighting", to_string_locale_independent( s.EnableTiledLighting ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "RendererMode", to_string_locale_independent( static_cast<int>(s.RendererMode) ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "WindQuality", to_string_locale_independent( s.WindQuality ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "WindStrength", to_string_locale_independent( s.GlobalWindStrength ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "WaterWaveAnimation", to_string_locale_independent( s.EnableWaterAnimation ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "HeroAffectsObjects", to_string_locale_independent( s.HeroAffectsObjects ? TRUE : FALSE ).c_str(), ini.c_str() );
     
 
-    WritePrivateProfileStringA( "Shadows", "EnableShadows", std::to_string( s.EnableShadows ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "ShadowFilterMode", std::to_string( static_cast<int>(s.ShadowFilterMode) ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "ShadowMapSize", std::to_string( s.ShadowMapSize ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "WorldShadowRangeScale", std::to_string( s.WorldShadowRangeScale ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "NumShadowCascades", std::to_string( s.NumShadowCascades ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "ShadowCascadePCFLimit", std::to_string( s.ShadowCascadePCFLimit ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "ShadowFrustumCullingMode", std::to_string( static_cast<int>(s.ShadowFrustumCullingMode) ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "PointlightShadows", std::to_string( s.EnablePointlightShadows ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "EnableDynamicLighting", std::to_string( s.EnableDynamicLighting ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "SmoothCameraUpdate", std::to_string( s.SmoothShadowCameraUpdate ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "SmoothShadowFrequency", std::to_string( s.SmoothShadowFrequency ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "ShadowStrength", std::to_string( s.ShadowStrength ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "ShadowSoftness", std::to_string( s.ShadowSoftness ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "ShadowAOStrength", std::to_string( s.ShadowAOStrength ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "WorldAOStrength", std::to_string( s.WorldAOStrength ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Shadows", "ShadowDepthSlopeBias", std::to_string( s.DebugSettings.ShadowCascades.ShadowDepthSlopeBias ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "EnableShadows", to_string_locale_independent( s.EnableShadows ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "ShadowFilterMode", to_string_locale_independent( static_cast<int>(s.ShadowFilterMode) ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "ShadowMapSize", to_string_locale_independent( s.ShadowMapSize ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "WorldShadowRangeScale", to_string_locale_independent( s.WorldShadowRangeScale ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "NumShadowCascades", to_string_locale_independent( s.NumShadowCascades ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "ShadowCascadePCFLimit", to_string_locale_independent( s.ShadowCascadePCFLimit ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "ShadowFrustumCullingMode", to_string_locale_independent( static_cast<int>(s.ShadowFrustumCullingMode) ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "PointlightShadows", to_string_locale_independent( s.EnablePointlightShadows ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "EnableDynamicLighting", to_string_locale_independent( s.EnableDynamicLighting ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "SmoothCameraUpdate", to_string_locale_independent( s.SmoothShadowCameraUpdate ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "SmoothShadowFrequency", to_string_locale_independent( s.SmoothShadowFrequency ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "ShadowStrength", to_string_locale_independent( s.ShadowStrength ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "ShadowSoftness", to_string_locale_independent( s.ShadowSoftness ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "ShadowAOStrength", to_string_locale_independent( s.ShadowAOStrength ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "WorldAOStrength", to_string_locale_independent( s.WorldAOStrength ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "ShadowDepthSlopeBias", to_string_locale_independent( s.DebugSettings.ShadowCascades.ShadowDepthSlopeBias ).c_str(), ini.c_str() );
 
-    // WritePrivateProfileStringA( "SMAA", "Enabled", std::to_string( s.EnableSMAA ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "AntiAliasing", std::to_string( (int)s.AntiAliasingMode ).c_str(), ini.c_str() );
+    // WritePrivateProfileStringA( "SMAA", "Enabled", to_string_locale_independent( s.EnableSMAA ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "AntiAliasing", to_string_locale_independent( (int)s.AntiAliasingMode ).c_str(), ini.c_str() );
 
-    WritePrivateProfileStringA( "SMAA", "SharpenFactor", std::to_string( s.SharpenFactor ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "SMAA", "SharpenFactor", to_string_locale_independent( s.SharpenFactor ).c_str(), ini.c_str() );
 
-    WritePrivateProfileStringA( "HBAO", "Enabled", std::to_string( s.HbaoSettings.Enabled ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "HBAO", "Bias", std::to_string( s.HbaoSettings.Bias ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "HBAO", "Radius", std::to_string( s.HbaoSettings.Radius ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "HBAO", "PowerExponent", std::to_string( s.HbaoSettings.PowerExponent ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "HBAO", "BlurSharpness", std::to_string( s.HbaoSettings.BlurSharpness ).c_str(), ini.c_str() );
-    //WritePrivateProfileStringA( "HBAO", "EnableDualLayerAO", std::to_string( s.HbaoSettings.EnableDualLayerAO ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "HBAO", "EnableBlur", std::to_string( s.HbaoSettings.EnableBlur ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "HBAO", "SsaoBlurRadius", std::to_string( s.HbaoSettings.SsaoBlurRadius ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "HBAO", "SsaoStepCount", std::to_string( s.HbaoSettings.SsaoStepCount ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "HBAO", "Enabled", to_string_locale_independent( s.HbaoSettings.Enabled ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "HBAO", "Bias", to_string_locale_independent( s.HbaoSettings.Bias ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "HBAO", "Radius", to_string_locale_independent( s.HbaoSettings.Radius ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "HBAO", "PowerExponent", to_string_locale_independent( s.HbaoSettings.PowerExponent ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "HBAO", "BlurSharpness", to_string_locale_independent( s.HbaoSettings.BlurSharpness ).c_str(), ini.c_str() );
+    //WritePrivateProfileStringA( "HBAO", "EnableDualLayerAO", to_string_locale_independent( s.HbaoSettings.EnableDualLayerAO ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "HBAO", "EnableBlur", to_string_locale_independent( s.HbaoSettings.EnableBlur ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "HBAO", "SsaoBlurRadius", to_string_locale_independent( s.HbaoSettings.SsaoBlurRadius ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "HBAO", "SsaoStepCount", to_string_locale_independent( s.HbaoSettings.SsaoStepCount ).c_str(), ini.c_str() );
 
-    WritePrivateProfileStringA( "AO", "Mode", std::to_string( static_cast<int>(s.AoMode) ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "SAO", "Radius", std::to_string( s.SaoSettings.Radius ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "SAO", "Bias", std::to_string( s.SaoSettings.Bias ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "SAO", "Intensity", std::to_string( s.SaoSettings.Intensity ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "SAO", "NumSamples", std::to_string( s.SaoSettings.NumSamples ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "SAO", "BlurSharpness", std::to_string( s.SaoSettings.BlurSharpness ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "AO", "Mode", to_string_locale_independent( static_cast<int>(s.AoMode) ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "SAO", "Radius", to_string_locale_independent( s.SaoSettings.Radius ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "SAO", "Bias", to_string_locale_independent( s.SaoSettings.Bias ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "SAO", "Intensity", to_string_locale_independent( s.SaoSettings.Intensity ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "SAO", "NumSamples", to_string_locale_independent( s.SaoSettings.NumSamples ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "SAO", "BlurSharpness", to_string_locale_independent( s.SaoSettings.BlurSharpness ).c_str(), ini.c_str() );
 
-    WritePrivateProfileStringA( "FontRendering", "Enable", std::to_string( s.EnableCustomFontRendering ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "FontRendering", "Enable", to_string_locale_independent( s.EnableCustomFontRendering ? TRUE : FALSE ).c_str(), ini.c_str() );
 
-    WritePrivateProfileStringA( "Debug", "ThreadedShadowCulling", std::to_string( s.ThreadedShadowCulling ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Debug", "UseShadowAtlas", std::to_string( s.DebugSettings.FeatureSet.UseShadowAtlas ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Debug", "UseScreenSpaceShadowMask", std::to_string( s.DebugSettings.FeatureSet.UseScreenSpaceShadowMask ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Debug", "ForceFeatureLevel10", std::to_string( s.DebugSettings.FeatureSet.ForceFeatureLevel10 ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Debug", "EnableDriverExtensions", std::to_string( s.DebugSettings.FeatureSet.EnableDriverExtensions ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Debug", "ThreadedShadowCulling", to_string_locale_independent( s.ThreadedShadowCulling ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Debug", "UseShadowAtlas", to_string_locale_independent( s.DebugSettings.FeatureSet.UseShadowAtlas ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Debug", "UseScreenSpaceShadowMask", to_string_locale_independent( s.DebugSettings.FeatureSet.UseScreenSpaceShadowMask ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Debug", "ForceFeatureLevel10", to_string_locale_independent( s.DebugSettings.FeatureSet.ForceFeatureLevel10 ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Debug", "EnableDriverExtensions", to_string_locale_independent( s.DebugSettings.FeatureSet.EnableDriverExtensions ? TRUE : FALSE ).c_str(), ini.c_str() );
 
     return XR_SUCCESS;
 }

--- a/D3D11Engine/Shaders/DS_Defines.h
+++ b/D3D11Engine/Shaders/DS_Defines.h
@@ -17,8 +17,7 @@ struct FORWARD_PLUS_PS_OUTPUT
 {
 	float4 vColor : SV_TARGET0;
 	float2 vNrm : SV_TARGET1;
-	float2 vSI_SP : SV_TARGET2;
-	float2 vVelocity : SV_TARGET3;
+	float2 vVelocity : SV_TARGET2;
 };
 
 

--- a/D3D11Engine/Shaders/PS_Atmosphere.hlsl
+++ b/D3D11Engine/Shaders/PS_Atmosphere.hlsl
@@ -84,6 +84,10 @@ PS_OUTPUT PSMain( PS_INPUT Input )
 	atmoColor += night * 0.4f;
 
 
+	// The sky world matrix uses XMMatrixTranspose(scale * translation), which strips the
+	// camera-position translation out of positionWorld.  What's left is v_local * OuterRadius,
+	// so normalize gives the unit sphere direction — correct for use with w=0 in ViewProj
+	// (w=0 already ignores translation; only the rotation delta between frames matters).
 	float4 viewDir = float4(normalize(Input.vWorldPosition), 0.0f);
 	float4 curPosClip = mul(viewDir, Frame_UnjitteredViewProj);
 	float4 prevPosClip = mul(viewDir, Frame_PrevViewProj);

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -164,7 +164,6 @@ FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 	float focusBrightness = 1.0f + step(1.5f, Input.vDiffuse.w) * 1.0f;
 	output.vColor = float4(litPixel * focusBrightness, 1);
 	output.vNrm = EncodeNormalGBuffer(nrm);
-	output.vSI_SP = float2(specIntensity, specPower);
 	output.vVelocity = CalculateVelocity(Input.vCurrClipPos, Input.vPrevClipPos);
 
 	return output;

--- a/D3D11Engine/ThreadPool.h
+++ b/D3D11Engine/ThreadPool.h
@@ -14,36 +14,15 @@
 #include <algorithm>
 #include <utility>
 
-class CancellationToken
-{
-private:
-    std::shared_ptr<std::atomic<bool>> cancelledFlag;
-
-public:
-    CancellationToken() : cancelledFlag(std::make_shared<std::atomic<bool>>(false))
-    {
-    }
-
-    bool isCancelled() const
-    {
-        return cancelledFlag->load(std::memory_order_acquire);
-    }
-
-    void cancel()
-    {
-        cancelledFlag->store(true, std::memory_order_release);
-    }
-};
-
 template <typename T>
 struct TaskHandle
 {
     std::future<T> future;
-    CancellationToken token;
+    std::stop_source token;
 
     void cancel()
     {
-        token.cancel();
+        token.request_stop();
     }
 };
 
@@ -52,21 +31,21 @@ class ThreadPool
 public:
     ThreadPool(
         const wchar_t* poolIdentifier,
-        size_t threads = std::clamp(static_cast<size_t>(std::thread::hardware_concurrency()), static_cast<size_t>(1),
-                                    static_cast<size_t>(6)));
+        size_t threads = std::clamp( static_cast<size_t>(std::thread::hardware_concurrency()), static_cast<size_t>(1),
+            static_cast<size_t>(6) ) );
 
-    //  enqueue returns a TaskHandle and expects 'F' to accept CancellationToken as its first param
+    //  enqueue returns a TaskHandle and expects 'F' to accept std::stop_source as its first param
     template <typename F, typename... Args>
     auto enqueue( F&& f, Args&&... args ) {
-        using ReturnType = std::invoke_result_t<F, CancellationToken, Args...>;
+        using ReturnType = std::invoke_result_t<F, std::stop_token, Args...>;
 
-        CancellationToken token;
+        std::stop_source token;
 
         auto task = std::make_shared<std::packaged_task<ReturnType()>>(
             [f = std::forward<F>( f ),
              token,
              ...args = std::forward<Args>( args )]() mutable {
-                     return std::invoke( std::move( f ), token, std::forward<Args>( args )... );
+                 return std::invoke( std::move( f ), token.get_token(), std::forward<Args>(args)...);
             }
         );
 
@@ -78,9 +57,9 @@ public:
                 throw std::runtime_error( "enqueue on stopped ThreadPool" );
             }
 
-            tasks.emplace( [task]() 
-            { 
-                (*task)(); 
+            tasks.emplace( [task]()
+            {
+                (*task)();
             }, token );
         }
         condition.notify_one();
@@ -94,37 +73,36 @@ public:
 
     bool getIsBusy()
     {
-        std::unique_lock<std::mutex> lock(queue_mutex);
+        std::unique_lock<std::mutex> lock( queue_mutex );
         return !tasks.empty() || activeTasks.load() > 0;
     }
 
     void clearAndFlush()
     {
         // Swap out the tasks quickly to minimize mutex lock time
-        std::queue<std::pair<std::function<void()>, CancellationToken>> pending_tasks;
+        std::queue<std::pair<std::function<void()>, std::stop_source>> pending_tasks;
         {
-            std::unique_lock<std::mutex> lock(queue_mutex);
-            std::swap(tasks, pending_tasks);
+            std::unique_lock<std::mutex> lock( queue_mutex );
+            std::swap( tasks, pending_tasks );
         }
 
         // Cancel and invoke all pending tasks so promises are fulfilled gracefully
-        while (!pending_tasks.empty())
-        {
+        while ( !pending_tasks.empty() ) {
             auto& taskItem = pending_tasks.front();
-            taskItem.second.cancel(); // Trigger the cancellation state
+            taskItem.second.request_stop(); // Trigger the cancellation state
             taskItem.first(); // Invoke the task, assume it will immediately return.
             pending_tasks.pop();
         }
 
         // Wait for actively running tasks to finish
-        while (getIsBusy()) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        while ( getIsBusy() ) {
+            std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
         }
     }
 
 private:
     std::vector<std::thread> workers;
-    std::queue<std::pair<std::function<void()>, CancellationToken>> tasks;
+    std::queue<std::pair<std::function<void()>, std::stop_source>> tasks;
 
     std::atomic_int activeTasks{0};
     std::mutex queue_mutex;


### PR DESCRIPTION
- locale independent parsing: use `from_chars` and `to_chars`
- std::stop_token: replace CancellationToken with c++20 stop_token
- SRV/RTV warnings in Forward+: remove specular output
- improve TAA ping-pong: remove needless fullscreen blit
- fix FSR1: missing vertex shader setup
- fix sky motion vectors with atmospheric scattering: incorrect PS Cb setup and incorrectly "set" previous view directly after geometry, before drawing sky.