### PR TITLE
feat: compressed normals (BC5), default to OpenGL style normals (configurable), optimize DrawString

### DIFF
--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -231,7 +231,7 @@ public:
         RenderToTextureBuffer* bufferParticleColor,
         RenderToTextureBuffer* bufferParticleDistortion) {}
 
-    virtual void DrawString( const std::string& str, float x, float y, const zFont* font, zColor& fontColor ) {};
+    virtual void DrawString( std::string_view str, float x, float y, const zFont* font, zColor& fontColor ) {};
     
     virtual XRESULT UpdateRenderStates() { return XR_SUCCESS; };
 

--- a/D3D11Engine/D3D11DeferredRenderer.cpp
+++ b/D3D11Engine/D3D11DeferredRenderer.cpp
@@ -133,12 +133,12 @@ bool D3D11DeferredRenderer::BindShaderForTexture( D3D11ShaderManager& shaderMana
     PShaderID resolvedDiffuseNormalmappedAlphatest,
     PShaderID resolvedDiffuseNormalmappedAlphatestFxMap ) {
 
-    auto active = activePS;
+    const auto& active = activePS;
     auto newShader = activePS;
 
-    bool blendAdd = zMatAlphaFunc == zMAT_ALPHA_FUNC_ADD;
-    bool blendBlend = zMatAlphaFunc == zMAT_ALPHA_FUNC_BLEND;
-    bool linZ = (Engine::GAPI->GetRendererState().GraphicsState.FF_GSwitches & GSWITCH_LINEAR_DEPTH) != 0;
+    const bool blendAdd = zMatAlphaFunc == zMAT_ALPHA_FUNC_ADD;
+    const bool blendBlend = zMatAlphaFunc == zMAT_ALPHA_FUNC_BLEND;
+    const bool linZ = (Engine::GAPI->GetRendererState().GraphicsState.FF_GSwitches & GSWITCH_LINEAR_DEPTH) != 0;
 
     if ( materialType == MaterialInfo::MT_Portal ) {
         newShader = shaderManager.GetPShader( PShaderID::PS_PortalDiffuse );

--- a/D3D11Engine/D3D11ForwardPlusRenderer.cpp
+++ b/D3D11Engine/D3D11ForwardPlusRenderer.cpp
@@ -339,9 +339,9 @@ bool D3D11ForwardPlusRenderer::BindShaderForTexture(
     PShaderID resolvedDiffuseNormalmappedAlphatestFxMap ) {
 
     // Special material types fall through to deferred (non-lit) shaders
-    bool blendAdd = zMatAlphaFunc == zMAT_ALPHA_FUNC_ADD; 
-    bool blendBlend = zMatAlphaFunc == zMAT_ALPHA_FUNC_BLEND;
-    bool linZ = (Engine::GAPI->GetRendererState().GraphicsState.FF_GSwitches & GSWITCH_LINEAR_DEPTH) != 0;
+    const bool blendAdd = zMatAlphaFunc == zMAT_ALPHA_FUNC_ADD; 
+    const bool blendBlend = zMatAlphaFunc == zMAT_ALPHA_FUNC_BLEND;
+    const bool linZ = (Engine::GAPI->GetRendererState().GraphicsState.FF_GSwitches & GSWITCH_LINEAR_DEPTH) != 0;
 
     if ( materialType == MaterialInfo::MT_Portal ||
          materialType == MaterialInfo::MT_WaterfallFoam ||
@@ -353,7 +353,7 @@ bool D3D11ForwardPlusRenderer::BindShaderForTexture(
             resolvedDiffuseNormalmappedAlphatest, resolvedDiffuseNormalmappedAlphatestFxMap );
     }
 
-    auto active = activePS;
+    const auto& active = activePS;
     auto newShader = activePS;
     if ( texture->HasAlphaChannel() || forceAlphaTest ) {
         if ( texture->GetSurface()->GetFxMap() ) {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -9171,7 +9171,7 @@ void D3D11GraphicsEngine::SaveScreenshot() {
 namespace UI::zFont {
     void AppendGlyphs(
         std::vector<ExVertexStruct>& vertices,
-        const std::string& str, size_t strLen,
+        std::string_view str,
         float x, float y,
         const ::zFont* font,
         zColor fontColor, float scale = 1.0f, zCCamera* camera = nullptr ) {
@@ -9184,8 +9184,8 @@ namespace UI::zFont {
         if ( camera ) farZ = camera->GetNearPlane() + 1.0f;
         else                       farZ = 1.0f;
 
-        vertices.resize( strLen * 6 );
-        for ( size_t i = 0; i < strLen; ++i ) {
+        vertices.resize( str.size() * 6 );
+        for ( size_t i = 0; i < str.size(); ++i ) {
             const unsigned char& c = str[i];
 
             auto topLeft = font->fontuv1[c];
@@ -9258,7 +9258,7 @@ float  D3D11GraphicsEngine::UpdateCustomFontMultiplierFontRendering( float multi
     return res; 
 }
 
-void D3D11GraphicsEngine::DrawString( const std::string& str, float x, float y, const zFont* font, zColor& fontColor ) {
+void D3D11GraphicsEngine::DrawString( std::string_view str, float x, float y, const zFont* font, zColor& fontColor ) {
     if ( !font ) return;
     if ( !font->tex ) return;
 
@@ -9271,6 +9271,7 @@ void D3D11GraphicsEngine::DrawString( const std::string& str, float x, float y, 
         --maxLen;
     }
     if ( !maxLen ) return;
+    str = str.substr(0, maxLen);
 
     float UIScale = 1.0f;
     static int savedBarSize = -1;
@@ -9293,11 +9294,11 @@ void D3D11GraphicsEngine::DrawString( const std::string& str, float x, float y, 
     //
     // Set alpha blending
     //
-    DWORD zrenderer = *reinterpret_cast<DWORD*>(GothicMemoryLocations::GlobalObjects::zRenderer);
-    reinterpret_cast<void( __thiscall* )(DWORD, int, int)>(GothicMemoryLocations::zCRndD3D::XD3D_SetRenderState)(zrenderer, 27, 1);
-    reinterpret_cast<void( __thiscall* )(DWORD, int, int)>(GothicMemoryLocations::zCRndD3D::XD3D_SetRenderState)(zrenderer, 15, 0);
-    reinterpret_cast<void( __thiscall* )(DWORD, int, int)>(GothicMemoryLocations::zCRndD3D::XD3D_SetRenderState)(zrenderer, 19, 5);
-    reinterpret_cast<void( __thiscall* )(DWORD, int, int)>(GothicMemoryLocations::zCRndD3D::XD3D_SetRenderState)(zrenderer, 20, 6);
+    DWORD_PTR zrenderer = *reinterpret_cast<DWORD_PTR*>(GothicMemoryLocations::GlobalObjects::zRenderer);
+    reinterpret_cast<void( __thiscall* )(DWORD_PTR, int, int)>(GothicMemoryLocations::zCRndD3D::XD3D_SetRenderState)(zrenderer, 27, 1); // D3DRENDERSTATE_ALPHABLENDENABLE
+    reinterpret_cast<void( __thiscall* )(DWORD_PTR, int, int)>(GothicMemoryLocations::zCRndD3D::XD3D_SetRenderState)(zrenderer, 15, 0); // D3DRENDERSTATE_ALPHATESTENABLE
+    reinterpret_cast<void( __thiscall* )(DWORD_PTR, int, int)>(GothicMemoryLocations::zCRndD3D::XD3D_SetRenderState)(zrenderer, 19, 5); // D3DRENDERSTATE_SRCBLEND
+    reinterpret_cast<void( __thiscall* )(DWORD_PTR, int, int)>(GothicMemoryLocations::zCRndD3D::XD3D_SetRenderState)(zrenderer, 20, 6); // D3DRENDERSTATE_DESTBLEND
 
     //
     // Backup old renderstates, BlendState can be ignored here.
@@ -9345,7 +9346,7 @@ void D3D11GraphicsEngine::DrawString( const std::string& str, float x, float y, 
     static std::vector<ExVertexStruct> vertices;
     vertices.clear();
 
-    UI::zFont::AppendGlyphs( vertices, str, maxLen, x, y, font, fontColor, UIScale, zCCamera::GetCamera() );
+    UI::zFont::AppendGlyphs( vertices, str, x, y, font, fontColor, UIScale, zCCamera::GetCamera() );
 
     // Bind the texture.
     tx->Bind( 0 );
@@ -9354,7 +9355,7 @@ void D3D11GraphicsEngine::DrawString( const std::string& str, float x, float y, 
     // Populate TempVertexBuffer
     //
     EnsureTempVertexBufferSize( TempVertexBuffer, sizeof( ExVertexStruct ) * vertices.size() );
-    TempVertexBuffer->UpdateBuffer( &vertices[0], sizeof( ExVertexStruct ) * vertices.size() );
+    TempVertexBuffer->UpdateBuffer(vertices.data(), sizeof( ExVertexStruct ) * vertices.size() );
 
     //
     // Draw the verticies

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -163,7 +163,7 @@ public:
     /** Saves a screenshot */
     void SaveScreenshot() override;
 
-    void DrawString( const std::string& str, float x, float y, const zFont* font, zColor& fontColor ) override;
+    void DrawString( std::string_view str, float x, float y, const zFont* font, zColor& fontColor ) override;
 
     //virtual int MeasureString(std::string str, zFont* zFont) override;
 

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -325,6 +325,7 @@ XRESULT D3D11ShaderManager::Init() {
     ShaderInfo::MacroBuilder normalmappingConfigurationBuilder = [](std::vector<D3D_SHADER_MACRO>& list) {
         const auto& s = Engine::GAPI->GetRendererState().RendererSettings;
         list.push_back( {"NORMAL_MAP_RESTORE_Z", s.CompressedNormalsSupport > 0 ? "1" : "0"} );
+		list.push_back( {"NORMAL_MAP_MODE", sNums[std::clamp<size_t>(s.AllowNormalmaps, 1, 2)]} );
     };
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DS_AtmosphericScattering>( "PS_DS_AtmosphericScattering.hlsl" )

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -321,6 +321,11 @@ XRESULT D3D11ShaderManager::Init() {
         list.push_back( {"PCF_FILTER_TAPS_NEAR",  isTaaEnabled ? "8" : "16"} );
         list.push_back( {"PCF_FILTER_TAPS_FAR",   isTaaEnabled ? "4" : "8"} );
     };
+    
+    ShaderInfo::MacroBuilder normalmappingConfigurationBuilder = [](std::vector<D3D_SHADER_MACRO>& list) {
+        const auto& s = Engine::GAPI->GetRendererState().RendererSettings;
+        list.push_back( {"NORMAL_MAP_RESTORE_Z", s.CompressedNormalsSupport > 0 ? "1" : "0"} );
+    };
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DS_AtmosphericScattering>( "PS_DS_AtmosphericScattering.hlsl" )
         .with_macros( shadowMacroBuilder )
@@ -345,12 +350,14 @@ XRESULT D3D11ShaderManager::Init() {
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_LinDepth>( "PS_LinDepth.hlsl" )  );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DiffuseNormalmapped>( "PS_Diffuse.hlsl" )
+        .with_macros(normalmappingConfigurationBuilder)
         .with_macros( {
             {"NORMALMAPPING", "1"},
             {"ALPHATEST", "0"},
         } ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DiffuseNormalmappedFxMap>( "PS_Diffuse.hlsl" )
+        .with_macros(normalmappingConfigurationBuilder)
         .with_macros( {
             {"NORMALMAPPING", "1"},
             {"ALPHATEST", "0"},
@@ -371,12 +378,14 @@ XRESULT D3D11ShaderManager::Init() {
             } ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DiffuseNormalmappedAlphaTest>( "PS_Diffuse.hlsl" )
+        .with_macros(normalmappingConfigurationBuilder)
         .with_macros( {
             {"NORMALMAPPING", "1"},
             {"ALPHATEST", "1"},
         } ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_DiffuseNormalmappedAlphaTestFxMap>( "PS_Diffuse.hlsl" )
+        .with_macros(normalmappingConfigurationBuilder)
         .with_macros( {
             {"NORMALMAPPING", "1"},
             {"ALPHATEST", "1"},
@@ -500,6 +509,7 @@ XRESULT D3D11ShaderManager::Init() {
 
         Shaders.push_back( ShaderInfo::make<PShaderID::PS_FP_DiffuseNormalmapped>( "PS_Diffuse.hlsl" )
             .with_macros(shadowMacroBuilder)
+            .with_macros(normalmappingConfigurationBuilder)
             .with_macros( {
                 { "FORWARD_PLUS", "1" },
                 { "NORMALMAPPING", "1" },
@@ -508,6 +518,7 @@ XRESULT D3D11ShaderManager::Init() {
 
         Shaders.push_back( ShaderInfo::make<PShaderID::PS_FP_DiffuseNormalmappedFxMap>( "PS_Diffuse.hlsl" )
             .with_macros(shadowMacroBuilder)
+            .with_macros(normalmappingConfigurationBuilder)
             .with_macros( {
                 { "FORWARD_PLUS", "1" },
                 { "NORMALMAPPING", "1" },
@@ -525,6 +536,7 @@ XRESULT D3D11ShaderManager::Init() {
 
         Shaders.push_back( ShaderInfo::make<PShaderID::PS_FP_DiffuseNormalmappedAlphaTest>( "PS_Diffuse.hlsl" )
             .with_macros(shadowMacroBuilder)
+            .with_macros(normalmappingConfigurationBuilder)
             .with_macros( {
                 { "FORWARD_PLUS", "1" },
                 { "NORMALMAPPING", "1" },
@@ -533,6 +545,7 @@ XRESULT D3D11ShaderManager::Init() {
 
         Shaders.push_back( ShaderInfo::make<PShaderID::PS_FP_DiffuseNormalmappedAlphaTestFxMap>( "PS_Diffuse.hlsl" )
             .with_macros(shadowMacroBuilder)
+            .with_macros(normalmappingConfigurationBuilder)
             .with_macros( {
                 { "FORWARD_PLUS", "1" },
                 { "NORMALMAPPING", "1" },

--- a/D3D11Engine/D3D11ShaderManager.h
+++ b/D3D11Engine/D3D11ShaderManager.h
@@ -46,7 +46,18 @@ public:
     /** Chainable setters for builder pattern */
     ShaderInfo& with_layout( EVERTEX_INPUT_LAYOUT l ) { layout = l; return *this; }
     ShaderInfo& with_macros( std::vector<D3D_SHADER_MACRO> m ) { shaderMakros = std::move(m); return *this; }
-    ShaderInfo& with_macros( MacroBuilder b ) { macroBuilder = std::move( b ); return *this; }
+    ShaderInfo& with_macros( MacroBuilder b ) {
+        if (macroBuilder) {
+            macroBuilder = [previous = std::move(macroBuilder), current = std::move( b )](std::vector<D3D_SHADER_MACRO>& m)
+            {
+               previous(m);
+                current(m);
+            };
+        } else {
+            macroBuilder = std::move( b );
+        }
+        return *this;
+    }
     ShaderInfo& with_category( ShaderCategory c ) { contentCategory = c; return *this; }
     ShaderInfo& with_entrypoint( std::string ep ) { entryPoint = std::move( ep ); return *this; }
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -128,7 +128,7 @@ void MaterialInfo::LoadFromFile( const std::string_view name ) {
     // Write the version first
     int version;
     memcpy( &version, ReadBuffer, sizeof( int ) );
-
+    
     // Then the data
     ZeroMemory( &buffer, sizeof( MaterialInfo::Buffer ) );
     memcpy( &buffer, ReadBuffer + sizeof( int ), sizeof( MaterialInfo::Buffer ) );
@@ -5246,7 +5246,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "General", "DoFFocusRange", float_to_string( s.DoFFocusRange, 1 ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "DoFBokehRadius", float_to_string( s.DoFBokehRadius, 1 ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "DoFMaxBlur", float_to_string( s.DoFMaxBlur, 1 ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "AllowNormalmaps", to_string_locale_independent( s.AllowNormalmaps ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "AllowNormalmaps", to_string_locale_independent( s.AllowNormalmaps ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "AllowNumpadKeys", to_string_locale_independent( s.AllowNumpadKeys ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "EnableInactiveFpsLock", to_string_locale_independent( s.EnableInactiveFpsLock ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "MultiThreadResourceManager", to_string_locale_independent( s.MTResoureceManager ? TRUE : FALSE ).c_str(), ini.c_str() );
@@ -5377,7 +5377,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.DoFFocusRange = GetPrivateProfileFloatA( "General", "DoFFocusRange", ds.DoFFocusRange, ini );
         s.DoFBokehRadius = GetPrivateProfileFloatA( "General", "DoFBokehRadius", ds.DoFBokehRadius, ini );
         s.DoFMaxBlur = GetPrivateProfileFloatA( "General", "DoFMaxBlur", ds.DoFMaxBlur, ini );
-        s.AllowNormalmaps = GetPrivateProfileBoolA( "General", "AllowNormalmaps", ds.AllowNormalmaps, ini );
+        s.AllowNormalmaps = GetPrivateProfileIntA( "General", "AllowNormalmaps", ds.AllowNormalmaps, ini.c_str() );
         s.AllowNumpadKeys = GetPrivateProfileBoolA( "General", "AllowNumpadKeys", ds.AllowNumpadKeys, ini );
         s.EnableInactiveFpsLock = GetPrivateProfileBoolA( "General", "EnableInactiveFpsLock", ds.EnableInactiveFpsLock, ini );
         s.MTResoureceManager = GetPrivateProfileBoolA( "General", "MultiThreadResourceManager", ds.MTResoureceManager, ini );

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -150,18 +150,6 @@ __declspec(align(4)) struct GothicPipelineState {
 };
 
 struct GothicPipelineKeyHasher {
-    static const size_t bucket_size = 10; // mean bucket size that the container should try not to exceed
-    static const size_t min_buckets = (1 << 10); // minimum number of buckets, power of 2, >0
-
-    static std::size_t hash_value( float value ) {
-        std::hash<float> hasher;
-        return hasher( value );
-    }
-
-    static void hash_combine( std::size_t& seed, float value ) {
-        seed ^= hash_value( value ) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    }
-
     std::size_t operator()( const GothicPipelineState& k ) const {
         return k.Hash;
     }

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -778,6 +778,7 @@ struct GothicRendererSettings {
 
         LimitLightIntesity = false;
         AllowNormalmaps = false;
+        CompressedNormalsSupport = true;
 
         AllowNumpadKeys = false;
         EnableDebugLog = true;
@@ -1038,7 +1039,8 @@ struct GothicRendererSettings {
     E_AntiAliasingMode AntiAliasingMode;
     E_SharpeningMode SharpeningMode;
     E_GraphicsPreset GraphicsPreset;
-    
+    bool CompressedNormalsSupport;
+
     struct {
         struct {
             bool DepthMotionVectors;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -777,7 +777,7 @@ struct GothicRendererSettings {
         //DisableEverything();
 
         LimitLightIntesity = false;
-        AllowNormalmaps = false;
+        AllowNormalmaps = 0;
         CompressedNormalsSupport = true;
 
         AllowNumpadKeys = false;
@@ -1015,7 +1015,7 @@ struct GothicRendererSettings {
     bool EnableRainEffects;
 
     bool LimitLightIntesity;
-    bool AllowNormalmaps;
+    int AllowNormalmaps;
 
     bool AllowNumpadKeys;
     bool EnableDebugLog;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1256,6 +1256,9 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 ImGui::Checkbox("Use World Section BVH", &settings.DebugSettings.FeatureSet.UseWorldSectionBVH );
                 ImGui::SetItemTooltip("Use Bounding Volume Hierarchy for world sections. Improves culling performance.");
 
+                ImGui::Checkbox("Compressed Normalmaps support", &settings.CompressedNormalsSupport );
+                ImGui::SetItemTooltip("Enables support for BC5 compressed Normalmaps.");
+
                 ImGui::Checkbox("Force Feature Level 10", &settings.DebugSettings.FeatureSet.ForceFeatureLevel10 );
                 ImGui::SetItemTooltip("Force DirectX 10 era feature support. Requires restart.");
                 ImGui::EndTabItem();

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1256,7 +1256,9 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 ImGui::Checkbox("Use World Section BVH", &settings.DebugSettings.FeatureSet.UseWorldSectionBVH );
                 ImGui::SetItemTooltip("Use Bounding Volume Hierarchy for world sections. Improves culling performance.");
 
-                ImGui::Checkbox("Compressed Normalmaps support", &settings.CompressedNormalsSupport );
+                if (ImGui::Checkbox("Compressed Normalmaps support", &settings.CompressedNormalsSupport )) {
+                    Engine::GraphicsEngine->ReloadShaders();
+                }
                 ImGui::SetItemTooltip("Enables support for BC5 compressed Normalmaps.");
 
                 ImGui::Checkbox("Force Feature Level 10", &settings.DebugSettings.FeatureSet.ForceFeatureLevel10 );

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -469,7 +469,14 @@ void ImGuiShim::RenderSettingsWindow()
         {
             ImGui::BeginGroup();
             ImGui::Checkbox( "Vsync", &settings.EnableVSync );
-            if ( ImGui::Checkbox( "NormalMaps", &settings.AllowNormalmaps ) ) {
+            bool enabled = settings.AllowNormalmaps > 0; 
+            if ( ImGui::Checkbox( "NormalMaps", &enabled ) ) {
+                if (enabled) {
+                    settings.AllowNormalmaps = 1;
+                } else {
+                    settings.AllowNormalmaps = 0;
+                }
+                Engine::GraphicsEngine->ReloadShaders();
                 Engine::GAPI->UpdateTextureMaxSize();
             }
 
@@ -1260,6 +1267,20 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                     Engine::GraphicsEngine->ReloadShaders();
                 }
                 ImGui::SetItemTooltip("Enables support for BC5 compressed Normalmaps.");
+
+                static const std::vector<std::pair<const char*, int>> normalMapType = {
+                    { "Disabled",   0 },
+                    { "OpenGL (Y+)",   1 }, 
+                    { "DirectX (Y-)",   2 },
+                };
+                if ( ImComboBoxC( "Normalmapping texture mode", normalMapType, &settings.AllowNormalmaps, []
+                {
+                    Engine::GraphicsEngine->ReloadShaders();
+                    Engine::GAPI->UpdateTextureMaxSize();
+                } ) ) {
+                    ImGui::EndCombo();
+                }
+                ImGui::SetItemTooltip("Enable Normalmapping.\nIf in doubt ask the creator of the Normalmaps you use.\nRequires Normalmaps with RGB channel layout.");
 
                 ImGui::Checkbox("Force Feature Level 10", &settings.DebugSettings.FeatureSet.ForceFeatureLevel10 );
                 ImGui::SetItemTooltip("Force DirectX 10 era feature support. Requires restart.");

--- a/D3D11Engine/Shaders/Toolbox.h
+++ b/D3D11Engine/Shaders/Toolbox.h
@@ -28,8 +28,20 @@ float3x3 cotangent_frame( float3 N, float3 p, float2 uv )
     return float3x3( T * invmax, B * invmax, N );
 }
 
+#ifndef NORMAL_MAP_MODE
+// 1 = OpenGL (Y+)
+// 2 = DirectX (Y-)
+#define NORMAL_MAP_MODE 1
+#endif
+
+#ifndef NORMAL_MAP_RESTORE_Z
+// NORMAL_MAP_RESTORE_Z allows to use BC5 compressed normal maps.
+#define NORMAL_MAP_RESTORE_Z 1
+#endif
+
+
 /** Magic TBN-Calculation function */
-float3 perturb_normal( float3 N, float3 V, Texture2D normalmap, float2 texcoord, SamplerState samplerState, float normalmapDepth = 1.0f)
+float3 perturb_normal_rgb( float3 N, float3 V, Texture2D normalmap, float2 texcoord, SamplerState samplerState, float normalmapDepth = 1.0f)
 {
     // assume N, the interpolated vertex normal and 
     // V, the view vector (vertex to eye)
@@ -39,5 +51,38 @@ float3 perturb_normal( float3 N, float3 V, Texture2D normalmap, float2 texcoord,
 	nrmmap = normalize(nrmmap);
 	
     float3x3 TBN = cotangent_frame( N, -V, texcoord );
-    return normalize( mul(transpose(TBN), nrmmap) );
+    return normalize( mul( nrmmap, TBN ) );
+}
+
+/** Magic TBN-Calculation function */
+float3 perturb_normal_restore_z( float3 N, float3 V, Texture2D normalmap, float2 texcoord, SamplerState samplerState, float normalmapDepth = 1.0f)
+{
+    // assume N, the interpolated vertex normal and 
+    // V, the view vector (vertex to eye)
+    float2 nrmmap_xy = normalmap.Sample(samplerState, texcoord).xy * 2 - 1;
+#if NORMAL_MAP_MODE == 2
+    // flip G channel in DirectX Normals
+	nrmmap_xy.y = -nrmmap_xy.y;
+#endif
+	nrmmap_xy.xy *= normalmapDepth;
+
+    // Reconstruct the Z (Blue) channel using the Pythagorean theorem
+    // saturate() prevents a negative square root if length(xy) happens to exceed 1.0
+    float nrmmap_z = sqrt(saturate(1.0f - dot(nrmmap_xy, nrmmap_xy)));
+
+    // 4. Combine them back into a full float3 normal vector
+    float3 nrmmap = float3(nrmmap_xy, nrmmap_z);
+
+	nrmmap = normalize(nrmmap);
+	
+    float3x3 TBN = cotangent_frame( N, -V, texcoord );
+    return normalize( mul( nrmmap, TBN ) );
+}
+
+float3 perturb_normal( float3 N, float3 V, Texture2D normalmap, float2 texcoord, SamplerState samplerState, float normalmapDepth = 1.0f) {
+#if NORMAL_MAP_RESTORE_Z == 1
+    return perturb_normal_restore_z(N, V, normalmap, texcoord, samplerState, normalmapDepth);
+#else
+    return perturb_normal_rgb(N, V, normalmap, texcoord, samplerState, normalmapDepth);
+#endif
 }

--- a/D3D11Engine/Shaders/Toolbox.h
+++ b/D3D11Engine/Shaders/Toolbox.h
@@ -18,12 +18,17 @@ float3x3 cotangent_frame( float3 N, float3 p, float2 uv )
     float3 dp1perp = cross( N, dp1 );
     float3 T = dp2perp * duv1.x + dp1perp * duv2.x;
     float3 B = dp2perp * duv1.y + dp1perp * duv2.y;
- 
-	// Negate because of left-handedness
-	//T *= -1;
-	//B *= -1;
- 
-    // construct a scale-invariant frame 
+
+    // Handedness of the derived (T, B) frame flips per-triangle for mirrored UV islands.
+    // Detect it from the signed area of the UV-space triangle so mirrored islands get the
+    // opposite correction instead of relying on one hardcoded global flip.
+    // NOTE: the comparison direction below is our pipeline's calibrated convention bias
+    // (previously expressed as an unconditional X-negate on the sampled normal map).
+    // If specular highlights look mirrored after this change, flip "< 0" to "> 0" here.
+    float handedness = ( duv1.x * duv2.y - duv1.y * duv2.x ) < 0.0f ? 1.0f : -1.0f;
+    T *= handedness;
+
+    // construct a scale-invariant frame
     float invmax = rsqrt( max( dot(T,T), dot(B,B) ) );
     return float3x3( T * invmax, B * invmax, N );
 }
@@ -50,7 +55,6 @@ float3 perturb_normal_rgb( float3 N, float3 V, Texture2D normalmap, float2 texco
     // flip G channel in DirectX Normals
 	nrmmap.y = -nrmmap.y;
 #endif
-    nrmmap.x = -nrmmap.x; // we require inverted x or specular shading will be incorrect in some angles
 	nrmmap.xy *= normalmapDepth;
 	nrmmap = normalize(nrmmap);
 	
@@ -68,7 +72,6 @@ float3 perturb_normal_restore_z( float3 N, float3 V, Texture2D normalmap, float2
     // flip G channel in DirectX Normals
 	nrmmap_xy.y = -nrmmap_xy.y;
 #endif
-    nrmmap_xy.x = -nrmmap_xy.x; // we require inverted x or specular shading will be incorrect in some angles
 	nrmmap_xy.xy *= normalmapDepth;
 
     // Reconstruct the Z (Blue) channel using the Pythagorean theorem

--- a/D3D11Engine/Shaders/Toolbox.h
+++ b/D3D11Engine/Shaders/Toolbox.h
@@ -46,7 +46,10 @@ float3 perturb_normal_rgb( float3 N, float3 V, Texture2D normalmap, float2 texco
     // assume N, the interpolated vertex normal and 
     // V, the view vector (vertex to eye)
     float3 nrmmap = normalmap.Sample(samplerState, texcoord).xyz * 2 - 1;
-	nrmmap.xy *= -1.0f;
+#if NORMAL_MAP_MODE == 2
+    // flip G channel in DirectX Normals
+	nrmmap.y = -nrmmap.y;
+#endif
 	nrmmap.xy *= normalmapDepth;
 	nrmmap = normalize(nrmmap);
 	

--- a/D3D11Engine/Shaders/Toolbox.h
+++ b/D3D11Engine/Shaders/Toolbox.h
@@ -50,6 +50,7 @@ float3 perturb_normal_rgb( float3 N, float3 V, Texture2D normalmap, float2 texco
     // flip G channel in DirectX Normals
 	nrmmap.y = -nrmmap.y;
 #endif
+    nrmmap.x = -nrmmap.x; // we require inverted x or specular shading will be incorrect in some angles
 	nrmmap.xy *= normalmapDepth;
 	nrmmap = normalize(nrmmap);
 	
@@ -67,6 +68,7 @@ float3 perturb_normal_restore_z( float3 N, float3 V, Texture2D normalmap, float2
     // flip G channel in DirectX Normals
 	nrmmap_xy.y = -nrmmap_xy.y;
 #endif
+    nrmmap_xy.x = -nrmmap_xy.x; // we require inverted x or specular shading will be incorrect in some angles
 	nrmmap_xy.xy *= normalmapDepth;
 
     // Reconstruct the Z (Blue) channel using the Pythagorean theorem

--- a/D3D11Engine/zCView.h
+++ b/D3D11Engine/zCView.h
@@ -60,10 +60,10 @@ public:
             return;
         }
 
-        int len = s.Length();
+        auto len = s.Length();
         if ( len > 0 ) {
             Engine::GraphicsEngine->DrawString(
-                std::string( s.ToChar(), len ),
+                std::string_view{ s.ToChar(), len },
                 static_cast<float>( x ),
                 static_cast<float>( y ),
                 thisptr->font, thisptr->fontColor );

--- a/D3D11Engine/zSTRING.h
+++ b/D3D11Engine/zSTRING.h
@@ -40,7 +40,7 @@ public:
 
 private:
     void* _vtblString;
-    void* _unknwn;
+    void* _allocator;
     //---
     char* _dataPtr;
     size_t length;


### PR DESCRIPTION
- Normalmapping
  - support compressed normalmaps by always re-computing Z from X(R) & Y(G) by default.
    BC5 offers superior quality as each channel is encoded separately and there is no channel cross-talk. It shares the same file size as BC7, but only works on two channels.
    - added option to revert to old RGB-style normalmap usage, but not needed unless computing Z is way too expensive on the hardware (toaster?)
      should not be necessery, any PC powerfull enough to run Normalmaps should be powerfull enough to be able to decode Z from XY
  - Ensure tanget space normals are always the correct handedness even if using mirrored UVs
  - Only Flip "X" (G) if Normalmap Mode == DirectX
- Optimize `DrawString` by using `string_view` instead of allocation new strings constantly.