### PR TITLE
fix torches not updating correctly with Dynamic lights set to "Update Dynamic", exclude `isStatic`-Lights from producing specular highlights, ...

### DIFF
--- a/D3D11Engine/D3D11LegacyDeferredShading.cpp
+++ b/D3D11Engine/D3D11LegacyDeferredShading.cpp
@@ -87,6 +87,7 @@ XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
         vob->DoAnimation();
 
         plcb.PL_Color = float4( vob->GetLightColor() );
+        plcb.PL_Color.w = vob->IsStatic() ? 0.0f : 1.0f;
         plcb.PL_Range = vob->GetLightRange();
         plcb.Pl_PositionWorld = vob->GetPositionWorld();
         plcb.PL_Outdoor = light->IsIndoorVob ? 0.0f : 1.0f;

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -17,6 +17,16 @@ D3D11PointLight::D3D11PointLight( VobLightInfo* info, bool dynamicLight ) {
     LightInfo = info;
     DynamicLight = dynamicLight;
     
+    if ( !info->IsPFXVobLight ) {
+        const auto vob = info->Vob;
+        const auto& lightFlags = vob->GetLightInfoFlags();
+        if ( lightFlags.m_bCanMove && !info->IsPFXVobLight ) {
+            if ( auto parent = vob->GetVobParent(); parent->GetObjectName().Length() > 0 ) {
+                m_ForceRealtimeShadows = true;
+            }
+        }
+    }
+    
     // Ensure this light is actually in the VobLightMap
     // some lights don't seem to be in here!
     Engine::GAPI->VobLightMap[info->Vob] = info;
@@ -111,8 +121,12 @@ void D3D11PointLight::ClearTiledSlot() {
 int D3D11PointLight::GetCurrentShadowMode() const {
     auto mode = static_cast<int>(Engine::GAPI->GetRendererState().RendererSettings.EnablePointlightShadows);
     if ( mode > 1 ) {
+        if ( m_ForceRealtimeShadows ) {
+            // movable fire sources like torches, not just any dynamic light.
+            return GothicRendererSettings::EPointLightShadowMode::PLS_FULL;
+        }
         if ( LightInfo->Vob->GetLightInfoFlags().isStatic ) {
-            return GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY; 
+            return GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY;
         }
     }
     return mode;

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -106,6 +106,8 @@ protected:
     bool DrawnOnce;
     bool m_StaticShadowReady = false;
     int m_LastShadowMode = -1;
+    // used to denote things like torches which move with NPCs
+    bool m_ForceRealtimeShadows = false;
 
     // Tiled deferred slot (non-owning, owned by D3D11TiledDeferredShading)
     int m_TiledSlotIndex = -1;

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -393,7 +393,7 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
         TiledPointLight& tl = lightData[result.TiledLightCount];
         tl.PositionView = posView;
         tl.Range = lightRange;
-        tl.Color = XMFLOAT4( lightColor.x, lightColor.y, lightColor.z, lightColor.w );
+        tl.Color = XMFLOAT4( lightColor.x, lightColor.y, lightColor.z, vob->IsStatic() ? 0.0f : 1.0f );
         tl.PositionWorld = XMFLOAT3( posWorld.x, posWorld.y, posWorld.z );
 
         if ( hasShadow ) {

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -73,7 +73,7 @@ auto CompareGhostDistance = []( const TransparencyVobInfo& a, const Transparency
 extern float vobAnimation_WindStrength;
 
 /** Writes this info to a file */
-void MaterialInfo::WriteToFile( const std::string& name ) {
+void MaterialInfo::WriteToFile( const std::string_view name ) {
     thread_local std::string infoPath{};
     infoPath.reserve( 255 );
     infoPath.clear();

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4122,6 +4122,8 @@ void GothicAPI::CollectVisibleVobs(
 
             // Update the lights shadows if: Light is dynamic or full shadow-updates are set
             if ( !vi->IsPFXVobLight ) {
+                // TODO: should things like "light-spell" also cast shadows?
+                // i mean, we make torches cast them, why not also spells?
                 if ( lightUpdateEnabled && !vi->Vob->IsStatic() ) {
                     const float lightRange = vi->Vob->GetLightRange();
                     if ( lightRange > minDynamicUpdateLightRange && distSq < (lightRange * lightRange) )

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -208,7 +208,7 @@ struct MaterialInfo {
     MaterialInfo& operator=( const MaterialInfo& ) = delete;
 
     /** Writes this info to a file */
-    void WriteToFile( const std::string& name );
+    void WriteToFile( const std::string_view name );
 
     /** Loads this info from a file */
     void LoadFromFile( const std::string_view name );

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -233,7 +233,7 @@ struct MaterialInfo {
     EMaterialType MaterialType;
     Buffer buffer;
 
-    bool IsSame( MaterialInfo* other ) {
+    bool IsSame(const MaterialInfo* other ) const {
         if ( other == nullptr ) return false;
         return PixelShader == other->PixelShader
             && MaterialType == other->MaterialType

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -113,9 +113,17 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
         maxLighting = max( maxLighting, lighting );
     }
 
-    float3 activeLighting = LimitLightIntensity ? maxLighting : totalLighting;
+    float3 activeLighting;
+    [branch]
+    if ( LimitLightIntensity ) {
+        activeLighting = maxLighting;
+    } else {
+        activeLighting = totalLighting;
+    }
+
     if ( any( activeLighting > 0 ) ) {
         float4 existing = RW_HDR[pixelCoord];
+        [branch]
         if ( LimitLightIntensity ) {
             // Match legacy MAX blend: each light uses max(light, existing) individually.
             // Since we see all lights at once, take the per-light max.

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -98,7 +98,7 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
         float falloff = PLS_ComputeRangeFalloff( distance, light.Range );
 
         float3 H = normalize( lightDir + V );
-        float spec = PLS_CalcBlinnPhongLighting( normal, H );
+        float spec = PLS_CalcBlinnPhongLighting( normal, H ) * light.Color.w;
         float3 lighting = PLS_ComputePointLightLighting( diffuse.rgb, light.Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod );
 
         // Apply shadow if this light has a shadow cubemap and contribution is non-negligible

--- a/D3D11Engine/Shaders/FixedFunctionPipeline.h
+++ b/D3D11Engine/Shaders/FixedFunctionPipeline.h
@@ -133,14 +133,16 @@ float4 __runStage(int colorop, int colorarg1, int colorarg2, float4 current, flo
 float4 GetColorFromStates(float4 diffuse, float2 uv, float2 uv2, SamplerState samplerState)
 {		
 	float4 color = __runStage(FF_Stages[0].colorop, FF_Stages[0].colorarg1, FF_Stages[0].colorarg2, diffuse, diffuse, texture0, uv, samplerState);
-	
+
+	[branch]
 	if(FF_Stages[1].colorop != D3DTOP_DISABLE)
 	{
 		color = __runStage(FF_Stages[1].colorop, FF_Stages[1].colorarg1, FF_Stages[1].colorarg2, color, diffuse, texture1, uv2, samplerState);
 	}
-	
+
 	float4 alpha = color;//__runStage(FF_Stages[0].alphaop, FF_Stages[0].alphaarg1, FF_Stages[0].alphaarg2, diffuse, diffuse, texture0, uv, samplerState);
 
+	[branch]
 	if(FF_AlphaTestEnabled())
 		DoAlphaTest(alpha.a);
 	

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -276,6 +276,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	// CSM: Use soft cascaded shadow map with configurable softness
     float3 wsNormal = normalize(mul(float4(normal, 0.0f), SQ_InvView).xyz);
 
+    [branch]
     if(AC_LightPos.y > 0) // only get shadow value if it isn't night-time
 	{
         float3 wsLightDirection = normalize(mul(float4(SQ_LightDirectionVS, 0.0f), SQ_InvView).xyz);

--- a/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
@@ -128,7 +128,7 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	// Compute specular lighting
 	float3 V = normalize(-vsPosition);
 	float3 H = normalize(lightDir + V);
-	float spec = PLS_CalcBlinnPhongLighting(normal, H);
+	float spec = PLS_CalcBlinnPhongLighting(normal, H) * PL_Color.w;
 	float specMod = PLS_ComputeSpecMod(diffuse.rgb);
 	
 	// Blend this with the light color, world diffuse and specular term.

--- a/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
@@ -109,7 +109,7 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	// Compute specular lighting
 	float3 V = normalize(-vsPosition);
 	float3 H = normalize(lightDir + V);
-	float spec = PLS_CalcBlinnPhongLighting(normal, H);
+	float spec = PLS_CalcBlinnPhongLighting(normal, H) * PL_Color.w;
 	float specMod = PLS_ComputeSpecMod(diffuse.rgb);
 	float3 lighting = PLS_ComputePointLightLighting(diffuse.rgb, PL_Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod);
 	

--- a/D3D11Engine/Shaders/PS_Diffuse.hlsl
+++ b/D3D11Engine/Shaders/PS_Diffuse.hlsl
@@ -121,6 +121,7 @@ FORWARD_PLUS_PS_OUTPUT PSMain( PS_INPUT Input )
 	float shadow = vertLighting;
 #if SHD_ENABLE
 	float3 wsNormal = normalize(mul(float4(nrm, 0.0f), SQ_InvView).xyz);
+	[branch]
 	if (AC_LightPos.y > 0)
 	{
 		#if FP_USE_SHADOW_MASK

--- a/D3D11Engine/Shaders/PS_PFX_VelocityDebug.hlsl
+++ b/D3D11Engine/Shaders/PS_PFX_VelocityDebug.hlsl
@@ -38,7 +38,8 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
     velocity *= VD_Amplification;
     
     float4 output;
-    
+
+    [branch]
     if (VD_ShowMagnitude > 0.5)
     {
         // Magnitude mode: show velocity length as grayscale
@@ -64,6 +65,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
     else
     {
         // Direction mode: show velocity as color
+        [branch]
         if (VD_AbsoluteMode > 0.5)
         {
             // Absolute mode: R = |velocity.x|, G = |velocity.y|

--- a/D3D11Engine/Shaders/ShadowSampling.h
+++ b/D3D11Engine/Shaders/ShadowSampling.h
@@ -191,6 +191,7 @@ float2 RotationSCFromNoise(float rawNoise)
 float2 GetPoissonRotationSCForCascade(float2 screenPos, int cascadeIndex)
 {
     // If TAA is disabled return identity (standard unrotated PCF, no noise).
+    [branch]
     if (SQ_FrameIndex == 0)
         return float2(1.0f, 0.0f);
 
@@ -204,6 +205,7 @@ float2 GetPoissonRotationSC(float2 screenPos)
 
 float2 GetPoissonRotationSCRForCascade(float2 screenPos, int cascadeIndex, out float rawNoise)
 {
+    [branch]
     if (SQ_FrameIndex == 0)
     {
         rawNoise = 0.5f;

--- a/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
+++ b/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
@@ -167,7 +167,7 @@ float3 FP_ComputePointLighting(
         float falloff = PLS_ComputeRangeFalloff( distance, light.Range );
 
         float3 H = normalize( lightDir + V );
-        float spec = PLS_CalcBlinnPhongLighting( normal, H );
+        float spec = PLS_CalcBlinnPhongLighting( normal, H ) * light.Color.w;
         float3 lighting = PLS_ComputePointLightLighting( diffuseColor, light.Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod );
 
         // Don't fetch shadows if the light contribution is effectively zero.

--- a/D3D11Engine/zCVob.h
+++ b/D3D11Engine/zCVob.h
@@ -162,7 +162,7 @@ public:
 
     /** Returns the name of this vob */
     std::string GetName() const {
-        return __GetObjectName().ToChar();
+        return GetObjectName().ToChar();
     }
 
     /** Returns the world-position of this vob */
@@ -390,8 +390,8 @@ protected:
         }
         return false;
     }
-
-    zSTRING& __GetObjectName() const {
+public:
+    zSTRING& GetObjectName() const {
         return reinterpret_cast<zSTRING&( __fastcall* )( const zCVob* )>( GothicMemoryLocations::zCObject::GetObjectName )( this );
     }
 };


### PR DESCRIPTION
- added new `D3D11PointLight::m_ForceRealtimeShadows bool`
  - set for any light source that is not PFX and has a parent vob node.
  this excludes things like streetlamps, but includes torches.
- introduce some manual `[branch]` into a few shaders where each pixel would evaluate the same result based on a constantbuffer value.
- update `MaterialInfo::WriteToFile` to use `std::string_view` instead of `std::string`
- prevent static light from contributing to specular lighting.
  some homes, like lehmars and the house where Daron rests in G2 are full of lighting and cause ugly specular effects on door entrances and outdoors.
  This does NOT include "dynamic"-lights (gothic dynamic lights, thos where isStatic=false), those still provide specular highlights, same with the sun.
