### PR TITLE
fix: fixed pointlights constantly re-rendering the static part. Fix "moved" check, C++23...

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,7 +13,7 @@
       "architecture": "Win32",
       "binaryDir": "${sourceDir}/out/build/${presetName}",
       "cacheVariables": {
-        "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_CXX_STANDARD": "23",
         "GD3D11_BUILD_ENGINE": "ON",
         "GD3D11_BUILD_LAUNCHER": "ON",
         "GD3D11_GAME": "G2",
@@ -37,7 +37,7 @@
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
-        "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_CXX_STANDARD": "23",
         "GD3D11_BUILD_ENGINE": "ON",
         "GD3D11_BUILD_LAUNCHER": "ON",
         "GD3D11_GAME": "G2",

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -314,7 +314,7 @@
       </AdditionalIncludeDirectories>
       <FloatingPointModel>Fast</FloatingPointModel>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
-      <AdditionalOptions>/Zc:inline /Zc:throwingNew %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -368,7 +368,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       </AdditionalIncludeDirectories>
       <FloatingPointModel>Fast</FloatingPointModel>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
-      <AdditionalOptions>/Zc:inline /Zc:throwingNew %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -415,7 +415,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       </AdditionalIncludeDirectories>
       <FloatingPointModel>Fast</FloatingPointModel>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
-      <AdditionalOptions>/Zc:inline /Zc:throwingNew %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -462,7 +462,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       </AdditionalIncludeDirectories>
       <FloatingPointModel>Fast</FloatingPointModel>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
-      <AdditionalOptions>/Zc:inline /Zc:throwingNew %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -513,7 +513,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       </AdditionalIncludeDirectories>
       <FloatingPointModel>Fast</FloatingPointModel>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
-      <AdditionalOptions>/Zc:inline /Zc:throwingNew %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>true</BufferSecurityCheck>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -566,6 +566,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <OpenMPSupport>true</OpenMPSupport>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -607,6 +608,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <FloatingPointExceptions>false</FloatingPointExceptions>
       <OpenMPSupport>true</OpenMPSupport>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -648,6 +650,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <FloatingPointExceptions>false</FloatingPointExceptions>
       <OpenMPSupport>true</OpenMPSupport>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -690,6 +693,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <FloatingPointExceptions>false</FloatingPointExceptions>
       <OpenMPSupport>true</OpenMPSupport>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -728,6 +732,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <FloatingPointModel>Fast</FloatingPointModel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -766,6 +771,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <FloatingPointModel>Fast</FloatingPointModel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -804,6 +810,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -838,6 +845,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <FloatingPointModel>Fast</FloatingPointModel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -869,6 +877,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <FloatingPointModel>Fast</FloatingPointModel>
       <FloatingPointExceptions>false</FloatingPointExceptions>
+      <AdditionalOptions>/Zc:inline /Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -318,7 +318,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>Default</LanguageStandard_C>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <FloatingPointExceptions>false</FloatingPointExceptions>
@@ -372,7 +372,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>Default</LanguageStandard_C>
       <FloatingPointExceptions>false</FloatingPointExceptions>
     </ClCompile>
@@ -419,7 +419,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>Default</LanguageStandard_C>
       <FloatingPointExceptions>false</FloatingPointExceptions>
     </ClCompile>
@@ -466,7 +466,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>Default</LanguageStandard_C>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <FloatingPointExceptions>false</FloatingPointExceptions>
@@ -517,7 +517,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>true</BufferSecurityCheck>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>Default</LanguageStandard_C>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <FloatingPointExceptions>false</FloatingPointExceptions>
@@ -557,7 +557,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4005;4530;4577;6246;6322;26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
@@ -599,7 +599,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4005;4530;4577;6246;6322;26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
@@ -641,7 +641,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4005;4530;4577;6246;6322;26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
@@ -684,7 +684,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4005;4530;4577;6246;6322;26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
@@ -727,7 +727,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4005;4530;4577;6246;6322;26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -766,7 +766,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4005;4530;4577;6246;6322;26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -806,7 +806,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4005;4530;4577;6246;6322;26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -840,7 +840,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4005;4530;4577;6246;6322;26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FloatingPointModel>Fast</FloatingPointModel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -870,7 +870,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Launcher|Win32'">
     <ClCompile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4744,8 +4744,12 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
     void* lastMat = nullptr;
     MaterialInfo* lastInfo = nullptr;
     for ( auto const& [meshKey, meshInfo] : list ) {
-        if ( zCTexture* texture = meshKey.Material->GetAniTexture() ) {
-            if (texture->CacheIn( 0.6f ) != zRES_CACHED_IN) {
+        zCMaterial* const mat = meshKey.Material;
+        if ( mat ) {
+            continue;
+        }
+        if ( zCTexture* texture = mat->GetAniTexture() ) {
+            if ( texture->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
                 // Draw what? black? :)
                 continue;
             }
@@ -4762,24 +4766,24 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
             srv[2] = surface->GetFxMap()
                 ? surface->GetFxMap()->GetShaderResourceView().Get()
                 : nullptr;
-            
-            int alphaFunc = meshKey.Material->GetAlphaFunc();
+
+            int alphaFunc = mat->GetAlphaFunc();
 
             if ( alphaFunc == 0 ) {
-                alphaFunc = zColor( meshKey.Material->GetColor() ).bgra.alpha < 255
+                alphaFunc = zColor( mat->GetColor() ).bgra.alpha < 255
                     ? zMAT_ALPHA_FUNC_BLEND
                     : zMAT_ALPHA_FUNC_MAT_DEFAULT;
             }
 
-            if (lastTex != texture) {
-                GetContext()->PSSetShaderResources( 0, 3, srv  );
+            if ( lastTex != texture ) {
+                GetContext()->PSSetShaderResources( 0, 3, srv );
                 lastTex = texture;
             }
-            
-            if (lastMat != meshKey.Material) {
+
+            if ( lastMat != mat ) {
                 //Get the right shader for it
                 BindShaderForTexture( texture, false, alphaFunc, meshKey.Info->MaterialType );
-                lastMat = meshKey.Material;
+                lastMat = mat;
             }
 
             // Check for alphablending on world mesh
@@ -4816,8 +4820,8 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
                 UpdateRenderStates();
                 lastAlphaFunc = alphaFunc;
             }
-            
-            if (meshKey.Material->GetEnvMapEnabled()) {
+
+            if ( mat->GetEnvMapEnabled()) {
                 if (Engine::GAPI->GetSky()->GetAtmosphereCB().AC_LightPos.y > 0) {
                     // sun is up
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4745,7 +4745,7 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
     MaterialInfo* lastInfo = nullptr;
     for ( auto const& [meshKey, meshInfo] : list ) {
         zCMaterial* const mat = meshKey.Material;
-        if ( mat ) {
+        if ( !mat ) {
             continue;
         }
         if ( zCTexture* texture = mat->GetAniTexture() ) {

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -496,7 +496,7 @@ void D3D11PointLight::RenderFullCubemap() {
     }
 
     const int shadowMode = GetCurrentShadowMode();
-    if ( shadowMode >= GothicRendererSettings::PLS_STATIC_ONLY && shadowMode != GothicRendererSettings::PLS_FULL ) {
+    if ( !m_StaticShadowReady && shadowMode >= GothicRendererSettings::PLS_STATIC_ONLY && shadowMode != GothicRendererSettings::PLS_FULL ) {
         RenderStaticShadowPass( *activeTarget, true );
         m_StaticShadowReady = true;
     }

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -59,12 +59,10 @@ D3D11PointLight::D3D11PointLight( VobLightInfo* info, bool dynamicLight ) {
         while (auto parent = vob->GetVobParent()) {
             if (auto visFx = parent->As<oCVisualFX>()) {
                 if (auto origin = visFx->GetOrigin(); origin && origin->As<oCItem>()) {
-                    m_ForceRealtimeShadows = true;
                     info->OriginVob = info->OriginVob ? info->OriginVob : origin;
                     break;
                 }
             } else if ( parent->As<oCItem>() ) {
-                m_ForceRealtimeShadows = true;
                 info->OriginVob = info->OriginVob ? info->OriginVob : info->Vob;
                 break;
             }
@@ -76,7 +74,7 @@ D3D11PointLight::D3D11PointLight( VobLightInfo* info, bool dynamicLight ) {
     // some lights don't seem to be in here!
     Engine::GAPI->VobLightMap[info->Vob] = info;
 
-    XMStoreFloat3( &LastUpdatePosition, LightInfo->Vob->GetPositionWorldXM() );
+    LastUpdatePosition = LightInfo->Vob->GetPositionWorld();
 
     m_DepthCubemap = nullptr;
     m_StaticDepthCubemap = nullptr;
@@ -166,10 +164,6 @@ void D3D11PointLight::ClearTiledSlot() {
 int D3D11PointLight::GetCurrentShadowMode() const {
     auto mode = static_cast<int>(Engine::GAPI->GetRendererState().RendererSettings.EnablePointlightShadows);
     if ( mode > 1 ) {
-        if ( m_ForceRealtimeShadows ) {
-            // movable fire sources like torches, not just any dynamic light.
-            return GothicRendererSettings::EPointLightShadowMode::PLS_FULL;
-        }
         if ( LightInfo->Vob->GetLightInfoFlags().isStatic ) {
             return GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY;
         }
@@ -333,6 +327,15 @@ bool D3D11PointLight::IsInited() {
     return InitDone.load();
 }
 
+namespace {
+    bool PositionEqualEps( const XMFLOAT3& a, const XMFLOAT3& b, float eps = 1.0f ) {
+        const XMVECTOR va = XMLoadFloat3( &a );
+        const XMVECTOR vb = XMLoadFloat3( &b );
+        const XMVECTOR vEps = XMVectorReplicate( eps );
+        return XMVector3NearEqual( va, vb, vEps );
+    }
+}
+
 /** Returns if this light needs an update */
 bool D3D11PointLight::NeedsUpdate() {
     if ( !IsReady() )
@@ -344,8 +347,7 @@ bool D3D11PointLight::NeedsUpdate() {
         return shadowMode > 0;
     }
 
-    FXMVECTOR lastPos = XMLoadFloat3( &LastUpdatePosition );
-    const bool moved = !XMVector3Equal( LightInfo->Vob->GetPositionWorldXM(), lastPos );
+    const bool moved = !PositionEqualEps(LastUpdatePosition,  LightInfo->Vob->GetPositionWorld());
 
     if ( shadowMode == GothicRendererSettings::PLS_STATIC_ONLY ) {
         return moved || !m_StaticShadowReady || NotYetDrawn();
@@ -391,8 +393,8 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate, D3D11ConstantBuffer* View
     //	return;
     D3D11GraphicsEngine* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine); // TODO: Remove and use newer system!
 
-    FXMVECTOR xmlastPos = XMLoadFloat3( &LastUpdatePosition );
-    const bool moved = !XMVector3Equal( LightInfo->Vob->GetPositionWorldXM(), xmlastPos );
+    XMFLOAT3 vobPos = LightInfo->Vob->GetPositionWorld();
+    const bool moved = !PositionEqualEps(LastUpdatePosition, vobPos);
 
     if ( moved ) {
         // Position changed, refresh our caches
@@ -413,11 +415,10 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate, D3D11ConstantBuffer* View
             return; // Don't update when we don't need to
     }
 
-    FXMVECTOR vEyePt = LightInfo->Vob->GetPositionWorldXM();
+    const XMVECTOR vEyePt = XMLoadFloat3( &vobPos );
     //vEyePt += XMVectorSet(0, 1, 0, 0) * 20.0f; // Move lightsource out of the ground or other objects (torches!)
     // TODO: Move the actual lightsource up too!
 
-    XMVECTOR vLookDir;
     const XMVECTOR c_XM_Right = XMVectorSet( 1.f, 0.f, 0.f, 0.f );
     const XMVECTOR c_XM_Left = XMVectorSet( -1.f, 0.f, 0.f, 0.f );
     const XMVECTOR c_XM_Up = XMVectorSet( 0.f, 1.f, 0.f, 0.f );
@@ -428,6 +429,7 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate, D3D11ConstantBuffer* View
     // Update indoor/outdoor-state
     LightInfo->IsIndoorVob = LightInfo->Vob->IsIndoorVob();
 
+    XMVECTOR vLookDir;
     // Generate cubemap view-matrices
     vLookDir = XMVectorAdd( c_XM_Right, vEyePt );
     XMStoreFloat4x4( &CubeMapViewMatrices[0], XMMatrixTranspose( XMMatrixLookAtLH( vEyePt, vLookDir, c_XM_Up ) ) );
@@ -479,7 +481,7 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate, D3D11ConstantBuffer* View
     Engine::GAPI->GetRendererState().GraphicsState.SetGraphicsSwitch( GSWITCH_LINEAR_DEPTH, false );
 
     LastUpdateColor = LightInfo->Vob->GetLightColor();
-    XMStoreFloat3( &LastUpdatePosition, vEyePt );
+    LastUpdatePosition = vobPos;
     DrawnOnce = true;
 }
 
@@ -496,22 +498,23 @@ void D3D11PointLight::RenderFullCubemap() {
     }
 
     const int shadowMode = GetCurrentShadowMode();
-    if ( !m_StaticShadowReady && shadowMode >= GothicRendererSettings::PLS_STATIC_ONLY && shadowMode != GothicRendererSettings::PLS_FULL ) {
+    if ( !m_StaticShadowReady && shadowMode == GothicRendererSettings::PLS_STATIC_ONLY ) {
         RenderStaticShadowPass( *activeTarget, true );
         m_StaticShadowReady = true;
+        return;
     }
 
     if ( shadowMode == GothicRendererSettings::PLS_UPDATE_DYNAMIC ) {
         DepthStencilPool* dsPool = engine->GetPfxRenderer()->GetDepthStencilPool();
         AcquireStaticAsideShadowMap( dsPool, m_CurrentResolution );
 
-        if ( !m_StaticShadowReady || !m_StaticDepthCubemap ) {
+        if ( !m_StaticShadowReady) {
             if ( m_StaticDepthCubemap ) {
                 RenderStaticShadowPass( *m_StaticDepthCubemap, true );
                 m_StaticShadowReady = true;
             } else {
+                // No aside buffer, we can't cache the static shadows.
                 RenderStaticShadowPass( *activeTarget, true );
-                m_StaticShadowReady = true;
             }
         }
 
@@ -520,7 +523,10 @@ void D3D11PointLight::RenderFullCubemap() {
         }
 
         RenderAnimatedShadowPass( *activeTarget, false );
-    } else if ( shadowMode == GothicRendererSettings::PLS_FULL ) {
+        return;
+    }
+    
+    if ( shadowMode == GothicRendererSettings::PLS_FULL ) {
         auto wc = &WorldMeshCache;
         if ( WorldCacheInvalid ) {
             wc = nullptr;

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -106,8 +106,6 @@ protected:
     bool DrawnOnce;
     bool m_StaticShadowReady = false;
     int m_LastShadowMode = -1;
-    // used to denote things like torches which move with NPCs
-    bool m_ForceRealtimeShadows = false;
 
     // Tiled deferred slot (non-owning, owned by D3D11TiledDeferredShading)
     int m_TiledSlotIndex = -1;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -2969,9 +2969,8 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
                     if ( g->GetRenderingStage() == DES_MAIN || g->GetRenderingStage() == DES_GHOST ) {
                         if ( updateState ) {
                             if ( mvi->LastAniUpdateFrame != now ) {
+                                WorldConverter::UpdateMorphMeshVisual( mm, mvi );
                                 mvi->LastAniUpdateFrame = now;
-                                mm->AdvanceAnis();
-                                mm->CalcVertexPositions();
                             }
                         }
                         DrawMorphMesh_Layered( mm, mvi->Meshes );
@@ -5727,43 +5726,49 @@ void GothicAPI::DrawMorphMesh( zCMorphMesh* msh, std::map<zCMaterial*, std::vect
 }
 
 void GothicAPI::DrawMorphMesh_Layered( zCMorphMesh* msh, std::map<zCMaterial*, std::vector<std::unique_ptr<MeshInfo>>>& meshes ) {
+    // layered draw always has WhiteTexture bound to PS Slot 0
+    // no need to bind a texture! Just used for shadows
     zCProgMeshProto* morphMesh = msh->GetMorphMesh();
     if ( !morphMesh )
         return;
 
+    // Ensure to call `WorldConverter::UpdateMorphMeshVisual( ... );` once per frame for this mesh to update the vertex buffers before drawing.
+
     D3D11GraphicsEngine* g = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
-    XMFLOAT3* posList = morphMesh->GetPositionList()->Array->toXMFLOAT3();
-    std::vector<ExVertexStruct> vertices;
+
+    D3D11Texture* whiteTexture = g->GetWhiteTexture();
+    void* lastTex = whiteTexture;
+
     for ( int i = 0; i < morphMesh->GetNumSubmeshes(); i++ ) {
-
         zCSubMesh* s = morphMesh->GetSubmesh( i );
-        vertices.clear();
-        vertices.reserve( s->WedgeList.NumInArray );
-        for ( int v = 0; v < s->WedgeList.NumInArray; v++ ) {
-            zTPMWedge& wedge = s->WedgeList.Array[v];
-            vertices.emplace_back();
-            ExVertexStruct& vx = vertices.back();
-            vx.Position = posList[wedge.position];
-            vx.Normal = wedge.normal;
-            vx.TexCoord = wedge.texUV;
-            vx.Color = 0xFFFFFFFF;
-        }
-
-        if ( zCTexture* texture = s->Material->GetAniTexture() ) {
-            if ( !g->BindTextureNRFX( texture, (g->GetRenderingStage() == DES_MAIN) ) )
-                continue;
-        }
 
         for ( auto const& it : meshes ) {
+            zCTexture* texture;
+            if ( it.first && (texture = it.first->GetAniTexture()) != nullptr ) {
+                if ( texture->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
+                    continue; // we cant determine if we need to draw this, alpha data is only available after loading a texture.
+                }
+
+                const bool needTex = texture != lastTex
+                    && (texture->HasAlphaChannel() || it.first->HasAlphaTest());
+
+                if ( needTex ) {
+                    texture->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
+                    lastTex = texture;
+                } else if ( lastTex != whiteTexture ) {
+                    whiteTexture->BindToPixelShader( 0 );
+                    lastTex = whiteTexture;
+                }
+            }
+
             for ( auto& mi : it.second ) {
                 if ( mi->MeshIndex == i ) {
-                    mi->MeshVertexBuffer->UpdateBuffer( &vertices[0], vertices.size() * sizeof( ExVertexStruct ) );
                     g->DrawVertexBufferInstancedIndexed( mi->GetMeshVertexBuffer(), mi->GetMeshIndexBuffer(), mi->Indices.size(), 6 );
                     goto Out_Of_Nested_Loop;
                 }
             }
         }
-        Out_Of_Nested_Loop:;
+    Out_Of_Nested_Loop:;
     }
 }
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -60,10 +60,6 @@
 #define OPT_DBG_NOINLINE
 #endif
 
-struct file_deleter {
-    void operator()( std::FILE* fp ) { std::fclose( fp ); }
-};
-
 // Duration how long the scene will stay wet, in MS
 const DWORD SCENE_WETNESS_DURATION_MS = 20 * 1000;
 
@@ -4123,7 +4119,6 @@ void GothicAPI::CollectVisibleVobs(
         std::vector<std::pair<float, VobLightInfo*>> lightWithDist;
         lightWithDist.reserve( renderQueue.lights.size() );
 
-        const auto camPos = ctx.cameraPosition;
         float lightPlayerDist;
         for ( auto vi : renderQueue.lights ) {
             if ( vi->Vob->IsEnabled() ) {
@@ -4874,7 +4869,7 @@ static void FixUpMaterial( MaterialInfo::Buffer& buffer ) {
 /** Returns the material info associated with the given material */
 MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex ) {
     auto it = MaterialInfos.find( tex );
-    MaterialInfo* mi = nullptr;
+    MaterialInfo* mi;
     if ( it == MaterialInfos.end() ) {
 
         // Make a new one and try to load it
@@ -4898,7 +4893,7 @@ MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex ) {
 
 MaterialInfo* GothicAPI::GetMaterialInfoFrom( zCTexture* tex, const std::string_view textureName ) {
         auto it = MaterialInfos.find( tex );
-        MaterialInfo* mi = nullptr;
+        MaterialInfo* mi;
         if ( it == MaterialInfos.end() ) {
             auto info = std::make_unique<MaterialInfo>();
             MaterialInfos.emplace( tex, std::move( info ) );
@@ -5441,7 +5436,6 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
             s.SectionDrawRadius = std::max( 3, s.SectionDrawRadius );
         }
 
-        static XMFLOAT3 defaultLightDirection = XMFLOAT3( 1, 1, 1 );
         s.EnableShadows = GetPrivateProfileBoolA( "Shadows", "EnableShadows", ds.EnableShadows, ini );
         s.ShadowFilterMode = static_cast<GothicRendererSettings::E_ShadowFilterMode>(
             GetPrivateProfileIntA( "Shadows", "ShadowFilterMode",
@@ -5740,8 +5734,6 @@ void GothicAPI::DrawMorphMesh_Layered( zCMorphMesh* msh, std::map<zCMaterial*, s
     void* lastTex = whiteTexture;
 
     for ( int i = 0; i < morphMesh->GetNumSubmeshes(); i++ ) {
-        zCSubMesh* s = morphMesh->GetSubmesh( i );
-
         for ( auto const& it : meshes ) {
             zCTexture* texture;
             if ( it.first && (texture = it.first->GetAniTexture()) != nullptr ) {

--- a/D3D11Engine/Shaders/PS_Water.hlsl
+++ b/D3D11Engine/Shaders/PS_Water.hlsl
@@ -306,7 +306,14 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float NdotV = saturate(dot(-viewDirection, wavesFres));
 	float reflectFresnel = pow(1.0f - NdotV, 3.0f);
 
-	float reflectAmount = saturate(max(saturate(ssrConfidence), reflectFresnel * 0.05f));
+	// Waterfalls (surface normal pointing mostly sideways rather than up) get a
+	// strong, distracting reflection because the geometry is nearly vertical while
+	// the shader still treats it like flat, horizontal water. Use the true geometric
+	// normal (not the wave-perturbed one) to detect this and fade the reflection out.
+	float waterfallFactor = 1.0f - saturate(abs(normalize(Input.vNormalWS).y));
+	float reflectSuppress = lerp(1.0f, 0.12f, waterfallFactor);
+
+	float reflectAmount = saturate(max(saturate(ssrConfidence), reflectFresnel * 0.05f)) * reflectSuppress;
 	color = lerp(color, reflection * lerp(1.0f, diffuse, 0.3f), reflectAmount);
 	
 	color.rgb = ApplyAtmosphericScatteringGround(Input.vWorldPosition, color.rgb);

--- a/D3D11Engine/ThreadPool.h
+++ b/D3D11Engine/ThreadPool.h
@@ -41,7 +41,7 @@ public:
 
         std::stop_source token;
 
-        auto task = std::make_shared<std::packaged_task<ReturnType()>>(
+        auto task = std::packaged_task<ReturnType()>(
             [f = std::forward<F>( f ),
              token,
              ...args = std::forward<Args>( args )]() mutable {
@@ -49,7 +49,7 @@ public:
             }
         );
 
-        std::future<ReturnType> future = task->get_future();
+        std::future<ReturnType> future = task.get_future();
         {
             std::scoped_lock lock( queue_mutex );
 
@@ -57,9 +57,9 @@ public:
                 throw std::runtime_error( "enqueue on stopped ThreadPool" );
             }
 
-            tasks.emplace( [task]()
+            tasks.emplace( [task = std::move(task)]() mutable
             {
-                (*task)();
+                task();
             }, token );
         }
         condition.notify_one();
@@ -80,7 +80,7 @@ public:
     void clearAndFlush()
     {
         // Swap out the tasks quickly to minimize mutex lock time
-        std::queue<std::pair<std::function<void()>, std::stop_source>> pending_tasks;
+        std::queue<std::pair<std::move_only_function<void()>, std::stop_source>> pending_tasks;
         {
             std::unique_lock<std::mutex> lock( queue_mutex );
             std::swap( tasks, pending_tasks );
@@ -102,7 +102,7 @@ public:
 
 private:
     std::vector<std::thread> workers;
-    std::queue<std::pair<std::function<void()>, std::stop_source>> tasks;
+    std::queue<std::pair<std::move_only_function<void()>, std::stop_source>> tasks;
 
     std::atomic_int activeTasks{0};
     std::mutex queue_mutex;
@@ -124,7 +124,7 @@ inline ThreadPool::ThreadPool(const wchar_t* poolIdentifier, size_t threads)
                 SetThreadDescription( GetCurrentThread(), (descriptionPrefix+std::to_wstring(workerId)).c_str() );
                 for (;;)
                 {
-                    std::function<void()> task;
+                    std::move_only_function<void()> task;
 
                     {
                         std::unique_lock<std::mutex> lock(pool->queue_mutex);

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -1476,8 +1476,9 @@ void WorldConverter::UpdateMorphMeshVisual( void* v, MeshVisualInfo* meshInfo ) 
         return;
 
     XMFLOAT3* posList = morphMesh->GetPositionList()->Array->toXMFLOAT3();
+    static std::vector<ExVertexStruct> vertices;
     for ( int i = 0; i < morphMesh->GetNumSubmeshes(); i++ ) {
-        std::vector<ExVertexStruct> vertices;
+        vertices.clear();
 
         zCSubMesh* s = morphMesh->GetSubmesh( i );
         vertices.reserve( s->WedgeList.NumInArray );

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -965,7 +965,6 @@ void WorldConverter::Extract3DSMeshFromVisual( zCProgMeshProto* visual, MeshVisu
     std::vector<ExVertexStruct> vertices;
 
     // Get the data out for all submeshes
-    vertices.clear();
     visual->ConstructVertexBuffer( &vertices );
 
     // This visual can hold multiple submeshes, each with it's own indices
@@ -974,28 +973,33 @@ void WorldConverter::Extract3DSMeshFromVisual( zCProgMeshProto* visual, MeshVisu
 
         // Get the data from the indices
         for ( int n = 0; n < m->WedgeList.NumInArray; n++ ) {
-            int idx = m->WedgeList.Get( n ).position;
+            const auto& wedge = m->WedgeList.Get( n );
+            int idx = wedge.position;
 
-            vertices[idx].TexCoord.x = m->WedgeList.Get( n ).texUV.x; // This produces wrong results
-            vertices[idx].TexCoord.y = m->WedgeList.Get( n ).texUV.y;
+            vertices[idx].TexCoord.x = wedge.texUV.x; // This produces wrong results
+            vertices[idx].TexCoord.y = wedge.texUV.y;
             vertices[idx].Color = 0xFFFFFFFF;
-            *vertices[idx].Normal.toXMFLOAT3() = (*m->WedgeList.Get( n ).normal.toXMFLOAT3());
+            vertices[idx].Normal = wedge.normal;
         }
 
         // Get indices
         std::vector<VERTEX_INDEX> indices;
+        indices.reserve( m->TriList.NumInArray * 3 );
         for ( int n = 0; n < m->TriList.NumInArray; n++ ) {
-            indices.emplace_back( m->WedgeList.Get( m->TriList.Get( n ).wedge[0] ).position );
-            indices.emplace_back( m->WedgeList.Get( m->TriList.Get( n ).wedge[1] ).position );
-            indices.emplace_back( m->WedgeList.Get( m->TriList.Get( n ).wedge[2] ).position );
+            const auto& triWedge = m->TriList.Get( n ).wedge;
+            indices.emplace_back( m->WedgeList.Get( triWedge[0] ).position );
+            indices.emplace_back( m->WedgeList.Get( triWedge[1] ).position );
+            indices.emplace_back( m->WedgeList.Get( triWedge[2] ).position );
         }
 
         zCMaterial* mat = m->Material;
 
         MeshInfo* mi = new MeshInfo;
 
+        // WTF. These meshes all have incrementally MORE vertices the further this goes.
+        // all meshes share the same vertex-vector
         mi->Vertices = vertices;
-        mi->Indices = indices;
+        mi->Indices = std::move(indices);
         mi->meshId = s_MeshManager->RecordMesh( m );
 
         // Create the buffers
@@ -1046,7 +1050,7 @@ void WorldConverter::ExtractSkeletalMeshFromVob( zCModel* model, SkeletalMeshVis
             int numNodes = *reinterpret_cast<int*>(stream);
             stream += 4;
 
-            ExSkelVertexStruct vx;
+            ExSkelVertexStruct& vx = posList.emplace_back();
             //vx.Position = s->GetPositionList()->Array[i];
             vx.Normal = float3( 0, 0, 0 );
             ZeroMemory( vx.weights, sizeof( vx.weights ) );
@@ -1075,8 +1079,6 @@ void WorldConverter::ExtractSkeletalMeshFromVob( zCModel* model, SkeletalMeshVis
                     vx.Position[n][2] = halfs[2];
                 }
             }
-
-            posList.emplace_back( vx );
         }
 
         // The rest is the same as a zCProgMeshProto, but with a different vertex type
@@ -1116,8 +1118,7 @@ void WorldConverter::ExtractSkeletalMeshFromVob( zCModel* model, SkeletalMeshVis
                 vx.TexCoord = wedge.texUV;
 
                 // Save vertexpos in bind pose, to run PNAEN on it
-                bindPoseVertices.emplace_back();
-                ExVertexStruct& pvx = bindPoseVertices.back();
+                ExVertexStruct& pvx = bindPoseVertices.emplace_back();
                 pvx.Position = s->GetPositionList()->Array[wedge.position];
                 pvx.Normal = vx.Normal;
                 pvx.TexCoord = vx.TexCoord;
@@ -1351,17 +1352,19 @@ void WorldConverter::ExtractProgMeshProtoFromMesh( zCMesh* mesh, MeshVisualInfo*
 
     for ( int i = 0; i < numPolys; i++ ) {
         zCPolygon* poly = polys[i];
+        zCVertex** const polyVerticies = poly->getVertices();
+        zCVertFeature** const polyFeatures = poly->getFeatures();
 
         // Extract poly vertices
         polyVertices.clear();
-        polyVertices.reserve( poly->GetNumPolyVertices() );
+        const auto numPolyVeritcies = poly->GetNumPolyVertices();
+        polyVertices.reserve( numPolyVeritcies );
 
-        for ( int v = 0; v < poly->GetNumPolyVertices(); v++ ) {
-            zCVertex* vertex = poly->getVertices()[v];
-            zCVertFeature* feature = poly->getFeatures()[v];
+        for ( int v = 0; v < numPolyVeritcies; v++ ) {
+            const zCVertex* vertex = polyVerticies[v];
+            const zCVertFeature* feature = poly->getFeatures()[v];
 
-            polyVertices.emplace_back();
-            ExVertexStruct& t = polyVertices.back();
+            ExVertexStruct& t = polyVertices.emplace_back();
             t.Position = vertex->Position;
             t.TexCoord = feature->texCoord;
             t.Normal = feature->normal;
@@ -1480,8 +1483,8 @@ void WorldConverter::UpdateMorphMeshVisual( void* v, MeshVisualInfo* meshInfo ) 
         vertices.reserve( s->WedgeList.NumInArray );
         for ( int v = 0; v < s->WedgeList.NumInArray; v++ ) {
             zTPMWedge& wedge = s->WedgeList.Array[v];
-            vertices.emplace_back();
-            ExVertexStruct& vx = vertices.back();
+
+            ExVertexStruct& vx = vertices.emplace_back();
             vx.Position = posList[wedge.position];
             vx.Normal = wedge.normal;
             vx.TexCoord = wedge.texUV;
@@ -1516,7 +1519,8 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
     // Construct unindexed mesh
     std::vector<ExVertexStruct> vertices;
     std::vector<VERTEX_INDEX> indices;
-    for ( int i = 0; i < visual->GetNumSubmeshes(); i++ ) {
+    const auto numSubmeshes = visual->GetNumSubmeshes();
+    for ( int i = 0; i < numSubmeshes; i++ ) {
         zCSubMesh* s = visual->GetSubmesh( i );
         vertices.clear();
         indices.clear();

--- a/D3D11Engine/zCProgMeshProto.h
+++ b/D3D11Engine/zCProgMeshProto.h
@@ -80,12 +80,11 @@ public:
         vertices->reserve( pl->NumInArray );
 
         for ( int i = 0; i < pl->NumInArray; i++ ) {
-            ExVertexStruct vx;
+            ExVertexStruct& vx = vertices->emplace_back();
             vx.Position = pl->Get( i );
             vx.Normal = float3( 0, 0, 0 );
             vx.TexCoord = float2( 0, 0 );
             vx.Color = 0xFFFFFFFF;
-            vertices->push_back( vx );
         }
     }
 };


### PR DESCRIPTION
fixed a bunch of performance issues related to Pointlights

- pointlights
  - `moved` check was too generous and compared floats without epsilon. We now use epsilon on `1.0f` as we compare world positions. (players, even when stationary, still wiggle around)
  - the static part always wrote into the `activeTarget` even if it should've been cached for dynamic draws.
  - no longer re-render static portion of e.g. torches when the player is standing still. Only update the dynamic part.
- layered drawing 
  - now skips using the models texture unless it needs alpha-testing and instead also just uses the `WhiteTexture`, reducing texture bindings.
  - doesn't re-calculate Morph-Mesh data every time, but instead relies on `UpdateMorphMeshVisual` just like the non-layered render path. Ensures we don't needlessly update graphics buffers all the time.
- reduce some unneccesery duplicated engine-accessors in `WorldConverter`
- reduce Screen Space Reflection effect on vertical waters (waterfalls)
- Update c++ build parameters to include `/Zc:__cplusplus` to make MVSC properly define `__cplusplus` versions, such that we can use modern c++ features also in DirectXMath or other places.
- Update to c++23
  - update Threadpool.h to make use of `std::move_only_function<void()>` instead of `std::function<void()>`