### PR TITLE
some back-ports from dx12 to dx11, some more regressions fixed in d12 and some other stuff.

### DIFF
--- a/D3D11Engine/D3D11ForwardPlusRenderer.cpp
+++ b/D3D11Engine/D3D11ForwardPlusRenderer.cpp
@@ -312,6 +312,12 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
                     tiledDeferred->IsShadowArrayCreated() ? tiledDeferred->GetShadowCubeArraySRV() : nullptr,
                 };
                 context->PSSetShaderResources( 8, 4, lightSRVs );
+
+                // --- Dynamic point-shadow overlay array at t14 (t12/t13 are the shadow and AO masks) ---
+                // May be null: no light can carry SHADOW_CUBE_HAS_DYNAMIC before the array exists.
+                ID3D11ShaderResourceView* dynCubeSRV = tiledDeferred->IsDynShadowArrayCreated()
+                    ? tiledDeferred->GetShadowDynCubeArraySRV() : nullptr;
+                context->PSSetShaderResources( 14, 1, &dynCubeSRV );
             }
 
             // --- Bind shadow mask at t12 ---
@@ -337,7 +343,7 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
             context->PSSetShaderResources( 3, 1, s_nullSRVs );
             context->PSSetShaderResources( 6, 1, s_nullSRVs );
             context->PSSetShaderResources( 8, 4, s_nullSRVs );
-            context->PSSetShaderResources( 12, 2, s_nullSRVs );
+            context->PSSetShaderResources( 12, 3, s_nullSRVs ); // shadow mask, AO mask, dynamic shadow cubes
 
             // Restore default depth comparison
             depthState.SetDefault();

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -5796,7 +5796,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                     }
 
                     // Check vob range
-                    if ( XMVector3Greater( XMVector3LengthSq( position - XMLoadFloat3( &it->LastRenderPosition ) ), vRangeSquared ) ) {
+                    if ( XMVector3Greater( XMVector3LengthSq( position - it->Vob->GetPositionWorldXM() ), vRangeSquared ) ) {
                         continue;
                     }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -1594,8 +1594,8 @@ XRESULT D3D11GraphicsEngine::OnBeginFrame() {
     for ( DeferredMipUpload& upload : stagingTextures ) {
         GetContext()->CopySubresourceRegion( upload.Destination.Get(), upload.Mip, 0, 0, 0, upload.Staging.Get(), 0, nullptr );
     }
-    // Both resources are ref-counted by the queue itself, so clearing it releases them - including the
-    // destinations of textures that got cached out again while their upload was still in flight.
+        // Both resources are ref-counted by the queue itself, so clearing it releases them - including the
+        // destinations of textures that got cached out again while their upload was still in flight.
     stagingTextures.clear();
 
     auto& mipMaps = Engine::GAPI->GetMipMapGeneration();

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -6721,6 +6721,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
         }
     }
 
+    const bool isCloseCascade = params.CascadeIndex < std::clamp(renderState.RendererSettings.NumShadowCascades, 1, 3);
     if ( renderState.RendererSettings.DrawVOBs ) {
         ZoneScopedN( "Shadows::DrawVOBs" );
 
@@ -6999,7 +7000,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
         }
     }
 
-    if ( renderState.RendererSettings.DrawSkeletalMeshes ) {
+    if ( renderState.RendererSettings.DrawSkeletalMeshes
+        && (isCloseCascade || renderState.RendererSettings.ShadowFrustumCullingMode == GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_DISABLED) ) {
         ZoneScopedN( "Shadows::DrawSkeletalMeshes" );
         auto _1 = RecordGraphicsEvent( GE_NAME( "Shadows::DrawSkeletalMeshes" ) );
 
@@ -7042,7 +7044,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
         DrawSkeletalMeshVobs( animatedSkeletalMeshVobs, FLT_MAX, false, drawAttachments );
     }
 
-    if ( renderState.RendererSettings.DrawVOBs ) {
+    if ( renderState.RendererSettings.DrawVOBs
+        && isCloseCascade ) {
         ZoneScopedN( "Shadows::DrawVegetation" );
         auto _1 = RecordGraphicsEvent( GE_NAME( "Shadows::DrawVegetation" ) );
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3023,7 +3023,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
     ConstantBufferAllocation defaultMaterialInfoAllocation = {};
 
-    const auto now = Engine::GAPI->GetTotalTimeDW();
+    const auto now = Engine::GAPI->GetFrameNumber();
 
     bool wantShader = true;
     if ( RenderingStage != DES_GHOST ) {

--- a/D3D11Engine/D3D11PFX_TAA.cpp
+++ b/D3D11Engine/D3D11PFX_TAA.cpp
@@ -7,16 +7,33 @@
 #include "D3D11GraphicsEngine.h"
 #include "D3D11PfxRenderer.h"
 #include "D3D11ShaderManager.h"
+#include "D3D11CShader.h"
 #include "RenderToTextureBuffer.h"
 #include "GothicAPI.h"
 
-D3D11PFX_TAA::D3D11PFX_TAA(D3D11PfxRenderer* rnd) 
+namespace {
+    // Bit layout of CS_PFX_TAAResolve.hlsl's DebugFlags. Everything except MarkNoHistory is on for the "best
+    // quality" configuration Intel documents; runtime bits (not #defines) so a suspected artifact can be
+    // bisected to one feature without a rebuild — same reasoning as the D3D12 backend's D3D12Taa.cpp.
+    constexpr uint32_t kTaaMarkNoHistory         = 0x01;
+    constexpr uint32_t kTaaDepthThreshold        = 0x02;
+    constexpr uint32_t kTaaBicubicFilter         = 0x04;
+    constexpr uint32_t kTaaVarianceClipping      = 0x08;
+    constexpr uint32_t kTaaYCoCg                 = 0x10;
+    constexpr uint32_t kTaaNeighbourhoodSampling = 0x20;
+    constexpr uint32_t kTaaLongestVelocityVector = 0x40;
+
+    // Relative view-Z tolerance for the disocclusion test. Same value and reasoning as the D3D12 backend.
+    constexpr float kTaaDepthTolerance = 0.05f;
+}
+
+D3D11PFX_TAA::D3D11PFX_TAA(D3D11PfxRenderer* rnd)
     : D3D11PFX_Effect(rnd)
     , m_JitterIndex(0)
     , m_Width(0)
     , m_Height(0)
     , m_FirstFrame(true) {
-    
+
     m_CurrentJitter = XMFLOAT2(0, 0);
     m_PreviousJitter = XMFLOAT2(0, 0);
     m_PrevCameraPosition = XMFLOAT3(0, 0, 0);
@@ -26,11 +43,8 @@ D3D11PFX_TAA::D3D11PFX_TAA(D3D11PfxRenderer* rnd)
 
 bool D3D11PFX_TAA::Init() {
     auto* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
-    
-    // TAA/velocity constant buffers now come from the per-frame dynamic ring pool
-    // (allocated at bind time in RenderVelocityBuffer / RenderPostFX).
-    
-    // Linear sampler for color sampling
+
+    // Linear sampler for color/history sampling
     D3D11_SAMPLER_DESC sampDesc = {};
     sampDesc.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
     sampDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
@@ -45,30 +59,43 @@ bool D3D11PFX_TAA::Init() {
     sampDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
     engine->GetDevice()->CreateSamplerState( &sampDesc, m_samplerPoint.GetAddressOf() );
 
-    // Create history buffer (same format as back buffer for color)
+    // History ping-pong: same format as the HDR scene colour, and UAV-capable so the compute resolve can write
+    // it directly (no extra copy through an intermediate RTV).
     DXGI_FORMAT format = engine->GetBackBufferFormat();
-    m_HistoryBuffer = std::make_unique<RenderToTextureBuffer>(
-        engine->GetDevice().Get(), m_Width, m_Height, format);
+    for ( UINT i = 0; i < 2; ++i ) {
+        m_HistoryBuffer[i] = std::make_unique<RenderToTextureBuffer>(
+            engine->GetDevice().Get(), m_Width, m_Height, format,
+            nullptr, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, 1, 1,
+            D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS );
+        SetDebugName( m_HistoryBuffer[i]->GetTexture().Get(), i == 0 ? "TAA_History0" : "TAA_History1" );
+    }
+    m_HistoryIndex = 0;
+    m_HistoryValid = false;
 
-    SetDebugName( m_HistoryBuffer->GetTexture().Get(), "TAA_HistoryBuffer" );
-    SetDebugName( m_HistoryBuffer->GetRenderTargetView().Get(), "TAA_HistoryBuffer_RTV" );
-    SetDebugName( m_HistoryBuffer->GetShaderResView().Get(), "TAA_HistoryBuffer_SRV" );
-    
-    // Create velocity buffer (RG16F for 2D motion vectors)
-    // Using R16G16_FLOAT for high precision motion vectors
+    // Private previous-depth snapshot: same typeless format as the engine's depth buffer, SRV-only (read in the
+    // resolve, written via CopyResource — see the end of RenderPostFX).
+    m_PrevDepthBuffer = std::make_unique<RenderToTextureBuffer>(
+        engine->GetDevice().Get(), m_Width, m_Height, DXGI_FORMAT_R32_TYPELESS,
+        nullptr, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R32_FLOAT, 1, 1,
+        D3D11_BIND_SHADER_RESOURCE );
+    SetDebugName( m_PrevDepthBuffer->GetTexture().Get(), "TAA_PrevDepth" );
+    m_PrevDepthValid = false;
+
+    // Velocity buffer (RG16F) for the camera-reconstructed fallback path (RenderVelocityBuffer).
     m_VelocityBuffer = std::make_unique<RenderToTextureBuffer>(
         engine->GetDevice().Get(), m_Width, m_Height, DXGI_FORMAT_R16G16_FLOAT);
 
     SetDebugName( m_VelocityBuffer->GetTexture().Get(), "TAA_VelocityBuffer" );
     SetDebugName( m_VelocityBuffer->GetRenderTargetView().Get(), "TAA_VelocityBuffer_RTV" );
     SetDebugName( m_VelocityBuffer->GetShaderResView().Get(), "TAA_VelocityBuffer_SRV" );
-    
+
     // Reset state on resize
     m_FirstFrame = true;
     m_JitterIndex = 0;
+    m_FrameNumber = 0;
     m_CurrentJitter = XMFLOAT2(0, 0);
     m_PreviousJitter = XMFLOAT2(0, 0);
-    
+
     return true;
 }
 
@@ -86,6 +113,9 @@ void D3D11PFX_TAA::OnDisabled() {
     m_PreviousJitter = XMFLOAT2( 0, 0 );
     m_JitterIndex = 0;
     m_FirstFrame = true;
+    // The accumulated history was (or will be) built with jitter; do not blend against it once TAA comes back.
+    m_HistoryValid = false;
+    m_PrevDepthValid = false;
 }
 
 void D3D11PFX_TAA::ReleaseResources() {
@@ -94,14 +124,17 @@ void D3D11PFX_TAA::ReleaseResources() {
     }
     m_recreate = true;
 
-    m_HistoryBuffer.reset();
+    m_HistoryBuffer[0].reset();
+    m_HistoryBuffer[1].reset();
+    m_PrevDepthBuffer.reset();
     m_VelocityBuffer.reset();
-    // m_TAACB / m_VelocityCB are persistent-pool slots; keep them across recreations.
+    m_HistoryValid = false;
+    m_PrevDepthValid = false;
     m_samplerLinear.Reset();
     m_samplerPoint.Reset();
 }
 
-void D3D11PFX_TAA::AdvanceJitter() {    
+void D3D11PFX_TAA::AdvanceJitter() {
     // Store the previous jitter for removal
     m_PreviousJitter = m_CurrentJitter;
 
@@ -124,18 +157,20 @@ void D3D11PFX_TAA::AdvanceJitter() {
         ffxFsr3GetJitterOffset( &jitterX, &jitterY, m_JitterIndex, phaseCount );
     }
 
+    ++m_FrameNumber;
+
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
     Engine::GAPI->SetViewTransformXM( view );
 
     auto projF = Engine::GAPI->GetProjectionMatrix();
-    
+
     // Remove the jitter applied in the previous frame.
     // just safety, as zEngine always resets Projection on frame start
     projF._13 = 0;
     projF._23 = 0;
-    
+
     XMMATRIX viewProj = XMMatrixMultiply( XMLoadFloat4x4( &projF ), view );
-    
+
     // row-major view proj
     XMStoreFloat4x4( &m_UnjitteredViewProj, viewProj );
 
@@ -145,7 +180,7 @@ void D3D11PFX_TAA::AdvanceJitter() {
         jitterX / static_cast<float>(m_Width),
         jitterY / static_cast<float>(m_Height)
     );
-    
+
     // Apply the new jitter to the projection matrix for scene rendering
     // The factor of 2 converts from UV space to clip space (-1 to 1)
     projF._13 = m_CurrentJitter.x * 2.0f;
@@ -156,7 +191,7 @@ void D3D11PFX_TAA::AdvanceJitter() {
 
 void D3D11PFX_TAA::RenderVelocityBuffer(
     const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& depthSRV) {
-    
+
     if ( m_recreate ) {
         if ( !Init() ) {
             return;
@@ -169,43 +204,43 @@ void D3D11PFX_TAA::RenderVelocityBuffer(
 
     auto* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
     auto& context = engine->GetContext();
-    
+
     // Set default states
     engine->SetDefaultStates();
     engine->UpdateRenderStates();
-    
+
     // Save old render targets
     Microsoft::WRL::ComPtr<ID3D11RenderTargetView> oldRTV;
     Microsoft::WRL::ComPtr<ID3D11DepthStencilView> oldDSV;
     context->OMGetRenderTargets(1, oldRTV.GetAddressOf(), oldDSV.GetAddressOf());
-    
+
     // Build velocity constant buffer
     VelocityBufferConstantBuffer vcb;
-    
+
     // Get the UNJITTERED inverse view-projection
     // m_UnjitteredViewProj is stored in column-major
     XMMATRIX unjitteredViewProj = XMLoadFloat4x4( &m_UnjitteredViewProj );
     XMMATRIX invViewProj = XMMatrixInverse( nullptr, unjitteredViewProj );
-    
+
     XMStoreFloat4x4(&vcb.InvViewProj, invViewProj );
-    
+
     // PrevViewProj is also stored Column-major
     XMMATRIX prevViewProj = XMLoadFloat4x4( &m_PrevViewProj );
     XMStoreFloat4x4( &vcb.PrevViewProj, prevViewProj );
-    
+
     vcb.JitterOffset = m_CurrentJitter;
     vcb.PrevJitterOffset = m_PreviousJitter;
     vcb.Resolution = XMFLOAT2(static_cast<float>(m_Width), static_cast<float>(m_Height));
-    
+
     engine->BindDynamicCBToPixelShader( 0, engine->AllocateDynamicCB( &vcb, sizeof( vcb ) ) );
-    
+
     // Set velocity buffer as render target
     context->OMSetRenderTargets(1, m_VelocityBuffer->GetRenderTargetView().GetAddressOf(), nullptr);
-    
+
     // Clear velocity buffer to zero (no motion)
     float clearColor[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
     context->ClearRenderTargetView(m_VelocityBuffer->GetRenderTargetView().Get(), clearColor);
-    
+
     // Bind shaders
     engine->GetShaderManager().GetVShader( VShaderID::VS_PFX )->Apply();
     auto velocityPS = engine->GetShaderManager().GetPShader( PShaderID::PS_PFX_Velocity );
@@ -215,20 +250,20 @@ void D3D11PFX_TAA::RenderVelocityBuffer(
         return;
     }
     velocityPS->Apply();
-    
+
     // Bind depth texture
     ID3D11ShaderResourceView* srvs[1] = { depthSRV.Get() };
     context->PSSetShaderResources(0, 1, srvs);
     context->PSSetSamplers( 0, 1, m_samplerLinear.GetAddressOf() );
     context->PSSetSamplers( 1, 1, m_samplerPoint.GetAddressOf() );
-    
+
     // Draw fullscreen quad
     FxRenderer->DrawFullScreenQuad();
-    
+
     // Cleanup
     ID3D11ShaderResourceView* nullSRVs[1] = { nullptr };
     context->PSSetShaderResources(0, 1, nullSRVs);
-    
+
     // Restore render targets
     context->OMSetRenderTargets(1, oldRTV.GetAddressOf(), oldDSV.Get());
 }
@@ -240,102 +275,114 @@ Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> D3D11PFX_TAA::GetVelocityBuffer
     return nullptr;
 }
 
+// The resolve: reads the scene colour + velocity + both depth buffers + last frame's history, writes this
+// frame's history via the compute UAV, then copies the result back over the scene colour (renderTarget) so the
+// pass stays transparent to bloom/HDR/tonemap downstream. Direct counterpart of D3D12GraphicsEngine::RenderTAA.
 void D3D11PFX_TAA::RenderPostFX(
     RenderToTextureBuffer& renderTarget,
     const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& depthSRV,
     const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& velocitySRV) {
-    
+
     if (m_recreate) {
         if (!Init()) {
             return;
         }
         m_recreate = false;
     }
-    
+
     auto* engine = reinterpret_cast<D3D11GraphicsEngine*>(Engine::GraphicsEngine);
     auto& context = engine->GetContext();
-    
-    // Set default states
+
     engine->SetDefaultStates();
     engine->UpdateRenderStates();
-    
-    // Save old render targets
+
+    // Save old render targets; compute writes need them unbound (a render target can't also be a UAV source).
     Microsoft::WRL::ComPtr<ID3D11RenderTargetView> oldRTV;
     Microsoft::WRL::ComPtr<ID3D11DepthStencilView> oldDSV;
     context->OMGetRenderTargets(1, oldRTV.GetAddressOf(), oldDSV.GetAddressOf());
+    context->OMSetRenderTargets( 0, nullptr, nullptr );
 
-    // Get temp buffer to render into
-    auto tempBuffer = FxRenderer->GetTempBuffer();
+    const UINT writeIdx = m_HistoryIndex;
+    const UINT readIdx = 1 - m_HistoryIndex;
 
-    // update the temp buffer with the latest backbuffer data
-    FxRenderer->CopyTextureToRTV( renderTarget.GetShaderResView(), tempBuffer->GetRenderTargetView(), engine->GetResolution() );
-    
-    // Build constant buffer
-    TAAConstantBuffer cb;
-    
+    // Every quality feature on — Intel's documented "best quality" set. MarkNoHistory stays off; it tints
+    // no-history pixels green, a debugging aid rather than a rendering mode.
+    uint32_t debugFlags = kTaaDepthThreshold | kTaaBicubicFilter | kTaaVarianceClipping
+                        | kTaaYCoCg | kTaaNeighbourhoodSampling | kTaaLongestVelocityVector;
+    // No previous-depth snapshot yet (first frame of a world / after a resize): comparing against a cleared
+    // (far-plane) snapshot would reject every pixel, so drop the depth test rather than let it hard-fail.
+    if ( !m_PrevDepthValid ) debugFlags &= ~kTaaDepthThreshold;
+
+    TAAResolveConstantBuffer cb = {};
+
     // Get the UNJITTERED inverse view-projection
     XMMATRIX unjitteredViewProj = XMLoadFloat4x4( &m_UnjitteredViewProj );
     XMMATRIX invViewProj = XMMatrixInverse( nullptr, unjitteredViewProj );
-    
-    XMStoreFloat4x4( &cb.InvViewProj, invViewProj );
+    XMStoreFloat4x4( &cb.InvUnjitteredViewProj, invViewProj );
 
-    // PrevViewProj transpose for HLSL
     XMMATRIX prevViewProj = XMLoadFloat4x4( &m_PrevViewProj );
     XMStoreFloat4x4( &cb.PrevViewProj, prevViewProj );
 
-    cb.JitterOffset = m_CurrentJitter;
-    cb.Resolution = XMFLOAT2(static_cast<float>(m_Width), static_cast<float>(m_Height));
+    cb.Resolution = XMFLOAT4(
+        static_cast<float>( m_Width ), static_cast<float>( m_Height ),
+        1.0f / static_cast<float>( m_Width ), 1.0f / static_cast<float>( m_Height ) );
+    cb.JitterTolerance = XMFLOAT4( m_CurrentJitterUnscaled.x, m_CurrentJitterUnscaled.y, kTaaDepthTolerance, 0.0f );
+    cb.FrameNumber = m_FrameNumber;
+    cb.DebugFlags = debugFlags;
+    // HistoryValid hard-forces the no-history branch in the shader when there is nothing accumulated yet — see
+    // CS_PFX_TAAResolve.hlsl's header comment for why merely pointing the SRV somewhere harmless isn't enough.
+    cb.HistoryValid = ( m_HistoryValid && !m_FirstFrame ) ? 1u : 0u;
 
-    cb.BlendFactor = m_FirstFrame ? 1.0f : 0.08f;
-
-
-    cb.MotionScale = 1.0f;
-    
-    engine->BindDynamicCBToPixelShader( 0, engine->AllocateDynamicCB( &cb, sizeof( cb ) ) );
-    
     m_PrevViewProj = m_UnjitteredViewProj;
-
-    // Store current camera position for next frame
     m_PrevCameraPosition = Engine::GAPI->GetCameraPosition();
 
-    // Set render target
-    context->OMSetRenderTargets( 1, oldRTV.GetAddressOf(), nullptr );
+    auto cs = engine->GetShaderManager().GetCShader( CShaderID::CS_PFX_TAAResolve );
+    cs->Apply();
+    cs->UpdateBuffer( "TaaCB", &cb, sizeof( cb ) );
 
-    // Bind shaders
-    engine->GetShaderManager().GetVShader( VShaderID::VS_PFX )->Apply();
-    auto taaPS = engine->GetShaderManager().GetPShader( PShaderID::PS_PFX_TAA );
-    taaPS->Apply();
+    ID3D11ShaderResourceView* readHistorySRV = ( m_HistoryValid && !m_FirstFrame )
+        ? m_HistoryBuffer[readIdx]->GetShaderResView().Get()
+        : renderTarget.GetShaderResView().Get();
 
-    // Bind textures:
-    // t0: Current frame
-    // t1: History buffer
-    // t2: Depth buffer
-    // t3: Velocity buffer
-    ID3D11ShaderResourceView* srvs[4] = {
-        tempBuffer->GetShaderResView().Get(),
-        m_FirstFrame ? renderTarget.GetShaderResView().Get() : m_HistoryBuffer->GetShaderResView().Get(),
-        depthSRV.Get(),
-        velocitySRV.Get()
+    ID3D11ShaderResourceView* srvs[5] = {
+        renderTarget.GetShaderResView().Get(),   // t0: scene colour (this frame)
+        readHistorySRV,                          // t1: history (previous frame, or a harmless substitute)
+        velocitySRV.Get(),                       // t2: RG16F motion vectors
+        depthSRV.Get(),                          // t3: depth (this frame)
+        m_PrevDepthValid ? m_PrevDepthBuffer->GetShaderResView().Get() : depthSRV.Get(), // t4: depth (previous)
     };
-    context->PSSetShaderResources(0, 4, srvs);
-    
-    // Bind samplers
-    context->PSSetSamplers( 0, 1, m_samplerLinear.GetAddressOf() );
-    context->PSSetSamplers( 1, 1, m_samplerPoint.GetAddressOf() );
+    context->CSSetShaderResources( 0, 5, srvs );
 
-    // Draw fullscreen quad
-    FxRenderer->DrawFullScreenQuad();
-    
-    // Copy output to history buffer for next frame
-    context->CopyResource(m_HistoryBuffer->GetTexture().Get(), 
-                          renderTarget.GetTexture().Get());
+    ID3D11SamplerState* samplers[2] = { m_samplerLinear.Get(), m_samplerPoint.Get() };
+    context->CSSetSamplers( 0, 2, samplers );
 
-    // Cleanup shader resources
-    ID3D11ShaderResourceView* nullSRVs[4] = { nullptr, nullptr, nullptr, nullptr };
-    context->PSSetShaderResources( 0, 4, nullSRVs );
+    context->CSSetUnorderedAccessViews( 0, 1, m_HistoryBuffer[writeIdx]->GetUnorderedAccessView().GetAddressOf(), nullptr );
 
-    // Restore original render targets
-    context->OMSetRenderTargets(1, oldRTV.GetAddressOf(), oldDSV.Get());
-    
+    context->Dispatch( ( m_Width + 7 ) / 8, ( m_Height + 7 ) / 8, 1 );
+
+    // Unbind: the write target becomes a CopyResource source next, and the read SRVs may be rebound elsewhere.
+    ID3D11UnorderedAccessView* nullUAV = nullptr;
+    context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
+    ID3D11ShaderResourceView* nullSRVs[5] = { nullptr, nullptr, nullptr, nullptr, nullptr };
+    context->CSSetShaderResources( 0, 5, nullSRVs );
+    context->CSSetShader( nullptr, nullptr, 0 );
+
+    // Hand the result back to the scene colour for bloom/tonemap. Both are the backbuffer format, so this is a
+    // straight CopyResource; nothing downstream reads scene-colour alpha, which now carries the TAA confidence
+    // weight instead.
+    context->CopyResource( renderTarget.GetTexture().Get(), m_HistoryBuffer[writeIdx]->GetTexture().Get() );
+
+    // Snapshot this frame's depth for the NEXT frame's disocclusion test. Must be our own copy rather than
+    // DepthStencilBufferCopy: that buffer is refilled with THIS frame's depth later in the frame (for
+    // upscaling), so by the time next frame's TAA runs it no longer holds what TAA needs.
+    Microsoft::WRL::ComPtr<ID3D11Resource> depthResource;
+    depthSRV->GetResource( depthResource.GetAddressOf() );
+    context->CopyResource( m_PrevDepthBuffer->GetTexture().Get(), depthResource.Get() );
+    m_PrevDepthValid = true;
+
+    context->OMSetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.Get() );
+
+    m_HistoryIndex = readIdx;   // ping-pong
+    m_HistoryValid = true;
     m_FirstFrame = false;
 }

--- a/D3D11Engine/D3D11PFX_TAA.h
+++ b/D3D11Engine/D3D11PFX_TAA.h
@@ -4,19 +4,23 @@
 
 struct RenderToTextureBuffer;
 
-// TAA Constant buffer structure
+// Constant buffer for the Intel Graphics Optimized TAA resolve (CS_PFX_TAAResolve.hlsl). Mirrors the D3D12
+// backend's TaaConstants (D3D12Taa.cpp) minus the bindless *Index fields, which D3D11 doesn't need since every
+// texture is bound to a fixed register instead.
 #pragma pack (push, 1)
-struct TAAConstantBuffer {
-    XMFLOAT4X4 InvViewProj;
+struct TAAResolveConstantBuffer {
+    XMFLOAT4X4 InvUnjitteredViewProj;
     XMFLOAT4X4 PrevViewProj;
-    XMFLOAT2 JitterOffset;
-    XMFLOAT2 Resolution;
-    float BlendFactor;      // 0.0 = all history, 1.0 = all current
-    float MotionScale;
-    XMFLOAT2 Padding;
+    XMFLOAT4 Resolution;        // width, height, 1/width, 1/height
+    XMFLOAT4 JitterTolerance;   // jitter.xy (pixels), DepthTolerance, unused
+    uint32_t FrameNumber;
+    uint32_t DebugFlags;
+    uint32_t HistoryValid;
+    uint32_t Padding;
 };
 
-// Velocity buffer constant buffer
+// Velocity buffer constant buffer (unchanged: still used by the camera-reconstructed fallback path in
+// RenderVelocityBuffer, which is only exercised when DebugSettings.TAA.DepthMotionVectors forces it).
 struct VelocityBufferConstantBuffer {
     XMFLOAT4X4 InvViewProj;      // Current frame's unjittered inverse view-projection
     XMFLOAT4X4 PrevViewProj;     // Previous frame's unjittered view-projection
@@ -38,7 +42,7 @@ public:
     /** Called on resize */
     void OnResize(const INT2& size);
 
-    /** Renders the TAA effect */
+    /** Renders the TAA effect (Intel Graphics Optimized TAA resolve, compute-dispatched) */
     void RenderPostFX(
         RenderToTextureBuffer& renderTarget,
         const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& depthSRV,
@@ -49,14 +53,14 @@ public:
 
     /** jitter in -0.5 to 0.5 range */
     XMFLOAT2 GetJitterOffsetUnscaled() const { return m_CurrentJitterUnscaled; }
-    
+
     /** Advances to next jitter sample */
     void AdvanceJitter();
 
-    /** Generates the velocity buffer from depth */
+    /** Generates the velocity buffer from depth (fallback path, see DepthMotionVectors) */
     void RenderVelocityBuffer(
         const Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>& depthSRV);
-    
+
     /** Gets the velocity buffer SRV */
     Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> GetVelocityBufferSRV() const;
 
@@ -71,13 +75,22 @@ public:
     void ReleaseResources();
 
 private:
-    // History buffer (previous frame's AA'd result)
-    std::unique_ptr<RenderToTextureBuffer> m_HistoryBuffer;
-    
-    // Velocity buffer (screen-space motion vectors)
+    // History ping-pong (previous frame's AA'd result, .a = accumulated confidence weight in [0.5, 1)). Two
+    // buffers because the resolve reads last frame's history while writing this frame's, and both must exist
+    // simultaneously (no in-place UAV read-modify-write of a texture being sampled elsewhere).
+    std::unique_ptr<RenderToTextureBuffer> m_HistoryBuffer[2];
+    UINT m_HistoryIndex = 0;
+    bool m_HistoryValid = false;
+
+    // Private previous-depth snapshot. Cannot borrow the engine's DepthStencilBufferCopy: that buffer is
+    // refilled with THIS frame's depth later in the same frame (for upscaling), so by the time next frame's
+    // TAA runs it would no longer hold what TAA needs. Snapshotted at the end of RenderPostFX instead.
+    std::unique_ptr<RenderToTextureBuffer> m_PrevDepthBuffer;
+    bool m_PrevDepthValid = false;
+
+    // Velocity buffer (screen-space motion vectors) — only used by the camera-reconstructed fallback path.
     std::unique_ptr<RenderToTextureBuffer> m_VelocityBuffer;
-    
-    
+
     Microsoft::WRL::ComPtr<ID3D11SamplerState>       m_samplerLinear;
     Microsoft::WRL::ComPtr<ID3D11SamplerState>       m_samplerPoint;
 
@@ -85,14 +98,15 @@ private:
     XMFLOAT2 m_CurrentJitter;
     XMFLOAT2 m_CurrentJitterUnscaled;
     XMFLOAT2 m_PreviousJitter;
-    
+    uint32_t m_FrameNumber = 0;
+
     // Previous frame matrices for reprojection
     XMFLOAT4X4 m_PrevViewProj;
     XMFLOAT4X4 m_UnjitteredViewProj;
-    
+
     // Previous camera position for motion vector calculation
     XMFLOAT3 m_PrevCameraPosition;
-    
+
     int m_Width;
     int m_Height;
     bool m_FirstFrame;

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -137,6 +137,7 @@ void D3D11PointLight::ReleaseShadowMap() {
     ReleaseStaticAsideShadowMap();
     m_CurrentResolution = 0;
     DrawnOnce = false;
+    m_HasDynamicOverlay = false;
 
 }
 
@@ -148,6 +149,7 @@ void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target
     StartReInit();
     DrawnOnce = false;
     m_StaticShadowReady = false;
+    m_HasDynamicOverlay = false;
 }
 
 void D3D11PointLight::ClearTiledSlot() {
@@ -158,7 +160,7 @@ void D3D11PointLight::ClearTiledSlot() {
     m_TiledDepthTarget = nullptr;
     m_TiledOwner = nullptr;
     m_StaticShadowReady = false;
-
+    m_HasDynamicOverlay = false;
 }
 
 int D3D11PointLight::GetCurrentShadowMode() const {
@@ -179,6 +181,7 @@ void D3D11PointLight::HandleShadowModeChange( int shadowMode ) {
     m_LastShadowMode = shadowMode;
     m_StaticShadowReady = false;
     DrawnOnce = false;
+    m_HasDynamicOverlay = false;
 
     if ( shadowMode != GothicRendererSettings::PLS_UPDATE_DYNAMIC ) {
         ReleaseStaticAsideShadowMap();
@@ -342,8 +345,12 @@ bool D3D11PointLight::NeedsUpdate() {
         return false;
 
     const int shadowMode = GetCurrentShadowMode();
+    // Report the pending mode switch, but do NOT latch it here. HandleShadowModeChange() is what acts on the
+    // transition (drops the cached static depth and the dynamic overlay), and it only runs once RenderCubemap()
+    // is actually called - which is *after* DrawPointlightShadows() has asked us this question. Consuming
+    // m_LastShadowMode here made that handler a no-op, so a light toggled to static kept advertising its
+    // frozen overlay and burned that NPC into the shadow permanently.
     if ( shadowMode != m_LastShadowMode ) {
-        m_LastShadowMode = shadowMode;
         return shadowMode > 0;
     }
 
@@ -404,6 +411,7 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate ) {
         // Invalidate worldcache
         WorldCacheInvalid = true;
         m_StaticShadowReady = false;
+        m_HasDynamicOverlay = false;
     }
 
     if ( shadowMode == GothicRendererSettings::PLS_STATIC_ONLY && !moved && m_StaticShadowReady && DrawnOnce ) {
@@ -506,6 +514,33 @@ void D3D11PointLight::RenderFullCubemap() {
     }
 
     if ( shadowMode == GothicRendererSettings::PLS_UPDATE_DYNAMIC ) {
+        // Tiled path: static depth stays resident in this slot of the main cube array and is only re-rendered
+        // when the light moves, while the moving casters go into the SAME slot of the dynamic-overlay array.
+        // The shader min's the two, which reproduces the old composited cube without the per-update 6-face
+        // CopySubresourceRegion (and without the per-light aside cube that fed it).
+        if ( m_TiledSlotIndex >= 0 && m_TiledOwner ) {
+            if ( RenderToDepthStencilBuffer* dynTarget = m_TiledOwner->GetDynSlotTarget( m_TiledSlotIndex ) ) {
+                // Nothing composites out of the aside cube on this path, so give its slab back to the pool if
+                // this light still holds one from the fallback path. Its clearing of m_StaticShadowReady is
+                // wanted, not incidental: the active slot would still hold the fallback path's COMPOSITED
+                // depth, so keeping it would bake that update's NPC in as a permanent static shadow.
+                if ( m_StaticDepthCubemap ) {
+                    ReleaseStaticAsideShadowMap();
+                }
+
+                if ( !m_StaticShadowReady ) {
+                    RenderStaticShadowPass( *activeTarget, true );
+                    m_StaticShadowReady = true;
+                }
+
+                // Clear: the overlay must hold ONLY this update's movers, never the previous one's.
+                RenderAnimatedShadowPass( *dynTarget, true );
+                m_HasDynamicOverlay = true;
+                return;
+            }
+            // Overlay array unavailable - fall through to the composited single-cube path below.
+        }
+
         DepthStencilPool* dsPool = engine->GetPfxRenderer()->GetDepthStencilPool();
         AcquireStaticAsideShadowMap( dsPool, m_CurrentResolution );
 
@@ -557,6 +592,7 @@ bool D3D11PointLight::IsReady()
 void D3D11PointLight::Invalidate() {
     DrawnOnce = false;
     m_StaticShadowReady = false;
+    m_HasDynamicOverlay = false;
     VobCache.clear();
     SkeletalVobCache.clear();
     WorldCacheInvalid = true;
@@ -648,6 +684,7 @@ void D3D11PointLight::OnVobRemovedFromWorld( BaseVobInfo* vob ) {
         SkeletalVobCache.clear();
         DrawnOnce = false;
         m_StaticShadowReady = false;
+        m_HasDynamicOverlay = false;
     }
 
     if (vob->Vob == LightInfo->Vob) {

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -52,6 +52,16 @@ public:
         return m_StaticShadowReady;
     }
 
+    /** True when this light's tiled slot in the dynamic-overlay cube array holds a valid, already-rendered set
+        of moving casters. Drives SHADOW_CUBE_HAS_DYNAMIC, i.e. whether the shader takes the second sample.
+        Only PLS_UPDATE_DYNAMIC ever refreshes that overlay, so the mode is re-checked here rather than trusted
+        to have been cleared: any other mode would otherwise keep sampling whatever the last update left in the
+        slot, freezing that NPC into the shadow. */
+    bool HasDynamicShadowOverlay() const {
+        return m_HasDynamicOverlay
+            && GetCurrentShadowMode() == GothicRendererSettings::PLS_UPDATE_DYNAMIC;
+    }
+
     bool HasShadowMap(int shadowMapKind ) const { 
         if ( shadowMapKind == 0 ) return m_DepthCubemap != nullptr;
         return m_TiledDepthTarget != nullptr;
@@ -104,6 +114,10 @@ protected:
     std::atomic<bool> InitDone;
     bool DrawnOnce;
     bool m_StaticShadowReady = false;
+    /** Set once the animated pass has rendered into this light's slot of the dynamic-overlay array; cleared
+        whenever the slot changes hands or the light's caches are invalidated, so we never advertise an
+        overlay that still holds another light's (or a stale) depth. */
+    bool m_HasDynamicOverlay = false;
     int m_LastShadowMode = -1;
 
     // Tiled deferred slot (non-owning, owned by D3D11TiledDeferredShading)

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1053,10 +1053,29 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
         }
     }
 
-    // Render the immediate priority lights
+    // Render the immediate priority lights - but never more than a handful in one frame.
+    //
+    // A global shadow-mode toggle dirties EVERY light at once. Each rebuild allocates its cubemap
+    // view-matrix CB from the 4 MB per-frame ring and keeps it bound at VS b3 / GS b2 across every draw of
+    // both its passes, while those draws keep allocating from that same ring. Once the ring wraps
+    // (ConstantBufferPool.cpp:61 resets the offset to 0 and overwrites in place) the earlier lights' view
+    // matrices are replaced mid-frame, so their cubes finish rendering with another light's projection -
+    // which shows up as point-light shadows randomly cut off along a cube-face edge, on a different set of
+    // lights every time. Overflow keeps its UpdateShadows flag and drains through the round-robin below.
+    constexpr int maxImportantUpdates = 8;
+    int importantDone = 0;
     for ( auto const& importantUpdate : importantUpdates ) {
+        if ( importantDone >= maxImportantUpdates ) {
+            auto& queue = graphicsEngine->FrameShadowUpdateLights;
+            if ( std::find( queue.begin(), queue.end(), importantUpdate ) == queue.end() ) {
+                queue.emplace_back( importantUpdate );
+            }
+            continue;
+        }
+
         static_cast<D3D11PointLight*>(importantUpdate->LightShadowBuffers.get())->RenderCubemap( importantUpdate->UpdateShadows );
         importantUpdate->UpdateShadows = false;
+        importantDone++;
     }
 
     // Process Background Queue (Round-Robin)

--- a/D3D11Engine/D3D11Texture.cpp
+++ b/D3D11Engine/D3D11Texture.cpp
@@ -309,7 +309,7 @@ XRESULT D3D11Texture::UpdateDataDeferred( void* data, int mip ) {
         return XR_FAILED;
     ::SetDebugName( stagingTexture.Get(), "D3D11Texture->UpdateDataDeferred->stagingTexture" );
 
-    Engine::GAPI->AddStagingTexture( mip, stagingTexture, destination );
+    Engine::GAPI->AddStagingTexture( this, mip, stagingTexture, destination );
     return XR_SUCCESS;
 }
 

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -116,6 +116,66 @@ void D3D11TiledDeferredShading::EnsureShadowArray() {
     }
 }
 
+void D3D11TiledDeferredShading::EnsureDynShadowArray() {
+    if ( m_ShadowDynArrayCreated ) return;
+    m_ShadowDynArrayCreated = true;
+
+    // Same shape and slot indexing as m_ShadowCubeArray - the shader addresses both with one slot index.
+    D3D11_TEXTURE2D_DESC desc = {};
+    desc.Width = SHADOW_CUBE_SIZE;
+    desc.Height = SHADOW_CUBE_SIZE;
+    desc.MipLevels = 1;
+    desc.ArraySize = MAX_SHADOW_CUBEMAPS * 6;
+    desc.Format = DXGI_FORMAT_R16_TYPELESS;
+    desc.SampleDesc.Count = 1;
+    desc.Usage = D3D11_USAGE_DEFAULT;
+    desc.BindFlags = D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE;
+    desc.MiscFlags = D3D11_RESOURCE_MISC_TEXTURECUBE;
+
+    // Unlike the main array this one can be declined without losing shadows entirely: GetDynSlotTarget()
+    // then returns null and the lights fall back to the composited single-cube path. Failing quietly would
+    // be much worse - a null SRV reads as 0, i.e. every light carrying the flag goes fully shadowed.
+    if ( FAILED( m_device->CreateTexture2D( &desc, nullptr, m_ShadowDynCubeArray.ReleaseAndGetAddressOf() ) ) ) {
+        LogWarn() << "Failed to create the point-light dynamic shadow overlay array; falling back to the "
+            "composited static+dynamic cube path.";
+        m_ShadowDynCubeArray.Reset();
+        return;
+    }
+    SetDebugName( m_ShadowDynCubeArray.Get(), "TiledDeferred_ShadowDynCubeArray" );
+
+    // 32-bit address space is scarce, so log what this costs (SHADOW_CUBE_SIZE^2 * 2 bytes * 6 faces * slots).
+    LogInfo() << "Allocated point-light dynamic shadow overlay array: " << MAX_SHADOW_CUBEMAPS << " cubes @ "
+        << SHADOW_CUBE_SIZE << "^2 R16 ("
+        << ( static_cast<size_t>(SHADOW_CUBE_SIZE) * SHADOW_CUBE_SIZE * 2 * 6 * MAX_SHADOW_CUBEMAPS ) / (1024 * 1024 )
+        << " MB)";
+
+    D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+    srvDesc.Format = DXGI_FORMAT_R16_UNORM;
+    srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBEARRAY;
+    srvDesc.TextureCubeArray.MostDetailedMip = 0;
+    srvDesc.TextureCubeArray.MipLevels = 1;
+    srvDesc.TextureCubeArray.First2DArrayFace = 0;
+    srvDesc.TextureCubeArray.NumCubes = MAX_SHADOW_CUBEMAPS;
+
+    m_device->CreateShaderResourceView( m_ShadowDynCubeArray.Get(), &srvDesc, m_ShadowDynCubeArraySRV.ReleaseAndGetAddressOf() );
+    SetDebugName( m_ShadowDynCubeArraySRV.Get(), "TiledDeferred_ShadowDynCubeArray_SRV" );
+
+    for ( uint32_t slot = 0; slot < MAX_SHADOW_CUBEMAPS; slot++ ) {
+        D3D11_DEPTH_STENCIL_VIEW_DESC dsvDesc = {};
+        dsvDesc.Format = DXGI_FORMAT_D16_UNORM;
+        dsvDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
+        dsvDesc.Texture2DArray.FirstArraySlice = slot * 6;
+        dsvDesc.Texture2DArray.ArraySize = 6;
+        dsvDesc.Texture2DArray.MipSlice = 0;
+
+        m_device->CreateDepthStencilView( m_ShadowDynCubeArray.Get(), &dsvDesc, m_SlotDynDSVs[slot].ReleaseAndGetAddressOf() );
+
+        m_SlotDynViews[slot] = std::make_unique<RenderToDepthStencilBuffer>(
+            m_ShadowDynCubeArray, m_SlotDynDSVs[slot], nullptr,
+            SHADOW_CUBE_SIZE, SHADOW_CUBE_SIZE );
+    }
+}
+
 int D3D11TiledDeferredShading::AllocateSlot() {
     EnsureShadowArray();
     for ( uint32_t i = 0; i < MAX_SHADOW_CUBEMAPS; i++ ) {
@@ -136,6 +196,13 @@ RenderToDepthStencilBuffer* D3D11TiledDeferredShading::GetSlotTarget( int slot )
     if ( slot >= 0 && static_cast<uint32_t>(slot) < MAX_SHADOW_CUBEMAPS && m_ShadowArrayCreated )
         return m_SlotViews[slot].get();
     return nullptr;
+}
+
+RenderToDepthStencilBuffer* D3D11TiledDeferredShading::GetDynSlotTarget( int slot ) {
+    if ( slot < 0 || static_cast<uint32_t>(slot) >= MAX_SHADOW_CUBEMAPS )
+        return nullptr;
+    EnsureDynShadowArray();
+    return m_SlotDynViews[slot].get();
 }
 
 void D3D11TiledDeferredShading::EnsureBuffers( uint32_t numTilesX, uint32_t numTilesY ) {
@@ -270,9 +337,12 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
         // even if the shader branches around SampleCmpLevelZero
         graphicsEngine->GetShadowMaps()->BindSamplerToCS( context.Get(), 2 );
 
-        // Bind shadow cubemap array SRV
+        // Bind shadow cubemap array SRVs (static at t11, dynamic overlay at t12). The overlay array may not
+        // exist yet - a null SRV is fine, no light can carry SHADOW_CUBE_HAS_DYNAMIC before it is created.
         if ( cullResult.HasShadowedTiledLights && m_ShadowArrayCreated ) {
             context->CSSetShaderResources( 11, 1, m_ShadowCubeArraySRV.GetAddressOf() );
+            ID3D11ShaderResourceView* dynSRV = m_ShadowDynArrayCreated ? m_ShadowDynCubeArraySRV.Get() : nullptr;
+            context->CSSetShaderResources( 12, 1, &dynSRV );
         }
 
         // Bind HDR UAV
@@ -284,8 +354,8 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
         // Unbind everything
         ID3D11UnorderedAccessView* nullUAV = nullptr;
         context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
-        ID3D11ShaderResourceView* nullSRVs[12] = {};
-        context->CSSetShaderResources( 0, 12, nullSRVs );
+        ID3D11ShaderResourceView* nullSRVs[13] = {};
+        context->CSSetShaderResources( 0, 13, nullSRVs ); // t0-t12, incl. both shadow cube arrays
         context->CSSetShader( nullptr, nullptr, 0 );
 
         // Restore HDR as RTV
@@ -397,7 +467,10 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
         tl.PositionWorld = XMFLOAT3( posWorld.x, posWorld.y, posWorld.z );
 
         if ( hasShadow ) {
-            tl.ShadowCubeIndex = pl->GetTiledSlot();
+            // The slot's static depth lives in the main array; flag the ones that also have this frame's
+            // skeletal overlay in the dynamic array so the shader knows to take the second sample.
+            tl.ShadowCubeIndex = pl->GetTiledSlot()
+                | ( pl->HasDynamicShadowOverlay() ? SHADOW_CUBE_HAS_DYNAMIC : 0 );
             hasShadowedTiledLights = true;
         } else {
             tl.ShadowCubeIndex = -1;

--- a/D3D11Engine/D3D11TiledDeferredShading.h
+++ b/D3D11Engine/D3D11TiledDeferredShading.h
@@ -16,12 +16,19 @@ constexpr uint32_t MAX_TILED_LIGHTS = 400;
 constexpr uint32_t MAX_SHADOW_CUBEMAPS = 128;
 constexpr uint32_t SHADOW_CUBE_SIZE = 128; // Must match POINTLIGHT_SHADOWMAP_SIZE
 
+// ShadowCubeIndex encoding: -1 = unshadowed, else (slot | flags). Bit 30 marks that the slot also has a valid
+// dynamic (skeletal overlay) cube in the second array, which the shader samples and min's with the static one.
+// Keeping the flag in bit 30 leaves the value positive, so "ShadowCubeIndex >= 0" still means shadowed.
+// Mirrors PLS_SHADOW_HAS_DYNAMIC / PLS_SHADOW_SLOT_MASK in Shaders/include/PointLightShadows.h.
+constexpr int32_t SHADOW_CUBE_HAS_DYNAMIC = 0x40000000;
+constexpr int32_t SHADOW_CUBE_SLOT_MASK = 0x3FFFFFFF;
+
 struct TiledPointLight {
     DirectX::XMFLOAT3 PositionView;
     float Range;
     DirectX::XMFLOAT4 Color;
     DirectX::XMFLOAT3 PositionWorld;
-    int32_t ShadowCubeIndex; // -1 = no shadow, else index into TextureCubeArray
+    int32_t ShadowCubeIndex; // -1 = no shadow, else (slot | SHADOW_CUBE_HAS_DYNAMIC)
 };
 
 struct LightGrid {
@@ -60,15 +67,21 @@ public:
     ID3D11ShaderResourceView* GetLightIndexListSRV() const { return m_LightIndexListSRV.Get(); }
     ID3D11ShaderResourceView* GetShadowCubeArraySRV() const { return m_ShadowCubeArraySRV.Get(); }
     bool IsShadowArrayCreated() const { return m_ShadowArrayCreated; }
+    ID3D11ShaderResourceView* GetShadowDynCubeArraySRV() const { return m_ShadowDynCubeArraySRV.Get(); }
+    bool IsDynShadowArrayCreated() const { return m_ShadowDynArrayCreated; }
 
     // Shadow cubemap array slot management
     int AllocateSlot();
     void FreeSlot( int slot );
     RenderToDepthStencilBuffer* GetSlotTarget( int slot );
+    /** Same slot index as GetSlotTarget, but into the dynamic-overlay array. Creates that array on first use,
+        so worlds that never render a moving caster into a point-light cube never pay for it. */
+    RenderToDepthStencilBuffer* GetDynSlotTarget( int slot );
 
 private:
     void EnsureBuffers( uint32_t numTilesX, uint32_t numTilesY );
     void EnsureShadowArray();
+    void EnsureDynShadowArray();
 
     Microsoft::WRL::ComPtr<ID3D11Device1> m_device;
     Microsoft::WRL::ComPtr<ID3D11DeviceContext1> m_context;
@@ -98,6 +111,16 @@ private:
     std::array<Microsoft::WRL::ComPtr<ID3D11DepthStencilView>, MAX_SHADOW_CUBEMAPS> m_SlotDSVs;
     std::array<std::unique_ptr<RenderToDepthStencilBuffer>, MAX_SHADOW_CUBEMAPS> m_SlotViews;
     bool m_ShadowArrayCreated = false;
+
+    // Dynamic-overlay cube array: a second, identically-indexed array holding ONLY the moving (skeletal)
+    // casters of a slot. It exists so the static depth can stay resident in m_ShadowCubeArray instead of being
+    // re-composited every update via a 6-face CopySubresourceRegion out of a per-light aside cube. Lazily
+    // created - only PLS_UPDATE_DYNAMIC ever renders into it.
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> m_ShadowDynCubeArray;
+    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_ShadowDynCubeArraySRV;
+    std::array<Microsoft::WRL::ComPtr<ID3D11DepthStencilView>, MAX_SHADOW_CUBEMAPS> m_SlotDynDSVs;
+    std::array<std::unique_ptr<RenderToDepthStencilBuffer>, MAX_SHADOW_CUBEMAPS> m_SlotDynViews;
+    bool m_ShadowDynArrayCreated = false;
 
     uint32_t m_lastNumTilesX = 0;
     uint32_t m_lastNumTilesY = 0;

--- a/D3D11Engine/D3D12Engine/D3D12AO.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12AO.cpp
@@ -1,17 +1,21 @@
 // D3D12GraphicsEngine — the AO entry point plus the simple screen-space AO ("SAO"). Intel XeGTAO, which is
-// what AoMode == AO_ASSAO selects on this backend, lives in D3D12GTAO.cpp and shares this file's m_PrevDepth
-// input, m_AOMask output and reprojection constants.
-// Simple SSAO ("SAO", plan item #4). Forward+ has no GBuffer normals before
-// lighting, so the main compute pass reconstructs view-space normals from neighbouring depth samples (mirrors
-// D3D11's CS_PFX_SAO.hlsl SAO_RECONSTRUCT_NORMALS fallback); a depth-aware separable blur denoises it
-// (mirrors CS_PFX_SAO_Blur.hlsl). See Shaders/D3D12/SSAO.hlsl for the shader source.
+// what AoMode == AO_ASSAO selects on this backend, lives in D3D12GTAO.cpp and shares this file's depth input,
+// m_AOMask output and m_ActiveAOMaskSrvSlot publication.
+// Simple SSAO ("SAO", plan item #4): the main compute pass reconstructs view-space normals from neighbouring
+// depth samples (mirrors D3D11's CS_PFX_SAO.hlsl SAO_RECONSTRUCT_NORMALS fallback); a depth-aware separable
+// blur denoises it (mirrors CS_PFX_SAO_Blur.hlsl). See Shaders/D3D12/SSAO.hlsl for the shader source.
 //
-// The AO source is the PREVIOUS frame's COMPLETE depth buffer (m_PrevDepth, snapshotted by CopyDepthForAO at
-// the end of world rendering), not this frame's depth prepass. The prepass only lays down world + instanced
-// VOBs + skeletal, so grass/foliage and the other late depth writers were both invisible to the AO *and*
-// wrongly lit by the mask of whatever sat behind them. A full-frame snapshot costs one depth-sized copy and
-// buys AO that includes every depth writer, at the price of being one frame stale — which the lit pixel
-// shaders undo by reprojecting per-pixel through m_PrevDepthViewProj (see include/ScreenSpaceAO.hlsl).
+// The AO source is THIS frame's depth buffer as the Forward+ DEPTH PREPASS left it — world mesh, instanced
+// VOBs, skeletals + node attachments and (range-limited) vegetation. RenderSSAO runs immediately after the
+// prepass and before any lit pass, so the mask it produces is already in this frame's screen space: the lit
+// pixel shaders read it at their own pixel with no reprojection (see include/ScreenSpaceAO.hlsl).
+//
+// It used to run off a full-frame COPY of the PREVIOUS frame's COMPLETED depth, because grass was not in the
+// prepass and a grass pixel would otherwise sample the AO of the terrain behind it. Folding vegetation into
+// the prepass removed that reason, and with it the depth-sized allocation, the per-frame CopyResource, the
+// one-frame lag and the per-pixel reprojection in five pixel shaders. The remaining late depth writers (water,
+// decals, particles, the blended transparencies) are not AO occluders — they were only ever occluders in the
+// snapshot scheme by accident of running a frame behind.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
 #include "../Engine.h"
@@ -22,10 +26,11 @@ using Microsoft::WRL::ComPtr;
 
 bool D3D12GraphicsEngine::CreateAOResources( INT2 size ) {
     m_AOResourcesReady = false;
-    m_PrevDepthValid = false;   // the snapshot below is freshly (re)allocated garbage until CopyDepthForAO runs
     if ( size.x < 4 || size.y < 4 || !m_DepthBuffer ) return false;
     ID3D12Device* device = m_Device.GetDevice();
     if ( !device ) return false;
+    // The blur pairs below alias m_DepthSrvSlot's view, so the depth buffer's own SRV must already exist.
+    if ( m_DepthSrvSlot == UINT_MAX ) return false;
 
     D3D12MA::ALLOCATION_DESC heapDefault = {};
     heapDefault.HeapType = D3D12_HEAP_TYPE_DEFAULT;
@@ -58,37 +63,12 @@ bool D3D12GraphicsEngine::CreateAOResources( INT2 size ) {
     if ( !makeTex( m_AOMask, m_AOMaskAlloc, L"AOMask" ) ) return false;
     if ( !makeTex( m_AOBlurTemp, m_AOBlurTempAlloc, L"AOBlurTemp" ) ) return false;
 
-    // Previous-frame depth snapshot. Deliberately created with the SAME resource desc as m_DepthBuffer
-    // (R32_TYPELESS + ALLOW_DEPTH_STENCIL, matching CreateDepthBuffer) so CopyResource is unambiguously legal:
-    // it requires identical dimensions/format, and matching the flags too costs nothing here.
-    {
-        D3D12_RESOURCE_DESC dd = {};
-        dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-        dd.Width = static_cast<UINT64>( size.x );
-        dd.Height = static_cast<UINT>( size.y );
-        dd.DepthOrArraySize = 1;
-        dd.MipLevels = 1;
-        dd.Format = DXGI_FORMAT_R32_TYPELESS;
-        dd.SampleDesc.Count = 1;
-        dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
-        dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
-        D3D12_CLEAR_VALUE clear = {};
-        clear.Format = DXGI_FORMAT_D32_FLOAT;
-        clear.DepthStencil.Depth = 0.0f;   // reversed-Z, same optimized clear as the real depth buffer
-        if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, kPrevDepthReadState, &clear,
-            m_PrevDepthAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( m_PrevDepth.ReleaseAndGetAddressOf() ) ) ) ) {
-            LogWarn() << "D3D12: failed to create the previous-frame depth copy (" << size.x << "x" << size.y << ").";
-            return false;
-        }
-        m_PrevDepth->SetName( L"PrevFrameDepth(AO)" );
-    }
-
     auto ensureSlot = [&]( UINT& slot ) -> bool {
         if ( slot == UINT_MAX ) slot = AllocateSrvSlot();
         return slot != UINT_MAX;
         };
     if ( !ensureSlot( m_AOMaskSrvSlot ) || !ensureSlot( m_AOMaskUavSlot ) || !ensureSlot( m_AOMaskUintUavSlot )
-        || !ensureSlot( m_AOBlurTempUavSlot ) || !ensureSlot( m_PrevDepthSrvSlot ) )
+        || !ensureSlot( m_AOBlurTempUavSlot ) )
         return false;
     // 2 contiguous slots per blur direction (see the header comment on m_AOBlurHPairSlot/m_AOBlurVPairSlot).
     if ( m_AOBlurHPairSlot == UINT_MAX ) {
@@ -122,107 +102,56 @@ bool D3D12GraphicsEngine::CreateAOResources( INT2 size ) {
     uintUav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
     device->CreateUnorderedAccessView( m_AOMask.Get(), nullptr, &uintUav, GetSrvCpuHandle( m_AOMaskUintUavSlot ) );
 
-    // R32_FLOAT view of the typeless depth SNAPSHOT (same view shape CreateDepthBuffer builds for the live
-    // buffer). Read by the AO main+blur compute passes AND, bindlessly, by the lit pixel shaders' reprojection
-    // disocclusion test — hence it needs a stable heap slot of its own.
+    // R32_FLOAT view of the typeless LIVE depth buffer — a private copy of what m_DepthSrvSlot holds, because
+    // the blur passes bind (AO input, depth) as one 2-entry descriptor TABLE and those two must be heap-adjacent.
     D3D12_SHADER_RESOURCE_VIEW_DESC depthSrv = {};
     depthSrv.Format = DXGI_FORMAT_R32_FLOAT;
     depthSrv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
     depthSrv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
     depthSrv.Texture2D.MipLevels = 1;
-    device->CreateShaderResourceView( m_PrevDepth.Get(), &depthSrv, GetSrvCpuHandle( m_PrevDepthSrvSlot ) );
 
     device->CreateShaderResourceView( m_AOMask.Get(), &srv, GetSrvCpuHandle( m_AOBlurHPairSlot ) );
-    device->CreateShaderResourceView( m_PrevDepth.Get(), &depthSrv, GetSrvCpuHandle( m_AOBlurHPairSlot + 1 ) );
+    device->CreateShaderResourceView( m_DepthBuffer.Get(), &depthSrv, GetSrvCpuHandle( m_AOBlurHPairSlot + 1 ) );
     device->CreateShaderResourceView( m_AOBlurTemp.Get(), &srv, GetSrvCpuHandle( m_AOBlurVPairSlot ) );
-    device->CreateShaderResourceView( m_PrevDepth.Get(), &depthSrv, GetSrvCpuHandle( m_AOBlurVPairSlot + 1 ) );
+    device->CreateShaderResourceView( m_DepthBuffer.Get(), &depthSrv, GetSrvCpuHandle( m_AOBlurVPairSlot + 1 ) );
 
     m_AOMaskInPixelState = false;   // freshly (re)created above, born in UNORDERED_ACCESS
     m_AOResourcesReady = true;
     return true;
 }
 
-void D3D12GraphicsEngine::CopyDepthForAO() {
-    // End of world rendering: snapshot the COMPLETE depth buffer (world, VOBs, skeletal, grass, decals, water —
-    // everything that wrote depth this frame) for the NEXT frame's AO pass, together with the camera that
-    // produced it. Must run after the last depth-writing pass and before RenderFogAndGodRays, which is the
-    // first thing to move the depth buffer out of DEPTH_WRITE.
-    if ( !m_FrameOpen || !m_DepthBuffer || !m_PrevDepth ) return;
-
-    // AO off -> don't pay for a full-res depth copy every frame. Invalidate too, so re-enabling AO can't
-    // reproject through whatever camera happened to be current when it was switched off.
-    if ( Engine::GAPI->GetRendererState().RendererSettings.AoMode == AOMode::AO_NONE ) {
-        m_PrevDepthValid = false;
-        return;
-    }
-
-    DX_ZONE( m_CmdList, "Copy depth for AO" );
-
-    D3D12_RESOURCE_BARRIER pre[2] = {
-        TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_COPY_SOURCE ),
-        TransitionBarrier( m_PrevDepth.Get(), kPrevDepthReadState, D3D12_RESOURCE_STATE_COPY_DEST ),
-    };
-    m_CmdList->ResourceBarrier( 2, pre );
-
-    m_CmdList->CopyResource( m_PrevDepth.Get(), m_DepthBuffer.Get() );
-
-    D3D12_RESOURCE_BARRIER post[2] = {
-        TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE ),
-        TransitionBarrier( m_PrevDepth.Get(), D3D12_RESOURCE_STATE_COPY_DEST, kPrevDepthReadState ),
-    };
-    m_CmdList->ResourceBarrier( 2, post );
-
-    // Capture the camera that rendered these texels. Rebuilt exactly like DrawWorldMesh does (proj * view,
-    // identity world) — every geometry pass in this frame recomputed it identically, so this is the same
-    // matrix the depth above was rasterized with.
-    XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
-    Engine::GAPI->SetViewTransformXM( view );
-    Engine::GAPI->ResetWorldTransform();
-    const XMFLOAT4X4& viewM = Engine::GAPI->GetRendererState().TransformState.TransformView;
-    const XMFLOAT4X4& projM = Engine::GAPI->GetProjectionMatrix();
-    XMStoreFloat4x4( &m_PrevDepthViewProj, XMMatrixMultiply( XMLoadFloat4x4( &projM ), XMLoadFloat4x4( &viewM ) ) );
-    m_PrevDepthProj = projM;
-    m_PrevDepthValid = true;
-}
-
-void D3D12GraphicsEngine::UploadAoReprojConstants() {
-    // Publishes the reprojection block the lit World/Vob/Skeletal pixel shaders read out of the shadow CB they
-    // already bind. Written UNCONDITIONALLY every frame (including the "no valid snapshot" state) — a frame
-    // that skipped the write would reproject this frame's geometry through a stale camera.
+void D3D12GraphicsEngine::UploadAoScreenConstants() {
+    // The screen-space AO block of the shared shadow CB: 1/screen-size, which the lit pixel shaders multiply
+    // SV_Position by to get the mask UV. Written UNCONDITIONALLY every frame (AO on or off) — a frame that
+    // skipped it would sample through whatever resolution happened to be current when it was last written.
     // The writers of m_ShadowCB must tile exactly: D3D12ShadowMap::Prepare owns [0, kWetnessCbOffset),
-    // UploadWetnessConstants [kWetnessCbOffset, kAoReprojCbOffset), and this the rest (the CB is 512 bytes).
+    // UploadWetnessConstants [kWetnessCbOffset, kAoReprojCbOffset), this the next 80 bytes (of which only the
+    // first 8 are live) and UploadSkyIblConstants the rest. The CB is 512 bytes.
     static_assert( kWetnessCbOffset + sizeof( WetnessCBData ) == kAoReprojCbOffset,
-        "AO-reprojection CB block must start right after the wetness block" );
-    static_assert( kAoReprojCbOffset + sizeof( AoReprojCBData ) <= 512, "shadow CB overflow" );
+        "the AO screen block must start right after the wetness block" );
+    static_assert( sizeof( AoScreenCBData ) <= kAoReprojCbReservedBytes, "AO screen block overflows its slot" );
     if ( !m_ShadowCBMapped[m_FrameIndex] ) return;
 
-    AoReprojCBData cb = {};
-    const bool valid = m_PrevDepthValid && m_PrevDepth && m_PrevDepthSrvSlot != UINT_MAX;
-    cb.PrevViewProj = m_PrevDepthViewProj;
-    // Reversed-Z linearization terms of the snapshot's own projection (viewZ = ProjZY / (depth - ProjZX)),
-    // used by the disocclusion test to compare "where this pixel would have been" against what was stored.
-    cb.PrevProjZX = m_PrevDepthProj._33;
-    cb.PrevProjZY = m_PrevDepthProj._43;
-    // 0xFFFFFFFF is never dereferenced by the shader (ReprojValid gates it first), but keep it out of the
-    // valid-descriptor range regardless so a future reorder can't turn it into a wild bindless fetch.
-    cb.PrevDepthIndex = valid ? m_PrevDepthSrvSlot : 0xFFFFFFFFu;
-    cb.ReprojValid = valid ? 1.0f : 0.0f;
-
+    AoScreenCBData cb = {};
+    cb.InvResX = m_Resolution.x > 0 ? 1.0f / static_cast<float>( m_Resolution.x ) : 0.0f;
+    cb.InvResY = m_Resolution.y > 0 ? 1.0f / static_cast<float>( m_Resolution.y ) : 0.0f;
     memcpy( m_ShadowCBMapped[m_FrameIndex] + kAoReprojCbOffset, &cb, sizeof( cb ) );
 }
 
 void D3D12GraphicsEngine::RenderSSAO() {
-    // THE AO entry point. Called from OnStartWorldRendering right after DispatchLightCulling, before the lit
-    // geometry passes bind m_ActiveAOMaskSrvSlot. Reads m_PrevDepth (last frame's complete depth — see the file
-    // header), so unlike every other consumer of depth in this frame it needs NO barriers on the live
-    // m_DepthBuffer and does not serialise against the prepass.
+    // THE AO entry point. Called from OnStartWorldRendering right after the depth prepass (and the light cull),
+    // before the lit geometry passes bind m_ActiveAOMaskSrvSlot. Reads m_DepthBuffer, which at this point in
+    // the frame holds exactly the prepass content — see the file header.
     //
     // Two implementations write the same m_AOMask and are selected by AoMode:
     //   AO_ASSAO -> Intel XeGTAO (D3D12GTAO.cpp) — D3D12's replacement for D3D11's ASSAO port.
     //   anything else non-NONE -> the simple SSAO below. HBAO+ and SAO have no D3D12 port of their own, so both
     //   land here; that is unchanged behaviour.
-    m_ActiveAOMaskSrvSlot = m_WhiteTexture ? m_WhiteTexture->GetSrvSlot() : UINT_MAX;   // default: no occlusion
-    UploadAoReprojConstants();
+    //
+    // The mask defaults to the 1x1 white texture (no occlusion) so every consumer can read it unconditionally,
+    // including on frames where AO is off or bailed out below.
+    m_ActiveAOMaskSrvSlot = m_WhiteTexture ? m_WhiteTexture->GetSrvSlot() : UINT_MAX;
+    UploadAoScreenConstants();
 
     if ( Engine::GAPI->GetRendererState().RendererSettings.AoMode == AOMode::AO_NONE ) return;
 
@@ -233,12 +162,28 @@ void D3D12GraphicsEngine::RenderSSAO() {
     RenderSimpleSSAO();
 }
 
+void D3D12GraphicsEngine::BeginAoDepthRead() {
+    // The prepass left m_DepthBuffer in DEPTH_WRITE; the AO compute passes read it as an SRV. Same round-trip
+    // BuildHiZ does a few calls earlier — the DSV stays bound but nothing draws while it is in a read state.
+    auto b = TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE,
+        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+    m_CmdList->ResourceBarrier( 1, &b );
+}
+
+void D3D12GraphicsEngine::EndAoDepthRead() {
+    // Straight back to DEPTH_WRITE: the lit geometry passes right after this re-test (and re-write) depth, and
+    // every later transition of this resource asserts DEPTH_WRITE as its "before" state.
+    auto b = TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+        D3D12_RESOURCE_STATE_DEPTH_WRITE );
+    m_CmdList->ResourceBarrier( 1, &b );
+}
+
 void D3D12GraphicsEngine::RenderSimpleSSAO() {
     // The depth-reconstructed-normals Alchemy-AO estimate plus a separable depth-aware blur
     // (Shaders/D3D12/SSAO.hlsl). Callers go through RenderSSAO, which owns the mode selection and has already
-    // published the reprojection constants and the white-mask default.
+    // published the white-mask default.
     auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
-    if ( !m_FrameOpen || !m_AOResourcesReady || !m_PrevDepth || !m_PrevDepthValid
+    if ( !m_FrameOpen || !m_AOResourcesReady || !m_DepthBuffer || m_DepthSrvSlot == UINT_MAX
         || !m_Pipelines.AO.MainPSO || !m_Pipelines.AO.MainRootSig
         || !m_Pipelines.AO.BlurPSO || !m_Pipelines.AO.BlurRootSig )
         return;
@@ -246,14 +191,16 @@ void D3D12GraphicsEngine::RenderSimpleSSAO() {
     DX_ZONE( m_CmdList, "SSAO" );
 
     const auto& sao = settings.SaoSettings;
-    // The snapshot's OWN projection, not this frame's — the depth being unprojected here was rasterized with it.
-    const XMFLOAT4X4& projM = m_PrevDepthProj;
+    // This frame's projection — the same one the prepass depth below was rasterized with. Its _13/_23 carry the
+    // TAA jitter, which none of the terms used here read.
+    const XMFLOAT4X4& projM = Engine::GAPI->GetProjectionMatrix();
     const UINT gx = ( static_cast<UINT>( m_Resolution.x ) + 7 ) / 8;
     const UINT gy = ( static_cast<UINT>( m_Resolution.y ) + 7 ) / 8;
 
-    // m_PrevDepth already rests in a shader-read state, so the only resource that needs flipping here is the
-    // AO mask itself: it rests in UNORDERED_ACCESS (its creation state) except right after a prior successful
-    // run, which leaves it PIXEL_SHADER_RESOURCE for the lit passes.
+    BeginAoDepthRead();
+
+    // The AO mask rests in UNORDERED_ACCESS (its creation state) except right after a prior successful run,
+    // which leaves it PIXEL_SHADER_RESOURCE for the lit passes.
     if ( m_AOMaskInPixelState ) {
         auto b = TransitionBarrier( m_AOMask.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
         m_CmdList->ResourceBarrier( 1, &b );
@@ -274,7 +221,7 @@ void D3D12GraphicsEngine::RenderSimpleSSAO() {
     m_CmdList->SetPipelineState( m_Pipelines.AO.MainPSO.Get() );
     m_CmdList->SetComputeRootSignature( m_Pipelines.AO.MainRootSig.Get() );
     m_CmdList->SetComputeRoot32BitConstants( 0, 12, &cb, 0 );
-    m_CmdList->SetComputeRootDescriptorTable( 1, GetSrvGpuHandle( m_PrevDepthSrvSlot ) );
+    m_CmdList->SetComputeRootDescriptorTable( 1, GetSrvGpuHandle( m_DepthSrvSlot ) );
     m_CmdList->SetComputeRootDescriptorTable( 2, GetSrvGpuHandle( m_AOMaskUavSlot ) );
     m_CmdList->Dispatch( gx, gy, 1 );
 
@@ -297,7 +244,7 @@ void D3D12GraphicsEngine::RenderSimpleSSAO() {
     {
         BlurCB blurCb = { 1.0f / m_Resolution.x, 1.0f / m_Resolution.y, 1.0f, 0.0f, projM._33, projM._43, sao.BlurSharpness, 0.0f };
         m_CmdList->SetComputeRoot32BitConstants( 0, 8, &blurCb, 0 );
-        m_CmdList->SetComputeRootDescriptorTable( 1, GetSrvGpuHandle( m_AOBlurHPairSlot ) );   // t0=AOMask, t1=prev depth
+        m_CmdList->SetComputeRootDescriptorTable( 1, GetSrvGpuHandle( m_AOBlurHPairSlot ) );   // t0=AOMask, t1=depth
         m_CmdList->SetComputeRootDescriptorTable( 2, GetSrvGpuHandle( m_AOBlurTempUavSlot ) );
         m_CmdList->Dispatch( gx, gy, 1 );
     }
@@ -313,7 +260,7 @@ void D3D12GraphicsEngine::RenderSimpleSSAO() {
     {
         BlurCB blurCb = { 1.0f / m_Resolution.x, 1.0f / m_Resolution.y, 0.0f, 1.0f, projM._33, projM._43, sao.BlurSharpness, 0.0f };
         m_CmdList->SetComputeRoot32BitConstants( 0, 8, &blurCb, 0 );
-        m_CmdList->SetComputeRootDescriptorTable( 1, GetSrvGpuHandle( m_AOBlurVPairSlot ) );   // t0=AOBlurTemp, t1=prev depth
+        m_CmdList->SetComputeRootDescriptorTable( 1, GetSrvGpuHandle( m_AOBlurVPairSlot ) );   // t0=AOBlurTemp, t1=depth
         m_CmdList->SetComputeRootDescriptorTable( 2, GetSrvGpuHandle( m_AOMaskUavSlot ) );
         m_CmdList->Dispatch( gx, gy, 1 );
     }
@@ -330,6 +277,8 @@ void D3D12GraphicsEngine::RenderSimpleSSAO() {
         };
         m_CmdList->ResourceBarrier( 2, b );
     }
+
+    EndAoDepthRead();
 
     m_AOMaskInPixelState = true;
     m_ActiveAOMaskSrvSlot = m_AOMaskSrvSlot;

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -213,9 +213,17 @@ inline constexpr DXGI_FORMAT kGBufferNormalFormat = DXGI_FORMAT_R16G16_FLOAT;
 
 // Sentinel the velocity target is cleared to each frame. FillCameraVelocity (end of world rendering, when depth
 // is final) replaces every pixel STILL holding it with a camera-only depth reprojection — that is what covers
-// the sky, grass, water, decals and the transparents, none of which are in the depth prepass. Real velocities
+// the sky, water, decals and the transparents, none of which are in the depth prepass. Real velocities
 // are fractions of a screen (|v| <= ~2), so this can never collide with one, and it survives fp16 exactly.
 inline constexpr float kVelocitySentinel = -1.0e4f;
+
+// ...and the sentinel the NORMAL target is cleared to. Nothing ever fills these in (a pixel with no prepass
+// coverage has no normal), so XeGTAO's LoadNormal has to be able to RECOGNISE them: -2 is outside the [-1,1]
+// an octahedral pair can encode, whereas the obvious 0 clear is the perfectly legal encoding of world (0,0,1)
+// and would silently misreport every surface facing exactly +Z. Must match kOctNormalSentinel in
+// Shaders/D3D12/include/MotionVectors.hlsl and the ClearRenderTargetView call in BeginMotionGBuffer (which in
+// turn must match the optimized clear value CreateMotionResources passes, or fast-clear is lost).
+inline constexpr float kGBufferNormalSentinel = -2.0f;
 
 // --- CPU breadcrumb / debug-marker ring (DRED forensics + PIX events) ---
 // Why is BeginEvent not working as intended with Context on debugging this 32 bit app !!

--- a/D3D11Engine/D3D12Engine/D3D12Fx.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Fx.cpp
@@ -222,7 +222,7 @@ void D3D12GraphicsEngine::DrawQuadMarks() {
         // b6 MaterialCB, the same four root constants the world ExecuteIndirect commands push per draw:
         // no normal map (0xFFFFFFFF -> PSMain skips the perturb), the 1x1 default ORM (AO 1 / rough .5 /
         // metal 0, channel layout 0 = full RGB ORM), the mark's diffuse, and a zero normal strength.
-        const uint32_t matCb[4] = { 0xFFFFFFFFu, m_DefaultOrmTexture->GetSrvSlot(), diffuseSlot, 0u };
+        const uint32_t matCb[4] = { 0xFFFFFFFFu, GetDefaultOrmSrvSlot(), diffuseSlot, 0u };
         m_CmdList->SetGraphicsRoot32BitConstants( 10, 4, matCb, 0 );
 
         const UINT numVerts = static_cast<UINT>( info.NumVertices );

--- a/D3D11Engine/D3D12Engine/D3D12GTAO.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GTAO.cpp
@@ -4,16 +4,18 @@
 // see their headers). XeGTAO is what AOMode::AO_ASSAO selects on the D3D12 backend — the D3D11 renderer keeps
 // its own ASSAO port, untouched. Every other AO mode still lands on D3D12AO.cpp's simple SSAO.
 //
-// WHY IT LOOKS SO MUCH LIKE THE SSAO PATH IT REPLACES. It reads the same input (m_PrevDepth: the previous
-// frame's COMPLETE depth buffer, snapshotted by CopyDepthForAO after the last depth writer) and writes the same
-// output (m_AOMask, sampled with per-pixel reprojection by include/ScreenSpaceAO.hlsl). Both of those are
-// forced by Forward+, not by XeGTAO: lighting resolves inside the geometry pass, so this frame's depth does not
-// exist yet when the mask is needed, and the prepass alone would omit grass/foliage/decals/water. Keeping the
-// contract identical is what makes the two implementations interchangeable and leaves every consumer untouched.
+// WHY IT LOOKS SO MUCH LIKE THE SSAO PATH IT REPLACES. It reads the same input (m_DepthBuffer, straight out of
+// the Forward+ depth prepass) and writes the same output (m_AOMask, read at face value by
+// include/ScreenSpaceAO.hlsl). Both are forced by Forward+, not by XeGTAO: lighting resolves inside the
+// geometry pass, so the prepass is the only depth that exists when the mask is needed. Keeping the contract
+// identical is what makes the two implementations interchangeable and leaves every consumer untouched.
 //
-// THE FOUR DISPATCH STAGES:
+// THE DISPATCH STAGES:
 //   1. CSPrefilterDepths16x16  raw reversed-Z NDC depth -> a 5-level view-space depth pyramid.
-//   2. CSGenerateNormals       view-space normals from the same depth, packed R11G11B10_UNORM.
+//   2. CSGenerateNormals       view-space normals reconstructed from the same depth (R11G11B10_UNORM).
+//                              SKIPPED whenever the depth prepass's own normal G-buffer is available: those are
+//                              real shading normals for the exact geometry that wrote this depth, and they cost
+//                              nothing extra. See LoadNormal in XeGTAO.hlsl for the two decodes.
 //   3. CSGTAO{Low,...,Ultra}   the GTAO horizon integral -> working AO term (R8_UINT) + packed depth edges.
 //   4. CSDenoise[Last]Pass     1-3 edge-aware passes; the last writes m_AOMask and re-applies Intel's
 //                              XE_GTAO_OCCLUSION_TERM_SCALE. Even with denoising "disabled" one pass runs,
@@ -82,17 +84,27 @@ namespace {
         uint32_t Out2Index;
         uint32_t Out3Index;
         uint32_t Out4Index;
+        // 1 -> NormalsIndex is the prepass's RG16F octahedral WORLD-space normal G-buffer, which LoadNormal
+        // decodes and rotates into view space with the three rows below. 0 -> it is CSGenerateNormals' packed
+        // R11G11B10 view-space map, which needs neither.
+        uint32_t NormalsAreGBuffer;
         uint32_t Pad0;
-        uint32_t Pad1;
+        // This frame's view matrix, uploaded VERBATIM (row-major, as every other matrix in this backend is).
+        // The shader reads it back column-major and mul()s a w=0 direction through it; nothing transposes it
+        // on either side. The 12 uints above are exactly 3 cbuffer rows, so this lands 16-byte aligned.
+        XMFLOAT4X4 ViewMatrix;
 
         GtaoBindings() {
             RawDepthIndex = WorkingDepthIndex = NormalsIndex = EdgesIndex = AOTermIndex = 0xFFFFFFFFu;
             Out0Index = Out1Index = Out2Index = Out3Index = Out4Index = 0xFFFFFFFFu;
-            Pad0 = Pad1 = 0;
+            NormalsAreGBuffer = 0;
+            Pad0 = 0;
+            ViewMatrix = {};
         }
     };
-    static_assert( sizeof( GtaoBindings ) == 12 * sizeof( uint32_t ),
-        "GtaoBindings must match XeGTAO.hlsl's b1 block and the 12 root constants CreateGtao declares" );
+    static_assert( sizeof( GtaoBindings ) == 28 * sizeof( uint32_t ),
+        "GtaoBindings must match XeGTAO.hlsl's b1 block and the 28 root constants CreateGtao declares" );
+    constexpr UINT kGtaoBindingConstants = 28;
 
     // Intel's DenoiseBlurBeta convention: a very large beta makes the centre tap dominate to the point that the
     // spatial filter is a no-op, which is how "denoising disabled" is expressed without a separate shader.
@@ -101,9 +113,8 @@ namespace {
 }
 
 /** (Re)creates the four private intermediates and their persistent heap slots. Called from the same resize path
-    as CreateAOResources — which owns m_AOMask and m_PrevDepth, the input and output this pass shares with the
-    simple SSAO path, so this must run AFTER it. Heap slots persist across recreations; only resources and views
-    are rebuilt. */
+    as CreateAOResources — which owns m_AOMask, the output this pass shares with the simple SSAO path, so this
+    must run AFTER it. Heap slots persist across recreations; only resources and views are rebuilt. */
 bool D3D12GraphicsEngine::CreateGtaoResources( INT2 size ) {
     m_GtaoResourcesReady = false;
     // The working-depth pyramid is a fixed 5 levels (XE_GTAO_DEPTH_MIP_LEVELS is hard-coded upstream), and
@@ -210,13 +221,13 @@ bool D3D12GraphicsEngine::CreateGtaoResources( INT2 size ) {
     return true;
 }
 
-/** XeGTAO is the selected AO mode and everything it needs exists. Shares m_AOMask/m_PrevDepth with the simple
-    SSAO path, so it depends on that path's resources being ready too. */
+/** XeGTAO is the selected AO mode and everything it needs exists. Shares m_AOMask and the depth-prepass depth
+    with the simple SSAO path, so it depends on that path's resources being ready too. */
 bool D3D12GraphicsEngine::IsGtaoEnabled() const {
     const auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
     if ( settings.AoMode != AOMode::AO_ASSAO ) return false;
     if ( !m_GtaoResourcesReady || !m_AOResourcesReady ) return false;
-    if ( !m_PrevDepth || !m_PrevDepthValid || m_PrevDepthSrvSlot == UINT_MAX ) return false;
+    if ( !m_DepthBuffer || m_DepthSrvSlot == UINT_MAX ) return false;
     if ( m_AOMaskUintUavSlot == UINT_MAX ) return false;
     const auto& p = m_Pipelines.Gtao;
     if ( !p.RootSig || !p.PrefilterPSO || !p.NormalsPSO || !p.DenoisePSO || !p.DenoiseLastPSO ) return false;
@@ -224,8 +235,8 @@ bool D3D12GraphicsEngine::IsGtaoEnabled() const {
     return p.MainPSO[quality] != nullptr;
 }
 
-/** The full chain. Caller (RenderSSAO) has already published the reprojection constants and defaulted
-    m_ActiveAOMaskSrvSlot to the white "no occlusion" texture, and has verified IsGtaoEnabled(). */
+/** The full chain. Caller (RenderSSAO) has already defaulted m_ActiveAOMaskSrvSlot to the white "no occlusion" texture and
+    verified IsGtaoEnabled(). */
 void D3D12GraphicsEngine::RenderGTAO() {
     if ( !m_FrameOpen || !m_CmdList ) return;
 
@@ -243,10 +254,23 @@ void D3D12GraphicsEngine::RenderGTAO() {
     const UINT height = static_cast<UINT>( m_Resolution.y );
 
     // --- Constants -------------------------------------------------------------------------------------------
-    // Everything derives from the projection that rasterized the SNAPSHOT, not this frame's — the depth being
-    // unprojected here was produced with it. (Its _13/_23 carry the TAA jitter, which this ignores; that is a
-    // sub-pixel shift applied uniformly to the centre and every sample, so it cancels within the pass.)
-    const XMFLOAT4X4& projM = m_PrevDepthProj;
+    // This frame's projection — the one the depth prepass below was rasterized with. (Its _13/_23 carry the TAA
+    // jitter, which this ignores; that is a sub-pixel shift applied uniformly to the centre and every sample,
+    // so it cancels within the pass.)
+    const XMFLOAT4X4& projM = Engine::GAPI->GetProjectionMatrix();
+
+    // World -> view for the G-buffer normal path (LoadNormal). The SAME view matrix every geometry pass uploads,
+    // passed through untouched — see the warning in LoadNormal about hand-expanding it instead of mul()ing.
+    // Re-derived exactly like DrawWorldMesh does, so it cannot drift from the camera the prepass used.
+    XMMATRIX viewXM = Engine::GAPI->GetViewMatrixXM();
+    Engine::GAPI->SetViewTransformXM( viewXM );
+    Engine::GAPI->ResetWorldTransform();
+    const XMFLOAT4X4& viewM = Engine::GAPI->GetRendererState().TransformState.TransformView;
+
+    // Feed XeGTAO the depth prepass's own normals when they exist — real shading normals for exactly the
+    // geometry that wrote this depth. CSGenerateNormals (reconstruction from depth) stays as the fallback for
+    // when the G-buffer PSOs/targets failed to create.
+    const bool gbufNormals = MotionGBufferActive() && m_NormalBuffer && m_NormalSrvSlot != UINT_MAX;
 
     GtaoConstants cb = {};
     cb.ViewportSize[0] = static_cast<int32_t>( width );
@@ -294,10 +318,23 @@ void D3D12GraphicsEngine::RenderGTAO() {
     m_CmdList->SetComputeRootSignature( m_Pipelines.Gtao.RootSig.Get() );
     m_CmdList->SetComputeRoot32BitConstants( 0, 24, &cb, 0 );
 
+    // The per-dispatch bindings block, pre-seeded with everything that is the same for all of them.
+    GtaoBindings common;
+    common.NormalsAreGBuffer = gbufNormals ? 1u : 0u;
+    common.ViewMatrix = viewM;
+
     // --- Barriers --------------------------------------------------------------------------------------------
-    // Every resource here rests in UNORDERED_ACCESS, so the only pre-work is flipping m_AOMask back if a
-    // previous successful AO run left it readable for the lit passes. m_PrevDepth already rests in a
-    // shader-read state (kPrevDepthReadState) and is never written by this pass.
+    // Every private intermediate rests in UNORDERED_ACCESS. The depth buffer comes out of the prepass in
+    // DEPTH_WRITE and has to be flipped to a shader-read state (and back, at the bottom); the normal G-buffer
+    // comes out of it in RENDER_TARGET and gets the same treatment, since FillCameraVelocity at the end of the
+    // frame is what normally moves it and still expects to find it there.
+    BeginAoDepthRead();
+    if ( gbufNormals ) {
+        auto b = TransitionBarrier( m_NormalBuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
+            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+        m_CmdList->ResourceBarrier( 1, &b );
+    }
+    // ...and flip m_AOMask back if a previous successful AO run left it readable for the lit passes.
     if ( m_AOMaskInPixelState ) {
         auto b = TransitionBarrier( m_AOMask.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
@@ -319,38 +356,40 @@ void D3D12GraphicsEngine::RenderGTAO() {
     // --- 1. Prefilter depths ---------------------------------------------------------------------------------
     // 8x8 threads, each handling a 2x2 block: one group covers 16x16 pixels.
     {
-        GtaoBindings b;
-        b.RawDepthIndex = m_PrevDepthSrvSlot;
+        GtaoBindings b = common;
+        b.RawDepthIndex = m_DepthSrvSlot;
         b.Out0Index = m_GtaoWorkingDepthUavSlot[0];
         b.Out1Index = m_GtaoWorkingDepthUavSlot[1];
         b.Out2Index = m_GtaoWorkingDepthUavSlot[2];
         b.Out3Index = m_GtaoWorkingDepthUavSlot[3];
         b.Out4Index = m_GtaoWorkingDepthUavSlot[4];
-        m_CmdList->SetComputeRoot32BitConstants( 1, 12, &b, 0 );
+        m_CmdList->SetComputeRoot32BitConstants( 1, kGtaoBindingConstants, &b, 0 );
         m_CmdList->SetPipelineState( m_Pipelines.Gtao.PrefilterPSO.Get() );
         m_CmdList->Dispatch( ( width + 15 ) / 16, ( height + 15 ) / 16, 1 );
     }
 
-    // --- 2. Generate view-space normals from the same snapshot -----------------------------------------------
-    {
-        GtaoBindings b;
-        b.RawDepthIndex = m_PrevDepthSrvSlot;
+    // --- 2. Normals ------------------------------------------------------------------------------------------
+    // Only when there is no prepass G-buffer to take them from: that one already holds this frame's real
+    // shading normals for every prepass writer, so reconstructing worse ones from depth would be pure cost.
+    if ( !gbufNormals ) {
+        GtaoBindings b = common;
+        b.RawDepthIndex = m_DepthSrvSlot;
         b.Out0Index = m_GtaoNormalsUavSlot;
-        m_CmdList->SetComputeRoot32BitConstants( 1, 12, &b, 0 );
+        m_CmdList->SetComputeRoot32BitConstants( 1, kGtaoBindingConstants, &b, 0 );
         m_CmdList->SetPipelineState( m_Pipelines.Gtao.NormalsPSO.Get() );
         m_CmdList->Dispatch( ( width + 7 ) / 8, ( height + 7 ) / 8, 1 );
     }
 
     // --- 3. The GTAO integral --------------------------------------------------------------------------------
     toRead( m_GtaoWorkingDepth.Get() );
-    toRead( m_GtaoNormals.Get() );
+    if ( !gbufNormals ) toRead( m_GtaoNormals.Get() );
     {
-        GtaoBindings b;
+        GtaoBindings b = common;
         b.WorkingDepthIndex = m_GtaoWorkingDepthSrvSlot;
-        b.NormalsIndex = m_GtaoNormalsSrvSlot;
+        b.NormalsIndex = gbufNormals ? m_NormalSrvSlot : m_GtaoNormalsSrvSlot;
         b.Out0Index = m_GtaoAOTermUavSlot[0];
         b.Out1Index = m_GtaoEdgesUavSlot;
-        m_CmdList->SetComputeRoot32BitConstants( 1, 12, &b, 0 );
+        m_CmdList->SetComputeRoot32BitConstants( 1, kGtaoBindingConstants, &b, 0 );
         m_CmdList->SetPipelineState( m_Pipelines.Gtao.MainPSO[quality].Get() );
         m_CmdList->Dispatch( ( width + 7 ) / 8, ( height + 7 ) / 8, 1 );
     }
@@ -365,11 +404,11 @@ void D3D12GraphicsEngine::RenderGTAO() {
         const bool lastPass = ( pass == denoisePassCount - 1 );
         const int dstTerm = 1 - srcTerm;
 
-        GtaoBindings b;
+        GtaoBindings b = common;
         b.AOTermIndex = m_GtaoAOTermSrvSlot[srcTerm];
         b.EdgesIndex = m_GtaoEdgesSrvSlot;
         b.Out0Index = lastPass ? m_AOMaskUintUavSlot : m_GtaoAOTermUavSlot[dstTerm];
-        m_CmdList->SetComputeRoot32BitConstants( 1, 12, &b, 0 );
+        m_CmdList->SetComputeRoot32BitConstants( 1, kGtaoBindingConstants, &b, 0 );
         m_CmdList->SetPipelineState( ( lastPass ? m_Pipelines.Gtao.DenoiseLastPSO : m_Pipelines.Gtao.DenoisePSO ).Get() );
         m_CmdList->Dispatch( ( width + 15 ) / 16, ( height + 7 ) / 8, 1 );
 
@@ -383,24 +422,35 @@ void D3D12GraphicsEngine::RenderGTAO() {
     }
 
     // --- Rest states -----------------------------------------------------------------------------------------
-    // m_AOMask readable for the lit geometry passes' bindless fetch; everything else back to UNORDERED_ACCESS,
-    // which is what the next frame's barriers assert as the "before" state. Skipping any of these produces a
-    // GPU-validation RESOURCE_BARRIER_BEFORE_AFTER_MISMATCH on the next frame rather than a visible artifact.
+    // m_AOMask readable for the lit geometry passes' bindless fetch; every private intermediate back to
+    // UNORDERED_ACCESS, the depth buffer back to DEPTH_WRITE and the normal G-buffer back to RENDER_TARGET —
+    // which is what the next barrier on each asserts as its "before" state. Skipping any of these produces a
+    // GPU-validation RESOURCE_BARRIER_BEFORE_AFTER_MISMATCH rather than a visible artifact.
     {
-        D3D12_RESOURCE_BARRIER post[] = {
+        D3D12_RESOURCE_BARRIER post[5] = {
             TransitionBarrier( m_AOMask.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
                 D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE ),
             TransitionBarrier( m_GtaoWorkingDepth.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-            TransitionBarrier( m_GtaoNormals.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
             TransitionBarrier( m_GtaoEdges.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
             TransitionBarrier( m_GtaoAOTerm[srcTerm].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
+            {},   // m_GtaoNormals, only when the reconstruction path actually ran (see below)
         };
-        m_CmdList->ResourceBarrier( _countof( post ), post );
+        UINT postCount = 4;
+        if ( !gbufNormals ) {
+            post[postCount++] = TransitionBarrier( m_GtaoNormals.Get(),
+                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+        }
+        m_CmdList->ResourceBarrier( postCount, post );
     }
+    if ( gbufNormals ) {
+        auto b = TransitionBarrier( m_NormalBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+            D3D12_RESOURCE_STATE_RENDER_TARGET );
+        m_CmdList->ResourceBarrier( 1, &b );
+    }
+    EndAoDepthRead();
 
     m_AOMaskInPixelState = true;
     m_ActiveAOMaskSrvSlot = m_AOMaskSrvSlot;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -829,9 +829,13 @@ void D3D12GraphicsEngine::FreeSrvSlot( UINT slot ) {
 	if ( slot == UINT_MAX
 		|| slot == m_WhiteTexture->GetSrvSlot()
 		|| slot == m_BlackTexture->GetSrvSlot()
-		|| slot == m_DefaultOrmTexture->GetSrvSlot()
 		) {
 		return;
+	}
+	// Every default-ORM step is permanent, not just the one currently selected — the player can move the
+	// roughness slider back at any time, and a freed slot would already have been handed to a game texture.
+	for ( const auto& orm : m_DefaultOrmTextures ) {
+		if ( orm && slot == orm->GetSrvSlot() ) return;
 	}
 
 	ID3D12Device* device = m_Device.GetDevice();
@@ -946,13 +950,32 @@ bool D3D12GraphicsEngine::CreateWhiteTexture() {
 		return false;
 	}
 
-	CreateTexture( m_DefaultOrmTexture );
-	const uint32_t orm = 0xFF00B2FFu;
-	if ( XR_SUCCESS != m_DefaultOrmTexture->Init( INT2( 1, 1 ), GfxTexture::ETextureFormat::TF_R8G8B8A8, 1, &orm, "DefaultOrmTexture(1,0.69,0)" ) ) {
-		return false;
+	// One default-ORM texture per selectable roughness step. R = AO (1), G = roughness, B = metallic (0),
+	// laid out as a full ORM so EncodeOrmSlot's format 0 reads it correctly. Nine 1x1 textures cost nine
+	// SRV slots and 36 bytes of VRAM, which is why this is a table rather than one texture we rewrite:
+	// the slot then never moves, so nothing that baked it into a frame's draw commands can go stale.
+	for ( int i = 0; i < DefaultRoughness::kNumSteps; ++i ) {
+		CreateTexture( m_DefaultOrmTextures[i] );
+		const float roughness = DefaultRoughness::ForStep( i );
+		const uint32_t g = static_cast<uint32_t>( roughness * 255.0f + 0.5f ) & 0xFFu;
+		const uint32_t orm = 0xFF000000u | ( g << 8 ) | 0xFFu;   // ABGR in memory: R=255 G=rough B=0 A=255
+		char name[64];
+		snprintf( name, sizeof( name ), "DefaultOrmTexture(1,%.2f,0)", roughness );
+		if ( XR_SUCCESS != m_DefaultOrmTextures[i]->Init( INT2( 1, 1 ), GfxTexture::ETextureFormat::TF_R8G8B8A8, 1, &orm, name ) ) {
+			return false;
+		}
 	}
+	RefreshDefaultOrmSlot();
 
 	return true;
+}
+
+
+void D3D12GraphicsEngine::RefreshDefaultOrmSlot() {
+	const int step = DefaultRoughness::StepFor( Engine::GAPI->GetRendererState().RendererSettings.DefaultMaterialRoughness );
+	if ( m_DefaultOrmTextures[step] ) {
+		m_DefaultOrmSrvSlot = m_DefaultOrmTextures[step]->GetSrvSlot();
+	}
 }
 
 
@@ -1767,6 +1790,9 @@ XRESULT D3D12GraphicsEngine::OnBeginFrame() {
     m_DecalInstanceBufferOffset = 0;
     m_DecalInstanceOverflowLogged = false;
     m_LightOverflowLogged = false;   // light buffer is rebuilt from 0 each frame in BuildFrameLightBuffer
+    // Pick up an ImGui roughness change once, here, so every command builder this frame — including the
+    // cascade builds running on worker threads — reads the same slot.
+    RefreshDefaultOrmSlot();
     if ( !Engine::GAPI->IsGamePaused() )
         UpdateWindAnimation( m_WindBuffer );   // advances windDir/globalTime; DrawVobsInstanced fills min/maxHeight/playerPos
     m_CurrentTexture = nullptr;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -947,8 +947,8 @@ bool D3D12GraphicsEngine::CreateWhiteTexture() {
 	}
 
 	CreateTexture( m_DefaultOrmTexture );
-	const uint32_t orm = 0xFF00E6FFu;
-	if ( XR_SUCCESS != m_DefaultOrmTexture->Init( INT2( 1, 1 ), GfxTexture::ETextureFormat::TF_R8G8B8A8, 1, &orm, "DefaultOrmTexture(1,0.9,0)" ) ) {
+	const uint32_t orm = 0xFF00B2FFu;
+	if ( XR_SUCCESS != m_DefaultOrmTexture->Init( INT2( 1, 1 ), GfxTexture::ETextureFormat::TF_R8G8B8A8, 1, &orm, "DefaultOrmTexture(1,0.69,0)" ) ) {
 		return false;
 	}
 

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -898,10 +898,10 @@ bool D3D12GraphicsEngine::CreateShadowConstantBuffer() {
     // The per-frame-in-flight shadow CB every lit pass binds (b3 on the world/VOB root sig). Small and written
     // once per frame, so a persistently-mapped UPLOAD buffer per frame context — no ring offset needed.
     //
-    // 512, not 256: FOUR owners write four DISJOINT byte ranges of the same buffer, so none clobbers another.
+    // 512, not 256: THREE owners write three DISJOINT byte ranges of the same buffer, so none clobbers another.
     // [0, kWetnessCbOffset)  D3D12ShadowMap::Prepare       — cascade view-projs + sun dir/color/strength + texels
     // [kWetnessCbOffset, ..) UploadWetnessConstants        — scene wetness (needs the rain-shadow camera first)
-    // [kAoReprojCbOffset,..) UploadAoReprojConstants       — previous-frame depth reprojection for the AO mask
+    // [kAoReprojCbOffset,..) UNUSED HOLE                   — was the AO-mask reprojection block; see the header
     // [kSkyIblCbOffset,  ..) UploadSkyIblConstants         — sky-IBL cube indices + intensity
     // Each writer static_asserts its own block size against these offsets; keep them in sync with the HLSL
     // ShadowCB declaration.

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -328,6 +328,22 @@ private:
     // drains this list, so skipping the call would leak one entry per ghost vob per frame forever.
     void DrawGhostVobs();
     void DrawVegetation();    // GVegetationBox instanced grass cards (own PSO — see D3D12PipelineState::CreateGrass)
+    // Grass in the Forward+ DEPTH PREPASS. Runs from the prepass block, after the skeletal draws. Its whole
+    // purpose is the AO mask: RenderSSAO builds that from the prepass depth, so without this a grass pixel
+    // would sample the occlusion of the terrain BEHIND the blade and the blades would cast none of their own.
+    // It also gives grass true prepass velocity/normals instead of FillCameraVelocity's depth reprojection.
+    //
+    // HARD RANGE LIMIT, independent of OutdoorSmallVobDrawRadius: the prepass rasterizes every blade a second
+    // time, and at distance the cards are sub-pixel alpha-test noise whose AO contribution is invisible while
+    // the fill cost is not. Beyond it grass is simply absent from the mask and reads the terrain's AO, which is
+    // the pre-existing behaviour and barely noticeable at that distance.
+    static constexpr float kVegetationPrepassRange = 7500.0f;
+    void DrawVegetationDepthPrepass();
+    // The per-frame GrassCB (b1). Built ONCE per frame and pushed identically by the prepass, the CSM caster
+    // and the lit pass — every grass VS derives its swayed world position from these, so a pass that saw a
+    // different G_Time would place the blade somewhere else and z-fight against the prepass' own depth.
+    struct GrassCBData { float Time; float WindStrength; float HeroAffectStrength; float _pad0; XMFLOAT3 PlayerPosWS; float _pad1; };
+    GrassCBData MakeGrassConstants() const;
 
     // Binds every frame-constant root argument of World.RootSig (b0 ViewProj, b1 fog, the Forward+ light
     // SRV/count, the CSM CB + array, the point-shadow cubes, the SSAO mask index). Shared by the lit world
@@ -897,10 +913,10 @@ private:
     bool m_ShadowRecordingPending = false;   // BeginShadowRecording fanned work out; FinishShadowPasses must join
     bool m_ShadowRecordFailureLogged = false;   // one warning per session, not per frame
 
-    // Per-frame-in-flight shadow constant buffer, bound by every lit pass. FOUR disjoint byte ranges written by
-    // four owners: D3D12ShadowMap::Prepare owns the head [0, kWetnessCbOffset) (cascade view-projs + sun dir +
-    // strength + texel sizes), then UploadWetnessConstants, UploadAoReprojConstants and UploadSkyIblConstants
-    // each own a tail block. The buffer lives here because it is shared; see kWetnessCbOffset below.
+    // Per-frame-in-flight shadow constant buffer, bound by every lit pass. Three disjoint byte ranges written by
+    // three owners: D3D12ShadowMap::Prepare owns the head [0, kWetnessCbOffset) (cascade view-projs + sun dir +
+    // strength + texel sizes), then UploadWetnessConstants and UploadSkyIblConstants each own a tail block —
+    // with an unused 80-byte hole between them (kAoReprojCbOffset). The buffer lives here because it is shared.
     Microsoft::WRL::ComPtr<ID3D12Resource> m_ShadowCB[kBackBufferMax];
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_ShadowCBAlloc[kBackBufferMax];
     uint8_t* m_ShadowCBMapped[kBackBufferMax] = {};
@@ -1011,8 +1027,8 @@ private:
     // final blurred result; m_AOBlurTemp is the horizontal-blur scratch target), recreated on resize like the
     // bloom pyramid. RenderSSAO dispatches main-estimate -> blurH -> blurV (Shaders/D3D12/SSAO.hlsl) and leaves
     // m_AOMask in PIXEL_SHADER_RESOURCE for the lit geometry passes (World/Vob/Skeletal PS) to sample bindlessly.
-    // m_ActiveAOMaskSrvSlot is refreshed every frame by RenderSSAO: the AO mask's slot when SSAO ran, else the
-    // white texture's slot (mask = no occlusion) — mirrors D3D11's white-clear "AO disabled" default.
+    // m_ActiveAOMaskSrvSlot is refreshed every frame by RenderSSAO: the AO mask's slot when SSAO ran, else the white texture's
+    // slot (mask = no occlusion) — mirrors D3D11's white-clear "AO disabled" default.
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_AOMask;
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_AOMaskAlloc;
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_AOBlurTemp;
@@ -1033,7 +1049,10 @@ private:
     // pyramid's per-frame-rewritten pair slots, nothing here changes frame-to-frame, so no double-buffering race.
     UINT m_AOBlurHPairSlot = UINT_MAX;  // [0]=AOMask SRV (raw estimate), [1]=Depth SRV
     UINT m_AOBlurVPairSlot = UINT_MAX;  // [0]=AOBlurTemp SRV, [1]=Depth SRV
-    UINT m_ActiveAOMaskSrvSlot = UINT_MAX;   // this frame's bindless AO index for World/Vob/Skeletal PS (b7/b8 AOCB)
+    // The single b5/b7/b8 AOCB root constant every lit PS binds — this frame's AO mask heap slot. The matching
+    // 1/screen-size lives in the shadow CB instead (see kAoReprojCbOffset): the World root signature sits at
+    // 63 of its 64 DWORDs, so two more root constants would not fit there.
+    UINT m_ActiveAOMaskSrvSlot = UINT_MAX;
     bool m_AOResourcesReady = false;
     // m_AOMask rests in UNORDERED_ACCESS between RenderSSAO runs (its creation state) except right after a
     // successful run, which leaves it PIXEL_SHADER_RESOURCE for the lit passes' bindless read — tracks that so
@@ -1041,53 +1060,49 @@ private:
     // m_SceneColorInPixelState/m_LightGridInPixelState). Toggling AO off skips RenderSSAO entirely, so without
     // this the resource would still show PIXEL_SHADER_RESOURCE if AO is re-enabled a frame later.
     bool m_AOMaskInPixelState = false;
-    // --- Previous-frame depth (the AO source) --------------------------------------------------------------
-    // SSAO no longer runs off THIS frame's depth prepass: the prepass only covers world + instanced VOBs +
-    // skeletal, so everything drawn later in the color pass (grass/foliage, decals, water) was invisible to
-    // the AO and, worse, its screen pixels sampled the mask of whatever sat BEHIND it. Instead we snapshot
-    // the COMPLETE depth buffer at the end of world rendering (CopyDepthForAO, after every depth-writing pass)
-    // and run the whole AO chain off that copy on the next frame. The mask is therefore one frame stale and
-    // lives in the PREVIOUS frame's screen space, so the lit pixel shaders reproject into it per-pixel:
-    // world position -> m_PrevDepthViewProj -> UV (see Shaders/D3D12/include/ScreenSpaceAO.hlsl). That is exact
-    // for static geometry (not a camera-motion approximation) and only lags on moving objects.
-    // Side benefits: the AO chain never touches m_DepthBuffer, so RenderSSAO needs no depth barriers at all and
-    // no longer serialises against the prepass.
-    Microsoft::WRL::ComPtr<ID3D12Resource>      m_PrevDepth;        // full copy of last frame's D32 depth (R32_TYPELESS)
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_PrevDepthAlloc;
-    UINT m_PrevDepthSrvSlot = UINT_MAX;   // R32_FLOAT SRV: SSAO's t0 AND the lit PS's bindless disocclusion test
-    // Rest state is the combined shader-read state: the AO compute dispatches read it non-pixel, the lit pixel
-    // shaders read it pixel-side, and CopyDepthForAO flips it to COPY_DEST and straight back once per frame.
-    static constexpr D3D12_RESOURCE_STATES kPrevDepthReadState =
-        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    bool m_PrevDepthValid = false;        // false until the first CopyDepthForAO of a world (reset on resize/world load)
-    XMFLOAT4X4 m_PrevDepthViewProj = {};  // the camera that produced m_PrevDepth — the reprojection matrix
-    XMFLOAT4X4 m_PrevDepthProj = {};      // ...and its projection, for the AO pass's depth -> view-position math
-    // Reprojection tail of the shared shadow CB, written every frame by UploadAoReprojConstants (the third
-    // disjoint byte range of m_ShadowCB, after the D3D12ShadowMap::Prepare head and the UploadWetnessConstants block).
+    // --- The AO depth source ---------------------------------------------------------------------------------
+    // THIS frame's m_DepthBuffer, read straight after the Forward+ depth prepass and before any lit pass. The
+    // mask is therefore in this frame's screen space and the lit shaders read it at their own pixel — no
+    // reprojection, no lag (see Shaders/D3D12/include/ScreenSpaceAO.hlsl).
+    //
+    // This used to be a full-frame COPY of the PREVIOUS frame's completed depth (m_PrevDepth + CopyDepthForAO),
+    // because the prepass omitted grass — a grass pixel would then sample the AO of the terrain behind it, and
+    // the blades cast no AO of their own. Folding vegetation into the prepass (DrawVegetationDepthPrepass) fixed
+    // the cause, so the snapshot, its depth-sized allocation, the per-frame CopyResource and the per-pixel
+    // reprojection in five pixel shaders are all gone. Water/decals/particles still write depth after the
+    // prepass and are still not occluders; that was true of the whole scheme's near field anyway.
+    //
+    // Cost: RenderSSAO now has to round-trip m_DepthBuffer DEPTH_WRITE <-> NON_PIXEL_SHADER_RESOURCE and
+    // therefore serialises against the prepass, exactly like BuildHiZ does a few calls earlier.
+    //
+    // 80 bytes of the shared shadow CB, between the wetness block and the sky-IBL tail. Only the leading float2
+    // is live (1/screen-size, so the lit shaders can turn SV_Position into a mask UV); the rest is the hole the
+    // reprojection constants used to occupy, kept because the offsets of everything after it are baked into
+    // five HLSL cbuffer layouts.
     static constexpr UINT kAoReprojCbOffset = 352;
-    struct AoReprojCBData {
-        XMFLOAT4X4 PrevViewProj;
-        UINT  PrevDepthIndex;   float PrevProjZX;   float PrevProjZY;   float ReprojValid;
-    };
-    void UploadAoReprojConstants();           // publishes m_PrevDepth* into the shadow CB for the lit PS
-    void CopyDepthForAO();                    // end-of-world-render snapshot of the complete depth buffer
-    bool CreateAOResources( INT2 size );      // (re)builds m_AOMask/m_AOBlurTemp/m_PrevDepth + persistent SRV/UAV slots
-    void RenderSSAO();                        // the AO entry point: publishes the reprojection CB, then runs XeGTAO or simple SSAO
+    static constexpr UINT kAoReprojCbReservedBytes = 80;
+    struct AoScreenCBData { float InvResX; float InvResY; float _pad[2]; };
+    void UploadAoScreenConstants();           // publishes AoInvRes into the shadow CB (unconditional, every frame)
+    bool CreateAOResources( INT2 size );      // (re)builds m_AOMask/m_AOBlurTemp + persistent SRV/UAV slots
+    void RenderSSAO();                        // the AO entry point: publishes the AO constants, then runs XeGTAO or simple SSAO
     void RenderSimpleSSAO();                  // main estimate -> separable blur (Shaders/D3D12/SSAO.hlsl)
+    void BeginAoDepthRead();                  // m_DepthBuffer DEPTH_WRITE -> NON_PIXEL_SHADER_RESOURCE
+    void EndAoDepthRead();                    // ...and straight back (both AO implementations bracket with these)
 
     // ---- Intel XeGTAO (D3D12GTAO.cpp) ----------------------------------------------------------------------
     // Ground-truth ambient occlusion; this is what AOMode::AO_ASSAO selects on D3D12 (D3D11 keeps its own ASSAO
-    // port). Reads the SAME previous-frame depth snapshot the simple SSAO path does, for the same reason (see
-    // m_PrevDepth above) and writes the SAME m_AOMask, so the whole consumer side — the reprojected bindless
-    // fetch in include/ScreenSpaceAO.hlsl — is untouched and the two implementations are interchangeable.
+    // port). Reads the SAME depth-prepass depth the simple SSAO path does and writes the SAME m_AOMask, so the
+    // whole consumer side — the bindless fetch in include/ScreenSpaceAO.hlsl — is untouched and the two
+    // implementations are interchangeable.
     //
     // Four private intermediates, all recreated on resize alongside m_AOMask:
     //   m_GtaoWorkingDepth  R32_FLOAT with 5 MIPs — view-space depth pyramid built by the prefilter pass. FP32
     //                       rather than Intel's default R16_FLOAT because Gothic's view depths run past fp16's
     //                       65504 ceiling near the horizon (see the header of Shaders/D3D12/XeGTAO.hlsl).
-    //   m_GtaoNormals       R32_UINT — view-space normals packed R11G11B10_UNORM, generated from the same depth
-    //                       snapshot. Deliberately NOT the prepass normal G-buffer: that one omits grass/water
-    //                       and belongs to this frame's camera, not the snapshot's.
+    //   m_GtaoNormals       R32_UINT — view-space normals packed R11G11B10_UNORM, reconstructed from the depth.
+    //                       FALLBACK ONLY: when the prepass normal G-buffer (m_NormalBuffer) is available
+    //                       RenderGTAO skips this dispatch and feeds XeGTAO the real shading normals instead
+    //                       (LoadNormal in XeGTAO.hlsl decodes + rotates them into view space).
     //   m_GtaoEdges         R8_UNORM — packed depth edges the denoiser weights by.
     //   m_GtaoAOTerm[2]     R8_UINT — the working AO term, ping-ponged across denoise passes. The final pass
     //                       writes m_AOMask through m_AOMaskUintUavSlot instead.
@@ -1113,7 +1128,7 @@ private:
     UINT m_GtaoFrameNumber = 0;                // drives the temporal noise rotation; only advances while TAA is on
     bool CreateGtaoResources( INT2 size );     // (re)builds the four intermediates + their persistent heap slots
     bool IsGtaoEnabled() const;                // AoMode == AO_ASSAO and every resource/PSO it needs exists
-    void RenderGTAO();                         // prefilter -> normals -> GTAO integral -> N denoise passes
+    void RenderGTAO();                         // prefilter -> (normals) -> GTAO integral -> N denoise passes
 
     // ---- Motion-vector + normal G-buffer (D3D12Motion.cpp) -------------------------------------------------
     // Two extra full-resolution targets the Forward+ DEPTH PREPASS writes alongside depth, via the *GBuf PSO
@@ -1126,9 +1141,10 @@ private:
     //                      per-object velocity (static world via camera reprojection, VOBs via the instance
     //                      stream's prevWorld, skeletals via a second skinning pass through the previous bone
     //                      pose); FillCameraVelocity then replaces whatever sentinel is left.
-    //   m_NormalBuffer   — RG16F octahedral world-space normal, the XeGTAO input. Untouched by the fill pass:
-    //                      a pixel with no prepass coverage has no meaningful normal, and AO must treat it as
-    //                      "no geometry" rather than invent one.
+    //   m_NormalBuffer   — RG16F octahedral world-space shading normal, the XeGTAO input (see RenderGTAO /
+    //                      LoadNormal). Untouched by the fill pass: a pixel with no prepass coverage has no
+    //                      meaningful normal, so it keeps the kGBufferNormalSentinel clear and AO treats it as
+    //                      "no geometry" rather than integrating against an invented orientation.
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_VelocityBuffer;
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_VelocityAlloc;
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_NormalBuffer;
@@ -1193,11 +1209,14 @@ private:
     UINT m_TaaHistorySrvSlot[2] = { UINT_MAX, UINT_MAX };
     UINT m_TaaHistoryUavSlot[2] = { UINT_MAX, UINT_MAX };
     UINT m_TaaHistoryIndex = 0;
-    // TAA needs the PREVIOUS frame's depth for its disocclusion test, and cannot borrow m_PrevDepth: that one is
-    // refilled by CopyDepthForAO earlier in the SAME frame, so by the time TAA runs it already holds THIS
-    // frame's depth. Hence a private snapshot, taken at the end of RenderTAA.
+    // TAA needs the PREVIOUS frame's depth for its disocclusion test — nothing else in the frame keeps one, so
+    // this is a private snapshot taken at the end of RenderTAA.
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_TaaPrevDepth;
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_TaaPrevDepthAlloc;
+    // Rest state of that snapshot: the combined shader-read state, flipped to COPY_DEST and straight back once
+    // per frame by the snapshot copy.
+    static constexpr D3D12_RESOURCE_STATES kPrevDepthReadState =
+        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
     UINT m_TaaPrevDepthSrvSlot = UINT_MAX;
     bool m_TaaPrevDepthValid = false;
     bool m_TaaResourcesReady = false;
@@ -1259,8 +1278,8 @@ private:
     };
     SkyIblParams m_SkyLastParams;
     bool m_SkyEnvInReadState = false;              // tracks the rest state of m_SkyEnvCube (see RenderSkyIBL's barriers)
-    // Sky-IBL tail of the shared shadow CB — the FOURTH disjoint byte range of m_ShadowCB, after the
-    // D3D12ShadowMap::Prepare head [0,256), UploadWetnessConstants [256,352) and UploadAoReprojConstants [352,432).
+    // Sky-IBL tail of the shared shadow CB — the last byte range of m_ShadowCB, after the D3D12ShadowMap::Prepare
+    // head [0,256), UploadWetnessConstants [256,352) and the unused AO-reprojection hole [352,432).
     // Riding the CB the lit shaders already bind is what keeps this feature free of root-signature churn:
     // World/Vob/Skeletal/Vegetation all declare ShadowCB at their own register and just gained four fields.
     static constexpr UINT kSkyIblCbOffset = 432;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -631,7 +631,20 @@ private:
 
     std::unique_ptr<D3D12Texture> m_WhiteTexture;         // 1x1 white fallback for untextured draws
     std::unique_ptr<D3D12Texture> m_BlackTexture;         // 1x1 black fallback for untextured draws
-    std::unique_ptr<D3D12Texture> m_DefaultOrmTexture;    // 1x1 ORM default (AO 1, rough 0.5, metal 0)
+    // One 1x1 ORM texture per selectable default roughness (AO 1, rough = DefaultRoughness::ForStep(i),
+    // metal 0), all created up front by CreateWhiteTexture. Materials Gothic ships with no _FX/_ORM map —
+    // most of them — are handed one of these bindlessly, and the shader can't be given a scalar instead
+    // (MatOrmIndex is an SRV slot), hence a texture per step rather than a uniform. Never freed: FreeSrvSlot
+    // skips all of them, same as the white/black fallbacks.
+    std::unique_ptr<D3D12Texture> m_DefaultOrmTextures[DefaultRoughness::kNumSteps];
+    // SRV slot of the currently selected one. Resolved once per frame in OnBeginFrame rather than per
+    // material: the command builders read it thousands of times a frame, and the cascade builds read it
+    // from worker threads, so it must not move mid-frame. UINT_MAX until the textures exist.
+    UINT m_DefaultOrmSrvSlot = UINT_MAX;
+    /** SRV heap slot of the default ORM texture for this frame's DefaultMaterialRoughness setting. */
+    UINT GetDefaultOrmSrvSlot() const { return m_DefaultOrmSrvSlot; }
+    /** Re-resolves m_DefaultOrmSrvSlot from RendererSettings.DefaultMaterialRoughness. Frame-start only. */
+    void RefreshDefaultOrmSlot();
     std::unique_ptr<D3D12Texture> m_DistortionTexture;    // distortion2.dds — wet-ground normal fallback (see LoadDistortionTexture)
     bool LoadDistortionTexture();                         // one-time, non-fatal load (mirrors LoadSmaaTextures)
 

--- a/D3D11Engine/D3D12Engine/D3D12Motion.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Motion.cpp
@@ -18,21 +18,21 @@
 // it is a deferred/forward hybrid whose velocity consumer runs post-shading anyway. Here the prepass is both
 // cheaper and better placed.
 //
-// COVERAGE, AND THE SENTINEL
-// The prepass contains world mesh + instanced VOBs + skeletals + node attachments. It does NOT contain the sky,
-// grass/vegetation, water, decals, blended VOBs, particles or poly strips — those write depth (or don't) later
-// in the frame. So the velocity target is CLEARED TO kVelocitySentinel, and FillCameraVelocity (end of world
-// rendering, when depth is final) replaces every pixel still holding it with a camera-only depth reprojection.
-// For anything static that reprojection is exact; it under-reports only for things that moved without being in
-// the prepass, i.e. grass sway and water flow. Folding grass into the depth prepass is already a pending item
-// (it would also fix grass SSAO) and would upgrade it to true velocity for free.
+// COVERAGE, AND THE SENTINELS
+// The prepass contains world mesh + instanced VOBs + skeletals + node attachments + vegetation (the last one
+// range-limited — see DrawVegetationDepthPrepass). It does NOT contain the sky, water, decals, blended VOBs,
+// particles or poly strips — those write depth (or don't) later in the frame. So the velocity target is
+// CLEARED TO kVelocitySentinel, and FillCameraVelocity (end of world rendering, when depth is final) replaces
+// every pixel still holding it with a camera-only depth reprojection. For anything static that reprojection is
+// exact; it under-reports only for things that moved without being in the prepass, i.e. water flow.
 //
-// The NORMAL target is deliberately NOT filled: a pixel with no prepass coverage has no meaningful normal, and
-// an AO pass must treat that as absent geometry rather than consume an invented one.
+// The NORMAL target is deliberately NOT filled — a pixel with no prepass coverage has no meaningful normal, and
+// an AO pass must treat that as absent geometry rather than consume an invented one. It is cleared to
+// kGBufferNormalSentinel (not 0, which is a legal octahedral encoding) precisely so XeGTAO's LoadNormal can
+// tell the two apart.
 //
-// NOTHING READS EITHER TARGET YET. TAA, FSR3 and XeGTAO are the consumers and none exist. Verification is
-// therefore via RenderMotionDebugOverlay (the shared RendererSettings.DebugSettings.TAA.DisplayVelocity
-// setting), which is the whole reason that overlay is in this first increment.
+// CONSUMERS: XeGTAO reads the normal target (D3D12GTAO.cpp's RenderGTAO), the TAA resolve reads velocity, and
+// RenderMotionDebugOverlay renders either one for the DebugSettings.TAA.Display* flags.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
 #include "../Engine.h"
@@ -93,7 +93,7 @@ bool D3D12GraphicsEngine::CreateMotionResources( INT2 size ) {
         };
 
     const float velocityClear[4] = { kVelocitySentinel, kVelocitySentinel, 0.0f, 0.0f };
-    const float normalClear[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    const float normalClear[4] = { kGBufferNormalSentinel, kGBufferNormalSentinel, 0.0f, 0.0f };
     // The velocity target additionally needs UAV: FillCameraVelocity writes it from compute.
     if ( !makeTarget( m_VelocityBuffer, m_VelocityAlloc, kVelocityFormat, true, velocityClear, L"MotionVectors(RG16F)" ) )
         return false;
@@ -244,7 +244,7 @@ void D3D12GraphicsEngine::BeginMotionGBuffer() {
     // The sentinel clear is what lets FillCameraVelocity tell "no prepass draw covered this pixel" from a
     // genuine zero velocity (a static pixel under a static camera legitimately has velocity exactly 0).
     const float velocityClear[4] = { kVelocitySentinel, kVelocitySentinel, 0.0f, 0.0f };
-    const float normalClear[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    const float normalClear[4] = { kGBufferNormalSentinel, kGBufferNormalSentinel, 0.0f, 0.0f };
     m_CmdList->ClearRenderTargetView( m_VelocityRtv, velocityClear, 0, nullptr );
     m_CmdList->ClearRenderTargetView( m_NormalRtv, normalClear, 0, nullptr );
 
@@ -265,8 +265,8 @@ void D3D12GraphicsEngine::EndMotionGBuffer() {
 }
 
 /** Camera-only velocity for every pixel the depth prepass never covered — see the file header. Runs at the end
-    of world rendering, right next to CopyDepthForAO, because it needs the FINAL depth buffer (grass, water,
-    decals and the transparents have all written by then). */
+    of world rendering because it needs the FINAL depth buffer (water, decals and the transparents have all
+    written by then). */
 void D3D12GraphicsEngine::FillCameraVelocity() {
     if ( !m_FrameOpen || !m_MotionResourcesReady || !m_CmdList ) return;
     if ( !m_Pipelines.Motion.FillPSO || !m_Pipelines.Motion.FillRootSig ) return;
@@ -298,7 +298,7 @@ void D3D12GraphicsEngine::FillCameraVelocity() {
     m_CmdList->SetComputeRoot32BitConstants( 1, 4, fillConsts, 0 );
     m_CmdList->Dispatch( ( m_Resolution.x + 7 ) / 8, ( m_Resolution.y + 7 ) / 8, 1 );
 
-    // Depth back to DEPTH_WRITE (CopyDepthForAO and the fog/god-ray block downstream both expect it there);
+    // Depth back to DEPTH_WRITE (the fog/god-ray block downstream expects it there);
     // velocity to the combined shader-read state, which is where the debug overlay and next frame's
     // BeginMotionGBuffer both expect to find it.
     D3D12_RESOURCE_BARRIER toRead[] = {

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -654,11 +654,16 @@ bool D3D12PipelineState::CreateGrass() {
     rs.AddTable( D3D12RootLayout::SRVRange( 5 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 10: t5 CSM shadow-map array
     // 11: t6 point-shadow cube array (PBRLighting.hlsl requires this symbol)
     rs.AddTable( D3D12RootLayout::SRVRange( 6 ), D3D12_SHADER_VISIBILITY_PIXEL );
-    // 12 = simple-SSAO mask bindless SRV-heap index (b5 AOCB, PS only), set once per frame by
-    // DrawVegetation. Grass gets real AO now that RenderSSAO builds the mask from the PREVIOUS frame's COMPLETE
-    // depth rather than the depth prepass grass never joins — see Vegetation.hlsl's PSMain. The grass shadow
-    // CASTER (D3D12ShadowMap::CreateGrassCaster) shares this root sig but reads none of this.
+    // 12 = simple-SSAO mask bindless SRV-heap index (b5 AOCB, PS only), set once per frame by DrawVegetation.
+    // Grass gets real AO now that it joins the depth prepass RenderSSAO builds the mask from — see
+    // Vegetation.hlsl's PSMain. The grass shadow CASTER (D3D12ShadowMap::CreateGrassCaster) shares this root sig
+    // but reads none of this.
     rs.AddConstants( 5, 1, D3D12_SHADER_VISIBILITY_PIXEL );    // 12: b5 AOCB { AoMaskIndex }
+    // 13 = b6 MotionCB (root CBV), read ONLY by the G-buffer depth-prepass entry points (VSDepthGBuf). b6
+    // because b0..b5 above are all spoken for; a root CBV rather than constants because it is three matrices.
+    // Every other PSO on this root signature leaves the parameter unbound, which is legal for a parameter no
+    // bound shader statically references.
+    rs.AddCBV( 6, D3D12_SHADER_VISIBILITY_VERTEX );            // 13: b6 MotionCB
 
     rs.AddStaticSampler( D3D12RootLayout::SamplerAniso( 0, D3D12_SHADER_VISIBILITY_PIXEL ) );      // s0 diffuse
     // s2 PCF, matches World/Vob/Skeletal.
@@ -722,6 +727,77 @@ bool D3D12PipelineState::CreateGrass() {
 
     if ( FAILED( device->CreateGraphicsPipelineState( &pso, IID_PPV_ARGS( Grass.PSO.ReleaseAndGetAddressOf() ) ) ) ) {
         LogWarn() << "D3D12: CreateGraphicsPipelineState failed (grass).";
+        return false;
+    }
+
+    if ( !CreateGrassDepthPrepass( layout, _countof( layout ) ) ) {
+        // Non-fatal by design, exactly like the World-family G-buffer prepass PSOs: the lit grass PSO above is
+        // untouched, and DrawVegetationDepthPrepass just skips itself. Cost is grass being absent from the depth
+        // prepass again, i.e. no AO on the blades — never a broken frame.
+        LogWarn() << "D3D12: grass depth-prepass PSOs unavailable — vegetation stays out of the depth prepass "
+                     "(no screen-space AO on grass).";
+        Grass.DepthPrepassPSO.Reset();
+        Grass.DepthPrepassGBufPSO.Reset();
+    }
+    return true;
+}
+
+/** The two Forward+ depth-prepass PSOs for grass (see GrassPipeline). Split out of CreateGrass so a failure here
+    can be swallowed without also losing the lit grass pass. `layout`/`layoutCount` are CreateGrass's input
+    layout, reused verbatim: both prepass vertex shaders read the same POSITION/TEXCOORD + instance matrix. */
+bool D3D12PipelineState::CreateGrassDepthPrepass( const D3D12_INPUT_ELEMENT_DESC* layout, UINT layoutCount ) {
+    ID3D12Device* device = m_Device->GetDevice();
+    if ( !Grass.RootSig ) return false;
+
+    if ( !m_Shaders->CompileFromFile( "Vegetation.hlsl", "VSDepth", Shadermodel_VS, Grass.DepthVsBlob.ReleaseAndGetAddressOf() ) )
+        return false;
+    if ( !m_Shaders->CompileFromFile( "Vegetation.hlsl", "PSShadowClip", Shadermodel_PS, Grass.DepthPsBlob.ReleaseAndGetAddressOf() ) )
+        return false;
+    if ( !m_Shaders->CompileFromFile( "Vegetation.hlsl", "VSDepthGBuf", Shadermodel_VS, Grass.DepthGBufVsBlob.ReleaseAndGetAddressOf() ) )
+        return false;
+    if ( !m_Shaders->CompileFromFile( "Vegetation.hlsl", "PSDepthClipGBuf", Shadermodel_PS, Grass.DepthGBufPsBlob.ReleaseAndGetAddressOf() ) )
+        return false;
+
+    // Shared state: identical to the LIT grass PSO's (CULL_NONE for the crossed double-sided cards, reversed-Z
+    // GREATER_EQUAL with depth-write) so the depth laid down here is bit-identical to what the lit pass would
+    // write — which is the whole point, since the lit pass then re-tests GREATER_EQUAL against it.
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC pso = {};
+    pso.pRootSignature = Grass.RootSig.Get();
+    pso.InputLayout = { layout, layoutCount };
+    pso.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    pso.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+    pso.SampleDesc.Count = 1;
+    pso.SampleMask = UINT_MAX;
+    pso.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;
+    pso.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
+    pso.RasterizerState.DepthClipEnable = TRUE;
+    pso.DepthStencilState.DepthEnable = TRUE;
+    pso.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+    pso.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_GREATER_EQUAL;
+    pso.DepthStencilState.StencilEnable = FALSE;
+
+    // Depth-only variant: one scene-color RTV with every channel masked off, matching what the prepass has bound
+    // when the motion G-buffer is unavailable (same shape as World.DepthPrepassPSO).
+    pso.VS = { Grass.DepthVsBlob->GetBufferPointer(), Grass.DepthVsBlob->GetBufferSize() };
+    pso.PS = { Grass.DepthPsBlob->GetBufferPointer(), Grass.DepthPsBlob->GetBufferSize() };
+    pso.NumRenderTargets = 1;
+    pso.RTVFormats[0] = kSceneColorFormat;
+    pso.BlendState.RenderTarget[0].RenderTargetWriteMask = 0;
+    if ( FAILED( device->CreateGraphicsPipelineState( &pso, IID_PPV_ARGS( Grass.DepthPrepassPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+        LogWarn() << "D3D12: CreateGraphicsPipelineState failed (grass depth prepass).";
+        return false;
+    }
+
+    // G-buffer variant: the two real prepass targets instead.
+    pso.VS = { Grass.DepthGBufVsBlob->GetBufferPointer(), Grass.DepthGBufVsBlob->GetBufferSize() };
+    pso.PS = { Grass.DepthGBufPsBlob->GetBufferPointer(), Grass.DepthGBufPsBlob->GetBufferSize() };
+    pso.NumRenderTargets = 2;
+    pso.RTVFormats[0] = kVelocityFormat;
+    pso.RTVFormats[1] = kGBufferNormalFormat;
+    pso.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+    pso.BlendState.RenderTarget[1].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+    if ( FAILED( device->CreateGraphicsPipelineState( &pso, IID_PPV_ARGS( Grass.DepthPrepassGBufPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+        LogWarn() << "D3D12: CreateGraphicsPipelineState failed (grass G-buffer depth prepass).";
         return false;
     }
     return true;
@@ -2814,7 +2890,8 @@ bool D3D12PipelineState::CreateGtao() {
     // Intel XeGTAO — what AOMode::AO_ASSAO selects on D3D12 (Shaders/D3D12/XeGTAO.hlsl drives the vendored
     // XeGTAO.h/.hlsli next to it). One root signature for all eight passes:
     //   0 = b0, 24 root constants: XeGTAO's GTAOConstants block (see the static_assert in D3D12GTAO.cpp).
-    //   1 = b1, 12 root constants: the bindless heap indices for whichever pass is dispatching.
+    //   1 = b1, 28 root constants: the bindless heap indices for whichever pass is dispatching, plus the
+    //       normal-source flag and the view matrix LoadNormal needs for the G-buffer normal path.
     // Every texture and UAV is fetched through ResourceDescriptorHeap (SM6.6), so there are no descriptor
     // tables — hence CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED, the same shape as the TAA resolve.
     // Non-fatal throughout: RenderGTAO() guards on the PSOs and the AO chain falls back to the simple SSAO path.
@@ -2823,7 +2900,7 @@ bool D3D12PipelineState::CreateGtao() {
 
     D3D12RootLayout& rs = Layout( "Gtao" );
     rs.AddConstants( 0, 24, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 GTAOConstants
-    rs.AddConstants( 1, 12, D3D12_SHADER_VISIBILITY_ALL );   // 1: b1 GTAOBindingsCB
+    rs.AddConstants( 1, 28, D3D12_SHADER_VISIBILITY_ALL );   // 1: b1 GTAOBindingsCB
     // s0 point-clamp: XeGTAO gathers depth quads and samples explicit MIP levels. Any filtering would blend
     // across depth discontinuities and, per Intel's note in the main pass, interpolate depths within a MIP.
     rs.AddStaticSampler( D3D12RootLayout::SamplerPoint( 0, D3D12_SHADER_VISIBILITY_ALL ) );

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.h
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.h
@@ -32,6 +32,20 @@ public:
         Microsoft::WRL::ComPtr<ID3D12PipelineState> PSO;
         Microsoft::WRL::ComPtr<ID3DBlob>            CsBlob;
     };
+    // GVegetationBox grass. PSO/VsBlob/PsBlob are the LIT pass; the two below are its Forward+ depth-prepass
+    // variants (DrawVegetationDepthPrepass — grass joins the prepass so the AO mask contains the blades). Both
+    // are optional: DrawVegetationDepthPrepass simply skips the pass if the one it needs is null, which costs
+    // grass its AO contribution and nothing else. Only ONE of them may be used per frame, and which is decided
+    // by MotionGBufferActive() exactly as it is for the world/VOB/skeletal prepass draws — the whole prepass
+    // has to agree on the bound render targets.
+    struct GrassPipeline : GraphicsPipeline {
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> DepthPrepassPSO;       // VSDepth + PSShadowClip, mask-0 RTV
+        Microsoft::WRL::ComPtr<ID3DBlob>            DepthVsBlob;           // Vegetation.hlsl VSDepth
+        Microsoft::WRL::ComPtr<ID3DBlob>            DepthPsBlob;           // Vegetation.hlsl PSShadowClip
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> DepthPrepassGBufPSO;   // + velocity/normal G-buffer MRT
+        Microsoft::WRL::ComPtr<ID3DBlob>            DepthGBufVsBlob;       // Vegetation.hlsl VSDepthGBuf
+        Microsoft::WRL::ComPtr<ID3DBlob>            DepthGBufPsBlob;       // Vegetation.hlsl PSDepthClipGBuf
+    };
     // The shared opaque "world family": one root signature (b0 ViewProj, t0 diffuse, Forward+ light SRVs,
     // CSM + point-shadow tables, bindless material indices) anchors the lit world-mesh PSO, the lit
     // instanced-VOB PSO, and the depth-prepass PSOs. Skeletal + shadow-caster PSOs still living in the
@@ -479,6 +493,9 @@ public:
                                 // b2 bone-palette CBV, b7 GhostAlpha, t0 diffuse); reuses Skeletal.hlsl's VSDepth
     bool CreateGrass();       // GVegetationBox instanced grass cards (own root sig: b0 ViewProj, t0/t1 grass+ground
                               // textures, b1 GrassCB, b2 fog, Forward+ lights, b4 shadow CB, t5 CSM shadow map)
+    // The two Forward+ depth-prepass PSOs for grass; called by (and non-fatal to) CreateGrass, which passes its
+    // own input layout through since both prepass VS variants consume it unchanged.
+    bool CreateGrassDepthPrepass( const D3D12_INPUT_ELEMENT_DESC* layout, UINT layoutCount );
     bool CreateVideo();       // Bink YUV video playback (own root sig: b0 viewport consts, t0-t2 YUV planes)
     bool CreateSmaa();        // SMAA 3-pass AA (bindless root sig + edge/blend/neighborhood PSOs); textures stay in engine
     bool CreateSharpen();     // post-tonemap sharpen (bindless root sig + simple/CAS PSOs); LDR copy stays in engine
@@ -541,7 +558,7 @@ public:
     BloomPipeline    Bloom;
     GraphicsPipeline Ghost;
     GraphicsPipeline GhostSkeletal;
-    GraphicsPipeline Grass;
+    GrassPipeline    Grass;
     VideoPipeline    Video;
     SmaaPipeline     Smaa;
     SharpenPipeline  Sharpen;       // post-tonemap sharpening (Shaders/D3D12/Sharpen.hlsl)

--- a/D3D11Engine/D3D12Engine/D3D12Rain.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Rain.cpp
@@ -624,7 +624,7 @@ void D3D12GraphicsEngine::PrepareRainShadowmap() {
     m_RainVobDrawCount = 0;
 
     ID3D12PipelineState* casterPso = m_ShadowMap.GetWorldCasterPSO();
-    if ( !m_FrameOpen || !casterPso || !m_Pipelines.World.RootSig || !m_BlackTexture || !m_DefaultOrmTexture )
+    if ( !m_FrameOpen || !casterPso || !m_Pipelines.World.RootSig || !m_BlackTexture || GetDefaultOrmSrvSlot() == UINT_MAX )
         return;
 
     auto& state = Engine::GAPI->GetRendererState();
@@ -750,7 +750,7 @@ void D3D12GraphicsEngine::PrepareRainShadowmap() {
             d.indexCount = static_cast<UINT>( mesh->Indices.size() );
             d.startIndex = mesh->BaseIndexLocation;
             d.NormalIdx = 0xFFFFFFFFu;
-            d.OrmIdx = m_DefaultOrmTexture->GetSrvSlot();
+            d.OrmIdx = GetDefaultOrmSrvSlot();
             d.DiffuseIdx = diffuseIdx;
             g_RainShadowDraws.push_back( d );
         }

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -428,11 +428,9 @@ void D3D12GraphicsEngine::OnLoadWorld()
         v.Reset();
     }
     m_RainShadowVobs.Reset();
-    // The AO depth snapshot still holds the OLD world seen through the old camera — reprojecting the new
-    // world's geometry into it would produce garbage occlusion for one frame. RenderSSAO falls back to the
-    // white "no occlusion" mask until CopyDepthForAO refills it at the end of the first frame here.
-    m_PrevDepthValid = false;
-    // Same reasoning for TAA: the accumulated history and its depth snapshot belong to the world being left.
+    // AO needs no reset here — it runs entirely off THIS frame's depth prepass, so the first frame of the new
+    // world already produces a correct mask.
+    // TAA does: the accumulated history and its depth snapshot belong to the world being left.
     // Blending them into the new one would smear the old level across the first frames of the new one, and the
     // depth-confidence test would reject essentially every pixel while doing it.
     m_TaaHistoryValid = false;
@@ -1906,6 +1904,136 @@ void D3D12GraphicsEngine::DrawGhostVobs() {
 }
 
 
+D3D12GraphicsEngine::GrassCBData D3D12GraphicsEngine::MakeGrassConstants() const {
+	// Mirrors GVegetationBox::PopulateConstantBuffer, minus G_NormalVS (see Vegetation.hlsl) — 8 32-bit values
+	// to match GrassCB's HLSL layout exactly (root constants map by DWORD offset).
+	// Every grass pass in a frame MUST push the value this returns: Vegetation.hlsl's GrassWorldPos derives the
+	// swayed blade position from G_Time/G_WindStrength/the hero push, so a pass that read a different G_Time
+	// would rasterize the blade somewhere else than the depth prepass put it.
+	static_assert( sizeof( GrassCBData ) == 32, "GrassCBData must be 8 DWORDs to match Vegetation.hlsl's GrassCB" );
+	const auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+	GrassCBData gcb = {};
+	gcb.Time = Engine::GAPI->GetTimeSeconds();
+	gcb.WindStrength = settings.WindQuality > 0 ? settings.GlobalWindStrength : 0.0f;
+	if ( settings.HeroAffectsObjects ) {
+		gcb.PlayerPosWS = Engine::GAPI->GetPlayerVob() ? Engine::GAPI->GetPlayerVob()->GetPositionWorld() : XMFLOAT3( 0, 0, 0 );
+		gcb.HeroAffectStrength = 1.0f;
+	} else {
+		gcb.PlayerPosWS = XMFLOAT3( 0, 0, 0 );
+		gcb.HeroAffectStrength = 0.0f;
+	}
+	return gcb;
+}
+
+
+void D3D12GraphicsEngine::DrawVegetationDepthPrepass() {
+	// Grass into the Forward+ depth prepass — see the header comment on kVegetationPrepassRange for why, and for
+	// why the range is capped independently of the lit pass's OutdoorSmallVobDrawRadius.
+	//
+	// Deliberately a near-clone of DrawVegetation's cull + bind + draw loop rather than a shared helper: the two
+	// differ in the PSO, the cull radius, the root arguments they bind (this one touches neither lights, shadows,
+	// the ground texture nor the AO mask) and, in the G-buffer case, the extra MotionCB — which is most of what
+	// that loop is. What they MUST share is the vertex-position math, and that lives in the shader
+	// (GrassWorldPos) plus MakeGrassConstants, both of which they do share.
+	if ( !m_FrameOpen || !m_Pipelines.Grass.RootSig || !m_DepthBuffer ) return;
+
+	// The prepass is all-or-nothing about its render targets (see MotionGBufferActive): whichever variant the
+	// world/VOB/skeletal draws chose, this must choose too, or the PSO's RT formats won't match what is bound.
+	const D3D12_GPU_VIRTUAL_ADDRESS motionCb = GetMotionCbAddress();
+	const bool gbuf = motionCb && MotionGBufferActive();
+	ID3D12PipelineState* pso = gbuf ? m_Pipelines.Grass.DepthPrepassGBufPSO.Get()
+	                                : m_Pipelines.Grass.DepthPrepassPSO.Get();
+	if ( !pso ) return;
+
+	const auto& vegetationBoxes = Engine::GAPI->GetVegetationBoxes();
+	if ( vegetationBoxes.empty() ) return;
+
+	DX_ZONE( m_CmdList, "Depth Prepass (vegetation)" );
+	TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth Prepass (vegetation)" );
+
+	// ViewProj — identical derivation to DrawVegetation, so the depth laid down here is what the lit pass
+	// re-tests GREATER_EQUAL against.
+	XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
+	Engine::GAPI->SetViewTransformXM( view );
+	Engine::GAPI->ResetWorldTransform();
+	const XMFLOAT4X4& viewM = Engine::GAPI->GetRendererState().TransformState.TransformView;
+	const XMFLOAT4X4& projM = Engine::GAPI->GetProjectionMatrix();
+	XMFLOAT4X4 viewProj;
+	XMStoreFloat4x4( &viewProj, XMMatrixMultiply( XMLoadFloat4x4( &projM ), XMLoadFloat4x4( &viewM ) ) );
+
+	Frustum playerFrustum = Frustum::AlwaysContainingFrustum();
+	if ( auto cam = (zCCamera*)oCGame::GetGame()->_zCSession_camera ) {
+		const auto& camView = cam->trafoView;
+		const auto& camProj = cam->trafoProjection;
+		playerFrustum.BuildPerspective( XMMatrixTranspose( XMLoadFloat4x4( &camView ) ), XMLoadFloat4x4( &camProj ) );
+	}
+
+	const XMFLOAT3 camPos = Engine::GAPI->GetCameraPosition();
+	const auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+	// min(), not the hard limit alone: a player who lowered the vegetation draw radius below it must not get
+	// prepass depth for grass the lit pass then never draws — that would punch grass-shaped AO holes into the
+	// terrain behind it.
+	const float cullRadius = std::min( settings.OutdoorSmallVobDrawRadius, kVegetationPrepassRange );
+	const GrassCBData gcb = MakeGrassConstants();
+	// The PS only alpha-clips against t0, so t1/the fog CB/the lights/the shadow CB/the AO CB all stay unbound —
+	// D3D12 requires only the root parameters a bound shader statically references to be set.
+	const D3D12_GPU_DESCRIPTOR_HANDLE fallbackSrv = GetSrvGpuHandle( m_BlackTexture->GetSrvSlot() );
+	const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_Resolution.x ), static_cast<float>( m_Resolution.y ), 0.0f, 1.0f };
+	const D3D12_RECT     sc = { 0, 0, m_Resolution.x, m_Resolution.y };
+
+	bool bound = false;
+	for ( GVegetationBox* box : vegetationBoxes ) {
+		if ( !box || box->GetSpotCount() == 0 ) continue;
+
+		XMFLOAT3 bbMin, bbMax;
+		box->GetBoundingBox( &bbMin, &bbMax );
+		if ( Toolbox::ComputePointAABBDistance( camPos, bbMin, bbMax ) > cullRadius ) continue;
+		if ( !playerFrustum.Intersects( zTBBox3D{ bbMin, bbMax } ) ) continue;
+
+		GMeshSimple* mesh = box->GetVegetationMesh();
+		GfxVertexBuffer* instBuf = box->GetInstancingBuffer();
+		if ( !mesh || !instBuf ) continue;
+		D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( mesh->GetVertexBuffer() );
+		D3D12VertexBuffer* mib = D3D12VertexBuffer::From( mesh->GetIndexBuffer() );
+		D3D12VertexBuffer* mib_inst = D3D12VertexBuffer::From( instBuf );
+		if ( !mvb || !mib || !mib_inst || !mvb->GetResource() || !mib->GetResource() || !mib_inst->GetResource() ) continue;
+
+		if ( !bound ) {
+			bound = true;
+			m_CmdList->SetPipelineState( pso );
+			m_CmdList->SetGraphicsRootSignature( m_Pipelines.Grass.RootSig.Get() );
+			m_CmdList->SetGraphicsRoot32BitConstants( 0, 16, &viewProj, 0 );   // b0 ViewProj
+			m_CmdList->SetGraphicsRoot32BitConstants( 3, 8, &gcb, 0 );         // b1 GrassCB (the sway)
+			if ( gbuf ) m_CmdList->SetGraphicsRootConstantBufferView( 13, motionCb );   // b6 MotionCB
+			m_CmdList->RSSetViewports( 1, &vp );
+			m_CmdList->RSSetScissorRects( 1, &sc );
+			m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
+		}
+
+		// The alpha cutout must match the lit pass exactly or the two disagree about which texels exist — so
+		// the blade texture is bound here too. No ground texture: the prepass shades nothing.
+		D3D12_GPU_DESCRIPTOR_HANDLE grassSrv = fallbackSrv;
+		if ( GfxTexture* grassTex = box->GetVegetationTexture() ) {
+			D3D12Texture* d12 = D3D12Texture::From( grassTex );
+			if ( d12 && d12->HasSRV() ) grassSrv = d12->GetSrvGpuHandle();
+		}
+		m_CmdList->SetGraphicsRootDescriptorTable( 1, grassSrv );
+
+		const UINT numIndices = mesh->GetNumIndices();
+		const UINT numInstances = static_cast<UINT>( box->GetSpotCount() );
+		const D3D12_VERTEX_BUFFER_VIEW vbv = { mvb->GetGpuVirtualAddress(), mvb->GetSizeInBytes(), sizeof( SimpleObjectVertexStruct ) };
+		const D3D12_VERTEX_BUFFER_VIEW instVbv = { mib_inst->GetGpuVirtualAddress(), mib_inst->GetSizeInBytes(), sizeof( XMFLOAT4X4 ) };
+		const D3D12_VERTEX_BUFFER_VIEW views[2] = { vbv, instVbv };
+		m_CmdList->IASetVertexBuffers( 0, 2, views );
+		const D3D12_INDEX_BUFFER_VIEW ibv = { mib->GetGpuVirtualAddress(), mib->GetSizeInBytes(), DXGI_FORMAT_R16_UINT };
+		m_CmdList->IASetIndexBuffer( &ibv );
+		m_CmdList->DrawIndexedInstanced( numIndices, numInstances, 0, 0, 0 );
+	}
+	// Deliberately NOT counted into RendererInfo.FrameDrawnTriangles — the lit pass counts the same geometry,
+	// and reporting it twice would make the on-screen triangle count meaningless.
+}
+
+
 void D3D12GraphicsEngine::DrawVegetation() {
 	// GVegetationBox instanced grass cards (P2.12). Bypasses GVegetationBox's own D3D11-only
 	// PrepareRenderGeometryPipeline()/RenderVegetation() (a SetActiveVertexShader/SetupVS_Ex* state-machine
@@ -1942,20 +2070,7 @@ void D3D12GraphicsEngine::DrawVegetation() {
 	const float drawRadius = settings.OutdoorSmallVobDrawRadius;
 	const FogConstants fog = MakeFogConstants();
 
-	// Mirrors GVegetationBox::PopulateConstantBuffer, minus G_NormalVS (see Vegetation.hlsl) — 8 32-bit values
-	// to match GrassCB's HLSL layout exactly (root constants map by DWORD offset).
-	struct GrassCBData { float Time; float WindStrength; float HeroAffectStrength; float _pad0; XMFLOAT3 PlayerPosWS; float _pad1; };
-	static_assert( sizeof( GrassCBData ) == 32, "GrassCBData must be 8 DWORDs to match Vegetation.hlsl's GrassCB" );
-	GrassCBData gcb = {};
-	gcb.Time = Engine::GAPI->GetTimeSeconds();
-	gcb.WindStrength = settings.WindQuality > 0 ? settings.GlobalWindStrength : 0.0f;
-	if ( settings.HeroAffectsObjects ) {
-		gcb.PlayerPosWS = Engine::GAPI->GetPlayerVob() ? Engine::GAPI->GetPlayerVob()->GetPositionWorld() : XMFLOAT3( 0, 0, 0 );
-		gcb.HeroAffectStrength = 1.0f;
-	} else {
-		gcb.PlayerPosWS = XMFLOAT3( 0, 0, 0 );
-		gcb.HeroAffectStrength = 0.0f;
-	}
+	const GrassCBData gcb = MakeGrassConstants();
 
 	const D3D12_GPU_DESCRIPTOR_HANDLE whiteSrv = GetSrvGpuHandle( m_BlackTexture->GetSrvSlot() );
 	const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_Resolution.x ), static_cast<float>( m_Resolution.y ), 0.0f, 1.0f };
@@ -2222,6 +2337,11 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 		}
 	    DrawVobDepthPrepass();
 	    DrawSkeletalDepthPrepass();
+		// Vegetation last in the prepass — after the GPU VOB cull, which must see world-mesh-only depth, and
+		// after every other prepass writer, so the grass cards' alpha-tested fill is rejected early wherever
+		// solid geometry already sits in front. Range-limited (kVegetationPrepassRange); its reason for being
+		// here is RenderSSAO, which builds the AO mask out of exactly this depth.
+		DrawVegetationDepthPrepass();
 		// Back to the scene-color RT for the lit passes. The G-buffer targets stay in RENDER_TARGET until
 		// FillCameraVelocity flips them at the end of the frame.
 		EndMotionGBuffer();
@@ -2230,8 +2350,8 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// lights touch each 16x16 screen tile (bounded to real geometry on both the near and far side).
 	DispatchLightCulling();
 	// Screen-space AO: Intel XeGTAO when AoMode == AO_ASSAO, the simple depth-reconstructed SSAO otherwise.
-	// Both derive normals from the previous frame's depth snapshot (Forward+ has no GBuffer normals before
-	// lighting) and write the AO mask the lit passes below sample bindlessly via m_ActiveAOMaskSrvSlot.
+	// Both run off the depth prepass laid down just above and write the AO mask the lit passes below sample
+	// bindlessly via m_ActiveAOMaskSrvSlot. XeGTAO additionally takes its normals from the prepass' normal G-buffer.
 	// No-op (mask stays white) when AoMode == AO_NONE or resources are unavailable.
 	RenderSSAO();
 	// Sky image-based lighting: rebuilds the indirect-light cubes (specular chain + irradiance) when Gothic's
@@ -2340,16 +2460,10 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// far above) and after the collection lists are final. See D3D12Motion.cpp.
 	StoreVobPreviousTransforms();
 
-	// Snapshot the now-COMPLETE depth buffer for the next frame's SSAO (see D3D12AO.cpp). Deliberately here:
-	// every depth-writing pass (world, VOBs, skeletal, grass, decals, water, particles) has run, and
-	// RenderFogAndGodRays below is the first thing that moves the depth buffer out of DEPTH_WRITE.
-	CopyDepthForAO();
-
-	// Camera-only motion vectors for every pixel the depth prepass never covered — sky, grass, water, decals,
-	// the blended VOBs and the particle passes. Deliberately here, for the same reason CopyDepthForAO is: this
-	// is the first point at which the depth buffer is COMPLETE, and the fill reconstructs world positions from
-	// it. Only touches pixels still holding the clear sentinel, so the true per-object velocities the prepass
-	// wrote are left alone. See D3D12Motion.cpp.
+	// Camera-only motion vectors for every pixel the depth prepass never covered — sky, water, decals, the
+	// blended VOBs and the particle passes. Deliberately here: this is the first point at which the depth
+	// buffer is COMPLETE, and the fill reconstructs world positions from it. Only touches pixels still holding
+	// the clear sentinel, so the true per-object velocities the prepass wrote are left alone. See D3D12Motion.cpp.
 	FillCameraVelocity();
 
 	// Height fog + god rays (parity item #5): the last thing to touch the scene before the post-FX chain, same

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2725,7 +2725,7 @@ namespace {
 
     // Packs an SRV heap slot with the FxMap's channel layout for the D3D12 PS to unpack (see kOrmFormatShift).
     // EAdditionalMaterial::None/Specular (no _FX loaded, or the legacy D3D11-only _FX.dds) fall through to format
-    // 0 (ORM) — correct because m_DefaultOrmTexture is itself laid out as full AO/Rough/Metal in that case.
+    // 0 (ORM) — correct because the default ORM textures are themselves laid out as full AO/Rough/Metal.
     uint32_t EncodeOrmSlot( uint32_t srvSlot, EAdditionalMaterial availableMat ) {
         uint32_t fmt = 0;   // ORM: r=AO g=Roughness b=Metallic (also the default-texture / no-_FX case)
         switch ( availableMat ) {
@@ -2838,7 +2838,7 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
             zCTexture* tex = meshKey.Material->GetAniTexture();
             uint32_t diffuseIdx = m_BlackTexture->GetSrvSlot();
             uint32_t normalIdx  = 0xFFFFFFFFu;
-            uint32_t ormIdx     = m_DefaultOrmTexture->GetSrvSlot();
+            uint32_t ormIdx     = GetDefaultOrmSrvSlot();
             float normalStrength = 1.0f;
             if ( tex && tex->CacheIn( 0.6f ) == zRES_CACHED_IN ) {
                 if ( MyDirectDrawSurface7* s = tex->GetSurface() ) {
@@ -2972,7 +2972,7 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
     VobDrawCommand* cmds = reinterpret_cast<VobDrawCommand*>( argPtr );
     UINT count = 0;
     const uint32_t whiteSlot   = m_BlackTexture->GetSrvSlot();
-    const uint32_t defaultOrm  = m_DefaultOrmTexture->GetSrvSlot();
+    const uint32_t defaultOrm  = GetDefaultOrmSrvSlot();
     // Attribute the triangle stat to the main-view build only (resolveMaps): the shadow cascades build the same
     // geometry and would double-count. Reset here; the color pass adds it to FrameDrawnTriangles once.
     // NOTE: with GPU culling (culled=true) this is a pre-cull UPPER BOUND — the real instance counts only exist
@@ -3431,7 +3431,7 @@ void D3D12GraphicsEngine::BindMaterialMaps( zCTexture* tex, UINT matRootParam, U
 
 void D3D12GraphicsEngine::ResolveMaterialMapSlots( zCTexture* tex, UINT* outNormalOrm ) const {
     outNormalOrm[0] = 0xFFFFFFFFu;
-    outNormalOrm[1] = m_DefaultOrmTexture->GetSrvSlot();
+    outNormalOrm[1] = GetDefaultOrmSrvSlot();
     if ( tex ) {
         if ( MyDirectDrawSurface7* s = tex->GetSurface() ) {
             if ( GfxTexture* n = s->GetNormalmap() ) {

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -1103,6 +1103,15 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 			}
 			break;
 		}
+		// Advance ZENGIN's own light animation before reading the colour, exactly where D3D11 does it
+		// (D3D11TiledDeferredShading.cpp:433). zCVobLight::lightColor is only meaningful AFTER this call for any
+		// preset with colorAniFPS > 0: DoAnimation() samples colorAniList at colorAniActFrame and SetColor()s the
+		// result, so the stored lightColor of an animated light is nothing but the level/preset author's leftover
+		// base value — which is why every spell light (oCVisualFX builds its light via SetByPreset, and the spell
+		// presets are all colour-animated) rendered at one fixed wrong colour instead of its animated one.
+		// Must stay exactly once per frame per light: DoAnimation advances colorAniActFrame by the frame time.
+		vob->DoAnimation();
+
 		const DWORD c = vob->GetLightColor();   // 0xAARRGGBB
 		const float r = ((c >> 16) & 0xFF) / 255.0f;
 		const float g = ((c >> 8) & 0xFF) / 255.0f;

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -1677,7 +1677,7 @@ void D3D12GraphicsEngine::DrawGhostVobs() {
 	const D3D12_GPU_DESCRIPTOR_HANDLE whiteSrv = GetSrvGpuHandle( m_BlackTexture->GetSrvSlot() );
 	unsigned int drawnTris = 0;
 	const UINT frame = m_FrameIndex;
-	const auto now = Engine::GAPI->GetTotalTimeDW();
+	const auto now = Engine::GAPI->GetFrameNumber();
 	static std::vector<XMFLOAT4X4> ghostBoneCache;
 
 	// D3D11 draws these back-to-front (painter's algorithm) via a min/max-heap drain; the legacy
@@ -3853,7 +3853,7 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
     // measures against the camera and only routes vobs closer than kMorphMeshMaxDistance through the morph path.
     const XMVECTOR camPosXm = Engine::GAPI->GetCameraPositionXM();
     const UINT frame = m_FrameIndex;
-    const auto now = Engine::GAPI->GetTotalTimeDW();
+    const auto now = Engine::GAPI->GetFrameNumber();
     static std::vector<XMFLOAT4X4> boneCache;
 
     for ( SkeletalVobInfo* vi : vobs ) {

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -256,7 +256,8 @@ namespace {
 
     // Per-decal instance data (per-instance vertex stream, slot 1). World = world*offset*scale (view NOT
     // baked in — unlike D3D11, the D3D12 decal VS applies the standard ViewProj, so the CPU only needs the
-    // model matrix). Color.a = the material's ghost alpha ((GetColor()>>24)/255); rgb is unused. 80 bytes.
+    // model matrix). Color.a = the material's ghost alpha ((GetColor()>>24)/255); Color.r is the
+    // shade-lit flag (0 for the unlit ADD/MUL/MUL2 modes — see Decal.hlsl's PSMainBlend); .gb unused. 80 bytes.
     struct DecalInstanceInfo {
         DirectX::XMFLOAT4X4 World;
         DirectX::XMFLOAT4   Color;
@@ -1409,7 +1410,7 @@ void D3D12GraphicsEngine::DrawDecalList( const std::vector<zCVob*>& decals, bool
 	// Build the per-decal instance data on the CPU (filter + camera alignment) — a direct port of D3D11's
 	// DrawDecalList, minus the baked-in view matrix (the VS applies the standard ViewProj). The received
 	// list is already sorted back-to-front; we keep that order (painter's algorithm) and DON'T batch.
-	struct DecalMeta { zCTexture* texture; int alphaFunc; };
+	struct DecalMeta { zCTexture* texture; int alphaFunc; };   // both taken from the ANIMATED texture, see below
 	static std::vector<DecalInstanceInfo> gpu;
 	static std::vector<DecalMeta> meta;
 	gpu.clear(); meta.clear();
@@ -1516,12 +1517,32 @@ void D3D12GraphicsEngine::DrawDecalList( const std::vector<zCVob*>& decals, bool
 			}
 		}
 
+		// Texture + blend mode come from the ANIMATED texture, not the single one used for the pass filter
+		// above — same as D3D11, which re-derives both from GetAniTexture() in its draw loop. Gothic's
+		// animated decals (candle flames, torches) hand out a different frame every tick, and the frames do
+		// not all agree with the base texture on HasAlphaChannel(), so deriving the blend mode from
+		// GetTextureSingle() picks the wrong one for exactly the decals that look worst when it's wrong.
+		zCTexture* aniTex = material->GetAniTexture();
+		if ( !aniTex ) continue;
+
+		int drawAlphaFunc = material->GetAlphaFunc();
+		if ( drawAlphaFunc == zMAT_ALPHA_FUNC_MAT_DEFAULT ) {
+			drawAlphaFunc = zMAT_ALPHA_FUNC_BLEND;
+			if ( !aniTex->HasAlphaChannel() ) drawAlphaFunc = zMAT_ALPHA_FUNC_NONE;
+		}
+
+		// Only the alpha-blend modes are shaded; ADD is emissive and MUL/MUL2 multiply against the already
+		// lit scene, so lighting those blackens them. See the PSMainBlend comment in Decal.hlsl.
+		const bool shadeLit = lighting
+			|| drawAlphaFunc == zMAT_ALPHA_FUNC_BLEND
+			|| drawAlphaFunc == zMAT_ALPHA_FUNC_BLEND_TEST;
+
 		DecalInstanceInfo inst;
 		XMStoreFloat4x4( &inst.World, world * offset * scale );
 		const float ghostAlpha = lighting ? 1.0f : ((material->GetColor() >> 24) * (1.0f / 255.0f));
-		inst.Color = XMFLOAT4( 1.0f, 1.0f, 1.0f, ghostAlpha );
+		inst.Color = XMFLOAT4( shadeLit ? 1.0f : 0.0f, 1.0f, 1.0f, ghostAlpha );
 		gpu.push_back( inst );
-		meta.push_back( { material->GetAniTexture(), alphaFunc } );
+		meta.push_back( { aniTex, drawAlphaFunc } );
 	}
 
 	if ( gpu.empty() ) return;
@@ -1578,36 +1599,40 @@ void D3D12GraphicsEngine::DrawDecalList( const std::vector<zCVob*>& decals, bool
 	ID3D12PipelineState* lastPso = nullptr;
 	if ( lighting ) { m_CmdList->SetPipelineState( m_Pipelines.Decal.LitPSO.Get() ); lastPso = m_Pipelines.Decal.LitPSO.Get(); }
 
-	const D3D12_GPU_DESCRIPTOR_HANDLE whiteSrv = GetSrvGpuHandle( m_BlackTexture->GetSrvSlot() );
-	zCTexture* lastTex = reinterpret_cast<zCTexture*>(~static_cast<uintptr_t>(0));  // force first bind
+	zCTexture* lastTex = nullptr;
 	unsigned int drawnTris = 0;
 
 	for ( size_t i = 0; i < gpu.size(); ++i ) {
 		if ( !lighting ) {
 			GothicBlendStateInfo blend;
 			switch ( meta[i].alphaFunc ) {
-			case zMAT_ALPHA_FUNC_ADD:  blend.SetAdditiveBlending();  break;
-			case zMAT_ALPHA_FUNC_MUL:  blend.SetModulateBlending();  break;
-			case zMAT_ALPHA_FUNC_MUL2: blend.SetModulate2Blending(); break;
-			default:                   blend.SetAlphaBlending();     break;  // BLEND / BLEND_TEST
+			case zMAT_ALPHA_FUNC_BLEND:
+			case zMAT_ALPHA_FUNC_BLEND_TEST: blend.SetAlphaBlending();    break;
+			case zMAT_ALPHA_FUNC_ADD:        blend.SetAdditiveBlending(); break;
+			case zMAT_ALPHA_FUNC_MUL:        blend.SetModulateBlending(); break;
+			case zMAT_ALPHA_FUNC_MUL2:       blend.SetModulate2Blending(); break;
+			// The ani texture re-derived a mode this pass doesn't draw (NONE/TEST belong to the lit pass).
+			// D3D11 skips those too rather than falling back to alpha blending.
+			default: continue;
 			}
 			ID3D12PipelineState* pso = m_Pipelines.GetOrCreateDecalBlendPipeline( blend );
 			if ( !pso ) continue;
 			if ( pso != lastPso ) { m_CmdList->SetPipelineState( pso ); lastPso = pso; }
 		}
 
+		// Not-yet-cached surfaces are SKIPPED, never drawn with a fallback: the fallback is the 1x1 OPAQUE
+		// BLACK texture, so a decal whose texture is still streaming in used to rasterize as a solid black
+		// quad (alpha 1 passes both the lit pass's clip and the blend pass's alpha) instead of not being
+		// there yet. Same reason D3D11's draw loop `continue`s on a failed CacheIn.
 		zCTexture* tex = meta[i].texture;
 		if ( tex != lastTex ) {
-			D3D12_GPU_DESCRIPTOR_HANDLE srv = whiteSrv;
-			if ( tex && tex->CacheIn( 0.6f ) == zRES_CACHED_IN ) {
-				if ( MyDirectDrawSurface7* surface = tex->GetSurface() ) {
-					if ( GfxTexture* gfx = surface->GetEngineTexture() ) {
-						D3D12Texture* d12 = D3D12Texture::From( gfx );
-						if ( d12->HasSRV() ) srv = d12->GetSrvGpuHandle();
-					}
-				}
-			}
-			m_CmdList->SetGraphicsRootDescriptorTable( 1, srv );
+			if ( tex->CacheIn( 0.6f ) != zRES_CACHED_IN ) continue;
+			MyDirectDrawSurface7* surface = tex->GetSurface();
+			GfxTexture* gfx = surface ? surface->GetEngineTexture() : nullptr;
+			if ( !gfx ) continue;
+			D3D12Texture* d12 = D3D12Texture::From( gfx );
+			if ( !d12->HasSRV() ) continue;
+			m_CmdList->SetGraphicsRootDescriptorTable( 1, d12->GetSrvGpuHandle() );
 			lastTex = tex;
 		}
 

--- a/D3D11Engine/D3D12Engine/D3D12ShaderBackend.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShaderBackend.cpp
@@ -180,6 +180,7 @@ namespace {
 #else
         arguments.push_back( DXC_ARG_OPTIMIZATION_LEVEL3 );   // -O3 (Maximum optimization for release)
 #endif
+        arguments.push_back( L"-enable-16bit-types" ); // Enable 16-bit types for SM6+ (half, min16float, etc.)
 
         // Translate any legacy macro preprocessors into modern DXC -D parameters
         std::vector<std::wstring> wDefinesStore;

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -944,7 +944,7 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
 	if ( uint8_t* argPtr = m_WorldDrawArgsPtr[c][m_E->m_FrameIndex] ) {
 		auto* cmds = reinterpret_cast<D3D12GraphicsEngine::WorldDrawCommand*>( argPtr );
 		UINT drawCount = 0;
-		const uint32_t defaultOrm = m_E->m_DefaultOrmTexture->GetSrvSlot();
+		const uint32_t defaultOrm = m_E->GetDefaultOrmSrvSlot();
 		for ( const ShadowWorldCaster& caster : g_WorldCasters ) {
 			if ( !Engine::GAPI->IsWorldMeshVisibleInFrustum( caster.mesh, frustum ) ) continue;
 			if ( drawCount >= D3D12GraphicsEngine::kMaxWorldDrawCommands ) break;

--- a/D3D11Engine/D3D12Engine/D3D12SkyIbl.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12SkyIbl.cpp
@@ -176,8 +176,8 @@ void D3D12GraphicsEngine::UploadSkyIblConstants() {
     // disjoint block — see the static_asserts). Written UNCONDITIONALLY every frame: a frame that skipped the
     // write would leave the previous frame's indices standing, and on the frame the IBL first becomes
     // unavailable that would be a stale-but-valid descriptor rather than the intended flat-ambient fallback.
-    static_assert( kAoReprojCbOffset + sizeof( AoReprojCBData ) == kSkyIblCbOffset,
-        "sky-IBL CB block must start right after the AO-reprojection block" );
+    static_assert( kAoReprojCbOffset + kAoReprojCbReservedBytes == kSkyIblCbOffset,
+        "sky-IBL CB block must start right after the (now unused) AO-reprojection hole" );
     static_assert( kSkyIblCbOffset + sizeof( SkyIblCBData ) <= 512, "shadow CB overflow" );
     if ( !m_ShadowCBMapped[m_FrameIndex] ) return;
 

--- a/D3D11Engine/D3D12Engine/D3D12Taa.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Taa.cpp
@@ -42,8 +42,7 @@ namespace {
     constexpr uint32_t kTaaLongestVelocityVector = 0x40;
 
     // Relative view-Z tolerance for the disocclusion test. Generous enough to survive the sub-pixel reprojection
-    // error on a steeply slanted surface, tight enough to reject a genuinely different one — the same reasoning
-    // (and the same 5%) as ScreenSpaceAO.hlsl's kAoReprojDepthTolerance, which solves the identical problem.
+    // error on a steeply slanted surface, tight enough to reject a genuinely different one.
     constexpr float kTaaDepthTolerance = 0.05f;
 }
 
@@ -85,7 +84,7 @@ bool D3D12GraphicsEngine::CreateTaaResources( INT2 size ) {
     }
 
     // Private previous-depth snapshot. Same resource desc as m_DepthBuffer so CopyResource is unambiguously
-    // legal — identical reasoning to m_PrevDepth in CreateAOResources.
+    // legal — the same reasoning the water pass's depth copy follows.
     {
         D3D12_RESOURCE_DESC dd = {};
         dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
@@ -307,8 +306,8 @@ void D3D12GraphicsEngine::RenderTAA() {
         m_CmdList->CopyResource( m_SceneColor.Get(), m_TaaHistory[writeIdx].Get() );
     }
 
-    // Snapshot this frame's depth for the NEXT frame's disocclusion test. Must be here rather than borrowed
-    // from m_PrevDepth: CopyDepthForAO already refilled that one with this frame's depth earlier in the frame.
+    // Snapshot this frame's depth for the NEXT frame's disocclusion test. Nothing else in the frame keeps a
+    // previous-frame depth, so this pass owns the copy.
     if ( m_TaaPrevDepth ) {
         D3D12_RESOURCE_BARRIER toCopy[] = {
             TransitionBarrier( m_TaaPrevDepth.Get(), kPrevDepthReadState, D3D12_RESOURCE_STATE_COPY_DEST ),

--- a/D3D11Engine/D3D12Engine/D3D12Water.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Water.cpp
@@ -177,8 +177,8 @@ bool D3D12GraphicsEngine::EnsureWaterCopyResources() {
     }
 
     // Depth copy: SAME resource desc as m_DepthBuffer (R32_TYPELESS + ALLOW_DEPTH_STENCIL, see
-    // CreateDepthBuffer) so CopyResource is unambiguously legal — identical reasoning to m_PrevDepth in
-    // CreateAOResources.
+    // CreateDepthBuffer) so CopyResource is unambiguously legal — identical reasoning to m_TaaPrevDepth in
+    // CreateTaaResources.
     {
         D3D12_RESOURCE_DESC dd = {};
         dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -2561,19 +2561,9 @@ SkeletalMeshVisualInfo* GothicAPI::ResolveSkeletalVisualInfo( zCModel* model ) {
  *  (zParticle.cpp:2460) and every particle spawns on the vob's pivot - the "fire beast burns at one
  *  point until re-spawned" bug. Re-run the assignment here once the visual does exist. */
 void GothicAPI::RepairShapeMeshEmitter( zCVob* source, zCParticleFX* fx ) {
-#ifndef BUILD_GOTHIC_1_08k
-    zCParticleEmitter* emitter = fx->GetEmitter();
-    if ( !emitter || emitter->GetVisShpType() != 5 )
-        return;
-
-    // Only when ZENGIN left the shape unset - never second-guess a shape it did resolve.
-    if ( emitter->GetVisShpModel() || emitter->GetVisShpMesh() || emitter->GetVisShpProgMesh() )
-        return;
-
-    // emAdjustShpToOrigin is what makes oCVisualFX the *owner* of the shape mesh, so it is also
-    // what guarantees ReleasePFXMesh will drop the reference we add below. Without it we would leak.
+#ifndef BUILD_SPACER
     oCVisualFX* visFx = source ? source->As<oCVisualFX>() : nullptr;
-    if ( !visFx || !visFx->GetAdjustShapeToOrigin() )
+    if ( !visFx )
         return;
 
     zCVob* origin = visFx->GetOrigin();
@@ -2584,18 +2574,49 @@ void GothicAPI::RepairShapeMeshEmitter( zCVob* source, zCParticleFX* fx ) {
     if ( !originVisual )
         return; // Still nothing to point at - try again next frame
 
-    // Mirror CalcPFXMesh's zDYNAMIC_CAST<zCModel> branch. Only the model case is repaired here:
-    // zCMesh/zCProgMeshProto origins are served by ZENGIN itself and never reach our LOD hooks.
+    // Both repairs below mirror a `zDYNAMIC_CAST<zCModel>(origin->GetVisual())` test in ZENGIN.
     const char* ext = originVisual->GetFileExtension( 0 );
     if ( !ext || (strcmp( ext, ".MDS" ) != 0 && strcmp( ext, ".ASC" ) != 0) )
         return;
 
     zCModel* originModel = static_cast<zCModel*>(originVisual);
-    emitter->SetVisShpModel( originModel );
-    zCObject_AddRef( originModel ); // matches CalcPFXMesh's orgModel->AddRef()
 
-    LogInfo() << "Repaired shape-mesh emitter for '" << originModel->GetModelName().ToChar()
-        << "' - oCVisualFX started before the origin had a visual";
+    // (a) The emitter's shape mesh (oCVisualFX::CalcPFXMesh). Governs WHERE particles spawn:
+    //     without it the MESH case yields (0,0,0) and the whole effect sits on the pivot.
+#ifndef BUILD_GOTHIC_1_08k
+    if ( zCParticleEmitter* emitter = fx->GetEmitter();
+        emitter && emitter->GetVisShpType() == 5
+        && !emitter->GetVisShpModel() && !emitter->GetVisShpMesh() && !emitter->GetVisShpProgMesh()
+        // emAdjustShpToOrigin is what makes oCVisualFX the *owner* of the shape mesh, so it is also
+        // what guarantees ReleasePFXMesh drops the reference we add here. Without it we would leak.
+        && visFx->GetAdjustShapeToOrigin() ) {
+
+        emitter->SetVisShpModel( originModel );
+        zCObject_AddRef( originModel ); // matches CalcPFXMesh's orgModel->AddRef()
+
+        LogInfo() << "Repaired shape-mesh emitter for '" << originModel->GetModelName().ToChar()
+            << "' - oCVisualFX started before the origin had a visual";
+    }
+#endif
+
+    // (b) The origin NODE binding (oCVisualFX::Init, oVisFx.cpp:2305-2309). Governs WHERE THE WHOLE
+    //     EFFECT rides: with orgNode null, oCVisualFX::DoMovements' EM_TRJ_FIXED branch falls back
+    //     from origin->GetTrafoModelNodeToWorld(orgNode) to origin->GetNewTrafoObjToWorld(), i.e.
+    //     the vob pivot instead of the bone. This is what pinned the undead dragon's eye effects to
+    //     its origin. Same one-shot-resolve trap as (a), so the same repair applies.
+    if ( !visFx->GetOriginNode() ) {
+        const zSTRING* nodeName = visFx->GetOriginNodeName();
+        if ( nodeName && nodeName->Length() > 0 ) {
+            // ZENGIN uppercases emTrjOriginNode_S before the lookup; node names are upper case and
+            // so are the script instances in practice, so a mixed-case name simply fails to resolve
+            // here and we retry next frame rather than mutating Gothic's string.
+            if ( zCModelNodeInst* node = originModel->SearchNode( *nodeName ) ) {
+                visFx->SetOriginNode( node );
+                LogInfo() << "Repaired VisualFX origin node '" << nodeName->ToChar() << "' on '"
+                    << originModel->GetModelName().ToChar() << "'";
+            }
+        }
+    }
 #endif
 }
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -529,6 +529,7 @@ void GothicAPI::UpdateTextureMaxSize() {
 /** Called to update the world, before rendering */
 void GothicAPI::OnWorldUpdate() {
     ZoneScopedN( "GothicAPI::OnWorldUpdate" );
+    ++FrameNumber;
 #if BUILD_SPACER
     zCBspBase* rootBsp = oCGame::GetGame()->_zCSession_world->GetBspTree()->GetRootNode();
     BspInfo* root = &BspLeafVobLists[rootBsp];
@@ -1695,6 +1696,11 @@ void GothicAPI::GetVisibleParticleEffectsList( std::vector<zCVob*>& pfxList ) {
                 if ( auto vis = it->GetVisual() ) {
                     // Do update particle state, even if not in frustum, so that if player turns back to it, it doesn't restart.
                     auto particleFx = reinterpret_cast<zCParticleFX*>(vis);
+                    if ( IsUnservableSkeletalShapeEmitter( particleFx ) ) {
+                        // Its shape-mesh isn't skinned yet - ticking it would spawn every particle
+                        // on the model's origin. Let it start a few frames late instead.
+                        continue;
+                    }
                     particleFx->UpdateParticleFX();
                     if ( !particleFx->GetVisualDied() ) {
                         zCParticleFX::GetStaticPFXList()->TouchPfx( particleFx );
@@ -2496,10 +2502,11 @@ SkeletalMeshVisualInfo* GothicAPI::LoadzCModelData( oCNPC* npc ) {
     return mi;
 }
 
-int GothicAPI::GetLowestLODNumPolys_SkeletalMesh( zCModel* model ) {
-    int numPolys = 0;
-
+/** Looks up the extracted skeletal mesh data for a live zCModel. Returns nullptr while the data
+ *  does not exist yet or a background LoadzCModelData extraction is still running. */
+SkeletalMeshVisualInfo* GothicAPI::ResolveSkeletalVisualInfo( zCModel* model ) {
     SkeletalMeshVisualInfo* skeletalMesh = nullptr;
+
     zCVob* homeVob = model->GetHomeVob();
     if ( homeVob && homeVob->GetVobType() == zVOB_TYPE_NSC ) {
         oCNPC* npc = static_cast<oCNPC*>(homeVob);
@@ -2521,7 +2528,39 @@ int GothicAPI::GetLowestLODNumPolys_SkeletalMesh( zCModel* model ) {
         }
     }
 
-    if ( skeletalMesh && skeletalMesh->Ready.load() ) {
+    if ( !skeletalMesh || !skeletalMesh->Ready.load() )
+        return nullptr; // Still being built on a worker thread - don't touch its mesh data yet
+
+    return skeletalMesh;
+}
+
+/** True if this emitter samples its spawn positions off a skeletal shape-mesh we cannot serve yet.
+ *  ZENGIN's zCParticleEmitter::GetPosition falls back to (0,0,0) - the model's own origin - when
+ *  GetLowestLODNumPolys returns 0, so the whole effect would visibly collapse onto the model's
+ *  pivot. Skipping the emitter tick until the data is there is the lesser evil: the effect simply
+ *  starts a few frames late instead of starting wrong. */
+bool GothicAPI::IsUnservableSkeletalShapeEmitter( zCParticleFX* fx ) {
+    zCParticleEmitter* emitter = fx->GetEmitter();
+    if ( !emitter )
+        return false;
+
+    // zPFX_EMITTER_SHAPE_MESH. shpModel is only non-null on the oCVisualFX "emAdjustShpToOrigin"
+    // path, where it points at the *origin vob's live zCModel* (oVisFx.cpp).
+    if ( emitter->GetVisShpType() != 5 )
+        return false;
+
+    zCModel* shapeModel = emitter->GetVisShpModel();
+    if ( !shapeModel )
+        return false; // Plain zCMesh/zCProgMeshProto shapes are handled by ZENGIN itself
+
+    return ResolveSkeletalVisualInfo( shapeModel ) == nullptr;
+}
+
+int GothicAPI::GetLowestLODNumPolys_SkeletalMesh( zCModel* model ) {
+    int numPolys = 0;
+
+    SkeletalMeshVisualInfo* skeletalMesh = ResolveSkeletalVisualInfo( model );
+    if ( skeletalMesh ) {
         for ( auto const& itm : skeletalMesh->SkeletalMeshes ) {
             for ( auto& mesh : itm.second ) {
                 numPolys += static_cast<int>(mesh->Indices.size() / 3);
@@ -2537,38 +2576,33 @@ float3* GothicAPI::GetLowestLODPoly_SkeletalMesh( zCModel* model, const int poly
     size_t polyIndex = static_cast<size_t>(polyId) * 3;
     polyNormal = &defaultPolyNormal;
 
-    SkeletalMeshVisualInfo* skeletalMesh = nullptr;
-    zCVob* homeVob = model->GetHomeVob();
-    if ( homeVob && homeVob->GetVobType() == zVOB_TYPE_NSC ) {
-        oCNPC* npc = static_cast<oCNPC*>(homeVob);
-        auto it = SkeletalMeshNpcs.find( npc );
-        if ( it != SkeletalMeshNpcs.end() ) {
-            skeletalMesh = it->second;
-        }
-    } else {
-        auto visName = model->GetVisualName();
-        std::string str( visName.data(), visName.size() );
-        if ( str.empty() ) { // Happens when the model has no skeletal-mesh
-            zSTRING mds = model->GetModelName();
-            str.append( mds.ToView() );
-        }
-
-        auto it = SkeletalMeshVisuals.find( str );
-        if ( it != SkeletalMeshVisuals.end() ) {
-            skeletalMesh = it->second;
-        }
-    }
-
-    if ( skeletalMesh && skeletalMesh->Ready.load() ) {
+    SkeletalMeshVisualInfo* skeletalMesh = ResolveSkeletalVisualInfo( model );
+    if ( skeletalMesh ) {
+        // ZENGIN calls this once per spawned particle, so the skeleton is evaluated once per
+        // (model, frame) and reused. GetBoneTransformsTo writes into our own scratch buffer
+        // instead of zCModelNodeInst::TrafoObjToCam - we are inside an engine callback here and
+        // must not clobber ZENGIN's world-space node cache (see GetBoneTransformsTo).
         static std::vector<XMFLOAT4X4> transforms;
+        static zCModel* cachedModel = nullptr;
+        static size_t cachedFrame = static_cast<size_t>(-1);
+
+        const size_t now = GetFrameNumber();
+        if ( cachedModel != model || cachedFrame != now ) {
+            transforms.clear();
+            model->GetBoneTransformsTo( transforms );
+            cachedModel = model;
+            cachedFrame = now;
+        }
+
         for ( auto const& itm : skeletalMesh->SkeletalMeshes ) {
             for ( auto& mesh : itm.second ) {
                 if ( polyIndex >= mesh->Indices.size() ) {
                     polyIndex -= mesh->Indices.size();
                 } else {
+                    if ( transforms.empty() )
+                        break; // No node list on this model - fall through to the guard below
+
                     float fatness = model->GetModelFatness();
-                    transforms.clear();
-                    model->GetBoneTransforms( &transforms );
 
                     for ( int i = 0; i < 3; ++i ) {
                         VERTEX_INDEX _polyId = mesh->Indices[polyIndex + i];
@@ -2612,6 +2646,16 @@ float3* GothicAPI::GetLowestLODPoly_SkeletalMesh( zCModel* model, const int poly
         }
     }
 
+    // Last-resort guard. Every particle placed from here lands on the model's own origin, so this
+    // must stay rare - IsUnservableSkeletalShapeEmitter is supposed to stop the emitter from
+    // ticking at all while we cannot serve it. Log once per model so a regression is visible.
+    static std::unordered_set<zCModel*> loggedOriginFallback;
+    if ( loggedOriginFallback.insert( model ).second ) {
+        zSTRING mds = model->GetModelName();
+        LogWarn() << "GetLowestLODPoly_SkeletalMesh: no skinned mesh data for '" << mds.ToChar()
+            << "' - particles from this shape-mesh emitter fall back to the model origin";
+    }
+
     returnPositions[0] = float3( 0.f, 0.f, 0.f );
     returnPositions[1] = float3( 0.f, 0.f, 0.f );
     returnPositions[2] = float3( 0.f, 0.f, 0.f );
@@ -2649,7 +2693,7 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
     if ( !vi->Vob->GetShowVisual() )
         return;
 
-    const auto now = Engine::GAPI->GetTotalTimeDW();
+    const auto now = Engine::GAPI->GetFrameNumber();
 
     if ( updateState ) {
         // Update attachments
@@ -2912,7 +2956,7 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
     if ( !vi->Vob->GetShowVisual() )
         return;
 
-    const auto now = Engine::GAPI->GetTotalTimeDW();
+    const auto now = Engine::GAPI->GetFrameNumber();
 
     if ( updateState ) {
         // Update attachments
@@ -3293,6 +3337,18 @@ void GothicAPI::OnParticleFXDeleted( zCParticleFX* pfx ) {
 
 /** Draws a zCParticleFX */
 void GothicAPI::DrawParticleFX( zCVob* source, zCParticleFX* fx, ParticleFrameData& data ) {
+    if ( IsUnservableSkeletalShapeEmitter( fx ) ) {
+        // This emitter samples its spawn positions off a skeletal mesh whose skinned data we
+        // haven't extracted yet (LoadzCModelData runs on a worker). Spawning now would put every
+        // particle on the model's origin, so hold the effect instead - see
+        // IsUnservableSkeletalShapeEmitter. Nothing is drawn this frame either - anything already
+        // spawned sits on the origin and is exactly what we don't want on screen.
+        if ( !fx->GetVisualDied() ) {
+            zCParticleFX::GetStaticPFXList()->TouchPfx( fx );
+        }
+        return;
+    }
+
     // Update effects time
     fx->UpdateTime();
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5489,6 +5489,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "General", "BloomStrength", float_to_string( s.BloomStrength, 2 ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "BloomKnee", float_to_string( s.BloomKnee, 2 ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "BloomRadius", float_to_string( s.BloomRadius, 2 ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "DefaultMaterialRoughness", float_to_string( s.DefaultMaterialRoughness, 2 ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "EnableDebugLog", to_string_locale_independent( s.EnableDebugLog ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "EnableAutoupdates", to_string_locale_independent( s.EnableAutoupdates ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "EnableGodRays", to_string_locale_independent( s.EnableGodRays ? TRUE : FALSE ).c_str(), ini.c_str() );
@@ -5660,6 +5661,9 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.BloomStrength = GetPrivateProfileFloatA( "General", "BloomStrength", ds.BloomStrength, ini );
         s.BloomKnee = GetPrivateProfileFloatA( "General", "BloomKnee", ds.BloomKnee, ini );
         s.BloomRadius = GetPrivateProfileFloatA( "General", "BloomRadius", ds.BloomRadius, ini );
+        // Snap to a step the D3D12 backend actually built a 1x1 ORM texture for — the ini is hand-editable.
+        s.DefaultMaterialRoughness = DefaultRoughness::ForStep( DefaultRoughness::StepFor(
+            GetPrivateProfileFloatA( "General", "DefaultMaterialRoughness", ds.DefaultMaterialRoughness, ini ) ) );
         s.EnableDebugLog = GetPrivateProfileBoolA( "General", "EnableDebugLog", ds.EnableDebugLog, ini );
         s.EnableAutoupdates = GetPrivateProfileBoolA( "General", "EnableAutoupdates", ds.EnableAutoupdates, ini );
         s.EnableGodRays = GetPrivateProfileBoolA( "General", "EnableGodRays", ds.EnableGodRays, ini );

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -6560,8 +6560,12 @@ static void CollectLeafVobs(
         // with one pointer compare; a miss falls back to the map and repairs the slot.
         const bool mirrorUsable = static_cast<int>(base->Lights.size()) == numLights;
 
+        const bool dropStaticLights = Engine::GAPI->GetRendererState().RendererSettings.DisableStaticPointlights;
+
         for ( int i = 0; i < numLights; i++ ) {
             zCVobLight* vob = leaf->LightVobList.Array[i];
+
+            if ( dropStaticLights && vob->IsStatic() ) continue;
 
             // Range test first - it needs nothing but the zCVobLight, and keeping it ahead of the
             // resolve below preserves the original rule that an out-of-range light never causes a

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1696,6 +1696,7 @@ void GothicAPI::GetVisibleParticleEffectsList( std::vector<zCVob*>& pfxList ) {
                 if ( auto vis = it->GetVisual() ) {
                     // Do update particle state, even if not in frustum, so that if player turns back to it, it doesn't restart.
                     auto particleFx = reinterpret_cast<zCParticleFX*>(vis);
+                    RepairShapeMeshEmitter( it, particleFx );
                     if ( IsUnservableSkeletalShapeEmitter( particleFx ) ) {
                         // Its shape-mesh isn't skinned yet - ticking it would spawn every particle
                         // on the model's origin. Let it start a few frames late instead.
@@ -2531,6 +2532,18 @@ SkeletalMeshVisualInfo* GothicAPI::ResolveSkeletalVisualInfo( zCModel* model ) {
     if ( !skeletalMesh || !skeletalMesh->Ready.load() )
         return nullptr; // Still being built on a worker thread - don't touch its mesh data yet
 
+    // A model can reach OnAddVob before Gothic has built its soft-skin list (freshly spawned NPCs
+    // do). LoadzCModelData then caches an EMPTY extraction against this oCNPC*/visual and, since it
+    // only re-runs from OnAddVob, that empty result survives until the vob is removed and re-added.
+    // ZENGIN reads 0 polys from it and drops every particle on the model's origin - permanently.
+    // Repair it here, the same way the D3D12 skeletal prepare does (D3D12Scene.cpp:3905). Safe to
+    // do synchronously: Ready is true, so no background job is writing to this info, and it happens
+    // once per model. Interactive MOBs whose only content is a node attachment legitimately stay
+    // empty, hence the NumInArray guard.
+    if ( skeletalMesh->SkeletalMeshes.empty() && model->GetMeshSoftSkinList()->NumInArray > 0 ) {
+        WorldConverter::ExtractSkeletalMeshFromVob( model, skeletalMesh );
+    }
+
     return skeletalMesh;
 }
 
@@ -2539,6 +2552,53 @@ SkeletalMeshVisualInfo* GothicAPI::ResolveSkeletalVisualInfo( zCModel* model ) {
  *  GetLowestLODNumPolys returns 0, so the whole effect would visibly collapse onto the model's
  *  pivot. Skipping the emitter tick until the data is there is the lesser evil: the effect simply
  *  starts a few frames late instead of starting wrong. */
+/** ZENGIN's oCVisualFX::CalcPFXMesh (oVisFx.cpp:3961) points a zPFX_EMITTER_SHAPE_MESH emitter at
+ *  the origin vob's visual exactly once - while the FX's own visual is being created. If the origin
+ *  had no visual yet at that instant, none of its shpMesh/shpProgMesh/shpModel branches assign, and
+ *  the pointer stays null for the whole life of the effect (oCNpc::StartEffect's follow-up
+ *  SetPFXShapeVisual is likewise guarded by `if (GetVisual())`, oNpc.cpp:14437). ZENGIN's
+ *  zCParticleEmitter::GetPosition then falls through its MESH case to `return zVEC3(0,0,0)`
+ *  (zParticle.cpp:2460) and every particle spawns on the vob's pivot - the "fire beast burns at one
+ *  point until re-spawned" bug. Re-run the assignment here once the visual does exist. */
+void GothicAPI::RepairShapeMeshEmitter( zCVob* source, zCParticleFX* fx ) {
+#ifndef BUILD_GOTHIC_1_08k
+    zCParticleEmitter* emitter = fx->GetEmitter();
+    if ( !emitter || emitter->GetVisShpType() != 5 )
+        return;
+
+    // Only when ZENGIN left the shape unset - never second-guess a shape it did resolve.
+    if ( emitter->GetVisShpModel() || emitter->GetVisShpMesh() || emitter->GetVisShpProgMesh() )
+        return;
+
+    // emAdjustShpToOrigin is what makes oCVisualFX the *owner* of the shape mesh, so it is also
+    // what guarantees ReleasePFXMesh will drop the reference we add below. Without it we would leak.
+    oCVisualFX* visFx = source ? source->As<oCVisualFX>() : nullptr;
+    if ( !visFx || !visFx->GetAdjustShapeToOrigin() )
+        return;
+
+    zCVob* origin = visFx->GetOrigin();
+    if ( !origin )
+        return;
+
+    zCVisual* originVisual = origin->GetVisual();
+    if ( !originVisual )
+        return; // Still nothing to point at - try again next frame
+
+    // Mirror CalcPFXMesh's zDYNAMIC_CAST<zCModel> branch. Only the model case is repaired here:
+    // zCMesh/zCProgMeshProto origins are served by ZENGIN itself and never reach our LOD hooks.
+    const char* ext = originVisual->GetFileExtension( 0 );
+    if ( !ext || (strcmp( ext, ".MDS" ) != 0 && strcmp( ext, ".ASC" ) != 0) )
+        return;
+
+    zCModel* originModel = static_cast<zCModel*>(originVisual);
+    emitter->SetVisShpModel( originModel );
+    zCObject_AddRef( originModel ); // matches CalcPFXMesh's orgModel->AddRef()
+
+    LogInfo() << "Repaired shape-mesh emitter for '" << originModel->GetModelName().ToChar()
+        << "' - oCVisualFX started before the origin had a visual";
+#endif
+}
+
 bool GothicAPI::IsUnservableSkeletalShapeEmitter( zCParticleFX* fx ) {
     zCParticleEmitter* emitter = fx->GetEmitter();
     if ( !emitter )
@@ -2553,7 +2613,11 @@ bool GothicAPI::IsUnservableSkeletalShapeEmitter( zCParticleFX* fx ) {
     if ( !shapeModel )
         return false; // Plain zCMesh/zCProgMeshProto shapes are handled by ZENGIN itself
 
-    return ResolveSkeletalVisualInfo( shapeModel ) == nullptr;
+    // Not just "no info yet" - an info that resolves but carries no skinned geometry is equally
+    // unservable, and ZENGIN would never even reach GetLowestLODPoly for it (GetPosition bails on
+    // numPolys==0), so this is the only place that failure mode can be caught.
+    SkeletalMeshVisualInfo* info = ResolveSkeletalVisualInfo( shapeModel );
+    return info == nullptr || info->SkeletalMeshes.empty();
 }
 
 int GothicAPI::GetLowestLODNumPolys_SkeletalMesh( zCModel* model ) {
@@ -3337,6 +3401,9 @@ void GothicAPI::OnParticleFXDeleted( zCParticleFX* pfx ) {
 
 /** Draws a zCParticleFX */
 void GothicAPI::DrawParticleFX( zCVob* source, zCParticleFX* fx, ParticleFrameData& data ) {
+    // ZENGIN may have left this emitter's shape mesh unset because the origin had no visual yet.
+    RepairShapeMeshEmitter( source, fx );
+
     if ( IsUnservableSkeletalShapeEmitter( fx ) ) {
         // This emitter samples its spawn positions off a skeletal mesh whose skinned data we
         // haven't extracted yet (LoadzCModelData runs on a worker). Spawning now would put every

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5949,10 +5949,10 @@ POINT GothicAPI::GetCursorPosition() {
 }
 
 /** Adds a staging texture to the list of the staging textures for this frame */
-void GothicAPI::AddStagingTexture( UINT mip, const Microsoft::WRL::ComPtr<ID3D11Texture2D>& stagingTexture,
+void GothicAPI::AddStagingTexture( GfxTexture* gfx, UINT mip, const Microsoft::WRL::ComPtr<ID3D11Texture2D>& stagingTexture,
     const Microsoft::WRL::ComPtr<ID3D11Texture2D>& texture ) {
     Engine::GAPI->EnterResourceCriticalSection();
-    FrameStagingTextures.emplace_back( DeferredMipUpload{ mip, stagingTexture, texture } );
+    FrameStagingTextures.push_back( DeferredMipUpload{ gfx, mip, stagingTexture, texture } );
     Engine::GAPI->LeaveResourceCriticalSection();
 }
 
@@ -5968,6 +5968,9 @@ void GothicAPI::RemovePendingTextureCommands( GfxTexture* texture ) {
     Engine::GAPI->EnterResourceCriticalSection();
     // Usually empty, and never long: this only holds what one frame's worth of loading queued up.
     std::erase( FrameMipMapGenerations, texture );
+    std::erase_if( FrameStagingTextures, [texture]( const DeferredMipUpload& u ) {
+        return u.Texture == texture;
+    } );
     Engine::GAPI->LeaveResourceCriticalSection();
 }
 

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -1043,6 +1043,10 @@ private:
      *  origin, so the caller must skip the update entirely. */
     bool IsUnservableSkeletalShapeEmitter( zCParticleFX* fx );
 
+    /** Re-points a mesh-shaped emitter at its origin's model when ZENGIN's one-shot assignment
+     *  missed it (origin had no visual yet). Cheap no-op once the shape is set. */
+    void RepairShapeMeshEmitter( zCVob* source, zCParticleFX* fx );
+
     /** In-flight background extraction jobs, keyed by the SkeletalMeshVisualInfo they populate.
      *  Must be cancelled+waited-on before that SkeletalMeshVisualInfo (or the zCModel/oCNPC it
      *  reads from) is destroyed - see WaitForPendingSkeletalLoad(). */

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -294,6 +294,7 @@ struct PolyStripInfo {
     release builds, so the queue keeps both resources alive by itself instead of relying on whoever
     created them still being around. */
 struct DeferredMipUpload {
+    GfxTexture* Texture; // only to know which one to delete in case its removed
     UINT Mip;
     Microsoft::WRL::ComPtr<ID3D11Texture2D> Staging;
     Microsoft::WRL::ComPtr<ID3D11Texture2D> Destination;
@@ -847,11 +848,11 @@ public:
     XRESULT LoadMenuSettings( const std::string& file );
 
     /** Adds a staging texture to the list of the staging textures for this frame */
-    void AddStagingTexture( UINT mip, const Microsoft::WRL::ComPtr<ID3D11Texture2D>& stagingTexture,
+    void AddStagingTexture( GfxTexture* gfx, UINT mip, const Microsoft::WRL::ComPtr<ID3D11Texture2D>& stagingTexture,
         const Microsoft::WRL::ComPtr<ID3D11Texture2D>& texture );
 
     /** Gets a list of the staging textures for this frame */
-    std::vector<DeferredMipUpload>& GetStagingTextures() { return FrameStagingTextures; }
+    std::deque<DeferredMipUpload>& GetStagingTextures() { return FrameStagingTextures; }
 
     /** Adds a mip map generation deferred command */
     void AddMipMapGeneration( GfxTexture* texture );
@@ -861,7 +862,7 @@ public:
     void RemovePendingTextureCommands( GfxTexture* texture );
 
     /** Gets a list of the mip map generation commands for this frame */
-    std::list<GfxTexture*>& GetMipMapGeneration() {return FrameMipMapGenerations;}
+    std::deque<GfxTexture*>& GetMipMapGeneration() {return FrameMipMapGenerations;}
 
     /** Adds a texture to the list of the loaded textures for this frame */
     void AddFrameLoadedTexture( MyDirectDrawSurface7* srf );
@@ -1105,8 +1106,8 @@ private:
     DWORD MainThreadID;
 
     /** Textures loaded this frame */
-    std::vector<DeferredMipUpload> FrameStagingTextures;
-    std::list<GfxTexture*> FrameMipMapGenerations;
+    std::deque<DeferredMipUpload> FrameStagingTextures;
+    std::deque<GfxTexture*> FrameMipMapGenerations;
     std::list<MyDirectDrawSurface7*> FrameLoadedTextures;
 
     /** Quad marks loaded in the world */

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -625,6 +625,10 @@ public:
     /** Returns total time DWORD */
     DWORD GetTotalTimeDW();
 
+    /** Monotonic frame counter, bumped once per OnWorldUpdate. Unlike GetTotalTimeDW (a
+        millisecond wall clock) two distinct frames can never share a value. */
+    size_t GetFrameNumber() const { return FrameNumber; }
+
     /** Returns the current frame time */
     float GetFrameTimeSec();
 
@@ -1023,6 +1027,21 @@ private:
     /** Map for skeletal mesh visuals */
     gtl::flat_hash_map<std::string, SkeletalMeshVisualInfo*> SkeletalMeshVisuals;
     gtl::flat_hash_map<oCNPC*, SkeletalMeshVisualInfo*> SkeletalMeshNpcs;
+
+    /** Bumped once per OnWorldUpdate. See GetFrameNumber(). */
+    size_t FrameNumber = 0;
+
+    /** Looks up the extracted skeletal mesh data for a live zCModel, NPC-keyed first, then by
+     *  visual name. Returns nullptr while no data exists or a background extraction is still
+     *  running - callers must not substitute a placeholder position in that case, see
+     *  GetLowestLODPoly_SkeletalMesh. */
+    SkeletalMeshVisualInfo* ResolveSkeletalVisualInfo( zCModel* model );
+
+    /** True if this emitter samples its spawn positions from a skeletal shape-mesh
+     *  (zPFX_EMITTER_SHAPE_MESH + shpModel, set by oCVisualFX's emAdjustShpToOrigin) that we
+     *  cannot serve yet. Ticking such an emitter would spawn every particle at the model's
+     *  origin, so the caller must skip the update entirely. */
+    bool IsUnservableSkeletalShapeEmitter( zCParticleFX* fx );
 
     /** In-flight background extraction jobs, keyed by the SkeletalMeshVisualInfo they populate.
      *  Must be cancelled+waited-on before that SkeletalMeshVisualInfo (or the zCModel/oCNPC it

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -671,7 +671,7 @@ struct GothicRendererSettings {
 
         DrawSky = true;
         DrawFog = true;
-        FogRange = SWITCH_ENGINE12(1.0f, 3.0f);
+        FogRange = SwitchG1G2(1.0f, 3.0f);
         EnableHDR = false;
         HDRToneMap = E_HDRToneMap::ToneMap_Simple;
         ReplaceSunDirection = false;
@@ -883,7 +883,7 @@ struct GothicRendererSettings {
 
         ResetDebugSettings();
     }
-    
+
     void ApplyDx12Defaults()
     {
         EnableHDR = true;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -844,12 +844,12 @@ struct GothicRendererSettings {
         GothicUIScale = 1.0f;
         //DisableEverything();
 
-        LimitLightIntesity = false;
+        LimitLightIntesity = true;
         AllowNormalmaps = 0;
         CompressedNormalsSupport = true;
 
         AllowNumpadKeys = false;
-        EnableDebugLog = true;
+        EnableDebugLog = false;
         EnableCustomFontRendering = true;
         FastInventoryRendering = true;
 
@@ -859,13 +859,13 @@ struct GothicRendererSettings {
         StretchWindow = true;
         SmoothShadowCameraUpdate = true;
         SmoothShadowFrequency = 500.0f;
-        DisplayFlip = false;
+        DisplayFlip = true;
         LowLatency = false;
         HDR_Monitor = false;
         HDR_AutoMaxBrightness = true;
         HDR_MaxBrightness = 1000.0f;
         HDR_PaperWhite = 200.0f;
-        EnableInactiveFpsLock = true;
+        EnableInactiveFpsLock = false;
         MTResoureceManager = true;
         CompressBackBuffer = false;
         AnimateStaticVobs = true;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -783,9 +783,9 @@ struct GothicRendererSettings {
         PCSSLightSize = 0.140f; // Shadow-UV light radius used by PCSS blocker search
 
         SkyIblIntensity = 1.0f; // D3D12 only: scales the sky image-based indirect light (0 = flat ambient only)
-        SkyOcclusionStrength = 0.0f; // D3D12 only: how hard a roof cuts the sky ambient (0 = off, 1 = interiors get none)
+        SkyOcclusionStrength = 0.85f; // D3D12 only: how hard a roof cuts the sky ambient (0 = off, 1 = interiors get none)
         SkyIblNightFloor = 0.14f; // D3D12 only: minimum night sky radiance for the IBL (see D3D12SkyIbl.cpp)
-        DefaultMaterialRoughness = 0.75f; // D3D12 only: roughness for materials with no _FX/_ORM map
+        DefaultMaterialRoughness = 0.80f; // D3D12 only: roughness for materials with no _FX/_ORM map
 
         BloomStrength = 1.0f;
         EnableBloom = false;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -561,6 +561,31 @@ struct GTAOSettings {
     float DepthMIPSamplingOffset;       // [2.0, 6.0] bandwidth/quality trade-off in the MIP selection
 };
 
+/** D3D12 only: the discrete roughness values the default (no _FX/_ORM map) material can be set to.
+    The D3D12 backend can't sample an arbitrary roughness for these materials — it hands the shader a
+    bindless 1x1 ORM texture, so every selectable value needs its own texture created up front (see
+    D3D12GraphicsEngine::CreateWhiteTexture / m_DefaultOrmTextures). Nine steps of 0.05 from 0.50 to 0.90
+    is nine 1x1 textures, i.e. nothing, and covers everything from damp stone to chalky plaster.
+    Kept here rather than in the D3D12 headers so ImGuiShim can drive the slider without including them. */
+namespace DefaultRoughness {
+    constexpr float kMin  = 0.50f;
+    constexpr float kStep = 0.05f;
+    constexpr int   kNumSteps = 9;                          // 0.50 0.55 ... 0.90
+    constexpr float kMax = kMin + kStep * ( kNumSteps - 1 );
+
+    /** Roughness for step index i (clamped). */
+    inline float ForStep( int i ) {
+        if ( i < 0 ) i = 0;
+        if ( i >= kNumSteps ) i = kNumSteps - 1;
+        return kMin + kStep * static_cast<float>( i );
+    }
+    /** Nearest step index for an arbitrary roughness — the ini is free text, so this also sanitizes it. */
+    inline int StepFor( float roughness ) {
+        const int i = static_cast<int>( ( roughness - kMin ) / kStep + 0.5f );
+        return i < 0 ? 0 : ( i >= kNumSteps ? kNumSteps - 1 : i );
+    }
+}
+
 struct GothicRendererSettings {
     enum EPointLightShadowMode {
         PLS_DISABLED = 0,
@@ -760,6 +785,7 @@ struct GothicRendererSettings {
         SkyIblIntensity = 1.0f; // D3D12 only: scales the sky image-based indirect light (0 = flat ambient only)
         SkyOcclusionStrength = 0.0f; // D3D12 only: how hard a roof cuts the sky ambient (0 = off, 1 = interiors get none)
         SkyIblNightFloor = 0.14f; // D3D12 only: minimum night sky radiance for the IBL (see D3D12SkyIbl.cpp)
+        DefaultMaterialRoughness = 0.75f; // D3D12 only: roughness for materials with no _FX/_ORM map
 
         BloomStrength = 1.0f;
         EnableBloom = false;
@@ -1128,6 +1154,10 @@ struct GothicRendererSettings {
     // the deliberate non-physical fill that Gothic itself applies; D3D11's atmospheric scattering hardcodes the
     // equivalent (AtmosphericScattering.h: nightColor = (0.2,0.2,0.4) * NIGHT_BRIGHTNESS). 0 disables the floor.
     float SkyIblNightFloor;
+    // D3D12 only: the roughness handed to materials Gothic ships with no _FX/_ORM map, which is most of them.
+    // Snapped to one of the DefaultRoughness:: steps on load and on every ImGui edit, because the backend can
+    // only serve values it built a 1x1 ORM texture for at startup. AO stays 1 and metallic 0 for these.
+    float DefaultMaterialRoughness;
 
     float GodRayDecay;
     float GodRayWeight;

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -649,6 +649,7 @@ struct GothicMemoryLocations {
     struct zCModel {
         static const unsigned int RenderNodeList = 0x0055FA50;
         static const unsigned int UpdateAttachedVobs = 0x005667F0;
+        static const unsigned int SearchNode = 0x00563F80;
         static const unsigned int Offset_HomeVob = 0x54;
         static const unsigned int Offset_ModelProtoList = 0x58;
         static const unsigned int Offset_NodeList = 0x64;
@@ -746,6 +747,8 @@ struct GothicMemoryLocations {
     struct oCVisualFX
     {
         static const unsigned int Offset_origin = 0x458;
+        static const unsigned int Offset_orgNode = 0x44c;
+        static const unsigned int Offset_emTrjOriginNode_S = 0x15c;
         static const unsigned int Offset_emAdjustShpToOrigin = 0x29c;
     };
     

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -746,6 +746,7 @@ struct GothicMemoryLocations {
     struct oCVisualFX
     {
         static const unsigned int Offset_origin = 0x458;
+        static const unsigned int Offset_emAdjustShpToOrigin = 0x29c;
     };
     
 #define zALLOCATOR_SUPPORTED

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -577,6 +577,7 @@ struct GothicMemoryLocations {
     struct zCModel {
         static const unsigned int RenderNodeList = 0x00577E70;
         static const unsigned int UpdateAttachedVobs = 0x0057F330;
+        static const unsigned int SearchNode = 0x0057C810;
         static const unsigned int Offset_HomeVob = 0x54;
         static const unsigned int Offset_ModelProtoList = 0x58;
         static const unsigned int Offset_NodeList = 0x64;
@@ -642,6 +643,8 @@ struct GothicMemoryLocations {
     struct oCVisualFX
     {
         static const unsigned int Offset_origin = 0x458;
+        static const unsigned int Offset_orgNode = 0x44c;
+        static const unsigned int Offset_emTrjOriginNode_S = 0x15c;
         static const unsigned int Offset_emAdjustShpToOrigin = 0x29c;
     };
     

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -642,6 +642,7 @@ struct GothicMemoryLocations {
     struct oCVisualFX
     {
         static const unsigned int Offset_origin = 0x458;
+        static const unsigned int Offset_emAdjustShpToOrigin = 0x29c;
     };
     
     struct zAllocator

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -807,6 +807,7 @@ struct GothicMemoryLocations {
     struct oCVisualFX
     {
         static const unsigned int Offset_origin = 0x4a8;
+        static const unsigned int Offset_emAdjustShpToOrigin = 0x2d0;
     };
 
 #define zALLOCATOR_SUPPORTED

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -420,6 +420,7 @@ struct GothicMemoryLocations {
     struct zCModel {
         static const unsigned int RenderNodeList = 0x00579560;
         static const unsigned int UpdateAttachedVobs = 0x00580900;
+        static const unsigned int SearchNode = 0x0057DFF0;
         static const unsigned int Offset_HomeVob = 0x60;
         static const unsigned int Offset_ModelProtoList = 0x64;
         static const unsigned int Offset_NodeList = 0x70;
@@ -807,6 +808,8 @@ struct GothicMemoryLocations {
     struct oCVisualFX
     {
         static const unsigned int Offset_origin = 0x4a8;
+        static const unsigned int Offset_orgNode = 0x49c;
+        static const unsigned int Offset_emTrjOriginNode_S = 0x17c;
         static const unsigned int Offset_emAdjustShpToOrigin = 0x2d0;
     };
 

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -545,6 +545,8 @@ struct GothicMemoryLocations {
     struct oCVisualFX
     {
         static const unsigned int Offset_origin = 0x4a8;
+        static const unsigned int Offset_orgNode = 0x49c;
+        static const unsigned int Offset_emTrjOriginNode_S = 0x17c;
         static const unsigned int Offset_emAdjustShpToOrigin = 0x2d0;
     };
     

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -545,6 +545,7 @@ struct GothicMemoryLocations {
     struct oCVisualFX
     {
         static const unsigned int Offset_origin = 0x4a8;
+        static const unsigned int Offset_emAdjustShpToOrigin = 0x2d0;
     };
     
     struct zAllocator

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1722,6 +1722,23 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
             "(D3D11's atmospheric scattering hardcodes the same idea). 0 disables the floor.\n"
             "Blue-weighted, so it reads as moonlight rather than grey underexposure." );
 
+        // Default material roughness — only the discrete values the backend built a 1x1 ORM texture for at
+        // startup are reachable, so this is a slider over the step index that displays the roughness itself.
+        ImGui::SeparatorText( "Default Material (D3D12)##AdvancedDefaultMaterial" );
+        {
+            int step = DefaultRoughness::StepFor( settings.DefaultMaterialRoughness );
+            char label[16];
+            snprintf( label, sizeof( label ), "%.2f", DefaultRoughness::ForStep( step ) );
+            if ( ImGui::SliderInt( "Default roughness", &step, 0, DefaultRoughness::kNumSteps - 1, label,
+                ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput ) ) {
+                settings.DefaultMaterialRoughness = DefaultRoughness::ForStep( step );
+            }
+            ImGui::SetItemTooltip( "D3D12 only. Roughness used for materials that ship with no _FX/_ORM map,\n"
+                "which is most of Gothic's. Lower = glossier (damp stone, worn wood);\n"
+                "higher = flatter and chalkier (plaster, cloth). AO stays 1 and metallic 0.\n"
+                "Only these fixed steps exist - each one is a 1x1 texture built at startup." );
+        }
+
         ImGui::Separator();
 
         ImGui::Checkbox( "WireframeWorld", &settings.WireframeWorld );

--- a/D3D11Engine/ShaderIDs.h
+++ b/D3D11Engine/ShaderIDs.h
@@ -144,5 +144,6 @@ enum class CShaderID : size_t {
     CS_PFX_Bloom_Downsample,
     CS_PFX_Bloom_Upsample,
     CS_GenerateNormalsFromDepth,
+    CS_PFX_TAAResolve,
     COUNT
 };

--- a/D3D11Engine/ShaderRegistry.cpp
+++ b/D3D11Engine/ShaderRegistry.cpp
@@ -439,6 +439,9 @@ void ShaderRegistry::Build() {
 
         Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_Bloom_Upsample>( "CS_PFX_Bloom_Upsample.hlsl" ));
 
+        // Intel Graphics Optimized TAA resolve (port of the D3D12 backend's TAAResolve.hlsl to cs_5_0).
+        Shaders.push_back( ShaderInfo::make<CShaderID::CS_PFX_TAAResolve>( "CS_PFX_TAAResolve.hlsl" ));
+
         // Optional Forward+ smooth-normals-from-depth pass (feeds SAO/ASSAO AO producers)
         Shaders.push_back( ShaderInfo::make<CShaderID::CS_GenerateNormalsFromDepth>( "CS_GenerateNormalsFromDepth.hlsl" ));
 

--- a/D3D11Engine/Shaders/CS_PFX_TAAResolve.hlsl
+++ b/D3D11Engine/Shaders/CS_PFX_TAAResolve.hlsl
@@ -1,0 +1,653 @@
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2019-2020, Intel Corporation
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+// the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// BicubicSampling5 is from Microsoft's MiniEngine (MIT, Copyright (c) 2013-2015 Microsoft), which this shader
+// originally shipped inside of.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Port of Intel's Graphics Optimized TAA (TAAResolve.hlsl) to the GD3D11 D3D11 backend. This is the SAME algorithm
+// already ported to the D3D12 backend (see Shaders/D3D12/TAAResolve.hlsl, which documents the reasoning behind
+// every deviation from Intel's original in detail) - variance clipping in YCoCg, the velocity/depth confidence
+// factors, the 5-tap bicubic history filter, the longest-neighbourhood-velocity search and the neighbourhood
+// fallback for no-history pixels are all Intel's, unchanged. What's different here, on top of the D3D12 port's own
+// deviations, is purely plumbing for cs_5_0 (SM5, D3D11 feature level 11):
+//
+//  1. NO BINDLESS. D3D11 has no SM6.6 ResourceDescriptorHeap[]; every texture is a fixed t-register instead of a
+//     root-constant index (see the TaaCB layout below vs the D3D12 shader's *Index fields).
+//
+//  2. NO SHARED MotionCB. D3D12 pulls InvUnjitteredViewProj / PrevViewProj from the same per-frame constant
+//     buffer the depth prepass binds. D3D11 has no such shared buffer, so both matrices are pushed directly in
+//     this shader's own TaaCB (computed exactly the same way on the host: see D3D11PFX_TAA::RenderPostFX).
+//
+//  3. select() DOESN'T EXIST pre-SM6. ClipToAABB below uses a plain component-wise ternary instead, which is
+//     legal HLSL back to SM4 and produces identical code.
+//
+// Everything else - the reversed-Z relative depth-confidence maths, the Reinhard/InverseReinhard round trip that
+// keeps the resolve transparent to the rest of the (linear HDR) pipeline, the TGSM toggle, the FP16 toggle - is
+// unchanged from the D3D12 shader; see its header comment for the full rationale.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Whether to use real 16-bit floats. Off: D3D11's FXC path has no -enable-16bit-types equivalent worth chasing.
+#ifndef USE_FP16
+#define USE_FP16 0
+#endif
+
+typedef float  fp32_t;
+typedef float2 fp32_t2;
+typedef float3 fp32_t3;
+typedef float4 fp32_t4;
+
+typedef float  fp16_t;
+typedef float2 fp16_t2;
+typedef float3 fp16_t3;
+typedef float4 fp16_t4;
+typedef int    i16_t;
+typedef int2   i16_t2;
+typedef uint   ui16_t;
+typedef uint2  ui16_t2;
+
+// Thread-group shared memory for the current-frame colour neighbourhood. Off by default - see the D3D12 shader's
+// header for why the Gather-based fill buys nothing here and is the one part of this shader that's hardest to
+// reason about without running it.
+#ifndef USE_TGSM
+#define USE_TGSM 0
+#endif
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Params from the host app (D3D11PFX_TAA.cpp)
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+cbuffer TaaCB : register( b0 )
+{
+    // NOT row_major: matches every other per-frame matrix in this codebase (e.g. VS_Ex.hlsl's frame.M_ViewProj),
+    // which is fed straight from XMStoreFloat4x4 with no transpose and consumed as mul(vector, matrix).
+    float4x4 InvUnjitteredViewProj;  // current frame's UNJITTERED inverse view-projection
+    float4x4 PrevViewProj;           // previous frame's UNJITTERED view-projection
+    float4 Resolution;      // width, height, 1/width, 1/height
+    float4 JitterTolerance;  // jitter.xy (pixels), DepthTolerance, unused
+    uint   FrameNumber;
+    uint   DebugFlags;      // see the Allow* helpers at the bottom
+    uint   HistoryValid;    // 0 = no accumulated history yet; forces the no-history branch (see the main body)
+    uint   _Pad;
+};
+
+#define Jitter        JitterTolerance.xy
+#define DepthTolerance JitterTolerance.z
+
+Texture2D<float4> ColourTex   : register( t0 );  // RGBA16F linear-HDR scene colour (this frame)
+Texture2D<float4> HistoryTex  : register( t1 );  // RGBA16F linear-HDR history (.a = accumulated weight)
+Texture2D<float2> VelocityTex : register( t2 );  // RG16F UV-space motion, prevUV - currUV
+Texture2D<float>  DepthTex    : register( t3 );  // R32_FLOAT reversed-Z depth (this frame)
+Texture2D<float>  PrevDepthTex: register( t4 );  // R32_FLOAT reversed-Z depth (previous frame)
+
+RWTexture2D<float4> OutTexture : register( u0 ); // becomes next frame's history
+
+SamplerState MinMagLinearMipPointClamp : register( s0 );
+SamplerState MinMagMipPointClamp       : register( s1 );
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quality switches — Intel's, with their "best quality" defaults
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#define MIN_VARIANCE_GAMMA 0.75f    // under motion
+#define MAX_VARIANCE_GAMMA 2.0f     // no motion
+
+#define VARIANCE_INTERSECTION_MAX_T 100
+
+#define DEPTH_EDGE_REL_DIFF fp16_t( 0.02f )
+
+#ifndef USE_DEPTH_THRESHOLD
+#define USE_DEPTH_THRESHOLD 1
+#endif
+
+#define USE_SAMPLES_5 0
+#define USE_SAMPLES_9 1
+
+#ifndef VARIANCE_BBOX_NUMBER_OF_SAMPLES
+#define VARIANCE_BBOX_NUMBER_OF_SAMPLES USE_SAMPLES_9
+#endif
+
+#ifndef USE_VARIANCE_CLIPPING
+#define USE_VARIANCE_CLIPPING 1
+#endif
+
+#ifndef USE_YCOCG_SPACE
+#define USE_YCOCG_SPACE 1
+#endif
+
+#ifndef ALLOW_NEIGHBOURHOOD_SAMPLING
+#define ALLOW_NEIGHBOURHOOD_SAMPLING 1
+#endif
+
+#ifndef USE_BICUBIC_FILTER
+#define USE_BICUBIC_FILTER 1
+#endif
+
+#ifndef USE_LONGEST_VELOCITY_VECTOR
+#define USE_LONGEST_VELOCITY_VECTOR 1
+#endif
+
+#ifndef LONGEST_VELOCITY_VECTOR_SAMPLES
+#define LONGEST_VELOCITY_VECTOR_SAMPLES USE_SAMPLES_9
+#endif
+
+// Intel: 128 px is right for 1080p, "should be tweaked based on resolution" — so scale it with height instead
+// of hardcoding, or the no-history cutoff gets stricter the higher the player's resolution is.
+#define FRAME_VELOCITY_IN_PIXELS_DIFF ( Resolution.y * ( 128.0f / 1080.0f ) )
+
+#ifndef NEEDS_EDGE_DETECTION
+#define NEEDS_EDGE_DETECTION ( ( 0 == USE_BICUBIC_FILTER ) && ( 0 == USE_LONGEST_VELOCITY_VECTOR ) )
+#endif
+
+// Host-driven feature toggles (DebugFlags). Compile-time defaults above still apply when ENABLE_DEBUG is 0.
+#ifndef ENABLE_DEBUG
+#define ENABLE_DEBUG 1
+#endif
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Implementation
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#define NUM_THREADS_X 8
+#define NUM_THREADS_Y 8
+
+#if 1 == USE_TGSM
+#define FRAME_COLOUR_ST int
+#define TGSM_CACHE_WIDTH  ( NUM_THREADS_X + 2 )
+#define TGSM_CACHE_HEIGHT ( NUM_THREADS_Y + 2 )
+#define MAKEOFFSET( x, y ) FRAME_COLOUR_ST( ( y ) * TGSM_CACHE_WIDTH + ( x ) )
+groupshared float3 TGSM_Colour[ TGSM_CACHE_WIDTH * TGSM_CACHE_HEIGHT ];
+#else
+#define FRAME_COLOUR_ST int2
+#define MAKEOFFSET( x, y ) FRAME_COLOUR_ST( x, y )
+#endif
+
+bool AllowYCoCg();
+bool AllowVarianceClipping();
+bool AllowNeighbourhoodSampling();
+bool AllowBicubicFilter();
+bool AllowLongestVelocityVector();
+bool AllowDepthThreshold();
+float3 DebugColourNoHistory();
+
+// --- Colour space + tone mapping -------------------------------------------------------------------------------
+
+fp16_t3 RGB2YCoCg( fp16_t3 inRGB )
+{
+    if ( AllowYCoCg() )
+    {
+        const fp16_t y  = dot( inRGB, fp16_t3(  0.25f, 0.5f,  0.25f ) );
+        const fp16_t co = dot( inRGB, fp16_t3(  0.5f,  0.0f, -0.5f  ) );
+        const fp16_t cg = dot( inRGB, fp16_t3( -0.25f, 0.5f, -0.25f ) );
+        return fp16_t3( y, co, cg );
+    }
+    return inRGB;
+}
+
+fp16_t3 YCoCg2RGB( fp16_t3 inYCoCg )
+{
+    if ( AllowYCoCg() )
+    {
+        const fp16_t r = dot( inYCoCg, fp16_t3( 1.0f,  1.0f, -1.0f ) );
+        const fp16_t g = dot( inYCoCg, fp16_t3( 1.0f,  0.0f,  1.0f ) );
+        const fp16_t b = dot( inYCoCg, fp16_t3( 1.0f, -1.0f, -1.0f ) );
+        return fp16_t3( r, g, b );
+    }
+    return inYCoCg;
+}
+
+fp16_t LuminanceRec709( fp16_t3 inRGB )
+{
+    return dot( inRGB, fp16_t3( 0.2126f, 0.7152f, 0.0722f ) );
+}
+
+// Reinhard, used ONLY to do the neighbourhood/variance/lerp maths in a bounded range — the buffers this shader
+// reads and writes stay linear HDR.
+fp16_t3 Reinhard( fp16_t3 inRGB )
+{
+    return inRGB / ( fp16_t( 1.0f ) + LuminanceRec709( inRGB ) );
+}
+
+fp16_t3 InverseReinhard( fp16_t3 inRGB )
+{
+    // Guard the pole at luminance 1: a tone-mapped value can land there through interpolation, and the original
+    // divides straight through it. Without this, a single bright pixel can resolve to +inf and then poison its
+    // whole neighbourhood on the next frame through the variance AABB.
+    return inRGB / max( fp16_t( 1.0e-4f ), fp16_t( 1.0f ) - LuminanceRec709( inRGB ) );
+}
+
+// --- Source fetches ---------------------------------------------------------------------------------------------
+
+float2 GetUV( float2 inST )
+{
+    return ( inST + 0.5f.xx ) * Resolution.zw;
+}
+
+fp16_t3 LoadSceneColour( int2 inST )
+{
+    inST = clamp( inST, int2( 0, 0 ), int2( Resolution.xy ) - int2( 1, 1 ) );
+    return Reinhard( fp16_t3( ColourTex.Load( int3( inST, 0 ) ).rgb ) );
+}
+
+void StoreCurrentColourToSLM( ui16_t2 inGroupStartThread, i16_t2 inGroupThreadID )
+{
+#if 1 == USE_TGSM
+    // 5x5 threads each fill a 2x2 quad of the 10x10 tile (8x8 plus a one-pixel border).
+    if ( ( inGroupThreadID.x < 5 ) && ( inGroupThreadID.y < 5 ) )
+    {
+        const int2 indexMul2 = int2( inGroupThreadID.xy ) * 2;
+        const int  topLeft   = MAKEOFFSET( indexMul2.x, indexMul2.y );
+        const int2 baseST    = int2( inGroupStartThread ) + indexMul2 - int2( 1, 1 );
+
+        TGSM_Colour[ topLeft                          ] = LoadSceneColour( baseST + int2( 0, 0 ) );
+        TGSM_Colour[ topLeft + 1                      ] = LoadSceneColour( baseST + int2( 1, 0 ) );
+        TGSM_Colour[ topLeft + TGSM_CACHE_WIDTH       ] = LoadSceneColour( baseST + int2( 0, 1 ) );
+        TGSM_Colour[ topLeft + TGSM_CACHE_WIDTH + 1   ] = LoadSceneColour( baseST + int2( 1, 1 ) );
+    }
+    GroupMemoryBarrierWithGroupSync();
+#endif
+}
+
+fp16_t3 GetCurrentColour( FRAME_COLOUR_ST inST )
+{
+#if 1 == USE_TGSM
+    return fp16_t3( TGSM_Colour[ clamp( inST, 0, TGSM_CACHE_WIDTH * TGSM_CACHE_HEIGHT - 1 ) ] );
+#else
+    return LoadSceneColour( inST );
+#endif
+}
+
+// Velocity: UV-space in the buffer, PIXEL-space everywhere below (Intel's convention).
+fp16_t2 LoadVelocity( int2 inST )
+{
+    inST = clamp( inST, int2( 0, 0 ), int2( Resolution.xy ) - int2( 1, 1 ) );
+    return fp16_t2( VelocityTex.Load( int3( inST, 0 ) ) * Resolution.xy );
+}
+
+// Sample the neighbourhood and keep the longest vector — greatly improves edge quality under motion.
+fp16_t2 GetVelocity( i16_t2 inScreenST )
+{
+    fp16_t2 toReturn = LoadVelocity( inScreenST );
+
+    if ( AllowLongestVelocityVector() )
+    {
+#if LONGEST_VELOCITY_VECTOR_SAMPLES == USE_SAMPLES_9
+        const int2 offsets[ 8 ] = { int2( -1, -1 ), int2( -1, 0 ), int2( -1, 1 ), int2( 0, 1 ),
+                                    int2( 1, 1 ), int2( 1, 0 ), int2( 1, -1 ), int2( 0, -1 ) };
+        const uint numberOfSamples = 8;
+#else
+        const int2 offsets[ 4 ] = { int2( -1, -1 ), int2( -1, 1 ), int2( 1, 1 ), int2( 1, -1 ) };
+        const uint numberOfSamples = 4;
+#endif
+        fp32_t currentLengthSq = dot( toReturn, toReturn );
+        [unroll]
+        for ( uint i = 0; i < numberOfSamples; ++i )
+        {
+            const fp16_t2 velocity = LoadVelocity( inScreenST + offsets[ i ] );
+            const fp32_t sampleLengthSq = dot( velocity, velocity );
+            if ( sampleLengthSq > currentLengthSq )
+            {
+                toReturn = velocity;
+                currentLengthSq = sampleLengthSq;
+            }
+        }
+    }
+    return toReturn;
+}
+
+// --- Depth ------------------------------------------------------------------------------------------------------
+// Reversed-Z with an infinite far plane and NearClip pinned to 1, so `depth = 1 / viewZ`. A depth of 0 is the
+// cleared far plane (sky) and maps to "infinitely far" rather than a division by zero.
+fp16_t LinearViewZ( float depth )
+{
+    return fp16_t( depth > 0.0f ? ( 1.0f / depth ) : 1.0e9f );
+}
+
+fp16_t GetCurrentViewZ( int2 inST, out bool outIsOnEdge, out float outRawDepth )
+{
+    const float4 depths = DepthTex.Gather( MinMagMipPointClamp, GetUV( inST ) );
+    // THIS pixel's own depth, point-loaded rather than taken from the gather. The gather footprint straddles
+    // neighbouring texels, and at a silhouette its extreme belongs to a DIFFERENT surface.
+    outRawDepth = DepthTex.Load( int3( clamp( inST, int2( 0, 0 ), int2( Resolution.xy ) - int2( 1, 1 ) ), 0 ) );
+    // In reversed-Z the SMALLEST depth is the FARTHEST sample, so it produces the largest linear Z.
+    const fp16_t z0 = LinearViewZ( depths.x );
+    const fp16_t z1 = LinearViewZ( depths.y );
+    const fp16_t z2 = LinearViewZ( depths.z );
+    const fp16_t z3 = LinearViewZ( depths.w );
+    const fp16_t minZ = min( min( z0, z1 ), min( z2, z3 ) );
+#if 1 == NEEDS_EDGE_DETECTION
+    const fp16_t maxZ = max( max( z0, z1 ), max( z2, z3 ) );
+    outIsOnEdge = ( maxZ - minZ ) > ( DEPTH_EDGE_REL_DIFF * maxZ );
+#else
+    outIsOnEdge = false;
+#endif
+    return minZ;
+}
+
+// The view Z this pixel's surface HAD last frame, reconstructed rather than read out of a third velocity
+// channel. Unproject the current depth to a world position and push it through the previous camera: prevClip.w
+// is view Z by construction, since the projection pins _34 = NearClip = 1.
+fp16_t GetExpectedPreviousViewZ( int2 inST, float inCurrentDepth )
+{
+    const float2 uv  = GetUV( inST );
+    const float2 ndc = float2( uv.x * 2.0f - 1.0f, 1.0f - uv.y * 2.0f );
+    const float4 world = mul( float4( ndc, inCurrentDepth, 1.0f ), InvUnjitteredViewProj );
+    if ( world.w == 0.0f )
+        return fp16_t( 0.0f );
+    const float4 prevClip = mul( float4( world.xyz / world.w, 1.0f ), PrevViewProj );
+    return fp16_t( prevClip.w );
+}
+
+// Disocclusion test.
+fp16_t GetDepthConfidenceFactor( int2 inST, fp16_t2 inVelocity, float inCurrentDepth, bool inIsOnEdge )
+{
+    if ( !AllowDepthThreshold() )
+        return fp16_t( 1.0f );
+#if 1 == NEEDS_EDGE_DETECTION
+    if ( inIsOnEdge )
+        return fp16_t( 1.0f );
+#endif
+
+    // The jitter has to come off the lookup: the previous depth buffer was rasterized with ITS OWN sub-pixel
+    // offset, and chasing it with this frame's would bias the comparison by up to a texel at silhouettes.
+    const float2 prevUV = GetUV( float2( inST ) + float2( inVelocity ) + Jitter.xy );
+    const float4 prevDepths = PrevDepthTex.Gather( MinMagMipPointClamp, prevUV );
+
+    const fp16_t expectedViewZ = GetExpectedPreviousViewZ( inST, inCurrentDepth );
+    if ( !( expectedViewZ > fp16_t( 0.0f ) ) )
+        return fp16_t( 1.0f );   // behind last frame's eye plane; leave it to the UV/velocity confidence factors
+
+    const fp16_t speedPixels = length( inVelocity );
+    const fp16_t relTolerance = fp16_t( DepthTolerance ) * ( fp16_t( 1.0f ) + speedPixels * fp16_t( 0.25f ) );
+    const fp16_t tolerance = max( fp16_t( 0.05f ), relTolerance * expectedViewZ );
+
+    // Accept if ANY of the four covered texels matches - at a silhouette the reprojected sample lands between
+    // two surfaces, and demanding all four agree would throw history away along every object edge.
+    fp16_t bestDiff = fp16_t( 1.0e9f );
+    [unroll]
+    for ( uint i = 0; i < 4; ++i )
+        bestDiff = min( bestDiff, abs( LinearViewZ( prevDepths[ i ] ) - expectedViewZ ) );
+
+    return bestDiff <= tolerance ? fp16_t( 1.0f ) : fp16_t( 0.0f );
+}
+
+// --- History ----------------------------------------------------------------------------------------------------
+
+// 5-tap bicubic (Catmull-Rom) history fetch — from MiniEngine, approximating the 16-tap filter with 5 bilinear
+// fetches. This is what keeps the history from softening a little more every frame the way plain bilinear does.
+fp16_t4 BicubicSampling5( fp32_t2 inHistoryST )
+{
+    const fp32_t2 rcpResolution = Resolution.zw;
+    const fp32_t2 fractional = frac( inHistoryST );
+    const fp32_t2 uv = ( floor( inHistoryST ) + fp32_t2( 0.5f, 0.5f ) ) * rcpResolution;
+
+    const fp16_t2 t  = fp16_t2( fractional );
+    const fp16_t2 t2 = fp16_t2( fractional * fractional );
+    const fp16_t2 t3 = fp16_t2( fractional * fractional * fractional );
+    const fp16_t  s  = fp16_t( 0.5f );
+    const fp16_t2 w0 = -s * t3 + fp16_t( 2.0f ) * s * t2 - s * t;
+    const fp16_t2 w1 = ( fp16_t( 2.0f ) - s ) * t3 + ( s - fp16_t( 3.0f ) ) * t2 + fp16_t( 1.0f );
+    const fp16_t2 w2 = ( s - fp16_t( 2.0f ) ) * t3 + ( 3 - fp16_t( 2.0f ) * s ) * t2 + s * t;
+    const fp16_t2 w3 = s * t3 - s * t2;
+    const fp16_t2 s0 = w1 + w2;
+    const fp32_t2 f0 = w2 / ( w1 + w2 );
+    const fp32_t2 m0 = uv + f0 * rcpResolution;
+    const fp32_t2 tc0 = uv - 1.0f * rcpResolution;
+    const fp32_t2 tc3 = uv + 2.0f * rcpResolution;
+
+    const fp16_t4 A = fp16_t4( HistoryTex.SampleLevel( MinMagLinearMipPointClamp, fp32_t2( m0.x, tc0.y ), 0 ) );
+    const fp16_t4 B = fp16_t4( HistoryTex.SampleLevel( MinMagLinearMipPointClamp, fp32_t2( tc0.x, m0.y ), 0 ) );
+    const fp16_t4 C = fp16_t4( HistoryTex.SampleLevel( MinMagLinearMipPointClamp, fp32_t2( m0.x, m0.y ), 0 ) );
+    const fp16_t4 D = fp16_t4( HistoryTex.SampleLevel( MinMagLinearMipPointClamp, fp32_t2( tc3.x, m0.y ), 0 ) );
+    const fp16_t4 E = fp16_t4( HistoryTex.SampleLevel( MinMagLinearMipPointClamp, fp32_t2( m0.x, tc3.y ), 0 ) );
+    return ( fp16_t( 0.5f ) * ( A + B ) * w0.x + A * s0.x + fp16_t( 0.5f ) * ( A + B ) * w3.x ) * w0.y
+         + ( B * w0.x + C * s0.x + D * w3.x ) * s0.y
+         + ( fp16_t( 0.5f ) * ( B + E ) * w0.x + E * s0.x + fp16_t( 0.5f ) * ( D + E ) * w3.x ) * w3.y;
+}
+
+fp16_t4 GetHistory( fp32_t2 inHistoryUV, fp32_t2 inHistoryST, bool inIsOnEdge )
+{
+    fp16_t4 toReturn;
+    const bool useBilinearOnEdges = !AllowLongestVelocityVector();
+    const bool useBicubic = AllowLongestVelocityVector() || ( !inIsOnEdge && useBilinearOnEdges );
+
+    if ( AllowBicubicFilter() && useBicubic )
+    {
+        toReturn = BicubicSampling5( inHistoryST );
+    }
+    else
+    {
+        toReturn = fp16_t4( HistoryTex.SampleLevel( MinMagLinearMipPointClamp, inHistoryUV, 0 ) );
+    }
+
+    // History is stored LINEAR HDR — tone map it here so every comparison below happens in the same bounded
+    // space as the current-frame colour.
+    return fp16_t4( Reinhard( toReturn.rgb ), toReturn.a );
+}
+
+// --- Variance clipping (Marco Salvi, GDC16: "An excursion in Temporal Supersampling") ---------------------------
+
+fp16_t3 ClipToAABB( fp16_t3 inHistoryColour, fp16_t3 inCurrentColour, fp32_t3 inBBCentre, fp32_t3 inBBExtents )
+{
+    const fp16_t3 direction = inCurrentColour - inHistoryColour;
+    const fp32_t3 intersection = ( ( inBBCentre - sign( direction ) * inBBExtents ) - inHistoryColour ) / direction;
+    // No select() pre-SM6; a component-wise ternary with a vector condition is legal HLSL and does the same thing.
+    const fp32_t3 possibleT = intersection >= 0.0f.xxx ? intersection : ( VARIANCE_INTERSECTION_MAX_T + 1.0f ).xxx;
+    const fp32_t t = min( VARIANCE_INTERSECTION_MAX_T, min( possibleT.x, min( possibleT.y, possibleT.z ) ) );
+    return fp16_t3( t < VARIANCE_INTERSECTION_MAX_T ? inHistoryColour + direction * t : inHistoryColour );
+}
+
+fp16_t3 ClipHistoryColour( fp16_t3 inCurrentColour, fp16_t3 inHistoryColour, FRAME_COLOUR_ST inScreenST,
+                           fp16_t inVarianceGamma )
+{
+    if ( !AllowVarianceClipping() )
+        return inHistoryColour;
+
+#if VARIANCE_BBOX_NUMBER_OF_SAMPLES == USE_SAMPLES_9
+    const FRAME_COLOUR_ST offsets[ 8 ] = { MAKEOFFSET( -1, -1 ), MAKEOFFSET( -1, 0 ), MAKEOFFSET( -1, 1 ),
+                                           MAKEOFFSET( 0, 1 ), MAKEOFFSET( 1, 1 ), MAKEOFFSET( 1, 0 ),
+                                           MAKEOFFSET( 1, -1 ), MAKEOFFSET( 0, -1 ) };
+    const uint iteratorMax = 8;
+    const fp32_t rcpDivider = 1.0f / 9.0f;
+#else
+    const FRAME_COLOUR_ST offsets[ 4 ] = { MAKEOFFSET( -1, 0 ), MAKEOFFSET( 0, 1 ),
+                                           MAKEOFFSET( 1, 0 ), MAKEOFFSET( 0, -1 ) };
+    const uint iteratorMax = 4;
+    const fp32_t rcpDivider = 0.2f;
+#endif
+
+    const fp32_t3 currentColourInYCoCg = RGB2YCoCg( inCurrentColour );
+    fp32_t3 moment1 = currentColourInYCoCg;
+    fp32_t3 moment2 = currentColourInYCoCg * currentColourInYCoCg;
+    [unroll]
+    for ( uint i = 0; i < iteratorMax; ++i )
+    {
+        const fp32_t3 newColour = RGB2YCoCg( GetCurrentColour( inScreenST + offsets[ i ] ) );
+        moment1 += newColour;
+        moment2 += newColour * newColour;
+    }
+
+    const fp32_t3 mean = moment1 * rcpDivider;
+    const fp32_t3 variance = sqrt( max( 0.0f.xxx, moment2 * rcpDivider - mean * mean ) ) * inVarianceGamma;
+
+#if 1 == USE_VARIANCE_CLIPPING
+    const fp16_t3 minC = fp16_t3( mean - variance );
+    const fp16_t3 maxC = fp16_t3( mean + variance );
+    return clamp( inHistoryColour, YCoCg2RGB( minC ), YCoCg2RGB( maxC ) );
+#else
+    return YCoCg2RGB( ClipToAABB( RGB2YCoCg( inHistoryColour ), fp16_t3( currentColourInYCoCg ), mean, variance ) );
+#endif
+}
+
+// Cross-pattern filter for pixels with no usable history — softens the aliasing they would otherwise show
+// full-strength for one frame.
+fp16_t3 GetCurrentColourNeighbourhood( fp16_t3 inCurrentColour, FRAME_COLOUR_ST inScreenST )
+{
+    if ( !AllowNeighbourhoodSampling() )
+        return inCurrentColour;
+
+    const FRAME_COLOUR_ST offsets[ 4 ] = { MAKEOFFSET( -1, -1 ), MAKEOFFSET( -1, 1 ),
+                                           MAKEOFFSET( 1, 1 ), MAKEOFFSET( 1, -1 ) };
+    fp16_t3 accColour = inCurrentColour;
+    [unroll]
+    for ( uint i = 0; i < 4; ++i )
+        accColour += GetCurrentColour( inScreenST + offsets[ i ] );
+    return accColour * fp16_t( 0.2f );
+}
+
+// Final blend. Returns LINEAR HDR colour plus the weight to accumulate for the next frame, in [0.5, 1).
+fp16_t4 GetFinalColour( fp16_t3 inCurrentColour, fp16_t3 inHistoryColour, fp16_t inWeight )
+{
+    const fp16_t newWeight = saturate( fp16_t( 1.0f ) / ( fp16_t( 2.0f ) - inWeight ) );
+    const fp16_t3 blended = lerp( inCurrentColour, inHistoryColour, inWeight );
+    return fp16_t4( InverseReinhard( blended ), newWeight );
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+[numthreads( NUM_THREADS_X, NUM_THREADS_Y, 1 )]
+void CSMain( uint3 inDispatchIdx : SV_DispatchThreadID, uint3 inGroupID : SV_GroupID, uint3 inGroupThreadID : SV_GroupThreadID )
+{
+    const ui16_t2 groupStartingThread = ui16_t2( inGroupID.xy ) * ui16_t2( NUM_THREADS_X, NUM_THREADS_Y );
+    StoreCurrentColourToSLM( groupStartingThread, i16_t2( inGroupThreadID.xy ) );
+
+    if ( any( inDispatchIdx.xy >= uint2( Resolution.xy ) ) )
+        return;   // after the barrier above — every thread in the group must reach GroupMemoryBarrierWithGroupSync
+
+    const int2 screenST = int2( inDispatchIdx.xy );
+#if 1 == USE_TGSM
+    const FRAME_COLOUR_ST groupST = MAKEOFFSET( ( inGroupThreadID.x + 1 ), ( inGroupThreadID.y + 1 ) );
+#else
+    const FRAME_COLOUR_ST groupST = screenST;
+#endif
+
+    const fp16_t3 currentFrameColour = GetCurrentColour( groupST );
+
+    bool isOnEdge = false;
+    const fp16_t2 velocity = GetVelocity( i16_t2( screenST ) );
+
+    // Anything crossing more than FRAME_VELOCITY_IN_PIXELS_DIFF pixels in one frame is treated as no-history.
+    const fp16_t velocityConfidenceFactor =
+        saturate( fp16_t( 1.0f ) - length( velocity ) / fp16_t( FRAME_VELOCITY_IN_PIXELS_DIFF ) );
+
+    const fp32_t2 prevFrameScreenST = fp32_t2( screenST ) + fp32_t2( velocity );
+    const fp32_t2 prevFrameScreenUV = GetUV( prevFrameScreenST );
+
+    // Only the edge flag and the raw depth are wanted here; the linearized value is used inside the
+    // confidence test itself.
+    float rawDepth = 0.0f;
+    GetCurrentViewZ( screenST, isOnEdge, rawDepth );
+    const fp16_t depthDiffFactor = GetDepthConfidenceFactor( screenST, velocity, rawDepth, isOnEdge );
+
+    const fp16_t uvWeight = ( all( prevFrameScreenUV >= 0.0f.xx ) && all( prevFrameScreenUV < 1.0f.xx ) ) ? 1.0f : 0.0f;
+    // HistoryValid is the host's "there is no accumulated history at all" flag — first frame of a world, after a
+    // resize, or TAA just switched back on. It MUST hard-force the no-history branch rather than merely pointing
+    // the history sampler somewhere harmless: the accumulated weight lives in the history's ALPHA, and a
+    // substitute texture (the scene colour) carries alpha 1.0 from the geometry passes. Weight 1.0 means "100%
+    // history", and GetFinalColour would then feed back newWeight = 1/(2-1) = exactly 1.0 — a fixed point. The
+    // image would freeze permanently for as long as the camera held still, instead of accumulating up from 0.5.
+    const bool hasValidHistory = ( HistoryValid != 0 )
+        && ( velocityConfidenceFactor * depthDiffFactor * uvWeight ) > 0.0f;
+
+    fp16_t4 finalColour;
+    if ( hasValidHistory )
+    {
+        const fp16_t4 rawHistoryColour = GetHistory( prevFrameScreenUV, prevFrameScreenST, isOnEdge );
+
+        // Widen the clipping box when the image is still, so specular highlights are not eaten by the clamp;
+        // tighten it under motion, where ghosting is the bigger risk.
+        const fp16_t varianceGamma = fp16_t( lerp( MIN_VARIANCE_GAMMA, MAX_VARIANCE_GAMMA,
+                                                   velocityConfidenceFactor * velocityConfidenceFactor ) );
+
+        const fp16_t3 historyColour = ClipHistoryColour( currentFrameColour, rawHistoryColour.xyz, groupST, varianceGamma );
+        const fp16_t weight = rawHistoryColour.a * velocityConfidenceFactor * depthDiffFactor;
+        finalColour = GetFinalColour( currentFrameColour, historyColour, weight );
+    }
+    else
+    {
+        const fp16_t3 filtered = GetCurrentColourNeighbourhood( currentFrameColour, groupST ) * fp16_t3( DebugColourNoHistory() );
+        finalColour = fp16_t4( InverseReinhard( filtered ), fp16_t( 0.5f ) );
+    }
+
+    OutTexture[ inDispatchIdx.xy ] = float4( finalColour );
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Host-driven toggles. DebugFlags bits:
+//   0x01 MarkNoHistoryPixels | 0x02 DepthThreshold | 0x04 BicubicFilter | 0x08 VarianceClipping
+//   0x10 YCoCg               | 0x20 NeighbourhoodSampling | 0x40 LongestVelocityVector
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+float3 DebugColourNoHistory()
+{
+#if 1 == ENABLE_DEBUG
+    return ( DebugFlags & 0x1 ) ? float3( 0.2f, 0.8f, 0.2f ) : float3( 1.0f, 1.0f, 1.0f );
+#else
+    return float3( 1.0f, 1.0f, 1.0f );
+#endif
+}
+
+bool AllowDepthThreshold()
+{
+#if 1 == ENABLE_DEBUG
+    return ( DebugFlags & 0x2 ) != 0;
+#else
+    return 1 == USE_DEPTH_THRESHOLD;
+#endif
+}
+
+bool AllowBicubicFilter()
+{
+#if 1 == ENABLE_DEBUG
+    return ( DebugFlags & 0x4 ) != 0;
+#else
+    return 1 == USE_BICUBIC_FILTER;
+#endif
+}
+
+bool AllowVarianceClipping()
+{
+#if 1 == ENABLE_DEBUG
+    return ( DebugFlags & 0x8 ) != 0;
+#else
+    return 0 != USE_VARIANCE_CLIPPING;
+#endif
+}
+
+bool AllowYCoCg()
+{
+#if 1 == ENABLE_DEBUG
+    return ( DebugFlags & 0x10 ) != 0;
+#else
+    return 1 == USE_YCOCG_SPACE;
+#endif
+}
+
+bool AllowNeighbourhoodSampling()
+{
+#if 1 == ENABLE_DEBUG
+    return ( DebugFlags & 0x20 ) != 0;
+#else
+    return 1 == ALLOW_NEIGHBOURHOOD_SAMPLING;
+#endif
+}
+
+bool AllowLongestVelocityVector()
+{
+#if 1 == ENABLE_DEBUG
+    return ( DebugFlags & 0x40 ) != 0;
+#else
+    return 1 == USE_LONGEST_VELOCITY_VECTOR;
+#endif
+}

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -38,6 +38,9 @@ StructuredBuffer<LightGrid> SB_LightGrid : register( t9 );
 StructuredBuffer<uint> SB_LightIndexList : register( t10 );
 
 TextureCubeArray TX_ShadowCubeArray : register( t11 );
+// Per-slot overlay holding ONLY this frame's moving (skeletal) casters; min'd with the static cube above.
+// See PLS_SHADOW_HAS_DYNAMIC in include/PointLightShadows.h.
+TextureCubeArray TX_ShadowDynCubeArray : register( t12 );
 
 RWTexture2D<float4> RW_HDR : register( u0 );
 
@@ -103,7 +106,7 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
 
         // Apply shadow if this light has a shadow cubemap and contribution is non-negligible
         if ( light.ShadowCubeIndex >= 0 && any( lighting > 0.001f ) ) {
-            float shadow = PLS_SampleShadowCubeArray( TX_ShadowCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex );
+            float shadow = PLS_SampleShadowCubeArray( TX_ShadowCubeArray, TX_ShadowDynCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex );
             lighting *= shadow;
         }
 

--- a/D3D11Engine/Shaders/D3D12/Decal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Decal.hlsl
@@ -2,7 +2,8 @@
 // these as camera-aligned or wall-mounted zCDecal quads; DrawDecalList (D3D12Scene.cpp) draws them in two
 // passes — alpha-tested/opaque with the lit scene (PSMainLit), then blended over it (PSMainBlend).
 //
-// Both shaders are LIT. They used to emit the raw (linearized) texel with no lighting at all, which is what
+// The opaque pass is LIT, and so is the alpha-BLENDED half of the transparent pass (ADD/MUL/MUL2 stay unlit —
+// see PSMainBlend). They used to emit the raw (linearized) texel with no lighting at all, which is what
 // made every cobweb in a torch-lit cellar read as a blazing white slab: the D3D12 scene target holds LINEAR
 // radiance that is auto-exposed and tonemapped later, so a wall lit by one distant torch lands far below 1.0
 // while an unlit decal sat at its full ~0.9 albedo — and the eye adaptation, seeing a dark room, then scaled
@@ -76,7 +77,7 @@ struct VS_IN
     float3   pos    : POSITION;
     float2   uv     : TEXCOORD0;
     float4x4 iworld : INSTANCE_WORLD_MATRIX;   // per-instance model matrix (world*offset*scale)
-    float4   icolor : INSTANCE_COLOR;          // .a = ghost alpha, .rgb unused
+    float4   icolor : INSTANCE_COLOR;          // .a = ghost alpha, .r = shade-lit flag, .gb unused
 };
 struct VS_OUT
 {
@@ -86,6 +87,7 @@ struct VS_OUT
     float3 wpos    : TEXCOORD2;
     float3 wnrm    : TEXCOORD3;
     float  fogDist : TEXCOORD4;
+    float  lit     : TEXCOORD5;
 };
 
 VS_OUT VSMain( VS_IN i )
@@ -95,6 +97,7 @@ VS_OUT VSMain( VS_IN i )
     o.clip  = mul( float4( worldPos, 1.0 ), ViewProj );
     o.uv    = i.uv;
     o.alpha = i.icolor.a;
+    o.lit   = i.icolor.r;
     o.wpos  = worldPos;
     // The quad lies in its local XY plane, so +Z is its face normal. The instance matrix's non-uniform XY
     // scale (DecalSize * 2, y negated) doesn't rotate that axis, so transforming it by the 3x3 is exact up to
@@ -136,8 +139,17 @@ float4 PSMainLit( VS_OUT i ) : SV_TARGET   // opaque / alpha-test cutout, fully 
 float4 PSMainBlend( VS_OUT i ) : SV_TARGET // transparent — the PSO blend state picks add/alpha/modulate
 {
     float4 t = tx.Sample( smp, i.uv );
-    // Deliberately NOT fogged: this one PS is shared by the ADD/MUL/MUL2 blend modes, where lerping toward the
-    // fog colour would brighten (ADD) or darken (MUL) the surface instead of fading it into the distance.
-    // D3D11's PS_Transparency doesn't fog these either.
-    return float4( ShadeDecal( SrgbToLinear( t.rgb ), i.wpos, i.wnrm, i.clip.xyz ), t.a * i.alpha );
+    float3 albedo = SrgbToLinear( t.rgb );
+    // Only the true alpha-blend modes (BLEND / BLEND_TEST) are shaded. That is the case the "blazing white
+    // cobweb" fix above was actually about; ADD and MUL/MUL2 must stay unlit, exactly like D3D11 draws all of
+    // them with the unlit PS_Transparency:
+    //   * ADD is emissive by construction (candle flames, spell glows). Shading it turns the flame in a dark
+    //     cellar into a near-black quad added onto the scene, i.e. it disappears.
+    //   * MUL/MUL2 multiply against the ALREADY LIT scene colour, so shading the source applies the lighting a
+    //     second time and a floor stain reads as a black blob.
+    // Same split Fx.hlsl makes for the quad marks, which carry the identical blend modes.
+    // Deliberately NOT fogged: this one PS is shared by all the blend modes, where lerping toward the fog
+    // colour would brighten (ADD) or darken (MUL) the surface instead of fading it into the distance.
+    float3 rgb = ( i.lit != 0.0 ) ? ShadeDecal( albedo, i.wpos, i.wnrm, i.clip.xyz ) : albedo;
+    return float4( rgb, t.a * i.alpha );
 }

--- a/D3D11Engine/Shaders/D3D12/Decal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Decal.hlsl
@@ -43,8 +43,14 @@ cbuffer ShadowCB : register(b3)
     float4x4 RainViewProj;
     float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
     uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    float4x4 AoPrevViewProj;
-    uint     AoPrevDepthIndex;  float AoPrevProjZX;      float AoPrevProjZY;  float AoReprojValid;
+    // --- Screen-space AO block, 80 bytes, written by UploadAoScreenConstants (kAoReprojCbOffset). Only the
+    // first float2 is live: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask UV with.
+    // The other 72 bytes are the hole left by the AO REPROJECTION constants (previous-frame view-proj + depth
+    // index) from back when the mask was built off a previous-frame depth SNAPSHOT; RenderSSAO now runs off
+    // THIS frame's depth prepass and nothing reprojects. The hole stays so the sky-IBL tail below keeps its
+    // byte offset (kSkyIblCbOffset = 432). Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl.
+    float2   AoInvRes;          float2 _aopad0;
+    float4   _aoReserved[4];
     uint     SkyIrradianceIndex; uint  SkySpecularIndex;  float SkySpecularMips; float SkyIblIntensity;
 };
 Texture2DArray          ShadowMap : register(t4);
@@ -108,7 +114,7 @@ float3 ShadeDecal( float3 albedo, float3 wpos, float3 nrm, float3 svpos )
     if ( dot( N, normalize( CamPosWS - wpos ) ) < 0.0 ) N = -N;
 
     float shadow = ComputeSunShadow( wpos, N, 1.0 );
-    float ssao   = SampleScreenSpaceAO( wpos );
+    float ssao   = SampleScreenSpaceAO( svpos.xy );
     // vertLighting = 1: decals carry no Gothic vertex/ground light, and 1.0 is the neutral value for the two
     // AO terms it feeds inside ComputeSunLightingPBR (lerp(1, vertLighting, strength) == 1).
     float3 rgb = ComputeSunLightingPBR( wpos, N, albedo, 1.0, shadow,

--- a/D3D11Engine/Shaders/D3D12/SSAO.hlsl
+++ b/D3D11Engine/Shaders/D3D12/SSAO.hlsl
@@ -1,7 +1,8 @@
-// Input is the PREVIOUS frame's COMPLETE depth buffer (D3D12GraphicsEngine::CopyDepthForAO), not this frame's
-// depth prepass — that is what puts grass/foliage, decals and water into the occluder set. The one-frame
-// staleness is undone per-pixel in the lit shaders (include/ScreenSpaceAO.hlsl reprojects through the camera
-// that produced this depth), so everything below still works in a single consistent view space.
+// Input is THIS frame's depth buffer as the Forward+ DEPTH PREPASS left it: world mesh + instanced VOBs +
+// skeletals + node attachments + (range-limited) vegetation. So the mask is already in this frame's screen
+// space and the lit shaders read it straight (include/ScreenSpaceAO.hlsl) — no reprojection, no one-frame lag.
+// Water, decals and the late transparents are not in that depth and therefore not occluders; folding grass in
+// (D3D12Scene.cpp's DrawVegetationDepthPrepass) is what made that an acceptable trade.
 // Forward+ has no GBuffer normals before lighting (see PBRLighting.hlsl), so this reconstructs a view-space
 // normal from neighbouring depth samples (D3D11's CS_PFX_SAO SAO_RECONSTRUCT_NORMALS fallback) — same
 // Alchemy-AO/SAO spiral-sample formula as D3D11's CS_PFX_SAO.hlsl, self-contained (no shared D3D11 headers;

--- a/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
@@ -53,10 +53,14 @@ cbuffer ShadowCB : register(b5)
     float4x4 RainViewProj;
     float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
     uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // Screen-space AO reprojection tail — see World.hlsl for the layout notes; must stay identical in all
-    // three lit shaders and in the CPU-side AoReprojCBData.
-    float4x4 AoPrevViewProj;
-    uint     AoPrevDepthIndex;  float AoPrevProjZX;      float AoPrevProjZY;  float AoReprojValid;
+    // --- Screen-space AO block, 80 bytes, written by UploadAoScreenConstants (kAoReprojCbOffset). Only the
+    // first float2 is live: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask UV with.
+    // The other 72 bytes are the hole left by the AO REPROJECTION constants (previous-frame view-proj + depth
+    // index) from back when the mask was built off a previous-frame depth SNAPSHOT; RenderSSAO now runs off
+    // THIS frame's depth prepass and nothing reprojects. The hole stays so the sky-IBL tail below keeps its
+    // byte offset (kSkyIblCbOffset = 432). Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl.
+    float2   AoInvRes;          float2 _aopad0;
+    float4   _aoReserved[4];
     // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
     // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
     // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.
@@ -88,7 +92,7 @@ TextureCubeArray        PointShadowCubes : register(t5);   // point-light shadow
 cbuffer AOCB : register(b8) { uint AoMaskIndex; };
 // Point-clamp for the AO mask — see World.hlsl's identical declaration for why Sample (not Load) is required.
 SamplerState smpAoClamp : register(s1);
-// SampleScreenSpaceAO — see World.hlsl; needs AOCB/smpAoClamp + the ShadowCB reprojection tail declared above.
+// SampleScreenSpaceAO — see World.hlsl; needs AOCB/smpAoClamp declared above.
 #include "include/ScreenSpaceAO.hlsl"
 
 // DelightDiffuse, SamplePointShadow, ComputeSunShadow, the Cook-Torrance PBR helpers, PerturbNormal/
@@ -153,7 +157,7 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     float3 V = normalize( CamPosWS - i.wpos );
     float wetSheen;
     float wetness = ApplySceneWetness( i.wpos, V, N, albedo, orm.g, wetSheen );
-    float ssao = SampleScreenSpaceAO( i.wpos );
+    float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= lerp( 1.0, 0.8, wetness );
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );   // dynamic point lights on top (PBR)

--- a/D3D11Engine/Shaders/D3D12/TAAResolve.hlsl
+++ b/D3D11Engine/Shaders/D3D12/TAAResolve.hlsl
@@ -58,7 +58,7 @@
 
 // Whether to use real 16-bit floats. Requires SM6.2 and "-enable-16bit-types"; see note 5 above.
 #ifndef USE_FP16
-#define USE_FP16 0
+#define USE_FP16 1
 #endif
 
 typedef float  fp32_t;

--- a/D3D11Engine/Shaders/D3D12/TAAResolve.hlsl
+++ b/D3D11Engine/Shaders/D3D12/TAAResolve.hlsl
@@ -58,7 +58,7 @@
 
 // Whether to use real 16-bit floats. Requires SM6.2 and "-enable-16bit-types"; see note 5 above.
 #ifndef USE_FP16
-#define USE_FP16 1
+#define USE_FP16 0
 #endif
 
 typedef float  fp32_t;

--- a/D3D11Engine/Shaders/D3D12/Vegetation.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Vegetation.hlsl
@@ -39,15 +39,19 @@ cbuffer ShadowCB : register(b4)
     // 0 = the old unoccluded behaviour, 1 = interiors get no sky ambient at all. See the note there.
     float    SkyOccStrength;    float _shpad;
     // Scene-wetness (rain) block. Grass applies no wetness (no Wetness.hlsl include here), but the fields must
-    // be declared so the AO tail below lands at the byte offset UploadAoReprojConstants writes it to — this CB
-    // is the same 512-byte resource World/Vob/Skeletal bind, three disjoint writers into one layout.
+    // be declared so the sky-IBL tail below lands at the byte offset UploadSkyIblConstants writes it to — this
+    // CB is the same 512-byte resource World/Vob/Skeletal bind, three disjoint writers into one layout.
     float4x4 RainViewProj;
     float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
     uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // Screen-space AO reprojection tail — see World.hlsl for the layout notes; must stay identical in all
-    // lit shaders and in the CPU-side AoReprojCBData.
-    float4x4 AoPrevViewProj;
-    uint     AoPrevDepthIndex;  float AoPrevProjZX;      float AoPrevProjZY;  float AoReprojValid;
+    // --- Screen-space AO block, 80 bytes, written by UploadAoScreenConstants (kAoReprojCbOffset). Only the
+    // first float2 is live: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask UV with.
+    // The other 72 bytes are the hole left by the AO REPROJECTION constants (previous-frame view-proj + depth
+    // index) from back when the mask was built off a previous-frame depth SNAPSHOT; RenderSSAO now runs off
+    // THIS frame's depth prepass and nothing reprojects. The hole stays so the sky-IBL tail below keeps its
+    // byte offset (kSkyIblCbOffset = 432). Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl.
+    float2   AoInvRes;          float2 _aopad0;
+    float4   _aoReserved[4];
     // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
     // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
     // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.
@@ -65,9 +69,9 @@ TextureCubeArray        PointShadowCubes : register(t6);
 // Simple-SSAO mask (bindless, set once per frame — see D3D12GraphicsEngine::RenderSSAO/m_ActiveAOMaskSrvSlot).
 // b5: b0..b4 above are all spoken for on this root sig.
 cbuffer AOCB : register(b5) { uint AoMaskIndex; };
-// Point-clamp for the AO mask + the reprojection depth fetch — see World.hlsl for why Sample, not Load.
+// Point-clamp for the AO mask — see World.hlsl for why Sample, not Load.
 SamplerState smpAoClamp : register(s1);
-// SampleScreenSpaceAO — needs AOCB/smpAoClamp + the ShadowCB reprojection tail declared above.
+// SampleScreenSpaceAO — see World.hlsl; needs AOCB/smpAoClamp declared above.
 #include "include/ScreenSpaceAO.hlsl"
 
 // DelightDiffuse, ComputeSunShadow, ComputeSunLightingPBR and AccumTiledPointLights are shared with
@@ -95,9 +99,13 @@ struct VS_IN
 };
 struct VS_OUT { float4 clip : SV_POSITION; float2 uv : TEXCOORD0; float3 wpos : TEXCOORD1; float fogDist : TEXCOORD2; };
 
-VS_OUT VSMain( VS_IN i )
+// The instanced blade's swayed world position. Shared by every grass VS — the lit pass, the depth prepass and
+// the CSM caster — because a blade that lands at a different position in the prepass than in the color pass
+// z-fights against its own depth (the color PSO tests GREATER_EQUAL against what the prepass wrote). The host
+// side has the matching obligation: the same GrassCB (G_Time above all) must be pushed to every pass in a
+// frame, which is why D3D12GraphicsEngine::MakeGrassConstants exists.
+float3 GrassWorldPos( VS_IN i )
 {
-    VS_OUT o;
     float3 wpos = mul( float4( i.pos, 1.0 ), i.iworld ).xyz;
 
     float wind = sin( i.pos.z * 0.001f ) * 0.5f + 0.5f;
@@ -110,6 +118,14 @@ VS_OUT VSMain( VS_IN i )
 
     if ( G_HeroAffectStrength > 0 )
         wpos.xz += GrassHeroAffectOffsetXZ( wpos, i.pos.y );
+
+    return wpos;
+}
+
+VS_OUT VSMain( VS_IN i )
+{
+    VS_OUT o;
+    float3 wpos = GrassWorldPos( i );
 
     o.clip = mul( float4( wpos, 1.0 ), ViewProj );
     o.uv = i.uv;
@@ -154,11 +170,12 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     // hard at every cascade split. Ngeo is near-edge-on to the sun, so the bias gets its full magnitude here.
     float shadow = ComputeSunShadow( i.wpos, Ngeo, 1.0 );
     // orm: AO=1 (g_full), roughness=0.9 (matte), metallic=0 — grass has no ORM map, so a diffuse-leaning default.
-    // Screen-space AO applies here now: the mask is built from the PREVIOUS frame's COMPLETE depth (which the
-    // grass DID write, in the lit color pass), not from the depth prepass grass never joins. So the mask at a
-    // blade's reprojected position describes the blade itself and its neighbours, not the terrain behind it —
-    // the reason this used to pass a literal 1.0.
-    float ssao = SampleScreenSpaceAO( i.wpos );
+    // Screen-space AO applies here: grass now joins the depth prepass the mask is built from (VSDepthGBuf below,
+    // range-limited by DrawVegetationDepthPrepass), so this pixel's mask entry describes the blade itself and
+    // its neighbours rather than the terrain behind it — the reason this used to pass a literal 1.0. Beyond the
+    // prepass range limit the blade is absent from the mask and simply reads the terrain's AO, which is a much
+    // milder error at that distance than it would be up close.
+    float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, 1.0, shadow, 0.9, 0.0, 1.0, ssao );
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, 0.9, 0.0 );
     float f = saturate( ( i.fogDist - FogNear ) / max( 1.0, FogFar - FogNear ) );
@@ -174,20 +191,7 @@ struct VS_DEPTH_OUT { float4 clip : SV_POSITION; float2 uv : TEXCOORD0; };
 VS_DEPTH_OUT VSDepth( VS_IN i )
 {
     VS_DEPTH_OUT o;
-    float3 wpos = mul( float4( i.pos, 1.0 ), i.iworld ).xyz;
-
-    float wind = sin( i.pos.z * 0.001f ) * 0.5f + 0.5f;
-    wind += sin( i.pos.x * 0.001f ) * 0.5f + 0.5f;
-    wind += 0.2f;
-
-    wpos.xz += sin( G_Time + wind ) * 2.0f * i.pos.y * G_WindStrength;
-    wpos.xz += sin( G_Time * 3.0f + wind ) * 1.55f * i.pos.y * G_WindStrength;
-    wpos.xz += sin( G_Time * 5.0f + wind ) * 1.2f * i.pos.y * G_WindStrength;
-
-    if ( G_HeroAffectStrength > 0 )
-        wpos.xz += GrassHeroAffectOffsetXZ( wpos, i.pos.y );
-
-    o.clip = mul( float4( wpos, 1.0 ), ViewProj );
+    o.clip = mul( float4( GrassWorldPos( i ), 1.0 ), ViewProj );
     o.uv = i.uv;
     return o;
 }
@@ -196,4 +200,57 @@ void PSShadowClip( VS_DEPTH_OUT i )
 {
     // Matches PSMain's cutout threshold (0.7 blade-alpha scale before the 0.5 clip).
     clip( tx.Sample( smp, i.uv ).a * 0.7f - 0.5f );
+}
+
+// --- Forward+ DEPTH PREPASS variants (D3D12GraphicsEngine::DrawVegetationDepthPrepass) ------------------------
+// Grass joins the depth prepass so the AO mask RenderSSAO builds from that depth contains the blades instead of
+// the terrain behind them (and so the light cull bounds its clusters to the grass that is actually in front).
+// VSDepth/PSShadowClip above ARE the depth-only variant — this pair only adds the two G-buffer render targets
+// the prepass writes when the motion/normal buffers are available (see include/MotionVectors.hlsl).
+//
+// b6 for MotionCB: b0..b5 are all taken on Grass.RootSig. Only the prepass PSOs reference it, so the lit grass
+// PSO and the CSM grass caster (which share this root signature) leave that root parameter unbound, as D3D12
+// permits for a parameter no bound shader statically references.
+#define MOTIONCB_REGISTER b6
+#include "include/MotionVectors.hlsl"
+
+struct VS_DEPTH_GBUF_OUT
+{
+    float4 clip     : SV_POSITION;
+    float2 uv       : TEXCOORD0;
+    float3 wpos     : TEXCOORD1;
+    float4 currClip : TEXCOORD2;
+    float4 prevClip : TEXCOORD3;
+};
+
+VS_DEPTH_GBUF_OUT VSDepthGBuf( VS_IN i )
+{
+    VS_DEPTH_GBUF_OUT o;
+    float3 wpos = GrassWorldPos( i );
+    o.clip = mul( float4( wpos, 1.0 ), ViewProj );
+    o.uv   = i.uv;
+    o.wpos = wpos;
+    // CAMERA-ONLY velocity: the previous position is fed the CURRENT world position, so the sway itself reports
+    // as static. Reconstructing last frame's sway would mean carrying last frame's G_Time and re-evaluating the
+    // whole sine stack, and the result would still be wrong for the hero-push term (the player moved too).
+    // This is exactly what FillCameraVelocity used to synthesize for these pixels — no worse, one pass earlier,
+    // and now correct at silhouettes where the fill's depth reprojection was picking up the terrain behind.
+    o.currClip = mul( float4( wpos, 1.0 ), UnjitteredViewProj );
+    o.prevClip = mul( float4( wpos, 1.0 ), PrevViewProj );
+    return o;
+}
+
+GBUF_OUT PSDepthClipGBuf( VS_DEPTH_GBUF_OUT i )
+{
+    clip( tx.Sample( smp, i.uv ).a * 0.7f - 0.5f );   // identical cutout to PSShadowClip/PSMain
+
+    // The SAME shading normal PSMain lights with, derived the same way (geometric normal from the swayed world
+    // position's derivatives, bent 70% toward world-up) — see PSMain for why the raw card normal is unusable.
+    // XeGTAO consumes this, so it must describe the surface the lit pass will shade, not the cardboard quad.
+    float3 ngRaw = cross( ddx( i.wpos ), ddy( i.wpos ) );
+    float  ngLen = length( ngRaw );
+    float3 Ngeo  = ngLen > 1e-6f ? ngRaw / ngLen : float3( 0, 1, 0 );
+    if ( dot( Ngeo, CamPosWS - i.wpos ) < 0.0f ) Ngeo = -Ngeo;
+
+    return MakeGBufOut( i.currClip, i.prevClip, normalize( lerp( Ngeo, float3( 0, 1, 0 ), 0.7f ) ) );
 }

--- a/D3D11Engine/Shaders/D3D12/Vob.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Vob.hlsl
@@ -40,10 +40,14 @@ cbuffer ShadowCB : register(b3)
     float4x4 RainViewProj;
     float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
     uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // Screen-space AO reprojection tail — see World.hlsl for the layout notes; must stay identical in all
-    // three lit shaders and in the CPU-side AoReprojCBData.
-    float4x4 AoPrevViewProj;
-    uint     AoPrevDepthIndex;  float AoPrevProjZX;      float AoPrevProjZY;  float AoReprojValid;
+    // --- Screen-space AO block, 80 bytes, written by UploadAoScreenConstants (kAoReprojCbOffset). Only the
+    // first float2 is live: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask UV with.
+    // The other 72 bytes are the hole left by the AO REPROJECTION constants (previous-frame view-proj + depth
+    // index) from back when the mask was built off a previous-frame depth SNAPSHOT; RenderSSAO now runs off
+    // THIS frame's depth prepass and nothing reprojects. The hole stays so the sky-IBL tail below keeps its
+    // byte offset (kSkyIblCbOffset = 432). Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl.
+    float2   AoInvRes;          float2 _aopad0;
+    float4   _aoReserved[4];
     // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
     // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
     // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.
@@ -65,7 +69,7 @@ TextureCubeArray        PointShadowCubes : register(t5);
 cbuffer AOCB : register(b7) { uint AoMaskIndex; };
 // Point-clamp for the AO mask — see World.hlsl's identical declaration for why Sample (not Load) is required.
 SamplerState smpAoClamp : register(s1);
-// SampleScreenSpaceAO — see World.hlsl; needs AOCB/smpAoClamp + the ShadowCB reprojection tail declared above.
+// SampleScreenSpaceAO — see World.hlsl; needs AOCB/smpAoClamp declared above.
 #include "include/ScreenSpaceAO.hlsl"
 
 // DelightDiffuse, SamplePointShadow, ComputeSunShadow, the Cook-Torrance PBR helpers, PerturbNormal/
@@ -143,7 +147,7 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     float3 V = normalize( CamPosWS - i.wpos );
     float wetSheen;
     float wetness = ApplySceneWetness( i.wpos, V, N, albedo, orm.g, wetSheen );
-    float ssao = SampleScreenSpaceAO( i.wpos );
+    float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= lerp( 1.0, 0.8, wetness );
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
@@ -240,7 +244,7 @@ float4 PSMainBindless( VS_OUT i ) : SV_TARGET
     float3 V = normalize( CamPosWS - i.wpos );
     float wetSheen;
     float wetness = ApplySceneWetness( i.wpos, V, N, albedo, orm.g, wetSheen );
-    float ssao = SampleScreenSpaceAO( i.wpos );
+    float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= lerp( 1.0, 0.8, wetness );
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
@@ -280,7 +284,7 @@ float4 PSAlphaBlendBindless( VS_OUT i ) : SV_TARGET
     float3 albedo = SrgbToLinear( t.rgb );
     albedo = DelightDiffuse( albedo );
     float shadow = ComputeSunShadow( i.wpos, N, i.col.g );
-    float ssao = SampleScreenSpaceAO( i.wpos );
+    float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, i.col.g, shadow, orm.g, orm.b, orm.r, ssao );
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
     return float4( rgb, t.a * i.col.a );

--- a/D3D11Engine/Shaders/D3D12/World.hlsl
+++ b/D3D11Engine/Shaders/D3D12/World.hlsl
@@ -41,11 +41,14 @@ cbuffer ShadowCB : register(b3)
     float4x4 RainViewProj;
     float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
     uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // --- Screen-space AO reprojection tail, uploaded by UploadAoReprojConstants (kAoReprojCbOffset). The AO
-    // mask is computed from the PREVIOUS frame's complete depth, so it is sampled through the camera that
-    // produced it — see include/ScreenSpaceAO.hlsl. Keep in sync with Vob.hlsl/Skeletal.hlsl + AoReprojCBData.
-    float4x4 AoPrevViewProj;
-    uint     AoPrevDepthIndex;  float AoPrevProjZX;      float AoPrevProjZY;  float AoReprojValid;
+    // --- Screen-space AO block, 80 bytes, written by UploadAoScreenConstants (kAoReprojCbOffset). Only the
+    // first float2 is live: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask UV with.
+    // The other 72 bytes are the hole left by the AO REPROJECTION constants (previous-frame view-proj + depth
+    // index) from back when the mask was built off a previous-frame depth SNAPSHOT; RenderSSAO now runs off
+    // THIS frame's depth prepass and nothing reprojects. The hole stays so the sky-IBL tail below keeps its
+    // byte offset (kSkyIblCbOffset = 432). Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl.
+    float2   AoInvRes;          float2 _aopad0;
+    float4   _aoReserved[4];
     // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
     // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
     // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.
@@ -73,8 +76,8 @@ cbuffer AOCB : register(b7) { uint AoMaskIndex; };
 // Point-clamp for the AO mask: MUST be Sample-based (normalized UV, CLAMP addressing), not Load — Load() with
 // raw pixel coords returns 0 out-of-bounds, which the 1x1 "AO disabled" fallback always is at screen res.
 SamplerState smpAoClamp : register(s1);
-// SampleScreenSpaceAO — reprojects a world position into the previous-frame AO mask. Needs AOCB/smpAoClamp
-// and the ShadowCB reprojection tail above, hence the include lands here.
+// SampleScreenSpaceAO — a plain screen-space read of THIS frame's AO mask (RenderSSAO builds it from this
+// frame's depth prepass, so no reprojection). Needs AOCB/smpAoClamp above, hence the include lands here.
 #include "include/ScreenSpaceAO.hlsl"
 
 // Octahedral normal decode — matches Shaders/VertexPacking.h DecodeOctNormal (the packed 36-byte vertex
@@ -169,7 +172,7 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     float3 V = normalize( CamPosWS - i.wpos );
     float wetSheen;
     float wetness = ApplySceneWetness( i.wpos, V, N, albedo, orm.g, wetSheen );
-    float ssao = SampleScreenSpaceAO( i.wpos );
+    float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= lerp( 1.0, 0.8, wetness );   // D3D11 dims the SUN light color 20% where the surface is wet
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );

--- a/D3D11Engine/Shaders/D3D12/XeGTAO.hlsl
+++ b/D3D11Engine/Shaders/D3D12/XeGTAO.hlsl
@@ -6,11 +6,11 @@
 // D3D12 ONLY. This replaces ASSAO on the D3D12 backend (AoMode == AO_ASSAO); the D3D11 renderer keeps its own
 // ASSAO port untouched.
 //
-// DEPTH SOURCE. Every pass reads the PREVIOUS frame's COMPLETE depth buffer (m_PrevDepth, snapshotted by
-// CopyDepthForAO after the last depth writer of the frame), exactly like the simple-SSAO path it replaces —
-// Forward+ resolves lighting in the geometry pass, so this frame's depth does not exist yet when the AO mask is
-// needed, and the prepass alone would omit grass/foliage/decals/water. The resulting mask lives in the previous
-// frame's screen space and the lit pixel shaders reproject into it per-pixel (include/ScreenSpaceAO.hlsl).
+// DEPTH SOURCE. THIS frame's depth buffer, straight after the Forward+ depth prepass and before any lit pass —
+// world mesh + instanced VOBs + skeletals + node attachments + (range-limited) vegetation. Same for the simple
+// SSAO path this replaces. It used to run off a full-frame depth SNAPSHOT of the PREVIOUS frame, which bought
+// coverage of the late depth writers at the price of a one-frame lag and a per-pixel reprojection in every lit
+// shader; folding vegetation into the prepass removed the reason for that trade.
 //
 // FP32, NOT FP16. XE_GTAO_USE_HALF_FLOAT_PRECISION is off and XE_GTAO_FP32_DEPTHS on (Intel's own
 // `m_use32bitDepth` configuration). Two reasons, in order: Gothic's view-space depths run to tens of thousands
@@ -55,8 +55,15 @@ cbuffer GTAOBindingsCB : register( b1 )
     uint g_Out2Index;           // depth MIP2
     uint g_Out3Index;           // depth MIP3
     uint g_Out4Index;           // depth MIP4
+    // 0 -> g_NormalsIndex is the R32_UINT R11G11B10 VIEW-space map CSGenerateNormals derived from depth.
+    // 1 -> it is the depth prepass's RG16F OCTAHEDRAL WORLD-space normal G-buffer (D3D12Motion.cpp), which
+    //      LoadNormal then decodes and rotates into view space with g_ViewRow* below. See LoadNormal.
+    uint g_NormalsAreGBuffer;
     uint g_Pad0;
-    uint g_Pad1;
+    // THIS frame's view matrix, uploaded as the same row-major XMFLOAT4X4 every other matrix in this backend
+    // is (default column-major packing reads it back transposed, which is what makes plain mul() correct — see
+    // World.hlsl's header). Only read when g_NormalsAreGBuffer is set.
+    float4x4 g_ViewMatrix;
 };
 
 // Point-clamp. XeGTAO gathers depth quads and samples explicit MIP levels; any filtering would blend across
@@ -65,15 +72,47 @@ SamplerState g_samplerPointClamp : register( s0 );
 
 #include "XeGTAO.hlsli"
 
-// Engine-specific normal loader. The normals are GENERATED from the same depth snapshot by CSGenerateNormals
-// below, so they are already in the view space of that snapshot and need no basis change here.
+// Octahedral decode — same mapping as include/MotionVectors.hlsl's DecodeOctNormalMV and World.hlsl's
+// DecodeOctNormal. Duplicated rather than included: pulling MotionVectors.hlsl in here would also declare its
+// MotionCB, which this pass's root signature does not have.
+float3 XeGTAO_DecodeOctNormal( float2 e )
+{
+    float3 n = float3( e.xy, 1.0 - abs( e.x ) - abs( e.y ) );
+    float t = saturate( -n.z );
+    n.xy += select( n.xy >= 0.0, -t, t );
+    return normalize( n );
+}
+
+// Engine-specific normal loader, with two sources (g_NormalsAreGBuffer picks; the host decides per dispatch).
 //
-// Deliberately not the depth-prepass normal G-buffer (D3D12Motion.cpp), even though it exists and carries real
-// per-vertex normals: that buffer covers only the prepass writers, so grass, foliage and water would read the
-// sentinel, and it belongs to THIS frame's camera while everything else in this pass belongs to the previous
-// one's. Depth-derived normals are consistent with the depth by construction.
+// PREFERRED: the depth PREPASS's normal G-buffer (D3D12Motion.cpp) — real per-vertex/shading normals for the
+// exact geometry that wrote the depth this pass is integrating over, at no extra cost. They are octahedral
+// WORLD space, so they get rotated into view space here. Pixels no prepass draw covered carry the clear
+// sentinel (see kOctNormalSentinel in include/MotionVectors.hlsl); those are sky and the late transparents,
+// and reporting a camera-facing normal there collapses the horizon search to "unoccluded", which is right.
+//
+// FALLBACK: normals GENERATED from the depth itself by CSGenerateNormals below, already in view space. Used
+// whenever the G-buffer is unavailable (its PSOs or targets failed to create). Depth-derived normals are
+// consistent with the depth by construction, but they round off every real edge the depth doesn't resolve.
 lpfloat3 LoadNormal( int2 pos )
 {
+    if ( g_NormalsAreGBuffer )
+    {
+        Texture2D<float2> srcOctNormals = ResourceDescriptorHeap[g_NormalsIndex];
+        float2 e = srcOctNormals.Load( int3( pos, 0 ) ).xy;
+        if ( e.x < -1.5 )                             // clear sentinel: no prepass coverage
+            return lpfloat3( 0, 0, -1 );              // XeGTAO view space is +Z away from the eye
+        float3 n = XeGTAO_DecodeOctNormal( e );
+        // World -> view: the same mul() every other pass in this backend uses for a matrix, w = 0 for a
+        // direction. Do NOT hand-expand this into a linear combination of the uploaded matrix's rows — that
+        // computes R^T*n (the INVERSE rotation), because mul() sums v[i] * row i of the HLSL matrix, and a
+        // row-major upload read back column-major means row i of the HLSL matrix is COLUMN i of what was
+        // uploaded. That mistake shipped once: it is exact when the camera faces the identity direction and
+        // grows with yaw until dot(N, viewVec) flips sign, at which point XeGTAO's horizon integral degenerates
+        // to fully occluded and large flat walls turn black as you turn.
+        return (lpfloat3)normalize( mul( float4( n, 0.0 ), g_ViewMatrix ).xyz );
+    }
+
     Texture2D<uint> srcNormalmap = ResourceDescriptorHeap[g_NormalsIndex];
     uint packedInput = srcNormalmap.Load( int3( pos, 0 ) ).x;
     float3 unpackedOutput = XeGTAO_R11G11B10_UNORM_to_FLOAT3( packedInput );

--- a/D3D11Engine/Shaders/D3D12/include/ForwardPlusTypes.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/ForwardPlusTypes.hlsl
@@ -29,7 +29,8 @@
 
 // Per-frame visible point light (torches/campfires/spells), 64 B. Must stay in lockstep with the C++ GPULight
 // in D3D12Engine/D3D12EngineCommon.h and with LightCull.hlsl's TiledPointLight copy.
-// Forward shaders read PositionWorld/Range/Color for shading; PositionView feeds the tile cull;
+// Forward shaders read PositionWorld/Range/Color for shading (Color.w = 0 for an isStatic() light, and is used as
+// the specular scale so those diffuse-only fill lights cast no highlight); PositionView feeds the tile cull;
 // ShadowCubeIndex/ShadowOrigin/ShadowRange feed the point-shadow lookup.
 //
 // ShadowOrigin/ShadowRange are the CUBE's centre and far-plane basis, which are NOT the light's own whenever

--- a/D3D11Engine/Shaders/D3D12/include/MotionVectors.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/MotionVectors.hlsl
@@ -64,6 +64,12 @@ float2 EncodeOctNormal( float3 n )
     return n.xy;
 }
 
+// The value the NORMAL target is cleared to (kGBufferNormalSentinel on the CPU side, D3D12Motion.cpp). A real
+// octahedral pair lives in [-1,1], so -2 is unreachable by EncodeOctNormal and unambiguously means "no prepass
+// draw covered this pixel". A plain 0 would NOT do: (0,0) is the legal encoding of the world normal (0,0,1).
+static const float kOctNormalSentinel = -2.0;
+bool IsOctNormalSentinel( float2 e ) { return e.x < -1.5; }
+
 // Kept next to the encoder so a consumer (XeGTAO) can decode without pulling in the whole world shader.
 float3 DecodeOctNormalMV( float2 e )
 {

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -261,8 +261,11 @@ float  PBR_Pow5( float x ) { float x2 = x * x; return x2 * x2 * x; }
 float3 PBR_FresnelSchlick( float cosTheta, float3 F0 ) { return F0 + ( 1.0 - F0 ) * PBR_Pow5( saturate( 1.0 - cosTheta ) ); }
 
 // Full Cook-Torrance (energy-conserving diffuse + specular). attenuation folds in falloff/shadow; NdotL applied here.
+// specularScale scales ONLY the specular lobe (diffuse is untouched): 0 turns the light into a pure area-brightener.
+// Mirrors D3D11's `spec = PLS_CalcBlinnPhongLighting(...) * light.Color.w` in ForwardPlusLighting.hlsl /
+// CS_TiledShading.hlsl / PS_DS_PointLight*.hlsl — see ApplyTiledLight for who passes 0.
 float3 PBR_DirectLighting( float3 baseColor, float3 lightColor, float3 N, float3 V, float3 L,
-                           float roughness, float metallic, float attenuation )
+                           float roughness, float metallic, float attenuation, float specularScale )
 {
     float NdotL = saturate( dot( N, L ) );
     float NdotV = saturate( dot( N, V ) );
@@ -276,7 +279,7 @@ float3 PBR_DirectLighting( float3 baseColor, float3 lightColor, float3 N, float3
     float  D = PBR_DistributionGGX( NdotH, cr );
     float  G = PBR_GeometrySmith( NdotV, NdotL, cr );
     float3 F = PBR_FresnelSchlick( VdotH, F0 );
-    float3 specular = ( D * G * F ) / max( 4.0 * NdotV * NdotL, 1e-4 );
+    float3 specular = ( D * G * F ) / max( 4.0 * NdotV * NdotL, 1e-4 ) * specularScale;
     float3 kD = ( 1.0 - F ) * ( 1.0 - cm );
     float3 diffuse = kD * baseColor / PBR_PI;
     return ( diffuse + specular ) * lightColor * ( NdotL * attenuation );
@@ -463,7 +466,7 @@ float3 ComputeSunLightingPBR( float3 wpos, float3 N, float3 albedo, float vertLi
 
     // Direct Sun term
     float sunAtten = sun * worldAO * SunIntensity;
-    float3 directSun = PBR_DirectLighting( albedo, sunCol, N, V, L, roughness, metallic, sunAtten );
+    float3 directSun = PBR_DirectLighting( albedo, sunCol, N, V, L, roughness, metallic, sunAtten, 1.0 );
 
     return ambientSun + directSun;
 }
@@ -492,7 +495,11 @@ void ApplyTiledLight( uint lightIndex, float3 wpos, float3 N, float3 V, float3 a
     dir /= dist;
     float nd  = saturate( 1.0 - dist / L.Range );
     float falloff = nd * ( nd * 0.2 + 0.8 );   // PLS_ComputeRangeFalloff
-    float3 lit = PBR_DirectLighting( albedo, L.Color.rgb, N, V, dir, roughness, metallic, falloff );
+    // Color.w is the 0/1 "not static" flag BuildFrameLightBuffer packs (D3D12Scene.cpp), fed straight in as the
+    // specular scale: an isStatic() zCVobLight is one of the "atmospheric" fill lights Gothic pre-places to
+    // brighten a room, not a physical source, so it must contribute diffuse only — a highlight from it reads as a
+    // phantom lamp. Same suppression D3D11 does with light.Color.w.
+    float3 lit = PBR_DirectLighting( albedo, L.Color.rgb, N, V, dir, roughness, metallic, falloff, L.Color.w );
     if ( L.ShadowCubeIndex >= 0 )
     {
         // ShadowOrigin/ShadowRange, not PositionWorld/Range: a clustered static light samples a cube

--- a/D3D11Engine/Shaders/D3D12/include/ScreenSpaceAO.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/ScreenSpaceAO.hlsl
@@ -1,47 +1,26 @@
-// Screen-space AO lookup for the lit Forward+ pixel shaders (World.hlsl / Vob.hlsl / Skeletal.hlsl).
+// Screen-space AO lookup for the lit Forward+ pixel shaders (World / Vob / Skeletal / Vegetation / Decal).
 //
-// The AO mask is produced by D3D12GraphicsEngine::RenderSSAO from the PREVIOUS frame's COMPLETE depth buffer
-// (m_PrevDepth, snapshotted by CopyDepthForAO after every depth-writing pass) rather than from this frame's
-// depth prepass. That is what lets grass/foliage, decals and the other late depth writers both cast AO and be
-// correctly shaded by it — the prepass never contained them.
+// The AO mask is produced by D3D12GraphicsEngine::RenderSSAO from THIS frame's DEPTH PREPASS, immediately after
+// the prepass and before any lit pass runs. The mask is therefore already in this frame's screen space: the
+// lookup is a plain read at the pixel being shaded — no reprojection, no disocclusion test, no one-frame lag.
+// (It used to run off a full-frame depth SNAPSHOT of the PREVIOUS frame, which bought coverage of the late
+// depth writers at the cost of all of the above; vegetation joining the prepass is what made that trade
+// unnecessary — see D3D12Scene.cpp's DrawVegetationDepthPrepass.)
 //
-// The price is that the mask lives in the PREVIOUS frame's screen space, so this reprojects into it per-pixel:
-// the surface's world position is pushed through AoPrevViewProj (the exact camera that rasterized the
-// snapshot) to get the UV it occupied last frame. For static geometry that is exact — not a camera-motion
-// approximation — and it only lags on objects that themselves moved. Two rejections fall back to "unoccluded":
-//   * the reprojected UV leaving the screen (the surface simply wasn't visible last frame), and
-//   * a depth mismatch at that UV (disocclusion — last frame something ELSE was in front here, so its AO
-//     has nothing to do with this surface).
+// COVERAGE. The prepass contains the world mesh, instanced VOBs, skeletals + node attachments and vegetation
+// (the last range-limited to kVegetationPrepassRange). Water, decals, particles and the blended transparencies
+// write depth later and are not AO occluders; a pixel of one of those simply reads the mask of the opaque
+// surface behind it, which is the right answer for a decal and a harmless one for the rest.
 //
-// Requires, declared BEFORE this include: the ShadowCB reprojection tail (AoPrevViewProj/AoPrevDepthIndex/
-// AoPrevProjZ*/AoReprojValid), `cbuffer AOCB { uint AoMaskIndex; }` and `SamplerState smpAoClamp`.
+// Requires, declared BEFORE this include: `cbuffer AOCB { uint AoMaskIndex; }`, `SamplerState smpAoClamp`,
+// and the ShadowCB screen-space-AO block that carries AoInvRes. (AoInvRes rides ShadowCB rather than AOCB
+// because the World root signature is at 63 of its 64 DWORDs — two more root constants would not fit.)
 
-// Relative view-depth tolerance for the disocclusion test. Generous enough to survive the sub-pixel
-// reprojection error on a steeply-slanted surface, tight enough to reject a genuinely different surface.
-static const float kAoReprojDepthTolerance = 0.05;
-
-float SampleScreenSpaceAO( float3 wpos )
+// SampleLevel through the clamp sampler rather than Load(): when AO is off or its resources are unavailable the
+// host binds the 1x1 WHITE texture here, and a Load() at any real screen coordinate would fall outside that
+// single texel and return 0 — fully occluded — instead of 1.
+float SampleScreenSpaceAO( float2 svPos )
 {
-    // No snapshot yet (first frame of a world, or right after a resize) — nothing to reproject into.
-    if ( AoReprojValid < 0.5 ) return 1.0;
-
-    float4 prevClip = mul( float4( wpos, 1.0 ), AoPrevViewProj );
-    if ( prevClip.w <= 0.0 ) return 1.0;                      // behind last frame's camera
-    float invW = 1.0 / prevClip.w;
-    float2 uv = prevClip.xy * invW * float2( 0.5, -0.5 ) + 0.5;
-    if ( any( uv < 0.0 ) || any( uv > 1.0 ) ) return 1.0;     // off-screen last frame
-
-    // Disocclusion test: what the snapshot actually stored at that UV must be this same surface.
-    Texture2D prevDepthTex = ResourceDescriptorHeap[AoPrevDepthIndex];
-    float storedDepth = prevDepthTex.SampleLevel( smpAoClamp, uv, 0 ).r;
-    if ( storedDepth <= 0.0 ) return 1.0;                     // reversed-Z: cleared == sky, no occluder data
-
-    // Compare in linear view Z (reversed-Z depth is wildly non-uniform, so a raw depth epsilon is meaningless).
-    float thisDepth = prevClip.z * invW;
-    float zStored = AoPrevProjZY / ( storedDepth - AoPrevProjZX );
-    float zThis   = AoPrevProjZY / ( thisDepth   - AoPrevProjZX );
-    if ( abs( zStored - zThis ) > kAoReprojDepthTolerance * abs( zThis ) ) return 1.0;
-
     Texture2D aoTex = ResourceDescriptorHeap[AoMaskIndex];
-    return aoTex.SampleLevel( smpAoClamp, uv, 0 ).r;
+    return aoTex.SampleLevel( smpAoClamp, svPos * AoInvRes, 0 ).r;
 }

--- a/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
+++ b/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
@@ -127,6 +127,9 @@ StructuredBuffer<TiledPointLight> FP_Lights : register( t8 );
 StructuredBuffer<LightGrid> FP_LightGrid : register( t9 );
 StructuredBuffer<uint> FP_LightIndexList : register( t10 );
 TextureCubeArray FP_ShadowCubeArray : register( t11 );
+// Per-slot overlay holding ONLY this frame's moving (skeletal) casters; min'd with the static cube above.
+// t12/t13 are the shadow and AO masks, so this lands at t14. See PLS_SHADOW_HAS_DYNAMIC in PointLightShadows.h.
+TextureCubeArray FP_ShadowDynCubeArray : register( t14 );
 
 // ============================================
 // Point Light Accumulation (matches CS_TiledShading.hlsl)
@@ -175,7 +178,7 @@ float3 FP_ComputePointLighting(
         // Don't fetch shadows if the light contribution is effectively zero.
         if ( light.ShadowCubeIndex >= 0 && any(lighting > 0.001f) )
         {
-            float shadow = PLS_SampleShadowCubeArray( FP_ShadowCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex );
+            float shadow = PLS_SampleShadowCubeArray( FP_ShadowCubeArray, FP_ShadowDynCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex );
             lighting *= shadow;
         }
 

--- a/D3D11Engine/Shaders/include/PointLightShadows.h
+++ b/D3D11Engine/Shaders/include/PointLightShadows.h
@@ -6,6 +6,13 @@
 
 #if !defined(__cplusplus)
 
+// TiledPointLight::ShadowCubeIndex encoding: -1 = unshadowed, else (slot | flags). Bit 30 marks that the slot
+// also has a valid dynamic (skeletal overlay) cube in the SECOND array, which must be sampled and min'd with
+// the static one. Keeping the flag in bit 30 leaves the value positive, so "ShadowCubeIndex >= 0" still means
+// shadowed. Mirrors D3D11TiledDeferredShading.h.
+static const int PLS_SHADOW_HAS_DYNAMIC = 0x40000000;
+static const int PLS_SHADOW_SLOT_MASK = 0x3FFFFFFF;
+
 static const int PLS_SHADOW_BLUR_COUNT = 8;
 static const float2 PLS_SHADOW_BLUR_OFFSETS[PLS_SHADOW_BLUR_COUNT] = {
     float2( 0.076849f, -0.078216f),
@@ -167,13 +174,17 @@ float PLS_SampleShadowCube(
 
 float PLS_SampleShadowCubeArray(
     TextureCubeArray shadowCubeArray,
+    TextureCubeArray dynShadowCubeArray,
     SamplerComparisonState samplerState,
     float3 wsPosition,
-    float3 N, 
+    float3 N,
     float3 lightPosWorld,
     float lightRange,
-    int cubeIndex )
+    int encodedIndex )
 {
+    int cubeIndex = encodedIndex & PLS_SHADOW_SLOT_MASK;
+    bool hasDyn = ( encodedIndex & PLS_SHADOW_HAS_DYNAMIC ) != 0;
+
     float3 dir;
     float compareDistance;
     float fixedBias;
@@ -196,7 +207,17 @@ float PLS_SampleShadowCubeArray(
         float3 perturbedDir = normalize( dir + (right * rotatedKernel.x + up * rotatedKernel.y) * fixedBlurScale );
         float4 sampleCoord = float4( perturbedDir, (float)cubeIndex );
 
-        shd += shadowCubeArray.SampleCmpLevelZero( samplerState, sampleCoord, compareDistance - fixedBias );
+        // The slot keeps its STATIC depth in shadowCubeArray and this frame's moving (skeletal) casters in a
+        // SEPARATE array; taking the min of the two comparisons is "occluded by either", which is exactly what
+        // the old composited cube produced - minus the per-slot CopySubresourceRegion that used to build it
+        // every update. The flag is only set for slots whose overlay was actually rendered, so a light with no
+        // NPC nearby pays for no extra sample at all.
+        float s = shadowCubeArray.SampleCmpLevelZero( samplerState, sampleCoord, compareDistance - fixedBias );
+        if ( hasDyn )
+        {
+            s = min( s, dynShadowCubeArray.SampleCmpLevelZero( samplerState, sampleCoord, compareDistance - fixedBias ) );
+        }
+        shd += s;
     }
 
     float finalShadow = shd / PLS_SHADOW_BLUR_COUNT;

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -1407,6 +1407,15 @@ void WorldConverter::ExtractProgMeshProtoFromModel( zCModel* model, MeshVisualIn
                 // — exactly "same brightness in sun or in shadow".
                 XMStoreFloat3( &vx.Normal, XMVector3Normalize( XMVector3TransformNormal( XMLoadFloat3( &wedge.normal ), nodeTrafo ) ) );
                 vx.Color = 0xFFFFFFFF;
+
+                // Check bounding box
+                bbmin.x = bbmin.x > vx.Position.x ? vx.Position.x : bbmin.x;
+                bbmin.y = bbmin.y > vx.Position.y ? vx.Position.y : bbmin.y;
+                bbmin.z = bbmin.z > vx.Position.z ? vx.Position.z : bbmin.z;
+
+                bbmax.x = bbmax.x < vx.Position.x ? vx.Position.x : bbmax.x;
+                bbmax.y = bbmax.y < vx.Position.y ? vx.Position.y : bbmax.y;
+                bbmax.z = bbmax.z < vx.Position.z ? vx.Position.z : bbmax.z;
             }
 
 
@@ -1493,6 +1502,14 @@ void WorldConverter::ExtractProgMeshProtoFromModel( zCModel* model, MeshVisualIn
         wmi->MeshIndexBuffer->Init( &wrappedIndices[0], wrappedIndices.size() * sizeof( unsigned int ), D3D11VertexBuffer::B_INDEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
 
         meshInfo->FullMesh = wmi;
+    }
+
+    // No usable node visual at all: leave a degenerate-but-finite box. The ±FLT_MAX
+    // seeds would otherwise survive into MeshSize as an infinity, and MeshSize drives
+    // the small-vob/draw-distance and pointlight-shadow cull radii.
+    if ( vertexBuffers.empty() ) {
+        bbmin = XMFLOAT3( 0, 0, 0 );
+        bbmax = XMFLOAT3( 0, 0, 0 );
     }
 
     meshInfo->BBox.Min = bbmin;
@@ -1949,6 +1966,12 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
         wmi->MeshIndexBuffer->Init( &wrappedIndices[0], wrappedIndices.size() * sizeof( unsigned int ), D3D11VertexBuffer::B_INDEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
 
         meshInfo->FullMesh = wmi;
+    }
+
+    // Every submesh was empty: don't let the ±FLT_MAX seeds turn MeshSize into an infinity.
+    if ( vertexBuffers.empty() ) {
+        bbmin = XMFLOAT3( 0, 0, 0 );
+        bbmax = XMFLOAT3( 0, 0, 0 );
     }
 
     meshInfo->BBox.Min = bbmin;

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -1777,7 +1777,7 @@ void WorldConverter::UpdateMorphMeshVisual( void* v, MeshVisualInfo* meshInfo ) 
     zCMorphMesh* visual = reinterpret_cast<zCMorphMesh*>(v);
     visual->GetTexAniState()->UpdateTexList(); // always update tex list, otherwise texture corrupt (very rarely).
 
-    const auto now = Engine::GAPI->GetTotalTimeDW();
+    const auto now = Engine::GAPI->GetFrameNumber();
     if ( meshInfo->LastAniUpdateFrame == now ) {
         return;
     }

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -149,6 +149,8 @@ namespace {
         meshInfo->HasBoundingBox = true;
     }
 
+    void RepairZeroLengthVertexNormals( std::vector<ExVertexStruct>& vertices, const std::vector<VERTEX_INDEX>& indices );
+
     void BuildWorldMeshBuffers( WorldMeshInfo* mesh ) {
         ZoneScoped;
         std::vector<ExVertexStruct> indexedVertices;
@@ -163,8 +165,15 @@ namespace {
         Engine::GraphicsEngine->CreateVertexBuffer( mesh->MeshVertexBuffer );
         Engine::GraphicsEngine->CreateVertexBuffer( mesh->MeshIndexBuffer );
 
-        // Generate normals
-        WorldConverter::GenerateVertexNormals( mesh->Vertices, mesh->Indices );
+        // Keep ZenGin's own per-wedge vertex normals (zCVertFeature::vertNormal).
+        // The level compiler produced them with crease-angle smoothing across BSP
+        // neighbors (zCMesh::CalcVertexNormals in MAT mode, using the material's
+        // smoothAngle), so they smooth across UV seams, material changes and
+        // section boundaries alike. Recomputing them here could only ever do worse:
+        // this mesh is a single (section x material) bucket, so every seam the
+        // bucketing introduces would turn into a hard shading edge.
+        // Only patch up degenerate normals from broken source data.
+        RepairZeroLengthVertexNormals( mesh->Vertices, mesh->Indices );
 
         // Precompute MikkTSpace tangents (after final normals; survives the remap passes below
         // because they move the whole ExVertexStruct stride, including Tangent).
@@ -894,13 +903,24 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
         }
     }
 
+    size_t totalWorldVertices = 0;
+    size_t totalWorldIndices = 0;
     for ( WorldMeshInfo* mesh : allMeshes ) {
         vertexBuffers.emplace_back( &mesh->Vertices );
         indexBuffers.emplace_back( &mesh->Indices );
         shadowIndexBuffers.emplace_back( mesh->ShadowIndices.empty()
             ? &mesh->Indices
             : &mesh->ShadowIndices );
+
+        totalWorldVertices += mesh->Vertices.size();
+        totalWorldIndices += mesh->Indices.size();
     }
+
+    // Worth watching in a 32-bit process: the vertex count follows the weld key
+    // in CmpClass, which keeps wedges apart when their normal or baked color differs.
+    LogInfo() << "Worldmesh: " << allMeshes.size() << " meshes, " << totalWorldVertices
+        << " vertices (" << (totalWorldVertices * sizeof( ExVertexStruct )) / (1024 * 1024)
+        << " MB CPU-side), " << totalWorldIndices << " indices";
 
     std::vector<ExVertexStruct> wrappedVertices;
     std::vector<unsigned int> wrappedIndices;
@@ -1952,6 +1972,18 @@ struct CmpClass // class comparing vertices in the set
         if ( fabs( p1.first.TexCoord.x - p2.first.TexCoord.x ) > eps ) return p1.first.TexCoord.x < p2.first.TexCoord.x;
         if ( fabs( p1.first.TexCoord.y - p2.first.TexCoord.y ) > eps ) return p1.first.TexCoord.y < p2.first.TexCoord.y;
 
+        // Normal and Color are part of the key: these are per-wedge values from
+        // ZenGin (crease-smoothed vertNormal / baked lightStatic), and merging two
+        // wedges that only agree on position+UV would silently throw one of them
+        // away - which used to flatten shading across creases and destroy baked
+        // light. Color additionally carries the wave amplitude/speed bytes for
+        // water materials, so it must never be merged away either.
+        if ( fabs( p1.first.Normal.x - p2.first.Normal.x ) > eps ) return p1.first.Normal.x < p2.first.Normal.x;
+        if ( fabs( p1.first.Normal.y - p2.first.Normal.y ) > eps ) return p1.first.Normal.y < p2.first.Normal.y;
+        if ( fabs( p1.first.Normal.z - p2.first.Normal.z ) > eps ) return p1.first.Normal.z < p2.first.Normal.z;
+
+        if ( p1.first.Color != p2.first.Color ) return p1.first.Color < p2.first.Color;
+
         return false;
     }
 };
@@ -2021,49 +2053,6 @@ void WorldConverter::IndexVertices( ExVertexStruct* input, unsigned int numInput
     outVertices.resize( vertices.size() );
     for ( auto const& it : vertices )
         outVertices[it.second] = it.first;
-}
-
-/** Computes vertex normals for a mesh with face normals */
-void WorldConverter::GenerateVertexNormals( std::vector<ExVertexStruct>& vertices, std::vector<VERTEX_INDEX>& indices ) {
-    std::vector<XMFLOAT3> normals( vertices.size(), XMFLOAT3( 0, 0, 0 ) );
-
-    for ( unsigned int i = 0; i < indices.size(); i += 3 ) {
-        XMFLOAT3 v[3] = { vertices[indices[i]].Position, vertices[indices[i + 1]].Position, vertices[indices[i + 2]].Position };
-        FXMVECTOR normal = XMVector3Cross( (XMLoadFloat3( &v[1] ) - XMLoadFloat3( &v[0] )), (XMLoadFloat3( &v[2] ) - XMLoadFloat3( &v[0] )) );
-
-        for ( int j = 0; j < 3; ++j ) {
-            XMVECTOR a = XMLoadFloat3( &v[(j + 1) % 3] ) - XMLoadFloat3( &v[j] );
-            XMVECTOR b = XMLoadFloat3( &v[(j + 2) % 3] ) - XMLoadFloat3( &v[j] );
-            float lenA = XMVectorGetX( XMVector3Length( a ) );
-            float lenB = XMVectorGetX( XMVector3Length( b ) );
-
-            // Degenerate edge (duplicate/collapsed vertices): dividing by a
-            // zero length turns the ACos argument into NaN, which then
-            // poisons this vertex's accumulated normal (and every other
-            // triangle sharing it, since they add into the same slot).
-            // Skip the contribution instead.
-            if ( lenA <= 1e-8f || lenB <= 1e-8f )
-                continue;
-
-            float cosAngle = std::clamp( XMVectorGetX( XMVector3Dot( a, b ) ) / (lenA * lenB), -1.0f, 1.0f );
-            XMVECTOR weight = XMVectorReplicate( acosf( cosAngle ) );
-            XMVECTOR XMV_normals_indices = XMLoadFloat3( &normals[indices[(i + j)]] );
-            XMV_normals_indices += weight * normal;
-            XMStoreFloat3( &normals[indices[(i + j)]], XMV_normals_indices );
-        }
-    }
-
-    // Normalize everything and store it into the vertices
-    XMFLOAT3 Normal;
-    for ( unsigned int i = 0; i < normals.size(); i++ ) {
-        XMVECTOR n = XMLoadFloat3( &normals[i] );
-        // Isolated vertex or all contributing triangles were degenerate:
-        // fall back to a safe default instead of normalizing a zero vector into NaN.
-        if ( XMVectorGetX( XMVector3LengthSq( n ) ) <= 1e-12f )
-            n = XMVectorSet( 0.0f, 1.0f, 0.0f, 0.0f );
-        XMStoreFloat3( &Normal, XMVector3Normalize( n ) );
-        vertices[i].Normal = Normal;
-    }
 }
 
 /** Marks the edges of the mesh */

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -95,9 +95,6 @@ public:
     /** Marks the edges of the mesh */
     static void MarkEdges( std::vector<ExVertexStruct>& vertices, std::vector<VERTEX_INDEX>& indices );
 
-    /** Computes vertex normals for a mesh with face normals */
-    static void GenerateVertexNormals( std::vector<ExVertexStruct>& vertices, std::vector<VERTEX_INDEX>& indices );
-
     /** Creates the FullSectionMesh for the given section */
     static void GenerateFullSectionMesh( WorldMeshSectionInfo& section );
 

--- a/D3D11Engine/oCVisFX.h
+++ b/D3D11Engine/oCVisFX.h
@@ -16,6 +16,12 @@ public:
     zCVob* GetOrigin() const {
         return *reinterpret_cast<zCVob**>(THISPTR_OFFSET( GothicMemoryLocations::oCVisualFX::Offset_origin ));
     }
+
+    /** When set, oCVisualFX owns the particle emitter's shape mesh and points it at the origin
+        vob's visual (oCVisualFX::CalcPFXMesh). */
+    bool GetAdjustShapeToOrigin() const {
+        return *reinterpret_cast<int*>(THISPTR_OFFSET( GothicMemoryLocations::oCVisualFX::Offset_emAdjustShpToOrigin )) != 0;
+    }
 };
 
 class oCItem : public zCVob {

--- a/D3D11Engine/oCVisFX.h
+++ b/D3D11Engine/oCVisFX.h
@@ -22,6 +22,22 @@ public:
     bool GetAdjustShapeToOrigin() const {
         return *reinterpret_cast<int*>(THISPTR_OFFSET( GothicMemoryLocations::oCVisualFX::Offset_emAdjustShpToOrigin )) != 0;
     }
+
+    /** Name of the origin model's node this effect rides on, from the VisualFX script instance
+        (emTrjOriginNode). Empty when the effect is not node-bound. */
+    const zSTRING* GetOriginNodeName() const {
+        return reinterpret_cast<zSTRING*>(THISPTR_OFFSET( GothicMemoryLocations::oCVisualFX::Offset_emTrjOriginNode_S ));
+    }
+
+    /** Resolved node for GetOriginNodeName. ZENGIN resolves it once in oCVisualFX::Init and leaves
+        it null if the origin had no zCModel visual yet - see GothicAPI::RepairShapeMeshEmitter. */
+    zCModelNodeInst* GetOriginNode() const {
+        return *reinterpret_cast<zCModelNodeInst**>(THISPTR_OFFSET( GothicMemoryLocations::oCVisualFX::Offset_orgNode ));
+    }
+
+    void SetOriginNode( zCModelNodeInst* node ) {
+        *reinterpret_cast<zCModelNodeInst**>(THISPTR_OFFSET( GothicMemoryLocations::oCVisualFX::Offset_orgNode )) = node;
+    }
 };
 
 class oCItem : public zCVob {

--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -94,7 +94,7 @@ extern ZUnquantizeHalfFloat_X4 UnquantizeHalfFloat_X8;
 
 #ifdef BUILD_GOTHIC_2_6_fix
 #define SWITCH_ENGINE(G1, G1A, G2A, OTHER) G2A
-#elif defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
+#elif defined(BUILD_GOTHIC_1_CLASSIC)
 #define SWITCH_ENGINE(G1, G1A, G2A, OTHER) G1
 #elif defined(BUILD_GOTHIC_1_08k) && defined(BUILD_1_12F)
 #define SWITCH_ENGINE(G1, G1A, G2A, OTHER) G1A
@@ -103,3 +103,25 @@ extern ZUnquantizeHalfFloat_X4 UnquantizeHalfFloat_X8;
 #endif
 
 #define SWITCH_ENGINE12(G1, G2) SWITCH_ENGINE(G1, G1, G2, G2)
+
+template<typename T>
+[[nodiscard]] constexpr T SwitchEngine( T g1, T g1a, T g2a, T other ) {
+#ifdef BUILD_GOTHIC_2_6_fix
+    return g2a;
+#elif defined(BUILD_GOTHIC_1_CLASSIC)
+    return g1;
+#elif defined(BUILD_GOTHIC_1_08k) && defined(BUILD_1_12F)
+    return g1a;
+#else
+    return g2;
+#endif
+}
+
+template<typename T>
+[[nodiscard]] constexpr T SwitchG1G2( T g1, T g2 ) {
+#if defined(BUILD_GOTHIC_1_08k) // both G1 and G1 sequel
+    return g1;
+#else
+    return g2;
+#endif
+}

--- a/D3D11Engine/zCModel.h
+++ b/D3D11Engine/zCModel.h
@@ -345,6 +345,43 @@ public:
         }
     }
 
+    /** Same accumulation as GetBoneTransforms, but into a caller-owned scratch buffer.
+        GetBoneTransforms writes its result into zCModelNodeInst::TrafoObjToCam, which ZENGIN uses
+        as the *world*-space node cache (zCModel::CalcNodeListBBoxWorld, read back by
+        GetNodePositionWorld/GetBBox3DNodeWorld). Overwriting it with model-space matrices is fine
+        while we own the frame, but not from inside an engine callback - use this there. */
+    void GetBoneTransformsTo( std::vector<XMFLOAT4X4>& transforms ) const {
+        zCArray<zCModelNodeInst*>* nodeList = GetNodeList();
+        if ( !nodeList )
+            return;
+
+        const auto num = nodeList->NumInArray;
+        const auto array = nodeList->Array;
+
+        const size_t base = transforms.size();
+        transforms.resize( base + num );
+
+        for ( int i = 0; i < num; i++ ) {
+            zCModelNodeInst* node = array[i];
+            const zCModelNodeInst* parent = node->ParentNode;
+
+            if ( parent ) {
+                // The node list is parent-before-child, and the parent is nearly always the
+                // immediately preceding entry, so this walk back is O(1) in practice.
+                int parentIdx = -1;
+                for ( int j = i - 1; j >= 0; --j ) {
+                    if ( array[j] == parent ) { parentIdx = j; break; }
+                }
+                if ( parentIdx >= 0 ) {
+                    XMStoreFloat4x4( &transforms[base + i],
+                        XMMatrixMultiply( XMLoadFloat4x4( &transforms[base + parentIdx] ), XMLoadFloat4x4( &node->Trafo ) ) );
+                    continue;
+                }
+            }
+            transforms[base + i] = node->Trafo;
+        }
+    }
+
     const std::string_view GetVisualName() const {
         if ( GetMeshSoftSkinList()->NumInArray > 0 )
             return GetMeshSoftSkinList()->Array[0]->GetObjectNameView();

--- a/D3D11Engine/zCModel.h
+++ b/D3D11Engine/zCModel.h
@@ -314,6 +314,14 @@ public:
         return reinterpret_cast<zCArray<zTMdl_NodeVobAttachment>*>(THISPTR_OFFSET( GothicMemoryLocations::zCModel::Offset_AttachedVobList ));
     }
 
+#ifndef BUILD_SPACER
+    /** Looks a node up by name, exactly as ZENGIN does. Case sensitive - node names are upper case. */
+    zCModelNodeInst* SearchNode( const zSTRING& name ) {
+        return reinterpret_cast<zCModelNodeInst*( __fastcall* )( zCModel*, int, const zSTRING& )>
+            ( GothicMemoryLocations::zCModel::SearchNode )( this, 0, name );
+    }
+#endif
+
     /* Updates the world matrices of the attached VOBs */
     void UpdateAttachedVobs() {
         reinterpret_cast<void( __fastcall* )( zCModel* )>( GothicMemoryLocations::zCModel::UpdateAttachedVobs )( this );

--- a/D3D11Engine/zCParticleFX.h
+++ b/D3D11Engine/zCParticleFX.h
@@ -142,6 +142,12 @@ public:
     zCModel* GetVisShpModel() {
         return *reinterpret_cast<zCModel**>(THISPTR_OFFSET( GothicMemoryLocations::zCParticleEmitter::Offset_VisShpModel ));
     }
+
+    /** Only valid to call when the emitter's shape is owned by oCVisualFX (emAdjustShpToOrigin) -
+        ReleasePFXMesh will then drop the reference we add here. See GothicAPI::RepairShapeMeshEmitter. */
+    void SetVisShpModel( zCModel* model ) {
+        *reinterpret_cast<zCModel**>(THISPTR_OFFSET( GothicMemoryLocations::zCParticleEmitter::Offset_VisShpModel )) = model;
+    }
 #else
     float GetAlphaDist() {
         return 0;


### PR DESCRIPTION
- fix: Pfx effects on Models (like fire shadowbeast, undead dragon) only appearing after it spawned a second time
- fix: meshInfo->BBox.Min & BBox.Max are now computed immediately
- fix: fix broken decals like candle fire (dx12)
- fix: use `GetFrameNumber` instead of `GetTotalTimeDW` for per frame actions.
- fix: static lights no longer contribute specular highlights (dx12)
- fix: dynamic lights now have their correct light color and position computed (dx12)
- perf: dx11 shadows now render less stuff in the last (world scope) cascade.
- feat: replace our own TAA with intels TAA.
- feat: XeGTAO now uses current-frame depth buffer (dx12)
- feat: dynamic lights no longer need a static -> dynamic copy per light, instead we just have two parallel arrays (dx11, backport)
- feat: DisableStaticPointlights now also works in dx11
- feat: use zEngine compiled world smooth normals
- 