### PR TITLE
fix: G1 highlight NPCs only when not talking, introduce BUILD_GOTHIC_1_CLASSIC and BUILD_GOTHIC_1_SEQUEL

### DIFF
--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -403,7 +403,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;BUILD_SPACER_NET;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;BUILD_GOTHIC_1_CLASSIC;BUILD_SPACER_NET;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ExceptionHandling>false</ExceptionHandling>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -552,7 +552,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;BUILD_GOTHIC_1_CLASSIC;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -593,7 +593,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;BUILD_1_12F;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;BUILD_1_12F;BUILD_GOTHIC_1_SEQUEL;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -634,7 +634,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;BUILD_GOTHIC_1_CLASSIC;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -676,7 +676,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;BUILD_GOTHIC_1_CLASSIC;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -829,7 +829,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;BUILD_GOTHIC_1_CLASSIC;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4005;4530;4577;6246;6322;26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -7794,7 +7794,7 @@ XRESULT D3D11GraphicsEngine::DrawSky() {
         rendererState.RasterizerState.SetDirty();
         UpdateRenderStates();
 
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
         // Draw sky first
         reinterpret_cast<void( __fastcall* )(zCSkyController_Outdoor*)>(0x5C0900)(Engine::GAPI->GetLoadedWorldInfo()->MainWorld->GetSkyControllerOutdoor());
 
@@ -7888,7 +7888,7 @@ XRESULT D3D11GraphicsEngine::DrawSky() {
 
     if ( sky->GetSkyDome() ) sky->GetSkyDome()->DrawMesh();
 
-    #if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+    #if defined(BUILD_GOTHIC_1_CLASSIC)
     {
         SetDefaultStates();
         rendererState.DepthState.DepthWriteEnabled = false;

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -55,6 +55,7 @@
 #include "RenderGraph.h"
 #include "D3D11Upscaling.h"
 #include "oCMobInter.h"
+#include "zCParser.h"
 
 #ifdef BUILD_SPACER
 #define IS_SPACER_BUILD true
@@ -3001,7 +3002,14 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
     const float meleeFocusEnabled = oCGame::GetHighlightMeleeFocus() >= 2 && oCGame::GetNpcFocusIsHighlightActive();
     zCVob* playerFocusVob = oCGame::GetPlayer() ? oCGame::GetPlayer()->GetFocusVob() : nullptr;
     if ( playerFocusVob ) {
-        if ( playerFocusVob->As<oCNPC>() ) {
+        if ( auto npc = playerFocusVob->As<oCNPC>() ) {
+#ifdef BUILD_GOTHIC_1_CLASSIC
+            static int idxZsTalk = -2;
+            if (idxZsTalk == -2) { idxZsTalk = zCParser::GetParser()->GetIndex("ZS_TALK"); }
+            if ( npc->GetStates()->IsInState( idxZsTalk ) ) {
+                playerFocusVob = nullptr;
+            } else
+#endif
             if ( !meleeFocusEnabled ) {
                 playerFocusVob = nullptr;
             }

--- a/D3D11Engine/DLLMain.cpp
+++ b/D3D11Engine/DLLMain.cpp
@@ -27,7 +27,7 @@ ZUnquantizeHalfFloat_X4 UnquantizeHalfFloat_X8;
 
 static HINSTANCE hLThis = 0;
 static bool comInitialized = false;
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
 bool haveWindAnimations = false;
 #endif
 bool userHaveAMDGPU = false;
@@ -307,7 +307,7 @@ extern "C" void WINAPI LoadCustomZENResources() {
 }
 
 extern "C" void WINAPI EnableWindAnimations( void ) {
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
     haveWindAnimations = true;
 #endif
 }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -482,7 +482,7 @@ void GothicAPI::OnGameStart() {
 
     UpdateMTResourceManager();
 
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
     HookedFunctions::OriginalFunctions.InitAnimatedInventoryHooks();
 #endif
     void RegisterBinkPlayerHooks();

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -513,6 +513,11 @@ struct GothicMemoryLocations {
         static const unsigned int GetName = 0x0068D0B0;
         static const unsigned int HasFlag = 0x0068E150;
         static const unsigned int Offset_focus_vob = 0x9e4;
+        static const unsigned int Offset_states = 0x470;
+    };
+    
+    struct oCNpc_States {
+        static const unsigned int IsInState = 0x006c4c90;
     };
 
     struct oCGame {

--- a/D3D11Engine/HookedFunctions.cpp
+++ b/D3D11Engine/HookedFunctions.cpp
@@ -430,7 +430,7 @@ FARPROC WINAPI HookedFunctionInfo::hooked_GetProcAddress( HMODULE mod, const cha
     return GetProcAddress( mod, procName );
 }
 
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
 void HookedFunctionInfo::InitAnimatedInventoryHooks() {
     if ( *reinterpret_cast<BYTE*>(0x67303D) != 0xD8 ) {
         // Remove Animated_Inventory SystemPack memory jump and insert our function instead that doesn't fuckup items world matrix

--- a/D3D11Engine/HookedFunctions.h
+++ b/D3D11Engine/HookedFunctions.h
@@ -35,7 +35,7 @@ typedef void( __thiscall* oCNPCEnable )(void*, XMFLOAT3&);
 typedef void( __thiscall* zCBspTreeAddVob )(void*, zCVob*);
 typedef void( __thiscall* zCWorldLoadWorld )(void*, const zSTRING& fileName, const int loadMode);
 typedef void( __thiscall* oCGameEnterWorld )(void*, oCNPC* playerVob, int changePlayerPos, const zSTRING& startpoint);
-#if defined(BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
+#if defined(BUILD_GOTHIC_2_6_fix) || defined(BUILD_GOTHIC_1_CLASSIC)
 typedef void( __thiscall* oCGameDefineExternals_Ulfi )(void*, zCParser* parser);
 #endif
 typedef void( __thiscall* zCWorldVobRemovedFromWorld )(void*, zCVob*);
@@ -136,7 +136,7 @@ struct HookedFunctionInfo {
     zCBspTreeAddVob original_zCBspTreeAddVob = reinterpret_cast<zCBspTreeAddVob>(GothicMemoryLocations::zCBspTree::AddVob);
     zCWorldLoadWorld original_zCWorldLoadWorld = reinterpret_cast<zCWorldLoadWorld>(GothicMemoryLocations::zCWorld::LoadWorld);
     oCGameEnterWorld original_oCGameEnterWorld = reinterpret_cast<oCGameEnterWorld>(GothicMemoryLocations::oCGame::EnterWorld);
-#if defined(BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
+#if defined(BUILD_GOTHIC_2_6_fix) || defined(BUILD_GOTHIC_1_CLASSIC)
     oCGameDefineExternals_Ulfi original_oCGameDefineExternals_Ulfi = reinterpret_cast<oCGameDefineExternals_Ulfi>(GothicMemoryLocations::oCGame::DefineExternals_Ulfi);
 #endif
     zCWorldVobRemovedFromWorld original_zCWorldVobRemovedFromWorld = reinterpret_cast<zCWorldVobRemovedFromWorld>(GothicMemoryLocations::zCWorld::VobRemovedFromWorld);
@@ -158,7 +158,7 @@ struct HookedFunctionInfo {
     zCOptionReadInt original_zCOptionReadInt = reinterpret_cast<zCOptionReadInt>(GothicMemoryLocations::zCOption::ReadInt);
     zCOptionReadBool original_zCOptionReadBool = reinterpret_cast<zCOptionReadBool>(GothicMemoryLocations::zCOption::ReadBool);
     zCOptionReadDWORD original_zCOptionReadDWORD = reinterpret_cast<zCOptionReadDWORD>(GothicMemoryLocations::zCOption::ReadDWORD);
-#if (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)) || defined(BUILD_GOTHIC_2_6_fix)
+#if defined(BUILD_GOTHIC_1_CLASSIC) || defined(BUILD_GOTHIC_2_6_fix)
     zCViewBlitText original_zCViewBlit = reinterpret_cast<zCViewBlitText>(GothicMemoryLocations::zCView::Blit);
     zCViewBlitText original_zCViewBlitText = reinterpret_cast<zCViewBlitText>(GothicMemoryLocations::zCView::BlitText);
     zCViewPrint original_zCViewPrint = reinterpret_cast<zCViewPrint>(GothicMemoryLocations::zCView::Print);
@@ -216,7 +216,7 @@ struct HookedFunctionInfo {
 
     static FARPROC WINAPI hooked_GetProcAddress( HMODULE mod, const char* procName );
 
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
     void InitAnimatedInventoryHooks();
     static void __fastcall hooked_RotateInInventory( DWORD oCItem );
 #endif

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -22,7 +22,7 @@ namespace ImGui {
     }
 }
 
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
 extern bool haveWindAnimations;
 #endif
 
@@ -536,8 +536,8 @@ void ImGuiShim::RenderSettingsWindow()
             }
             ImGui::Checkbox( "Animate Static Vobs", &settings.AnimateStaticVobs );
 
-#if defined(BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_2_6_fix) || defined(BUILD_GOTHIC_1_CLASSIC)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
             if ( haveWindAnimations )
 #endif
             {
@@ -1166,8 +1166,8 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         ImGui::DragFloat( "BloomThreshold", &settings.BloomThreshold, 0.01f, 0.0f, 0.0f, "%.2f" );
         ImGui::DragFloat( "BloomStrength", &settings.BloomStrength, 0.01f, 0.0f, 0.0f, "%.2f" );
 
-#if defined(BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_2_6_fix) || defined(BUILD_GOTHIC_1_CLASSIC)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
         if ( haveWindAnimations )
 #endif
         {

--- a/D3D11Engine/oCGame.h
+++ b/D3D11Engine/oCGame.h
@@ -33,7 +33,7 @@ public:
     /** Hooks the functions of this Class */
     static void Hook() {
         DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCGameEnterWorld, hooked_EnterWorld  );
-#if defined(BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
+#if defined(BUILD_GOTHIC_2_6_fix) || defined(BUILD_GOTHIC_1_CLASSIC)
         DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_oCGameDefineExternals_Ulfi, hooked_DefineExternals_Ulfi  );
 #endif
     }
@@ -44,7 +44,7 @@ public:
         Engine::GAPI->OnWorldLoaded();
     }
 
-#if defined(BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
+#if defined(BUILD_GOTHIC_2_6_fix) || defined(BUILD_GOTHIC_1_CLASSIC)
     static void __fastcall hooked_DefineExternals_Ulfi( void* thisptr, void* unknwn, zCParser* parser ) {
         HookedFunctions::OriginalFunctions.original_oCGameDefineExternals_Ulfi( thisptr, parser );
 
@@ -63,7 +63,7 @@ public:
     static bool GetHighlightInteractFocus() {
 #if defined(BUILD_GOTHIC_2_6_fix)
         return *reinterpret_cast<int*>(GothicMemoryLocations::oCGame::Var_InteractiveFocusEnabled) != 0;
-#elif (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
+#elif defined(BUILD_GOTHIC_1_CLASSIC)
         return Engine::GAPI->GetRendererState().RendererSettings.G1HighlightInteractiveFocus;
 #else
         return false;

--- a/D3D11Engine/oCMobInter.h
+++ b/D3D11Engine/oCMobInter.h
@@ -12,7 +12,7 @@ public:
     }
 
     bool HasName() {
-#if defined(BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
+#if defined(BUILD_GOTHIC_2_6_fix) || defined(BUILD_GOTHIC_1_CLASSIC)
         zSTRING str;
         auto* _ = reinterpret_cast<zSTRING* (__fastcall*)(void* object, void* edx, zSTRING * retBuffer)>(GothicMemoryLocations::oCMob::GetName)(this, nullptr, &str);
         return str.Length() > 0;
@@ -30,7 +30,7 @@ public:
     }
 
     bool IsInteractingWith( oCNPC* other ) {
-#if defined(BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
+#if defined(BUILD_GOTHIC_2_6_fix) || defined(BUILD_GOTHIC_1_CLASSIC)
         return reinterpret_cast<int( __thiscall* )(oCMobInter*, oCNPC*)>(GothicMemoryLocations::oCMobInter::IsInteractingWith)(this, other) != 0;
 #else
         return false;

--- a/D3D11Engine/oCNPC.h
+++ b/D3D11Engine/oCNPC.h
@@ -14,6 +14,15 @@ enum oCNPCFlags : int
     NPC_FLAG_GHOST = (1 << 2)
 };
 
+class oCNPC;
+struct oCNpc_States {
+#ifdef BUILD_GOTHIC_1_CLASSIC
+    bool IsInState(int state) const {
+        return 0 != reinterpret_cast<int( __thiscall* )( const oCNpc_States*, int )>( GothicMemoryLocations::oCNpc_States::IsInState )( this, state );
+    }
+#endif
+};
+
 class oCNPC : public zCVob {
 public:
     static const zCClassDef* GetStaticClassDef() {
@@ -67,7 +76,7 @@ public:
     }
 
     zCVob* GetFocusVob() const {
-#if defined(BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F))
+#if defined(BUILD_GOTHIC_2_6_fix) || defined(BUILD_GOTHIC_1_CLASSIC)
         return *reinterpret_cast<zCVob**>(THISPTR_OFFSET( GothicMemoryLocations::oCNPC::Offset_focus_vob ));
 #else
         return nullptr;
@@ -86,6 +95,12 @@ public:
         reinterpret_cast<void( __fastcall* )( oCNPC*, int, zSTRING&, int )>( GothicMemoryLocations::oCNPC::GetName )( this, 0, str, i );
         return str;
     }
+    
+#ifdef BUILD_GOTHIC_1_CLASSIC
+    oCNpc_States* GetStates() {
+        return reinterpret_cast<oCNpc_States*>(THISPTR_OFFSET( GothicMemoryLocations::oCNPC::Offset_states ));
+    }
+#endif
 #ifndef BUILD_SPACER
     bool HasFlag( oCNPCFlags flag ) {
         return reinterpret_cast<bool( __fastcall* )( oCNPC*, int, oCNPCFlags )>( GothicMemoryLocations::oCNPC::HasFlag )( this, 0, flag );

--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -52,14 +52,6 @@ using namespace DirectX;
 #define BUILD_DATE __DATE__
 #endif
 
-#ifdef BUILD_GOTHIC_1_08k
-#ifdef BUILD_1_12F
-#define BUILD_GOTHIC_1_SEQUEL
-#else
-#define BUILD_GOTHIC_1_CLASSIC
-#endif
-#endif
-
 __declspec(selectany) const char* VERSION_NUMBER_STR = VERSION_NUMBER;
 
 extern bool FeatureLevel10Compatibility;

--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -52,6 +52,14 @@ using namespace DirectX;
 #define BUILD_DATE __DATE__
 #endif
 
+#ifdef BUILD_GOTHIC_1_08k
+#ifdef BUILD_1_12F
+#define BUILD_GOTHIC_1_SEQUEL
+#else
+#define BUILD_GOTHIC_1_CLASSIC
+#endif
+#endif
+
 __declspec(selectany) const char* VERSION_NUMBER_STR = VERSION_NUMBER;
 
 extern bool FeatureLevel10Compatibility;

--- a/D3D11Engine/zBinkPlayer.cpp
+++ b/D3D11Engine/zBinkPlayer.cpp
@@ -467,7 +467,7 @@ int __fastcall BinkPlayerPlayDeinit(DWORD BinkPlayer)
 int __fastcall BinkPlayerOpenVideo(DWORD BinkPlayer, DWORD _EDX, zSTRING videoName)
 {
     DWORD zCOption = *reinterpret_cast<DWORD*>(GothicMemoryLocations::GlobalObjects::zCOption);
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
 	zSTRING& directoryRoot = reinterpret_cast<zSTRING&(__thiscall*)(DWORD, int)>(GothicMemoryLocations::zCOption::GetDirectory)(zCOption, 23);
 #else
 	zSTRING& directoryRoot = reinterpret_cast<zSTRING&(__thiscall*)(DWORD, int)>(GothicMemoryLocations::zCOption::GetDirectory)(zCOption, 24);

--- a/D3D11Engine/zCInput_Win32.h
+++ b/D3D11Engine/zCInput_Win32.h
@@ -9,7 +9,7 @@ class zCInput_Win32 {
 public:
     /** Hooks the functions of this Class */
     static void Hook() {
-#if (defined( BUILD_GOTHIC_2_6_fix) || (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)))
+#if (defined( BUILD_GOTHIC_2_6_fix) || defined(BUILD_GOTHIC_1_CLASSIC))
         // TODO: Also implement for other gothics
         DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCInput_Win32__GetKey, hooked_GetKey  );
 #endif

--- a/D3D11Engine/zCView.h
+++ b/D3D11Engine/zCView.h
@@ -35,7 +35,7 @@ public:
             REPLACE_RANGE( GothicMemoryLocations::zCView::REPL_SetMode_ModechangeStart, GothicMemoryLocations::zCView::REPL_SetMode_ModechangeEnd - 1, INST_NOP );
         }
 
-#if (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)) || defined(BUILD_GOTHIC_2_6_fix)
+#if defined(BUILD_GOTHIC_1_CLASSIC) || defined(BUILD_GOTHIC_2_6_fix)
         DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCViewPrintChars, hooked_PrintChars  );
 #endif
     }
@@ -49,7 +49,7 @@ public:
         _zCView::SetVirtualMode( x, y, bpp );
     }
 
-#if (defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)) || defined(BUILD_GOTHIC_2_6_fix)
+#if defined(BUILD_GOTHIC_1_CLASSIC) || defined(BUILD_GOTHIC_2_6_fix)
     static void __fastcall hooked_PrintChars( _zCView* thisptr, void* unknwn, int x, int y, const zSTRING& s ) {
         if ( !Engine::GAPI->GetRendererState().RendererSettings.EnableCustomFontRendering ) {
             HookedFunctions::OriginalFunctions.original_zCViewPrintChars( thisptr, x, y, s );

--- a/D3D11Engine/zCVob.h
+++ b/D3D11Engine/zCVob.h
@@ -33,7 +33,7 @@ class zCVisual;
 class zCWorld;
 class oCGame;
 
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
 extern bool haveWindAnimations;
 #endif
 

--- a/D3D11Engine/zViewTypes.h
+++ b/D3D11Engine/zViewTypes.h
@@ -124,14 +124,14 @@ public:
     }
 
     void CheckAutoScroll() {
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
         reinterpret_cast<void( __fastcall* )( _zCView* )>( 0x006FC480 )( this );
 #elif defined(BUILD_GOTHIC_2_6_fix)
         reinterpret_cast<void( __fastcall* )( _zCView* )>( 0x007A5F60 )( this );
 #endif
     }
     void CheckTimedText() {
-#if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#if defined(BUILD_GOTHIC_1_CLASSIC)
         reinterpret_cast<void( __fastcall* )( _zCView* )>( 0x006FE0E0 )( this );
 #elif defined(BUILD_GOTHIC_2_6_fix)
         reinterpret_cast<void( __fastcall* )( _zCView* )>( 0x007A7C50 )( this );


### PR DESCRIPTION
- mimicks G1 original behavior of NPCs only being lit up when not talking to them.
- improve ugly `defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)` repetition