### PR TITLE
renderer cleanup and material lifetime fixes

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4980,6 +4980,10 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
         for ( auto const& renderItem : renderList ) {
             for ( auto const& worldMesh : renderItem->WorldMeshes ) {
                 if ( worldMesh.first.Material ) {
+                    if ( !Engine::GAPI->IsMaterialActive( worldMesh.first.Material ) ) {
+                        continue;
+                    }
+
                     zCTexture* aniTex = worldMesh.first.Material->GetTexture();
                     if ( !aniTex ) continue;
 
@@ -5560,6 +5564,10 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                 } else {
                     for ( auto&& meshInfoByKey = section->WorldMeshes.begin();
                         meshInfoByKey != section->WorldMeshes.end(); ++meshInfoByKey ) {
+                        if ( !meshInfoByKey->first.Material || !Engine::GAPI->IsMaterialActive( meshInfoByKey->first.Material ) ) {
+                            continue;
+                        }
+
                         // Check surface type
                         if ( meshInfoByKey->first.Info->MaterialType != MaterialInfo::MT_None ) {
                             continue;
@@ -5909,6 +5917,10 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
                 } else {
                     for ( auto&& meshInfoByKey = section->WorldMeshes.begin();
                         meshInfoByKey != section->WorldMeshes.end(); ++meshInfoByKey ) {
+                        if ( !meshInfoByKey->first.Material || !Engine::GAPI->IsMaterialActive( meshInfoByKey->first.Material ) ) {
+                            continue;
+                        }
+
                         // Check surface type
                         if ( meshInfoByKey->first.Info->MaterialType != MaterialInfo::MT_None ) {
                             continue;
@@ -6155,6 +6167,10 @@ void D3D11GraphicsEngine::ShadowPass_DrawWorldMesh_Indirect( const std::vector<W
         auto _scopeClassify = RecordGraphicsEvent( GE_NAME( "ShadowPass_DrawWorldMesh_Indirect::Classify" ) );
         for ( const WorldMeshSectionInfo* section : visibleSections ) {
             for ( const auto& meshPair : section->WorldMeshes ) {
+                if ( !meshPair.first.Material || !Engine::GAPI->IsMaterialActive( meshPair.first.Material ) ) {
+                    continue;
+                }
+
                 if ( meshPair.first.Info->MaterialType != MaterialInfo::MT_None )
                     continue;
 
@@ -6274,6 +6290,10 @@ void D3D11GraphicsEngine::ShadowPass_DrawWorldMesh( const std::vector<WorldMeshS
         auto _scopeClassify = RecordGraphicsEvent( GE_NAME( "ShadowPass_DrawWorldMesh::Classify" ) );
         for ( const WorldMeshSectionInfo* section : visibleSections ) {
             for ( const auto& meshPair : section->WorldMeshes ) {
+                if ( !meshPair.first.Material || !Engine::GAPI->IsMaterialActive( meshPair.first.Material ) ) {
+                    continue;
+                }
+
                 // Skip non-standard materials (water, portals, etc.)
                 if ( meshPair.first.Info->MaterialType != MaterialInfo::MT_None )
                     continue;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -781,19 +781,91 @@ void GothicAPI::RemoveVegetationBox( GVegetationBox* box ) {
     delete box;
 }
 
+namespace {
+    std::unordered_set<MeshVisualInfo*> PendingMeshVisuals;
+    std::unordered_set<SkeletalMeshVisualInfo*> PendingSkeletalVisuals;
+    std::unordered_set<VobInfo*> PendingVobInfos;
+    std::unordered_set<SkeletalVobInfo*> PendingSkeletalVobInfos;
+    std::unordered_set<VobLightInfo*> PendingVobLightInfos;
+
+    void PrepareMeshVisualForDelete( MeshVisualInfo* visual ) {
+        if ( !visual )
+            return;
+
+        visual->MorphMeshVisual = nullptr;
+    }
+
+    void PrepareSkeletalVobForDelete( SkeletalVobInfo* vobInfo ) {
+        if ( !vobInfo )
+            return;
+
+        for ( auto& [_, meshes] : vobInfo->NodeAttachments ) {
+            for ( MeshVisualInfo* visual : meshes ) {
+                PrepareMeshVisualForDelete( visual );
+            }
+        }
+    }
+
+    template <class T, class PrepareFn>
+    void DeletePendingSet( std::unordered_set<T*>& set, PrepareFn prepare ) {
+        for ( T* ptr : set ) {
+            prepare( ptr );
+            delete ptr;
+        }
+        set.clear();
+    }
+
+    void ReleasePendingRendererResources() {
+        DeletePendingSet( PendingMeshVisuals, PrepareMeshVisualForDelete );
+        DeletePendingSet( PendingSkeletalVisuals, []( SkeletalMeshVisualInfo* ) {} );
+        DeletePendingSet( PendingVobInfos, []( VobInfo* ) {} );
+        DeletePendingSet( PendingSkeletalVobInfos, PrepareSkeletalVobForDelete );
+        DeletePendingSet( PendingVobLightInfos, []( VobLightInfo* ) {} );
+    }
+
+    void QueueMeshVisualForRelease( MeshVisualInfo* visual ) {
+        if ( visual )
+            PendingMeshVisuals.insert( visual );
+    }
+
+    void QueueSkeletalVisualForRelease( SkeletalMeshVisualInfo* visual ) {
+        if ( visual )
+            PendingSkeletalVisuals.insert( visual );
+    }
+
+    void QueueVobInfoForRelease( VobInfo* vobInfo ) {
+        if ( vobInfo )
+            PendingVobInfos.insert( vobInfo );
+    }
+
+    void QueueSkeletalVobInfoForRelease( SkeletalVobInfo* vobInfo ) {
+        if ( vobInfo )
+            PendingSkeletalVobInfos.insert( vobInfo );
+    }
+
+    void QueueVobLightInfoForRelease( VobLightInfo* vobInfo ) {
+        if ( vobInfo )
+            PendingVobLightInfos.insert( vobInfo );
+    }
+}
+
 /** Resets the object, like at level load */
 void GothicAPI::ResetWorld() {
-    ResetVobs();
+    ReleasePendingRendererResources();
+
+    ResetVobs( false );
     ClearWorldSectionBVH();
     WorldSections.clear();
 
     SAFE_DELETE( WrappedWorldMesh );
+    ReleasePendingRendererResources();
 
     // Clear inventory too?
 }
 
 void GothicAPI::ReloadVobs() {
-    ResetVobs();
+    ResetVobs( false );
+    ReleasePendingRendererResources();
     OnWorldLoaded();
 }
 void GothicAPI::ReloadPlayerVob() {
@@ -806,7 +878,47 @@ void GothicAPI::ReloadPlayerVob() {
     OnAddVob( player, playerHomeworld );
 }
 /** Resets only the vobs */
-void GothicAPI::ResetVobs() {
+void GothicAPI::ResetVobs( bool releaseRendererResources ) {
+    std::unordered_set<void*> deletedVisuals;
+    std::unordered_set<void*> deletedVobInfos;
+
+    auto deleteOnce = []( auto* ptr, std::unordered_set<void*>& deletedPtrs ) {
+        if ( !ptr )
+            return false;
+
+        auto [_, inserted] = deletedPtrs.insert( ptr );
+        if ( inserted ) {
+            delete ptr;
+        }
+
+        return inserted;
+    };
+
+    auto deleteMeshVisualOnce = [&deletedVisuals]( MeshVisualInfo* ptr ) {
+        if ( !ptr )
+            return false;
+
+        auto [_, inserted] = deletedVisuals.insert( ptr );
+        if ( inserted ) {
+            PrepareMeshVisualForDelete( ptr );
+            delete ptr;
+        }
+
+        return inserted;
+    };
+
+    auto deleteSkeletalVobInfoOnce = [&deletedVobInfos]( SkeletalVobInfo* ptr ) {
+        if ( !ptr )
+            return false;
+
+        auto [_, inserted] = deletedVobInfos.insert( ptr );
+        if ( inserted ) {
+            PrepareSkeletalVobForDelete( ptr );
+            delete ptr;
+        }
+
+        return inserted;
+    };
     
     // complete what ever is currently working, and clear everything else.
     Engine::WorkerThreadPool->clearAndFlush();
@@ -815,7 +927,11 @@ void GothicAPI::ResetVobs() {
     // by deleting them first we block the thread until the destructor finished
     for ( auto const& it : VobLightMap ) {
         Engine::GraphicsEngine->OnVobRemovedFromWorld( it.first );
-        delete it.second;
+        if ( releaseRendererResources ) {
+            delete it.second;
+        } else {
+            QueueVobLightInfoForRelease( it.second );
+        }
     }
     VobLightMap.clear();
     
@@ -823,6 +939,7 @@ void GothicAPI::ResetVobs() {
     for ( auto&& itx : Engine::GAPI->GetWorldSections() ) {
         for ( auto&& ity : itx.second ) {
             ity.second.Vobs.clear();
+            ity.second.InstanceCache.Clear();
         }
     }
 
@@ -830,12 +947,15 @@ void GothicAPI::ResetVobs() {
     ResetVegetation();
 
     // Clear helper-lists
-    for ( zCVob* vob : ParticleEffectVobs ) {
-        DestroyParticleEffect( vob );
+    if ( releaseRendererResources ) {
+        for ( zCVob* vob : ParticleEffectVobs ) {
+            DestroyParticleEffect( vob );
+        }
     }
 
     FrameThunderPolyStrips.clear();
     FlashVisuals.clear();
+    FrameMeshInstances.clear();
     ParticleEffectVobs.clear();
     RegisteredVobs.clear();
     BspLeafVobLists.clear();
@@ -845,31 +965,66 @@ void GothicAPI::ResetVobs() {
     VobsByVisual.clear();
     SkeletalVobMap.clear();
 
+    if ( !releaseRendererResources ) {
+        for ( auto const& it : StaticMeshVisuals ) {
+            QueueMeshVisualForRelease( it.second );
+        }
+        for ( auto const& it : ParticleEffectProgMeshes ) {
+            QueueMeshVisualForRelease( it.second );
+        }
+        for ( auto const& it : SkeletalMeshVisuals ) {
+            QueueSkeletalVisualForRelease( it.second );
+        }
+        for ( auto const& it : SkeletalMeshNpcs ) {
+            QueueSkeletalVisualForRelease( it.second );
+        }
+        for ( auto const& it : VobMap ) {
+            QueueVobInfoForRelease( it.second );
+        }
+        for ( auto it : SkeletalMeshVobs ) {
+            QueueSkeletalVobInfoForRelease( it );
+        }
+
+        StaticMeshVisuals.clear();
+        ParticleEffectProgMeshes.clear();
+        SkeletalMeshVisuals.clear();
+        SkeletalMeshNpcs.clear();
+        VobMap.clear();
+        SkeletalMeshVobs.clear();
+        AnimatedSkeletalVobs.clear();
+        return;
+    }
+
     // Delete static mesh visuals
     for ( auto const& it : StaticMeshVisuals ) {
-        delete it.second;
+        deleteMeshVisualOnce( it.second );
     }
     StaticMeshVisuals.clear();
 
+    for ( auto const& it : ParticleEffectProgMeshes ) {
+        deleteMeshVisualOnce( it.second );
+    }
+    ParticleEffectProgMeshes.clear();
+
     // Delete skeletal mesh visuals
     for ( auto const& it : SkeletalMeshVisuals ) {
-        delete it.second;
+        deleteOnce( it.second, deletedVisuals );
     }
     for ( auto const& it : SkeletalMeshNpcs ) {
-        delete it.second;
+        deleteOnce( it.second, deletedVisuals );
     }
     SkeletalMeshVisuals.clear();
     SkeletalMeshNpcs.clear();
 
     // Delete static mesh vobs
     for ( auto const& it : VobMap ) {
-        delete it.second;
+        deleteOnce( it.second, deletedVobInfos );
     }
     VobMap.clear();
 
     // Delete skeletal mesh vobs
     for ( auto it : SkeletalMeshVobs ) {
-        delete it;
+        deleteSkeletalVobInfoOnce( it );
     }
     SkeletalMeshVobs.clear();
     AnimatedSkeletalVobs.clear();
@@ -1740,29 +1895,105 @@ void GothicAPI::GetVisibleDecalList( std::vector<zCVob*>& decals ) {
 
 /** Called when a material got removed */
 void GothicAPI::OnMaterialDeleted( zCMaterial* mat ) {
-#define UnloadMaterial(cont, m) \
-do { \
-    auto mit = cont.find(m); \
-    if ( mit != cont.end() ) { \
-        for ( auto& mi : mit->second ) { \
-            delete mi; \
-        } \
-        cont.erase(mit); \
-    } \
-} while (0)
-
     LoadedMaterials.erase( mat );
     if ( !mat )
         return;
+
+    auto eraseMeshKeyEntries = [mat]( auto& cont ) {
+        for ( auto it = cont.begin(); it != cont.end(); ) {
+            if ( it->first.Material == mat ) {
+                it = cont.erase( it );
+            } else {
+                ++it;
+            }
+        }
+    };
+
+    auto eraseCachedMeshKeyEntries = [mat]( auto& cont ) {
+        cont.erase( std::remove_if( cont.begin(), cont.end(),
+            [mat]( const auto& entry ) {
+                return entry.first.Material == mat;
+            } ), cont.end() );
+    };
+
+    auto unloadStaticMaterial = [mat, &eraseMeshKeyEntries, &eraseCachedMeshKeyEntries]( MeshVisualInfo* visual ) {
+        if ( !visual )
+            return;
+
+        auto mit = visual->Meshes.find( mat );
+        if ( mit != visual->Meshes.end() ) {
+            for ( MeshInfo* mi : mit->second ) {
+                delete mi;
+            }
+            visual->Meshes.erase( mit );
+        }
+
+        eraseMeshKeyEntries( visual->MeshesByTexture );
+        eraseCachedMeshKeyEntries( visual->MeshesCached );
+    };
+
+    auto unloadSkeletalMaterial = [mat]( SkeletalMeshVisualInfo* visual ) {
+        if ( !visual )
+            return;
+
+        auto meshIt = visual->Meshes.find( mat );
+        if ( meshIt != visual->Meshes.end() ) {
+            for ( MeshInfo* mi : meshIt->second ) {
+                delete mi;
+            }
+            visual->Meshes.erase( meshIt );
+        }
+
+        auto skelIt = visual->SkeletalMeshes.find( mat );
+        if ( skelIt != visual->SkeletalMeshes.end() ) {
+            for ( SkeletalMeshInfo* smi : skelIt->second ) {
+                delete smi;
+            }
+            visual->SkeletalMeshes.erase( skelIt );
+        }
+    };
+
+    for ( auto&& sectionX : WorldSections ) {
+        for ( auto&& sectionY : sectionX.second ) {
+            WorldMeshSectionInfo& section = sectionY.second;
+
+            for ( auto it = section.WorldMeshes.begin(); it != section.WorldMeshes.end(); ) {
+                if ( it->first.Material == mat ) {
+                    delete it->second;
+                    it = section.WorldMeshes.erase( it );
+                } else {
+                    ++it;
+                }
+            }
+
+            for ( auto it = section.SuppressedMeshes.begin(); it != section.SuppressedMeshes.end(); ) {
+                if ( it->first.Material == mat ) {
+                    delete it->second;
+                    it = section.SuppressedMeshes.erase( it );
+                } else {
+                    ++it;
+                }
+            }
+
+            section.WorldMeshesByCustomTextureOriginal.erase( mat );
+            section.InstanceCache.Clear();
+        }
+    }
+
+    for ( auto&& it : StaticMeshVisuals ) {
+        unloadStaticMaterial( it.second );
+    }
+
+    for ( auto&& it : ParticleEffectProgMeshes ) {
+        unloadStaticMaterial( it.second );
+    }
+
     for ( auto&& it : SkeletalMeshVisuals ) {
-        UnloadMaterial( it.second->Meshes, mat );
-        UnloadMaterial( it.second->SkeletalMeshes, mat );
+        unloadSkeletalMaterial( it.second );
     }
     for ( auto&& it : SkeletalMeshNpcs ) {
-        UnloadMaterial( it.second->Meshes, mat );
-        UnloadMaterial( it.second->SkeletalMeshes, mat );
+        unloadSkeletalMaterial( it.second );
     }
-#undef UnloadMaterial
 }
 
 /** Called when a material got created */

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -656,7 +656,7 @@ public:
     void ResetWorld();
 
     /** Resets only the vobs */
-    void ResetVobs();
+    void ResetVobs( bool releaseRendererResources = true );
 
     /** Get material by texture name */
     zCMaterial* GetMaterialByTextureName( const std::string& name );

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -41,7 +41,12 @@ void SkeletalVobInfo::UpdateState() {
 }
 
 SectionInstanceCache::~SectionInstanceCache() {
+    Clear();
+}
+
+void SectionInstanceCache::Clear() {
     InstanceCache.clear();
+    InstanceCacheData.clear();
 }
 
 MeshInfo::~MeshInfo() {

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -483,6 +483,9 @@ struct SectionInstanceCache {
     SectionInstanceCache() = default;
     ~SectionInstanceCache();
 
+    /** Releases all cached instance buffers and cached per-instance data */
+    void Clear();
+
     /** Clears the cache for the given progmesh */
     void ClearCacheForStatic( MeshVisualInfo* pm );
 

--- a/D3D11Engine/zCWorld.h
+++ b/D3D11Engine/zCWorld.h
@@ -112,7 +112,7 @@ public:
         ZoneScoped;
         // Reset only if this is the main world, inventory worlds are handled differently
         if ( thisptr == Engine::GAPI->GetLoadedWorldInfo()->MainWorld )
-            Engine::GAPI->ResetVobs();
+            Engine::GAPI->ResetVobs( false );
 
         HookedFunctions::OriginalFunctions.original_zCWorldDisposeVobs( thisptr, tree );
     }


### PR DESCRIPTION
The main goal of this pr is to reduce crashes/leaks caused by stale renderer-side references during world/VOB cleanup and material destruction.
Before these changes, when i changed world ~60 times my game crashed, after these changes i was able to change my world ~160 times without crash (possibly more). 
