### PR TITLE
fix: improve memory management a bit, ignore old materialinfo (`.mi`) files, fix normalmap-strength when raining and no normalmaps available

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2347,6 +2347,12 @@ bool D3D11GraphicsEngine::BindTextureNRFX( zCTexture* tex, bool bindShader, bool
         srvs[1] = nrm->GetShaderResourceView().Get();
     } else if ( Engine::GAPI->GetSceneWetness() > 1e-6 ) {
         srvs[1] = DistortionTexture->GetShaderResourceView().Get();
+        if (!info) { info = Engine::GAPI->GetMaterialInfoFrom( tex ); }
+        if (info) {
+            // Value override for non-normalmapped textures in case of rain
+            info->buffer.NormalmapStrength = DEFAULT_NOISE_NORMALMAP_STRENGTH;
+            info->buffer.SpecularIntensity = DEFAULT_NOISE_SPECULAR_STRENGTH;
+        }
     }
 
     if ( info && GetActivePS() ) {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3380,7 +3380,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                         if ( isShadowPass ) {
                             for ( auto const& itm : mvi->Meshes ) {
                                 for ( unsigned int m = 0; m < itm.second.size(); m++ ) {
-                                    Engine::GAPI->DrawMeshInfo( itm.first, itm.second[m] );
+                                    Engine::GAPI->DrawMeshInfo( itm.first, itm.second[m].get() );
                                 }
                             }
                         } else {
@@ -3391,7 +3391,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                                         continue;
                                 }
                                 for ( unsigned int m = 0; m < itm.second.size(); m++ ) {
-                                    Engine::GAPI->DrawMeshInfo( itm.first, itm.second[m] );
+                                    Engine::GAPI->DrawMeshInfo( itm.first, itm.second[m].get() );
                                 }
                             }
                         }
@@ -3410,7 +3410,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
                         for ( auto const& itm : mvi->Meshes ) {
                             for ( unsigned int m = 0; m < itm.second.size(); m++ ) {
-                                Engine::GAPI->DrawMeshInfo( itm.first, itm.second[m] );
+                                Engine::GAPI->DrawMeshInfo( itm.first, itm.second[m].get() );
                             }
                         }
                         continue;
@@ -3445,7 +3445,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                             FrameGeometryCache::SortKeyBuilder meshSortKey = sortKeyBase;
                             meshSortKey.withMesh( itm.second[m]->meshId );
 
-                            instancedDrawItems.emplace_back( meshSortKey.sortKey, itm.second[m], texture, itm.first, instData,
+                            instancedDrawItems.emplace_back( meshSortKey.sortKey, itm.second[m].get(), texture, itm.first, instData,
                                 (texture && texture->HasAlphaChannel()) || (itm.first && itm.first->HasAlphaTest())
                             );
                         }
@@ -5625,10 +5625,11 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                     }
                 }
                 for ( auto const& meshInfo : materialMesh.second ) {
+                    const auto mesh = meshInfo.get();
                     DrawVertexBufferIndexed(
                         meshInfo->MeshVertexBuffer,
-                        GetShadowAwareIndexBuffer( meshInfo, isAlpha ),
-                        GetShadowAwareIndexCount( meshInfo, isAlpha ) );
+                        GetShadowAwareIndexBuffer( mesh, isAlpha ),
+                        GetShadowAwareIndexCount( mesh, isAlpha ) );
                 }
             }
         }
@@ -5976,10 +5977,12 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
                     }
                 }
                 for ( auto const& meshInfo : materialMesh.second ) {
+                    const auto mesh = meshInfo.get();
+
                     DrawVertexBufferInstancedIndexed(
                         meshInfo->MeshVertexBuffer,
-                        GetShadowAwareIndexBuffer( meshInfo, isAlpha ),
-                        GetShadowAwareIndexCount( meshInfo, isAlpha ),
+                        GetShadowAwareIndexBuffer( mesh, isAlpha ),
+                        GetShadowAwareIndexCount( mesh, isAlpha ),
                         6 );
                 }
             }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -128,6 +128,10 @@ void MaterialInfo::LoadFromFile( const std::string_view name ) {
     // Write the version first
     int version;
     memcpy( &version, ReadBuffer, sizeof( int ) );
+    if (version < 6) {
+        buffer.SetDefault();
+        return;
+    }
     
     // Then the data
     ZeroMemory( &buffer, sizeof( MaterialInfo::Buffer ) );

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1740,29 +1740,17 @@ void GothicAPI::GetVisibleDecalList( std::vector<zCVob*>& decals ) {
 
 /** Called when a material got removed */
 void GothicAPI::OnMaterialDeleted( zCMaterial* mat ) {
-#define UnloadMaterial(cont, m) \
-do { \
-    auto mit = cont.find(m); \
-    if ( mit != cont.end() ) { \
-        for ( auto& mi : mit->second ) { \
-            delete mi; \
-        } \
-        cont.erase(mit); \
-    } \
-} while (0)
-
     LoadedMaterials.erase( mat );
     if ( !mat )
         return;
     for ( auto&& it : SkeletalMeshVisuals ) {
-        UnloadMaterial( it.second->Meshes, mat );
-        UnloadMaterial( it.second->SkeletalMeshes, mat );
+        it.second->Meshes.erase(mat);
+        it.second->SkeletalMeshes.erase(mat);
     }
     for ( auto&& it : SkeletalMeshNpcs ) {
-        UnloadMaterial( it.second->Meshes, mat );
-        UnloadMaterial( it.second->SkeletalMeshes, mat );
+        it.second->Meshes.erase(mat);
+        it.second->SkeletalMeshes.erase(mat);
     }
-#undef UnloadMaterial
 }
 
 /** Called when a material got created */
@@ -1771,13 +1759,8 @@ void GothicAPI::OnMaterialCreated( zCMaterial* mat ) {
 }
 
 /** Returns if the material is currently active */
-bool GothicAPI::IsMaterialActive( zCMaterial* mat ) {
-    std::set<zCMaterial*>::iterator it = LoadedMaterials.find( mat );
-    if ( it != LoadedMaterials.end() ) {
-        return true;
-    }
-
-    return false;
+bool GothicAPI::IsMaterialActive( zCMaterial* mat ) const {
+    return LoadedMaterials.contains(mat);
 }
 
 /** Called when a vob moved */
@@ -2737,7 +2720,7 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
 
                         // Go through all meshes using that material
                         for ( unsigned int m = 0; m < itm.second.size(); m++ ) {
-                            DrawMeshInfo( itm.first, itm.second[m] );
+                            DrawMeshInfo( itm.first, itm.second[m].get() );
                         }
                     }
                 } else {
@@ -2750,7 +2733,7 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
 
                         // Go through all meshes using that material
                         for ( unsigned int m = 0; m < itm.second.size(); m++ ) {
-                            DrawMeshInfo( itm.first, itm.second[m] );
+                            DrawMeshInfo( itm.first, itm.second[m].get() );
                         }
                     }
                 }
@@ -2975,7 +2958,7 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
 
                     // Go through all meshes using that material
                     for ( unsigned int m = 0; m < itm.second.size(); m++ ) {
-                        DrawMeshInfo_Layered( itm.first, itm.second[m] );
+                        DrawMeshInfo_Layered( itm.first, itm.second[m].get() );
                     }
                 }
             }
@@ -3473,7 +3456,7 @@ float GothicAPI::TraceVisualInfo( const XMFLOAT3& origin, const XMFLOAT3& dir, B
 
     for ( auto const& it : visual->Meshes ) {
         for ( unsigned int m = 0; m < it.second.size(); m++ ) {
-            MeshInfo* mesh = it.second[m];
+            auto& mesh = it.second[m];
 
             for ( unsigned int i = 0; i < mesh->Indices.size(); i += 3 ) {
                 if ( Toolbox::IntersectTri( *mesh->Vertices[mesh->Indices[i]].Position.toXMFLOAT3(),
@@ -5649,7 +5632,7 @@ void GothicAPI::SetFrameProcessedTexturesReady() {
 }
 
 /** Draws a morphmesh */
-void GothicAPI::DrawMorphMesh( zCMorphMesh* msh, std::map<zCMaterial*, std::vector<MeshInfo*>>& meshes ) {
+void GothicAPI::DrawMorphMesh( zCMorphMesh* msh, std::map<zCMaterial*, std::vector<std::unique_ptr<MeshInfo>>>& meshes ) {
     zCProgMeshProto* morphMesh = msh->GetMorphMesh();
     if ( !morphMesh )
         return;
@@ -5679,7 +5662,7 @@ void GothicAPI::DrawMorphMesh( zCMorphMesh* msh, std::map<zCMaterial*, std::vect
         }
 
         for ( auto const& it : meshes ) {
-            for ( MeshInfo* mi : it.second ) {
+            for ( auto& mi : it.second ) {
                 if ( mi->MeshIndex == i ) {
                     Engine::GraphicsEngine->DrawVertexBufferIndexed( mi->MeshVertexBuffer, mi->MeshIndexBuffer, mi->Indices.size() );
                     goto Out_Of_Nested_Loop;
@@ -5690,7 +5673,7 @@ void GothicAPI::DrawMorphMesh( zCMorphMesh* msh, std::map<zCMaterial*, std::vect
     }
 }
 
-void GothicAPI::DrawMorphMesh_Layered( zCMorphMesh* msh, std::map<zCMaterial*, std::vector<MeshInfo*>>& meshes ) {
+void GothicAPI::DrawMorphMesh_Layered( zCMorphMesh* msh, std::map<zCMaterial*, std::vector<std::unique_ptr<MeshInfo>>>& meshes ) {
     zCProgMeshProto* morphMesh = msh->GetMorphMesh();
     if ( !morphMesh )
         return;
@@ -5719,7 +5702,7 @@ void GothicAPI::DrawMorphMesh_Layered( zCMorphMesh* msh, std::map<zCMaterial*, s
         }
 
         for ( auto const& it : meshes ) {
-            for ( MeshInfo* mi : it.second ) {
+            for ( auto& mi : it.second ) {
                 if ( mi->MeshIndex == i ) {
                     mi->MeshVertexBuffer->UpdateBuffer( &vertices[0], vertices.size() * sizeof( ExVertexStruct ) );
                     g->DrawVertexBufferInstancedIndexed( mi->MeshVertexBuffer, mi->MeshIndexBuffer, mi->Indices.size(), 6 );

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -176,7 +176,7 @@ struct CameraReplacement {
 };
 
 /** Version of this struct */
-const int MATERIALINFO_VERSION = 5;
+const int MATERIALINFO_VERSION = 6;
 
 struct MaterialInfo {
     enum EMaterialType {
@@ -192,11 +192,7 @@ struct MaterialInfo {
         PixelShader(static_cast<PShaderID>(0)),
         MaterialType(MT_None)
     {
-        buffer.SpecularIntensity = 0.1f;
-        buffer.SpecularPower = 60.0f;
-        buffer.NormalmapStrength = 1.0f;
-        buffer.DisplacementFactor = 1.0f;
-        buffer.Color = 0xFFFFFFFF;
+        buffer.SetDefault();
     }
 
     ~MaterialInfo() = default;
@@ -220,6 +216,14 @@ struct MaterialInfo {
         float DisplacementFactor;
         float4 Color;
 
+        void SetDefault() {
+            SpecularIntensity = 0.2f;
+            SpecularPower = 60.0f;
+            NormalmapStrength = 1.0f;
+            DisplacementFactor = 0.1f;
+            Color = 0xFFFFFFFF;
+        }
+        
         bool operator==( const Buffer& other ) const noexcept {
             return SpecularIntensity == other.SpecularIntensity &&
                 SpecularPower == other.SpecularPower &&

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -374,8 +374,8 @@ public:
     void DrawInventory( zCWorld* world, zCCamera& camera );
 
     /** Draws a morphmesh */
-    void DrawMorphMesh( zCMorphMesh* msh, std::map<zCMaterial*, std::vector<MeshInfo*>>& meshes );
-    void DrawMorphMesh_Layered( zCMorphMesh* msh, std::map<zCMaterial*, std::vector<MeshInfo*>>& meshes );
+    void DrawMorphMesh( zCMorphMesh* msh, std::map<zCMaterial*, std::vector<std::unique_ptr<MeshInfo>>>& meshes );
+    void DrawMorphMesh_Layered( zCMorphMesh* msh, std::map<zCMaterial*, std::vector<std::unique_ptr<MeshInfo>>>& meshes );
 
     /** Locks the resource CriticalSection */
     void EnterResourceCriticalSection();
@@ -522,7 +522,7 @@ public:
     GInventory* GetInventory();
 
     /** Returns if the material is currently active */
-    bool IsMaterialActive( zCMaterial* mat );
+    bool IsMaterialActive( zCMaterial* mat ) const;
 
     /** Sets the current input state. Keeps an internal count of how many times it was disabled. */
     void SetEnableGothicInput( bool value );

--- a/D3D11Engine/ImGuiEditorView.cpp
+++ b/D3D11Engine/ImGuiEditorView.cpp
@@ -659,7 +659,7 @@ void ImGuiEditorView::DoSelection() {
         if (Selection.SelectedVobInfo != TracedVobInfo && hitMaterialVob) {
             XMFLOAT4X4 world;
             XMStoreFloat4x4(&world, XMMatrixTranspose(XMLoadFloat4x4(TracedVobInfo->Vob->GetWorldMatrixPtr())));
-            VisualizeMeshInfo(TracedVobInfo->VisualInfo->Meshes[hitMaterialVob][0], XMFLOAT4(1, 1, 1, 1), false, &world);
+            VisualizeMeshInfo(TracedVobInfo->VisualInfo->Meshes[hitMaterialVob][0].get(), XMFLOAT4(1, 1, 1, 1), false, &world);
         }
 
         return;

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -1408,7 +1408,7 @@ void WorldConverter::UpdateMorphMeshVisual( void* v, MeshVisualInfo* meshInfo ) 
         }
 
         for ( auto const& it : meshInfo->Meshes ) {
-            for ( MeshInfo* mi : it.second ) {
+            for ( auto& mi : it.second ) {
                 if ( mi->MeshIndex == i ) {
                     mi->MeshVertexBuffer->UpdateBuffer( &vertices[0], vertices.size() * sizeof( ExVertexStruct ) );
                     goto Out_Of_Nested_Loop;

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -170,21 +170,18 @@ struct BaseVisualInfo {
         MidPoint{},
         Visual{},
         VisualName{}
-    {};
-    BaseVisualInfo(BaseVisualInfo&& other) = default;
+    {}
+
+    BaseVisualInfo(BaseVisualInfo&& other) noexcept = default;
     BaseVisualInfo& operator=( BaseVisualInfo&& ) noexcept = default;
     BaseVisualInfo(const BaseVisualInfo& other) = delete;
     BaseVisualInfo& operator=(const BaseVisualInfo& other) = delete;
 
     virtual ~BaseVisualInfo() {
-        for ( auto& [k, meshes] : Meshes ) {
-            for ( MeshInfo* mi : meshes ) {
-                delete mi;
-            }
-        }
+        Meshes.clear();
     }
 
-    std::map<zCMaterial*, std::vector<MeshInfo*>> Meshes;
+    std::map<zCMaterial*, std::vector<std::unique_ptr<MeshInfo>>> Meshes;
 
     /** "size" of the mesh. The distance between it's bbox min and bbox max */
     float MeshSize;
@@ -260,36 +257,25 @@ class zCModel;
 struct SkeletalMeshVisualInfo : public BaseVisualInfo {
     SkeletalMeshVisualInfo() :
         SkeletalMeshes{}
-    {};
-    SkeletalMeshVisualInfo(SkeletalMeshVisualInfo&& other) = default;
+    {}
+
+    SkeletalMeshVisualInfo(SkeletalMeshVisualInfo&& other) noexcept = default;
     SkeletalMeshVisualInfo& operator=( SkeletalMeshVisualInfo&& ) = default;
     SkeletalMeshVisualInfo(const SkeletalMeshVisualInfo& other) = delete;
     SkeletalMeshVisualInfo& operator=(const SkeletalMeshVisualInfo& other) = delete;
     
     ~SkeletalMeshVisualInfo() override
     {
-        for ( auto& [k, meshes] : SkeletalMeshes ) {
-            for ( SkeletalMeshInfo* smi : meshes ) {
-                delete smi;
-            }
-        }
+        SkeletalMeshes.clear();
     }
 
     void ClearMeshes() {
-        for ( auto& [k, meshes] : SkeletalMeshes )
-            for ( SkeletalMeshInfo* smi : meshes )
-                delete smi;
-
-        for ( auto& [k, meshes] : Meshes )
-            for ( MeshInfo* mi : meshes )
-                delete mi;
-
         SkeletalMeshes.clear();
         Meshes.clear();
     }
 
     /** Submeshes of this visual */
-    std::map<zCMaterial*, std::vector<SkeletalMeshInfo*>> SkeletalMeshes;
+    std::map<zCMaterial*, std::vector<std::unique_ptr<SkeletalMeshInfo>>> SkeletalMeshes;
 };
 
 struct BaseVobInfo {


### PR DESCRIPTION
- improve memory management a bit by making SkeletalMeshVisualInfo and BaseVisualInfo use a vector of owned pointers
- ignore old materialinfo (`.mi`) files version < 6
- fix normalmap-strength when raining and no normalmaps available