### PR TITLE
dx12: proper clustered forward with no depth lookup and a much higher light

### DIFF
--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -254,8 +254,8 @@ private:
     D3D12_CPU_DESCRIPTOR_HANDLE GetDisplayRtv() const;
     // World/DepthPrepass/Vob pipeline creation now lives in m_Pipelines (CreateWorld/CreateDepthPrepass/CreateVob).
     void DrawDepthPrepass();          // lay down opaque world-mesh depth before the lit passes (Forward+ prepass)
-    bool CreateLightCullBuffers( INT2 size ); // per-resolution tile grid + index-list UAV buffers (rebuilt on resize)
-    void DispatchLightCulling();      // dispatch the tiled light cull (writes the per-tile light grid; not yet consumed)
+    bool CreateLightCullBuffers( INT2 size ); // per-resolution clustered light-grid UAV buffer (rebuilt on resize)
+    void DispatchLightCulling();      // dispatch the clustered light cull (writes the per-cluster mask grid)
     // Vob pipeline creation now lives in m_Pipelines.CreateVob (buffers stay: CreateVobInstanceBuffers).
     bool CreateVobInstanceBuffers();  // per-frame dynamic (upload-heap) VOB instance ring buffers
     void UploadFrameVobInstances();   // snapshot visible VOB instances into the ring ONCE (prepass + color share it)
@@ -275,7 +275,7 @@ private:
     void ResolveMaterialMapSlots( class zCTexture* tex, UINT* outNormalOrm ) const;
     bool CreateLightBuffer();         // per-frame point-light structured buffers (Forward+ MVP: brute-force)
     void BuildFrameLightBuffer();     // (re)fill this frame's light buffer from the collected visible lights
-    void BindFrameLights( UINT srvParam = 3, UINT countParam = 4, UINT gridParam = 5, UINT indexParam = 6 );   // light SRV(t1)+count+grid(t2)+index(t3); (3,4,5,6)=world, (4,5,6,7)=skeletal, (5,6,7,8)=grass
+    void BindFrameLights( UINT srvParam = 3, UINT countParam = 4, UINT gridParam = 5 );   // light SRV(t1)+count+cluster-mask(t2); (3,4,5)=world, (4,5,6)=skeletal, (5,6,7)=grass
     void DrawWaterSurfaces() override; // draw water peeled out of the opaque world pass (scrolled UV, blended)
     // Skeletal (animated NPC/monster) pipeline creation now lives in m_Pipelines.CreateSkeletal (root sig + lit +
     // depth-prepass PSOs). The per-frame skeletal CB ring stays here:
@@ -915,20 +915,18 @@ private:
     UINT ResolveDiffuseSlotCacheIn( zCTexture* tex );
 
 
-    // Forward+ tiled light culling (P2.9b-2): one global compute root sig + PSO; two resolution-sized
-    // DEFAULT-heap UAV buffers holding the per-tile {Offset,Count} grid and the per-tile light-index slices
-    // (fixed 32/tile, no global counter). All live permanently in UNORDERED_ACCESS. m_NumTilesX/Y = tile
-    // grid dimensions for the current resolution.
+    // Clustered Forward+ light culling (P2.14; tiled P2.9b-2 predecessor): one global compute root sig + PSO;
+    // one resolution-sized DEFAULT-heap UAV buffer holding the per-cluster 64-bit light-membership mask
+    // (NumTilesX * NumTilesY * kNumZSlices clusters). Lives permanently in UNORDERED_ACCESS. m_NumTilesX/Y =
+    // screen-tile grid dimensions for the current resolution (Z slice count is the compile-time kNumZSlices).
     // Light-cull pipeline (RootSig/PSO/blob) now lives in m_Pipelines.LightCull
-    Microsoft::WRL::ComPtr<ID3D12Resource> m_LightGridBuffer;    // RWStructuredBuffer<LightGrid> (numTiles * 8 B)
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_LightGridBuffer;    // RWStructuredBuffer<LightGrid> (numClusters * 8 B)
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_LightGridBufferAlloc;  // recreated on resize
-    Microsoft::WRL::ComPtr<ID3D12Resource> m_LightIndexBuffer;   // RWStructuredBuffer<uint>  (numTiles * 32 * 4 B)
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_LightIndexBufferAlloc; // recreated on resize
     UINT m_NumTilesX = 0;
     UINT m_NumTilesY = 0;
-    // Grid/index buffers round-trip UNORDERED_ACCESS (cull CS writes) -> PIXEL_SHADER_RESOURCE (lit PS reads)
-    // each frame. Tracks whether they're currently in the PS-read state so DispatchLightCulling knows whether
-    // it must transition them back to UAV before the next dispatch (false right after (re)creation in UAV).
+    // The grid buffer round-trips UNORDERED_ACCESS (cull CS writes) -> PIXEL_SHADER_RESOURCE (lit PS reads)
+    // each frame. Tracks whether it's currently in the PS-read state so DispatchLightCulling knows whether
+    // it must transition it back to UAV before the next dispatch (false right after (re)creation in UAV).
     bool m_LightGridInPixelState = false;
 
     // Bloom pyramid (P2.11, mirrors D3D11PFX_Bloom): resolution-dependent chain of progressively half-sized

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -89,14 +89,20 @@ bool D3D12PipelineState::CreateWorld() {
     rs.AddConstants( 1, 8, D3D12_SHADER_VISIBILITY_ALL );                     // 2: b1 fog — VS: CamPosWS; PS: color/near/far
 
     // 3 = point-light StructuredBuffer as a ROOT SRV at t1 (no descriptor slot consumed — a GPU VA
-    // straight in the root; aligns with the CPU-offload/bindless direction). 4 = b2 { light count,
-    // NumTilesX }. 5/6 = the Forward+ per-tile grid + index-list root SRVs at t2/t3. All four MUST
-    // be bound (BindFrameLights) by every draw using this root sig with a light-reading PSO (World.PSO/
+    // straight in the root; aligns with the CPU-offload/bindless direction). 4 = b2 LightCB. 5 = the
+    // clustered Forward+ per-cluster mask root SRV at t2. Both non-SRV params MUST be bound
+    // (BindFrameLights) by every draw using this root sig with a light-reading PSO (World.PSO/
     // World.VobPSO), else the count/grid are undefined root values and the shader loops away.
+    // Param 6 (t3) used to be the per-tile light-index list; clustered Forward+ (P2.14) replaced it with
+    // a 64-bit mask in LightGrid itself, so t3 is no longer declared by any shader and this slot is now
+    // PERMANENTLY UNBOUND — left in place (rather than renumbering every later param + BindFrameLights
+    // call site) since nothing ever reads register(t3) any more. Same pattern as the WindCB param below.
     rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_PIXEL );        // 3: t1 light StructuredBuffer
-    rs.AddConstants( 2, 5, D3D12_SHADER_VISIBILITY_PIXEL );  // 4: b2 LightCB { LightCount, NumTilesX, LimitLightIntensity, PointShadowLowIndex, PointShadowDynIndex }
-    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL );        // 5: t2 per-tile LightGrid {Offset,Count}
-    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );        // 6: t3 per-tile light-index list
+    // LightCB { LightCount, NumTilesX, LimitLightIntensity, PointShadowLowIndex, PointShadowDynIndex,
+    //           ProjA, ProjB, NearZ, FarZ } — the last 4 feed PBRLighting.hlsl's ComputeZSlice.
+    rs.AddConstants( 2, 9, D3D12_SHADER_VISIBILITY_PIXEL );  // 4: b2 LightCB
+    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL );        // 5: t2 per-cluster LightGrid (64-bit mask)
+    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );        // 6: t3 UNUSED/dead (see above)
 
     // 7 = shadow-sampling CB (b3) as a ROOT CBV (cascade view-projs are too big for root constants).
     // 8 = the CSM shadow-map Texture2DArray SRV (t4) via a one-entry descriptor table off the shared
@@ -640,10 +646,10 @@ bool D3D12PipelineState::CreateGrass() {
     rs.AddConstants( 1, 8, D3D12_SHADER_VISIBILITY_ALL );
     rs.AddConstants( 2, 8, D3D12_SHADER_VISIBILITY_ALL );      // 4: b2 fog — VS: CamPosWS; PS: color/near/far
     rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL );             // 5: t2 light StructuredBuffer (root SRV)
-    // 6: b3 { LightCount, NumTilesX, LimitLightIntensity, pad }
-    rs.AddConstants( 3, 5, D3D12_SHADER_VISIBILITY_PIXEL );   // b3 LightCB (5th = PointShadowDynIndex)
-    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 7: t3 per-tile LightGrid
-    rs.AddSRV( 4, D3D12_SHADER_VISIBILITY_PIXEL );             // 8: t4 per-tile light-index list
+    // 6: b3 LightCB, grown 5->9 for clustered Forward+ (P2.14): +ProjA/ProjB/NearZ/FarZ (ComputeZSlice).
+    rs.AddConstants( 3, 9, D3D12_SHADER_VISIBILITY_PIXEL );   // b3 LightCB
+    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 7: t3 per-cluster LightGrid (64-bit mask)
+    rs.AddSRV( 4, D3D12_SHADER_VISIBILITY_PIXEL );             // 8: t4 UNUSED/dead (formerly the per-tile light-index list — see World.RootSig)
     rs.AddCBV( 4, D3D12_SHADER_VISIBILITY_PIXEL );             // 9: b4 shadow-sampling CB (root CBV)
     rs.AddTable( D3D12RootLayout::SRVRange( 5 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 10: t5 CSM shadow-map array
     // 11: t6 point-shadow cube array (PBRLighting.hlsl requires this symbol)
@@ -1422,9 +1428,11 @@ bool D3D12PipelineState::CreateDecal() {
     rs.AddTable( D3D12RootLayout::SRVRange( 0 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 1: t0 diffuse
     rs.AddConstants( 1, 8, D3D12_SHADER_VISIBILITY_ALL );      // 2: b1 fog — VS: CamPosWS; PS: color/near/far
     rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_PIXEL );             // 3: t1 light StructuredBuffer
-    rs.AddConstants( 2, 5, D3D12_SHADER_VISIBILITY_PIXEL );    // 4: b2 LightCB (5th = PointShadowDynIndex)
-    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL );             // 5: t2 per-tile LightGrid
-    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 6: t3 per-tile light-index list
+    // LightCB grew 5->9 for clustered Forward+ (P2.14): +ProjA/ProjB/NearZ/FarZ (PBRLighting.hlsl's
+    // ComputeZSlice). Param 6 (t3, formerly the per-tile light-index list) is now dead/unbound — see World.RootSig.
+    rs.AddConstants( 2, 9, D3D12_SHADER_VISIBILITY_PIXEL );    // 4: b2 LightCB
+    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL );             // 5: t2 per-cluster LightGrid (64-bit mask)
+    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 6: t3 UNUSED/dead
     rs.AddCBV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 7: b3 shadow CB
     rs.AddTable( D3D12RootLayout::SRVRange( 4 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 8: t4 CSM array
     rs.AddTable( D3D12RootLayout::SRVRange( 5 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 9: t5 point-shadow cubes
@@ -1564,9 +1572,10 @@ bool D3D12PipelineState::CreateSkeletal() {
     // Forward+ point lights (mirrors World.RootSig params 3/4/5/6, here at 4..7 — see BindFrameLights). All
     // MUST be bound at every skeletal draw or the PS light-loop bound/grid is undefined → GPU hang.
     rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_PIXEL );             // 4: t1 light StructuredBuffer (root SRV)
-    rs.AddConstants( 4, 5, D3D12_SHADER_VISIBILITY_PIXEL );    // 5: b4 LightCB (5th = PointShadowDynIndex)
-    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL );             // 6: t2 per-tile LightGrid {Offset,Count}
-    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 7: t3 per-tile light-index list
+    // LightCB grew 5->9 for clustered Forward+ (P2.14): +ProjA/ProjB/NearZ/FarZ (ComputeZSlice).
+    rs.AddConstants( 4, 9, D3D12_SHADER_VISIBILITY_PIXEL );    // 5: b4 LightCB
+    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL );             // 6: t2 per-cluster LightGrid (64-bit mask)
+    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 7: t3 UNUSED/dead (formerly the per-tile light-index list — see World.RootSig)
     // 8: b5 shadow-sampling CB (skeletal's b3/b4 are fog/light count)
     rs.AddCBV( 5, D3D12_SHADER_VISIBILITY_PIXEL );
     // CSM sampling (P2.9c-4b): shadow-map array SRV at t4 (skeletal PS samples it like world/VOB);
@@ -2153,21 +2162,20 @@ bool D3D12PipelineState::CreateWater() {
 }
 
 bool D3D12PipelineState::CreateLightCull() {
-    // Forward+ tiled light-culling compute pipeline (P2.9b-2). One GLOBAL compute root signature + PSO,
-    // created once. b0 = cull constants (8 root 32-bit values); t0 = the point-light StructuredBuffer as a
-    // root SRV (same UPLOAD buffer the world PS reads); u0/u1 = the light grid / index-list DEFAULT-heap UAVs
-    // as root UAVs (RWStructuredBuffers are valid as root UAVs; stride comes from the HLSL declaration). t1 =
-    // the depth buffer SRV, which (being a Texture2D) can't be a root SRV, so it rides a one-entry descriptor
-    // table off the shared SRV heap — used to tighten each tile's far-Z bound (P2.9b-3 flicker fix).
+    // CLUSTERED Forward+ light-culling compute pipeline (P2.14; tiled P2.9b-2 predecessor). One GLOBAL compute
+    // root signature + PSO, created once. b0 = cull constants (8 root 32-bit values); t0 = the point-light
+    // StructuredBuffer as a root SRV (same UPLOAD buffer the world PS reads); u0 = the per-cluster 64-bit mask
+    // DEFAULT-heap UAV as a root UAV (RWStructuredBuffer is valid as a root UAV; stride comes from the HLSL
+    // declaration). Cluster Z bounds are now analytic (log-distributed over CullCB's NearZ/FarZ), not derived
+    // from the depth prepass, so this pass no longer touches the depth buffer at all — no t1 DepthTex table,
+    // no depth-buffer barrier round-trip in DispatchLightCulling, and no ordering dependency on the prepass.
     ID3D12Device* device = m_Device->GetDevice();
 
     D3D12RootLayout& rs = Layout( "LightCull" );
-    // 0: b0 CullCB — ProjScale(2) + ScreenDim(2) + TotalLights + NumTilesX + ProjA + ProjB
+    // 0: b0 CullCB — ProjScale(2) + ScreenDim(2) + TotalLights + NumTilesX + NearZ + FarZ
     rs.AddConstants( 0, 8, D3D12_SHADER_VISIBILITY_ALL );
     rs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL );   // 1: t0 SB_Lights
-    rs.AddUAV( 0, D3D12_SHADER_VISIBILITY_ALL );   // 2: u0 RW_LightGrid
-    rs.AddUAV( 1, D3D12_SHADER_VISIBILITY_ALL );   // 3: u1 RW_LightIndexList
-    rs.AddTable( D3D12RootLayout::SRVRange( 1 ), D3D12_SHADER_VISIBILITY_ALL );   // 4: t1 DepthTex (SRV heap)
+    rs.AddUAV( 0, D3D12_SHADER_VISIBILITY_ALL );   // 2: u0 RW_LightGrid (per-cluster 64-bit mask)
 
     if ( !rs.Build( device ) )   // compute: no IA input layout
         return false;

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -124,29 +124,15 @@ namespace {
     // main pass would see background occluded through the gaps). Reuses m_Pipelines.World.RootSig: only b0 (ViewProj)
     // and t0/s0 are referenced — fog/light params are NOT bound (no light loop here, so no hang risk).
 
-    // Forward+ tiled light-culling COMPUTE shader (P2.9b-2). One thread group per 16x16 screen tile; each
-    // group builds its tile's view-space AABB from the prepass depth and records which point lights touch it
-    // into a per-tile slice of RW_LightIndexList (fixed MAX_LIGHTS_PER_TILE stride — no global atomic counter,
-    // so no counter buffer/clear), with the per-tile {Offset,Count} landing in RW_LightGrid. This is the D3D11
-    // reference Shaders/CS_LightCulling.hlsl (min/max-depth AABB + SphereInsideAABB) with two divergences:
-    //   1. Reversed-Z + world-only prepass. The reference's ScreenToView z-inverse is written for finite
-    //      standard-Z; we feed it the ACTUAL projection z-row terms (viewZ = Proj._43/(depth-Proj._33)), which
-    //      is correct for our reversed-Z infinite-far camera. And because our depth prepass lays down WORLD
-    //      MESH ONLY, an "empty" tile (no world depth — sky, or a VOB/NPC in front of nothing) falls back to an
-    //      all-encompassing AABB (stay conservatively lit) rather than the reference's collapse-to-near-plane,
-    //      which would unlight characters against the sky. The bounded near+far AABB is the whole point: it
-    //      pulls in only lights whose sphere actually reaches the tile's geometry, so a wall at 15m no longer
-    //      overflows the per-tile light cap the way the earlier camera-origin cone (near fixed at 1) did. NOTE prior
-    //      retired versions here: an unbounded [1,100000] AABB (far corners blew up off-axis), then side-planes
-    //      with a fixed [1,100000] slab and then a far-only slab — all still over-included and overflowed.
-    //      Residual: a short-range light on a VOB/NPC that pokes in front of distant world geometry and can't
-    //      reach that world can still be culled; completing the prepass (VOB+skeletal depth) removes it.
-    //   2. Fixed per-tile index slice instead of a compacted global list, dropping RW_IndexCounter and its
-    //      per-frame clear. At 1080p this is ~2 MB (8160 tiles * 64 * 4 B) — negligible, and simpler/safer.
-    //   3. Slots are handed out by a groupshared PREFIX SUM over buffer order, not by an InterlockedAdd race, so
-    //      an over-cap tile always drops the same (farthest) lights instead of a different set every frame. See
-    //      the CSMain comment in LightCull.hlsl — race-order selection was a visible per-tile flicker in rooms
-    //      full of static atmospheric lights.
+    // CLUSTERED Forward+ light-culling COMPUTE shader (P2.14; tiled P2.9b-2 predecessor). One thread group per
+    // (16x16 screen tile x Z slice) cluster; each group builds its cluster's view-space AABB analytically (a
+    // log-distributed Z slice over CullCB's NearZ/FarZ — no depth-buffer read at all, unlike the old per-tile
+    // scheme which bounded each tile's far-Z from the prepass depth) and tests up to MAX_ACTIVE_LIGHTS lights
+    // against it, one per thread. A pass sets that light's bit in a 64-bit groupshared mask (InterlockedOr),
+    // written out as the cluster's LightGrid.Mask — no index list, no global atomic counter, and no per-tile
+    // light cap: the cap is now a single global one (the frame's nearest MAX_ACTIVE_LIGHTS, see
+    // ForwardPlusTypes.hlsl), so it can never differ between clusters or flicker frame-to-frame the way the
+    // old per-tile InterlockedAdd race used to. See LightCull.hlsl's CSMain for the full rationale.
     // PositionView is filled CPU-side in BuildFrameLightBuffer using the same transpose(view) transform the
     // D3D11 CullLights uses, so this shader's view space matches. SM6.6: no ternary (use min()/select()).
 
@@ -200,8 +186,34 @@ namespace {
 
 
     // Forward+ MVP light buffer (P2.9a): the whole visible-light list is rebuilt from offset 0 each frame,
-    // so the ring is just kBackBufferCount snapshots (no per-draw offset). Cap matches D3D11 MAX_TILED_LIGHTS.
-    constexpr UINT kMaxFrameLights = 400;
+    // so the ring is just kBackBufferCount snapshots (no per-draw offset). MUST match MAX_ACTIVE_LIGHTS in
+    // Shaders/D3D12/include/ForwardPlusTypes.hlsl (raising one without the other either wastes cluster-mask
+    // capacity or silently drops lights past the smaller of the two — see that header's comment). Raised from
+    // the original 400 (D3D11 MAX_TILED_LIGHTS parity) to 1024 after in-game testing showed ambient-heavy scenes
+    // (static "atmospheric" fill lights stacking with dynamic torches/spells) regularly exceeding 400 visible
+    // point lights and clipping.
+    constexpr UINT kMaxFrameLights = 1024;
+
+    // Clustered Forward+ (P2.14). MUST match NUM_Z_SLICES in Shaders/D3D12/include/ForwardPlusTypes.hlsl.
+    constexpr UINT kNumZSlices = 16;
+    // MUST match MASK_WORDS in Shaders/D3D12/include/ForwardPlusTypes.hlsl (MAX_ACTIVE_LIGHTS / 32) — sizes the
+    // per-cluster LightGrid.Mask array on the C++ side of CreateLightCullBuffers.
+    constexpr UINT kMaskWordsPerCluster = kMaxFrameLights / 32;
+    // Gothic's reversed-Z camera projection has no real far plane (infinite far), so the cluster Z grid needs a
+    // chosen practical far distance to log-distribute its slices over. This is a FLOOR, not the actual value
+    // used — GetClusterFarZ() below clamps it up to the user's VisualFXDrawRadius setting, which is the CPU-side
+    // distance point lights are even collected out to (up to 50000 in the ImGui slider). A fixed 4096 here used
+    // to hard-clip any light farther than that from the camera: BOTH the cull compute's cluster AABBs (Z capped
+    // at FarZ) and the lit pixel shaders' ComputeZSlice clamp to [NearZ,FarZ], so a light beyond FarZ could never
+    // intersect any cluster no matter how far the user's draw-distance setting said to collect it from — it just
+    // silently stopped lighting anything, which read as point lights vanishing at a short, seemingly arbitrary
+    // range regardless of VisualFXDrawRadius. Tying FarZ to that setting (with this constant only as a floor for
+    // very small settings) fixes that without costing extra memory: buffer size depends on tile/slice/mask
+    // counts, not on FarZ, which only changes how far apart the log-distributed Z slices land.
+    constexpr float kClusterMinFarZ = 4096.0f;
+    float GetClusterFarZ() {
+        return std::max( kClusterMinFarZ, Engine::GAPI->GetRendererState().RendererSettings.VisualFXDrawRadius );
+    }
 
 
     constexpr UINT kSkeletalConstantBufferBytes = 8 * 1024 * 1024; // per-frame skeletal CB ring (instance + bone palettes)
@@ -756,22 +768,23 @@ UINT D3D12GraphicsEngine::ResolveDiffuseSlotCacheIn( zCTexture* tex ) {
 
 
 bool D3D12GraphicsEngine::CreateLightCullBuffers( INT2 size ) {
-	// Per-resolution Forward+ tile grid storage (P2.9b-2). Recreated on resize alongside the depth buffer.
-	// RW_LightGrid: one {Offset,Count} (8 B) per 16x16 tile. RW_LightIndexList: a fixed MAX_LIGHTS_PER_TILE
-	// (=64) uint slice per tile (no compaction/global counter — see the shader header). Both are DEFAULT-heap
-	// UAV buffers created in UNORDERED_ACCESS; each frame DispatchLightCulling writes them (UAV) then transitions
-	// them to PIXEL_SHADER_RESOURCE for the lit geometry passes to read, then back. ~2 MB total at 1080p.
+	// Per-resolution CLUSTERED Forward+ grid storage (P2.14; tiled P2.9b-2 predecessor). Recreated on resize
+	// alongside the depth buffer. RW_LightGrid: one MAX_ACTIVE_LIGHTS-bit membership mask (kMaskWordsPerCluster
+	// * 4 B) per (16x16 screen tile x Z slice) cluster — see LightCull.hlsl/PBRLighting.hlsl. There is no
+	// separate index-list buffer: the mask itself IS the light list (bit i = light i). DEFAULT-heap UAV buffer
+	// created in UNORDERED_ACCESS; each frame DispatchLightCulling writes it (UAV) then transitions it to
+	// PIXEL_SHADER_RESOURCE for the lit geometry passes to read, then back.
 	if ( size.x <= 0 || size.y <= 0 ) return false;
 	ID3D12Device* device = m_Device.GetDevice();
 
 	constexpr UINT kTileSize = 16;
-	// MUST match MAX_LIGHTS_PER_TILE in Shaders/D3D12/LightCull.hlsl and include/ForwardPlusTypes.hlsl — this is
-	// the stride the cull writes with and every lit shader reads with. 64 matches D3D11's ConstantBufferStructs.h.
-	constexpr UINT kMaxLightsPerTile = 64;
 	m_NumTilesX = (static_cast<UINT>(size.x) + kTileSize - 1) / kTileSize;
 	m_NumTilesY = (static_cast<UINT>(size.y) + kTileSize - 1) / kTileSize;
 	const UINT numTiles = m_NumTilesX * m_NumTilesY;
 	if ( numTiles == 0 ) return false;
+	// MUST match NUM_Z_SLICES in Shaders/D3D12/include/ForwardPlusTypes.hlsl — both sides derive the same
+	// cluster index (tileIndex * kNumZSlices + slice) from it, so a mismatch silently misindexes every cluster.
+	const UINT numClusters = numTiles * kNumZSlices;
 
 	D3D12MA::ALLOCATION_DESC heapDefault = {};
 	heapDefault.HeapType = D3D12_HEAP_TYPE_DEFAULT;
@@ -797,9 +810,7 @@ bool D3D12GraphicsEngine::CreateLightCullBuffers( INT2 size ) {
 		return true;
 		};
 
-	if ( !makeUavBuffer( static_cast<UINT64>(numTiles) * 2u * sizeof( uint32_t ), L"LightGrid", m_LightGridBuffer, m_LightGridBufferAlloc ) )
-		return false;
-	if ( !makeUavBuffer( static_cast<UINT64>(numTiles) * kMaxLightsPerTile * sizeof( uint32_t ), L"LightIndexList", m_LightIndexBuffer, m_LightIndexBufferAlloc ) )
+	if ( !makeUavBuffer( static_cast<UINT64>(numClusters) * kMaskWordsPerCluster * sizeof( uint32_t ), L"LightGrid", m_LightGridBuffer, m_LightGridBufferAlloc ) )
 		return false;
 	m_LightGridInPixelState = false;   // freshly created in UNORDERED_ACCESS (see DispatchLightCulling round-trip)
 	return true;
@@ -1071,7 +1082,7 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 		s_cands.push_back( { vob, pw, range, distSq, isStatic, li->IsIndoorVob,
 			pw, range, reinterpret_cast<uint64_t>( vob ) } );
 	}
-	// Total order, not just "by distance": the tile cull keeps the first MAX_LIGHTS_PER_TILE candidates in BUFFER
+	// Total order, not just "by distance": the cluster cull keeps the first MAX_ACTIVE_LIGHTS candidates in BUFFER
 	// order, so the buffer order has to be a pure function of the visible light SET. std::sort is unstable, so
 	// equal distances (co-located atmospheric lights are common) would otherwise permute between frames and make
 	// the cap flicker again. The vob pointer breaks ties and is fixed for a light's lifetime.
@@ -1142,15 +1153,17 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 }
 
 
-void D3D12GraphicsEngine::BindFrameLights( UINT srvParam, UINT countParam, UINT gridParam, UINT indexParam ) {
-	// Bind the Forward+ tiled point-light root params: srvParam = the light StructuredBuffer as a root SRV
-	// (t1), countParam = LightCB { LightCount, NumTilesX, LimitLightIntensity }, gridParam/indexParam = the
-	// per-tile grid (t2) and light-index list (t3) root SRVs produced by DispatchLightCulling. EVERY draw
-	// whose bound PSO reads the tiled light loop MUST call this after setting its root signature, or the loop
-	// bound (Count) and grid are UNDEFINED root values and can run billions of iterations → GPU timeout/
-	// removal. Root args are cleared on every SetGraphicsRootSignature. The param indices differ per root
-	// sig: m_Pipelines.World.RootSig uses (3,4,5,6) — the default — for the world mesh / instanced VOBs /
-	// node attachments; m_Pipelines.Skeletal.RootSig uses (4,5,6,7); m_Pipelines.Grass.RootSig uses (5,6,7,8).
+void D3D12GraphicsEngine::BindFrameLights( UINT srvParam, UINT countParam, UINT gridParam ) {
+	// Bind the CLUSTERED Forward+ point-light root params: srvParam = the light StructuredBuffer as a root SRV
+	// (t1), countParam = LightCB { LightCount, NumTilesX, LimitLightIntensity, PointShadowLowIndex,
+	// PointShadowDynIndex, ProjA, ProjB, NearZ, FarZ }, gridParam = the per-cluster 64-bit mask root SRV (t2)
+	// produced by DispatchLightCulling. EVERY draw whose bound PSO reads the tiled light loop MUST call this
+	// after setting its root signature, or the loop bound (Count) and grid are UNDEFINED root values and can
+	// run billions of iterations → GPU timeout/removal. Root args are cleared on every SetGraphicsRootSignature.
+	// The param indices differ per root sig: m_Pipelines.World.RootSig uses (3,4,5) — the default — for the
+	// world mesh / instanced VOBs / node attachments; m_Pipelines.Skeletal.RootSig uses (4,5,6);
+	// m_Pipelines.Grass.RootSig uses (5,6,7). (Param 6/7/8, formerly the light-index-list SRV, is now dead —
+	// see the root-sig comments in D3D12PipelineState.cpp.)
 	m_CmdList->SetGraphicsRootShaderResourceView( srvParam, m_LightBuffer[m_FrameIndex]->GetGPUVirtualAddress() );
 	m_CmdList->SetGraphicsRoot32BitConstant( countParam, m_FrameLightCount, 0 );   // LightCount @ b*.x
 	m_CmdList->SetGraphicsRoot32BitConstant( countParam, m_NumTilesX, 1 );         // NumTilesX  @ b*.y
@@ -1168,8 +1181,13 @@ void D3D12GraphicsEngine::BindFrameLights( UINT srvParam, UINT countParam, UINT 
 	// by a light whose ShadowCubeIndex carries kShadowHasDynamic, so the 0 fallback is never dereferenced.
 	const UINT dynCubeSrv = m_PointShadows.GetDynSrvSlot();
 	m_CmdList->SetGraphicsRoot32BitConstant( countParam, dynCubeSrv == UINT_MAX ? 0u : dynCubeSrv, 4 );
+	// ProjA/ProjB/NearZ/FarZ (P2.14): let every lit pixel shader reconstruct ITS OWN cluster Z slice from its
+	// own SV_Position.z (PBRLighting.hlsl's ComputeZSlice) — must match DispatchLightCulling's CullCB exactly,
+	// or a pixel picks a different cluster than the one the compute pass culled lights into.
+	const XMFLOAT4X4& projM = Engine::GAPI->GetProjectionMatrix();
+	const float clusterConsts[4] = { projM._33, projM._43, Engine::GAPI->GetNearPlane(), GetClusterFarZ() };
+	m_CmdList->SetGraphicsRoot32BitConstants( countParam, 4, clusterConsts, 5 );
 	m_CmdList->SetGraphicsRootShaderResourceView( gridParam, m_LightGridBuffer->GetGPUVirtualAddress() );
-	m_CmdList->SetGraphicsRootShaderResourceView( indexParam, m_LightIndexBuffer->GetGPUVirtualAddress() );
 }
 
 
@@ -1542,7 +1560,7 @@ void D3D12GraphicsEngine::DrawDecalList( const std::vector<zCVob*>& decals, bool
 	// and VOB passes bind, at the same root-parameter indices (the Decal layout mirrors World's order).
 	const FogConstants decalFog = MakeFogConstants();
 	m_CmdList->SetGraphicsRoot32BitConstants( 2, 8, &decalFog, 0 );                                  // b1 fog
-	BindFrameLights();                                                                               // 3..6
+	BindFrameLights();                                                                               // 3..5
 	m_CmdList->SetGraphicsRootConstantBufferView( 7, m_ShadowCBGpu[frame] );                         // b3 shadow CB
 	m_CmdList->SetGraphicsRootDescriptorTable( 8, GetSrvGpuHandle( m_ShadowMap.GetSrvSlot() ) );     // t4 CSM
 	m_CmdList->SetGraphicsRootDescriptorTable( 9, GetSrvGpuHandle( m_PointShadows.GetSrvSlot() ) );  // t5 cubes
@@ -1971,7 +1989,7 @@ void D3D12GraphicsEngine::DrawVegetation() {
 			m_CmdList->SetGraphicsRoot32BitConstants( 0, 16, &viewProj, 0 );
 			m_CmdList->SetGraphicsRoot32BitConstants( 3, 8, &gcb, 0 );
 			m_CmdList->SetGraphicsRoot32BitConstants( 4, 8, &fog, 0 );
-			BindFrameLights( 5, 6, 7, 8 );
+			BindFrameLights( 5, 6, 7 );
 			m_CmdList->SetGraphicsRootConstantBufferView( 9, m_ShadowCBGpu[m_FrameIndex] );
 			m_CmdList->SetGraphicsRootDescriptorTable( 10, GetSrvGpuHandle( m_ShadowMap.GetSrvSlot() ) );
 			m_CmdList->SetGraphicsRootDescriptorTable( 11, GetSrvGpuHandle( m_PointShadows.GetSrvSlot() ) );
@@ -3192,14 +3210,13 @@ void D3D12GraphicsEngine::DrawDepthPrepass() {
 
 
 void D3D12GraphicsEngine::DispatchLightCulling() {
-    // Forward+ tiled light cull (P2.9b-2). Runs after the depth prepass, before the lit passes: one 16x16
-    // thread group per screen tile writes {Offset,Count} into m_LightGridBuffer and the touching light
-    // indices into m_LightIndexBuffer. This increment only PRODUCES the grid — nothing consumes it yet, so
-    // the frame is visually unchanged; verify by inspecting the two buffers in RenderDoc (per-tile Count
-    // should be non-zero where torches/spells are on screen, zero for empty sky). The lit pixel shaders read
-    // this grid instead of looping all lights. The cull reads the prepass depth (transitioned to a compute SRV
-    // and back below) to clamp each tile's FAR-Z to real geometry — see the shader header for why far-only.
-    if ( !m_FrameOpen || !m_Pipelines.LightCull.PSO || !m_Pipelines.LightCull.RootSig || !m_LightGridBuffer || !m_LightIndexBuffer )
+    // CLUSTERED Forward+ light cull (P2.14; tiled P2.9b-2 predecessor). One thread group per (16x16 screen
+    // tile x Z slice) cluster writes a 64-bit light-membership mask into m_LightGridBuffer — see
+    // Shaders/D3D12/LightCull.hlsl. Cluster Z bounds are analytic (log-distributed over CullCB's NearZ/FarZ),
+    // so unlike the old per-tile scheme this pass never touches the depth buffer: no prepass ordering
+    // dependency, no depth-SRV round-trip. Verify in RenderDoc: m_LightGridBuffer's Mask should be non-zero for
+    // clusters torches/spells occupy, zero elsewhere.
+    if ( !m_FrameOpen || !m_Pipelines.LightCull.PSO || !m_Pipelines.LightCull.RootSig || !m_LightGridBuffer )
         return;
     if ( !m_LightBuffer[m_FrameIndex] || m_NumTilesX == 0 || m_NumTilesY == 0 )
         return;
@@ -3207,25 +3224,19 @@ void D3D12GraphicsEngine::DispatchLightCulling() {
     DX_ZONE( m_CmdList, "Light Culling (compute)" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Light Culling (compute)" );
 
-    // The lit geometry passes left the grid/index buffers in PIXEL_SHADER_RESOURCE last frame; transition them
-    // back to UNORDERED_ACCESS so the cull CS can write them as root UAVs. Skipped on the first dispatch after
-    // (re)creation, when they're already in UAV (see CreateLightCullBuffers / m_LightGridInPixelState).
-    D3D12_RESOURCE_BARRIER batchPre[3] = {};
-    UINT preCount = 0;
-
+    // The lit geometry passes left the grid buffer in PIXEL_SHADER_RESOURCE last frame; transition it back to
+    // UNORDERED_ACCESS so the cull CS can write it as a root UAV. Skipped on the first dispatch after
+    // (re)creation, when it's already in UAV (see CreateLightCullBuffers / m_LightGridInPixelState).
     if ( m_LightGridInPixelState ) {
-        batchPre[preCount++] = TransitionBarrier( m_LightGridBuffer.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-        batchPre[preCount++] = TransitionBarrier( m_LightIndexBuffer.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+        D3D12_RESOURCE_BARRIER pre = TransitionBarrier( m_LightGridBuffer.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+        m_CmdList->ResourceBarrier( 1, &pre );
         m_LightGridInPixelState = false;
     }
 
-    batchPre[preCount++] = TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-    m_CmdList->ResourceBarrier( preCount, batchPre );
-
     // ProjScale = the projection's x/y view->clip scale (diagonal terms; layout-invariant so no transpose
-    // worry). ProjA/ProjB = the z-row terms (_33, _43) the CS inverts to turn a reversed-Z depth sample into
-    // a view-space Z (viewZ = ProjB / (depth - ProjA)); same scalars read straight off the CPU matrix, so no
-    // transpose concern either. Same projection the geometry passes use.
+    // worry) — used to derive each cluster's view-space XY bounds at its analytic near/far Z. NearZ/FarZ log-
+    // distribute the Z slices (see LightCull.hlsl); MUST match what BindFrameLights uploads into LightCB's
+    // NearZ/FarZ for the lit pixel shaders, or a pixel picks a different cluster than the one culled for it.
     const XMFLOAT4X4& projM = Engine::GAPI->GetProjectionMatrix();
 
     struct LightCullConstants {
@@ -3233,7 +3244,7 @@ void D3D12GraphicsEngine::DispatchLightCulling() {
         uint32_t ScreenX, ScreenY;
         uint32_t TotalLights;
         uint32_t NumTilesX;
-        float    ProjA, ProjB;   // projM._33, projM._43 (reversed-Z depth -> viewZ reconstruction)
+        float    NearZ, FarZ;
     } cb{};
     cb.ProjScaleX = projM._11;
     cb.ProjScaleY = projM._22;
@@ -3241,34 +3252,18 @@ void D3D12GraphicsEngine::DispatchLightCulling() {
     cb.ScreenY = static_cast<uint32_t>( m_Resolution.y );
     cb.TotalLights = m_FrameLightCount;
     cb.NumTilesX = m_NumTilesX;
-    cb.ProjA = projM._33;
-    cb.ProjB = projM._43;
-
-    // The depth prepass left the depth buffer in DEPTH_WRITE; make it readable by this compute pass, then hand
-    // it back to DEPTH_WRITE below so the lit passes (GREATER_EQUAL depth-write) see it exactly as before.
-    D3D12_RESOURCE_BARRIER depthToSrv = {};
-    depthToSrv.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-    depthToSrv.Transition.pResource = m_DepthBuffer.Get();
-    depthToSrv.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-    depthToSrv.Transition.StateBefore = D3D12_RESOURCE_STATE_DEPTH_WRITE;
-    depthToSrv.Transition.StateAfter  = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+    cb.NearZ = Engine::GAPI->GetNearPlane();
+    cb.FarZ = GetClusterFarZ();
 
     m_CmdList->SetPipelineState( m_Pipelines.LightCull.PSO.Get() );
     m_CmdList->SetComputeRootSignature( m_Pipelines.LightCull.RootSig.Get() );
     m_CmdList->SetComputeRoot32BitConstants( 0, 8, &cb, 0 );
     m_CmdList->SetComputeRootShaderResourceView( 1, m_LightBuffer[m_FrameIndex]->GetGPUVirtualAddress() );
     m_CmdList->SetComputeRootUnorderedAccessView( 2, m_LightGridBuffer->GetGPUVirtualAddress() );
-    m_CmdList->SetComputeRootUnorderedAccessView( 3, m_LightIndexBuffer->GetGPUVirtualAddress() );
-    m_CmdList->SetComputeRootDescriptorTable( 4, GetSrvGpuHandle( m_DepthSrvSlot ) );   // t1 DepthTex (SRV heap already bound)
-    m_CmdList->Dispatch( m_NumTilesX, m_NumTilesY, 1 );
+    m_CmdList->Dispatch( m_NumTilesX, m_NumTilesY, kNumZSlices );
 
-    D3D12_RESOURCE_BARRIER batchPost[3] = {
-        TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE ),
-        TransitionBarrier( m_LightGridBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE ),
-        TransitionBarrier( m_LightIndexBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE )
-    };
-
-    m_CmdList->ResourceBarrier( 3, batchPost );
+    D3D12_RESOURCE_BARRIER post = TransitionBarrier( m_LightGridBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
+    m_CmdList->ResourceBarrier( 1, &post );
     m_LightGridInPixelState = true;
 }
 
@@ -4191,7 +4186,7 @@ void D3D12GraphicsEngine::DrawSkeletalColor() {
         m_CmdList->SetGraphicsRootSignature( m_Pipelines.Skeletal.RootSig.Get() );
         m_CmdList->SetGraphicsRoot32BitConstants( 0, 16, &viewProj, 0 );
         m_CmdList->SetGraphicsRoot32BitConstants( 3, 8, &fog, 0 );   // b3 fog
-        BindFrameLights( 4, 5, 6, 7 );   // light SRV(t1)+count(b4)+grid(t2)+index(t3) — MUST set all (see BindFrameLights)
+        BindFrameLights( 4, 5, 6 );   // light SRV(t1)+count(b4)+cluster-mask(t2) — MUST set all (see BindFrameLights)
         m_CmdList->SetGraphicsRootConstantBufferView( 8, m_ShadowCBGpu[m_FrameIndex] );        // b5 shadow CB
         m_CmdList->SetGraphicsRootDescriptorTable( 9, GetSrvGpuHandle( m_ShadowMap.GetSrvSlot() ) );    // t4 shadow map
         m_CmdList->SetGraphicsRootDescriptorTable( 10, GetSrvGpuHandle( m_PointShadows.GetSrvSlot() ) ); // t5 point-shadow cubes

--- a/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
@@ -381,7 +381,7 @@ void D3D12GraphicsEngine::DrawVobAlphaMeshes() {
     // parameter DrawVobsInstanced binds. Fog is bound for the VS's CamPosWS even though the PS drops the term.
     const FogConstants fog = MakeSceneFogConstants();
     m_CmdList->SetGraphicsRoot32BitConstants( 2, 8, &fog, 0 );                                       // b1 fog
-    BindFrameLights();                                                                               // 3..6
+    BindFrameLights();                                                                               // 3..5
     m_CmdList->SetGraphicsRootConstantBufferView( 7, m_ShadowCBGpu[m_FrameIndex] );                  // b3 shadow CB
     m_CmdList->SetGraphicsRootDescriptorTable( 8, GetSrvGpuHandle( m_ShadowMap.GetSrvSlot() ) );     // t4 CSM
     m_CmdList->SetGraphicsRootDescriptorTable( 9, GetSrvGpuHandle( m_PointShadows.GetSrvSlot() ) );  // t5 cubes

--- a/D3D11Engine/Shaders/D3D12/Decal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Decal.hlsl
@@ -16,14 +16,17 @@
 // with CULL_NONE.
 cbuffer FrameCB : register(b0) { float4x4 ViewProj; };   // default column-major packing (see world shader)
 cbuffer FogCB   : register(b1) { float3 FogColor; float FogNear; float3 CamPosWS; float FogFar; };
-cbuffer LightCB : register(b2) { uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex; };
+// ProjA/ProjB/NearZ/FarZ feed PBRLighting.hlsl's ComputeZSlice (clustered Forward+, P2.14) — see World.hlsl.
+cbuffer LightCB : register(b2) {
+    uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex;
+    float ProjA; float ProjB; float NearZ; float FarZ;
+};
 
 #include "include/ForwardPlusTypes.hlsl"
 
-// Forward+ tiled point lights (root-descriptor SRVs + per-tile grid) — same t1/t2/t3 the world pass binds.
+// Forward+ tiled point lights (root-descriptor SRVs + per-cluster mask) — same t1/t2 the world pass binds.
 StructuredBuffer<GPULight>  Lights        : register(t1);
 StructuredBuffer<LightGrid> LightGridBuf  : register(t2);
-StructuredBuffer<uint>      LightIndexBuf : register(t3);
 
 Texture2D    tx  : register(t0);
 SamplerState smp : register(s0);   // linear CLAMP: a decal is a single [0,1] sprite; wrap would bleed the edge
@@ -95,9 +98,9 @@ VS_OUT VSMain( VS_IN i )
     return o;
 }
 
-// Shared by both entry points: the Forward+ evaluation at the decal's surface. `svpos` is SV_Position.xy,
-// which AccumTiledPointLights needs to find the light tile.
-float3 ShadeDecal( float3 albedo, float3 wpos, float3 nrm, float2 svpos )
+// Shared by both entry points: the Forward+ evaluation at the decal's surface. `svpos` is SV_Position.xyz,
+// which AccumTiledPointLights needs to find the light cluster (xy = screen tile, z = hardware depth -> Z slice).
+float3 ShadeDecal( float3 albedo, float3 wpos, float3 nrm, float3 svpos )
 {
     float3 N = normalize( nrm );
     // Double-sided: shade the face actually turned toward the camera, else a wall decal seen from its "back"
@@ -118,7 +121,7 @@ float4 PSMainLit( VS_OUT i ) : SV_TARGET   // opaque / alpha-test cutout, fully 
 {
     float4 t = tx.Sample( smp, i.uv );
     clip( t.a - 0.5 );
-    float3 rgb = ShadeDecal( SrgbToLinear( t.rgb ), i.wpos, i.wnrm, i.clip.xy );
+    float3 rgb = ShadeDecal( SrgbToLinear( t.rgb ), i.wpos, i.wnrm, i.clip.xyz );
     // Distance fog, like every other opaque surface (D3D11 draws this pass with PS_World_NoMV, which fogs).
     float f = saturate( ( i.fogDist - FogNear ) / max( 1.0, FogFar - FogNear ) );
     return float4( lerp( rgb, SrgbToLinear( FogColor ), f ), 1.0 );
@@ -130,5 +133,5 @@ float4 PSMainBlend( VS_OUT i ) : SV_TARGET // transparent — the PSO blend stat
     // Deliberately NOT fogged: this one PS is shared by the ADD/MUL/MUL2 blend modes, where lerping toward the
     // fog colour would brighten (ADD) or darken (MUL) the surface instead of fading it into the distance.
     // D3D11's PS_Transparency doesn't fog these either.
-    return float4( ShadeDecal( SrgbToLinear( t.rgb ), i.wpos, i.wnrm, i.clip.xy ), t.a * i.alpha );
+    return float4( ShadeDecal( SrgbToLinear( t.rgb ), i.wpos, i.wnrm, i.clip.xyz ), t.a * i.alpha );
 }

--- a/D3D11Engine/Shaders/D3D12/LightCull.hlsl
+++ b/D3D11Engine/Shaders/D3D12/LightCull.hlsl
@@ -1,5 +1,7 @@
-#define TILE_SIZE 16
-#define MAX_LIGHTS_PER_TILE 64
+#define TILE_SIZE 16u
+#define MAX_ACTIVE_LIGHTS 1024u
+#define MASK_WORDS (MAX_ACTIVE_LIGHTS / 32u)
+#define NUM_Z_SLICES 16u
 
 // MUST stay layout-identical to GPULight (C++ D3D12EngineCommon.h / HLSL include/ForwardPlusTypes.hlsl) — this
 // is a StructuredBuffer, so a stride mismatch silently misindexes EVERY light. The cull only reads
@@ -10,36 +12,38 @@ struct TiledPointLight {
     float3 PositionWorld; int ShadowCubeIndex;
     float3 ShadowOrigin;  float ShadowRange;
 };
-struct LightGrid { uint Offset; uint Count; };
+// Clustered Forward+ (P2.14): a MAX_ACTIVE_LIGHTS-bit membership mask, one bit per light in
+// SB_Lights[0..MAX_ACTIVE_LIGHTS). MASK_WORDS * 4 bytes, same layout as ForwardPlusTypes.hlsl's copy.
+struct LightGrid { uint Mask[MASK_WORDS]; };
 
-StructuredBuffer<TiledPointLight> SB_Lights       : register(t0);
-RWStructuredBuffer<LightGrid>     RW_LightGrid     : register(u0);
-RWStructuredBuffer<uint>          RW_LightIndexList : register(u1);
-Texture2D<float>                  DepthTex          : register(t1);   // prepass depth (reversed-Z); per-tile far-Z
+StructuredBuffer<TiledPointLight> SB_Lights   : register(t0);
+RWStructuredBuffer<LightGrid>     RW_LightGrid : register(u0);
 
 cbuffer CullCB : register(b0) {
     float2 ProjScale;    // (Proj._11, Proj._22): view->clip x/y scale (diagonal terms, layout-invariant)
     uint2  ScreenDim;    // render-target pixel size
-    uint   TotalLights;  // valid light count in SB_Lights (<= light buffer capacity)
+    uint   TotalLights;  // valid light count in SB_Lights (may exceed MAX_ACTIVE_LIGHTS; only the first
+                          // MAX_ACTIVE_LIGHTS are ever tested — see the numthreads note below)
     uint   NumTilesX;    // ceil(ScreenDim.x / TILE_SIZE)
-    float2 ProjZ;        // (Proj._33, Proj._43): reversed-Z depth->viewZ  (viewZ = ProjZ.y / (depth - ProjZ.x))
+    float  NearZ;        // camera near plane (Engine::GAPI->GetNearPlane()) — inner bound of the cluster Z range
+    float  FarZ;         // fixed practical cluster far distance (kClusterFarZ in D3D12Scene.cpp) — Gothic's
+                          // reversed-Z projection has no real far plane, so clustering needs a chosen one;
+                          // anything beyond it collapses into the last (coarsest) Z slice.
 };
 
-groupshared uint gs_Count;
-groupshared uint gs_Indices[MAX_LIGHTS_PER_TILE];
-groupshared uint gs_Scan[TILE_SIZE * TILE_SIZE];   // per-chunk prefix sum of the pass flags (see CSMain)
-groupshared uint gs_MinDepthInt;   // nearest/farthest opaque depth in the tile, as sortable float bits
-groupshared uint gs_MaxDepthInt;
+groupshared uint   gs_Mask[MASK_WORDS];
+groupshared float3 gs_AabbMin;
+groupshared float3 gs_AabbMax;
 
-// View-space position of a screen pixel at a given reversed-Z depth. The four packed projection scalars
-// (ProjScale = _11/_22, ProjZ = _33/_43) are exactly the terms D3D11's ScreenToView uses; the z inverse is
-// valid for our reversed-Z infinite-far camera because they are the actual matrix entries. ndc.y flipped.
-float3 ScreenToView( float2 pixel, float depth ) {
+// View-space XY at a given pixel and a KNOWN view-space Z (unlike the old per-tile cull, this Z comes from the
+// analytic cluster slice bounds below, not from sampling the depth buffer — that's what makes this CLUSTERED
+// rather than "tiled with scene-derived depth bounds": every cluster's shape is fixed by the camera projection
+// alone, so the cull no longer depends on the depth prepass having run first.
+float2 ViewXYAtZ( float2 pixel, float zView ) {
     float2 ndc;
     ndc.x = pixel.x / (float)ScreenDim.x * 2.0 - 1.0;
     ndc.y = -(pixel.y / (float)ScreenDim.y * 2.0 - 1.0);
-    float zView = ProjZ.y / ( depth - ProjZ.x );
-    return float3( ndc.x / ProjScale.x * zView, ndc.y / ProjScale.y * zView, zView );
+    return float2( ndc.x / ProjScale.x * zView, ndc.y / ProjScale.y * zView );
 }
 
 // Closest-point sphere/AABB overlap (view space). Keeps a light iff its sphere touches the box.
@@ -49,108 +53,46 @@ bool SphereInsideAABB( float3 center, float radius, float3 aabbMin, float3 aabbM
     return dot( delta, delta ) <= radius * radius;
 }
 
-[numthreads( TILE_SIZE, TILE_SIZE, 1 )]
-void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID ) {
-    uint ti = threadID.y * TILE_SIZE + threadID.x;
-    if ( ti == 0 ) { gs_Count = 0; gs_MinDepthInt = 0x7F7FFFFF; gs_MaxDepthInt = 0; }
-    GroupMemoryBarrierWithGroupSync();
+// One thread group per (tileX, tileY, zSlice) cluster; one thread per candidate light (thread ti tests light
+// ti — see MAX_ACTIVE_LIGHTS). Dispatch is (NumTilesX, NumTilesY, NUM_Z_SLICES); groupID.z is the Z slice.
+[numthreads( MAX_ACTIVE_LIGHTS, 1, 1 )]
+void CSMain( uint3 groupID : SV_GroupID, uint ti : SV_GroupIndex ) {
+    // Only the first MASK_WORDS threads need to clear the mask (one word each) — cheap even though the group
+    // has many more threads than that.
+    if ( ti < MASK_WORDS ) gs_Mask[ti] = 0;
 
-    // Per-tile depth bounds from the prepass. Each of the 256 threads owns exactly one tile pixel and folds
-    // its reversed-Z depth into the group min/max (asuint keeps float ordering for depth in [0,1]). Sky /
-    // cleared pixels read 0 and are skipped. This is the D3D11 CS_LightCulling min/max; the AABB it builds is
-    // bounded on BOTH the near and far side by real geometry, so the tile only pulls in lights whose sphere
-    // actually reaches the surfaces in it — the earlier camera-origin cone (near fixed at 1) instead counted
-    // every light between the camera and the geometry, so a wall at 15m still overflowed the 32-light cap.
-    {
-        uint2 px = uint2( groupID.xy ) * TILE_SIZE + threadID.xy;
-        if ( px.x < ScreenDim.x && px.y < ScreenDim.y ) {
-            float d = DepthTex.Load( int3( int2( px ), 0 ) );
-            if ( d > 0.0 ) {   // reversed-Z: 0 == cleared (sky / no opaque geometry)
-                uint di = asuint( d );
-                InterlockedMin( gs_MinDepthInt, di );
-                InterlockedMax( gs_MaxDepthInt, di );
-            }
-        }
-    }
-    GroupMemoryBarrierWithGroupSync();
-
-    // Tile AABB in view space, spanning the near..far corners of the tile's screen rect at the min/max depth.
-    float2 tileMin = float2( groupID.xy ) * TILE_SIZE;
-    float2 tileMax = float2( groupID.xy + uint2( 1, 1 ) ) * TILE_SIZE;
-    float3 aabbMin, aabbMax;
-    if ( gs_MinDepthInt == 0x7F7FFFFF ) {
-        // No world-mesh depth in this tile (sky, or a VOB/NPC the world-only prepass didn't lay down). Fall
-        // back to an all-encompassing box so those tiles stay conservatively lit — DELIBERATELY divergent from
-        // D3D11 (which collapses empty tiles to the near plane), because our prepass is world-mesh only and
-        // collapsing here would unlight characters standing against the sky. (Complete the prepass to remove.)
-        aabbMin = float3( -1e9, -1e9, -1e9 );
-        aabbMax = float3(  1e9,  1e9,  1e9 );
-    } else {
-        float minDepth = asfloat( gs_MinDepthInt );   // reversed-Z: smaller depth == farther
-        float maxDepth = asfloat( gs_MaxDepthInt );
-        float3 c0 = ScreenToView( float2( tileMin.x, tileMin.y ), minDepth );
-        float3 c1 = ScreenToView( float2( tileMax.x, tileMin.y ), minDepth );
-        float3 c2 = ScreenToView( float2( tileMin.x, tileMax.y ), minDepth );
-        float3 c3 = ScreenToView( float2( tileMax.x, tileMax.y ), minDepth );
-        float3 c4 = ScreenToView( float2( tileMin.x, tileMin.y ), maxDepth );
-        float3 c5 = ScreenToView( float2( tileMax.x, tileMin.y ), maxDepth );
-        float3 c6 = ScreenToView( float2( tileMin.x, tileMax.y ), maxDepth );
-        float3 c7 = ScreenToView( float2( tileMax.x, tileMax.y ), maxDepth );
-        aabbMin = min( min( min( c0, c1 ), min( c2, c3 ) ), min( min( c4, c5 ), min( c6, c7 ) ) );
-        aabbMax = max( max( max( c0, c1 ), max( c2, c3 ) ), max( max( c4, c5 ), max( c6, c7 ) ) );
-    }
-
-    // Distribute the light test across the group's threads. Clamp the external count (root constant) to the
-    // buffer capacity so a garbage TotalLights can never spin the loop (lasting D3D12 rule).
-    //
-    // The kept set MUST be a deterministic function of the light buffer, not of GPU scheduling. An
-    // InterlockedAdd append gives each passing light whatever slot it wins the race for, so once a tile has more
-    // than MAX_LIGHTS_PER_TILE candidates the 64 that survive the cap differ every frame and the tile visibly
-    // flickers at 16x16 granularity — which is exactly what Gothic's static "atmospheric" light rooms (hundreds
-    // of co-located lights, every tile far over the cap) do. Instead the group walks the buffer in fixed chunks
-    // of numThreads and compacts each chunk's pass flags with a Hillis-Steele prefix sum, so a light's slot is
-    // its rank in BUFFER ORDER. BuildFrameLightBuffer sorts that buffer by distance to the camera, so the cap
-    // now deterministically keeps the NEAREST candidates and drops the farthest — stable frame to frame.
-    //
-    // Every barrier below sits in group-uniform flow: the chunk loop bound is uniform (a root constant) and is
-    // deliberately NOT cut short when the tile fills up, since at kMaxFrameLights=400 that is at most two
-    // chunks and an early-out would put a barrier behind a groupshared-derived condition.
-    uint total = min( TotalLights, 4096u );
-    const uint numThreads = TILE_SIZE * TILE_SIZE;
-    for ( uint base = 0; base < total; base += numThreads ) {
-        uint i = base + ti;
-        uint pass = 0;
-        if ( i < total ) {
-            TiledPointLight L = SB_Lights[i];
-            pass = SphereInsideAABB( L.PositionView, L.Range * 1.05, aabbMin, aabbMax ) ? 1u : 0u;
-        }
-
-        // Inclusive scan of `pass` over the group; gs_Scan[numThreads-1] ends up as the chunk's total.
-        gs_Scan[ti] = pass;
-        GroupMemoryBarrierWithGroupSync();
-        [unroll] for ( uint s = 1; s < numThreads; s <<= 1 ) {
-            uint v = ( ti >= s ) ? gs_Scan[ti - s] : 0u;
-            GroupMemoryBarrierWithGroupSync();
-            gs_Scan[ti] += v;
-            GroupMemoryBarrierWithGroupSync();
-        }
-
-        // gs_Count carries the lights kept by earlier chunks; the exclusive prefix is this light's rank inside
-        // the chunk. Overflow simply doesn't write (gs_Count still counts, and is clamped when it is stored).
-        uint slot = gs_Count + gs_Scan[ti] - pass;
-        if ( pass != 0 && slot < MAX_LIGHTS_PER_TILE ) gs_Indices[slot] = i;
-        GroupMemoryBarrierWithGroupSync();
-        if ( ti == 0 ) gs_Count += gs_Scan[numThreads - 1];
-        GroupMemoryBarrierWithGroupSync();
-    }
+    // Log-distributed cluster Z bounds (Doom/Olsson clustered shading): slice 0 is thinnest (nearest, where
+    // depth precision/occupancy is highest) and slices widen geometrically out to FarZ. This is pure view-space
+    // math and has nothing to do with the reversed-Z hardware depth encoding — that only matters where a hardware
+    // depth is converted back to a view-space Z (PBRLighting.hlsl's ComputeZSlice does that for the pixel shader
+    // side; this compute pass never touches hardware depth at all).
+    const uint slice = groupID.z;
+    const float sliceNearZ = NearZ * pow( FarZ / NearZ, (float)slice / (float)NUM_Z_SLICES );
+    const float sliceFarZ  = NearZ * pow( FarZ / NearZ, (float)( slice + 1 ) / (float)NUM_Z_SLICES );
 
     if ( ti == 0 ) {
-        uint count = min( gs_Count, (uint)MAX_LIGHTS_PER_TILE );
-        uint tileIndex = groupID.y * NumTilesX + groupID.x;
-        uint offset = tileIndex * MAX_LIGHTS_PER_TILE;   // fixed per-tile slice (no global counter)
-        RW_LightGrid[tileIndex].Offset = offset;
-        RW_LightGrid[tileIndex].Count  = count;
-        for ( uint j = 0; j < count; ++j )
-            RW_LightIndexList[offset + j] = gs_Indices[j];
+        const float2 tileMin = float2( groupID.xy ) * TILE_SIZE;
+        const float2 tileMax = float2( groupID.xy + uint2( 1, 1 ) ) * TILE_SIZE;
+        const float2 n0 = ViewXYAtZ( tileMin, sliceNearZ ), n1 = ViewXYAtZ( tileMax, sliceNearZ );
+        const float2 f0 = ViewXYAtZ( tileMin, sliceFarZ ),  f1 = ViewXYAtZ( tileMax, sliceFarZ );
+        gs_AabbMin = float3( min( min( n0, n1 ), min( f0, f1 ) ), sliceNearZ );
+        gs_AabbMax = float3( max( max( n0, n1 ), max( f0, f1 ) ), sliceFarZ );
+    }
+    GroupMemoryBarrierWithGroupSync();
+
+    if ( ti < TotalLights ) {
+        TiledPointLight L = SB_Lights[ti];
+        if ( SphereInsideAABB( L.PositionView, L.Range * 1.05, gs_AabbMin, gs_AabbMax ) ) {
+            InterlockedOr( gs_Mask[ti / 32u], 1u << ( ti % 32u ) );
+        }
+    }
+    GroupMemoryBarrierWithGroupSync();
+
+    if ( ti == 0 ) {
+        const uint tileIndex = groupID.y * NumTilesX + groupID.x;
+        const uint clusterIndex = tileIndex * NUM_Z_SLICES + slice;
+        [unroll]
+        for ( uint w = 0; w < MASK_WORDS; ++w )
+            RW_LightGrid[clusterIndex].Mask[w] = gs_Mask[w];
     }
 }

--- a/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
@@ -18,14 +18,18 @@ cbuffer InstanceCB : register(b1)
 // every skeletal command. 192 is 2 * NUM_MAX_BONES; only the allocated prefix is ever indexed.
 cbuffer BonesCB    : register(b2) { float4x4 Bones[192]; };
 cbuffer FogCB      : register(b3) { float3 FogColor; float FogNear; float3 CamPosWS; float FogFar; };
-cbuffer LightCB    : register(b4) { uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex; };   // Forward+ tiled: light count + tiles/row + low-res cube heap slot
+// Forward+ tiled: light count + tiles/row + low-res cube heap slot. ProjA/ProjB/NearZ/FarZ feed
+// PBRLighting.hlsl's ComputeZSlice (clustered Forward+, P2.14) — see World.hlsl.
+cbuffer LightCB    : register(b4) {
+    uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex;
+    float ProjA; float ProjB; float NearZ; float FarZ;
+};
 
 #include "include/ForwardPlusTypes.hlsl"
 
-// Forward+ tiled point lights (root-descriptor SRVs + per-tile grid) — see the world shader for the rationale.
+// Forward+ tiled point lights (root-descriptor SRVs + per-cluster mask) — see the world shader for the rationale.
 StructuredBuffer<GPULight>  Lights        : register(t1);
 StructuredBuffer<LightGrid> LightGridBuf  : register(t2);
-StructuredBuffer<uint>      LightIndexBuf : register(t3);
 
 // No t0 diffuse texture: EVERY entry point in this file (lit, depth-prepass, shadow-clip and ghost) fetches its
 // diffuse bindlessly from MaterialCB.MatDiffuseIndex, so neither Skeletal.RootSig nor GhostSkeletal.RootSig
@@ -152,7 +156,7 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     float ssao = SampleScreenSpaceAO( i.wpos );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= lerp( 1.0, 0.8, wetness );
-    rgb += AccumTiledPointLights( i.clip.xy, i.wpos, N, albedo, orm.g, orm.b );   // dynamic point lights on top (PBR)
+    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );   // dynamic point lights on top (PBR)
     rgb += wetSheen * ( 1.0 + shadow ) * SrgbToLinear( SunColor ) * SunIntensity;
     float f = saturate( ( i.fogDist - FogNear ) / max( 1.0, FogFar - FogNear ) );
     return float4( lerp( rgb, SrgbToLinear( FogColor ), f ), 1.0 );

--- a/D3D11Engine/Shaders/D3D12/Vegetation.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Vegetation.hlsl
@@ -12,14 +12,17 @@ cbuffer GrassCB : register(b1)
     float3 G_PlayerPosWS;     float _gpad1;
 };
 cbuffer FogCB : register(b2) { float3 FogColor; float FogNear; float3 CamPosWS; float FogFar; };
-cbuffer LightCB : register(b3) { uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex; };
+// ProjA/ProjB/NearZ/FarZ feed PBRLighting.hlsl's ComputeZSlice (clustered Forward+, P2.14) — see World.hlsl.
+cbuffer LightCB : register(b3) {
+    uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex;
+    float ProjA; float ProjB; float NearZ; float FarZ;
+};
 
 #include "include/ForwardPlusTypes.hlsl"
 
-// Forward+ tiled point lights (root-descriptor SRVs + per-tile grid) — see World.hlsl for the rationale.
+// Forward+ tiled point lights (root-descriptor SRVs + per-cluster mask) — see World.hlsl for the rationale.
 StructuredBuffer<GPULight>  Lights        : register(t2);
 StructuredBuffer<LightGrid> LightGridBuf  : register(t3);
-StructuredBuffer<uint>      LightIndexBuf : register(t4);
 
 Texture2D    tx       : register(t0);   // grass blade texture (GVegetationBox::VegetationTexture)
 Texture2D    txGround : register(t1);   // ground/undercoat texture (GVegetationBox::MeshTexture) — tints the blades
@@ -157,7 +160,7 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     // the reason this used to pass a literal 1.0.
     float ssao = SampleScreenSpaceAO( i.wpos );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, 1.0, shadow, 0.9, 0.0, 1.0, ssao );
-    rgb += AccumTiledPointLights( i.clip.xy, i.wpos, N, albedo, 0.9, 0.0 );
+    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, 0.9, 0.0 );
     float f = saturate( ( i.fogDist - FogNear ) / max( 1.0, FogFar - FogNear ) );
     return float4( lerp( rgb, SrgbToLinear( FogColor ), f ), 1.0 );
 }

--- a/D3D11Engine/Shaders/D3D12/Vob.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Vob.hlsl
@@ -1,6 +1,10 @@
 cbuffer WorldCB : register(b0) { float4x4 ViewProj; };   // default column-major packing (see world shader)
 cbuffer FogCB   : register(b1) { float3 FogColor; float FogNear; float3 CamPosWS; float FogFar; };
-cbuffer LightCB : register(b2) { uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex; };
+// ProjA/ProjB/NearZ/FarZ feed PBRLighting.hlsl's ComputeZSlice (clustered Forward+, P2.14) — see World.hlsl.
+cbuffer LightCB : register(b2) {
+    uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex;
+    float ProjA; float ProjB; float NearZ; float FarZ;
+};
 // Wind sway for instanced VOBs (flags/foliage). Mirrors D3D11's WindParams cbuffer (VS_ExInstancedObj.hlsl);
 // minHeight/maxHeight are the flat (non-WIND_META_SRV) per-visual bounding-box fallback, refreshed per visual
 // by DrawVobsInstanced before each visual's draw calls (see WindMinHeight/WindMaxHeight below).
@@ -17,7 +21,6 @@ cbuffer WindCB : register(b4)
 // Forward+ tiled point lights (root-descriptor SRVs + per-tile grid)
 StructuredBuffer<GPULight>  Lights        : register(t1);
 StructuredBuffer<LightGrid> LightGridBuf  : register(t2);
-StructuredBuffer<uint>      LightIndexBuf : register(t3);
 
 Texture2D    tx  : register(t0);
 SamplerState smp : register(s0);
@@ -143,7 +146,7 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     float ssao = SampleScreenSpaceAO( i.wpos );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= lerp( 1.0, 0.8, wetness );
-    rgb += AccumTiledPointLights( i.clip.xy, i.wpos, N, albedo, orm.g, orm.b );
+    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
     rgb += wetSheen * ( 1.0 + shadow ) * SrgbToLinear( SunColor ) * SunIntensity;
     float f = saturate( ( i.fogDist - FogNear ) / max( 1.0, FogFar - FogNear ) );
     return float4( lerp( rgb, SrgbToLinear( FogColor ), f ), 1.0 );
@@ -240,7 +243,7 @@ float4 PSMainBindless( VS_OUT i ) : SV_TARGET
     float ssao = SampleScreenSpaceAO( i.wpos );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= lerp( 1.0, 0.8, wetness );
-    rgb += AccumTiledPointLights( i.clip.xy, i.wpos, N, albedo, orm.g, orm.b );
+    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
     rgb += wetSheen * ( 1.0 + shadow ) * SrgbToLinear( SunColor ) * SunIntensity;
     float f = saturate( ( i.fogDist - FogNear ) / max( 1.0, FogFar - FogNear ) );
     return float4( lerp( rgb, SrgbToLinear( FogColor ), f ), 1.0 );
@@ -279,7 +282,7 @@ float4 PSAlphaBlendBindless( VS_OUT i ) : SV_TARGET
     float shadow = ComputeSunShadow( i.wpos, N, i.col.g );
     float ssao = SampleScreenSpaceAO( i.wpos );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, i.col.g, shadow, orm.g, orm.b, orm.r, ssao );
-    rgb += AccumTiledPointLights( i.clip.xy, i.wpos, N, albedo, orm.g, orm.b );
+    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
     return float4( rgb, t.a * i.col.a );
 }
 

--- a/D3D11Engine/Shaders/D3D12/World.hlsl
+++ b/D3D11Engine/Shaders/D3D12/World.hlsl
@@ -2,15 +2,19 @@
 // row-major XMFLOAT4X4 bytes we upload here, so mul(float4(pos,1), ViewProj) is byte-for-byte identical.
 cbuffer WorldCB : register(b0) { float4x4 ViewProj; };
 cbuffer FogCB   : register(b1) { float3 FogColor; float FogNear; float3 CamPosWS; float FogFar; };
-cbuffer LightCB : register(b2) { uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex; };   // Forward+ tiled: light count + tiles/row + low-res cube heap slot
+// Forward+ tiled: light count + tiles/row + low-res cube heap slot. ProjA/ProjB/NearZ/FarZ feed
+// PBRLighting.hlsl's ComputeZSlice (clustered Forward+, P2.14) — see that header for what each means.
+cbuffer LightCB : register(b2) {
+    uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex;
+    float ProjA; float ProjB; float NearZ; float FarZ;
+};
 
 #include "include/ForwardPlusTypes.hlsl"
 
-// Bound as a ROOT descriptor SRV (no descriptor-table slot). The per-tile grid produced by the light-cull
-// compute (DispatchLightCulling) narrows this loop to only the lights that touch each 16x16 screen tile.
+// Bound as a ROOT descriptor SRV (no descriptor-table slot). The per-cluster mask produced by the light-cull
+// compute (DispatchLightCulling) narrows this loop to only the lights visible in this pixel's cluster.
 StructuredBuffer<GPULight>  Lights        : register(t1);   // root SRV — all visible lights, indexed by the grid
-StructuredBuffer<LightGrid> LightGridBuf  : register(t2);   // root SRV — per-tile {Offset,Count}
-StructuredBuffer<uint>      LightIndexBuf : register(t3);   // root SRV — per-tile light-index slices
+StructuredBuffer<LightGrid> LightGridBuf  : register(t2);   // root SRV — per-cluster 64-bit membership mask
 
 Texture2D    tx  : register(t0);
 SamplerState smp : register(s0);
@@ -168,7 +172,7 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     float ssao = SampleScreenSpaceAO( i.wpos );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= lerp( 1.0, 0.8, wetness );   // D3D11 dims the SUN light color 20% where the surface is wet
-    rgb += AccumTiledPointLights( i.clip.xy, i.wpos, N, albedo, orm.g, orm.b );
+    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
     // Additive wet sheen (D3D11's specWet, boosted where the sun actually reaches: specWet += specWet * shadow).
     rgb += wetSheen * ( 1.0 + shadow ) * SrgbToLinear( SunColor ) * SunIntensity;
     // Linear distance fog toward the (linearized) atmosphere color — keeps the HDR buffer consistently linear.

--- a/D3D11Engine/Shaders/D3D12/include/ForwardPlusTypes.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/ForwardPlusTypes.hlsl
@@ -5,6 +5,28 @@
 // (LightCB/ShadowCB live at different b-slots per shader) still belong to each file, only the *shapes* are
 // common here.
 
+#define TILE_SIZE 16u
+// Clustered Forward+ (P2.14): a global cap on SIMULTANEOUSLY-SHADED point lights, not a per-tile cap. The
+// frame's light buffer (kMaxFrameLights in D3D12Scene.cpp, sorted nearest-to-camera) feeds only its first
+// MAX_ACTIVE_LIGHTS entries into the cluster bitmask — thread ti of LightCull.hlsl's CSMain tests light ti, and
+// the mask has exactly this many bits, so the constant is load-bearing on BOTH sides, not just a cap. Lights
+// beyond this rank in the sorted buffer simply never light anything (same "farthest dropped first" policy the
+// old per-tile prefix-sum cap used, just applied once globally instead of independently per tile).
+// Must match LightCull.hlsl's numthreads(MAX_ACTIVE_LIGHTS,1,1) AND kMaxFrameLights in D3D12Scene.cpp (raising
+// one without the other either wastes capacity or silently drops lights past the smaller of the two).
+// Raised from 64 (P2.14's initial cap clipped visibly in ambient-heavy scenes — Gothic can have 400+
+// simultaneously visible point lights once static "atmospheric" fill lights are counted) to 1024 = 32 * 32-bit
+// words. Each cluster's mask is MASK_WORDS * 4 bytes: at 1080p (~8160 16x16 tiles * NUM_Z_SLICES=16 slices =
+// 130560 clusters) that's ~16.7 MB total — small next to a single HDR scene target, so still "low" by this
+// codebase's standards despite the 16x jump from the 64-bit original.
+#define MAX_ACTIVE_LIGHTS 1024u
+#define MASK_WORDS (MAX_ACTIVE_LIGHTS / 32u)
+// Cluster Z slice count (log-distributed over [NearZ, FarZ], see LightCB's NearZ/FarZ/ProjA/ProjB and
+// PBRLighting.hlsl's ComputeZSlice). Must match kNumZSlices in D3D12Scene.cpp — it sizes the LightGrid buffer
+// and both sides derive the SAME cluster index from it, so a mismatch silently misindexes every cluster.
+#define NUM_Z_SLICES 16u
+#define NUM_CSM_CASCADES 3
+
 // Per-frame visible point light (torches/campfires/spells), 64 B. Must stay in lockstep with the C++ GPULight
 // in D3D12Engine/D3D12EngineCommon.h and with LightCull.hlsl's TiledPointLight copy.
 // Forward shaders read PositionWorld/Range/Color for shading; PositionView feeds the tile cull;
@@ -19,7 +41,10 @@ struct GPULight {
     float3 PositionWorld; int ShadowCubeIndex;
     float3 ShadowOrigin;  float ShadowRange;
 };
-struct LightGrid { uint Offset; uint Count; };
+// Clustered Forward+ grid cell: a MAX_ACTIVE_LIGHTS-bit membership mask over the frame's active light list (bit
+// i set = light i is visible in this cluster), NOT an {Offset,Count} index slice — see LightCull.hlsl/
+// PBRLighting.hlsl's AccumTiledPointLights. MASK_WORDS * 4 bytes per cluster.
+struct LightGrid { uint Mask[MASK_WORDS]; };
 
 // ShadowCubeIndex encoding: -1 = unshadowed, else (slot | tier). Bit 30 selects the low-res static cube array
 // over the full-res dynamic one, and keeps the value positive so "ShadowCubeIndex >= 0" still means shadowed.
@@ -28,8 +53,3 @@ static const int kShadowTierLow  = 0x40000000;
 // Full-res slots only; absent means a pure static shadow and no second sample. Mirrors D3D12EngineCommon.h.
 static const int kShadowHasDynamic = 0x20000000;
 static const int kShadowSlotMask = 0x1FFFFFFF;
-
-#define TILE_SIZE 16u
-// Must match LightCull.hlsl's copy AND kMaxLightsPerTile in D3D12Scene.cpp (it strides RW_LightIndexList).
-#define MAX_LIGHTS_PER_TILE 64u
-#define NUM_CSM_CASCADES 3

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -6,13 +6,17 @@
 // point-light accumulator.
 //
 // #include this AFTER the including shader has already declared (with its own, per-shader register slots):
-//   #include "include/ForwardPlusTypes.hlsl"   (GPULight, LightGrid, TILE_SIZE, MAX_LIGHTS_PER_TILE, NUM_CSM_CASCADES)
+//   #include "include/ForwardPlusTypes.hlsl"   (GPULight, LightGrid, TILE_SIZE, MAX_ACTIVE_LIGHTS, NUM_Z_SLICES,
+//                                                NUM_CSM_CASCADES)
 //   cbuffer FogCB    { ...; float3 CamPosWS; ...; }
-//   cbuffer LightCB  { uint LightCount; uint NumTilesX; uint LimitLightIntensity; ...; }
+//   cbuffer LightCB  { uint LightCount; uint NumTilesX; uint LimitLightIntensity; ...;
+//                      float ProjA; float ProjB; float NearZ; float FarZ; }   -- the last 4 feed ComputeZSlice
+//                      (ProjA/ProjB = reversed-Z depth->viewZ terms, matches LightCull.hlsl's CullCB;
+//                      NearZ/FarZ = the log-distributed cluster Z range, also matching CullCB)
 //   cbuffer ShadowCB { float4x4 CascadeViewProj[NUM_CSM_CASCADES]; float3 SunDirWS; float ShadowMapSize;
 //                      float3 SunColor; float SunIntensity; float3 CascadeTexelWorld; float AmbientStrength;
 //                      float ShadowAOStrength; float WorldAOStrength; ...; }
-//   StructuredBuffer<GPULight> Lights; StructuredBuffer<LightGrid> LightGridBuf; StructuredBuffer<uint> LightIndexBuf;
+//   StructuredBuffer<GPULight> Lights; StructuredBuffer<LightGrid> LightGridBuf;
 //   Texture2DArray ShadowMap; SamplerComparisonState shadowCmp; TextureCubeArray PointShadowCubes;
 // The LOW-RES static cube array is not a declared binding: it is fetched bindlessly (SM6.6
 // ResourceDescriptorHeap) from LightCB's PointShadowLowIndex, so adding the second tier cost no root
@@ -464,42 +468,71 @@ float3 ComputeSunLightingPBR( float3 wpos, float3 N, float3 albedo, float vertLi
     return ambientSun + directSun;
 }
 
-// Accumulate dynamic point lights at a world-space surface point using the Forward+ tile grid: derive the
-// tile from SV_Position.xy, read its {Offset,Count} slice, and loop ONLY the lights culled into that tile
-// (indices into the global Lights buffer). `albedo` is LINEAR (sRGB-decoded in the PS). Ports D3D11 feat/pbr
-// FP_ComputePointLighting (PLS_ComputePointLightLightingPBR): range cull, falloff = nd*(nd*0.2+0.8), full
-// Cook-Torrance BRDF per light, additive. The count is clamped to the per-tile capacity so a garbage grid
-// entry can never spin the loop away (that reads as a GPU timeout).
-float3 AccumTiledPointLights( float2 svpos, float3 wpos, float3 N, float3 albedo, float roughness, float metallic )
+// Reconstructs THIS pixel's cluster Z slice from its own hardware depth (reversed-Z), analytically — no depth-
+// buffer fetch (unlike the old per-tile scheme, which sampled a prepass depth texture in the cull compute pass).
+// ProjA/ProjB invert the reversed-Z depth to a linear view-space Z (same formula as LightCull.hlsl's CullCB);
+// NearZ/FarZ bound the log-distributed slice range LightCull.hlsl's CSMain used to build the cluster grid — the
+// two sides MUST agree on NearZ/FarZ/NUM_Z_SLICES or a pixel picks a different cluster than the one culled for it.
+uint ComputeZSlice( float hwDepth )
 {
-    uint2 tile = uint2( svpos ) / TILE_SIZE;
+    float d = max( hwDepth, 1e-6 );   // guard: hwDepth==0 (cleared/sky) would divide-by-zero below
+    float viewZ = ProjB / ( d - ProjA );
+    float t = log2( max( viewZ, NearZ ) / NearZ ) / log2( FarZ / NearZ );
+    return (uint)clamp( floor( t * (float)NUM_Z_SLICES ), 0.0, (float)( NUM_Z_SLICES - 1 ) );
+}
+
+// Applies one light's contribution (direct BRDF + its shadow, if any) and folds it into `total`/`maxLit`.
+void ApplyTiledLight( uint lightIndex, float3 wpos, float3 N, float3 V, float3 albedo, float roughness,
+                       float metallic, inout float3 total, inout float3 maxLit )
+{
+    GPULight L = Lights[lightIndex];
+    float3 dir = L.PositionWorld - wpos;
+    float dist = length( dir );
+    if ( dist >= L.Range ) return;
+    dir /= dist;
+    float nd  = saturate( 1.0 - dist / L.Range );
+    float falloff = nd * ( nd * 0.2 + 0.8 );   // PLS_ComputeRangeFalloff
+    float3 lit = PBR_DirectLighting( albedo, L.Color.rgb, N, V, dir, roughness, metallic, falloff );
+    if ( L.ShadowCubeIndex >= 0 )
+    {
+        // ShadowOrigin/ShadowRange, not PositionWorld/Range: a clustered static light samples a cube
+        // centred on its cluster, while its own position/range still drive the shading above.
+        float sh = SamplePointShadow( L.ShadowCubeIndex, wpos, N, L.ShadowOrigin, L.ShadowRange );
+        float camDist = length( L.PositionView );
+        float fade    = saturate( ( camDist - L.Range * 6.0 ) / ( L.Range * 3.0 ) );
+        lit *= lerp( sh, 1.0, fade );
+    }
+    total += lit;
+    maxLit = max( maxLit, lit );
+}
+
+// Accumulate dynamic point lights at a world-space surface point using the CLUSTERED Forward+ grid: derive the
+// cluster from SV_Position.xy (screen tile) and SV_Position.z (Z slice, via ComputeZSlice), read its
+// MAX_ACTIVE_LIGHTS-bit membership mask, and bit-scan ONLY the lights it flags (indices into the global Lights
+// buffer — bit i is light i, see MAX_ACTIVE_LIGHTS). `svpos` is the shader's SV_Position (xy = screen pixel,
+// z = hardware depth). `albedo` is LINEAR (sRGB-decoded in the PS). Ports D3D11 feat/pbr
+// FP_ComputePointLighting (PLS_ComputePointLightLightingPBR): range cull, falloff = nd*(nd*0.2+0.8), full
+// Cook-Torrance BRDF per light, additive. Bit-scanning a fixed-width mask (rather than looping an
+// {Offset,Count} index slice) can never spin away on a garbage grid entry — the loop bound is the popcount of
+// the mask, not an unclamped Count. Most words are 0 for a typical cluster, so the per-word while() is cheap.
+float3 AccumTiledPointLights( float3 svpos, float3 wpos, float3 N, float3 albedo, float roughness, float metallic )
+{
+    uint2 tile = uint2( svpos.xy ) / TILE_SIZE;
     uint  tileIndex = tile.y * NumTilesX + tile.x;
-    LightGrid g = LightGridBuf[tileIndex];
-    uint n = min( g.Count, MAX_LIGHTS_PER_TILE );
+    uint  slice = ComputeZSlice( svpos.z );
+    LightGrid g = LightGridBuf[tileIndex * NUM_Z_SLICES + slice];
     float3 V = normalize( CamPosWS - wpos );
     float3 total = 0;
     float3 maxLit = 0;
-    for ( uint k = 0; k < n; k++ )
+    for ( uint w = 0; w < MASK_WORDS; ++w )
     {
-        GPULight L = Lights[ LightIndexBuf[g.Offset + k] ];
-        float3 dir = L.PositionWorld - wpos;
-        float dist = length( dir );
-        if ( dist >= L.Range ) continue;
-        dir /= dist;
-        float nd  = saturate( 1.0 - dist / L.Range );
-        float falloff = nd * ( nd * 0.2 + 0.8 );   // PLS_ComputeRangeFalloff
-        float3 lit = PBR_DirectLighting( albedo, L.Color.rgb, N, V, dir, roughness, metallic, falloff );
-        if ( L.ShadowCubeIndex >= 0 )
+        uint m = g.Mask[w];
+        while ( m != 0 )
         {
-            // ShadowOrigin/ShadowRange, not PositionWorld/Range: a clustered static light samples a cube
-            // centred on its cluster, while its own position/range still drive the shading above.
-            float sh = SamplePointShadow( L.ShadowCubeIndex, wpos, N, L.ShadowOrigin, L.ShadowRange );
-            float camDist = length( L.PositionView );
-            float fade    = saturate( ( camDist - L.Range * 6.0 ) / ( L.Range * 3.0 ) );
-            lit *= lerp( sh, 1.0, fade );
+            uint bit = firstbitlow( m );
+            m &= m - 1;   // clear the lowest set bit
+            ApplyTiledLight( w * 32u + bit, wpos, N, V, albedo, roughness, metallic, total, maxLit );
         }
-        total += lit;
-        maxLit = max( maxLit, lit );
     }
     // LimitLightIntensity: swap "sum of every light" for "brightest single light" (mirrors D3D11's
     // ForwardPlusLighting.hlsl / CS_TiledShading.hlsl MAX-blend mode) to avoid overexposure where many


### PR DESCRIPTION
eliminates light flickering in tight corridors with many lights.

only affects dx12 forward+ lighting.