### PR TITLE
fix missing null-check in `if ( auto parent = vob->GetVobParent(); parent->GetObjectName().Length() > 0 )`

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -1104,8 +1104,11 @@ XRESULT D3D11GraphicsEngine::RecreateBuffers() {
     }
 
     auto roundedTextureResolution = GetResolution( );
-    if ( lastRoundedTextureResolution == roundedTextureResolution ) {
+    if ( DepthStencilBuffer 
+        && lastRoundedTextureResolution == roundedTextureResolution ) {
         // same resolution, just adjusting the viewport
+        // if DepthStencilBuffer is missing, we're likely changing display mode.
+        // thus continue with the work.
         return XR_SUCCESS;
     }
     lastRoundedTextureResolution = roundedTextureResolution;

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -21,7 +21,7 @@ D3D11PointLight::D3D11PointLight( VobLightInfo* info, bool dynamicLight ) {
         const auto vob = info->Vob;
         const auto& lightFlags = vob->GetLightInfoFlags();
         if ( lightFlags.m_bCanMove && !info->IsPFXVobLight ) {
-            if ( auto parent = vob->GetVobParent(); parent->GetObjectName().Length() > 0 ) {
+            if ( auto parent = vob->GetVobParent(); parent && parent->GetObjectName().Length() > 0 ) {
                 m_ForceRealtimeShadows = true;
             }
         }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -6196,7 +6196,7 @@ static void CollectLeafVobs(
                 if ( vit == VobLightMap.end() ) {
                     bool PFXVobLight = false;
                     if ( zCVob* parent = vob->GetVobParent() ) {
-                        if ( parent->As<oCVisualFX>() ) {
+                        if ( parent && parent->As<oCVisualFX>() ) {
                             PFXVobLight = true;
                         }
                     }


### PR DESCRIPTION
fixes #400

also fixes crash when changing window modes at runtime, e.g. from borderless to windowed.