### PR TITLE
feat: introduce `MaterialHandle` and `zCMaterialManager`

### DIFF
--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1061,6 +1061,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="include\imgui\imstb_truetype.h" />
     <ClInclude Include="InstructionSet.h" />
     <ClInclude Include="Logger.h" />
+    <ClInclude Include="MaterialHandle.h" />
     <ClInclude Include="MemoryTracker.h" />
     <ClInclude Include="MeshManager.h" />
     <ClInclude Include="MeshModifier.h" />
@@ -1105,6 +1106,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="VertexTypes.h" />
     <ClInclude Include="WorldConverter.h" />
     <ClInclude Include="zCBspTree.h" />
+    <ClInclude Include="zCMaterialManager.h" />
     <ClInclude Include="zCMesh.h" />
     <ClInclude Include="zCMeshSoftSkin.h" />
     <ClInclude Include="zCModel.h" />
@@ -1305,6 +1307,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="BaseShadowedPointLight.cpp" />
+    <ClCompile Include="zCMaterialManager.cpp" />
     <ClCompile Include="zSndMss.cpp" />
     <None Include="Shaders\PS_Grass.hlsl" />
     <None Include="Shaders\VS_GrassInstanced.hlsl" />

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4687,10 +4687,14 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
     ffdata.textureFactor = float4( 1.0f, 1.0f, 1.0f, 1.0f );
     
     void* lastTex = nullptr;
-    void* lastMat = nullptr;
+    MaterialHandle lastMat{};
     MaterialInfo* lastInfo = nullptr;
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
     for ( auto const& [meshKey, meshInfo] : list ) {
-        if ( zCTexture* texture = meshKey.Material->GetAniTexture() ) {
+        auto material = materialManager.GetMaterial(meshKey.Material);
+        if (!material) continue;
+
+        if ( zCTexture* texture = material->GetAniTexture() ) {
             if (texture->CacheIn( 0.6f ) != zRES_CACHED_IN) {
                 // Draw what? black? :)
                 continue;
@@ -4709,10 +4713,10 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
                 ? surface->GetFxMap()->GetShaderResourceView().Get()
                 : nullptr;
             
-            int alphaFunc = meshKey.Material->GetAlphaFunc();
+            int alphaFunc = material->GetAlphaFunc();
 
             if ( alphaFunc == 0 ) {
-                alphaFunc = zColor( meshKey.Material->GetColor() ).bgra.alpha < 255
+                alphaFunc = zColor( material->GetColor() ).bgra.alpha < 255
                     ? zMAT_ALPHA_FUNC_BLEND
                     : zMAT_ALPHA_FUNC_MAT_DEFAULT;
             }
@@ -4763,7 +4767,7 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
                 lastAlphaFunc = alphaFunc;
             }
             
-            if (meshKey.Material->GetEnvMapEnabled()) {
+            if (material->GetEnvMapEnabled()) {
                 if (Engine::GAPI->GetSky()->GetAtmosphereCB().AC_LightPos.y > 0) {
                     // sun is up
 
@@ -4773,14 +4777,14 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
 
                     float minIntensity = 0.1f;
                     float maxIntensity = 0.7f;
-                    float currentIntensity = std::clamp( meshKey.Material->GetEnvMapStrength() * std::lerp( minIntensity, maxIntensity, lerpFactor ), 0.0f, 1.0f);
+                    float currentIntensity = std::clamp( material->GetEnvMapStrength() * std::lerp( minIntensity, maxIntensity, lerpFactor ), 0.0f, 1.0f);
                     ffdata.textureFactor = zColor( 255, 255, 255, (uint8_t)(255.0f * currentIntensity) ).ToFloat4();
                 } else {
-                    ffdata.textureFactor = zColor( 255, 255, 255, (uint8_t)(255.0f * meshKey.Material->GetEnvMapStrength() * 0.1f) ).ToFloat4();
+                    ffdata.textureFactor = zColor( 255, 255, 255, (uint8_t)(255.0f * material->GetEnvMapStrength() * 0.1f) ).ToFloat4();
                 }
             } else {
-                if ( zColor( meshKey.Material->GetColor() ).bgra.alpha < 255 ) {
-                    ffdata.textureFactor = zColor( meshKey.Material->GetColor() ).ToFloat4();
+                if ( zColor( material->GetColor() ).bgra.alpha < 255 ) {
+                    ffdata.textureFactor = zColor( material->GetColor() ).ToFloat4();
                 }
             }
 
@@ -4813,7 +4817,8 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
     // Draw again, but only to depthbuffer this time to make them work with
     // fogging
     for ( auto const& [meshKey, meshInfo] : list ) {
-        if ( meshKey.Material->GetAniTexture() != nullptr && meshKey.Info->MaterialType != MaterialInfo::MT_Portal ) {
+        const auto material = materialManager.GetMaterial(meshKey.Material);
+        if ( material && material->GetAniTexture() != nullptr && meshKey.Info->MaterialType != MaterialInfo::MT_Portal ) {
             // Draw the section-part
             DrawVertexBufferIndexedUINT( nullptr, nullptr, meshInfo->Indices.size(),
                 meshInfo->BaseIndexLocation );
@@ -4922,72 +4927,71 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
         static std::vector<WorldMeshSectionInfo*> alphaBlendedThings;
         alphaBlendedThings.clear();
         alphaBlendedThings.reserve( 200 );
+        auto& materialManager = Engine::GAPI->GetMaterialManager();
 
         for ( auto const& renderItem : renderList ) {
             for ( auto const& worldMesh : renderItem->WorldMeshes ) {
-                if ( worldMesh.first.Material ) {
-                    if ( !Engine::GAPI->IsMaterialActive( worldMesh.first.Material ) ) {
+                auto material = materialManager.GetMaterial(worldMesh.first.Material);
+                if ( !material ) {
+                    continue;
+                }
+                zCTexture* aniTex = material->GetTexture();
+                if ( !aniTex ) continue;
+
+                // Check surface type
+                if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_Water ) {
+                    if ( !isZPrepass ) {
+                        FrameWaterSurfaces[aniTex].push_back( worldMesh.second );
+                    }
+                    continue;
+                }
+
+                const float distanceSq = ComputeWorldMeshDistanceSqFromCamera( renderItem, worldMesh.second, cameraPosition );
+                const std::pair<MeshKey, MeshInfo*> transparencyMesh = { worldMesh.first, worldMesh.second };
+
+                if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_Portal ) {
+                    if ( !isZPrepass ) {
+                        portalTransparencyMeshes.push_back( { transparencyMesh, distanceSq } );
+                    }
+                    continue;
+                } else if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_WaterfallFoam ) {
+                    if ( !isZPrepass ) {
+                        waterfallTransparencyMeshes.push_back( { transparencyMesh, distanceSq } );
+                    }
+                    continue;
+                }
+
+                // Check for alphablending
+                if ( (material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
+                    material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST)
+                    // || (material->GetEnvMapEnabled())
+                    ) {
+                    if ( !isZPrepass ) {
+                        transparencyMeshes.push_back( { transparencyMesh, distanceSq } );
+                    }
+                    continue;
+                } else {
+
+                    if ( aniTex->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
                         continue;
                     }
-
-                    zCTexture* aniTex = worldMesh.first.Material->GetTexture();
-                    if ( !aniTex ) continue;
-
-                    // Check surface type
-                    if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_Water ) {
-                        if ( !isZPrepass ) {
-                            FrameWaterSurfaces[aniTex].push_back( worldMesh.second );
-                        }
-                        continue;
+                    int alphaLevel = 0;
+                    if ( worldMesh.first.Texture && worldMesh.first.Texture->HasAlphaChannel() ) {
+                        alphaLevel = 2;
+                    } else if ( material && material->HasAlphaTest() ) {
+                        alphaLevel = 1;
                     }
 
-                    const float distanceSq = ComputeWorldMeshDistanceSqFromCamera( renderItem, worldMesh.second, cameraPosition );
-                    const std::pair<MeshKey, MeshInfo*> transparencyMesh = { worldMesh.first, worldMesh.second };
+                    WorldMeshKey key = {
+                        aniTex,
+                        material,
+                        worldMesh.first.Info,
+                        alphaLevel,
+                        distanceSq,
+                    };
 
-                    if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_Portal ) {
-                        if ( !isZPrepass ) {
-                            portalTransparencyMeshes.push_back( { transparencyMesh, distanceSq } );
-                        }
-                        continue;
-                    } else if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_WaterfallFoam ) {
-                        if ( !isZPrepass ) {
-                            waterfallTransparencyMeshes.push_back( { transparencyMesh, distanceSq } );
-                        }
-                        continue;
-                    }
-
-                    // Check for alphablending
-                    if ( (worldMesh.first.Material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
-                        worldMesh.first.Material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST)
-                        // || (worldMesh.first.Material->GetEnvMapEnabled())
-                        ) {
-                        if ( !isZPrepass ) {
-                            transparencyMeshes.push_back( { transparencyMesh, distanceSq } );
-                        }
-                        continue;
-                    } else {
-
-                        if ( aniTex->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
-                            continue;
-                        }
-                        int alphaLevel = 0;
-                        if ( worldMesh.first.Texture && worldMesh.first.Texture->HasAlphaChannel() ) {
-                            alphaLevel = 2;
-                        } else if ( worldMesh.first.Material && worldMesh.first.Material->HasAlphaTest() ) {
-                            alphaLevel = 1;
-                        }
-
-                        WorldMeshKey key = {
-                            aniTex,
-                            worldMesh.first.Material,
-                            worldMesh.first.Info,
-                            alphaLevel,
-                            distanceSq,
-                        };
-
-                        // Create a new pair using the animated texture
-                        meshList.emplace_back( key, worldMesh.second );
-                    }
+                    // Create a new pair using the animated texture
+                    meshList.emplace_back( key, worldMesh.second );
                 }
             }
         }
@@ -5442,6 +5446,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
     const bool drawVobCasters = (casterMask & SHADOW_CASTER_VOBS) != 0;
     const bool drawMobCasters = (casterMask & SHADOW_CASTER_MOBS) != 0;
     const bool drawAnimatedCasters = (casterMask & SHADOW_CASTER_ANIMATED) != 0;
+    
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
 
     if ( drawWorldCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh ) {
         vsBufMPI.Update( &identityMatrix ).Bind();
@@ -5453,19 +5459,20 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
         if ( worldMeshCache && !worldMeshCache->empty() ) {
             for ( auto&& meshInfoByKey = worldMeshCache->begin(); meshInfoByKey != worldMeshCache->end(); ++meshInfoByKey ) {
                 bool isAlpha = false;
+                auto material = materialManager.GetMaterial(meshInfoByKey->first.Material);
                 // Bind texture
-                if ( meshInfoByKey->first.Material && meshInfoByKey->first.Material->GetTexture() ) {
+                if ( material && material->GetTexture() ) {
                     // Check surface type
 
                     if ( meshInfoByKey->first.Info->MaterialType != MaterialInfo::MT_None ) {
                         continue;
                     }
 
-                    if ( meshInfoByKey->first.Material->HasAlphaTest() || meshInfoByKey->first.Material->GetTexture()->HasAlphaChannel() ) {
-                        if ( alphaRef > 0.0f && meshInfoByKey->first.Material->GetTexture()->CacheIn( 0.6f ) == zRES_CACHED_IN ) {
-                            void* engineTex = meshInfoByKey->first.Material->GetTexture()->GetSurface()->GetEngineTexture();
+                    if ( material->HasAlphaTest() || material->GetTexture()->HasAlphaChannel() ) {
+                        if ( alphaRef > 0.0f && material->GetTexture()->CacheIn( 0.6f ) == zRES_CACHED_IN ) {
+                            void* engineTex = material->GetTexture()->GetSurface()->GetEngineTexture();
                             if ( lastTex != engineTex ) {
-                                meshInfoByKey->first.Material->GetTexture()->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
+                                material->GetTexture()->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
                                 lastTex = engineTex;
                             }
                             ActivePS->Apply();
@@ -5512,25 +5519,25 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                 } else {
                     for ( auto&& meshInfoByKey = section->WorldMeshes.begin();
                         meshInfoByKey != section->WorldMeshes.end(); ++meshInfoByKey ) {
-                        if ( !meshInfoByKey->first.Material || !Engine::GAPI->IsMaterialActive( meshInfoByKey->first.Material ) ) {
-                            continue;
-                        }
-
                         // Check surface type
                         if ( meshInfoByKey->first.Info->MaterialType != MaterialInfo::MT_None ) {
+                            continue;
+                        }
+                        auto material = materialManager.GetMaterial(meshInfoByKey->first.Material);
+                        if (!material) {
                             continue;
                         }
 
                         bool isAlpha = false;
                         // Bind texture
-                        if ( meshInfoByKey->first.Material && meshInfoByKey->first.Material->GetTexture() ) {
-                            if ( meshInfoByKey->first.Material->HasAlphaTest() || meshInfoByKey->first.Material->GetTexture()->HasAlphaChannel() ) {
+                        if ( material && material->GetTexture() ) {
+                            if ( material->HasAlphaTest() || material->GetTexture()->HasAlphaChannel() ) {
                                 if ( alphaRef > 0.0f &&
-                                    meshInfoByKey->first.Material->GetTexture()->CacheIn( 0.6f ) ==
+                                    material->GetTexture()->CacheIn( 0.6f ) ==
                                     zRES_CACHED_IN ) {
-                                    void* engineTex = meshInfoByKey->first.Material->GetTexture()->GetSurface()->GetEngineTexture();
+                                    void* engineTex = material->GetTexture()->GetSurface()->GetEngineTexture();
                                     if ( lastTex != engineTex ) {
-                                        meshInfoByKey->first.Material->GetTexture()->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
+                                        material->GetTexture()->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
                                         lastTex = engineTex;
                                     }
                                     ActivePS->Apply();
@@ -5796,6 +5803,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
     const bool drawMobCasters = (casterMask & SHADOW_CASTER_MOBS) != 0;
     const bool drawAnimatedCasters = (casterMask & SHADOW_CASTER_ANIMATED) != 0;
 
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
+    
     void* lastTex = nullptr;
     if ( drawWorldCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh ) { 
         ActiveVS->GetBuffer( "Matrices_PerInstances" ).Update( &identityMatrix ).Bind();
@@ -5807,19 +5816,20 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
         if ( worldMeshCache && !worldMeshCache->empty() ) {
             for ( auto&& meshInfoByKey = worldMeshCache->begin(); meshInfoByKey != worldMeshCache->end(); ++meshInfoByKey ) {
                 // Bind texture
+                auto material = materialManager.GetMaterial(meshInfoByKey->first.Material);
                 bool isAlpha = false;
-                if ( meshInfoByKey->first.Material && meshInfoByKey->first.Material->GetTexture() ) {
+                if ( material && material->GetTexture() ) {
                     // Check surface type
 
                     if ( meshInfoByKey->first.Info->MaterialType != MaterialInfo::MT_None ) {
                         continue;
                     }
 
-                    if ( meshInfoByKey->first.Material->HasAlphaTest() || meshInfoByKey->first.Material->GetTexture()->HasAlphaChannel() ) {
-                        if ( alphaRef > 0.0f && meshInfoByKey->first.Material->GetTexture()->CacheIn(
+                    if ( material->HasAlphaTest() || material->GetTexture()->HasAlphaChannel() ) {
+                        if ( alphaRef > 0.0f && material->GetTexture()->CacheIn(
                             0.6f ) == zRES_CACHED_IN ) {
-                            lastTex = meshInfoByKey->first.Material->GetTexture()->GetSurface()->GetEngineTexture();
-                            meshInfoByKey->first.Material->GetTexture()->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
+                            lastTex = material->GetTexture()->GetSurface()->GetEngineTexture();
+                            material->GetTexture()->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
                             ActivePS->Apply();
                             isAlpha = true;
                         } else
@@ -5865,25 +5875,25 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
                 } else {
                     for ( auto&& meshInfoByKey = section->WorldMeshes.begin();
                         meshInfoByKey != section->WorldMeshes.end(); ++meshInfoByKey ) {
-                        if ( !meshInfoByKey->first.Material || !Engine::GAPI->IsMaterialActive( meshInfoByKey->first.Material ) ) {
-                            continue;
-                        }
 
                         // Check surface type
                         if ( meshInfoByKey->first.Info->MaterialType != MaterialInfo::MT_None ) {
                             continue;
                         }
-
+                        auto material = materialManager.GetMaterial(meshInfoByKey->first.Material);
+                        if ( !material ) {
+                            continue;
+                        }
                         bool isAlpha = false;
                         // Bind texture
-                        if ( meshInfoByKey->first.Material && meshInfoByKey->first.Material->GetTexture() ) {
-                            if ( meshInfoByKey->first.Material ->HasAlphaTest() || meshInfoByKey->first.Material->GetTexture()->HasAlphaChannel()) {
+                        if ( material && material->GetTexture() ) {
+                            if ( material ->HasAlphaTest() || material->GetTexture()->HasAlphaChannel()) {
                                 if ( alphaRef > 0.0f &&
-                                    meshInfoByKey->first.Material->GetTexture()->CacheIn( 0.6f ) ==
+                                    material->GetTexture()->CacheIn( 0.6f ) ==
                                     zRES_CACHED_IN ) {
 
-                                    lastTex = meshInfoByKey->first.Material->GetTexture()->GetSurface()->GetEngineTexture();
-                                    meshInfoByKey->first.Material->GetTexture()->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
+                                    lastTex = material->GetTexture()->GetSurface()->GetEngineTexture();
+                                    material->GetTexture()->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
                                     ActivePS->Apply();
                                     isAlpha = true;
                                 } else
@@ -6110,17 +6120,19 @@ void D3D11GraphicsEngine::ShadowPass_DrawWorldMesh_Indirect( const std::vector<W
         alphaMeshes.reserve( 512 );
     }
 
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
+    
     {
         TracyD3D11ZoneCGX( "ShadowPass_DrawWorldMesh_Indirect::Classify" );
         auto _scopeClassify = RecordGraphicsEvent( GE_NAME( "ShadowPass_DrawWorldMesh_Indirect::Classify" ) );
+
         for ( const WorldMeshSectionInfo* section : visibleSections ) {
             for ( const auto& meshPair : section->WorldMeshes ) {
-                if ( !meshPair.first.Material || !Engine::GAPI->IsMaterialActive( meshPair.first.Material ) ) {
-                    continue;
-                }
-
                 if ( meshPair.first.Info->MaterialType != MaterialInfo::MT_None )
                     continue;
+
+                const auto material = materialManager.GetMaterial(meshPair.first.Material);
+                if (!material) continue;
 
                 WorldMeshInfo* mesh = meshPair.second;
                 if ( cullingFrustum && !Engine::GAPI->IsWorldMeshVisibleInFrustum( mesh, *cullingFrustum ) ) {
@@ -6128,13 +6140,13 @@ void D3D11GraphicsEngine::ShadowPass_DrawWorldMesh_Indirect( const std::vector<W
                 }
 
                 // we don't draw alpha stuff into shadowmaps.
-                if ( (meshPair.first.Material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
-                    meshPair.first.Material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST)
-                        || (meshPair.first.Material->GetAlphaFunc() == 0 && zColor( meshPair.first.Material->GetColor() ).bgra.alpha < 255) ) {
+                if ( (material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
+                    material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST)
+                        || (material->GetAlphaFunc() == 0 && zColor( material->GetColor() ).bgra.alpha < 255) ) {
                     continue;
                 }
 
-                zCTexture* tex = meshPair.first.Material ? meshPair.first.Material->GetTexture() : nullptr;
+                zCTexture* tex = material ? material->GetTexture() : nullptr;
                 unsigned int indexCount = 0;
 
                 if ( tex && tex->HasAlphaChannel() && alphaRef > 0.0f ) {
@@ -6232,32 +6244,33 @@ void D3D11GraphicsEngine::ShadowPass_DrawWorldMesh( const std::vector<WorldMeshS
     static thread_local std::vector<std::pair<zCTexture*, MeshInfo*>> alphaMeshes;
     opaqueMeshes.clear();
     alphaMeshes.clear();
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
 
     {
         ZoneScopedN( "ShadowPass_DrawWorldMesh::Classify" );
         auto _scopeClassify = RecordGraphicsEvent( GE_NAME( "ShadowPass_DrawWorldMesh::Classify" ) );
         for ( const WorldMeshSectionInfo* section : visibleSections ) {
             for ( const auto& meshPair : section->WorldMeshes ) {
-                if ( !meshPair.first.Material || !Engine::GAPI->IsMaterialActive( meshPair.first.Material ) ) {
-                    continue;
-                }
-
                 // Skip non-standard materials (water, portals, etc.)
                 if ( meshPair.first.Info->MaterialType != MaterialInfo::MT_None )
                     continue;
+
+                const auto material = materialManager.GetMaterial(meshPair.first.Material);
+                if (!material) continue;
 
                 if ( cullingFrustum && !Engine::GAPI->IsWorldMeshVisibleInFrustum( meshPair.second, *cullingFrustum ) ) {
                     continue;
                 }
 
+                
                 // we don't draw alpha stuff into shadowmaps.
-                if ( (meshPair.first.Material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
-                    meshPair.first.Material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST)
-                        || (meshPair.first.Material->GetAlphaFunc() == 0 && zColor( meshPair.first.Material->GetColor() ).bgra.alpha < 255) ) {
+                if ( (material->GetAlphaFunc() > zMAT_ALPHA_FUNC_NONE &&
+                    material->GetAlphaFunc() != zMAT_ALPHA_FUNC_TEST)
+                        || (material->GetAlphaFunc() == 0 && zColor( material->GetColor() ).bgra.alpha < 255) ) {
                     continue;
                 }
 
-                zCTexture* tex = meshPair.first.Material ? meshPair.first.Material->GetTexture() : nullptr;
+                zCTexture* tex = material ? material->GetTexture() : nullptr;
 
                 if ( tex && tex->HasAlphaChannel() && alphaRef > 0.0f ) {
                     // Need alpha testing - cache texture
@@ -6441,7 +6454,9 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
             ShadowPass_DrawWorldMesh( visibleSections, currentFrustum );
         }
     }
-
+    
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
+    
     if ( renderState.RendererSettings.DrawVOBs ) {
         ZoneScopedN( "Shadows::DrawVOBs" );
 
@@ -6598,39 +6613,40 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
                 }
             }
         }
-        std::vector<std::tuple<MeshVisualInfo*, MeshKey, MeshInfo*, uint64_t>> instancedMeshesToDraw;
+        std::vector<std::tuple<MeshVisualInfo*, zCMaterial*, MeshInfo*, uint64_t>> instancedMeshesToDraw;
         instancedMeshesToDraw.reserve( numMeshesToDraw );
 
         for ( auto const& staticMeshVisual : activeVisuals ) {
             if ( staticMeshVisual->Instances.empty() ) continue;
             for ( auto const& itt : staticMeshVisual->MeshesByTexture ) {
-                const std::vector<MeshInfo*>& mlist = itt.second;
+                const auto material = materialManager.GetMaterial(itt.first.Material);
+                if (!material) continue;
 
+                const std::vector<MeshInfo*>& mlist = itt.second;
+                
                 uint64_t sortKeyBase = 0;
-                if ( itt.first.Material && itt.first.Material->GetAniTexture() ) {
-                    if ( itt.first.Material->GetAniTexture()->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
+                if ( material->GetAniTexture() ) {
+                    if ( material->GetAniTexture()->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
                         continue; // cant draw if no texture
                     }
-                    sortKeyBase = BuildSortKeyBase( itt.first.Material );
+                    sortKeyBase = BuildSortKeyBase( material );
                 }
 
                 if ( mlist.empty() ) continue;
-                for ( unsigned int i = 0; i < mlist.size(); i++ ) {
-                    MeshInfo* mi = mlist[i];
-
-                    instancedMeshesToDraw.emplace_back( staticMeshVisual, itt.first, mi, sortKeyBase + mi->meshId );
+                for (auto mi : mlist) {
+                    instancedMeshesToDraw.emplace_back( staticMeshVisual, material, mi, sortKeyBase + mi->meshId );
                 }
             }
         }
 
-        std::sort( instancedMeshesToDraw.begin(), instancedMeshesToDraw.end(), []( const std::tuple<MeshVisualInfo*, MeshKey, MeshInfo*, uint64_t>& a, const std::tuple<MeshVisualInfo*, MeshKey, MeshInfo*, uint64_t>& b ) {
+        std::sort( instancedMeshesToDraw.begin(), instancedMeshesToDraw.end(), []( const std::tuple<MeshVisualInfo*, zCMaterial*, MeshInfo*, uint64_t>& a, const std::tuple<MeshVisualInfo*, zCMaterial*, MeshInfo*, uint64_t>& b ) {
             return std::get<3>( a ) < std::get<3>( b );
         } );
 
         zCTexture* previousTx = nullptr;
         MeshVisualInfo* lastWindVisual = nullptr;
 
-        for ( auto const& [staticMeshVisual, meshKey, meshInfo, _] : instancedMeshesToDraw ) {
+        for ( auto const& [staticMeshVisual, material, meshInfo, _] : instancedMeshesToDraw ) {
             if ( !useWindMetadata && windBuffer.GetRawBuffer() && lastWindVisual != staticMeshVisual ) {
                 lastWindVisual = staticMeshVisual;
                 g_windBuffer.minHeight = staticMeshVisual->BBox.Min.y;
@@ -6638,10 +6654,10 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
                 windBuffer.Update( &g_windBuffer );
             }
 
-            zCTexture* tx = meshKey.Material->GetAniTexture();
+            zCTexture* tx = material->GetAniTexture();
 
             bool bindTexture = tx
-                && (tx->HasAlphaChannel() || colorWritesEnabled || meshKey.Material->HasAlphaTest());
+                && (tx->HasAlphaChannel() || colorWritesEnabled || material->HasAlphaTest());
             const bool isAlpha = bindTexture;
 
             // Bind texture
@@ -7000,6 +7016,8 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
             }
         }
 
+        auto& materialManager = Engine::GAPI->GetMaterialManager();
+        
         if ( renderSettings.DrawVOBs ) {
             auto _1 = Engine::GraphicsEngine->RecordGraphicsEvent( GE_NAME( "DrawVOBsInstanced->DrawVOBs" ) );
             TracyD3D11ZoneCGX( "DrawVOBsInstanced->VOBs" );
@@ -7091,15 +7109,16 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                     for ( auto const& itt : cv.Visual->MeshesByTexture ) {
                         const std::vector<MeshInfo*>& mlist = itt.second;
                         if ( mlist.empty() ) continue;
+                        
+                        const auto material = materialManager.GetMaterial(itt.first.Material);
+                        if (!material) continue;
 
                         FrameGeometryCache::SortKeyBuilder sortKeyBase{ 0 };
-                        if ( itt.first.Material ) {
-                            const auto alphaFunc = itt.first.Material->GetAlphaFunc();
-                            if ( alphaFunc > zMAT_ALPHA_FUNC_NONE && alphaFunc != zMAT_ALPHA_FUNC_TEST ) {
-                                sortKeyBase.withAlphaType(2);
-                            } else if ( alphaFunc == zMAT_ALPHA_FUNC_TEST ) {
-                                sortKeyBase.withAlphaType(1);
-                            }
+                        const auto alphaFunc = material->GetAlphaFunc();
+                        if ( alphaFunc > zMAT_ALPHA_FUNC_NONE && alphaFunc != zMAT_ALPHA_FUNC_TEST ) {
+                            sortKeyBase.withAlphaType(2);
+                        } else if ( alphaFunc == zMAT_ALPHA_FUNC_TEST ) {
+                            sortKeyBase.withAlphaType(1);
                         }
                         if ( itt.first.Texture ) {
                             if ( itt.first.Texture->HasAlphaChannel() && sortKeyBase.GetAlphaType() == 0 ) {
@@ -7211,6 +7230,7 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
             
             if ( !cache.sortedInstancedMeshes.empty() ) {
                 TracyD3D11ZoneCGX( "DrawVOBsInstanced::OpaqueSubmission" );
+                auto& materialManager = Engine::GAPI->GetMaterialManager();
                 auto _scopeOpaqueSubmission = RecordGraphicsEvent( GE_NAME( "DrawVOBsInstanced::OpaqueSubmission" ) );
                 for ( auto const& drawItem : cache.sortedInstancedMeshes ) {
                     if ( drawItem.VisualIndex >= cache.vobVisuals.size() || !drawItem.MeshEntry ) {
@@ -7220,9 +7240,10 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                     const auto* cachedVisual = &cache.vobVisuals[drawItem.VisualIndex];
                     const MeshKey& meshKey = drawItem.Mesh;
                     MeshInfo* meshInfo = drawItem.MeshEntry;
-                    const bool isAlphaBlendMesh = meshKey.Material &&
-                        (meshKey.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_BLEND ||
-                         meshKey.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_ADD);
+                    auto material = materialManager.GetMaterial(meshKey.Material);
+                    const bool isAlphaBlendMesh = material &&
+                        (material->GetAlphaFunc() == zMAT_ALPHA_FUNC_BLEND ||
+                         material->GetAlphaFunc() == zMAT_ALPHA_FUNC_ADD);
 
                     if ( isAlphaBlendMesh ) {
                         if ( !isZPrepass ) {
@@ -7265,7 +7286,7 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                         windBuffer.Update( &g_windBuffer );
                     }
 
-                    zCTexture* tx = meshKey.Material ? meshKey.Material->GetAniTexture() : nullptr;
+                    zCTexture* tx = material ? material->GetAniTexture() : nullptr;
 
                     if ( !tx ) {
 #ifndef BUILD_SPACER_NET
@@ -7310,7 +7331,7 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                             continue;
                         }
                         // Previously this forced alpha testing, now we need to check material flags as well for that and only enable the shader if absolutely necessery
-                        const bool wantShader = !isZPrepass || (tx->HasAlphaChannel() || meshKey.Material->HasAlphaTest());
+                        const bool wantShader = !isZPrepass || (tx->HasAlphaChannel() || material->HasAlphaTest());
 
                         MyDirectDrawSurface7* surface = tx->GetSurface();
                         ID3D11ShaderResourceView* srv[3];
@@ -7350,8 +7371,8 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
 
                                 if ( BindShaderForTexture( tx,
                                     tx->HasAlphaChannel()
-                                    || meshKey.Material->HasAlphaTest()
-                                    , meshKey.Material->GetAlphaFunc(),
+                                    || material->HasAlphaTest()
+                                    , material->GetAlphaFunc(),
                                     meshKey.Info->MaterialType ) ) {
                                     
                                     PsSimpleFFdata ffdata = { };
@@ -7379,12 +7400,14 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                 }
             }
             if ( !isZPrepass ) {
+                auto& materialManager = Engine::GAPI->GetMaterialManager();
                 for ( auto const& cv : cache.vobVisuals ) {
                     bool clear = true;
                     for ( auto& [meshKey, _] : cv.Visual->MeshesByTexture ) {
-                        if ( meshKey.Material &&
-                            (meshKey.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_BLEND ||
-                                meshKey.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_ADD) ) {
+                        auto material = materialManager.GetMaterial(meshKey.Material);
+                        if ( material &&
+                            (material->GetAlphaFunc() == zMAT_ALPHA_FUNC_BLEND ||
+                                material->GetAlphaFunc() == zMAT_ALPHA_FUNC_ADD) ) {
                             clear = false;
                             break;
                         }
@@ -7534,14 +7557,17 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
     {
         TracyD3D11ZoneCGX( "DrawFrameAlphaMeshes::Replay" );
         auto _scopeAlphaReplay = RecordGraphicsEvent( GE_NAME( "DrawFrameAlphaMeshes::Replay" ) );
+        auto& materialManager = Engine::GAPI->GetMaterialManager();
         for ( auto const& alphaMesh : m_AlphaMeshes ) {
             const MeshKey& mk = alphaMesh.mk;
-            zCTexture* tx = mk.Material->GetAniTexture();
+            auto material = materialManager.GetMaterial(mk.Material);
+            if (!material) continue;
+            zCTexture* tx = material->GetAniTexture();
             if ( !tx ) continue;
 
             // Check for alphablending on world mesh
-            bool blendAdd = mk.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_ADD;
-            bool blendBlend = mk.Material->GetAlphaFunc() == zMAT_ALPHA_FUNC_BLEND;
+            bool blendAdd = material->GetAlphaFunc() == zMAT_ALPHA_FUNC_ADD;
+            bool blendBlend = material->GetAlphaFunc() == zMAT_ALPHA_FUNC_BLEND;
 
             // Bind texture
             MeshInfo* mi = alphaMesh.mi;

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -7310,13 +7310,13 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                         }
                         bool showHelpers = *reinterpret_cast<int*>(GothicMemoryLocations::zCVob::s_ShowHelperVisuals) != 0;
 
-                        if ( showHelpers ) {
+                        if ( showHelpers && material ) {
                             WhiteTexture->BindToPixelShader( 0 );
                             ShaderManager->GetPShader( PShaderID::PS_DiffuseAlphaTest )->Apply();
 
                             MaterialInfo::Buffer b = {};
 
-                            b.Color = meshKey.Material->GetColor();
+                            b.Color = material->GetColor();
                             ShaderManager->GetPShader( PShaderID::PS_DiffuseAlphaTest )->GetBuffer( "MI_MaterialInfo" ).Update( &b ).Bind();
 
                         } else {

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -328,7 +328,7 @@ XRESULT D3D11ShaderManager::Init() {
     
     ShaderInfo::MacroBuilder normalmappingConfigurationBuilder = [](std::vector<D3D_SHADER_MACRO>& list) {
         const auto& s = Engine::GAPI->GetRendererState().RendererSettings;
-        list.push_back( {"NORMAL_MAP_RESTORE_Z", s.CompressedNormalsSupport > 0 ? "1" : "0"} );
+        list.push_back( {"NORMAL_MAP_RESTORE_Z", s.CompressedNormalsSupport ? "1" : "0"} );
 		list.push_back( {"NORMAL_MAP_MODE", sNums[std::clamp<size_t>(s.AllowNormalmaps, 1, 2)]} );
     };
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1898,7 +1898,7 @@ void GothicAPI::GetVisibleDecalList( std::vector<zCVob*>& decals ) {
 /** Called when a material got removed */
 void GothicAPI::OnMaterialDeleted( zCMaterial* mat ) {
     auto matHandle = GetMaterialManager().FindMaterialHandle(mat);
-    GetMaterialManager().DeleteMaterial(mat);
+    GetMaterialManager().DeleteMaterial(matHandle);
     LoadedMaterials.erase( mat );
     if ( !mat )
         return;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -154,6 +154,8 @@ GothicAPI::GothicAPI() {
     CurrentCamera = nullptr;
 
     MainThreadID = GetCurrentThreadId();
+    
+    materialManager = std::make_unique<zCMaterialManager>();
 
     _canRain = false;
     _canClearVobsByVisual = false;
@@ -1895,6 +1897,7 @@ void GothicAPI::GetVisibleDecalList( std::vector<zCVob*>& decals ) {
 
 /** Called when a material got removed */
 void GothicAPI::OnMaterialDeleted( zCMaterial* mat ) {
+    GetMaterialManager().DeleteMaterial(mat);
     LoadedMaterials.erase( mat );
     if ( !mat )
         return;
@@ -1998,6 +2001,7 @@ void GothicAPI::OnMaterialDeleted( zCMaterial* mat ) {
 
 /** Called when a material got created */
 void GothicAPI::OnMaterialCreated( zCMaterial* mat ) {
+    GetMaterialManager().AddMaterial(mat);
     LoadedMaterials.insert( mat );
 }
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1897,14 +1897,15 @@ void GothicAPI::GetVisibleDecalList( std::vector<zCVob*>& decals ) {
 
 /** Called when a material got removed */
 void GothicAPI::OnMaterialDeleted( zCMaterial* mat ) {
+    auto matHandle = GetMaterialManager().FindMaterialHandle(mat);
     GetMaterialManager().DeleteMaterial(mat);
     LoadedMaterials.erase( mat );
     if ( !mat )
         return;
 
-    auto eraseMeshKeyEntries = [mat]( auto& cont ) {
+    auto eraseMeshKeyEntries = [matHandle]( auto& cont ) {
         for ( auto it = cont.begin(); it != cont.end(); ) {
-            if ( it->first.Material == mat ) {
+            if ( it->first.Material == matHandle ) {
                 it = cont.erase( it );
             } else {
                 ++it;
@@ -1912,10 +1913,10 @@ void GothicAPI::OnMaterialDeleted( zCMaterial* mat ) {
         }
     };
 
-    auto eraseCachedMeshKeyEntries = [mat]( auto& cont ) {
+    auto eraseCachedMeshKeyEntries = [matHandle]( auto& cont ) {
         cont.erase( std::remove_if( cont.begin(), cont.end(),
-            [mat]( const auto& entry ) {
-                return entry.first.Material == mat;
+            [matHandle]( const auto& entry ) {
+                return entry.first.Material == matHandle;
             } ), cont.end() );
     };
 
@@ -1961,7 +1962,7 @@ void GothicAPI::OnMaterialDeleted( zCMaterial* mat ) {
             WorldMeshSectionInfo& section = sectionY.second;
 
             for ( auto it = section.WorldMeshes.begin(); it != section.WorldMeshes.end(); ) {
-                if ( it->first.Material == mat ) {
+                if ( it->first.Material == matHandle ) {
                     delete it->second;
                     it = section.WorldMeshes.erase( it );
                 } else {
@@ -1970,7 +1971,7 @@ void GothicAPI::OnMaterialDeleted( zCMaterial* mat ) {
             }
 
             for ( auto it = section.SuppressedMeshes.begin(); it != section.SuppressedMeshes.end(); ) {
-                if ( it->first.Material == mat ) {
+                if ( it->first.Material == matHandle ) {
                     delete it->second;
                     it = section.SuppressedMeshes.erase( it );
                 } else {

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -2002,8 +2002,10 @@ void GothicAPI::OnMaterialDeleted( zCMaterial* mat ) {
 
 /** Called when a material got created */
 void GothicAPI::OnMaterialCreated( zCMaterial* mat ) {
-    GetMaterialManager().AddMaterial(mat);
-    LoadedMaterials.insert( mat );
+    auto handle = GetMaterialManager().AddMaterial(mat);
+    if ( handle.isValid()) {
+        LoadedMaterials.insert( mat );
+    }
 }
 
 /** Returns if the material is currently active */

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -3752,7 +3752,9 @@ bool GothicAPI::TraceWorldMesh( const XMFLOAT3& origin, const XMFLOAT3& dir, XMF
     }
     // Distance-sort
     hitSections.sort( TraceWorldMeshBoxCmp );
-
+    
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
+    
     int numProcessed = 0;
     for ( auto const& bit : hitSections ) {
         for ( auto it = bit.first->WorldMeshes.begin(); it != bit.first->WorldMeshes.end(); ++it ) {
@@ -3775,13 +3777,15 @@ bool GothicAPI::TraceWorldMesh( const XMFLOAT3& origin, const XMFLOAT3& dir, XMF
                         if ( hitMesh ) {
                             *hitMesh = it->second;
                         }
-
-                        if ( hitMaterial ) {
-                            *hitMaterial = it->first.Material;
+                        
+                        auto material = materialManager.GetMaterial(it->first.Material);
+                        
+                        if ( hitMaterial ) { 
+                            *hitMaterial = material;
                         }
 
-                        if ( hitTextureName && it->first.Material && it->first.Material->GetTexture() )
-                            *hitTextureName = it->first.Material->GetTexture()->GetNameWithoutExt();
+                        if ( hitTextureName && material && material->GetTexture() )
+                            *hitTextureName = material->GetTexture()->GetNameWithoutExt();
                     }
                 }
             }
@@ -5240,13 +5244,15 @@ void GothicAPI::SaveCustomZENResources() {
 
 /** Applys the suppressed textures */
 void GothicAPI::ApplySuppressedSectionTextures() {
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
+
     for ( auto const& it : SuppressedTexturesBySection ) {
         WorldMeshSectionInfo* section = it.first;
 
         // Look into each mesh of this section and find the texture
         for ( auto mit = section->WorldMeshes.begin(); mit != section->WorldMeshes.end(); ) {
             bool movedToSuppressed = false;
-            if (auto mat = mit->first.Material ) {
+            if (auto mat = materialManager.GetMaterial((mit->first.Material)) ) {
                 if ( auto tx = mat->GetTexture()) {
                     auto txName = tx->GetNameWithoutExtView();
                     for ( unsigned int i = 0; i < it.second.size(); i++ ) {
@@ -6187,18 +6193,22 @@ void GothicAPI::GetIntersectingSections( const XMFLOAT3& min, const XMFLOAT3& ma
 
 /** Generates zCPolygons for the loaded sections */
 void GothicAPI::CreatezCPolygonsForSections() {
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
+
     for ( std::map<int, std::map<int, WorldMeshSectionInfo>>::iterator itx = Engine::GAPI->GetWorldSections().begin(); itx != Engine::GAPI->GetWorldSections().end(); itx++ ) {
         for ( std::map<int, WorldMeshSectionInfo>::iterator ity = itx->second.begin(); ity != itx->second.end(); ity++ ) {
             WorldMeshSectionInfo& section = ity->second;
 
             for ( auto it = section.WorldMeshes.begin(); it != section.WorldMeshes.end(); ++it ) {
-                if ( !it->first.Material ||
-                    it->first.Material->HasAlphaTest() )
+                auto material = materialManager.GetMaterial(it->first.Material);
+                
+                if ( !material || 
+                    material->HasAlphaTest() )
                     continue;
 
-                it->first.Material->SetAlphaFunc( zMAT_ALPHA_FUNC_NONE );
+                material->SetAlphaFunc( zMAT_ALPHA_FUNC_NONE );
 
-                WorldConverter::ConvertExVerticesTozCPolygons( it->second->Vertices, it->second->Indices, it->first.Material, section.SectionPolygons );
+                WorldConverter::ConvertExVerticesTozCPolygons( it->second->Vertices, it->second->Indices, material, section.SectionPolygons );
             }
         }
     }

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -11,6 +11,7 @@
 #include "RenderQueue.h"
 #include "RenderToTextureBuffer.h"
 #include "ShaderIDs.h"
+#include "zCMaterialManager.h"
 
 static const char* MENU_SETTINGS_FILE = "system\\GD3D11\\UserSettings.ini";
 const float INDOOR_LIGHT_DISTANCE_SCALE_FACTOR = 0.5f;
@@ -662,6 +663,8 @@ public:
     zCMaterial* GetMaterialByTextureName( const std::string& name );
     void GetMaterialListByTextureName( const std::string& name, std::list<zCMaterial*>& list );
 
+    zCMaterialManager& GetMaterialManager() const { return *materialManager; }
+    
     /** Returns the time since the last frame */
     float GetDeltaTime();
 
@@ -1011,6 +1014,8 @@ private:
 
     /** Internal list of futures, so they can run until they are finished */
     std::vector<std::future<void>> FutureList;
+    
+    std::unique_ptr<zCMaterialManager> materialManager;
 
     bool _canRain;
 

--- a/D3D11Engine/MaterialHandle.h
+++ b/D3D11Engine/MaterialHandle.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <cstdint>
+
+struct MaterialHandle {
+    struct IdxGen {
+        uint32_t index      : 24;
+        uint32_t generation : 8; // zero gen means invalid
+    };
+    
+    union {
+        uint32_t handle = 0;
+        IdxGen idxgen;
+    };
+
+    bool isValid() const { return handle != 0; }
+    
+    MaterialHandle() noexcept: handle(0) {}
+    MaterialHandle(uint32_t idx, uint8_t gen) noexcept {
+        idxgen.index = idx;
+        idxgen.generation = gen;
+    }
+
+    bool operator>(const MaterialHandle& material) const { return handle > material.handle; }
+    bool operator<(const MaterialHandle& material) const { return handle < material.handle; }
+    bool operator==(const MaterialHandle& material) const { return handle == material.handle; }
+    
+    explicit operator bool() const { return isValid(); }
+};

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -76,7 +76,7 @@ void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float ra
 
     INT2 s = GetSectionOfPos( position );
     MeshKey opaqueKey;
-    opaqueKey.Material = nullptr;
+    opaqueKey.Material = {};
     opaqueKey.Info = nullptr;
     opaqueKey.Texture = nullptr;
 
@@ -217,13 +217,17 @@ XRESULT WorldConverter::LoadWorldMeshFromFile( const std::string& file, std::map
     std::vector<std::string>& textures = mesh->GetTextures();
     std::map<std::string, D3D11Texture*> loadedTextures;
     gtl::flat_hash_set<std::string> missingTextures;
+    
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
 
     // run through meshes and pack them into sections
     for ( unsigned int m = 0; m < meshes.size(); m++ ) {
-        D3D11Texture* customTexture = nullptr;
         zCMaterial* mat = Engine::GAPI->GetMaterialByTextureName( textures[m] );
+        
+        auto materialHandle = materialManager.FindMaterialHandle(mat);
+        
         MeshKey key;
-        key.Material = mat;
+        key.Material = materialHandle;
         key.Texture = mat != nullptr ? mat->GetTextureSingle() : nullptr;
 
         // Save missing textures
@@ -471,6 +475,10 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
     
     // Go through every polygon and put it into its section
     std::vector<ExVertexStruct> polyVertices;
+    
+    std::unordered_map<zCMaterial*, MaterialHandle> materialMap;
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
+    
     for ( unsigned int i = 0; i < numPolygons; i++ ) {
         zCPolygon* poly = polys[i];
 
@@ -483,6 +491,8 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
         if ( !mat ) {
             continue;
         }
+        auto materialHandle = materialManager.FindMaterialHandle(mat);
+        
         std::string_view matName = mat->__GetName().ToChar();
         // std::string_view textureName = mat->GetTextureSingle() ? mat->GetTextureSingle()->__GetName().ToChar() : "";
 
@@ -524,7 +534,7 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
         // Use the map to put the polygon to those using the same material
         MeshKey key;
         key.Texture = _tex ? _tex : mat->GetTextureSingle();
-        key.Material = mat;
+        key.Material = materialHandle;
 
         auto it = sectionInfo.WorldMeshes.find( key );
         if ( it == sectionInfo.WorldMeshes.end() ) {
@@ -745,11 +755,14 @@ void WorldConverter::GenerateFullSectionMesh( WorldMeshSectionInfo& section ) {
     ZoneScoped;
 
     std::vector<ExVertexStruct> vx;
-
+    
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
+    
     // Pre-calculate total triangle count to avoid reallocations
     size_t totalVerts = 0;
     for ( auto const& it : section.WorldMeshes ) {
-        if ( !it.first.Material || it.first.Material->HasAlphaTest() ) continue;
+        auto material = materialManager.GetMaterial(it.first.Material);
+        if ( !material || material->HasAlphaTest() ) continue;
         totalVerts += it.second->Indices.size();
     }
     for ( auto const& it : section.Vobs ) {
@@ -763,8 +776,10 @@ void WorldConverter::GenerateFullSectionMesh( WorldMeshSectionInfo& section ) {
     vx.reserve( totalVerts );
 
     for ( auto const& it : section.WorldMeshes ) {
-        if ( !it.first.Material ||
-            it.first.Material->HasAlphaTest() )
+        auto material = materialManager.GetMaterial(it.first.Material);
+
+        if ( !material ||
+            material->HasAlphaTest() )
             continue;
 
         for ( unsigned int i = 0; i < it.second->Indices.size(); i += 3 ) {
@@ -1095,6 +1110,9 @@ void WorldConverter::ExtractProgMeshProtoFromModel( zCModel* model, MeshVisualIn
     zSTRING mds = model->GetModelName();
     const char* visualName = mds.ToChar();
     zCArray<zCModelNodeInst*>* nodeList = model->GetNodeList();
+
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
+    
     for ( int i = 0; i < nodeList->NumInArray; i++ ) {
         zCModelNodeInst* node = nodeList->Array[i];
         if ( !node->NodeVisual )
@@ -1190,12 +1208,15 @@ void WorldConverter::ExtractProgMeshProtoFromModel( zCModel* model, MeshVisualIn
 
             Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize += mi->Vertices.size() * sizeof( ExVertexStruct );
             Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize += mi->Indices.size() * sizeof( VERTEX_INDEX );
-
+            
             zCMaterial* mat = m->Material;
+
+            auto materialHandle = materialManager.FindMaterialHandle(mat);
+            
             meshInfo->Meshes[mat].emplace_back( mi );
 
             MeshKey key;
-            key.Material = mat;
+            key.Material = materialHandle;
             key.Texture = mat->GetTextureSingle();
             key.Info = Engine::GAPI->GetMaterialInfoFrom( key.Texture );
 
@@ -1430,6 +1451,8 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
     std::list<std::vector<VERTEX_INDEX>*> indexBuffers;
     std::list<MeshInfo*> meshInfos;
 
+    auto& materialManager = Engine::GAPI->GetMaterialManager();
+    
     // Construct unindexed mesh
     std::vector<ExVertexStruct> vertices;
     std::vector<VERTEX_INDEX> indices;
@@ -1519,10 +1542,13 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
         Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize += mi->Indices.size() * sizeof( VERTEX_INDEX );
 
         zCMaterial* mat = s->Material;
+        
+        auto materialHandle = materialManager.FindMaterialHandle(mat);
+        
         meshInfo->Meshes[mat].emplace_back( mi );
 
         MeshKey key;
-        key.Material = mat;
+        key.Material = materialHandle;
         key.Texture = mat->GetTextureSingle();
         key.Info = Engine::GAPI->GetMaterialInfoFrom( key.Texture );
 

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -11,6 +11,7 @@
 #include "zCPolygon.h"
 #include "BaseShadowedPointLight.h"
 #include "D3D11VertexBuffer.h"
+#include "MaterialHandle.h"
 
 class zCMaterial;
 class zCPolygon;
@@ -51,7 +52,7 @@ struct RainParticleStatic {
 
 struct MeshKey {
     zCTexture* Texture;
-    zCMaterial* Material;
+    MaterialHandle Material;
     MaterialInfo* Info;
     //zCLightmap* Lightmap;
     
@@ -69,7 +70,7 @@ struct cmpMeshKey {
 
 struct meshKeyHasher {
     size_t operator()( const MeshKey& a ) const {
-        size_t seed = reinterpret_cast<size_t>(a.Material);
+        size_t seed = a.Material.handle;
         Toolbox::hash_combine(seed, reinterpret_cast<size_t>(a.Texture));
         return seed;
     }

--- a/D3D11Engine/zCCamera.h
+++ b/D3D11Engine/zCCamera.h
@@ -7,10 +7,56 @@
 #include "BaseGraphicsEngine.h"
 #include "zViewTypes.h"
 
+inline float cachedNearPlaneFor_CorrectPosForNearClip = 1.0f;
 
+constexpr uintptr_t kPatchStart  = 0x004AF8BF;  // push 0x934 (operator new size)
+constexpr uintptr_t kPatchEnd    = 0x004AF911;  // fnstsw ax  (kept, continues here)
+constexpr uint32_t  kRealOneAddr = 0x0082ED70;  // __real@3f800000 (same one the original fcomp uses)
+
+inline bool PatchCorrectPosForNearClip()
+{
+    static_assert(sizeof(void*) == 4, "x86 (32-bit) build required");
+
+    uint8_t* target = reinterpret_cast<uint8_t*>(kPatchStart);
+
+    // Guard against double-patching / wrong binary version.
+    static const uint8_t expected[] = { 0x68, 0x34, 0x09, 0x00, 0x00 }; // push 0x934
+    if (memcmp(target, expected, sizeof(expected)) != 0)
+        return false;
+
+    uint8_t code[kPatchEnd - kPatchStart];   // 0x52 bytes
+    memset(code, 0x90, sizeof(code));        // nop filler
+    uint8_t* p = code;
+
+    // fld dword ptr [&cachedNearPlaneFor_CorrectPosForNearClip]
+    *p++ = 0xD9; *p++ = 0x05;
+    const float* src = &cachedNearPlaneFor_CorrectPosForNearClip;
+    memcpy(p, &src, 4); p += 4;
+
+    // fst dword ptr [esp+0x10]   ; local_68 — non-popping, value stays on ST0 for the compare
+    *p++ = 0xD9; *p++ = 0x54; *p++ = 0x24; *p++ = 0x10;
+
+    // fcomp dword ptr [__real@3f800000]      ; pops ST0 — FPU stack balanced
+    *p++ = 0xD8; *p++ = 0x1D;
+    memcpy(p, &kRealOneAddr, 4); p += 4;
+
+    // jmp short 0x004AF911 (fnstsw ax) — hop over the nop pad
+    uint8_t rel = static_cast<uint8_t>(kPatchEnd - (kPatchStart + (p - code) + 2));
+    *p++ = 0xEB; *p++ = rel;
+
+    DWORD oldProt;
+    if (!VirtualProtect(target, sizeof(code), PAGE_EXECUTE_READWRITE, &oldProt))
+        return false;
+    memcpy(target, code, sizeof(code));
+    VirtualProtect(target, sizeof(code), oldProt, &oldProt);
+    FlushInstructionCache(GetCurrentProcess(), target, sizeof(code));
+    return true;
+}
+
+typedef void*( __fastcall* zCCameraCtor)(void*, void*);
 class zCCamera {
 public:
-
+    inline static zCCameraCtor original_zCCameraConstructor = reinterpret_cast<zCCameraCtor>(static_cast<unsigned int>(0x00549e60)); 
     enum ETransformType {
         TT_WORLD,
         TT_VIEW,
@@ -22,8 +68,23 @@ public:
     static void Hook() {
         DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCCamera__Activate, Activate_Hook  );
         DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCCamera__UpdateViewport, UpdateViewport_Hook  );
+        
+#ifdef BUILD_GOTHIC_2_6_fix
+        // Fix engine constantly creating zCCamera just to call GetNearPlane to get the engine default INI value
+        DetourAttachTyped( &original_zCCameraConstructor, Constructor_Hook  );
+        PatchCorrectPosForNearClip();
+#endif
     }
 
+    static void* __fastcall Constructor_Hook(zCCamera* thisPtr, void* _) {
+        auto result = original_zCCameraConstructor(thisPtr, _ );
+
+        // copy the default near plane, as zCPathSearch::CorrectPosForNearClip wants this
+        cachedNearPlaneFor_CorrectPosForNearClip = thisPtr->GetNearPlane(); 
+        
+        return result;
+    }
+    
     static bool IsFreeLookActive() {
 #ifdef BUILD_GOTHIC_2_6_fix
         return *reinterpret_cast<int*>(GothicMemoryLocations::zCCamera::Var_FreeLook) != 0;

--- a/D3D11Engine/zCMaterial.h
+++ b/D3D11Engine/zCMaterial.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "pch.h"
 #include "HookedFunctions.h"
-#include "zCPolygon.h"
 #include "Engine.h"
 #include "GothicAPI.h"
 #include "zCTexture.h"

--- a/D3D11Engine/zCMaterialManager.cpp
+++ b/D3D11Engine/zCMaterialManager.cpp
@@ -1,0 +1,83 @@
+#include "zCMaterialManager.h"
+#include "zCMaterial.h"
+
+static MaterialHandle InvalidHandle = {0, 0};
+
+MaterialHandle zCMaterialManager::FindMaterialHandle(zCMaterial* material) const {
+    if (const auto it = std::ranges::find(materials.items, material); it != materials.items.end()) {
+        const uint32_t index = std::distance(materials.items.begin(), it);
+        const auto generation = materials.generations[index];
+        return {index, static_cast<uint8_t>(generation)};
+    }
+    return InvalidHandle;
+}
+
+MaterialHandle zCMaterialManager::InsertMaterial(zCMaterial* material)
+{
+    const size_t numGen = materials.generations.size();
+    for (size_t i = 0; i < numGen; ++i) {
+        // free slot, eg after clear, or at the start
+        if (materials.generations[i] == 0
+            // free slot as material was deleted.
+            || materials.items[i] == nullptr) {
+            const auto generation = UpdateSlot(i, material);
+            return {i, generation};
+        }
+    }
+    // no slot, re-allocate and provide more space.
+    materials.resize(materials.size()*2);
+
+    // append it to the end of the vector
+    materials.generations[numGen] = 1;
+    materials.items[numGen] = material;
+    return {numGen, 1};
+}
+
+uint8_t zCMaterialManager::UpdateSlot(uint32_t slot, zCMaterial* material) {
+    auto generation = ++materials.generations[slot];
+    if (generation > std::numeric_limits<uint8_t>::max()) {
+        // wrap around to 1. Materials are likely not loaded multiple hundred times and still be in use.
+        generation = 1;
+    }
+    materials.items[slot] = material;
+    return static_cast<uint8_t>(generation);
+}
+
+void zCMaterialManager::DeleteMaterial(const MaterialHandle handle) {
+    if (handle.isValid()) {
+        // already registered this pointer
+        const uint32_t index = handle.idxgen.index;
+        UpdateSlot(index, nullptr);
+    }
+}
+
+void zCMaterialManager::DeleteMaterial(zCMaterial* material) {
+    if (const auto handle = FindMaterialHandle(material)) {
+        DeleteMaterial(handle);
+    }
+}
+
+MaterialHandle zCMaterialManager::AddMaterial(zCMaterial* material) {
+    if (const auto handle = FindMaterialHandle(material); handle.idxgen.generation != 0) {
+        // already registered this pointer
+        const uint32_t index = handle.idxgen.index;
+        const auto generation = UpdateSlot(index, material);
+        return {index, generation};
+    }
+    
+    return InsertMaterial(material);
+}
+    
+zCMaterial* zCMaterialManager::GetMaterial(const MaterialHandle handle) const {
+    const auto index = handle.idxgen.index;
+    const auto generation = handle.idxgen.generation;
+    if (generation == 0) {
+        // invalid handle
+        return nullptr;
+    }
+    if (generation != materials.generations[index]) {
+        // handle is dead
+        return nullptr;
+    }
+    return materials.items[index];
+}

--- a/D3D11Engine/zCMaterialManager.cpp
+++ b/D3D11Engine/zCMaterialManager.cpp
@@ -14,7 +14,7 @@ MaterialHandle zCMaterialManager::FindMaterialHandle(zCMaterial* material) const
 
 MaterialHandle zCMaterialManager::InsertMaterial(zCMaterial* material)
 {
-    const size_t numGen = materials.generations.size();
+    const size_t numGen = materials.size();
     for (size_t i = 0; i < numGen; ++i) {
         // free slot, eg after clear, or at the start
         if (materials.generations[i] == 0
@@ -25,12 +25,10 @@ MaterialHandle zCMaterialManager::InsertMaterial(zCMaterial* material)
         }
     }
     // no slot, re-allocate and provide more space.
-    materials.resize(materials.size()*2);
+    materials.resize(numGen*2);
 
-    // append it to the end of the vector
-    materials.generations[numGen] = 1;
-    materials.items[numGen] = material;
-    return {numGen, 1};
+    const auto generation = UpdateSlot(numGen, material);
+    return {numGen, generation};
 }
 
 uint8_t zCMaterialManager::UpdateSlot(uint32_t slot, zCMaterial* material) {

--- a/D3D11Engine/zCMaterialManager.h
+++ b/D3D11Engine/zCMaterialManager.h
@@ -1,0 +1,47 @@
+#pragma once
+#include <mutex>
+#include <vector>
+
+struct MaterialHandle;
+class zCMaterial;
+
+template <typename T>
+struct GenerationalVectors {
+    std::vector<T> items;
+    std::vector<uint16_t> generations;
+
+    size_t size() const { return items.size(); }
+    void resize(size_t size) {
+        items.resize(size);
+        generations.resize(size);
+    }
+};
+
+class zCMaterialManager
+{
+private:
+    GenerationalVectors<zCMaterial*> materials;
+    
+    MaterialHandle InsertMaterial(zCMaterial* material);
+
+    // updates the slot and returns the new generation value.
+    uint8_t UpdateSlot(uint32_t slot, zCMaterial* material);
+public:
+    zCMaterialManager() {
+        materials.resize(512);
+    }
+
+    ~zCMaterialManager() = default;
+    
+    zCMaterialManager(zCMaterialManager&&) = delete;
+    zCMaterialManager& operator=( zCMaterialManager&& ) = delete;
+
+    zCMaterialManager(const zCMaterialManager&) = delete;
+    zCMaterialManager& operator=( const zCMaterialManager& ) = delete;
+    
+    MaterialHandle FindMaterialHandle(zCMaterial* material) const;
+    void DeleteMaterial(zCMaterial* material);
+    void DeleteMaterial(MaterialHandle handle);
+    MaterialHandle AddMaterial(zCMaterial* material);
+    zCMaterial* GetMaterial(MaterialHandle handle) const;
+};

--- a/D3D11Engine/zFILE.h
+++ b/D3D11Engine/zFILE.h
@@ -4,7 +4,6 @@
 #include "zCPolygon.h"
 #include "Engine.h"
 #include "GothicAPI.h"
-#include "zCMaterial.h"
 #include "zSTRING.h"
 
 class zFILE {

--- a/D3D11Engine/zFILE_VDFS.h
+++ b/D3D11Engine/zFILE_VDFS.h
@@ -123,7 +123,7 @@ public:
         return vftable->Read( this, scr, bytes );
     }
 
-    long Size() {
-        return vftable->Size( this );
+    size_t Size() {
+        return static_cast<size_t>(vftable->Size( this ));
     }
 };


### PR DESCRIPTION
- `MaterialHandle` represents a generationally tracked index into a flat zCMaterial* vector.
- `zCMaterialManager` holds and validates any Handles.
- Engine uses MaterialHandle for geometry and vobs which live for a long time. Things like PolyStrips are knowingly excluded as they are short lived and their material will likely always be valid.
- `MeshKey` uses `MaterialHandle` to ensure any left-over and overriden zCMaterial* with the same pointer but different value are ignored.
- Workaround for G2 where the engine constantly creates new zCCamera and with that new zCMesh and zCMaterial just to grab the "default" NearPlane value of a freshly constructed camera.
  instead we just grab the fresh NearPlane of any zCCamera that gets created and store that and provide it to the engine.