### PR TITLE
fix resource loading. fixes #434 & #435

### DIFF
--- a/D3D11Engine/D3D11Effect.cpp
+++ b/D3D11Engine/D3D11Effect.cpp
@@ -441,22 +441,12 @@ XRESULT D3D11Effect::LoadRainResources()
 {
     D3D11GraphicsEngineBase* e = reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine);
 
-    std::string path;
-    path.resize( MAX_PATH );
-    path.resize(GetModuleFileNameA( nullptr, path.data(), path.size()-1 ));
-
-    std::filesystem::path basePath = std::filesystem::path( path ).parent_path() / "GD3D11" / "Textures";
-    
     if ( !RainTextureArray.Get() ) {
         HRESULT hr = S_OK;
         // Load textures...
         LogInfo() << "Loading rain-drop textures";
         ZoneScopedN( "LoadRainTextures" );
-        LE( LoadTextureArray( e->GetDevice().Get(), R"(\_work\Data\Textures\GD3D11\Raindrops\cv0_vPositive_)", 370, &RainTextureArray, &RainTextureArraySRV ) );
-        if (!SUCCEEDED(hr)) {
-            // try old file paths
-            LE( LoadTextureArray( e->GetDevice().Get(), R"(\System\GD3D11\Textures\Raindrops\cv0_vPositive_)", 370, &RainTextureArray, &RainTextureArraySRV ) );
-        }
+        LE( LoadTextureArray( e->GetDevice().Get(), R"(\System\GD3D11\Textures\Raindrops\cv0_vPositive_)", 370, &RainTextureArray, &RainTextureArraySRV ) );
     }
 
     if ( !SnowTextureArray.Get() ) {
@@ -464,10 +454,7 @@ XRESULT D3D11Effect::LoadRainResources()
         // Load textures...
         LogInfo() << "Loading snow flake textures";
         ZoneScopedN( "LoadSnowTextures" );
-        LE( LoadTextureArray( e->GetDevice().Get(), R"(\_work\Data\Textures\GD3D11\Snowflakes\Snow_)", 256, &SnowTextureArray, &SnowTextureArraySRV ) );
-        if (!SUCCEEDED(hr)) {
-            LE( LoadTextureArray( e->GetDevice().Get(), R"(\System\GD3D11\Textures\Snowflakes\Snow_)", 256, &SnowTextureArray, &SnowTextureArraySRV ) );
-        }
+        LE( LoadTextureArray( e->GetDevice().Get(), R"(\System\GD3D11\Textures\Snowflakes\Snow_)", 256, &SnowTextureArray, &SnowTextureArraySRV ) );
     }
 
     if ( !RainShadowmap.get() ) {

--- a/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
+++ b/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
@@ -170,7 +170,7 @@ void MyDirectDrawSurface7::LoadAdditionalResources( zCTexture* ownedTexture ) {
         }
     
         currentResource.clear();
-        currentResource.append(systemWorkPath).append(gameName).append("\\").append(textureName);
+        currentResource.append(systemWorkPath).append("Normalmaps_").append(gameName).append("\\").append(textureName);
         LoadResource(currentResource, textureName, storage, texture);
     }
 

--- a/D3D11Engine/DDSArrayLoader.h
+++ b/D3D11Engine/DDSArrayLoader.h
@@ -5,23 +5,9 @@
 #include <algorithm>
 #include "Logger.h"
 #include "zFILE_VDFS.h"
-
-// Define MAKEFOURCC if not already defined by Windows/DirectX headers
-#ifndef MAKEFOURCC
-#define MAKEFOURCC(ch0, ch1, ch2, ch3) \
-    ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) | \
-    ((uint32_t)(uint8_t)(ch2) << 16) | ((uint32_t)(uint8_t)(ch3) << 24 ))
-#endif
+#include "DDSFormat.h"   // shared DDS constants + format decoding / pitch math (DDS:: namespace)
 
 namespace {
-
-    constexpr uint32_t DDS_MAGIC = 0x20534444; // "DDS "
-
-    // FourCC codes
-    constexpr uint32_t FOURCC_DX10 = MAKEFOURCC( 'D', 'X', '1', '0' );
-    constexpr uint32_t FOURCC_ATI1 = MAKEFOURCC( 'A', 'T', 'I', '1' );
-    constexpr uint32_t FOURCC_BC4U = MAKEFOURCC( 'B', 'C', '4', 'U' );
-    constexpr uint32_t FOURCC_BC4S = MAKEFOURCC( 'B', 'C', '4', 'S' );
 
     struct DDS_PIXELFORMAT {
         uint32_t size;
@@ -59,70 +45,25 @@ namespace {
         uint32_t miscFlags2;
     };
 
-    // Simple helper to calculate DDS memory pitch size and block-aligned dimensions.
+    // Block-aware DDS surface size, delegating to the shared format tables (handles BC1..BC7 + every
+    // common uncompressed format, no silent 32-bit fallback for unknowns).
     inline void GetSurfaceInfo( uint32_t width, uint32_t height, DXGI_FORMAT format,
                                uint32_t& outNumBytes, uint32_t& outRowBytes )
     {
-        bool bc = false;
-        uint32_t bpe = 0; // Bytes Per Element
-
-        switch ( format ) {
-        case DXGI_FORMAT_BC4_UNORM:
-        case DXGI_FORMAT_BC4_SNORM:
-            bc = true;
-            bpe = 8;
-            break;
-        case DXGI_FORMAT_BC1_UNORM:
-        case DXGI_FORMAT_BC1_UNORM_SRGB:
-            bc = true;
-            bpe = 8;
-            break;
-        case DXGI_FORMAT_BC2_UNORM:
-        case DXGI_FORMAT_BC2_UNORM_SRGB:
-        case DXGI_FORMAT_BC3_UNORM:
-        case DXGI_FORMAT_BC3_UNORM_SRGB:
-        case DXGI_FORMAT_BC5_UNORM:
-        case DXGI_FORMAT_BC5_SNORM:
-        case DXGI_FORMAT_BC6H_UF16:
-        case DXGI_FORMAT_BC6H_SF16:
-        case DXGI_FORMAT_BC7_UNORM:
-        case DXGI_FORMAT_BC7_UNORM_SRGB:
-            bc = true;
-            bpe = 16;
-            break;
-        case DXGI_FORMAT_R8_UNORM:
-        case DXGI_FORMAT_R8_UINT:
-        case DXGI_FORMAT_R8_SNORM:
-        case DXGI_FORMAT_R8_SINT:
-            bpe = 1;
-            break;
-        default:
-            // Default fallback (e.g. RGBA 32-bit targets)
-            bpe = 4;
-            break;
-        }
-
-        if ( bc ) {
-            uint32_t numBlocksWide = (width > 0) ? std::max<uint32_t>( 1, (width + 3) / 4 ) : 0;
-            uint32_t numBlocksHigh = (height > 0) ? std::max<uint32_t>( 1, (height + 3) / 4 ) : 0;
-            outRowBytes = numBlocksWide * bpe;
-            outNumBytes = outRowBytes * numBlocksHigh;
-        } else {
-            outRowBytes = (width * bpe + 7) / 8; // Bit-to-byte alignment
-            outNumBytes = outRowBytes * height;
-        }
+        outRowBytes = DDS::RowPitch( format, width );
+        outNumBytes = DDS::SurfaceBytes( format, width, height );
     }
 }
 
-typedef HRESULT( *VirtualFileReader )(const char* path, std::vector<uint8_t> buffer, long* numRead);
+typedef HRESULT( *VirtualFileReader )(const char* path, std::vector<uint8_t>& buffer, long* numRead);
 
-inline HRESULT zVdfsReadFile( const char* str, std::vector<uint8_t> buffer, long* numRead ) {
+inline HRESULT zVdfsReadFile( const char* str, std::vector<uint8_t>& buffer, long* numRead ) {
     auto file = zFILE_VDFS::Create( str );
     if ( !file->Exists() ) {
         LogError() << "File does not exist: " << str;
         return E_FAIL;
     }
-    if ( file->Open( false ) != 0 ) {
+    if ( file->Open( false ) != zERRORS::zERROR_NONE ) {
         LogError() << "Failed to open filepath: " << str;
         return E_FAIL;
     }
@@ -177,13 +118,13 @@ inline HRESULT LoadTextureArray(
         const size_t rawSize = fileBuffers[i].size();
 
         if ( rawSize < (sizeof( uint32_t ) + sizeof( DDS_HEADER )) ) {
-            LogError() << "DDS data too small at index: " << i;
+            LogError() << "DDS data too small at index: " << i << " was: " << rawSize << ", expected: " << (sizeof( uint32_t ) + sizeof( DDS_HEADER )) << " prefix was: " << sTexturePrefix;
             return E_FAIL;
         }
 
         // Validate DDS Magic Header Number
         uint32_t magicNumber = *reinterpret_cast<const uint32_t*>( rawData );
-        if ( magicNumber != DDS_MAGIC ) {
+        if ( magicNumber != DDS::Magic ) {
             LogError() << "Invalid DDS magic number at index: " << i;
             return E_FAIL;
         }
@@ -194,15 +135,13 @@ inline HRESULT LoadTextureArray(
             return E_FAIL;
         }
 
-        // Detect Format
+        // Detect format (shared decoder: BC1..BC7, DX10-extended, and uncompressed formats via masks).
         DXGI_FORMAT parsedFormat = DXGI_FORMAT_UNKNOWN;
         size_t offset = sizeof( uint32_t ) + sizeof( DDS_HEADER );
 
-        if ( header->ddspf.flags & 0x4 ) { // DDPF_FOURCC
-            uint32_t fourCC = header->ddspf.fourCC;
-
-            if ( fourCC == FOURCC_DX10 ) {
-                // If it is a DX10 container, parse the secondary header to get the exact DXGI_FORMAT
+        if ( header->ddspf.flags & DDS::FlagFourCC ) {
+            if ( header->ddspf.fourCC == DDS::Dx10 ) {
+                // DX10 container: the secondary header carries the exact DXGI_FORMAT.
                 if ( rawSize < (offset + sizeof( DDS_HEADER_DXT10 )) ) {
                     LogError() << "DDS file missing DXT10 extended header at index: " << i;
                     return E_FAIL;
@@ -210,19 +149,18 @@ inline HRESULT LoadTextureArray(
                 const auto* headerDX10 = reinterpret_cast<const DDS_HEADER_DXT10*>( rawData + offset );
                 parsedFormat = static_cast<DXGI_FORMAT>( headerDX10->dxgiFormat );
                 offset += sizeof( DDS_HEADER_DXT10 );
-            } else if ( fourCC == FOURCC_ATI1 || fourCC == FOURCC_BC4U ) {
-                parsedFormat = DXGI_FORMAT_BC4_UNORM;
-            } else if ( fourCC == FOURCC_BC4S ) {
-                parsedFormat = DXGI_FORMAT_BC4_SNORM;
+            } else {
+                parsedFormat = DDS::FromFourCC( header->ddspf.fourCC );
             }
-        } else if ( header->ddspf.flags & 0x20000 ) { // DDPF_LUMINANCE / Single channel
-            if ( header->ddspf.rgbBitCount == 8 ) {
-                parsedFormat = DXGI_FORMAT_R8_UNORM;
-            }
+        } else {
+            parsedFormat = DDS::FromPixelFormat( header->ddspf.flags, header->ddspf.rgbBitCount,
+                header->ddspf.rBitMask, header->ddspf.gBitMask, header->ddspf.bBitMask, header->ddspf.aBitMask );
         }
 
-        if ( parsedFormat == DXGI_FORMAT_UNKNOWN ) {
-            LogError() << "Unsupported format (only BC4_UNORM, BC4_SNORM, and R8_UNORM supported) at index: " << i;
+        // Reject anything the size math can't describe (neither a known BC format nor a known bpp).
+        if ( DDS::BCBlockBytes( parsedFormat ) == 0 && DDS::BitsPerPixel( parsedFormat ) == 0 ) {
+            LogError() << "Unsupported DDS format (fourCC=" << header->ddspf.fourCC << " flags=" << header->ddspf.flags
+                       << " -> DXGI " << static_cast<int>( parsedFormat ) << ") at index: " << i;
             return E_FAIL;
         }
 

--- a/D3D11Engine/DDSFormat.h
+++ b/D3D11Engine/DDSFormat.h
@@ -1,0 +1,208 @@
+#pragma once
+// Shared DDS format helpers used by every hand-rolled DDS parser in the codebase (the D3D12 texture
+// loader and DDSArrayLoader). D3D11's single-texture path uses DirectXTK's CreateDDSTextureFromFile*
+// and does not need this. Centralising the format tables here keeps the parsers in sync and replaces
+// the magic bit-masks / FOURCC integers with named constants.
+#include <dxgiformat.h>
+#include <cstdint>
+
+namespace DDS {
+
+    // constexpr equivalent of the Win SDK MAKEFOURCC macro. Used instead of the macro itself because the
+    // SDK version expands to DWORD/BYTE casts, which aren't in scope in every TU that includes this header
+    // (it deliberately doesn't pull <windows.h>). Keeps the four-char codes below visibly obvious.
+    constexpr uint32_t FourCC( char a, char b, char c, char d ) {
+        return static_cast<uint32_t>( static_cast<uint8_t>( a ) )
+            | (static_cast<uint32_t>( static_cast<uint8_t>( b ) ) << 8)
+            | (static_cast<uint32_t>( static_cast<uint8_t>( c ) ) << 16)
+            | (static_cast<uint32_t>( static_cast<uint8_t>( d ) ) << 24);
+    }
+
+    // NOTE: these are intentionally NOT named DDPF_*/FOURCC_*/D3DFMT_* — those are Win SDK preprocessor
+    // macros (ddraw.h / d3d9types.h, both pulled in by this ddraw-wrapper project). A `constexpr` named after
+    // a macro is rewritten by the preprocessor before the compiler sees it, so we use namespace-scoped
+    // mixed-case names (DDS::FlagRgb, DDS::Dxt1, …) that can't collide.
+
+    constexpr uint32_t Magic = FourCC( 'D', 'D', 'S', ' ' );   // 0x20534444
+
+    // DDS_PIXELFORMAT.dwFlags bits (DDPF_*).
+    constexpr uint32_t FlagAlphaPixels = 0x00000001;
+    constexpr uint32_t FlagAlpha       = 0x00000002;
+    constexpr uint32_t FlagFourCC      = 0x00000004;
+    constexpr uint32_t FlagRgb         = 0x00000040;
+    constexpr uint32_t FlagLuminance   = 0x00020000;
+    constexpr uint32_t FlagBumpDuDv    = 0x00080000;
+
+    // Four-character-code pixel formats (DDS_PIXELFORMAT.dwFourCC).
+    constexpr uint32_t Dxt1 = FourCC( 'D', 'X', 'T', '1' );
+    constexpr uint32_t Dxt2 = FourCC( 'D', 'X', 'T', '2' ); // premultiplied-alpha BC2
+    constexpr uint32_t Dxt3 = FourCC( 'D', 'X', 'T', '3' );
+    constexpr uint32_t Dxt4 = FourCC( 'D', 'X', 'T', '4' ); // premultiplied-alpha BC3
+    constexpr uint32_t Dxt5 = FourCC( 'D', 'X', 'T', '5' );
+    constexpr uint32_t Ati1 = FourCC( 'A', 'T', 'I', '1' ); // BC4 (single channel)
+    constexpr uint32_t Bc4u = FourCC( 'B', 'C', '4', 'U' );
+    constexpr uint32_t Bc4s = FourCC( 'B', 'C', '4', 'S' );
+    constexpr uint32_t Ati2 = FourCC( 'A', 'T', 'I', '2' ); // BC5 (two channel, normal maps)
+    constexpr uint32_t Bc5u = FourCC( 'B', 'C', '5', 'U' );
+    constexpr uint32_t Bc5s = FourCC( 'B', 'C', '5', 'S' );
+    constexpr uint32_t Dx10 = FourCC( 'D', 'X', '1', '0' ); // extended header carries a raw DXGI_FORMAT
+
+    // Legacy D3DFMT enum values stored directly in the FOURCC dword (float / wide surfaces from older tools).
+    constexpr uint32_t LegacyA16B16G16R16  = 36;
+    constexpr uint32_t LegacyQ16W16V16U16  = 110;
+    constexpr uint32_t LegacyR16F          = 111;
+    constexpr uint32_t LegacyG16R16F       = 112;
+    constexpr uint32_t LegacyA16B16G16R16F = 113;
+    constexpr uint32_t LegacyR32F          = 114;
+    constexpr uint32_t LegacyG32R32F       = 115;
+    constexpr uint32_t LegacyA32B32G32R32F = 116;
+
+    // Block-compressed (BC1..BC7) block byte size: 8 for BC1/BC4, 16 for BC2/3/5/6/7. Returns 0 for
+    // uncompressed formats. Covers UNORM / SRGB / SNORM / TYPELESS variants.
+    inline uint32_t BCBlockBytes( DXGI_FORMAT f ) {
+        switch ( f ) {
+        case DXGI_FORMAT_BC1_TYPELESS: case DXGI_FORMAT_BC1_UNORM: case DXGI_FORMAT_BC1_UNORM_SRGB:
+        case DXGI_FORMAT_BC4_TYPELESS: case DXGI_FORMAT_BC4_UNORM: case DXGI_FORMAT_BC4_SNORM:
+            return 8;
+        case DXGI_FORMAT_BC2_TYPELESS: case DXGI_FORMAT_BC2_UNORM: case DXGI_FORMAT_BC2_UNORM_SRGB:
+        case DXGI_FORMAT_BC3_TYPELESS: case DXGI_FORMAT_BC3_UNORM: case DXGI_FORMAT_BC3_UNORM_SRGB:
+        case DXGI_FORMAT_BC5_TYPELESS: case DXGI_FORMAT_BC5_UNORM: case DXGI_FORMAT_BC5_SNORM:
+        case DXGI_FORMAT_BC6H_TYPELESS: case DXGI_FORMAT_BC6H_UF16: case DXGI_FORMAT_BC6H_SF16:
+        case DXGI_FORMAT_BC7_TYPELESS: case DXGI_FORMAT_BC7_UNORM: case DXGI_FORMAT_BC7_UNORM_SRGB:
+            return 16;
+        default: return 0;
+        }
+    }
+    inline bool IsBC( DXGI_FORMAT f ) { return BCBlockBytes( f ) != 0; }
+
+    // Bits-per-pixel for uncompressed formats (0 = unknown / compressed). Covers the common 8/16/32/64/128-bit
+    // formats a DDS can carry; drives the row-pitch / surface-size math for non-BC textures.
+    inline uint32_t BitsPerPixel( DXGI_FORMAT f ) {
+        switch ( f ) {
+        case DXGI_FORMAT_R32G32B32A32_TYPELESS: case DXGI_FORMAT_R32G32B32A32_FLOAT:
+        case DXGI_FORMAT_R32G32B32A32_UINT:     case DXGI_FORMAT_R32G32B32A32_SINT:
+            return 128;
+        case DXGI_FORMAT_R32G32B32_TYPELESS: case DXGI_FORMAT_R32G32B32_FLOAT:
+        case DXGI_FORMAT_R32G32B32_UINT:     case DXGI_FORMAT_R32G32B32_SINT:
+            return 96;
+        case DXGI_FORMAT_R16G16B16A16_TYPELESS: case DXGI_FORMAT_R16G16B16A16_FLOAT:
+        case DXGI_FORMAT_R16G16B16A16_UNORM:    case DXGI_FORMAT_R16G16B16A16_UINT:
+        case DXGI_FORMAT_R16G16B16A16_SNORM:    case DXGI_FORMAT_R16G16B16A16_SINT:
+        case DXGI_FORMAT_R32G32_TYPELESS:       case DXGI_FORMAT_R32G32_FLOAT:
+        case DXGI_FORMAT_R32G32_UINT:           case DXGI_FORMAT_R32G32_SINT:
+            return 64;
+        case DXGI_FORMAT_R10G10B10A2_TYPELESS: case DXGI_FORMAT_R10G10B10A2_UNORM:
+        case DXGI_FORMAT_R10G10B10A2_UINT:     case DXGI_FORMAT_R11G11B10_FLOAT:
+        case DXGI_FORMAT_R8G8B8A8_TYPELESS:    case DXGI_FORMAT_R8G8B8A8_UNORM:
+        case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:  case DXGI_FORMAT_R8G8B8A8_UINT:
+        case DXGI_FORMAT_R8G8B8A8_SNORM:       case DXGI_FORMAT_R8G8B8A8_SINT:
+        case DXGI_FORMAT_B8G8R8A8_TYPELESS:    case DXGI_FORMAT_B8G8R8A8_UNORM:
+        case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:  case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+        case DXGI_FORMAT_B8G8R8X8_UNORM:       case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+        case DXGI_FORMAT_R16G16_TYPELESS:      case DXGI_FORMAT_R16G16_FLOAT:
+        case DXGI_FORMAT_R16G16_UNORM:         case DXGI_FORMAT_R16G16_UINT:
+        case DXGI_FORMAT_R16G16_SNORM:         case DXGI_FORMAT_R16G16_SINT:
+        case DXGI_FORMAT_R32_TYPELESS:         case DXGI_FORMAT_R32_FLOAT:
+        case DXGI_FORMAT_R32_UINT:             case DXGI_FORMAT_R32_SINT:
+        case DXGI_FORMAT_D32_FLOAT:
+            return 32;
+        case DXGI_FORMAT_R8G8_TYPELESS: case DXGI_FORMAT_R8G8_UNORM: case DXGI_FORMAT_R8G8_UINT:
+        case DXGI_FORMAT_R8G8_SNORM:    case DXGI_FORMAT_R8G8_SINT:
+        case DXGI_FORMAT_R16_TYPELESS:  case DXGI_FORMAT_R16_FLOAT:  case DXGI_FORMAT_R16_UNORM:
+        case DXGI_FORMAT_R16_UINT:      case DXGI_FORMAT_R16_SNORM:  case DXGI_FORMAT_R16_SINT:
+        case DXGI_FORMAT_D16_UNORM:
+        case DXGI_FORMAT_B5G6R5_UNORM:  case DXGI_FORMAT_B5G5R5A1_UNORM: case DXGI_FORMAT_B4G4R4A4_UNORM:
+            return 16;
+        case DXGI_FORMAT_R8_TYPELESS: case DXGI_FORMAT_R8_UNORM: case DXGI_FORMAT_R8_UINT:
+        case DXGI_FORMAT_R8_SNORM:    case DXGI_FORMAT_R8_SINT:  case DXGI_FORMAT_A8_UNORM:
+            return 8;
+        default: return 0;
+        }
+    }
+
+    // Maps a FOURCC pixel format to a DXGI format (UNKNOWN if unrecognized). Does NOT handle FOURCC_DX10 —
+    // that carries a raw DXGI_FORMAT in the extended header, which the caller reads directly.
+    inline DXGI_FORMAT FromFourCC( uint32_t fourCC ) {
+        switch ( fourCC ) {
+        case Dxt1: return DXGI_FORMAT_BC1_UNORM;
+        case Dxt2: case Dxt3: return DXGI_FORMAT_BC2_UNORM;
+        case Dxt4: case Dxt5: return DXGI_FORMAT_BC3_UNORM;
+        case Ati1: case Bc4u: return DXGI_FORMAT_BC4_UNORM;
+        case Bc4s: return DXGI_FORMAT_BC4_SNORM;
+        case Ati2: case Bc5u: return DXGI_FORMAT_BC5_UNORM;
+        case Bc5s: return DXGI_FORMAT_BC5_SNORM;
+        case LegacyA16B16G16R16:  return DXGI_FORMAT_R16G16B16A16_UNORM;
+        case LegacyQ16W16V16U16:  return DXGI_FORMAT_R16G16B16A16_SNORM;
+        case LegacyR16F:          return DXGI_FORMAT_R16_FLOAT;
+        case LegacyG16R16F:       return DXGI_FORMAT_R16G16_FLOAT;
+        case LegacyA16B16G16R16F: return DXGI_FORMAT_R16G16B16A16_FLOAT;
+        case LegacyR32F:          return DXGI_FORMAT_R32_FLOAT;
+        case LegacyG32R32F:       return DXGI_FORMAT_R32G32_FLOAT;
+        case LegacyA32B32G32R32F: return DXGI_FORMAT_R32G32B32A32_FLOAT;
+        default: return DXGI_FORMAT_UNKNOWN;
+        }
+    }
+
+    // Maps an uncompressed (non-FOURCC) DDS_PIXELFORMAT to a DXGI format from its channel masks. Returns
+    // DXGI_FORMAT_UNKNOWN for layouts with no direct DXGI equivalent (e.g. 24-bit RGB, which needs expansion).
+    inline DXGI_FORMAT FromPixelFormat( uint32_t flags, uint32_t bits, uint32_t r, uint32_t g, uint32_t b, uint32_t a ) {
+        auto m = [&]( uint32_t rr, uint32_t gg, uint32_t bb, uint32_t aa ) {
+            return r == rr && g == gg && b == bb && a == aa;
+            };
+        if ( flags & (FlagRgb | FlagBumpDuDv) ) {
+            switch ( bits ) {
+            case 32:
+                if ( m( 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000 ) ) return DXGI_FORMAT_R8G8B8A8_UNORM;
+                if ( m( 0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000 ) ) return DXGI_FORMAT_B8G8R8A8_UNORM;
+                if ( m( 0x00ff0000, 0x0000ff00, 0x000000ff, 0x00000000 ) ) return DXGI_FORMAT_B8G8R8X8_UNORM;
+                // 10:10:10:2 — both channel orderings map to R10G10B10A2 (A2R10G10B10 is a common authoring mistake).
+                if ( m( 0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000 ) ) return DXGI_FORMAT_R10G10B10A2_UNORM;
+                if ( m( 0x000003ff, 0x000ffc00, 0x3ff00000, 0xc0000000 ) ) return DXGI_FORMAT_R10G10B10A2_UNORM;
+                if ( m( 0x0000ffff, 0xffff0000, 0x00000000, 0x00000000 ) ) return DXGI_FORMAT_R16G16_UNORM;
+                if ( m( 0xffffffff, 0x00000000, 0x00000000, 0x00000000 ) ) return DXGI_FORMAT_R32_FLOAT;
+                break;
+            case 16:
+                if ( m( 0xf800, 0x07e0, 0x001f, 0x0000 ) ) return DXGI_FORMAT_B5G6R5_UNORM;
+                if ( m( 0x7c00, 0x03e0, 0x001f, 0x8000 ) ) return DXGI_FORMAT_B5G5R5A1_UNORM;
+                if ( m( 0x0f00, 0x00f0, 0x000f, 0xf000 ) ) return DXGI_FORMAT_B4G4R4A4_UNORM;
+                if ( m( 0x00ff, 0xff00, 0x0000, 0x0000 ) ) return DXGI_FORMAT_R8G8_UNORM;
+                if ( m( 0xffff, 0x0000, 0x0000, 0x0000 ) ) return DXGI_FORMAT_R16_UNORM;
+                break;
+            case 8:
+                if ( m( 0xff, 0, 0, 0 ) ) return DXGI_FORMAT_R8_UNORM;
+                break;
+            }
+        }
+        if ( flags & FlagLuminance ) {
+            if ( bits == 8 && m( 0xff, 0, 0, 0 ) ) return DXGI_FORMAT_R8_UNORM;
+            if ( bits == 16 && m( 0xffff, 0, 0, 0 ) ) return DXGI_FORMAT_R16_UNORM;
+            // L8A8 has no direct DXGI equivalent — carry it as R8G8 (a consumer shader swizzles .r/.g as L/A).
+            if ( bits == 16 && r == 0x00ff && a == 0xff00 ) return DXGI_FORMAT_R8G8_UNORM;
+        }
+        if ( (flags & FlagAlpha) && bits == 8 ) return DXGI_FORMAT_A8_UNORM;
+        return DXGI_FORMAT_UNKNOWN;
+    }
+
+    // Row pitch (bytes) of one mip row, block-aware. width should be the mip's width (>=1).
+    inline uint32_t RowPitch( DXGI_FORMAT f, uint32_t width ) {
+        const uint32_t w = width ? width : 1u;
+        if ( const uint32_t block = BCBlockBytes( f ) ) {
+            const uint32_t blocksWide = (w + 3) / 4 > 0 ? (w + 3) / 4 : 1u;
+            return blocksWide * block;
+        }
+        uint32_t bpp = BitsPerPixel( f );
+        if ( bpp == 0 ) bpp = 32;   // unknown: assume 32-bit (callers reject unknown formats upstream)
+        return (w * bpp + 7) / 8;
+    }
+
+    // Total bytes of one mip surface, block-aware. width/height should be the mip's dims (>=1).
+    inline uint32_t SurfaceBytes( DXGI_FORMAT f, uint32_t width, uint32_t height ) {
+        const uint32_t h = height ? height : 1u;
+        if ( BCBlockBytes( f ) ) {
+            const uint32_t blocksHigh = (h + 3) / 4 > 0 ? (h + 3) / 4 : 1u;
+            return RowPitch( f, width ) * blocksHigh;
+        }
+        return RowPitch( f, width ) * h;
+    }
+
+}   // namespace DDS


### PR DESCRIPTION
- A missing letter (`&`) caused the Raindrop textures to never be loaded, as the staging buffer was copied instead of referenced.
- A missing prefix `Normalmaps_` caused legacy style normalmap directories to not be considered.


fixes #434
fixes #435 