### PR TITLE
disable resource manager hooks until source for mss32 crash is found

### DIFF
--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -892,7 +892,7 @@ struct GothicRendererSettings {
         HDR_MaxBrightness = 1000.0f;
         HDR_PaperWhite = 200.0f;
         EnableInactiveFpsLock = false;
-        MTResoureceManager = true;
+        MTResoureceManager = false;
         CompressBackBuffer = false;
         AnimateStaticVobs = true;
         RunInSpacerNet = false;

--- a/D3D11Engine/zCResourceManager.h
+++ b/D3D11Engine/zCResourceManager.h
@@ -34,12 +34,12 @@ public:
 
     /** Hooks the functions of this Class */
     static void Hook() {
-        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCResourceManagerPurgeCaches, hooked_PurgeCaches );
+        // DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCResourceManagerPurgeCaches, hooked_PurgeCaches );
         //DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCResourceManagerCacheOut, hooked_CacheOut  );
 #if defined(BUILD_GOTHIC_1_08k) || defined(BUILD_GOTHIC_2_6_fix)
-        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCClassCacheInsertRes, hooked_InsertRes );
-        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCClassCacheTouchRes, hooked_TouchRes );
-        DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCClassCacheRemoveRes, hooked_RemoveRes );
+        // DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCClassCacheInsertRes, hooked_InsertRes );
+        // DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCClassCacheTouchRes, hooked_TouchRes );
+        // DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCClassCacheRemoveRes, hooked_RemoveRes );
 #endif
     }
 


### PR DESCRIPTION
only on level change: game crashes with Mss32.dll errors.
Will need more time with resource manager hook...