### PR TITLE
feat: shadow LOD, render lower detail VOBs/MOBs in the most distant cascade. fixes: #433

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -276,3 +276,5 @@ redist*/
 D3D11Engine/G2_Debug/
 G2_Debug/
 cmake-build-debug
+D3D11Engine/D3D11Engine/Spacer_NET_G1
+D3D11Engine/Spacer_NET_G1

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1415,6 +1415,21 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
     </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12DoF.cpp">
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_12f|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+    </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12Taa.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -1003,6 +1003,9 @@
     <ClCompile Include="D3D12Engine\D3D12Taa.cpp">
       <Filter>Engine\D3D12</Filter>
     </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12DoF.cpp">
+      <Filter>Engine\D3D12</Filter>
+    </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12GTAO.cpp">
       <Filter>Engine\D3D12</Filter>
     </ClCompile>

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3450,8 +3450,15 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                 const XMMATRIX curTransform = XMLoadFloat4x4( &transforms[i] );
                 XMFLOAT4X4 finalWorld; XMStoreFloat4x4( &finalWorld, world * curTransform );
 
+                // Motion vectors: the node's own bone transform animates as well (a head shaking,
+                // a weapon swinging), so the previous world matrix has to be paired with the
+                // *previous* bone transform. Using curTransform here cancels out all node-local
+                // motion and leaves attachments with only the vob's root velocity.
                 const XMMATRIX prevWorldXm = XMLoadFloat4x4( &prevWorld );
-                XMFLOAT4X4 finalPrevWorld; XMStoreFloat4x4( &finalPrevWorld, prevWorldXm * curTransform );
+                const XMMATRIX prevTransform = ( vi->HasValidPrevTransforms && i < vi->PrevBoneTransforms.size() )
+                    ? XMLoadFloat4x4( &vi->PrevBoneTransforms[i] )
+                    : curTransform;
+                XMFLOAT4X4 finalPrevWorld; XMStoreFloat4x4( &finalPrevWorld, prevWorldXm * prevTransform );
 
                 for ( MeshVisualInfo* mvi : nodeAttachment->second ) {
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4486,14 +4486,24 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     graph.AddPass( RG_PASS_NAME("Draw PolyStrips"), [&]( RGBuilder& builder, RenderPass& pass ) {
         builder.Write( backBufferHandle );
 
-        pass.m_executeCallback = [this](const RenderGraph&) {
+        pass.m_executeCallback = [this, backBufferHandle](const RenderGraph& graph) {
             TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw PolyStrips" );
 
             // Calc weapon/effect trail mesh data
             Engine::GAPI->CalcPolyStripMeshes();
             // Calc lightning flashes mesh data
             Engine::GAPI->CalcFlashMeshes();
-            // Draw those
+
+            // Poly-strips are world geometry and have to be depth-tested against the scene, but the
+            // preceding particle pass ends on a PfxRenderer blit which leaves the OM with an RTV and
+            // NO depth-stencil view. Drawing on top of that made trails and the barrier's lightning
+            // punch straight through walls whenever any particle effect was on screen. Re-bind the
+            // scene's depth buffer here; DrawPolyStrips keeps depth-writes off.
+            auto backBuffer = graph.GetPhysicalTexture( backBufferHandle );
+            GetContext()->PSSetShaderResources( 0, 4, s_nullSRVs ); // depth may still be bound as SRV
+            GetContext()->OMSetRenderTargets( 1, backBuffer->GetRenderTargetView().GetAddressOf(),
+                DepthStencilBuffer->GetDepthStencilView().Get() );
+
             // For some reasons the viewport gets messed up, so set it again
             SetViewport( ViewportInfo( 0, 0, GetResolution() ) );
             DrawPolyStrips();
@@ -7954,9 +7964,32 @@ XRESULT D3D11GraphicsEngine::DrawPolyStrips( bool noTextures ) {
 
     SetDefaultStates();
 
+    auto& polyStripState = Engine::GAPI->GetRendererState();
+
     // Setup renderstates
-    Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_NONE;
-    Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+    polyStripState.RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_NONE;
+
+    // ZenGin draws the barrier's lightning from oCBarrier::Render, which bumps the camera's far
+    // clip to 2,000,000 first: the bolts sit on the "magicfrontier" sky sphere, tens of thousands
+    // of units above and away from the player, well past our own far plane. We keep our projection
+    // - the depth values have to stay comparable to the scene's depth buffer - and rely on depth
+    // clipping being off (SetDefault's value, spelled out here because this pass depends on it) so
+    // a bolt crossing the far plane is depth-clamped to the far plane instead of being sliced up.
+    polyStripState.RasterizerState.DepthClipEnable = false;
+    polyStripState.RasterizerState.SetDirty();
+
+    // Depth-tested, but never depth-writing - oCBarrier::Render wraps its thunder list in
+    // SetZBufferWriteEnabled(FALSE), and it renders during RenderSkyPre, i.e. before the world, so
+    // in the original the scene always covers the bolts. Testing against the finished scene depth
+    // gives the same result here, and rejects the sky-wide bolt quads that are behind geometry
+    // before they are ever shaded.
+    polyStripState.DepthState.DepthBufferEnabled = true;
+    polyStripState.DepthState.DepthWriteEnabled = false;
+    polyStripState.DepthState.SetDirty();
+
+    // Commit them now: DrawVertexBuffer does not resolve pipeline state, and only the per-material
+    // blend branch below calls UpdateRenderStates.
+    UpdateRenderStates();
 
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
     Engine::GAPI->SetViewTransformXM( view );
@@ -8019,17 +8052,20 @@ XRESULT D3D11GraphicsEngine::DrawPolyStrips( bool noTextures ) {
             // Bind both
             Context->PSSetShaderResources( 0, 3, srv );
 
-            if ( (blendAdd || blendBlend) && !Engine::GAPI->GetRendererState().BlendState.BlendEnabled ) {
+            // Pick the blend mode per material. This used to be guarded by "&& !BlendEnabled",
+            // which meant the first blended material latched the mode for the whole pass and an
+            // ADD strip following a BLEND one (or vice versa) got the wrong one.
+            if ( blendAdd || blendBlend ) {
                 if ( blendAdd )
-                    Engine::GAPI->GetRendererState().BlendState.SetAdditiveBlending();
-                else if ( blendBlend )
-                    Engine::GAPI->GetRendererState().BlendState.SetAlphaBlending();
+                    polyStripState.BlendState.SetAdditiveBlending();
+                else
+                    polyStripState.BlendState.SetAlphaBlending();
 
-                Engine::GAPI->GetRendererState().BlendState.SetDirty();
-
-                Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled = false;
-                Engine::GAPI->GetRendererState().DepthState.SetDirty();
-
+                polyStripState.BlendState.SetDirty();
+                UpdateRenderStates();
+            } else if ( polyStripState.BlendState.BlendEnabled ) {
+                polyStripState.BlendState.SetDefault();
+                polyStripState.BlendState.SetDirty();
                 UpdateRenderStates();
             }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4494,11 +4494,8 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
             // Calc lightning flashes mesh data
             Engine::GAPI->CalcFlashMeshes();
 
-            // Poly-strips are world geometry and have to be depth-tested against the scene, but the
-            // preceding particle pass ends on a PfxRenderer blit which leaves the OM with an RTV and
-            // NO depth-stencil view. Drawing on top of that made trails and the barrier's lightning
-            // punch straight through walls whenever any particle effect was on screen. Re-bind the
-            // scene's depth buffer here; DrawPolyStrips keeps depth-writes off.
+            // Re-bind the depth buffer: the preceding particle pass ends on a PfxRenderer blit that leaves
+            // the OM with an RTV and no DSV, so trails and lightning drew through walls.
             auto backBuffer = graph.GetPhysicalTexture( backBufferHandle );
             GetContext()->PSSetShaderResources( 0, 4, s_nullSRVs ); // depth may still be bound as SRV
             GetContext()->OMSetRenderTargets( 1, backBuffer->GetRenderTargetView().GetAddressOf(),
@@ -7969,26 +7966,18 @@ XRESULT D3D11GraphicsEngine::DrawPolyStrips( bool noTextures ) {
     // Setup renderstates
     polyStripState.RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_NONE;
 
-    // ZenGin draws the barrier's lightning from oCBarrier::Render, which bumps the camera's far
-    // clip to 2,000,000 first: the bolts sit on the "magicfrontier" sky sphere, tens of thousands
-    // of units above and away from the player, well past our own far plane. We keep our projection
-    // - the depth values have to stay comparable to the scene's depth buffer - and rely on depth
-    // clipping being off (SetDefault's value, spelled out here because this pass depends on it) so
-    // a bolt crossing the far plane is depth-clamped to the far plane instead of being sliced up.
+    // The barrier's bolts sit on the "magicfrontier" sky sphere, way past our far plane - oCBarrier::Render
+    // raises the far clip to 2,000,000 for them. We keep our projection so the depth values stay comparable
+    // to the scene's, and let depth clipping stay off so a bolt crossing the far plane is clamped, not sliced.
     polyStripState.RasterizerState.DepthClipEnable = false;
     polyStripState.RasterizerState.SetDirty();
 
-    // Depth-tested, but never depth-writing - oCBarrier::Render wraps its thunder list in
-    // SetZBufferWriteEnabled(FALSE), and it renders during RenderSkyPre, i.e. before the world, so
-    // in the original the scene always covers the bolts. Testing against the finished scene depth
-    // gives the same result here, and rejects the sky-wide bolt quads that are behind geometry
-    // before they are ever shaded.
+    // Depth-tested, never depth-writing (oCBarrier::Render does SetZBufferWriteEnabled(FALSE)).
     polyStripState.DepthState.DepthBufferEnabled = true;
     polyStripState.DepthState.DepthWriteEnabled = false;
     polyStripState.DepthState.SetDirty();
 
-    // Commit them now: DrawVertexBuffer does not resolve pipeline state, and only the per-material
-    // blend branch below calls UpdateRenderStates.
+    // DrawVertexBuffer does not resolve pipeline state, and only the blend branch below calls this.
     UpdateRenderStates();
 
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
@@ -8052,9 +8041,8 @@ XRESULT D3D11GraphicsEngine::DrawPolyStrips( bool noTextures ) {
             // Bind both
             Context->PSSetShaderResources( 0, 3, srv );
 
-            // Pick the blend mode per material. This used to be guarded by "&& !BlendEnabled",
-            // which meant the first blended material latched the mode for the whole pass and an
-            // ADD strip following a BLEND one (or vice versa) got the wrong one.
+            // Per material, not latched on the first blended one - an ADD strip after a BLEND one
+            // (or the reverse) used to get the wrong mode.
             if ( blendAdd || blendBlend ) {
                 if ( blendAdd )
                     polyStripState.BlendState.SetAdditiveBlending();
@@ -8225,20 +8213,34 @@ XRESULT D3D11GraphicsEngine::DrawSky() {
 
     if ( sky->GetSkyDome() ) sky->GetSkyDome()->DrawMesh();
 
-    #if defined(BUILD_GOTHIC_1_CLASSIC)
-    {
+    // The magic barrier (dome + lightning) is drawn by a derived sky controller's RenderSkyPre override -
+    // vanilla oCWorld installs an oCSkyControler_Barrier in every world of both games. Called through the
+    // vtable so a mod's own controller gets its override, instead of one hardcoded address per version.
+    if ( zCSkyController_Outdoor* skyCtrl = Engine::GAPI->GetLoadedWorldInfo()->MainWorld->GetSkyControllerOutdoor();
+        skyCtrl && skyCtrl->HasDerivedRenderSkyPre() && skyCtrl->WantsBarrierRender() ) {
+        // Required: STAGE_DRAW_SKY picks the FORCE_MAX_Z vertex shaders for Gothic's XYZRHW sky draws and
+        // ignores its D3DRENDERSTATE_ZENABLE writes. Without it the sky keeps its screen-space Z, which
+        // under reversed-Z lands in front of the whole scene.
+        const auto oldBarrierStage = rendererState.RendererInfo.RenderStage;
+        rendererState.RendererInfo.RenderStage = STAGE_DRAW_SKY;
+
         SetDefaultStates();
+        rendererState.DepthState.DepthBufferEnabled = true;
         rendererState.DepthState.DepthWriteEnabled = false;
+        rendererState.DepthState.DepthBufferCompareFunc = GothicDepthBufferStateInfo::CF_COMPARISON_GREATER_EQUAL;
         rendererState.DepthState.SetDirty();
+        rendererState.RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
+        rendererState.RasterizerState.SetDirty();
         UpdateRenderStates();
 
-        // Draw barrier after sky
-        reinterpret_cast<void( __fastcall* )(zCSkyController_Outdoor*)>(0x632140)(Engine::GAPI->GetLoadedWorldInfo()->MainWorld->GetSkyControllerOutdoor());
+        skyCtrl->RenderSkyPre();
+
+        // The engine breaks the far plane on its way through; restore it.
         Engine::GAPI->SetFarPlane(
             rendererState.RendererSettings.SectionDrawRadius *
             WORLD_SECTION_SIZE );
+        rendererState.RendererInfo.RenderStage = oldBarrierStage;
     }
-    #endif
 
     return XR_SUCCESS;
 }

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3934,7 +3934,13 @@ namespace {
         }
     }
 
-    GfxVertexBuffer* GetShadowAwareIndexBuffer( MeshInfo* mesh, bool isAlpha ) {
+    // Cascade 0 covers everything close to the camera and keeps full-detail casters; from cascade 1 out
+    // the shadow is small enough on screen that the baked progressive-mesh LOD is free silhouette. Both
+    // reduced buffers are position-welded, so neither may be used where the pixel shader alpha-tests:
+    // welding merges wedges that share a position but not a UV. cascadeIndex -1 = not a cascade render.
+    constexpr int FIRST_LOD_SHADOW_CASCADE = 1;
+
+    GfxVertexBuffer* GetShadowAwareIndexBuffer( MeshInfo* mesh, bool isAlpha, int cascadeIndex = -1 ) {
         if ( !mesh ) {
             return nullptr;
         }
@@ -3943,13 +3949,18 @@ namespace {
             return mesh->GetMeshIndexBuffer();
         }
 
+        if ( cascadeIndex >= FIRST_LOD_SHADOW_CASCADE
+            && mesh->MeshLodIndexBuffer && !mesh->LodIndices.empty() ) {
+            return mesh->GetMeshLodIndexBuffer();
+        }
+
         if ( mesh->MeshShadowIndexBuffer && !mesh->ShadowIndices.empty() ) {
             return mesh->GetMeshShadowIndexBuffer();
         }
         return mesh->GetMeshIndexBuffer();
     }
 
-    unsigned int GetShadowAwareIndexCount( const MeshInfo* mesh, bool isAlpha ) {
+    unsigned int GetShadowAwareIndexCount( const MeshInfo* mesh, bool isAlpha, int cascadeIndex = -1 ) {
         if ( !mesh ) {
             return 0;
         }
@@ -3957,6 +3968,9 @@ namespace {
         if ( isAlpha ) {
         return mesh->Indices.size();
     }
+        if ( cascadeIndex >= FIRST_LOD_SHADOW_CASCADE && !mesh->LodIndices.empty() ) {
+            return static_cast<unsigned int>( mesh->LodIndices.size() );
+        }
         return static_cast<unsigned int>(mesh->ShadowIndices.empty() ? mesh->Indices.size() : mesh->ShadowIndices.size() );
     }
 }
@@ -6960,7 +6974,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
 
             /* Dont re-bind buffer all the time*/
             const auto vb = D3D11VertexBuffer::From( mi->GetMeshVertexBuffer() );
-            const auto ib = D3D11VertexBuffer::From( GetShadowAwareIndexBuffer( mi, isAlpha ) );
+            const auto ib = D3D11VertexBuffer::From( GetShadowAwareIndexBuffer( mi, isAlpha, params.CascadeIndex ) );
 
             UINT offset[] = { 0 };
             UINT uStride[] = { sizeof( ExVertexStruct ) };
@@ -6968,7 +6982,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
                 vb->GetVertexBuffer().Get()
             };
 
-            auto numIndices = static_cast<size_t>(GetShadowAwareIndexCount( mi, isAlpha ));
+            auto numIndices = static_cast<size_t>(GetShadowAwareIndexCount( mi, isAlpha, params.CascadeIndex ));
             const auto numInstances = staticMeshVisual->Instances.size();
             const auto startInstanceNum = staticMeshVisual->StartInstanceNum;
             const auto indexOffset = 0;

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3940,7 +3940,7 @@ namespace {
     // welding merges wedges that share a position but not a UV. cascadeIndex -1 = not a cascade render.
     constexpr int FIRST_LOD_SHADOW_CASCADE = 2;
 
-    GfxVertexBuffer* GetShadowAwareIndexBuffer( MeshInfo* mesh, bool isAlpha, int cascadeIndex = -1 ) {
+    GfxVertexBuffer* GetShadowAwareIndexBuffer( MeshInfo* mesh, bool isAlpha, int cascadeIndex = -1, int lodCascadeIndex = FIRST_LOD_SHADOW_CASCADE ) {
         if ( !mesh ) {
             return nullptr;
         }
@@ -3949,7 +3949,7 @@ namespace {
             return mesh->GetMeshIndexBuffer();
         }
 
-        if ( cascadeIndex >= FIRST_LOD_SHADOW_CASCADE
+        if ( cascadeIndex >= lodCascadeIndex
             && mesh->MeshLodIndexBuffer && !mesh->LodIndices.empty() ) {
             return mesh->GetMeshLodIndexBuffer();
         }
@@ -6938,14 +6938,17 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
             if ( !useWindMetadata && windBuffer != INVALID_SHADER_CB_SLOT && lastWindVisual != staticMeshVisual ) {
                 lastWindVisual = staticMeshVisual;
                 g_windBuffer.minHeight = staticMeshVisual->BBox.Min.y;
-                g_windBuffer.maxHeight = staticMeshVisual->BBox.Max.y;
+                g_windBuffer.maxHeight = staticMeshVisual->BBox.Max.y; 
                 BindDynamicCBToVertexShader(windBuffer, AllocateDynamicCB(&g_windBuffer));
             }
 
             zCTexture* tx = meshKey.Material->GetAniTexture();
 
             bool bindTexture = tx
-                && (tx->HasAlphaChannel() || colorWritesEnabled || meshKey.Material->HasAlphaTest());
+                && ((tx->GetCacheState() == zRES_CACHED_IN && tx->HasAlphaChannel()) 
+                    || colorWritesEnabled
+                    || meshKey.Material->GetAlphaFunc() != zRND_ALPHA_FUNC_NONE);
+
             const bool isAlpha = bindTexture;
 
             // Bind texture

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3967,7 +3967,7 @@ namespace {
         return mesh->GetMeshIndexBuffer();
     }
 
-    unsigned int GetShadowAwareIndexCount( const MeshInfo* mesh, bool isAlpha, int cascadeIndex = -1 ) {
+    unsigned int GetShadowAwareIndexCount( const MeshInfo* mesh, bool isAlpha, int cascadeIndex = -1, int lodCascadeIndex = FIRST_LOD_SHADOW_CASCADE ) {
         if ( !mesh ) {
             return 0;
         }
@@ -3975,7 +3975,7 @@ namespace {
         if ( isAlpha ) {
         return mesh->Indices.size();
     }
-        if ( cascadeIndex >= FIRST_LOD_SHADOW_CASCADE && !mesh->LodIndices.empty() ) {
+        if ( cascadeIndex >= lodCascadeIndex && !mesh->LodIndices.empty() ) {
             return static_cast<unsigned int>( mesh->LodIndices.size() );
         }
         return static_cast<unsigned int>(mesh->ShadowIndices.empty() ? mesh->Indices.size() : mesh->ShadowIndices.size() );
@@ -6941,6 +6941,10 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
         zCTexture* previousTx = nullptr;
         MeshVisualInfo* lastWindVisual = nullptr;
 
+        // use LOD shadows only for last cascade for now, as it looks uuuugly in gothic 1 due to mesh trees becoming large blobs.
+        // TODO: Maybe we need more LOD levels for large geometry?
+        const int lodCascadeStart = std::max(renderState.RendererSettings.NumShadowCascades - 1, 2);
+
         for ( auto const& [staticMeshVisual, meshKey, meshInfo, _] : instancedMeshesToDraw ) {
             if ( !useWindMetadata && windBuffer != INVALID_SHADER_CB_SLOT && lastWindVisual != staticMeshVisual ) {
                 lastWindVisual = staticMeshVisual;
@@ -6956,7 +6960,9 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
                     || colorWritesEnabled
                     || meshKey.Material->GetAlphaFunc() != zRND_ALPHA_FUNC_NONE);
 
-            const bool isAlpha = bindTexture;
+            // also ignore the fact that something is alpha-tested if its the last cascade
+            // will cause some pop-in, but allows us to render much less expensive verticies
+            const bool isAlpha = bindTexture && (params.CascadeIndex != lodCascadeStart);
 
             // Bind texture
             if ( bindTexture ) {
@@ -6991,7 +6997,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
 
             /* Dont re-bind buffer all the time*/
             const auto vb = D3D11VertexBuffer::From( mi->GetMeshVertexBuffer() );
-            const auto ib = D3D11VertexBuffer::From( GetShadowAwareIndexBuffer( mi, isAlpha, params.CascadeIndex ) );
+            const auto ib = D3D11VertexBuffer::From( GetShadowAwareIndexBuffer( mi, isAlpha, params.CascadeIndex, lodCascadeStart ) );
 
             UINT offset[] = { 0 };
             UINT uStride[] = { sizeof( ExVertexStruct ) };
@@ -6999,7 +7005,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
                 vb->GetVertexBuffer().Get()
             };
 
-            auto numIndices = static_cast<size_t>(GetShadowAwareIndexCount( mi, isAlpha, params.CascadeIndex ));
+            auto numIndices = static_cast<size_t>(GetShadowAwareIndexCount( mi, isAlpha, params.CascadeIndex, lodCascadeStart ));
             const auto numInstances = staticMeshVisual->Instances.size();
             const auto startInstanceNum = staticMeshVisual->StartInstanceNum;
             const auto indexOffset = 0;

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3938,7 +3938,7 @@ namespace {
     // the shadow is small enough on screen that the baked progressive-mesh LOD is free silhouette. Both
     // reduced buffers are position-welded, so neither may be used where the pixel shader alpha-tests:
     // welding merges wedges that share a position but not a UV. cascadeIndex -1 = not a cascade render.
-    constexpr int FIRST_LOD_SHADOW_CASCADE = 1;
+    constexpr int FIRST_LOD_SHADOW_CASCADE = 2;
 
     GfxVertexBuffer* GetShadowAwareIndexBuffer( MeshInfo* mesh, bool isAlpha, int cascadeIndex = -1 ) {
         if ( !mesh ) {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -8233,13 +8233,18 @@ XRESULT D3D11GraphicsEngine::DrawSky() {
         rendererState.RasterizerState.SetDirty();
         UpdateRenderStates();
 
-        skyCtrl->RenderSkyPre();
+        // The override renders the stock sky before the barrier; drop that half so it doesn't paint over
+        // the dome we just rendered. The barrier's own draws still go through.
+        {
+            zCSkyController_Outdoor::ScopedBarrierRender barrierScope;
+            skyCtrl->RenderSkyPre();
+        }
+        rendererState.RendererInfo.RenderStage = oldBarrierStage;
 
         // The engine breaks the far plane on its way through; restore it.
         Engine::GAPI->SetFarPlane(
             rendererState.RendererSettings.SectionDrawRadius *
             WORLD_SECTION_SIZE );
-        rendererState.RendererInfo.RenderStage = oldBarrierStage;
     }
 
     return XR_SUCCESS;

--- a/D3D11Engine/D3D11ShadowMap.h
+++ b/D3D11Engine/D3D11ShadowMap.h
@@ -169,9 +169,9 @@ public:
     inline static struct { float lambda; float bias; } lambdaBiasTable[] {
         /* 0 */ { 0, 0 },
         /* 1 */ { 1.0f, 1.0f },
-        /* 2 */ { 0.90f, 1.0f }, // 2 cascades really is bare minimum for quality
-        /* 3 */ { 0.85f, 1.0f }, // with 3 cascades, we can show higher quality shadows further
-        /* 4 */ { 0.80f, 1.0f }, // Players should really want to use 4 cascades for best quality and furthest
+        /* 2 */ { 0.80f, 1.0f }, // 2 cascades really is bare minimum for quality
+        /* 3 */ { 0.70f, 1.0f }, // with 3 cascades, we can show higher quality shadows further
+        /* 4 */ { 0.50f, 1.0f }, // Players should really want to use 4 cascades for best quality and furthest
     };
 
     D3D11RenderQueue* GetRenderQueue( int cascadeIndex ) { return m_RenderQueues[cascadeIndex].get(); }

--- a/D3D11Engine/D3D11VertexBuffer.cpp
+++ b/D3D11Engine/D3D11VertexBuffer.cpp
@@ -36,6 +36,43 @@ namespace {
         return true;
     }
 
+    /** Carries a baked progressive-mesh LOD index list through the vertex-fetch remap OptimizeVertices
+        just applied to the mesh, then position-welds it exactly like the shadow index list. On anything
+        unexpected the list is cleared instead of left half-remapped - callers treat an empty LOD list as
+        "this mesh has no reduced level" and fall back to full detail, which is always correct. */
+    void OptimizeLodIndices( std::vector<VERTEX_INDEX>& lodIndices,
+        const std::vector<unsigned int>& remap,
+        const std::vector<byte>& remappedVertices,
+        size_t fetchedVertexCount,
+        unsigned int stride ) {
+        if ( lodIndices.size() % 3 != 0 ) {
+            lodIndices.clear();
+            return;
+        }
+
+        std::vector<unsigned int> lod;
+        ConvertIndicesToUInt32( lodIndices.data(), lodIndices.size(), lod );
+
+        for ( unsigned int& idx : lod ) {
+            // A collapsed triangle can only reference wedges that survive, and every surviving wedge is
+            // referenced by the full-detail index buffer too - so remap never hands back the ~0u it
+            // reserves for unreferenced vertices. Verified rather than trusted: mod content is content.
+            if ( idx >= remap.size() || remap[idx] >= fetchedVertexCount ) {
+                lodIndices.clear();
+                return;
+            }
+            idx = remap[idx];
+        }
+
+        std::vector<unsigned int> welded( lod.size() );
+        meshopt_generateShadowIndexBuffer( welded.data(), lod.data(), lod.size(),
+            remappedVertices.data(), fetchedVertexCount, sizeof( float ) * 3, stride );
+
+        if ( !ConvertIndicesToVertexIndex( welded, lodIndices.data(), lodIndices.size() ) ) {
+            lodIndices.clear();
+        }
+    }
+
     float DequantizeSnorm( int v, int bits ) {
         const int maxValue = (1 << (bits - 1)) - 1;
         if ( v > maxValue ) {
@@ -238,10 +275,13 @@ Microsoft::WRL::ComPtr <ID3D11Buffer>& D3D11VertexBuffer::GetVertexBuffer() {
 }
 
 /** Optimizes the given set of vertices */
-XRESULT D3D11VertexBuffer::OptimizeVertices( VERTEX_INDEX* indices, byte* vertices, unsigned int numIndices, unsigned int numVertices, unsigned int stride, std::vector<VERTEX_INDEX>* outShadowIndices ) {
+XRESULT D3D11VertexBuffer::OptimizeVertices( VERTEX_INDEX* indices, byte* vertices, unsigned int numIndices, unsigned int numVertices, unsigned int stride, std::vector<VERTEX_INDEX>* outShadowIndices, std::vector<VERTEX_INDEX>* inOutLodIndices ) {
     if ( !indices || !vertices || numIndices == 0 || numVertices == 0 || stride == 0 ) {
         if ( outShadowIndices ) {
             outShadowIndices->clear();
+        }
+        if ( inOutLodIndices ) {
+            inOutLodIndices->clear();
         }
         return XR_SUCCESS;
     }
@@ -250,6 +290,9 @@ XRESULT D3D11VertexBuffer::OptimizeVertices( VERTEX_INDEX* indices, byte* vertic
     if ( stride > 256 ) {
         if ( outShadowIndices ) {
             outShadowIndices->clear();
+        }
+        if ( inOutLodIndices ) {
+            inOutLodIndices->clear();
         }
         return XR_SUCCESS;
     }
@@ -293,10 +336,17 @@ XRESULT D3D11VertexBuffer::OptimizeVertices( VERTEX_INDEX* indices, byte* vertic
         }
     }
 
+    if ( inOutLodIndices && !inOutLodIndices->empty() ) {
+        OptimizeLodIndices( *inOutLodIndices, remap, remappedVertices, fetchedVertexCount, stride );
+    }
+
     if ( !ConvertIndicesToVertexIndex( remappedIndices, indices, numIndices ) ) {
         LogError() << "OptimizeVertices: remapped index exceeds VERTEX_INDEX range";
         if ( outShadowIndices ) {
             outShadowIndices->clear();
+        }
+        if ( inOutLodIndices ) {
+            inOutLodIndices->clear();
         }
         return XR_FAILED;
     }

--- a/D3D11Engine/D3D11VertexBuffer.h
+++ b/D3D11Engine/D3D11VertexBuffer.h
@@ -32,7 +32,7 @@ public:
     XRESULT Unmap() override;
 
     /** Optimizes the given set of vertices */
-    XRESULT OptimizeVertices( VERTEX_INDEX* indices, byte* vertices, unsigned int numIndices, unsigned int numVertices, unsigned int stride, std::vector<VERTEX_INDEX>* outShadowIndices = nullptr ) override;
+    XRESULT OptimizeVertices( VERTEX_INDEX* indices, byte* vertices, unsigned int numIndices, unsigned int numVertices, unsigned int stride, std::vector<VERTEX_INDEX>* outShadowIndices = nullptr, std::vector<VERTEX_INDEX>* inOutLodIndices = nullptr ) override;
 
     /** Optimizes the given set of vertices */
     XRESULT OptimizeFaces( VERTEX_INDEX* indices, byte* vertices, unsigned int numIndices, unsigned int numVertices, unsigned int stride ) override;

--- a/D3D11Engine/D3D12Engine/D3D12DoF.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12DoF.cpp
@@ -1,0 +1,295 @@
+// D3D12GraphicsEngine — depth of field.
+//
+// Compute port of D3D11PFX_DepthOfField::RenderCS. The three passes and all of their maths live in
+// Shaders/D3D12/DoF.hlsl (which documents where it diverges from the three D3D11 CS_PFX_DoF* shaders — only in
+// the plumbing); this file is the host side: the resources, the focus ping-pong and the dispatches.
+//
+// FRAME SLOT. RenderDepthOfField runs on the LINEAR HDR scene colour, after the TAA resolve and before bloom.
+// That is D3D11's slot exactly: DoF is the first pass of its "Post-processing B" block, which sits after the
+// upscale/TAA stage and ahead of bloom and the tonemap. Blurring before bloom is what makes an out-of-focus
+// highlight bloom as the disc it has become rather than as the point it was, and it keeps DoF out of the
+// temporal accumulation — a blur inside TAA history smears as the focus point moves.
+//
+// TRANSPARENCY TO THE REST OF THE CHAIN. Scene colour in, scene colour out (the composite goes to a scratch
+// texture and is copied back), so nothing downstream has to know the pass ran.
+#include "../pch.h"
+#include "D3D12GraphicsEngine.h"
+#include "../Engine.h"
+#include "../GothicAPI.h"
+
+using Microsoft::WRL::ComPtr;
+#include "D3D12EngineCommon.h"
+
+namespace {
+    // Combined shader-read state for the depth buffer, matching what the fog/god-ray and AO passes use: the
+    // blur and composite read it from compute (NON_PIXEL), and keeping PIXEL in the mask costs nothing while
+    // making the state identical to the one every other depth-reading pass parks it in.
+    constexpr D3D12_RESOURCE_STATES kDoFDepthRead =
+        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+}
+
+/** (Re)creates the focus ping-pong pair, the half-res blur target and the full-res composite scratch.
+
+    Called LAZILY from RenderDepthOfField the first time DoF is actually switched on, and from the resize path
+    only if they already exist — see the header note on why these are not built unconditionally like the bloom
+    pyramid. Heap slots are allocated once and re-pointed at the fresh resources, the same pattern the bloom /
+    AO / TAA resources follow. Non-fatal: on failure m_DoFResourcesReady stays false and RenderDepthOfField
+    no-ops, leaving the scene in focus. */
+bool D3D12GraphicsEngine::CreateDoFResources( INT2 size ) {
+    m_DoFResourcesReady = false;
+    m_DoFCreateAttempted = true;
+    if ( size.x < 4 || size.y < 4 ) return false;
+    ID3D12Device* device = m_Device.GetDevice();
+    if ( !device || !m_Allocator ) return false;
+    // Init runs before the first CreateSwapChain; don't build resources for a pipeline that failed there.
+    if ( !m_Pipelines.DoF.FocusPSO || !m_Pipelines.DoF.CompositePSO ) return false;
+
+    D3D12MA::ALLOCATION_DESC heapDefault = {};
+    heapDefault.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
+    auto ensureSlot = [&]( UINT& slot ) -> bool {
+        if ( slot == UINT_MAX ) slot = AllocateSrvSlot();
+        return slot != UINT_MAX;
+        };
+
+    auto makeTex = [&]( int w, int h, DXGI_FORMAT fmt, ComPtr<ID3D12Resource>& out,
+        ComPtr<D3D12MA::Allocation>& outAlloc, const wchar_t* name ) -> bool {
+        D3D12_RESOURCE_DESC dd = {};
+        dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+        dd.Width = static_cast<UINT64>( w );
+        dd.Height = static_cast<UINT>( h );
+        dd.DepthOrArraySize = 1;
+        dd.MipLevels = 1;
+        dd.Format = fmt;
+        dd.SampleDesc.Count = 1;
+        dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+        dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+        // Every one of these rests in UNORDERED_ACCESS between frames (see RenderDepthOfField), so create them
+        // in it — that makes the "before" state at the top of the pass deterministic on the very first frame.
+        if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+            nullptr, outAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( out.ReleaseAndGetAddressOf() ) ) ) ) {
+            LogWarn() << "D3D12: failed to create a depth-of-field texture (" << w << "x" << h << ").";
+            return false;
+        }
+        out->SetName( name );
+        return true;
+        };
+
+    D3D12_SHADER_RESOURCE_VIEW_DESC srv = {};
+    srv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    srv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    srv.Texture2D.MipLevels = 1;
+    D3D12_UNORDERED_ACCESS_VIEW_DESC uav = {};
+    uav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+
+    // --- Focus pair: 1x1 R32_FLOAT, the auto-focus distance. Resolution-independent, but rebuilt with the rest
+    // so there is exactly one creation path; the history is worthless across a resolution change anyway.
+    for ( UINT i = 0; i < 2; ++i ) {
+        if ( !makeTex( 1, 1, DXGI_FORMAT_R32_FLOAT, m_DoFFocus[i], m_DoFFocusAlloc[i],
+            i == 0 ? L"DoFFocus0" : L"DoFFocus1" ) ) return false;
+        if ( !ensureSlot( m_DoFFocusSrvSlot[i] ) || !ensureSlot( m_DoFFocusUavSlot[i] ) ) return false;
+        srv.Format = DXGI_FORMAT_R32_FLOAT;
+        uav.Format = DXGI_FORMAT_R32_FLOAT;
+        device->CreateShaderResourceView( m_DoFFocus[i].Get(), &srv, GetSrvCpuHandle( m_DoFFocusSrvSlot[i] ) );
+        device->CreateUnorderedAccessView( m_DoFFocus[i].Get(), nullptr, &uav, GetSrvCpuHandle( m_DoFFocusUavSlot[i] ) );
+    }
+    m_DoFFocusIndex = 0;
+    m_DoFFocusValid = false;   // contents are undefined until the first resolve writes one of them
+
+    // --- Half-res bokeh target (rgb = blur, a = centre CoC). Integer-divided like D3D11's res.x / 2, and never
+    // below 1 texel so a tiny window can't produce a zero-sized resource.
+    m_DoFHalfSize = { std::max( 1, size.x / 2 ), std::max( 1, size.y / 2 ) };
+    if ( !makeTex( m_DoFHalfSize.x, m_DoFHalfSize.y, kSceneColorFormat, m_DoFHalf, m_DoFHalfAlloc, L"DoFHalfRes" ) )
+        return false;
+    if ( !ensureSlot( m_DoFHalfSrvSlot ) || !ensureSlot( m_DoFHalfUavSlot ) ) return false;
+    srv.Format = kSceneColorFormat;
+    uav.Format = kSceneColorFormat;
+    device->CreateShaderResourceView( m_DoFHalf.Get(), &srv, GetSrvCpuHandle( m_DoFHalfSrvSlot ) );
+    device->CreateUnorderedAccessView( m_DoFHalf.Get(), nullptr, &uav, GetSrvCpuHandle( m_DoFHalfUavSlot ) );
+
+    // --- Full-res composite scratch. Same format as the scene colour, which is what lets the result be handed
+    // back with a plain CopyResource instead of a full-screen blit (the TAA history does the same).
+    if ( !makeTex( size.x, size.y, kSceneColorFormat, m_DoFComposite, m_DoFCompositeAlloc, L"DoFComposite" ) )
+        return false;
+    if ( !ensureSlot( m_DoFCompositeUavSlot ) ) return false;
+    device->CreateUnorderedAccessView( m_DoFComposite.Get(), nullptr, &uav, GetSrvCpuHandle( m_DoFCompositeUavSlot ) );
+
+    m_DoFResourcesReady = true;
+    return true;
+}
+
+
+/** Focus resolve -> half-res blur -> full-res composite -> copy back over the scene colour. */
+void D3D12GraphicsEngine::RenderDepthOfField() {
+    auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+    if ( !settings.EnableDoF ) return;
+    if ( !m_FrameOpen || !m_CmdList || !m_SceneColor || m_SceneColorSrvSlot == UINT_MAX
+        || !m_DepthBuffer || m_DepthSrvSlot == UINT_MAX )
+        return;
+    if ( !m_Pipelines.DoF.RootSig || !m_Pipelines.DoF.FocusPSO || !m_Pipelines.DoF.CompositePSO )
+        return;
+
+    // Lazily build the textures the first time DoF is switched on (they are ~20 MB of VA at 1080p and DoF is off
+    // in a stock config — see the header). Creating a resource mid-frame is safe: nothing is destroyed here, so
+    // there is no in-flight resource to fence against. m_DoFCreateAttempted keeps a failure from retrying every
+    // frame; it is cleared on resize, which is the only thing that could change the outcome.
+    if ( !m_DoFResourcesReady ) {
+        if ( m_DoFCreateAttempted ) return;
+        if ( !CreateDoFResources( m_Resolution ) ) {
+            LogWarn() << "D3D12: depth of field is enabled but its textures could not be created — DoF disabled.";
+            return;
+        }
+    }
+    // Resolution changed without the resources following (the resize path only rebuilds them if they already
+    // exist, so this is a belt-and-braces check rather than an expected state).
+    if ( m_DoFHalfSize.x != std::max( 1, m_Resolution.x / 2 ) || m_DoFHalfSize.y != std::max( 1, m_Resolution.y / 2 ) )
+        return;
+
+    ID3D12PipelineState* blurPso = settings.DoFGaussBlur
+        ? m_Pipelines.DoF.GaussPSO.Get()
+        : m_Pipelines.DoF.BlurPSO.Get();
+    if ( !blurPso ) return;
+
+    DX_ZONE( m_CmdList, "Depth of Field" );
+    TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth of Field" );
+
+    const UINT prevIdx = m_DoFFocusIndex;
+    const UINT curIdx = 1 - m_DoFFocusIndex;
+
+    // b0 DoFCB — see Shaders/D3D12/DoF.hlsl. One block for all three passes; the per-pass fields (OutIndex and
+    // the output resolution) are rewritten between dispatches, everything else is set once here.
+    struct DoFConsts {
+        float    FocusRange;
+        float    BokehRadius;
+        float    MaxBlur;
+        uint32_t FocusValid;
+        uint32_t SceneIndex;
+        uint32_t DepthIndex;
+        uint32_t PrevFocusIndex;
+        uint32_t FocusIndex;
+        uint32_t BlurIndex;
+        uint32_t FocusUavIndex;
+        uint32_t OutIndex;
+        uint32_t Pad;
+        float    FullResX;
+        float    FullResY;
+        float    OutResX;
+        float    OutResY;
+    } cb = {};
+    static_assert( sizeof( DoFConsts ) == 16 * sizeof( uint32_t ),
+        "DoFConsts must match DoF.hlsl's b0 DoFCB and the 16 root constants pushed below" );
+
+    // The same three tuning values D3D11PFX_DepthOfField pushes, straight from the shared settings. D3D11 also
+    // uploads DoF_ProjParams / near / far, which none of the three compute shaders read (depth linearization is
+    // the parameter-free reversed-Z reciprocal) — so they are not carried over.
+    cb.FocusRange = settings.DoFFocusRange;
+    cb.BokehRadius = settings.DoFBokehRadius;
+    cb.MaxBlur = settings.DoFMaxBlur;
+    cb.FocusValid = m_DoFFocusValid ? 1u : 0u;
+    cb.SceneIndex = m_SceneColorSrvSlot;
+    cb.DepthIndex = m_DepthSrvSlot;
+    cb.PrevFocusIndex = m_DoFFocusSrvSlot[prevIdx];
+    cb.FocusIndex = m_DoFFocusSrvSlot[curIdx];
+    cb.BlurIndex = m_DoFHalfSrvSlot;
+    cb.FocusUavIndex = m_DoFFocusUavSlot[curIdx];
+    cb.FullResX = static_cast<float>( m_Resolution.x );
+    cb.FullResY = static_cast<float>( m_Resolution.y );
+
+    // Scene colour RENDER_TARGET -> compute-readable, depth out of DEPTH_WRITE, previous focus UAV -> readable.
+    // The DSV/RTV must be unbound first: a resource cannot be bound as a render target while it is read through
+    // an SRV (same dance RenderTAA / RenderBloom / RenderFogAndGodRays do).
+    m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
+    {
+        D3D12_RESOURCE_BARRIER pre[3];
+        UINT n = 0;
+        if ( !m_SceneColorInPixelState ) {
+            pre[n++] = TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
+                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+        }
+        pre[n++] = TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, kDoFDepthRead );
+        pre[n++] = TransitionBarrier( m_DoFFocus[prevIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+        m_CmdList->ResourceBarrier( n, pre );
+        m_SceneColorInPixelState = true;
+    }
+
+    m_CmdList->SetComputeRootSignature( m_Pipelines.DoF.RootSig.Get() );
+
+    // --- Pass 0: focus resolve (1x1) ---
+    // This pass writes through FocusUavIndex, not OutIndex, and reads neither OutRes — it is the one pass whose
+    // output is a fixed 1x1 texel, so those three fields stay at their zero-init values here.
+    m_CmdList->SetPipelineState( m_Pipelines.DoF.FocusPSO.Get() );
+    m_CmdList->SetComputeRoot32BitConstants( 0, 16, &cb, 0 );
+    m_CmdList->Dispatch( 1, 1, 1 );
+
+    // This frame's focus value becomes the read side for the two passes below; hand the previous one back to its
+    // resting UAV state. A UAV-write -> SRV-read handover needs a real state transition, not a UAV barrier: a
+    // UAV barrier only orders UAV access and performs no cache flush, so the SRV read would be undefined.
+    {
+        D3D12_RESOURCE_BARRIER b[2] = {
+            TransitionBarrier( m_DoFFocus[curIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE ),
+            TransitionBarrier( m_DoFFocus[prevIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
+        };
+        m_CmdList->ResourceBarrier( 2, b );
+    }
+    m_DoFFocusIndex = curIdx;
+    m_DoFFocusValid = true;
+
+    // --- Pass 1: half-res bokeh (or Gaussian) blur ---
+    m_CmdList->SetPipelineState( blurPso );
+    cb.OutIndex = m_DoFHalfUavSlot;
+    cb.OutResX = static_cast<float>( m_DoFHalfSize.x );
+    cb.OutResY = static_cast<float>( m_DoFHalfSize.y );
+    m_CmdList->SetComputeRoot32BitConstants( 0, 16, &cb, 0 );
+    m_CmdList->Dispatch( ( m_DoFHalfSize.x + 7 ) / 8, ( m_DoFHalfSize.y + 7 ) / 8, 1 );
+
+    {
+        auto b = TransitionBarrier( m_DoFHalf.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+        m_CmdList->ResourceBarrier( 1, &b );
+    }
+
+    // --- Pass 2: full-res composite into the scratch texture ---
+    m_CmdList->SetPipelineState( m_Pipelines.DoF.CompositePSO.Get() );
+    cb.OutIndex = m_DoFCompositeUavSlot;
+    cb.OutResX = static_cast<float>( m_Resolution.x );
+    cb.OutResY = static_cast<float>( m_Resolution.y );
+    m_CmdList->SetComputeRoot32BitConstants( 0, 16, &cb, 0 );
+    m_CmdList->Dispatch( ( m_Resolution.x + 7 ) / 8, ( m_Resolution.y + 7 ) / 8, 1 );
+
+    // Hand the result back to the scene colour. Both are kSceneColorFormat, so this is a straight CopyResource.
+    {
+        D3D12_RESOURCE_BARRIER toCopy[2] = {
+            TransitionBarrier( m_DoFComposite.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+                D3D12_RESOURCE_STATE_COPY_SOURCE ),
+            TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                D3D12_RESOURCE_STATE_COPY_DEST ),
+        };
+        m_CmdList->ResourceBarrier( 2, toCopy );
+        m_CmdList->CopyResource( m_SceneColor.Get(), m_DoFComposite.Get() );
+    }
+
+    // Resting states for the next frame: every DoF texture back to UNORDERED_ACCESS, depth back to DEPTH_WRITE,
+    // scene colour back to RENDER_TARGET for bloom / the tonemap.
+    {
+        D3D12_RESOURCE_BARRIER post[5] = {
+            TransitionBarrier( m_DoFComposite.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE,
+                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
+            TransitionBarrier( m_DoFHalf.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
+            TransitionBarrier( m_DoFFocus[curIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
+            TransitionBarrier( m_DepthBuffer.Get(), kDoFDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE ),
+            TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_COPY_DEST,
+                D3D12_RESOURCE_STATE_RENDER_TARGET ),
+        };
+        m_CmdList->ResourceBarrier( 5, post );
+        m_SceneColorInPixelState = false;
+    }
+
+    // Rebind the scene colour + depth for whatever comes next in the frame (bloom re-transitions the scene
+    // colour itself, but the render target must not be left unbound).
+    BindSceneColorTarget();
+}

--- a/D3D11Engine/D3D12Engine/D3D12Fx.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Fx.cpp
@@ -355,14 +355,13 @@ XRESULT D3D12GraphicsEngine::DrawPolyStrips( bool noTextures ) {
     m_CmdList->RSSetViewports( 1, &vp );
     m_CmdList->RSSetScissorRects( 1, &sc );
 
-    // D3D11's state machine: the FIRST blended material turns blending on and depth-write off, and every
-    // later material keeps that state (the test is `(blendAdd||blendBlend) && !BlendState.BlendEnabled`) —
-    // so a pass that starts with an ADD strip stays additive even across a later BLEND strip. Faithful,
-    // order-dependent, and cheap: at most one PSO switch for the whole pass.
+    // Depth-tested, never depth-writing, for the whole pass. ZenGin wraps the barrier's thunder list in
+    // SetZBufferWriteEnabled(FALSE) (oCBarrier::Render) and trails are ordinary late alpha content; a strip
+    // must never occlude what is drawn after it. Matches D3D11's DrawPolyStrips.
     GothicBlendStateInfo blend;
     blend.SetDefault();
-    bool blendEnabled = false;
-    bool depthWrite = true;
+    int lastAlphaFunc = -1;
+    constexpr bool depthWrite = false;
     ID3D12PipelineState* pso = m_Pipelines.GetOrCreateFxPipeline( blend, depthWrite );
     if ( !pso ) return XR_SUCCESS;
     m_CmdList->SetPipelineState( pso );
@@ -384,11 +383,14 @@ XRESULT D3D12GraphicsEngine::DrawPolyStrips( bool noTextures ) {
         const int matAlphaFunc = mat->GetAlphaFunc();
         const bool blendAdd = matAlphaFunc == zMAT_ALPHA_FUNC_ADD;
         const bool blendBlend = matAlphaFunc == zMAT_ALPHA_FUNC_BLEND;
-        if ( ( blendAdd || blendBlend ) && !blendEnabled ) {
-            if ( blendAdd ) blend.SetAdditiveBlending();
-            else            blend.SetAlphaBlending();
-            blendEnabled = true;
-            depthWrite = false;
+        // Blend mode per material, not latched on the first blended one: the map is iterated in texture
+        // order, so an ADD strip followed by a BLEND strip (or the reverse) used to get the wrong mode.
+        // The list is short and PSOs are cached, so the extra switches are noise.
+        if ( matAlphaFunc != lastAlphaFunc ) {
+            if ( blendAdd )        blend.SetAdditiveBlending();
+            else if ( blendBlend ) blend.SetAlphaBlending();
+            else                   blend.SetDefault();
+            lastAlphaFunc = matAlphaFunc;
             ID3D12PipelineState* next = m_Pipelines.GetOrCreateFxPipeline( blend, depthWrite );
             if ( !next ) continue;
             m_CmdList->SetPipelineState( next );

--- a/D3D11Engine/D3D12Engine/D3D12Fx.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Fx.cpp
@@ -355,9 +355,7 @@ XRESULT D3D12GraphicsEngine::DrawPolyStrips( bool noTextures ) {
     m_CmdList->RSSetViewports( 1, &vp );
     m_CmdList->RSSetScissorRects( 1, &sc );
 
-    // Depth-tested, never depth-writing, for the whole pass. ZenGin wraps the barrier's thunder list in
-    // SetZBufferWriteEnabled(FALSE) (oCBarrier::Render) and trails are ordinary late alpha content; a strip
-    // must never occlude what is drawn after it. Matches D3D11's DrawPolyStrips.
+    // Depth-tested, never depth-writing (oCBarrier::Render does SetZBufferWriteEnabled(FALSE)).
     GothicBlendStateInfo blend;
     blend.SetDefault();
     int lastAlphaFunc = -1;
@@ -383,9 +381,8 @@ XRESULT D3D12GraphicsEngine::DrawPolyStrips( bool noTextures ) {
         const int matAlphaFunc = mat->GetAlphaFunc();
         const bool blendAdd = matAlphaFunc == zMAT_ALPHA_FUNC_ADD;
         const bool blendBlend = matAlphaFunc == zMAT_ALPHA_FUNC_BLEND;
-        // Blend mode per material, not latched on the first blended one: the map is iterated in texture
-        // order, so an ADD strip followed by a BLEND strip (or the reverse) used to get the wrong mode.
-        // The list is short and PSOs are cached, so the extra switches are noise.
+        // Per material, not latched on the first blended one - an ADD strip after a BLEND one (or the
+        // reverse) used to get the wrong mode. PSOs are cached, so the extra switches are noise.
         if ( matAlphaFunc != lastAlphaFunc ) {
             if ( blendAdd )        blend.SetAdditiveBlending();
             else if ( blendBlend ) blend.SetAlphaBlending();

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -289,6 +289,12 @@ XRESULT D3D12GraphicsEngine::Init() {
     if ( !m_Pipelines.CreateTaa() ) {
         LogWarn() << "D3D12GraphicsEngine::Init: failed to create the TAA pipeline (temporal AA unavailable).";
     }
+    // Depth of field. Non-fatal and opt-in (RendererSettings.EnableDoF, off by default): RenderDepthOfField
+    // guards on the PSOs and leaves the whole scene in focus if this failed. Its textures are built lazily the
+    // first time DoF is switched on, not here — see CreateDoFResources.
+    if ( !m_Pipelines.CreateDoF() ) {
+        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the depth-of-field pipeline (DoF unavailable).";
+    }
     if ( !m_Pipelines.CreateSkyIbl() ) {
         // Non-fatal: the lit shaders test the sky-IBL cube indices for 0xFFFFFFFF and fall back to the flat
         // ambient term they used before this existed, so a failure here costs indirect specular, not lighting.
@@ -1603,6 +1609,11 @@ bool D3D12GraphicsEngine::CreateSwapChain( INT2 size ) {
     // TAA history + its private previous-depth snapshot. Non-fatal for the same reason; also resets the
     // accumulated history, which a resolution change invalidates outright.
     CreateTaaResources( size );
+    // Depth-of-field textures are built lazily on first use (they are ~20 MB of VA and DoF is off by default),
+    // so only track the new resolution here if they already exist. Clearing m_DoFCreateAttempted lets a
+    // previously-failed creation retry at the new, possibly smaller, size.
+    m_DoFCreateAttempted = false;
+    if ( m_DoFResourcesReady ) CreateDoFResources( size );
     CreateHiZResources( size );      // non-fatal: without it the GPU VOB cull runs frustum-only (no occlusion)
     CreateFogResources( size );      // non-fatal: height fog/god rays are opt-in; RenderFogAndGodRays no-ops if this failed
     ReleaseWaterCopyResources();     // lazily rebuilt at the new size by the next frame that renders water
@@ -2496,6 +2507,10 @@ bool D3D12GraphicsEngine::ResizeSwapChain( INT2 size ) {
     // TAA history + its private previous-depth snapshot. Non-fatal for the same reason; also resets the
     // accumulated history, which a resolution change invalidates outright.
     CreateTaaResources( size );
+    // See the CreateSwapChain call site: lazily built, so only re-sized here if they are already up. The GPU is
+    // idle at this point (WaitForGpuIdle above), which is what makes releasing the old ones safe.
+    m_DoFCreateAttempted = false;
+    if ( m_DoFResourcesReady ) CreateDoFResources( size );
     CreateHiZResources( size );      // non-fatal: see the CreateSwapChain call site
     CreateFogResources( size );      // non-fatal: see the CreateSwapChain call site
     ReleaseWaterCopyResources();     // GPU is idle here; the next water frame rebuilds them at the new size

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -6,6 +6,7 @@
 
 #include "../BaseGraphicsEngine.h"
 #include "../Frustum.h"
+#include "../WorldConverter.h"   // SHADOW_LOD_FIRST_CASCADE
 #include "D3D12Device.h"
 #include <memory>
 #include <unordered_map>
@@ -763,8 +764,12 @@ private:
     // and >= kFirstLodShadowCascade takes the baked progressive-mesh LOD on top of that. Both reduced
     // buffers merge wedges that share a position but not a UV, so a material the caster alpha-clips
     // always keeps its render indices regardless of pass.
+    //
+    // The LOD gate is shared with D3D11 (WorldConverter.h) rather than picked per backend: an edge
+    // collapse MOVES the caster surface, so a cascade whose bias is smaller than that deviation
+    // self-shadows the full-detail surface black. See the constant's comment for the failure mode.
     static constexpr int kVobIndicesMainView = -1;
-    static constexpr int kFirstLodShadowCascade = 1;
+    static constexpr int kFirstLodShadowCascade = SHADOW_LOD_FIRST_CASCADE;
     UINT BuildVobDrawCommands( const std::vector<FrameVobUpload>& uploads, uint8_t* argPtr, bool resolveMaps,
         UINT maxCommands, bool culled = false, bool cacheIn = true,
         int shadowCascade = kVobIndicesMainView );
@@ -1259,6 +1264,46 @@ private:
     void AdvanceJitter();                  // per-frame jitter into TransformProj._13/_23 (no-op when TAA is off)
     void RenderTAA();                      // the resolve dispatch + copy back over the scene colour
     bool IsTaaEnabled() const;             // AntiAliasingMode == AA_TAA and everything it needs exists
+
+    // ---- Depth of field (D3D12DoF.cpp) ----------------------------------------------------------------------
+    // Compute port of D3D11PFX_DepthOfField::RenderCS (Shaders/D3D12/DoF.hlsl). Three passes on the LINEAR HDR
+    // scene colour, in D3D11's slot: after the TAA resolve and BEFORE bloom — D3D11 runs it at the head of its
+    // "Post-processing B" block, which is exactly there. Scene colour in, scene colour out, so nothing
+    // downstream needs to know it ran.
+    //
+    //   m_DoFFocus[2]  1x1 R32_FLOAT ping-pong. The auto-focus distance, temporally smoothed against the
+    //                  previous frame's value — pass 0 reads [m_DoFFocusIndex] and writes [1 - m_DoFFocusIndex].
+    //   m_DoFHalf      half-res kSceneColorFormat: rgb = bokeh blur, a = centre CoC (pass 1).
+    //   m_DoFComposite full-res kSceneColorFormat scratch. Compute cannot read and write the scene colour in one
+    //                  dispatch, so pass 2 writes here and the result is CopyResource'd back — same shape as the
+    //                  TAA resolve's history copy, and both are kSceneColorFormat so the copy is a straight one.
+    //
+    // Unlike the bloom/AO/TAA resources these are built LAZILY (see CreateDoFResources): DoF is off in a stock
+    // config, and a full-res RGBA16F scratch plus a half-res one is ~20 MB of virtual address space at 1080p —
+    // real money in a 32-bit process. The resize path only rebuilds them if they already exist.
+    Microsoft::WRL::ComPtr<ID3D12Resource>      m_DoFFocus[2];
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_DoFFocusAlloc[2];
+    UINT m_DoFFocusSrvSlot[2] = { UINT_MAX, UINT_MAX };
+    UINT m_DoFFocusUavSlot[2] = { UINT_MAX, UINT_MAX };
+    UINT m_DoFFocusIndex = 0;
+    // The focus textures' initial contents are undefined, so the first resolve must SNAP to the measured depth
+    // instead of blending against garbage (DoFCB::FocusValid). Cleared whenever the pair is (re)created.
+    bool m_DoFFocusValid = false;
+    Microsoft::WRL::ComPtr<ID3D12Resource>      m_DoFHalf;
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_DoFHalfAlloc;
+    UINT m_DoFHalfSrvSlot = UINT_MAX;
+    UINT m_DoFHalfUavSlot = UINT_MAX;
+    INT2 m_DoFHalfSize = { 0, 0 };
+    Microsoft::WRL::ComPtr<ID3D12Resource>      m_DoFComposite;
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_DoFCompositeAlloc;
+    UINT m_DoFCompositeUavSlot = UINT_MAX;
+    bool m_DoFResourcesReady = false;
+    // Set once creation has been attempted at the current resolution, so a failure (out of heap slots, out of
+    // memory) is logged once and not retried every frame while DoF stays enabled. Cleared on resize.
+    bool m_DoFCreateAttempted = false;
+
+    bool CreateDoFResources( INT2 size );  // (re)builds the focus pair, the half-res blur target and the scratch
+    void RenderDepthOfField();             // focus resolve -> half-res blur -> composite -> copy back
 
     // ---- Sky image-based lighting (indirect light for the Forward+ PBR shaders) -----------------------------
     // Replaces the flat greyscale ambient floor in PBRLighting.hlsl's ComputeSunLightingPBR

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -757,8 +757,17 @@ private:
     // the build a pure read so it can run on a cascade's worker thread (CacheIn mutates Gothic's resource
     // manager). A texture that has not been pulled in yet simply alpha-clips against black for that frame —
     // a caster silhouette, not a visible surface, so the inaccuracy never reaches the screen as a wrong pixel.
+    // shadowCascade picks which of a sub-mesh's index buffers each command draws, mirroring D3D11's
+    // GetShadowAwareIndexBuffer: kVobIndicesMainView keeps the full render indices (the lit and prepass
+    // draws need per-wedge normals/UVs), a cascade index >= 0 takes the position-welded shadow indices,
+    // and >= kFirstLodShadowCascade takes the baked progressive-mesh LOD on top of that. Both reduced
+    // buffers merge wedges that share a position but not a UV, so a material the caster alpha-clips
+    // always keeps its render indices regardless of pass.
+    static constexpr int kVobIndicesMainView = -1;
+    static constexpr int kFirstLodShadowCascade = 1;
     UINT BuildVobDrawCommands( const std::vector<FrameVobUpload>& uploads, uint8_t* argPtr, bool resolveMaps,
-        UINT maxCommands, bool culled = false, bool cacheIn = true );
+        UINT maxCommands, bool culled = false, bool cacheIn = true,
+        int shadowCascade = kVobIndicesMainView );
 
     // ---- GPU-driven skeletal meshes + node attachments (T9): ExecuteIndirect + bindless materials ----------
     // The prerequisite was the bindless-skeletal / bindless-attachment work: neither Skeletal.RootSig nor the

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -2729,12 +2729,8 @@ ID3D12PipelineState* D3D12PipelineState::GetOrCreateFxPipeline( const GothicBlen
     // keep SetDefaultStates' CM_CULL_BACK — they are closed meshes, and drawing both faces would double the
     // contribution of every additively-blended one.
     pso.RasterizerState.CullMode = cullBack ? D3D12_CULL_MODE_BACK : D3D12_CULL_MODE_NONE;
-    // FALSE, unlike the world PSOs: the barrier's lightning lives on the "magicfrontier" sky sphere, tens
-    // of thousands of units out, and ZenGin draws it with the far clip pushed to 2,000,000
-    // (oCBarrier::Render). We keep our own projection so the depth values stay comparable to the scene's
-    // depth buffer, and let the far part of a bolt clamp to the far plane instead of being clipped into
-    // angular fragments. This also matches D3D11, whose GothicRasterizerStateInfo::SetDefault leaves depth
-    // clipping off for every FF draw.
+    // FALSE, unlike the world PSOs: the barrier's bolts sit way past our far plane, and clamping them to it
+    // beats slicing them up. Matches D3D11, whose rasterizer default leaves depth clipping off for FF draws.
     pso.RasterizerState.DepthClipEnable = FALSE;
 
     // Gothic blend enums are laid out for D3D11, whose _BLEND/_OP values equal D3D12's — cast directly.

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -3053,6 +3053,59 @@ bool D3D12PipelineState::CreateTaa() {
     return true;
 }
 
+bool D3D12PipelineState::CreateDoF() {
+    // Depth of field (Shaders/D3D12/DoF.hlsl) — the compute port of D3D11PFX_DepthOfField::RenderCS. Non-fatal:
+    // RenderDepthOfField guards on every PSO and simply leaves the scene in focus if this fails.
+    ID3D12Device* device = m_Device->GetDevice();
+    if ( !device ) return false;
+
+    // One root signature for all four PSOs: b0 as 16 root constants (the three tuning values, the history-valid
+    // flag, six bindless heap indices and the two resolutions — see DoF.hlsl's DoFCB). Every texture and UAV is
+    // fetched through ResourceDescriptorHeap, so there is no descriptor table — hence
+    // CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED, same as the TAA resolve above.
+    D3D12RootLayout& rs = Layout( "DoF" );
+    rs.AddConstants( 0, 16, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 DoFCB
+    // s0 linear-clamp only. The one place the D3D11 shader deliberately avoids filtering — the half-res pass's
+    // centre depth — uses Load() rather than a point sampler, so there is nothing for an s1 to do here.
+    rs.AddStaticSampler( D3D12RootLayout::SamplerLinear( 0, D3D12_SHADER_VISIBILITY_ALL,
+        D3D12_TEXTURE_ADDRESS_MODE_CLAMP ) );
+    if ( !rs.Build( device, D3D12_ROOT_SIGNATURE_FLAG_CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED ) )
+        return false;
+    DoF.RootSig = rs.RootSig();
+
+    // The Gaussian variant is the same CSBlur entry point recompiled with DOF_GAUSS_BLUR — exactly how the D3D11
+    // side splits CS_PFX_DoF into CS_PFX_DoF / CS_PFX_DoF_Gauss.
+    const D3D_SHADER_MACRO gaussMacros[] = { { "DOF_GAUSS_BLUR", "1" }, { nullptr, nullptr } };
+    if ( !m_Shaders->CompileFromFile( "DoF.hlsl", "CSFocusResolve", Shadermodel_CS, DoF.FocusCsBlob.ReleaseAndGetAddressOf() )
+        || !m_Shaders->CompileFromFile( "DoF.hlsl", "CSBlur", Shadermodel_CS, DoF.BlurCsBlob.ReleaseAndGetAddressOf() )
+        || !m_Shaders->CompileFromFile( "DoF.hlsl", "CSBlur", Shadermodel_CS, DoF.GaussCsBlob.ReleaseAndGetAddressOf(), gaussMacros )
+        || !m_Shaders->CompileFromFile( "DoF.hlsl", "CSComposite", Shadermodel_CS, DoF.CompositeCsBlob.ReleaseAndGetAddressOf() ) )
+        return false;
+    rs.ValidateShaders( {
+        { DoF.FocusCsBlob.Get(),     "DoF.hlsl:CSFocusResolve",           D3D12_SHADER_VISIBILITY_ALL },
+        { DoF.BlurCsBlob.Get(),      "DoF.hlsl:CSBlur",                   D3D12_SHADER_VISIBILITY_ALL },
+        { DoF.GaussCsBlob.Get(),     "DoF.hlsl:CSBlur (DOF_GAUSS_BLUR)",  D3D12_SHADER_VISIBILITY_ALL },
+        { DoF.CompositeCsBlob.Get(), "DoF.hlsl:CSComposite",              D3D12_SHADER_VISIBILITY_ALL },
+        } );
+
+    struct { ID3DBlob* cs; Microsoft::WRL::ComPtr<ID3D12PipelineState>* pso; const char* name; } passes[] = {
+        { DoF.FocusCsBlob.Get(),     &DoF.FocusPSO,     "focus resolve" },
+        { DoF.BlurCsBlob.Get(),      &DoF.BlurPSO,      "bokeh blur" },
+        { DoF.GaussCsBlob.Get(),     &DoF.GaussPSO,     "gaussian blur" },
+        { DoF.CompositeCsBlob.Get(), &DoF.CompositePSO, "composite" },
+    };
+    for ( const auto& p : passes ) {
+        D3D12_COMPUTE_PIPELINE_STATE_DESC pso = {};
+        pso.pRootSignature = DoF.RootSig.Get();
+        pso.CS = { p.cs->GetBufferPointer(), p.cs->GetBufferSize() };
+        if ( FAILED( device->CreateComputePipelineState( &pso, IID_PPV_ARGS( p.pso->ReleaseAndGetAddressOf() ) ) ) ) {
+            LogWarn() << "D3D12: CreateComputePipelineState failed (depth of field, " << p.name << ").";
+            return false;
+        }
+    }
+    return true;
+}
+
 bool D3D12PipelineState::CreateSky() {
     // Procedural atmospheric-scattering sky dome (Shaders/D3D12/Sky.hlsl) — the replacement for Gothic's
     // fixed-function sky. Non-fatal: DrawAtmosphereSkyDome() guards on both PSOs and DrawSky() falls back to
@@ -3501,6 +3554,7 @@ bool D3D12PipelineState::ReloadAll( bool hdrEncodeActive, std::vector<std::strin
     runOptional( "Gtao", &D3D12PipelineState::CreateGtao );
     runOptional( "Motion", &D3D12PipelineState::CreateMotion );
     runOptional( "Taa", &D3D12PipelineState::CreateTaa );
+    runOptional( "DoF", &D3D12PipelineState::CreateDoF );
     runOptional( "SkyIbl", &D3D12PipelineState::CreateSkyIbl );
     runOptional( "Sky", &D3D12PipelineState::CreateSky );
     runOptional( "Fog", &D3D12PipelineState::CreateFog );

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -2729,7 +2729,13 @@ ID3D12PipelineState* D3D12PipelineState::GetOrCreateFxPipeline( const GothicBlen
     // keep SetDefaultStates' CM_CULL_BACK — they are closed meshes, and drawing both faces would double the
     // contribution of every additively-blended one.
     pso.RasterizerState.CullMode = cullBack ? D3D12_CULL_MODE_BACK : D3D12_CULL_MODE_NONE;
-    pso.RasterizerState.DepthClipEnable = TRUE;
+    // FALSE, unlike the world PSOs: the barrier's lightning lives on the "magicfrontier" sky sphere, tens
+    // of thousands of units out, and ZenGin draws it with the far clip pushed to 2,000,000
+    // (oCBarrier::Render). We keep our own projection so the depth values stay comparable to the scene's
+    // depth buffer, and let the far part of a bolt clamp to the far plane instead of being clipped into
+    // angular fragments. This also matches D3D11, whose GothicRasterizerStateInfo::SetDefault leaves depth
+    // clipping off for every FF draw.
+    pso.RasterizerState.DepthClipEnable = FALSE;
 
     // Gothic blend enums are laid out for D3D11, whose _BLEND/_OP values equal D3D12's — cast directly.
     D3D12_RENDER_TARGET_BLEND_DESC& rt = pso.BlendState.RenderTarget[0];

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.h
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.h
@@ -270,6 +270,25 @@ public:
         Microsoft::WRL::ComPtr<ID3D12PipelineState> PSO;
     };
 
+    // Depth of field (Shaders/D3D12/DoF.hlsl — the compute port of D3D11PFX_DepthOfField::RenderCS). Three
+    // compute passes over ONE root signature (b0 16 root constants, fully bindless like the TAA resolve):
+    // the 1x1 focus resolve, the half-res blur, and the full-res composite. The blur has two variants,
+    // selected at runtime by RendererSettings.DoFGaussBlur exactly as on D3D11 — the 48-tap bokeh spiral
+    // (BlurPSO) or the cheap 16-tap Gaussian (GaussPSO, the DOF_GAUSS_BLUR macro). The focus ping-pong pair,
+    // the half-res blur target and the full-res composite scratch are GPU resources and live in the engine
+    // (D3D12DoF.cpp), like the bloom pyramid / TAA history.
+    struct DoFPipeline {
+        Microsoft::WRL::ComPtr<ID3D12RootSignature> RootSig;
+        Microsoft::WRL::ComPtr<ID3DBlob>            FocusCsBlob;
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> FocusPSO;
+        Microsoft::WRL::ComPtr<ID3DBlob>            BlurCsBlob;       // 48-tap bokeh spiral
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> BlurPSO;
+        Microsoft::WRL::ComPtr<ID3DBlob>            GaussCsBlob;      // DOF_GAUSS_BLUR: 16-tap Gaussian
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> GaussPSO;
+        Microsoft::WRL::ComPtr<ID3DBlob>            CompositeCsBlob;
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> CompositePSO;
+    };
+
     struct MotionPipeline {
         Microsoft::WRL::ComPtr<ID3D12RootSignature> FillRootSig;
         Microsoft::WRL::ComPtr<ID3DBlob>            FillCsBlob;
@@ -510,6 +529,7 @@ public:
     bool CreateGtao();        // Intel XeGTAO compute pipelines (AO_ASSAO on D3D12); textures stay in engine
     bool CreateMotion();      // motion-vector fill compute + debug-overlay pipelines; textures stay in engine
     bool CreateTaa();         // Intel TAA resolve compute pipeline; history buffers stay in engine
+    bool CreateDoF();         // depth-of-field focus/blur/composite compute pipelines; textures stay in engine
     bool CreateSkyIbl();      // sky IBL: analytic radiance + GGX prefilter + irradiance compute pipelines; cubes stay in engine
     bool CreateSky();         // procedural scattering sky dome (own bindless root sig + inner/outer PSOs); dome mesh is GSky's
     bool CreateFog();         // height fog + god rays: 2 god-ray compute PSOs + the fullscreen composition PSO
@@ -567,6 +587,7 @@ public:
     GtaoPipeline     Gtao;
     MotionPipeline   Motion;
     TaaPipeline      Taa;
+    DoFPipeline      DoF;            // depth of field (Shaders/D3D12/DoF.hlsl)
     SkyIblPipeline   SkyIbl;        // sky image-based lighting (Shaders/D3D12/SkyIbl.hlsl)
     SkyPipeline      Sky;           // procedural scattering sky dome (Shaders/D3D12/Sky.hlsl)
     FogPipeline      Fog;        // height fog + god rays (Shaders/D3D12/HeightFog.hlsl + GodRays.hlsl)

--- a/D3D11Engine/D3D12Engine/D3D12Rain.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Rain.cpp
@@ -600,8 +600,11 @@ void D3D12GraphicsEngine::CollectRainShadowVobs() {
 
     // culled=false, resolveMaps=false: CPU-culled like the cascades (never GPU-compacted), and the void
     // alpha-clip PS reads nothing but the diffuse, so normal/ORM resolution is pure waste here.
+    // shadowCascade=0: depth-only, so the position-welded shadow indices apply, but not the LOD level —
+    // the wetness map is one coarse projection over the whole scene rather than a distance band, so there
+    // is no near/far split here that would justify dropping caster detail.
     m_RainVobDrawCount = BuildVobDrawCommands( rainUploads, m_RainVobDrawArgsPtr[frame], false,
-        kMaxRainVobDrawCommands, false );
+        kMaxRainVobDrawCommands, false, true, 0 );
 }
 
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2972,7 +2972,7 @@ bool D3D12GraphicsEngine::CreateVobIndirect() {
 
 
 UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload>& uploads, uint8_t* argPtr, bool resolveMaps,
-    UINT maxCommands, bool culled, bool cacheIn ) {
+    UINT maxCommands, bool culled, bool cacheIn, int shadowCascade ) {
     // Fill an arg buffer with one command per (visual x material x sub-mesh): resolve the material's bindless
     // indices (diffuse always; normal/ORM only when resolveMaps — the depth/shadow passes just alpha-clip on
     // diffuse), pack the mesh + instance VB views + IB view, the per-visual wind min/max, and DrawIndexedInstanced.
@@ -3031,6 +3031,13 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
             const bool blended = peelBlended
                 && ( alphaFunc == zMAT_ALPHA_FUNC_BLEND || alphaFunc == zMAT_ALPHA_FUNC_ADD );
 
+            // The caster PS alpha-clips against this material's diffuse, and both reduced index buffers are
+            // position-welded — which merges wedges that share a position but not a UV. Feeding a leaf card
+            // the wrong UV would clip away the wrong texels, so alpha-relevant materials keep full indices
+            // in every pass. Same condition D3D11's shadow VOB loop gates on.
+            const bool alphaTested = ( tex && tex->HasAlphaChannel() )
+                || ( meshKey.Material && meshKey.Material->HasAlphaTest() );
+
             for ( MeshInfo* mi : meshList ) {
                 if ( !mi || mi->Indices.empty() || !mi->GetMeshVertexBuffer() || !mi->GetMeshIndexBuffer() )
                     continue;
@@ -3067,6 +3074,29 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                     return count;
                 }
 
+                // Pick this command's index buffer. A missing level just falls through to the next-best one,
+                // so a mesh that ships no LOD data still gets the welded shadow indices, and one that has
+                // neither still draws — the only cost of an absent level is that nothing is saved.
+                D3D12VertexBuffer* cmdIb = mib;
+                UINT cmdIndexCount = static_cast<UINT>( mi->Indices.size() );
+                if ( shadowCascade != kVobIndicesMainView && !alphaTested ) {
+                    if ( shadowCascade >= kFirstLodShadowCascade && !mi->LodIndices.empty()
+                        && mi->GetMeshLodIndexBuffer() ) {
+                        if ( D3D12VertexBuffer* lodIb = D3D12VertexBuffer::From( mi->GetMeshLodIndexBuffer() );
+                            lodIb->GetResource() ) {
+                            cmdIb = lodIb;
+                            cmdIndexCount = static_cast<UINT>( mi->LodIndices.size() );
+                        }
+                    }
+                    if ( cmdIb == mib && !mi->ShadowIndices.empty() && mi->GetMeshShadowIndexBuffer() ) {
+                        if ( D3D12VertexBuffer* shadowIb = D3D12VertexBuffer::From( mi->GetMeshShadowIndexBuffer() );
+                            shadowIb->GetResource() ) {
+                            cmdIb = shadowIb;
+                            cmdIndexCount = static_cast<UINT>( mi->ShadowIndices.size() );
+                        }
+                    }
+                }
+
                 VobDrawCommand& c = cmds[count++];
                 c.MeshVBV = { mvb->GetGpuVirtualAddress(), mvb->GetSizeInBytes(), sizeof( ExVertexStruct ) };
                 // GPU-culled: draw from the compacted buffer CSCull writes (same byte range, different base)
@@ -3074,19 +3104,19 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 c.InstVBV = culled ? up.culledInstView : up.instView;
                 c.VisualIndex = culled ? up.cullVisualIndex : 0xFFFFFFFFu;
                 c._cmdPad = 0;
-                c.IBV     = { mib->GetGpuVirtualAddress(), mib->GetSizeInBytes(), DXGI_FORMAT_R16_UINT };
+                c.IBV     = { cmdIb->GetGpuVirtualAddress(), cmdIb->GetSizeInBytes(), DXGI_FORMAT_R16_UINT };
                 c.MatNormalIndex  = normalIdx;
                 c.MatOrmIndex     = ormIdx;
                 c.MatDiffuseIndex = diffuseIdx;
                 c.WindMinHeight   = minH;
                 c.WindMaxHeight   = maxH;
-                c.Draw.IndexCountPerInstance = static_cast<UINT>( mi->Indices.size() );
+                c.Draw.IndexCountPerInstance = cmdIndexCount;
                 c.Draw.InstanceCount         = up.numInstances;
                 c.Draw.StartIndexLocation    = 0;
                 c.Draw.BaseVertexLocation    = 0;
                 c.Draw.StartInstanceLocation = 0;
                 if ( resolveMaps )
-                    m_VobDrawnTriangles += (static_cast<unsigned int>( mi->Indices.size() ) / 3) * up.numInstances;
+                    m_VobDrawnTriangles += (cmdIndexCount / 3) * up.numInstances;
             }
         }
     }

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2599,28 +2599,15 @@ XRESULT D3D12GraphicsEngine::DrawSky() {
 	// time of day — it is driven by the same AC_* constants D3D11's sky is — so that failure mode is gone, but
 	// the fallback is kept for exactly the case where the dome cannot draw.)
 	if ( rs.RendererSettings.AtmosphericScattering && DrawAtmosphereSkyDome() ) {
-#if defined(BUILD_GOTHIC_1_CLASSIC)
-		// G1's magic barrier. In G1 the active sky controller may be an oCSkyControler_Barrier, whose
-		// RenderSkyPre() override draws the barrier dome + its lightning (verified against
-		// Gothic_I_Classic/API/oBarrier.h: oCSkyControler_Barrier::RenderSkyPre == 0x632140, a virtual
-		// override of zCSkyControler_Outdoor::RenderSkyPre == 0x5C0900). D3D11's DrawSky calls 0x632140
-		// directly here in its scattering path; this goes through the VTABLE instead
-		// (zCSkyController::RenderSkyPre dispatches via VTBL_RenderSkyPre), which is the same call whenever a
-		// barrier controller IS installed but strictly safer and more mod-friendly otherwise:
-		//   * hardcoding 0x632140 reads `barrier` at this+0x680, one dword PAST the end of a plain
-		//     zCSkyControler_Outdoor (sizeof 0x680) — fine for a barrier controller (sizeof 0x688), an
-		//     out-of-bounds read for any other. The vtable resolves to the base instead, which is safe.
-		//   * a mod that re-enables the barrier — or installs any other derived sky controller — gets ITS
-		//     override called, rather than one hardcoded address for one game version.
-		//
-		// The override internally calls zCSkyControler_Outdoor::RenderSkyPre() first, so on G1 the
-		// fixed-function sky is still drawn over our dome and G1 keeps paying for it. That is pre-existing
-		// D3D11 behaviour, mirrored deliberately rather than "fixed": the guard conditions inside the override
-		// are NOT verifiable from the available source (the oBarrier.cpp in the G2 tree gates on
-		// renderLightning/weather members that G1-Classic's zCSkyControler_Outdoor does not even have), so
-		// reimplementing the barrier half to skip the redundant sky draw would be guesswork on a path that
-		// cannot be GPU-tested here. The draw-call win is therefore G2-only for now; correctness is both.
-		if ( zCSkyController_Outdoor* skyCtrl = Engine::GAPI->GetLoadedWorldInfo()->MainWorld->GetSkyControllerOutdoor() ) {
+		// The magic barrier (dome + lightning) is drawn by a derived sky controller's RenderSkyPre override -
+		// vanilla oCWorld installs an oCSkyControler_Barrier in every world of both games. Called through the
+		// vtable so a mod's own controller gets its override; hardcoding G1's 0x632140 would also read
+		// `barrier` one dword past the end of a plain zCSkyControler_Outdoor.
+		if ( zCSkyController_Outdoor* skyCtrl = Engine::GAPI->GetLoadedWorldInfo()->MainWorld->GetSkyControllerOutdoor();
+			skyCtrl && skyCtrl->HasDerivedRenderSkyPre() && skyCtrl->WantsBarrierRender() ) {
+			// Required: STAGE_DRAW_SKY picks the FORCE_MAX_Z vertex shaders for Gothic's XYZRHW sky draws and
+			// ignores its D3DRENDERSTATE_ZENABLE writes. Without it the sky keeps its screen-space Z, which
+			// under reversed-Z lands in front of the whole scene.
 			const RenderStage oldBarrierStage = rs.RendererInfo.RenderStage;
 			rs.RendererInfo.RenderStage = STAGE_DRAW_SKY;
 			rs.DepthState.DepthBufferEnabled = true;
@@ -2637,7 +2624,6 @@ XRESULT D3D12GraphicsEngine::DrawSky() {
 			Engine::GAPI->SetFarPlane( rs.RendererSettings.SectionDrawRadius * WORLD_SECTION_SIZE );
 			rs.RendererInfo.RenderStage = oldBarrierStage;
 		}
-#endif
 		return XR_SUCCESS;
 	}
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2513,6 +2513,12 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// scene colour back in place, so nothing below needs to know it ran. No-op unless AA_TAA.
 	RenderTAA();
 
+	// Depth of field, on the resolved LINEAR HDR scene: D3D11 runs it as the first pass of its "Post-processing
+	// B" block, i.e. after the upscale/TAA stage and before bloom. Blurring before bloom is what makes an
+	// out-of-focus highlight bloom as the disc it has become rather than as the point it was; being after TAA
+	// keeps a moving focus point from smearing through the temporal history. No-op unless EnableDoF.
+	RenderDepthOfField();
+
 	RenderBloom();
 	RenderLuminanceAdapt();
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2618,11 +2618,16 @@ XRESULT D3D12GraphicsEngine::DrawSky() {
 			rs.RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
 			rs.RasterizerState.SetDirty();
 
-			skyCtrl->RenderSkyPre();   // virtual -> oCSkyControler_Barrier's override when one is installed
+			// The override renders the stock sky before the barrier; drop that half so it doesn't paint
+			// over the dome we just rendered. The barrier's own draws still go through.
+			{
+				zCSkyController_Outdoor::ScopedBarrierRender barrierScope;
+				skyCtrl->RenderSkyPre();
+			}
+			rs.RendererInfo.RenderStage = oldBarrierStage;
 
 			// The engine breaks the far plane on its way through; restore it as D3D11's DrawSky does.
 			Engine::GAPI->SetFarPlane( rs.RendererSettings.SectionDrawRadius * WORLD_SECTION_SIZE );
-			rs.RendererInfo.RenderStage = oldBarrierStage;
 		}
 		return XR_SUCCESS;
 	}

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -920,8 +920,10 @@ void D3D12ShadowMap::BuildCascade( UINT cascade ) {
 	// culled=false: the cascades CPU-cull against their own frustum (a caster invisible to the player can
 	// still cast into view), so they draw the uncompacted ring with the CPU's instance counts.
 	// cacheIn=false: see above — this runs on a worker thread and must not mutate Gothic.
+	// shadowCascade=c: cascade 0 keeps full-detail casters (it covers what the player is standing in),
+	// the outer cascades draw the baked progressive-mesh LOD instead — same command count, fewer triangles.
 	m_VobDrawCount[c] = m_E->BuildVobDrawCommands( cascadeUploads, m_VobDrawArgsPtr[c][frame], false,
-		D3D12GraphicsEngine::kMaxShadowVobDrawCommands, false, false );
+		D3D12GraphicsEngine::kMaxShadowVobDrawCommands, false, false, static_cast<int>( c ) );
 }
 
 

--- a/D3D11Engine/D3D12Engine/D3D12VertexBuffer.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12VertexBuffer.cpp
@@ -39,6 +39,43 @@ namespace {
         return true;
     }
 
+    /** Carries a baked progressive-mesh LOD index list through the vertex-fetch remap OptimizeVertices
+        just applied to the mesh, then position-welds it exactly like the shadow index list. On anything
+        unexpected the list is cleared instead of left half-remapped - callers treat an empty LOD list as
+        "this mesh has no reduced level" and fall back to full detail, which is always correct. */
+    void OptimizeLodIndices( std::vector<VERTEX_INDEX>& lodIndices,
+        const std::vector<unsigned int>& remap,
+        const std::vector<uint8_t>& remappedVertices,
+        size_t fetchedVertexCount,
+        unsigned int stride ) {
+        if ( lodIndices.size() % 3 != 0 ) {
+            lodIndices.clear();
+            return;
+        }
+
+        std::vector<unsigned int> lod;
+        ConvertIndicesToUInt32( lodIndices.data(), lodIndices.size(), lod );
+
+        for ( unsigned int& idx : lod ) {
+            // A collapsed triangle can only reference wedges that survive, and every surviving wedge is
+            // referenced by the full-detail index buffer too - so remap never hands back the ~0u it
+            // reserves for unreferenced vertices. Verified rather than trusted: mod content is content.
+            if ( idx >= remap.size() || remap[idx] >= fetchedVertexCount ) {
+                lodIndices.clear();
+                return;
+            }
+            idx = remap[idx];
+        }
+
+        std::vector<unsigned int> welded( lod.size() );
+        meshopt_generateShadowIndexBuffer( welded.data(), lod.data(), lod.size(),
+            remappedVertices.data(), fetchedVertexCount, sizeof( float ) * 3, stride );
+
+        if ( !ConvertIndicesToVertexIndex( welded, lodIndices.data(), lodIndices.size() ) ) {
+            lodIndices.clear();
+        }
+    }
+
     float DequantizeSnorm( int v, int bits ) {
         const int maxValue = (1 << (bits - 1)) - 1;
         if ( v > maxValue ) {
@@ -258,15 +295,18 @@ XRESULT D3D12VertexBuffer::Unmap() {
 }
 
 XRESULT D3D12VertexBuffer::OptimizeVertices( VERTEX_INDEX* indices, uint8_t* vertices, unsigned int numIndices,
-    unsigned int numVertices, unsigned int stride, std::vector<VERTEX_INDEX>* outShadowIndices ) {
+    unsigned int numVertices, unsigned int stride, std::vector<VERTEX_INDEX>* outShadowIndices,
+    std::vector<VERTEX_INDEX>* inOutLodIndices ) {
     if ( !indices || !vertices || numIndices == 0 || numVertices == 0 || stride == 0 ) {
         if ( outShadowIndices ) outShadowIndices->clear();
+        if ( inOutLodIndices ) inOutLodIndices->clear();
         return XR_SUCCESS;
     }
 
     // meshoptimizer supports per-vertex element sizes up to 256 bytes.
     if ( stride > 256 ) {
         if ( outShadowIndices ) outShadowIndices->clear();
+        if ( inOutLodIndices ) inOutLodIndices->clear();
         return XR_SUCCESS;
     }
 
@@ -309,9 +349,14 @@ XRESULT D3D12VertexBuffer::OptimizeVertices( VERTEX_INDEX* indices, uint8_t* ver
         }
     }
 
+    if ( inOutLodIndices && !inOutLodIndices->empty() ) {
+        OptimizeLodIndices( *inOutLodIndices, remap, remappedVertices, fetchedVertexCount, stride );
+    }
+
     if ( !ConvertIndicesToVertexIndex( remappedIndices, indices, numIndices ) ) {
         LogError() << "OptimizeVertices: remapped index exceeds VERTEX_INDEX range";
         if ( outShadowIndices ) outShadowIndices->clear();
+        if ( inOutLodIndices ) inOutLodIndices->clear();
         return XR_FAILED;
     }
 

--- a/D3D11Engine/D3D12Engine/D3D12VertexBuffer.h
+++ b/D3D11Engine/D3D12Engine/D3D12VertexBuffer.h
@@ -52,7 +52,8 @@ public:
     XRESULT Unmap() override;
 
     XRESULT OptimizeVertices( VERTEX_INDEX* indices, uint8_t* vertices, unsigned int numIndices,
-        unsigned int numVertices, unsigned int stride, std::vector<VERTEX_INDEX>* outShadowIndices = nullptr ) override;
+        unsigned int numVertices, unsigned int stride, std::vector<VERTEX_INDEX>* outShadowIndices = nullptr,
+        std::vector<VERTEX_INDEX>* inOutLodIndices = nullptr ) override;
     XRESULT OptimizeFaces( VERTEX_INDEX* indices, uint8_t* vertices, unsigned int numIndices,
         unsigned int numVertices, unsigned int stride ) override;
 

--- a/D3D11Engine/D3D7/MyDirect3DDevice7.h
+++ b/D3D11Engine/D3D7/MyDirect3DDevice7.h
@@ -253,6 +253,16 @@ public:
             state.DepthState.SetDirty();
             break;
         }
+
+        case D3DRENDERSTATE_ZWRITEENABLE: {
+            if ( state.RendererInfo.RenderStage == STAGE_DRAW_SKY ) {
+                // we do custom Sky rendering behavior
+                break;
+            }
+            state.DepthState.DepthWriteEnabled = Value != 0;
+            state.DepthState.SetDirty();
+            break;
+        }
 		case D3DRENDERSTATE_ALPHATESTENABLE: state.GraphicsState.SetGraphicsSwitch( GSWITCH_ALPHAREF, Value != 0 );	break;
 		case D3DRENDERSTATE_SRCBLEND: state.BlendState.SrcBlend = static_cast<GothicBlendStateInfo::EBlendFunc>(Value); state.BlendState.SetDirty(); break;
 		case D3DRENDERSTATE_DESTBLEND: state.BlendState.DestBlend = static_cast<GothicBlendStateInfo::EBlendFunc>(Value); state.BlendState.SetDirty(); break;
@@ -544,8 +554,8 @@ public:
                 ? VShaderID::VS_TransformedEx_MAX_Z
                 : VShaderID::VS_TransformedEx;
 
-			Engine::GraphicsEngine->SetActiveVertexShader( VShaderID::VS_TransformedEx );
-			Engine::GraphicsEngine->BindViewportInformation( VShaderID::VS_TransformedEx, 0 );
+			Engine::GraphicsEngine->SetActiveVertexShader( vs );
+			Engine::GraphicsEngine->BindViewportInformation( vs, 0 );
 			break;
         }
 

--- a/D3D11Engine/GfxVertexBuffer.h
+++ b/D3D11Engine/GfxVertexBuffer.h
@@ -56,8 +56,11 @@ public:
     virtual XRESULT Map( int flags, void** dataPtr, unsigned int* size ) = 0;
     virtual XRESULT Unmap() = 0;
 
-    /** CPU-side vertex-cache optimization (meshoptimizer; backend-agnostic in practice) */
-    virtual XRESULT OptimizeVertices( VERTEX_INDEX* indices, uint8_t* vertices, unsigned int numIndices, unsigned int numVertices, unsigned int stride, std::vector<VERTEX_INDEX>* outShadowIndices = nullptr ) = 0;
+    /** CPU-side vertex-cache optimization (meshoptimizer; backend-agnostic in practice).
+        inOutLodIndices, if given, is an index list over the SAME pre-optimization vertex numbering (a
+        baked progressive-mesh LOD, say) that gets carried through the vertex remap and position-welded
+        in place, so it stays valid against the reordered vertex buffer. */
+    virtual XRESULT OptimizeVertices( VERTEX_INDEX* indices, uint8_t* vertices, unsigned int numIndices, unsigned int numVertices, unsigned int stride, std::vector<VERTEX_INDEX>* outShadowIndices = nullptr, std::vector<VERTEX_INDEX>* inOutLodIndices = nullptr ) = 0;
     virtual XRESULT OptimizeFaces( VERTEX_INDEX* indices, uint8_t* vertices, unsigned int numIndices, unsigned int numVertices, unsigned int stride ) = 0;
 
     /** Returns the size in bytes of this buffer */

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1471,7 +1471,7 @@ void GothicAPI::CalcPolyStripMeshes() {
     PolyStripInfos.clear();
 
     for ( const auto& pStrip : PolyStripVisuals ) {
-        if ( !pStrip ) return;
+        if ( !pStrip ) continue;
 
         //Pointer passed is a placeholder, it'll not be used inside the function.
         //We need gothic engine to only execute relevant calculations inside native Render()
@@ -1526,9 +1526,10 @@ void GothicAPI::CalcPolyStripMeshes() {
             }
 #endif
 #ifdef BUILD_GOTHIC_2_6_fix
-            //For G2 polyList only contains a single polygon (supposed to be kind of a reference it seems) 
+            //For G2 polyList only contains a single polygon (supposed to be kind of a reference it seems)
             //and vertices should be taken from vertList, while preserving a correct order making up a
             //properly winded polygon
+            uint8_t maxSegAlpha = 0;
             for ( int n = 0; n < 4; n++ ) {
                 //In similar fashion to segment index - vertex index should overflow numVert.
                 int vInd = ((segIndex << 1) + vertOrder[n]) % pStripInst->numVert;
@@ -1545,7 +1546,13 @@ void GothicAPI::CalcPolyStripMeshes() {
                 float alpha = alphaList[vSegInd];
                 if ( alpha < 0.f ) alpha = 0.f;
                 reinterpret_cast<uint8_t*>(&vert.Color)[3] = alpha;
+                maxSegAlpha = std::max<uint8_t>( maxSegAlpha, reinterpret_cast<uint8_t*>(&vert.Color)[3] );
             }
+
+            // A fully faded-out segment contributes nothing: both blend modes poly-strips use
+            // (ADD and BLEND) scale the source colour by SRC_ALPHA. Dropping it here saves the
+            // rasterizer a screen-filling, completely invisible quad.
+            if ( maxSegAlpha == 0 ) continue;
 #endif
 
             //Convert list of quads to list of triangles
@@ -1569,8 +1576,12 @@ void GothicAPI::CalcFlashMeshes() {
     for ( auto it = FlashVisuals.begin(); it != FlashVisuals.end();) {
         zCFlash* flash = it->first;
         if ( XMVector3Greater(XMVector3LengthSq( flash->GetStartPositionWorld() - camPos ), vVfxRangeSq) &&
-            XMVector3Greater(XMVector3LengthSq( flash->GetEndPositionWorld() - camPos ), vVfxRangeSq) )
+            XMVector3Greater(XMVector3LengthSq( flash->GetEndPositionWorld() - camPos ), vVfxRangeSq) ) {
+            // Out of range this frame - skip it, but keep it alive. Advancing the iterator here is
+            // not optional: this loop only steps at its own tail, so a bare continue hangs the game.
+            ++it;
             continue;
+        }
 
         if ( flash->RenderFlash( polyStrips ) ) {
             zCVob* connectedVob = it->second;
@@ -1641,9 +1652,10 @@ void GothicAPI::CalcFlashMeshes() {
             }
 #endif
 #ifdef BUILD_GOTHIC_2_6_fix
-            //For G2 polyList only contains a single polygon (supposed to be kind of a reference it seems) 
+            //For G2 polyList only contains a single polygon (supposed to be kind of a reference it seems)
             //and vertices should be taken from vertList, while preserving a correct order making up a
             //properly winded polygon
+            uint8_t maxSegAlpha = 0;
             for ( int n = 0; n < 4; n++ ) {
                 //In similar fashion to segment index - vertex index should overflow numVert.
                 int vInd = ((segIndex << 1) + vertOrder[n]) % pStripInst->numVert;
@@ -1660,7 +1672,14 @@ void GothicAPI::CalcFlashMeshes() {
                 float alpha = alphaList[vSegInd];
                 if ( alpha < 0.f ) alpha = 0.f;
                 reinterpret_cast<uint8_t*>( &vert.Color )[3] = alpha;
+                maxSegAlpha = std::max<uint8_t>( maxSegAlpha, reinterpret_cast<uint8_t*>( &vert.Color )[3] );
             }
+
+            // A fully faded-out segment contributes nothing: both blend modes poly-strips use
+            // (ADD and BLEND) scale the source colour by SRC_ALPHA. Dropping it here saves the
+            // rasterizer a screen-filling, completely invisible quad - the barrier's lightning
+            // spans the whole sky dome and spends most of its life fading in and out.
+            if ( maxSegAlpha == 0 ) continue;
 #endif
 
             //Convert list of quads to list of triangles

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1549,9 +1549,7 @@ void GothicAPI::CalcPolyStripMeshes() {
                 maxSegAlpha = std::max<uint8_t>( maxSegAlpha, reinterpret_cast<uint8_t*>(&vert.Color)[3] );
             }
 
-            // A fully faded-out segment contributes nothing: both blend modes poly-strips use
-            // (ADD and BLEND) scale the source colour by SRC_ALPHA. Dropping it here saves the
-            // rasterizer a screen-filling, completely invisible quad.
+            // Both blend modes scale by SRC_ALPHA, so a fully faded-out segment is an invisible quad.
             if ( maxSegAlpha == 0 ) continue;
 #endif
 
@@ -1566,6 +1564,9 @@ void GothicAPI::CalcPolyStripMeshes() {
 void GothicAPI::CalcFlashMeshes() {
     ZoneScopedN( "GothicAPI::CalcFlashMeshes" );
     if ( !RendererState.RendererSettings.DrawParticleEffects || (FlashVisuals.empty() && FrameThunderPolyStrips.empty()) ) {
+        // Only consumer of the list, so drain it even when we draw nothing - otherwise it grows for as
+        // long as the barrier keeps pushing bolts.
+        FrameThunderPolyStrips.clear();
         return;
     }
     
@@ -1577,8 +1578,7 @@ void GothicAPI::CalcFlashMeshes() {
         zCFlash* flash = it->first;
         if ( XMVector3Greater(XMVector3LengthSq( flash->GetStartPositionWorld() - camPos ), vVfxRangeSq) &&
             XMVector3Greater(XMVector3LengthSq( flash->GetEndPositionWorld() - camPos ), vVfxRangeSq) ) {
-            // Out of range this frame - skip it, but keep it alive. Advancing the iterator here is
-            // not optional: this loop only steps at its own tail, so a bare continue hangs the game.
+            // Out of range this frame, but keep it alive. Must advance - the loop only steps at its tail.
             ++it;
             continue;
         }
@@ -1675,10 +1675,8 @@ void GothicAPI::CalcFlashMeshes() {
                 maxSegAlpha = std::max<uint8_t>( maxSegAlpha, reinterpret_cast<uint8_t*>( &vert.Color )[3] );
             }
 
-            // A fully faded-out segment contributes nothing: both blend modes poly-strips use
-            // (ADD and BLEND) scale the source colour by SRC_ALPHA. Dropping it here saves the
-            // rasterizer a screen-filling, completely invisible quad - the barrier's lightning
-            // spans the whole sky dome and spends most of its life fading in and out.
+            // Both blend modes scale by SRC_ALPHA, so a fully faded-out segment is an invisible quad -
+            // and the barrier's sky-wide bolts spend most of their life fading.
             if ( maxSegAlpha == 0 ) continue;
 #endif
 

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -152,6 +152,10 @@ struct GothicMemoryLocations {
     struct zCSkyController_Outdoor {
         static const unsigned int OBJ_ActivezCSkyController = 0x0099AC8C;
 
+        // Stock zCSkyControler_Outdoor::RenderSkyPre. Never called - only compared against the live
+        // controller's vtable slot to detect a derived controller. See HasDerivedRenderSkyPre().
+        static const unsigned int RenderSkyPre = 0x005C0900;
+
         // zCSkyPlanet planets[2] — [0] sun, [1] moon. 0x5F4 is the GOTHIC 2 offset (see the 2_6_fix header);
         // G1's zCSkyControler_Outdoor lays out differently, verified 0x5DC against
         // ZenGin/Gothic_I_Classic/API/zSky.h (`zCSkyPlanet planets[NUM_PLANETS]; // offset 5DCh`), which also

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -123,6 +123,10 @@ struct GothicMemoryLocations {
     struct zCSkyController_Outdoor {
         static const unsigned int OBJ_ActivezCSkyController = 0x0099AC8C;
 
+        // Stock zCSkyControler_Outdoor::RenderSkyPre. Never called - only compared against the live
+        // controller's vtable slot to detect a derived controller. See HasDerivedRenderSkyPre().
+        static const unsigned int RenderSkyPre = 0x005DE790;
+
         // Same MEMBER layout as 1.08k (only code addresses moved between the two G1 builds — note this header
         // shares its Offset_MasterTime/Offset_FarZ/Offset_OutdoorRainFXWeight values with it verbatim), so the
         // planet/fog-scale offsets verified against ZenGin/Gothic_I_Classic/API/zSky.h apply here too.

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -211,6 +211,10 @@ struct GothicMemoryLocations {
     struct zCSkyController_Outdoor {
         static const unsigned int OBJ_ActivezCSkyController = 0x0099AC8C;
 
+        // Stock zCSkyControler_Outdoor::RenderSkyPre. Never called - only compared against the live
+        // controller's vtable slot to detect a derived controller. See HasDerivedRenderSkyPre().
+        static const unsigned int RenderSkyPre = 0x005EA850;
+
         static const unsigned int Offset_Sun = 0x5F4; // First of the two planets
         // Same address as Offset_Sun, named for the array it actually is: zCSkyPlanet planets[2], [0] sun,
         // [1] moon (verified against ZenGin/Gothic_II_Addon/API/zSky_Outdoor.h: `planets[NUM_PLANETS];

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -100,6 +100,9 @@ struct GothicMemoryLocations {
     struct zCSkyController_Outdoor {
         static const unsigned int OBJ_ActivezCSkyController = 0x00B186AC;
 
+        // Not determined for Spacer.exe. 0 means unknown, and HasDerivedRenderSkyPre() then answers false.
+        static const unsigned int RenderSkyPre = 0;
+
         static const unsigned int Offset_Sun = 0x5F4; // First of the two planets
         // zCSkyPlanet planets[2] — [0] sun, [1] moon. Same member layout as the retail 2.6fix build.
         static const unsigned int Offset_Planets = 0x5F4;

--- a/D3D11Engine/HookedFunctions.h
+++ b/D3D11Engine/HookedFunctions.h
@@ -104,6 +104,7 @@ typedef void( __thiscall* zCCamera__Activate )(void*);
 typedef void( __thiscall* zCCamera__UpdateViewport )(void*);
 
 typedef void( __thiscall* zCSkyControler_ClearBackground )(void*, zColor);
+typedef void( __thiscall* zCSkyControler_Outdoor_RenderSkyPre )(void*);
 
 struct zTRndSurfaceDesc;
 
@@ -221,6 +222,7 @@ struct HookedFunctionInfo {
 #endif
     zCInput_Win32__GetKey original_zCInput_Win32__GetKey = reinterpret_cast<zCInput_Win32__GetKey>(GothicMemoryLocations::zCInput_Win32::GetKey);
     zCSkyControler_ClearBackground original_zCSkyControler_ClearBackground = reinterpret_cast<zCSkyControler_ClearBackground>(GothicMemoryLocations::zCSkyController::ClearBackground);
+    zCSkyControler_Outdoor_RenderSkyPre original_zCSkyControler_Outdoor_RenderSkyPre = reinterpret_cast<zCSkyControler_Outdoor_RenderSkyPre>(GothicMemoryLocations::zCSkyController_Outdoor::RenderSkyPre);
     //zCModelPrototypeLoadModelASC original_zCModelPrototypeLoadModelASC = reinterpret_cast<zCModelPrototypeLoadModelASC>(GothicMemoryLocations::zCModelPrototype::LoadModelASC);
     //zCModelPrototypeReadMeshAndTreeMSB original_zCModelPrototypeReadMeshAndTreeMSB = reinterpret_cast<zCModelPrototypeReadMeshAndTreeMSB>(GothicMemoryLocations::zCModelPrototype::ReadMeshAndTreeMSB);
 

--- a/D3D11Engine/Shaders/D3D12/DoF.hlsl
+++ b/D3D11Engine/Shaders/D3D12/DoF.hlsl
@@ -1,0 +1,286 @@
+//--------------------------------------------------------------------------------------
+// Depth of Field (D3D12 port of Shaders/CS_PFX_DoF_FocusResolve.hlsl, CS_PFX_DoF.hlsl and
+// CS_PFX_DoF_Composite.hlsl — the FL11+ compute path D3D11PFX_DepthOfField::RenderCS drives).
+//
+// The MATHS is unchanged from those three shaders: the same 13-tap centre-weighted focus disc with
+// the same adaptive temporal smoothing, the same 48-tap spiral bokeh kernel with luminance boost and
+// asymmetric foreground rejection (or the 16-tap Gaussian when DOF_GAUSS_BLUR is defined), and the
+// same 5-tap min-CoC erosion in the composite. What changed is the plumbing:
+//
+//  1. BINDLESS. The t0..t3 / u0 bindings become SM6.6 ResourceDescriptorHeap[] fetches off root
+//     constants, matching the rest of this backend (TAA, XeGTAO, SMAA, sharpen).
+//  2. ONE ROOT SIGNATURE, ONE CONSTANT BLOCK. All three passes share the 16-root-constant DoFCB
+//     below; each uses the subset it needs. Unused indices are simply not read.
+//  3. RESOLUTIONS ARE PASSED, NOT QUERIED. The D3D11 shaders call GetDimensions because they had no
+//     constants to spare; here FullRes/OutRes are in the root block.
+//  4. THREE ENTRY POINTS IN ONE FILE instead of three files, since they share the constant block.
+//
+// LinearizeDepth is inlined rather than pulled from ../DepthReconstruction.h — same convention as
+// TAAResolve.hlsl and SSAO.hlsl on this backend. Reversed-Z with an infinite far plane and NearClip
+// pinned to 1, so depth == 1 / viewZ.
+//--------------------------------------------------------------------------------------
+
+cbuffer DoFCB : register( b0 )
+{
+    float DoF_FocusRange;      // range around the focus point that stays sharp (RendererSettings.DoFFocusRange)
+    float DoF_BokehRadius;     // blur disc size in full-res pixels
+    float DoF_MaxBlur;         // hard cap on the above
+    uint  DoF_FocusValid;      // 0 = the previous-focus texture holds no history yet (snap instead of blending)
+
+    uint  DoF_SceneIndex;      // SRV: full-res HDR scene colour
+    uint  DoF_DepthIndex;      // SRV: full-res hardware depth (R32_FLOAT view)
+    uint  DoF_PrevFocusIndex;  // SRV: 1x1 focus distance from the previous frame
+    uint  DoF_FocusIndex;      // SRV: 1x1 focus distance for THIS frame (written by CSFocusResolve)
+
+    uint  DoF_BlurIndex;       // SRV: half-res bokeh result (rgb = blur, a = CoC) — composite input
+    uint  DoF_FocusUavIndex;   // UAV: CSFocusResolve's 1x1 output
+    uint  DoF_OutIndex;        // UAV: CSBlur's half-res target / CSComposite's full-res target
+    uint  DoF_Pad;
+
+    float DoF_FullResX;        // full-res scene/depth dimensions
+    float DoF_FullResY;
+    float DoF_OutResX;         // dispatch/output dimensions of the pass being run
+    float DoF_OutResY;
+};
+
+SamplerState SS_LinearClamp : register( s0 );
+
+float LinearizeDepth( float d )
+{
+    return rcp( max( d, 1e-8f ) );
+}
+
+float ComputeCoC( float linearDepth, float focusDepth )
+{
+    return saturate( ( linearDepth - focusDepth ) / DoF_FocusRange );
+}
+
+//--------------------------------------------------------------------------------------
+// Pass 0 — focus resolve. Samples depth across a centre-weighted disc (~12% of the screen: "what is
+// the player looking at") and temporally smooths it into a 1x1 R32_FLOAT texture.
+//--------------------------------------------------------------------------------------
+[numthreads(1, 1, 1)]
+void CSFocusResolve( uint3 DTid : SV_DispatchThreadID )
+{
+    static const float2 offsets[13] = {
+        float2( 0.000,  0.000),
+        float2(-0.035,  0.000), float2( 0.035,  0.000),
+        float2( 0.000, -0.035), float2( 0.000,  0.035),
+        float2(-0.025, -0.025), float2( 0.025, -0.025),
+        float2(-0.025,  0.025), float2( 0.025,  0.025),
+        float2(-0.060,  0.000), float2( 0.060,  0.000),
+        float2( 0.000, -0.060), float2( 0.000,  0.060),
+    };
+
+    static const float weights[13] = {
+        0.20,
+        0.08, 0.08,
+        0.08, 0.08,
+        0.06, 0.06,
+        0.06, 0.06,
+        0.04, 0.04,
+        0.04, 0.04,
+    };
+
+    Texture2D<float>   depthTex = ResourceDescriptorHeap[DoF_DepthIndex];
+    Texture2D<float>   prevTex  = ResourceDescriptorHeap[DoF_PrevFocusIndex];
+    RWTexture2D<float> outFocus = ResourceDescriptorHeap[DoF_FocusUavIndex];
+
+    float targetDepth = 0.0;
+    float totalWeight = 0.0;
+    for ( int i = 0; i < 13; i++ )
+    {
+        float2 uv = float2( 0.5, 0.5 ) + offsets[i];
+        float d = depthTex.SampleLevel( SS_LinearClamp, uv, 0 );
+        targetDepth += LinearizeDepth( d ) * weights[i];
+        totalWeight += weights[i];
+    }
+    targetDepth /= totalWeight;
+
+    float prevFocus = prevTex.SampleLevel( SS_LinearClamp, float2( 0.5, 0.5 ), 0 );
+
+    // No usable history: the very first frame after the textures were created (their contents are
+    // undefined, hence the explicit DoF_FocusValid flag rather than trusting a <= 0 test alone), or a
+    // frame in which the previous value was never written.
+    if ( DoF_FocusValid == 0 || prevFocus <= 0.0 )
+    {
+        outFocus[uint2(0, 0)] = targetDepth;
+        return;
+    }
+
+    // Adaptive smoothing: creep while the focus target is stable, snap harder when it jumps.
+    float relDiff = abs( targetDepth - prevFocus ) / max( prevFocus, 1.0 );
+    float smoothing = lerp( 0.015, 0.20, saturate( relDiff * 2.0 ) );
+
+    outFocus[uint2(0, 0)] = lerp( prevFocus, targetDepth, smoothing );
+}
+
+//--------------------------------------------------------------------------------------
+// Pass 1 — half-res bokeh (or Gaussian) blur. Writes rgb = blurred colour, a = centre CoC.
+//--------------------------------------------------------------------------------------
+static const int SAMPLE_COUNT = 48;
+
+float2 GetSpiralSample( int index, int count )
+{
+    float r = sqrt( ( float(index) + 0.5 ) / float(count) );
+    float theta = float(index) * 2.39996323;
+    return float2( r * cos( theta ), r * sin( theta ) );
+}
+
+// Point-sample (nearest texel) the centre depth. This pass runs at half-res, so a half-res texel
+// centre falls between full-res depth texels; bilinear filtering would blend foreground and
+// background there into a phantom depth, skewing the centre CoC at silhouettes. Load has no address
+// clamping, so clamp to the depth texture extent.
+// (The spiral taps stay bilinear — they feed a blur and don't need per-texel precision.)
+float SampleCenterDepthPoint( Texture2D<float> depthTex, float2 uv )
+{
+    int2 dim = int2( DoF_FullResX, DoF_FullResY );
+    int2 px = clamp( int2( uv * float2( dim ) ), int2( 0, 0 ), dim - int2( 1, 1 ) );
+    return depthTex.Load( int3( px, 0 ) );
+}
+
+[numthreads(8, 8, 1)]
+void CSBlur( uint3 DTid : SV_DispatchThreadID )
+{
+    const float2 outSize = float2( DoF_OutResX, DoF_OutResY );
+    if ( DTid.x >= (uint)DoF_OutResX || DTid.y >= (uint)DoF_OutResY )
+        return;
+
+    Texture2D<float4>   sceneTex  = ResourceDescriptorHeap[DoF_SceneIndex];
+    Texture2D<float>    depthTex  = ResourceDescriptorHeap[DoF_DepthIndex];
+    Texture2D<float>    focusTex  = ResourceDescriptorHeap[DoF_FocusIndex];
+    RWTexture2D<float4> outBlur   = ResourceDescriptorHeap[DoF_OutIndex];
+
+    float2 texcoord = ( float2( DTid.xy ) + 0.5 ) / outSize;
+
+    // Texel size of the FULL-res scene: the sample offsets are in full-res pixels (DoF_BokehRadius),
+    // even though this pass rasterizes at half res.
+    float2 texelSize = 1.0 / float2( DoF_FullResX, DoF_FullResY );
+
+    float focusDepth = focusTex.SampleLevel( SS_LinearClamp, float2( 0.5, 0.5 ), 0 );
+
+    float centerDepth = SampleCenterDepthPoint( depthTex, texcoord );
+    float centerLinear = LinearizeDepth( centerDepth );
+    float centerCoC = ComputeCoC( centerLinear, focusDepth );
+
+    float3 centerColor = sceneTex.SampleLevel( SS_LinearClamp, texcoord, 0 ).rgb;
+
+    // Early out: pass through sharp pixel
+    if ( centerCoC < 0.01 )
+    {
+        outBlur[DTid.xy] = float4( centerColor, 0.0 );
+        return;
+    }
+
+    float blurRadius = min( centerCoC * DoF_BokehRadius, DoF_MaxBlur );
+
+#ifdef DOF_GAUSS_BLUR
+    // --- Simple Gaussian blur (16 taps) ---
+    // Uses a radial Gaussian kernel with exp(-r^2 * 3) weights. Much cheaper than the bokeh path; no
+    // highlight boost or foreground rejection — just a smooth, uniform blur.
+    static const int GAUSS_SAMPLE_COUNT = 16;
+
+    float3 colorAccum = 0.0;
+    float weightAccum = 0.0;
+
+    [unroll]
+    for ( int i = 0; i < GAUSS_SAMPLE_COUNT; i++ )
+    {
+        float2 offset = GetSpiralSample( i, GAUSS_SAMPLE_COUNT );
+        float2 sampleUV = texcoord + offset * blurRadius * texelSize;
+
+        float3 sampleColor = sceneTex.SampleLevel( SS_LinearClamp, sampleUV, 0 ).rgb;
+
+        float r2 = dot( offset, offset );
+        float weight = exp( -r2 * 3.0 );
+
+        colorAccum += sampleColor * weight;
+        weightAccum += weight;
+    }
+#else
+    // --- Bokeh spiral blur (48 taps) ---
+    // Seed the accumulator with the centre pixel so that if all 48 spiral samples are
+    // foreground-rejected (e.g. background visible through a leaf gap), the result falls back to the
+    // centre colour instead of producing black. Weight uses the same luminance-boost formula applied
+    // to every spiral sample.
+    float centerLum = dot( centerColor, float3( 0.2126, 0.7152, 0.0722 ) );
+    float3 colorAccum = centerColor * ( 1.0 + centerLum * 2.0 );
+    float weightAccum = 1.0 + centerLum * 2.0;
+
+    [unroll]
+    for ( int i = 0; i < SAMPLE_COUNT; i++ )
+    {
+        float2 offset = GetSpiralSample( i, SAMPLE_COUNT );
+        float2 sampleUV = texcoord + offset * blurRadius * texelSize;
+
+        float3 sampleColor = sceneTex.SampleLevel( SS_LinearClamp, sampleUV, 0 ).rgb;
+        float sampleDepth = depthTex.SampleLevel( SS_LinearClamp, sampleUV, 0 );
+        float sampleLinear = LinearizeDepth( sampleDepth );
+        float sampleCoC = ComputeCoC( sampleLinear, focusDepth );
+
+        float weight = ( sampleCoC >= length( offset ) * centerCoC ) ? 1.0 : sampleCoC;
+
+        // Asymmetric foreground rejection
+        float depthMargin = max( centerLinear * 0.05, 5.0 );
+        float foregroundReject = saturate( ( sampleLinear - centerLinear + depthMargin ) / depthMargin );
+        weight *= foregroundReject;
+
+        float luminance = dot( sampleColor, float3( 0.2126, 0.7152, 0.0722 ) );
+        weight *= 1.0 + luminance * 2.0;
+
+        colorAccum += sampleColor * weight;
+        weightAccum += weight;
+    }
+#endif
+
+    colorAccum /= max( weightAccum, 0.001 );
+
+    outBlur[DTid.xy] = float4( colorAccum, centerCoC );
+}
+
+//--------------------------------------------------------------------------------------
+// Pass 2 — full-res composite. Blends the sharp scene against the bilinearly-upsampled half-res
+// bokeh by per-pixel CoC, eroded by one pixel at depth discontinuities.
+//--------------------------------------------------------------------------------------
+[numthreads(8, 8, 1)]
+void CSComposite( uint3 DTid : SV_DispatchThreadID )
+{
+    const float2 outSize = float2( DoF_OutResX, DoF_OutResY );
+    if ( DTid.x >= (uint)DoF_OutResX || DTid.y >= (uint)DoF_OutResY )
+        return;
+
+    Texture2D<float4>   sceneTex = ResourceDescriptorHeap[DoF_SceneIndex];
+    Texture2D<float4>   blurTex  = ResourceDescriptorHeap[DoF_BlurIndex];
+    Texture2D<float>    depthTex = ResourceDescriptorHeap[DoF_DepthIndex];
+    Texture2D<float>    focusTex = ResourceDescriptorHeap[DoF_FocusIndex];
+    RWTexture2D<float4> outComp  = ResourceDescriptorHeap[DoF_OutIndex];
+
+    float2 texcoord = ( float2( DTid.xy ) + 0.5 ) / outSize;
+
+    float3 sharpColor = sceneTex.SampleLevel( SS_LinearClamp, texcoord, 0 ).rgb;
+
+    float focusDepth = focusTex.SampleLevel( SS_LinearClamp, float2( 0.5, 0.5 ), 0 );
+
+    // Compute CoC at centre and 4 neighbours, use the minimum. This erodes the blur zone by one pixel
+    // at depth discontinuities, which is what keeps a sharp foreground from bleeding outwards.
+    float2 dtexel = 1.0 / float2( DoF_FullResX, DoF_FullResY );
+
+    float cocC = ComputeCoC( LinearizeDepth( depthTex.SampleLevel( SS_LinearClamp, texcoord, 0 ) ), focusDepth );
+    float cocL = ComputeCoC( LinearizeDepth( depthTex.SampleLevel( SS_LinearClamp, texcoord + float2( -dtexel.x, 0 ), 0 ) ), focusDepth );
+    float cocR = ComputeCoC( LinearizeDepth( depthTex.SampleLevel( SS_LinearClamp, texcoord + float2(  dtexel.x, 0 ), 0 ) ), focusDepth );
+    float cocU = ComputeCoC( LinearizeDepth( depthTex.SampleLevel( SS_LinearClamp, texcoord + float2( 0, -dtexel.y ), 0 ) ), focusDepth );
+    float cocD = ComputeCoC( LinearizeDepth( depthTex.SampleLevel( SS_LinearClamp, texcoord + float2( 0,  dtexel.y ), 0 ) ), focusDepth );
+
+    float minCoC = min( min( cocC, cocL ), min( cocR, min( cocU, cocD ) ) );
+
+    // Bilinear-upsampled half-res bokeh blur
+    float4 blurSample = blurTex.SampleLevel( SS_LinearClamp, texcoord, 0 );
+
+    float blendFactor = smoothstep( 0.0, 1.0, minCoC );
+    float3 finalColor = lerp( sharpColor, blurSample.rgb, blendFactor );
+
+    // Alpha: the scene colour target's alpha is not read by anything downstream on this backend
+    // (bloom, luminance reduce and the tonemap all take .rgb), and the D3D11 composite writes 1.0
+    // here too.
+    outComp[DTid.xy] = float4( finalColor, 1.0 );
+}

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -47,6 +47,112 @@ namespace {
             D3D11VertexBuffer::U_IMMUTABLE );
     }
 
+    /** ZENGIN's zPMINDEX_NONE: terminator of a WedgeMap collapse chain. */
+    constexpr VERTEX_INDEX PM_INDEX_NONE = 0xFFFF;
+
+    /** Builds a reduced index list for one sub-mesh out of ZENGIN's own progressive-mesh data, at
+        SHADOW_LOD_VERTEX_FRACTION of that mesh's collapse sequence.
+
+        The .MRM/.MDM formats store a Hoppe-style edge collapse: VertexUpdates[n] gives the number of
+        triangles and wedges still live once n vertex positions are active, and WedgeMap chains every
+        dead wedge onto the wedge it collapsed into. Rebuilding a level is therefore just "keep the first
+        numTri triangles, and pull each of their wedge indices down below numWedge" - which is exactly
+        what zCProgMeshProto::RenderStaticLOD does per frame in the original engine. Because a collapse
+        only ever redirects indices onto wedges that already exist, the result indexes the caller's
+        unchanged vertex buffer; it is a second index buffer, not a second mesh. Winding matches the
+        caller's (wedge 2,1,0).
+
+        Returns false when the visual ships no LOD data (~2% of the vanilla .MRMs), when the sub-mesh is
+        too small to be worth a buffer, or when the collapse data does not check out. */
+    bool BuildProgMeshLodIndices( zCSubMesh* submesh, std::vector<VERTEX_INDEX>& outIndices ) {
+        outIndices.clear();
+        if ( !submesh ) {
+            return false;
+        }
+
+        const int numUpdates = submesh->VertexUpdates.NumInArray;
+        const int numWedges = submesh->WedgeList.NumInArray;
+        const int numTris = submesh->TriList.NumInArray;
+
+        // numUpdates <= 1 is ZENGIN's own "no LOD" marker (zCProgMeshProto::HasLOD).
+        if ( numUpdates <= 1 || numWedges <= 0 || numTris < SHADOW_LOD_MIN_TRIANGLES ) {
+            return false;
+        }
+        if ( !submesh->VertexUpdates.Array || !submesh->WedgeMap.Array
+            || submesh->WedgeMap.NumInArray < numWedges ) {
+            return false;
+        }
+
+        int posIndex = static_cast<int>(SHADOW_LOD_VERTEX_FRACTION * (numUpdates - 1));
+        if ( posIndex < 0 ) posIndex = 0;
+        if ( posIndex > numUpdates - 1 ) posIndex = numUpdates - 1;
+        const zTPMVertexUpdate& update = submesh->VertexUpdates.Array[posIndex];
+        const int lodTris = update.numNewTri;
+        const int lodWedges = update.numNewWedge;
+
+        // Collapsed to nothing, or no saving to be had - either way there is no point in a second buffer.
+        if ( lodTris <= 0 || lodTris >= numTris || lodWedges <= 0 || lodWedges > numWedges ) {
+            return false;
+        }
+
+        // Wedges below lodWedges survive as themselves; the rest follow their collapse chain down.
+        static thread_local std::vector<VERTEX_INDEX> wedgeRemap;
+        wedgeRemap.resize( numWedges );
+        for ( int i = 0; i < lodWedges; ++i ) {
+            wedgeRemap[i] = static_cast<VERTEX_INDEX>(i);
+        }
+        for ( int i = lodWedges; i < numWedges; ++i ) {
+            int wedge = i;
+            int guard = 0;
+            while ( wedge >= lodWedges ) {
+                const VERTEX_INDEX next = submesh->WedgeMap.Array[wedge];
+                // A chain that terminates, loops, or leaves the array means the collapse data does not
+                // describe this mesh - drop the whole level rather than emit indices we can't justify.
+                if ( next == PM_INDEX_NONE || next >= numWedges || ++guard > numWedges ) {
+                    return false;
+                }
+                wedge = next;
+            }
+            wedgeRemap[i] = static_cast<VERTEX_INDEX>(wedge);
+        }
+
+        outIndices.reserve( static_cast<size_t>(lodTris) * 3 );
+        for ( int t = 0; t < lodTris; ++t ) {
+            const zTPMTriangle& tri = submesh->TriList.Array[t];
+            if ( tri.wedge[0] >= numWedges || tri.wedge[1] >= numWedges || tri.wedge[2] >= numWedges ) {
+                return false;
+            }
+
+            const VERTEX_INDEX a = wedgeRemap[tri.wedge[2]];
+            const VERTEX_INDEX b = wedgeRemap[tri.wedge[1]];
+            const VERTEX_INDEX c = wedgeRemap[tri.wedge[0]];
+
+            // Triangles whose corners collapsed onto each other have no area left. ZENGIN still submits
+            // them; we drop them, which is free silhouette-neutral savings in a depth-only pass.
+            if ( a == b || b == c || a == c ) {
+                continue;
+            }
+
+            outIndices.emplace_back( a );
+            outIndices.emplace_back( b );
+            outIndices.emplace_back( c );
+        }
+
+        return !outIndices.empty();
+    }
+
+    void CreateLodIndexBuffer( MeshInfo* meshInfo ) {
+        if ( !meshInfo || meshInfo->LodIndices.empty() ) {
+            return;
+        }
+
+        Engine::GraphicsEngine->CreateVertexBuffer( meshInfo->MeshLodIndexBuffer );
+        meshInfo->MeshLodIndexBuffer->Init( meshInfo->LodIndices.data(),
+            meshInfo->LodIndices.size() * sizeof( VERTEX_INDEX ),
+            D3D11VertexBuffer::B_INDEXBUFFER,
+            D3D11VertexBuffer::U_IMMUTABLE );
+    }
+
     /** Builds a position-only (float3) companion buffer in the same vertex ordering as the source
         interleaved vertices. Bound for opaque depth/shadow passes; indices remain valid because the
         ordering matches the mesh/shadow index buffers built from the same array. */
@@ -1899,6 +2005,11 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
             // Init and fill it
             mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_DYNAMIC, D3D11VertexBuffer::CA_WRITE );
         } else {
+            // Reduced caster geometry for the distant shadow cascades, rebuilt from this sub-mesh's own
+            // progressive-mesh data. Built here because it is expressed in the pre-optimization wedge
+            // numbering; OptimizeVertices below carries it through the vertex remap it applies.
+            BuildProgMeshLodIndices( s, mi->LodIndices );
+
             // Optimize faces
             mi->MeshVertexBuffer->OptimizeFaces(&mi->Indices[0],
                 reinterpret_cast<byte*>(&mi->Vertices[0]),
@@ -1912,16 +2023,19 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
                 mi->Indices.size(),
                 mi->Vertices.size(),
                 sizeof( ExVertexStruct ),
-                &mi->ShadowIndices );
+                &mi->ShadowIndices,
+                &mi->LodIndices );
 
             // Init and fill it
             mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
         }
         mi->MeshIndexBuffer->Init( &mi->Indices[0], mi->Indices.size() * sizeof( VERTEX_INDEX ), D3D11VertexBuffer::B_INDEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
         CreateShadowIndexBuffer( mi );
+        CreateLodIndexBuffer( mi );
 
         Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize += mi->Vertices.size() * sizeof( ExVertexStruct );
         Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize += mi->Indices.size() * sizeof( VERTEX_INDEX );
+        Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize += mi->LodIndices.size() * sizeof( VERTEX_INDEX );
 
         zCMaterial* mat = s->Material;
         meshInfo->Meshes[mat].emplace_back( mi );

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -32,6 +32,14 @@ constexpr float SHADOW_LOD_VERTEX_FRACTION = 0.35f;
     the scarce resource here, not GPU time. */
 constexpr int SHADOW_LOD_MIN_TRIANGLES = 96;
 
+/** First shadow cascade that may draw the baked LOD index buffer instead of the full-detail (but still
+    position-welded) shadow indices. An edge collapse MOVES the caster surface, so a cascade whose depth
+    bias is smaller than that deviation self-shadows the full-detail surface it is casting onto - the
+    failure mode is building facades going black as the camera tilts up. Cascades 0 and 1 are too tightly
+    biased for that, so the LOD only starts at 2.
+    NOTE: D3D11's GetShadowAwareIndexBuffer still carries its own FIRST_LOD_SHADOW_CASCADE = 1. */
+constexpr int SHADOW_LOD_FIRST_CASCADE = 2;
+
 class zCProgMeshProto;
 class zCModel;
 class zCModelPrototype;

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -16,6 +16,22 @@ const float4 DEFAULT_LIGHTMAP_POLY_COLOR_F = float4( 0.05f, 0.05f, 0.05f, 0.05f 
 const DWORD DEFAULT_LIGHTMAP_POLY_COLOR = DEFAULT_LIGHTMAP_POLY_COLOR_F.ToDWORD();
 const float3 DEFAULT_INDOOR_VOB_AMBIENT = float3( 0.15f, 0.15f, 0.15f );
 
+/** Strength of the progressive-mesh LOD baked for distant shadow cascades, as the fraction of a
+    visual's active vertices kept: 1.0f is full detail, 0.25f a quarter of the vertices. ZENGIN meshes
+    ship Hoppe-style edge-collapse data (zCSubMesh::WedgeMap + VertexUpdates, ~98% of the vanilla .MRMs
+    have it), so this picks one entry out of that collapse sequence and bakes the resulting triangle set
+    into a second index buffer over the unchanged vertex buffer. Measured over Meshes.vdf +
+    Meshes_Addon.vdf: 0.75f keeps ~72% of the triangles, 0.5f ~45%, 0.25f ~19%, 0.1f ~6%.
+
+    Compile-time on purpose: the buffers are baked once at visual-extraction time, so changing this at
+    runtime would mean re-extracting every loaded visual. */
+constexpr float SHADOW_LOD_VERTEX_FRACTION = 0.35f;
+
+/** Sub-meshes below this triangle count do not get a LOD index buffer at all. Reducing a 40-triangle
+    crate saves nothing worth measuring, while every extra buffer costs 32-bit address space - which is
+    the scarce resource here, not GPU time. */
+constexpr int SHADOW_LOD_MIN_TRIANGLES = 96;
+
 class zCProgMeshProto;
 class zCModel;
 class zCModelPrototype;

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -32,11 +32,9 @@ constexpr float SHADOW_LOD_VERTEX_FRACTION = 0.35f;
     the scarce resource here, not GPU time. */
 constexpr int SHADOW_LOD_MIN_TRIANGLES = 96;
 
-/** First shadow cascade that may draw the baked LOD index buffer instead of the full-detail (but still
-    position-welded) shadow indices. An edge collapse MOVES the caster surface, so a cascade whose depth
-    bias is smaller than that deviation self-shadows the full-detail surface it is casting onto - the
-    failure mode is building facades going black as the camera tilts up. Cascades 0 and 1 are too tightly
-    biased for that, so the LOD only starts at 2.
+/** First shadow cascade that may use the baked LOD index buffer. An edge collapse moves the caster
+    surface, so a cascade biased tighter than that deviation self-shadows itself black (building facades
+    going dark as the camera tilts up) - cascades 0 and 1 are too tight for it.
     NOTE: D3D11's GetShadowAwareIndexBuffer still carries its own FIRST_LOD_SHADOW_CASCADE = 1. */
 constexpr int SHADOW_LOD_FIRST_CASCADE = 2;
 

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -106,6 +106,7 @@ struct MeshInfo {
     GfxVertexBuffer* GetMeshPositionBuffer() const { return MeshPositionBuffer.get(); }
     GfxVertexBuffer* GetMeshIndexBuffer() const { return MeshIndexBuffer.get(); }
     GfxVertexBuffer* GetMeshShadowIndexBuffer() const { return MeshShadowIndexBuffer.get(); }
+    GfxVertexBuffer* GetMeshLodIndexBuffer() const { return MeshLodIndexBuffer.get(); }
 
     std::unique_ptr<GfxVertexBuffer> MeshVertexBuffer;
     // Optional position-only (float3, 12 bytes) copy of MeshVertexBuffer, in the same vertex
@@ -114,9 +115,16 @@ struct MeshInfo {
     std::unique_ptr<GfxVertexBuffer> MeshPositionBuffer;
     std::unique_ptr<GfxVertexBuffer> MeshIndexBuffer;
     std::unique_ptr<GfxVertexBuffer> MeshShadowIndexBuffer;
+    // Optional reduced index buffer for distant shadow cascades, baked from ZENGIN's own progressive-mesh
+    // data (zCSubMesh::WedgeMap/VertexUpdates) at SHADOW_LOD_VERTEX_FRACTION. Indexes the very same
+    // MeshVertexBuffer as the other two - a collapse only ever redirects indices onto surviving vertices,
+    // it never produces new ones. Only populated for meshes that actually ship LOD data and clear the
+    // SHADOW_LOD_MIN_TRIANGLES gate, so it is nullptr far more often than not.
+    std::unique_ptr<GfxVertexBuffer> MeshLodIndexBuffer;
     std::vector<ExVertexStruct> Vertices;
     std::vector<VERTEX_INDEX> Indices;
     std::vector<VERTEX_INDEX> ShadowIndices;
+    std::vector<VERTEX_INDEX> LodIndices;
 
     // Offset in wrapped world mesh
     unsigned int BaseIndexLocation;

--- a/D3D11Engine/zCSkyController_Outdoor.h
+++ b/D3D11Engine/zCSkyController_Outdoor.h
@@ -148,7 +148,26 @@ public:
 
         if ( HookedFunctions::OriginalFunctions.original_zCSkyControler_ClearBackground )
             DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCSkyControler_ClearBackground, &zCSkyController_Outdoor::hooked_zCSkyControler_ClearBackground  );
+
+        if constexpr ( GothicMemoryLocations::zCSkyController_Outdoor::RenderSkyPre != 0 )
+            DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCSkyControler_Outdoor_RenderSkyPre, &zCSkyController_Outdoor::hooked_RenderSkyPre );
     }
+
+    /** Set while we call a barrier controller's RenderSkyPre override just to get the barrier out of it.
+        The override always renders the stock sky first, which would paint Gothic's fixed-function sky over
+        our atmospheric-scattering dome; the hook below drops that half of the call. */
+    static inline bool SuppressStockSky = false;
+
+    static void __fastcall hooked_RenderSkyPre( void* thisPtr, void* ) {
+        if ( SuppressStockSky ) return;
+        HookedFunctions::OriginalFunctions.original_zCSkyControler_Outdoor_RenderSkyPre( thisPtr );
+    }
+
+    /** RAII for SuppressStockSky. */
+    struct ScopedBarrierRender {
+        ScopedBarrierRender() { SuppressStockSky = true; }
+        ~ScopedBarrierRender() { SuppressStockSky = false; }
+    };
 
     static void __fastcall hooked_zCSkyControler_ClearBackground( void* thisPtr, void* vtbl, zColor color ) {
         // Prevent the skycontroller from clearing the backbuffer/depth buffer.

--- a/D3D11Engine/zCSkyController_Outdoor.h
+++ b/D3D11Engine/zCSkyController_Outdoor.h
@@ -160,6 +160,32 @@ public:
         HookedFunctions::OriginalFunctions.original_zCSkyControler_ClearBackground( thisPtr, color );
     }
 
+    /** True when a derived class overrides RenderSkyPre - normally oCSkyControler_Barrier, which vanilla
+        oCWorld installs in every world of both games. Lets us skip the barrier path entirely if a mod
+        installs a plain controller instead. */
+    bool HasDerivedRenderSkyPre() {
+        constexpr unsigned int stockRenderSkyPre = GothicMemoryLocations::zCSkyController_Outdoor::RenderSkyPre;
+        if constexpr ( stockRenderSkyPre == 0 ) {
+            return false; // address unknown for this build - assume stock and change nothing
+        } else {
+            DWORD* vtbl = reinterpret_cast<DWORD*>(*reinterpret_cast<DWORD*>(this));
+            return vtbl[GothicMemoryLocations::zCSkyController::VTBL_RenderSkyPre] != stockRenderSkyPre;
+        }
+    }
+
+    /** Whether calling the RenderSkyPre override is worth it. The override's own guards decide if the
+        barrier draws; we only skip the call when sky effects are off altogether. */
+    bool WantsBarrierRender() {
+#ifdef BUILD_GOTHIC_1_08k
+        return true;
+#else
+#ifdef OPT_MANAGE_SKY_EFFECTS_SUPPORTED
+        if ( !GetSkyEffectsEnabled() ) return false;
+#endif
+        return true;
+#endif
+    }
+
     /** Updates the rain-weight and sound-effects */
     void ProcessRainFX() {
         reinterpret_cast<void( __fastcall* )( zCSkyController_Outdoor* )>


### PR DESCRIPTION
- fixes #433 (at least it didnt appear anymore)
- Ensure better compatibility with something like zBarrier plugin
  - ensure we dont allow SkyControler_Outdoor::PreRenderSky if we have atmospheric scattering enabled.
- Adjust shadow cascade lambda values to a more lenient `0.7`. a bit less detail in general, but more detail in the distance, plays well with the introduced LOD by putting the final cascade further away from players eyes. (there will still be pop-in for LOD shadow meshes)
- fix dx11 missing motion vectors for Heads/weapons
- feat: dx12 now also has Depth of Field