### PR TITLE
a bunch of smaller fixes, DirectXMath update, native `Alg_Rotation3DNRad` implementation

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,9 +34,9 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/out/build/${presetName}",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
-        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_STANDARD": "20",
         "GD3D11_BUILD_ENGINE": "ON",
         "GD3D11_BUILD_LAUNCHER": "ON",
@@ -177,8 +177,17 @@
       "name": "Release_NoOpt_Clang",
       "inherits": "base-clang",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "GD3D11_PROFILE": "NOOPT",
+        "GD3D11_TRACY_ENABLE": "ON",
+        "GD3D11_TRACY_ON_DEMAND": "ON",
+        "GD3D11_TRACY_CALLSTACK": "8"
+      }
+    },
+    {
+      "name": "Release_AVX_Clang",
+      "inherits": "base-clang",
+      "cacheVariables": {
+        "GD3D11_SIMD": "AVX",
         "GD3D11_TRACY_ENABLE": "ON",
         "GD3D11_TRACY_ON_DEMAND": "ON",
         "GD3D11_TRACY_CALLSTACK": "8"

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1389,8 +1389,8 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\directxmesh_desktop_2019.2023.4.28.1\build\native\directxmesh_desktop_2019.targets" Condition="Exists('..\packages\directxmesh_desktop_2019.2023.4.28.1\build\native\directxmesh_desktop_2019.targets')" />
     <Import Project="..\packages\directxtk_desktop_2019.2023.4.28.1\build\native\directxtk_desktop_2019.targets" Condition="Exists('..\packages\directxtk_desktop_2019.2023.4.28.1\build\native\directxtk_desktop_2019.targets')" />
-    <Import Project="..\packages\directxmath.2025.4.3.1\build\native\directxmath.targets" Condition="Exists('..\packages\directxmath.2025.4.3.1\build\native\directxmath.targets')" />
     <Import Project="..\packages\Microsoft.XAudio2.Redist.1.2.13\build\native\Microsoft.XAudio2.Redist.targets" Condition="Exists('..\packages\Microsoft.XAudio2.Redist.1.2.13\build\native\Microsoft.XAudio2.Redist.targets')" />
+    <Import Project="..\packages\directxmath.2026.6.12.1\build\native\directxmath.targets" Condition="Exists('..\packages\directxmath.2026.6.12.1\build\native\directxmath.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -1398,8 +1398,8 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\directxmesh_desktop_2019.2023.4.28.1\build\native\directxmesh_desktop_2019.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxmesh_desktop_2019.2023.4.28.1\build\native\directxmesh_desktop_2019.targets'))" />
     <Error Condition="!Exists('..\packages\directxtk_desktop_2019.2023.4.28.1\build\native\directxtk_desktop_2019.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtk_desktop_2019.2023.4.28.1\build\native\directxtk_desktop_2019.targets'))" />
-    <Error Condition="!Exists('..\packages\directxmath.2025.4.3.1\build\native\directxmath.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxmath.2025.4.3.1\build\native\directxmath.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.XAudio2.Redist.1.2.13\build\native\Microsoft.XAudio2.Redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.XAudio2.Redist.1.2.13\build\native\Microsoft.XAudio2.Redist.targets'))" />
+    <Error Condition="!Exists('..\packages\directxmath.2026.6.12.1\build\native\directxmath.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxmath.2026.6.12.1\build\native\directxmath.targets'))" />
   </Target>
   <!-- For NuGet! This is needed because we use different configuration names than the defaults -->
   <PropertyGroup>

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -404,9 +404,7 @@ void __cdecl AGS_EndUAVOverlap( ID3D11DeviceContext* context ) {
     agsDevice->EndUAVOverlap( context );
 }
 
-void D3D11GraphicsEngine::CreateAndBindDefaultSampler() {
-    HRESULT hr;
-    
+void D3D11GraphicsEngine::CreateAndBindDefaultSampler() {   
     float scaleRatio = static_cast<float>(GetScaledResolution().x) / static_cast<float>(GetBackbufferResolution().x);
     // Calculate raw bias, but clamp it to a maximum of 0.0f to protect Supersampling
     float mipBias = std::min(0.0f, std::log2(scaleRatio));

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -569,8 +569,8 @@ XRESULT D3D11ShadowMap::PrepareRender()
     // Array für alle Cascade-Matrizen
     bool isOutdoor = Engine::GAPI->GetLoadedWorldInfo()->BspTree->GetBspTreeMode() == zBSP_MODE_OUTDOOR;
 
-    const FXMVECTOR p = WorldShadowCP + dir * 10000.0f;
-    const FXMVECTOR lookAt = WorldShadowCP;
+    const XMVECTOR p = WorldShadowCP + dir * 10000.0f;
+    const XMVECTOR lookAt = WorldShadowCP;
 
     const XMVECTOR lastCascadeP = lastCascadeData.Position + lastCascadeData.LightDir * 10000.0f;
     const XMVECTOR lastCascadeLookAt = lastCascadeData.Position;

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -52,10 +52,9 @@ void CalculateTemporalInterpolatedPosition(
     // Additionally apply quantization for sub-texel stability
     // This snaps the direction to discrete steps to prevent micro-flickering
     XMVECTOR scale = XMVectorReplicate( frequency );
-    dir = XMVectorDivide(
-        _mm_cvtepi32_ps( _mm_cvtps_epi32( XMVectorMultiply( dir, scale ) ) ),
-        scale
-    );
+    dir = XMVectorMultiply( dir, scale );
+    dir = XMVectorRound( dir );
+    dir = XMVectorDivide( dir, scale );
     outDir = XMVector3Normalize( dir );
 }
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1,4 +1,5 @@
 #include <Windows.h>
+#include <algorithm>
 #include <string>
 #include <sstream>
 #include "pch.h"
@@ -1392,7 +1393,7 @@ void GothicAPI::DrawWorldMeshNaive() {
             // Schedule for drawing in later stage if this vob is ghost
             if ( vobInfo->Vob->GetVisualAlpha() ) {
                 TransparencyVobs.emplace_back( dist, vobInfo->Vob->GetVobTransparency(), vobInfo, nullptr );
-                std::push_heap( TransparencyVobs.begin(), TransparencyVobs.end(), CompareGhostDistance );
+                std::ranges::push_heap(TransparencyVobs, CompareGhostDistance );
                 continue;
             }
 
@@ -1726,7 +1727,7 @@ void GothicAPI::GetVisibleDecalList( std::vector<zCVob*>& decals ) {
     }
 
     // Sort back to front
-    std::sort( decalDistances.begin(), decalDistances.end(), DecalSortcmpFunc );
+    std::ranges::sort(decalDistances, DecalSortcmpFunc );
 
     // Put into output list
     decals.reserve(decalDistances.size());
@@ -2064,13 +2065,13 @@ void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world ) {
     VobLightInfo* li = VobLightMap[static_cast<zCVobLight*>(vob)];
 
     // Erase it from the particle-effect list
-    auto pit = std::find( ParticleEffectVobs.begin(), ParticleEffectVobs.end(), vob );
+    auto pit = std::ranges::find(ParticleEffectVobs, vob );
     if ( pit != ParticleEffectVobs.end() ) {
         DestroyParticleEffect( *pit );
         *pit = ParticleEffectVobs.back();
         ParticleEffectVobs.pop_back();
     }
-    auto dit = std::find( DecalVobs.begin(), DecalVobs.end(), vob );
+    auto dit = std::ranges::find(DecalVobs, vob );
     if ( dit != DecalVobs.end() ) {
         *dit = DecalVobs.back();
         DecalVobs.pop_back();
@@ -3075,7 +3076,7 @@ void GothicAPI::DrawTransparencyVobs() {
             }
         }
 
-        std::pop_heap( TransparencyVobs.begin(), TransparencyVobs.end(), CompareGhostDistance );
+        std::ranges::pop_heap(TransparencyVobs, CompareGhostDistance );
         TransparencyVobs.pop_back();
     }
 }
@@ -4036,7 +4037,7 @@ void GothicAPI::CollectVisibleVobs(
             sortList.push_back( { v, d } );
         }
 
-        std::sort( sortList.begin(), sortList.end(), []( const SortableVob& a, const SortableVob& b ) {
+        std::ranges::sort(sortList, []( const SortableVob& a, const SortableVob& b ) {
             return a.distSq < b.distSq;
         } );
         for ( size_t i = 0; i < vobs.size(); ++i ) vobs[i] = sortList[i].vob;
@@ -4053,7 +4054,7 @@ void GothicAPI::CollectVisibleVobs(
             skelsortList.push_back( { v, d } );
         }
 
-        std::sort( skelsortList.begin(), skelsortList.end(), []( const SortableSkeletalVob& a, const SortableSkeletalVob& b ) {
+        std::ranges::sort(skelsortList, []( const SortableSkeletalVob& a, const SortableSkeletalVob& b ) {
             return a.distSq < b.distSq;
         } );
         for ( size_t i = 0; i < mobs.size(); ++i ) mobs[i] = skelsortList[i].vob;
@@ -4090,7 +4091,7 @@ void GothicAPI::CollectVisibleVobs(
             // ignore dead items in renderQueue.transparent after move-insert
 
             // sort back to front
-            std::sort( TransparencyVobs.begin(), TransparencyVobs.end(), CompareGhostDistance );
+            std::ranges::sort(TransparencyVobs, CompareGhostDistance );
         }
 
         float minDynamicUpdateLightRange = Engine::GAPI->GetRendererState().RendererSettings.MinLightShadowUpdateRange;
@@ -4108,7 +4109,7 @@ void GothicAPI::CollectVisibleVobs(
             }
         }
 
-        std::sort( lightWithDist.begin(), lightWithDist.end(), []( const std::pair<float, VobLightInfo*>& a, const std::pair<float, VobLightInfo*>& b ) {
+        std::ranges::sort(lightWithDist, []( const std::pair<float, VobLightInfo*>& a, const std::pair<float, VobLightInfo*>& b ) {
             return a.first < b.first;
         });
 
@@ -4608,20 +4609,20 @@ void GothicAPI::BuildBspVobMapCacheHelper( zCBspBase* base ) {
                     // Treat indoor vobs as indoor vobs only in outdoor locations
                     if ( outdoorLocation && vob->IsIndoorVob() ) {
                         // Only add once
-                        if ( std::find( bvi.IndoorVobs.begin(), bvi.IndoorVobs.end(), v ) == bvi.IndoorVobs.end() ) {
+                        if (std::ranges::find(bvi.IndoorVobs, v ) == bvi.IndoorVobs.end() ) {
                             v->ParentBSPNodes.push_back( &bvi );
                             bvi.IndoorVobs.push_back( v );
                             v->IsIndoorVob = true;
                         }
                     } else if ( v->VisualInfo->MeshSize < vobSmallSize ) {
                         // Only add once
-                        if ( std::find( bvi.SmallVobs.begin(), bvi.SmallVobs.end(), v ) == bvi.SmallVobs.end() ) {
+                        if (std::ranges::find(bvi.SmallVobs, v ) == bvi.SmallVobs.end() ) {
                             v->ParentBSPNodes.push_back( &bvi );
                             bvi.SmallVobs.push_back( v );
                         }
                     } else {
                         // Only add once
-                        if ( std::find( bvi.Vobs.begin(), bvi.Vobs.end(), v ) == bvi.Vobs.end() ) {
+                        if (std::ranges::find(bvi.Vobs, v ) == bvi.Vobs.end() ) {
                             v->ParentBSPNodes.push_back( &bvi );
                             bvi.Vobs.push_back( v );
                         }
@@ -4635,7 +4636,7 @@ void GothicAPI::BuildBspVobMapCacheHelper( zCBspBase* base ) {
                 SkeletalVobInfo* v = sit->second;
                 if ( v ) {
                     // Only add once
-                    if ( std::find( bvi.Mobs.begin(), bvi.Mobs.end(), v ) == bvi.Mobs.end() ) {
+                    if (std::ranges::find(bvi.Mobs, v ) == bvi.Mobs.end() ) {
                         v->ParentBSPNodes.push_back( &bvi );
                         bvi.Mobs.push_back( v );
                     }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -3606,7 +3606,7 @@ XMFLOAT3 GothicAPI::GetCameraPosition() {
     return oCGame::GetGame()->_zCSession_camVob->GetPositionWorld();
 }
 /** Returns the current cameraposition */
-FXMVECTOR GothicAPI::GetCameraPositionXM() {
+XMVECTOR GothicAPI::GetCameraPositionXM() {
     if ( !oCGame::GetGame()->_zCSession_camVob )
         return g_XMZero;
 
@@ -3708,10 +3708,10 @@ float GothicAPI::GetFarZ() {
 }
 
 /** Returns the fog-color */
-FXMVECTOR GothicAPI::GetFogColor() {
+XMVECTOR GothicAPI::GetFogColor() {
     zCSkyController_Outdoor* sc = oCGame::GetGame()->_zCSession_world->GetSkyControllerOutdoor();
 
-    FXMVECTOR FogColorMod = XMLoadFloat3( RendererState.RendererSettings.FogColorMod.toXMFLOAT3() );
+    XMVECTOR FogColorMod = XMLoadFloat3( RendererState.RendererSettings.FogColorMod.toXMFLOAT3() );
 
     // Only give the overridden color out if the flag is set
     if ( !sc || !sc->GetOverrideFlag() )
@@ -6137,7 +6137,7 @@ static void CollectLeafVobs(
     const float vobOutdoorSmallDistSq = ctx.drawDistancesSq.OutdoorVobsSmall;
     const float visualFXDrawRadius = ctx.drawDistances.VisualFX;
     const float visualFXDrawRadiusSq = ctx.drawDistancesSq.VisualFX;
-    const FXMVECTOR cameraPosition = XMLoadFloat3( &ctx.cameraPosition );
+    const XMVECTOR cameraPosition = XMLoadFloat3( &ctx.cameraPosition );
     const bool collectIndoorVobs = ctx.drawFlags.CollectIndoorVobs;
     const bool collectMobs = ctx.drawFlags.CollectMobs;
     const bool collectLights = ctx.drawFlags.CollectLights;
@@ -6229,7 +6229,7 @@ static void CollectVisibleVobsHelper( BspInfo* base,
 ) {
     const float vobOutdoorDist = ctx.drawDistances.OutdoorVobs;
     const XMFLOAT3 camPos = ctx.cameraPosition;
-    const FXMVECTOR cameraPosition = XMLoadFloat3( &camPos );
+    const XMVECTOR cameraPosition = XMLoadFloat3( &camPos );
     const bool enableOcclusionCulling = ctx.drawFlags.EnableOcclusionCulling;
     while ( base->OriginalNode ) {
         // Check for occlusion-culling

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -476,7 +476,7 @@ public:
 
     /** Returns the current cameraposition */
     XMFLOAT3 GetCameraPosition();
-    FXMVECTOR XM_CALLCONV GetCameraPositionXM();
+    XMVECTOR XM_CALLCONV GetCameraPositionXM();
     zTCam_ClipType GetCameraBBox3DInFrustum(const zTBBox3D& box, int clipFlags = EGothicCullFlags::CullAll);
     zTCam_ClipType GetCameraBBox3DInFrustum(const zCVob* vob, int clipFlags, bool isLocalCamera);
 
@@ -513,7 +513,7 @@ public:
     float GetFarZ();
 
     /** Returns the fog-color */
-    FXMVECTOR GetFogColor();
+    XMVECTOR GetFogColor();
 
     /** Returns true if the game is overwriting the fog color with a fog-zone */
     float GetFogOverride();

--- a/D3D11Engine/Toolbox.cpp
+++ b/D3D11Engine/Toolbox.cpp
@@ -130,8 +130,8 @@ namespace Toolbox {
     }
 
     /** Computes the Normal of a triangle */
-    FXMVECTOR ComputeNormal( const XMFLOAT3& v0, const XMFLOAT3& v1, const XMFLOAT3& v2 ) {
-        FXMVECTOR Normal = XMVector3Normalize( XMVector3Cross( (XMLoadFloat3( &v1 ) - XMLoadFloat3( &v0 )), (XMLoadFloat3( &v2 ) - XMLoadFloat3( &v0 )) ) );
+    XMVECTOR ComputeNormal( const XMFLOAT3& v0, const XMFLOAT3& v1, const XMFLOAT3& v2 ) {
+        XMVECTOR Normal = XMVector3Normalize( XMVector3Cross( (XMLoadFloat3( &v1 ) - XMLoadFloat3( &v0 )), (XMLoadFloat3( &v2 ) - XMLoadFloat3( &v0 )) ) );
 
         return Normal;
     }

--- a/D3D11Engine/Toolbox.h
+++ b/D3D11Engine/Toolbox.h
@@ -180,7 +180,7 @@ namespace Toolbox {
     bool IntersectTri( const XMFLOAT3& v0, const XMFLOAT3& v1, const XMFLOAT3& v2, const XMFLOAT3& origin, const XMFLOAT3& direction, float& u, float& v, float& t );
 
     /** Computes the normal of a triangle */
-    FXMVECTOR ComputeNormal( const XMFLOAT3& v0, const XMFLOAT3& v1, const XMFLOAT3& v2 );
+    XMVECTOR ComputeNormal( const XMFLOAT3& v0, const XMFLOAT3& v1, const XMFLOAT3& v2 );
 
     /** Computes the distance of a point to an AABB */
     float ComputePointAABBDistance( const XMFLOAT3& p, const XMFLOAT3& min, const XMFLOAT3& max );

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -780,8 +780,7 @@ void WorldConverter::GenerateFullSectionMesh( WorldMeshSectionInfo& section ) {
         if ( it->IsIndoorVob )
             continue;
 
-        XMFLOAT4X4 world;
-        it->Vob->GetWorldMatrix( &world );
+        XMFLOAT4X4 world; it->Vob->GetWorldMatrix( world );
         XMMATRIX XMM_world = XMMatrixTranspose( XMLoadFloat4x4( &world ) );
 
         // Insert the vob

--- a/D3D11Engine/amd_ags.h
+++ b/D3D11Engine/amd_ags.h
@@ -1,4 +1,6 @@
+#ifdef __clang__
 #pragma clang diagnostic ignored "-Wignored-attributes"
+#endif
 
 //
 // Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/D3D11Engine/packages.config
+++ b/D3D11Engine/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="directxmath" version="2025.4.3.1" targetFramework="native" />
+  <package id="directxmath" version="2026.6.12.1" targetFramework="native" />
   <package id="directxmesh_desktop_2019" version="2023.4.28.1" targetFramework="native" />
   <package id="directxtk_desktop_2019" version="2023.4.28.1" targetFramework="native" />
   <package id="Microsoft.XAudio2.Redist" version="1.2.13" targetFramework="native" />

--- a/D3D11Engine/zCFlash.h
+++ b/D3D11Engine/zCFlash.h
@@ -55,14 +55,14 @@ public:
     }
 
     /** Returns the world-position of this visual */
-    FXMVECTOR XM_CALLCONV GetStartPositionWorld() const {
+    XMVECTOR XM_CALLCONV GetStartPositionWorld() const {
         return XMVectorSet( *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCFlash::Offset_StartPosX )),
             *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCFlash::Offset_StartPosY )),
             *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCFlash::Offset_StartPosZ )),
             0.0f );
     }
 
-    FXMVECTOR XM_CALLCONV GetEndPositionWorld() const {
+    XMVECTOR XM_CALLCONV GetEndPositionWorld() const {
         return XMVectorSet( *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCFlash::Offset_EndPosX )),
             *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCFlash::Offset_EndPosY )),
             *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCFlash::Offset_EndPosZ )),

--- a/D3D11Engine/zCSkyController_Outdoor.h
+++ b/D3D11Engine/zCSkyController_Outdoor.h
@@ -284,18 +284,13 @@ public:
 
     __forceinline void __vectorcall MatrixVector3Multiply( XMFLOAT3& p, FXMVECTOR V, FXMMATRIX M ) noexcept
     {
-        __m128 R0 = _mm_add_ss( XMVector3Dot( M.r[0], V ), _mm_shuffle_ps( M.r[0], M.r[0], _MM_SHUFFLE( 3, 3, 3, 3 ) ) );
-        __m128 R1 = _mm_add_ss( XMVector3Dot( M.r[1], V ), _mm_shuffle_ps( M.r[1], M.r[1], _MM_SHUFFLE( 3, 3, 3, 3 ) ) );
-        __m128 R2 = _mm_add_ss( XMVector3Dot( M.r[2], V ), _mm_shuffle_ps( M.r[2], M.r[2], _MM_SHUFFLE( 3, 3, 3, 3 ) ) );
-        p.x = _mm_cvtss_f32( R0 );
-        p.y = _mm_cvtss_f32( R1 );
-        p.z = _mm_cvtss_f32( R2 );
+        XMVECTOR result = XMVector3Transform( V, M );
+        XMStoreFloat3( &p, result );
     }
 
     XMMATRIX XM_CALLCONV Alg_Rotation3DNRad( FXMVECTOR Axis, const float angleRad ) {
         // requires axis to be normalized
-        // Engine takes in angleRad and calculates it reverse
-        return XMMatrixRotationNormal( Axis, -angleRad );
+        return XMMatrixRotationNormal( Axis, angleRad );
     }
 
     /** Returns the sun position in world coords */
@@ -320,8 +315,8 @@ public:
 
         // constexpr XMVECTORF32 sunPos = { -60, 0, 100, 0 };
         // pre-calculated using XMVector3Normalize
-        constexpr XMVECTORF32 sunPosNormalized = { -0.514495730, 0.00000000, 0.857492924, 0 };
-        constexpr XMVECTORF32 rotAxis = { 1, 0, 0, 0 };
+        constexpr XMVECTORF32 sunPosNormalized = { -0.514495730f, 0.0f, 0.857492924f, 0.0f };
+        constexpr XMVECTORF32 rotAxis = { 1.0f, 0.0f, 0.0f, 0.0f };
 
         XMFLOAT3 pos;
         //XMVector3NormalizeEst leads to jumping shadows dueto reduced accuracy in combination with XMStoreFloat3( &LightDir, XMVector3NormalizeEst( XMLoadFloat3( &LightDir ) ) ); but setting this mentioned code line in this comment to non Est does not influence if this active code line before the comment is Est or not

--- a/D3D11Engine/zCSkyController_Outdoor.h
+++ b/D3D11Engine/zCSkyController_Outdoor.h
@@ -238,7 +238,7 @@ public:
             ( GothicMemoryLocations::zCSkyController_Outdoor::GetUnderwaterFX )( this );
     }
 
-    zColor ChangeSaturation( zColor color, float sat )
+    static zColor ChangeSaturation( zColor color, float sat )
     {
         float avg = (color.bgra.r + color.bgra.g + color.bgra.b) / 3.0f;
 
@@ -282,13 +282,13 @@ public:
 #endif
     }
 
-    __forceinline void __vectorcall MatrixVector3Multiply( XMFLOAT3& p, FXMVECTOR V, FXMMATRIX M ) noexcept
+    static __forceinline void __vectorcall MatrixVector3Multiply( XMFLOAT3& p, FXMVECTOR V, FXMMATRIX M ) noexcept
     {
         XMVECTOR result = XMVector3Transform( V, M );
         XMStoreFloat3( &p, result );
     }
 
-    XMMATRIX XM_CALLCONV Alg_Rotation3DNRad( FXMVECTOR Axis, const float angleRad ) {
+    static XMMATRIX XM_CALLCONV Alg_Rotation3DNRad( FXMVECTOR Axis, const float angleRad ) {
         // requires axis to be normalized
         return XMMatrixRotationNormal( Axis, angleRad );
     }

--- a/D3D11Engine/zCSkyController_Outdoor.h
+++ b/D3D11Engine/zCSkyController_Outdoor.h
@@ -292,6 +292,12 @@ public:
         p.z = _mm_cvtss_f32( R2 );
     }
 
+    XMMATRIX XM_CALLCONV Alg_Rotation3DNRad( FXMVECTOR Axis, const float angleRad ) {
+        // requires axis to be normalized
+        // Engine takes in angleRad and calculates it reverse
+        return XMMatrixRotationNormal( Axis, -angleRad );
+    }
+
     /** Returns the sun position in world coords */
     XMFLOAT3 GetSunWorldPosition( float timeScale = 1.0f ) {
         float skyTime = GetMasterTime();
@@ -312,14 +318,15 @@ public:
             angle = skyTime * timeScale * XM_2PI + XM_PIDIV2;
         }
 
-        constexpr XMVECTORF32 sunPos = { -60, 0, 100, 0 };
-        XMFLOAT3 rotAxis = XMFLOAT3( 1, 0, 0 );
+        // constexpr XMVECTORF32 sunPos = { -60, 0, 100, 0 };
+        // pre-calculated using XMVector3Normalize
+        constexpr XMVECTORF32 sunPosNormalized = { -0.514495730, 0.00000000, 0.857492924, 0 };
+        constexpr XMVECTORF32 rotAxis = { 1, 0, 0, 0 };
 
         XMFLOAT3 pos;
         //XMVector3NormalizeEst leads to jumping shadows dueto reduced accuracy in combination with XMStoreFloat3( &LightDir, XMVector3NormalizeEst( XMLoadFloat3( &LightDir ) ) ); but setting this mentioned code line in this comment to non Est does not influence if this active code line before the comment is Est or not
-        const XMFLOAT4X4 sunRotation = HookedFunctions::OriginalFunctions.original_Alg_Rotation3DNRad( rotAxis, -angle );
-        MatrixVector3Multiply( pos, XMVector3Normalize( sunPos ), XMLoadFloat4x4( &sunRotation ) );
-
+        const XMMATRIX sunRotation = Alg_Rotation3DNRad( rotAxis, -angle );
+        MatrixVector3Multiply( pos, sunPosNormalized, sunRotation );
         return pos;
     }
 

--- a/D3D11Engine/zCVob.h
+++ b/D3D11Engine/zCVob.h
@@ -174,9 +174,9 @@ public:
     }
 
     /** Returns the world-position of this vob */
-    FXMVECTOR XM_CALLCONV GetPositionWorldXM() const {
+    XMVECTOR XM_CALLCONV GetPositionWorldXM() const {
         // Get the data right off the memory to save a function call
-        FXMVECTOR pos = XMVectorSet( *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_WorldPosX )),
+        XMVECTOR pos = XMVectorSet( *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_WorldPosX )),
             *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_WorldPosY )),
             *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_WorldPosZ )), 0 );
         return pos;
@@ -210,7 +210,7 @@ public:
     }
 
     /** Return the world/global bbox of the vob */
-    zTBBox3D GetBBox() const {
+    const zTBBox3D& GetBBox() const {
         return *reinterpret_cast<zTBBox3D*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_WorldBBOX ));
     }
 
@@ -220,8 +220,8 @@ public:
     }
 
     /** Copys the world matrix into the given memory location */
-    void GetWorldMatrix( XMFLOAT4X4* m ) const {
-        *m = *GetWorldMatrixPtr();
+    void GetWorldMatrix( XMFLOAT4X4& m ) const {
+        m = *GetWorldMatrixPtr();
     }
 
     /** Returns a copy of the world matrix */

--- a/cmake/GD3D11Helpers.cmake
+++ b/cmake/GD3D11Helpers.cmake
@@ -251,6 +251,7 @@ function(gd3d11_apply_common_compile_settings target_name)
         $<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fms-extensions>
         -Wno-switch
         -Wno-defaulted-function-deleted # DirectXMath uses = default for XMFLOAT4X4 which causes this warning
+        -fno-strict-aliasing # disable strict aliasing
       )
       target_link_options(${target_name} PRIVATE -m32)
     endif()
@@ -260,7 +261,7 @@ function(gd3d11_apply_common_compile_settings target_name)
     if(GD3D11_SIMD STREQUAL "AVX")
       target_compile_options(${target_name} PRIVATE -mavx)
     elseif(GD3D11_SIMD STREQUAL "AVX2")
-      target_compile_options(${target_name} PRIVATE -mavx2)
+      target_compile_options(${target_name} PRIVATE -mavx2 -mfma -mf16c)
     else()
       target_compile_options(${target_name} PRIVATE -msse2)
     endif()


### PR DESCRIPTION
- make some helper functions `static`
- cmake
  - add build preset for AVX
  - make AVX2 preset also enable `fma` & `f16c` which are both needed for msvc equivalency and DirectXMath assumes it's availability when AVX2 is enabled.
  - cmake optimized builds are still broken as frustum culling doesn't work for some (UB?) reason.
- apply usage of `std::ranges::(sort|push_heap|pop_heap)`
- fix some incorrect `FXMVECTOR` type declarations