### PR TITLE
fix crash in odyssee, which seems to equip/unequip/equip armors.

### DIFF
--- a/D3D11Engine/CGameManager.h
+++ b/D3D11Engine/CGameManager.h
@@ -73,12 +73,51 @@ public:
         // DetourAttachTyped( &original_CGameManagerWrite_Savegame, hooked_Write_Savegame  );
 
         HookRunLoopFramePacing();
+        DisableApplySettingsTexMaxSizeRefresh();
 #elif defined(BUILD_GOTHIC_1_CLASSIC)
         // BUILD_1_12F (the cancelled sequel G1 build) isn't patched here yet: the call-site
         // address hasn't been verified against that binary. D3D11GraphicsEngine falls
         // back to pacing from OnBeginFrame/OnEndFrame in that case.
         HookRunLoopFramePacing();
+        DisableApplySettingsTexMaxSizeRefresh();
 #endif
+    }
+
+    /** Kills the "Textur-Detail" block of CGameManager::ApplySomeSettings().
+
+        Vanilla derives a texture size from the texDetailIndex slider (32/64/128/256/512/16384
+        - nothing in between), compares it against the zTexMaxSize option and, on any mismatch,
+        does zCTexture::RefreshTexMaxSize() + zresMan->PurgeCaches(zCTexture) - throwing away
+        every cached texture. Our zCOption::ReadInt hook forces zTexMaxSize to the renderer's
+        own textureMaxSize, so the two sides can never agree for a size ZENGIN cannot express
+        (1024, 2048, ...) and every menu close purges the whole texture cache. zCOption.h's
+        texDetailIndex ReadReal hack exists only to paper over that.
+
+        Texture quality is ours now (settings window -> GothicAPI::UpdateTextureMaxSize, which
+        refreshes and purges when the size actually changes), so the vanilla path has nothing
+        left to do: we make its "nothing changed" branch unconditional. Patching the `CMP
+        ECX,EDI` / `JZ skip` pair (8 bytes) with `JMP skip` + 3 NOPs jumps straight past the
+        refresh, the purge and the zERR_MESSAGE that follow it.
+
+        Stage two - should ZENGIN's slider ever need to drive texture quality again - is to put
+        a naked trampoline here instead that compares zCTexture's live max size against
+        RendererSettings.textureMaxSize and re-joins at ApplySettingsTexMaxSizeCheck + 8. */
+    static void DisableApplySettingsTexMaxSizeRefresh() {
+        const unsigned int checkAddr = GothicMemoryLocations::CGameManager::ApplySettingsTexMaxSizeCheck;
+        const unsigned int skipAddr = GothicMemoryLocations::CGameManager::ApplySettingsTexMaxSizeSkip;
+        if ( !checkAddr || !skipAddr )
+            return; // Not located in this binary - leave the vanilla behavior alone.
+
+        // CMP ECX,EDI ; JZ rel32 - bail out rather than corrupt code if this isn't the build we mapped.
+        static const unsigned char expected[] = { 0x3B, 0xCF, 0x0F, 0x84 };
+        if ( memcmp( reinterpret_cast<const void*>(checkAddr), expected, sizeof( expected ) ) != 0 ) {
+            LogWarn() << "CGameManager::ApplySomeSettings texture-detail check not found at "
+                << std::hex << checkAddr << " - texture cache will still be purged when closing the menu";
+            return;
+        }
+
+        PatchJMP( checkAddr, skipAddr );
+        PatchAddr( checkAddr + 5, "\x90\x90\x90" );
     }
 
     static void HookRunLoopFramePacing() {

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1148,6 +1148,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="zCOption.h" />
     <ClInclude Include="zCParser.h" />
     <ClInclude Include="zCParticleFX.h" />
+    <ClInclude Include="zCPathSearch.h" />
     <ClInclude Include="zCPolygon.h" />
     <ClInclude Include="zCPolyStrip.h" />
     <ClInclude Include="zCProgMeshProto.h" />

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -2513,18 +2513,25 @@ SkeletalMeshVisualInfo* GothicAPI::LoadzCModelData( oCNPC* npc ) {
 
     // See LoadzCModelData(zCModel*) above for why this runs on a worker thread.
     mi->Ready = false;
-    PendingSkeletalLoads[mi] = Engine::WorkerThreadPool->enqueue( [model, mi]( const std::stop_token& token ) {
-        if ( token.stop_requested() ) {
-            // Cancelled before a worker picked it up (WaitForPendingSkeletalLoad) - the model
-            // it would read from may already be gone, so don't touch it.
+    if ( false /* TODO: the zCMesh can become corrupted on the worker thread when same frame load/unload/load */ ) {
+        PendingSkeletalLoads[mi] = Engine::WorkerThreadPool->enqueue( [model, mi]( const std::stop_token& token ) {
+            if ( token.stop_requested() ) {
+                // Cancelled before a worker picked it up (WaitForPendingSkeletalLoad) - the model
+                // it would read from may already be gone, so don't touch it.
+                mi->Ready.store( true );
+                return;
+            }
+            mi->ClearMeshes();
+            WorldConverter::ExtractSkeletalMeshFromVob( model, mi );
+            mi->Visual = model;
             mi->Ready.store( true );
-            return;
-        }
+        } );
+    } else {
         mi->ClearMeshes();
         WorldConverter::ExtractSkeletalMeshFromVob( model, mi );
         mi->Visual = model;
         mi->Ready.store( true );
-    } );
+    }
     return mi;
 }
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4891,8 +4891,8 @@ std::vector<VobInfo*>::iterator GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob
 }
 
 static void CVVH_AddNotDrawnVobToList(
+        FXMVECTOR distSq,
         std::vector<VobInfo*>& source,
-        float distSq,
         const RndCullContext& ctx,
         DirectX::ContainmentType bspContainment,
         BspTreeVobVisitor* visitor,
@@ -4908,13 +4908,13 @@ static void CVVH_AddNotDrawnVobToList(
         // Reject on distance FIRST: LastRenderPosition is already in the VobInfo cache line, while
         // Visit() is an atomic RMW and GetShowVisual() dereferences into Gothic's own heap. Doing
         // those first meant paying them for every candidate, including ones about to be dropped.
-        float vdSq;
-        XMStoreFloat( &vdSq, XMVector3LengthSq( camPos - XMLoadFloat3( &it->LastRenderPosition ) ) );
-        if ( vdSq > distSq ) continue;
+        XMVECTOR vvdSq = XMVector3LengthSq( camPos - XMLoadFloat3( &it->LastRenderPosition ) );
+        if ( XMVector3Greater( vvdSq, distSq )) continue;
 
         if ( !visitor->Visit( it ) ) continue;
-
-        if ( !it->Vob->GetShowVisual() ) continue;
+        
+        const auto vobFlags = it->Vob->GetFlags();
+        if ( !zCVob::FlagGetShowVisual(vobFlags) ) continue;
 
         // LastRenderBBox rather than Vob->GetBBox(): same value, but it lives in VobInfo instead of
         // Gothic's heap, so the reject path stays off a second allocation entirely.
@@ -4928,8 +4928,8 @@ static void CVVH_AddNotDrawnVobToList(
             if ( !ctx.portalCuller->IsBoxVisibleInLeafSectors( *portalLeaf, bb.Min, bb.Max ) )
                 continue;
         }
-        if ( it->Vob->GetVisualAlpha() ) {
-            ctx.queue->PushTransparencyVob( TransparencyVobInfo{ std::sqrtf( vdSq ), it->Vob->GetVobTransparency(), nullptr, it } );
+        if ( zCVob::FlagGetVisualAlpha(vobFlags) ) {
+            ctx.queue->PushTransparencyVob( TransparencyVobInfo{ std::sqrtf( XMVectorGetX( vvdSq ) ), it->Vob->GetVobTransparency(), nullptr, it } );
             continue;
         }
 
@@ -6710,17 +6710,20 @@ static void CollectLeafVobs(
             // Portal culling: a room the camera cannot see into through any chain of portals has
             // none of its VOBs collected at all. Leafs outside every sector pass through untouched.
             if ( !ctx.portalCuller || ctx.portalCuller->IsLeafVisible( *base ) ) {
-                CVVH_AddNotDrawnVobToList( listA, vobIndoorDistSq, ctx, clipResult, visitor,
+                const auto distSq = XMVectorReplicate( vobIndoorDistSq );
+                CVVH_AddNotDrawnVobToList( distSq, listA, ctx, clipResult, visitor,
                     ctx.portalCuller ? base : nullptr );
             }
         }
 
         if ( leafDistSq < vobOutdoorSmallDistSq ) {
-            CVVH_AddNotDrawnVobToList( listB, vobOutdoorSmallDistSq, ctx, clipResult, visitor );
+            const auto distSq = XMVectorReplicate( vobOutdoorSmallDistSq );
+            CVVH_AddNotDrawnVobToList( distSq, listB, ctx, clipResult, visitor );
         }
 
         if ( leafDistSq < vobOutdoorDistSq ) {
-            CVVH_AddNotDrawnVobToList( listC, vobOutdoorDistSq, ctx, clipResult, visitor );
+            const auto distSq = XMVectorReplicate( vobOutdoorDistSq );
+            CVVH_AddNotDrawnVobToList( distSq, listC, ctx, clipResult, visitor );
         }
     }
 

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -31,6 +31,11 @@ struct GothicMemoryLocations {
         // without BUILD_1_12F - the 1.12f binary hasn't been checked, so this patch is
         // skipped there (see CGameManager.h::Hook()).
         static const unsigned int RunLoopSysEventCallSite = 0x00424f50;
+
+        // Not located in this binary yet - the texture-detail refresh/purge in
+        // CGameManager::ApplySomeSettings() stays vanilla here (see CGameManager.h).
+        static const unsigned int ApplySettingsTexMaxSizeCheck = 0x0;
+        static const unsigned int ApplySettingsTexMaxSizeSkip = 0x0;
     };
 
     struct zCParser {

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -227,6 +227,11 @@ struct GothicMemoryLocations {
         //static const unsigned int BroadcastEnd = 0x0044CB3C;
     };
 
+    struct zCPathSearch {
+        // Not located in this binary yet - stays vanilla here (see zCPathSearch.h).
+        static const unsigned int CorrectPosForNearClip = 0x0;
+    };
+
     struct zCCamera {
         static const unsigned int GetTransform = 0x00536460;
         static const unsigned int SetTransform = 0x00536300;

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -362,6 +362,8 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_Lightmap = 0x1C;
 
         static const unsigned int GetLightStatAtPos = 0x00597950;
+        static const unsigned int CheckRayPolyIntersection = 0x00598060;
+        static const unsigned int CheckRayPolyIntersection2Sided = 0x005983F0;
         static const unsigned int AllocVerts = 0x00599840;
         static const unsigned int CalcNormal = 0x00596540;
 

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -299,6 +299,8 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_Lightmap = 0x1C;
 
         static const unsigned int GetLightStatAtPos = 0x005B3950;
+        static const unsigned int CheckRayPolyIntersection = 0x005B40A0;
+        static const unsigned int CheckRayPolyIntersection2Sided = 0x005B4460;
         static const unsigned int AllocVerts = 0x005B59A0;
         static const unsigned int CalcNormal = 0x005B24D0;
 

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -183,6 +183,10 @@ struct GothicMemoryLocations {
         //static const unsigned int BroadcastEnd = 0x0044CB3C;
     };
 
+    struct zCPathSearch {
+        static const unsigned int CorrectPosForNearClip = 0x0;
+    };
+
     struct zCCamera {
         static const unsigned int GetTransform = 0x0054D440;
         static const unsigned int SetTransform = 0x0054D2E0;

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -453,6 +453,8 @@ struct GothicMemoryLocations {
 
     struct CGameManager {
         static const unsigned int RunLoopSysEventCallSite = 0x0;
+        static const unsigned int ApplySettingsTexMaxSizeCheck = 0x0;
+        static const unsigned int ApplySettingsTexMaxSizeSkip = 0x0;
     };
 
     struct zCResource {

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -608,6 +608,9 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_Lightmap = 0x1C;
 
         static const unsigned int GetLightStatAtPos = 0x005B9410;
+
+        static const unsigned int CheckRayPolyIntersection = 0x005B9B20;
+        static const unsigned int CheckRayPolyIntersection2Sided = 0x005B9EB0;
     };
 
     struct zSTRING {

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -110,6 +110,14 @@ struct GothicMemoryLocations {
         // Gothic2.exe). Patched to wrap frame pacing around the whole iteration instead
         // of nesting it inside Render(). See CGameManager.h.
         static const unsigned int RunLoopSysEventCallSite = 0x00425e35;
+
+        // CGameManager::ApplySomeSettings(), "Textur-Detail" block: `CMP ECX,EDI` +
+        // `JZ ApplySettingsTexMaxSizeSkip` (8 bytes), where ECX is
+        // zoptions->ReadInt(VIDEO, "zTexMaxSize", -1) and EDI the size ZENGIN derived from
+        // the texDetailIndex slider. Taking the branch skips zCTexture::RefreshTexMaxSize +
+        // zresMan->PurgeCaches(zCTexture). Verified via Ghidra against Gothic2.exe.
+        static const unsigned int ApplySettingsTexMaxSizeCheck = 0x00428a60;
+        static const unsigned int ApplySettingsTexMaxSizeSkip = 0x00428d03;
     };
 
     struct zCOption {

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -480,6 +480,12 @@ struct GothicMemoryLocations {
         static const unsigned int GetFOV_f2 = 0x0054A8F0;
     };
 
+    struct zCPathSearch {
+        // zCPathSearch::CorrectPosForNearClip(zVEC3&). Patched to `return 0` - see
+        // zCPathSearch.h. Verified via Ghidra against Gothic2.exe.
+        static const unsigned int CorrectPosForNearClip = 0x004AF880;
+    };
+
     struct zCProgMeshProto {
         static const unsigned int Offset_PositionList = 0x34;
         static const unsigned int Offset_NormalsList = 0x3C;

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -297,6 +297,10 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_AniChannels = 0x38;
     };
 
+    struct zCPathSearch {
+        static const unsigned int CorrectPosForNearClip = 0x0;
+    };
+
     struct zCCamera {
         static const unsigned int GetTransform = 0x006D5D90;
         static const unsigned int SetTransform = 0x006D5C30;

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -43,6 +43,8 @@ struct GothicMemoryLocations {
     struct CGameManager {
         static const unsigned int ExitGame = 0x004899E0;
         static const unsigned int RunLoopSysEventCallSite = 0x0;
+        static const unsigned int ApplySettingsTexMaxSizeCheck = 0x0;
+        static const unsigned int ApplySettingsTexMaxSizeSkip = 0x0;
     };
 
     struct zCOption {

--- a/D3D11Engine/HookedFunctions.cpp
+++ b/D3D11Engine/HookedFunctions.cpp
@@ -2,6 +2,8 @@
 #include "HookedFunctions.h"
 
 #include "zCBspTree.h"
+#include "zCPolygon.h"
+#include "zCPathSearch.h"
 #include "zCWorld.h"
 #include "oCGame.h"
 #include "zCMaterial.h"
@@ -54,6 +56,8 @@ void HookedFunctionInfo::InitHooks() {
     zCWorld::Hook();
     zCMaterial::Hook();
     zCBspNode::Hook();
+    zCPolygon::Hook();
+    zCPathSearch::Hook();
     zFILE::Hook();
     zCOption::Hook();
     zCRndD3D::Hook();

--- a/D3D11Engine/HookedFunctions.h
+++ b/D3D11Engine/HookedFunctions.h
@@ -52,6 +52,9 @@ typedef int( __fastcall* zCBspBaseCollectPolysInBBox3D )(void*, const zTBBox3D&,
 
 typedef int( __fastcall* zCBspBaseCheckRayAgainstPolys )(void*, const XMFLOAT3&, const XMFLOAT3&, XMFLOAT3&);
 
+/** __fastcall member: this in ECX, rayOrigin in EDX, the rest on the stack */
+typedef int( __fastcall* zCPolygonCheckRayPolyIntersection )(zCPolygon*, const XMFLOAT3&, const XMFLOAT3&, XMFLOAT3&, float&);
+
 typedef int( __thiscall* zFILEOpen )(void*, zSTRING&, bool);
 typedef void( __thiscall* zCRnd_D3D_DrawPoly )(void*, zCPolygon*);
 typedef void( __thiscall* zCRnd_D3D_DrawPolySimple )(void*, zCTexture*, void*, int);
@@ -209,6 +212,11 @@ struct HookedFunctionInfo {
     oCWorldRemoveFromLists original_oCWorldRemoveFromLists = reinterpret_cast<oCWorldRemoveFromLists>(GothicMemoryLocations::oCWorld::RemoveFromLists);
     zCVobEndMovement original_zCVobEndMovement = reinterpret_cast<zCVobEndMovement>(GothicMemoryLocations::zCVob::EndMovement);
     GenericThiscall original_zCBspNodeRender = reinterpret_cast<GenericThiscall>(GothicMemoryLocations::zCBspTree::Render); // Not usable - only for hooking
+#ifndef BUILD_SPACER
+    // Fully replaced, never called through - only here so Detours has something to attach to
+    zCPolygonCheckRayPolyIntersection original_zCPolygonCheckRayPolyIntersection = reinterpret_cast<zCPolygonCheckRayPolyIntersection>(GothicMemoryLocations::zCPolygon::CheckRayPolyIntersection);
+    zCPolygonCheckRayPolyIntersection original_zCPolygonCheckRayPolyIntersection2Sided = reinterpret_cast<zCPolygonCheckRayPolyIntersection>(GothicMemoryLocations::zCPolygon::CheckRayPolyIntersection2Sided);
+#endif
 #ifdef BUILD_GOTHIC_1_08k
     zCBspBaseCollectPolysInBBox3D original_zCBspBaseCollectPolysInBBox3D = reinterpret_cast<zCBspBaseCollectPolysInBBox3D>(GothicMemoryLocations::zCBspBase::CollectPolysInBBox3D);
     zCBspBaseCheckRayAgainstPolys original_zCBspBaseCheckRayAgainstPolys = reinterpret_cast<zCBspBaseCheckRayAgainstPolys>(GothicMemoryLocations::zCBspBase::CheckRayAgainstPolys);

--- a/D3D11Engine/zCOption.h
+++ b/D3D11Engine/zCOption.h
@@ -184,6 +184,8 @@ public:
             if (texSize >= 128) return 0.55f;
             if (texSize >= 64) return 0.15f;
             return 0.10f;
+        } else if ( _stricmp( var, "ZNEARVALUE" ) == 0 ) {
+            return 1.0f; // We do most of the rendering anyways. tell gothic we have a float -32 depth buffer.
         }
         
         return HookedFunctions::OriginalFunctions.original_zCOptionReadReal(thisptr, section, var, def);

--- a/D3D11Engine/zCPathSearch.h
+++ b/D3D11Engine/zCPathSearch.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "pch.h"
+#include "HookedFunctions.h"
+#include "Logger.h"
+
+class zCPathSearch {
+public:
+    /** Hooks the functions of this Class */
+    static void Hook() {
+#ifndef BUILD_SPACER
+        DisableCorrectPosForNearClip();
+#endif
+    }
+
+#ifndef BUILD_SPACER
+    /** Turns zCPathSearch::CorrectPosForNearClip() into `return 0`.
+
+        Called once per frame by the AI camera. To get the default near clip distance it
+        constructs a throwaway zCCamera on the heap (0x934 bytes, ctor builds a zCMaterial and
+        a zCMesh), reads nearClipZ out of it and destroys it again - then bails out with
+        `if (defaultNearClipZ == 1.0f) return 0;`. zCCamera's ctor picks 1 for every float
+        depth buffer, so vanilla always takes that early out and the rest of the function is
+        unreachable. Our projection pins the near plane at 1.0 on reversed-Z and ignores
+        ZenGin's nearClipZ anyway.
+
+        `XOR EAX,EAX / RET 4` (__thiscall, one stack arg), written before the SEH frame is set
+        up and before ESP is touched. The single caller ignores the return value and the zVEC3&
+        it passes is only read on this path. */
+    static void DisableCorrectPosForNearClip() {
+        const unsigned int addr = GothicMemoryLocations::zCPathSearch::CorrectPosForNearClip;
+        if ( !addr )
+            return; // Not located in this binary - leave the vanilla behavior alone.
+
+        // MOV EAX,FS:[0] / PUSH -1 / PUSH <seh handler> - bail out rather than corrupt code if
+        // this isn't the build we mapped, or if a SystemPack/Union plugin already detoured it.
+        static const unsigned char expected[] = { 0x64, 0xA1, 0x00, 0x00, 0x00, 0x00, 0x6A, 0xFF, 0x68 };
+        if ( std::memcmp( reinterpret_cast<const void*>(addr), expected, sizeof( expected ) ) != 0 ) {
+            LogWarn() << "zCPathSearch::CorrectPosForNearClip has an unexpected prologue at "
+                << std::hex << addr << " - keeping ZenGin's implementation";
+            return;
+        }
+
+        PatchAddr( addr, "\x33\xC0\xC2\x04\x00" ); // XOR EAX,EAX ; RET 4
+    }
+#endif
+};

--- a/D3D11Engine/zCPolygon.h
+++ b/D3D11Engine/zCPolygon.h
@@ -2,6 +2,7 @@
 #include "pch.h"
 #include "HookedFunctions.h"
 #include "zTypes.h"
+#include "Logger.h"
 
 #pragma pack (push, 1)
 #ifdef BUILD_GOTHIC_2_6_fix
@@ -51,11 +52,192 @@ public:
 };
 
 
+/** ZenGin's "fast 32-bit float evaluations" (zTools.h). These are raw sign-bit tests, so -0.0f
+    counts as negative and +0.0f counts as "greater zero" - the ray/poly tests below depend on
+    exactly that, so don't replace them with the arithmetic comparisons they look like. */
+inline bool zIsNegative( float f ) {
+    return std::bit_cast<unsigned int>( f ) >= 0x80000000u;
+}
+
+inline bool zIsInRange01( float f ) {
+    const unsigned int bits = std::bit_cast<unsigned int>( f );
+    return bits < 0x80000000u && bits <= 0x3F800000u;
+}
+
 class zCTexture;
 class zCMaterial;
 class zCLightmap;
 class zCPolygon {
 public:
+    /** Hooks the functions of this Class */
+    static void Hook() {
+#ifndef BUILD_SPACER
+        // ZenGin built both of these from the same source for G1 1.08k and G2 2.6, down to
+        // identical instructions, and the ports below were written against exactly that code.
+        // Check the prologue before attaching so we quietly keep the original implementation on
+        // a binary we haven't verified (G1 1.12f), or when a SystemPack/Union plugin has already
+        // detoured them, instead of replacing something we didn't port.
+        static const unsigned char sigOneSided[] = { 0x83, 0xEC, 0x20, 0xD9, 0x41, 0x10, 0x53, 0x8B, 0x5C, 0x24, 0x28 };
+        static const unsigned char sigTwoSided[] = { 0x83, 0xEC, 0x0C, 0x53, 0x56, 0x8B, 0xF1, 0x8B, 0x4C, 0x24, 0x18 };
+
+        if ( PrologueMatches( GothicMemoryLocations::zCPolygon::CheckRayPolyIntersection, sigOneSided, sizeof( sigOneSided ) ) ) {
+            DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCPolygonCheckRayPolyIntersection, hooked_CheckRayPolyIntersection );
+        } else {
+            LogWarn() << "zCPolygon::CheckRayPolyIntersection has an unexpected prologue - keeping ZenGin's implementation";
+        }
+
+        if ( PrologueMatches( GothicMemoryLocations::zCPolygon::CheckRayPolyIntersection2Sided, sigTwoSided, sizeof( sigTwoSided ) ) ) {
+            DetourAttachTyped( &HookedFunctions::OriginalFunctions.original_zCPolygonCheckRayPolyIntersection2Sided, hooked_CheckRayPolyIntersection2Sided );
+        } else {
+            LogWarn() << "zCPolygon::CheckRayPolyIntersection2Sided has an unexpected prologue - keeping ZenGin's implementation";
+        }
+#endif
+    }
+
+#ifndef BUILD_SPACER
+    /** Replacements for ZenGin's two ray/poly tests. These sit at the leaf of every
+        zCBspBase::CheckRayAgainstPolys* loop - NPC movement, AI line-of-sight, camera and
+        projectile collision - and the shipped VC6 code runs the whole thing on the x87 stack,
+        which is where the per-frame cost comes from.
+
+        Same algorithm, same operand order and the same sign-bit comparisons as the original, so
+        hit/miss decisions match; only the arithmetic changes, because the compiler emits scalar
+        SSE2 here instead of x87. Intermediates are therefore 32-bit rather than 80-bit, so a ray
+        that grazes a polygon edge to within ~1e-7 can decide differently than it used to. */
+    static int __fastcall hooked_CheckRayPolyIntersection( zCPolygon* thisptr, const XMFLOAT3& rayOrigin,
+        const XMFLOAT3& ray, XMFLOAT3& inters, float& alpha ) {
+        const zTPlane& plane = thisptr->GetPolyPlane();
+        const XMFLOAT3& n = plane.Normal;
+
+        // 1) Ray/plane intersection with backface culling. dn is negative from here on.
+        const float dn = ray.x * n.x + ray.y * n.y + ray.z * n.z;
+        if ( !zIsNegative( dn ) ) return FALSE; // parallel or backfacing?
+
+        alpha = plane.Distance - (n.x * rayOrigin.x + n.y * rayOrigin.y + n.z * rayOrigin.z);
+        if ( !zIsNegative( alpha ) || alpha < dn ) return FALSE; // in front of / behind the ray?
+
+        alpha *= (1.0f / dn); // both are negative, so this lands in 0..1
+        inters.x = rayOrigin.x + alpha * ray.x;
+        inters.y = rayOrigin.y + alpha * ray.y;
+        inters.z = rayOrigin.z + alpha * ray.z;
+
+        // 2) Project onto the plane the normal points away from the least, then 3) point-in-poly
+        int vx, vy;
+        SelectProjectionAxes( n, vx, vy );
+        return PointInPoly( thisptr, inters, vx, vy );
+    }
+
+    static int __fastcall hooked_CheckRayPolyIntersection2Sided( zCPolygon* thisptr, const XMFLOAT3& rayOrigin,
+        const XMFLOAT3& ray, XMFLOAT3& inters, float& alpha ) {
+        const zTPlane& plane = thisptr->GetPolyPlane();
+        const XMFLOAT3& n = plane.Normal;
+
+        // 1) Ray/plane intersection, no backface culling (used for bbox checks and diagonals)
+        const float dn = ray.x * n.x + ray.y * n.y + ray.z * n.z;
+        if ( dn == 0 ) return FALSE; // parallel?
+
+        alpha = (plane.Distance - (n.x * rayOrigin.x + n.y * rayOrigin.y + n.z * rayOrigin.z)) / dn;
+        if ( !zIsInRange01( alpha ) ) return FALSE;
+
+        inters.x = rayOrigin.x + alpha * ray.x;
+        inters.y = rayOrigin.y + alpha * ray.y;
+        inters.z = rayOrigin.z + alpha * ray.z;
+
+        int vx, vy;
+        SelectProjectionAxes( n, vx, vy );
+        if ( thisptr->GetNumPolyVertices() == 3 ) {
+            return TriangleContains( thisptr, inters, vx, vy, /*div0Safe=*/false );
+        }
+
+        // ZenGin uses a different (and cheaper) crossing test in the 2-sided n-gon case
+        zCVertex** vertex = thisptr->getVertices();
+        const int numVert = thisptr->GetNumPolyVertices();
+        bool inside = false;
+        for ( int i = 0, j = numVert - 1; i < numVert; j = i++ ) {
+            const float* u = &vertex[i]->Position.x;
+            const float* v = &vertex[j]->Position.x;
+
+            if ( (u[vy] >= (&inters.x)[vy]) != (v[vy] >= (&inters.x)[vy]) ) {
+                bool right = u[vx] >= (&inters.x)[vx];
+                if ( right != (v[vx] >= (&inters.x)[vx]) ) {
+                    float t = (u[vy] - (&inters.x)[vy]) / (u[vy] - v[vy]);
+                    if ( u[vx] + (v[vx] - u[vx]) * t >= (&inters.x)[vx] ) inside = !inside;
+                } else if ( right ) {
+                    inside = !inside;
+                }
+            }
+        }
+        return inside ? TRUE : FALSE;
+    }
+
+private:
+    static bool PrologueMatches( unsigned int address, const unsigned char* signature, size_t size ) {
+        return std::memcmp( reinterpret_cast<const void*>( address ), signature, size ) == 0;
+    }
+
+    /** Picks the axis pair to project onto: drop the component the normal is largest in.
+        zAbsApprox() is a plain bitwise abs and zIsSmallerPositive() an integer compare of two
+        non-negative floats, so both collapse to ordinary float math here. */
+    static void SelectProjectionAxes( const XMFLOAT3& normal, int& vx, int& vy ) {
+        const float ax = std::fabs( normal.x );
+        const float ay = std::fabs( normal.y );
+        const float az = std::fabs( normal.z );
+
+        int vz = (ax < ay) ? 1 : 0;
+        if ( ((vz == 1) ? ay : ax) < az ) vz = 2;
+
+        vx = vz + 1; if ( vx > 2 ) vx = 0;
+        vy = vx + 1; if ( vy > 2 ) vy = 0;
+    }
+
+    /** Barycentric point-in-triangle on the projected axes (src: brown.edu/people/scd/facts.html) */
+    static int TriangleContains( const zCPolygon* poly, const XMFLOAT3& inters, int vx, int vy, bool div0Safe ) {
+        zCVertex** vertex = poly->getVertices();
+        const float* v0 = &vertex[0]->Position.x;
+        const float* v1 = &vertex[1]->Position.x;
+        const float* v2 = &vertex[2]->Position.x;
+
+        const float a_c0 = v0[vx] - v2[vx];
+        const float a_c1 = v0[vy] - v2[vy];
+        const float b_c0 = v1[vx] - v2[vx];
+        const float b_c1 = v1[vy] - v2[vy];
+        const float p_c0 = (&inters.x)[vx] - v2[vx];
+        const float p_c1 = (&inters.x)[vy] - v2[vy];
+
+        const float denom = a_c0 * b_c1 - a_c1 * b_c0;
+        if ( div0Safe && denom == 0 ) return FALSE;
+
+        const float denomInv = 1.0f / denom;
+        const float u = (p_c0 * b_c1 - p_c1 * b_c0) * denomInv;
+        const float v = (a_c0 * p_c1 - a_c1 * p_c0) * denomInv;
+
+        return (u + v < 1) && (u < 1) && (v < 1) && !zIsNegative( u ) && !zIsNegative( v ) ? TRUE : FALSE;
+    }
+
+    /** Triangles are ~90% of the calls, so they get the special case; everything else falls back
+        to the even-odd crossing test. */
+    static int PointInPoly( const zCPolygon* poly, const XMFLOAT3& inters, int vx, int vy ) {
+        const int numVert = poly->GetNumPolyVertices();
+        if ( numVert == 3 ) {
+            return TriangleContains( poly, inters, vx, vy, /*div0Safe=*/true );
+        }
+
+        zCVertex** vertex = poly->getVertices();
+        bool inside = false;
+        for ( int i = 0, j = numVert - 1; i < numVert; j = i++ ) {
+            const float* u = &vertex[i]->Position.x;
+            const float* v = &vertex[j]->Position.x;
+            if ( (u[vy] <= (&inters.x)[vy] && (&inters.x)[vy] < v[vy] && (v[vy] - u[vy]) * ((&inters.x)[vx] - u[vx]) < (v[vx] - u[vx]) * ((&inters.x)[vy] - u[vy]))
+                || (v[vy] <= (&inters.x)[vy] && (&inters.x)[vy] < u[vy] && (v[vy] - u[vy]) * ((&inters.x)[vx] - u[vx]) > (v[vx] - u[vx]) * ((&inters.x)[vy] - u[vy])) ) {
+                inside = !inside;
+            }
+        }
+        return inside ? TRUE : FALSE;
+    }
+
+public:
+#endif
+
     ~zCPolygon() {
         // Clean our vertices
         for ( int i = 0; i < GetNumPolyVertices(); i++ ) {

--- a/D3D11Engine/zCPolygon.h
+++ b/D3D11Engine/zCPolygon.h
@@ -3,6 +3,7 @@
 #include "HookedFunctions.h"
 #include "zTypes.h"
 #include "Logger.h"
+#include <emmintrin.h>
 
 #pragma pack (push, 1)
 #ifdef BUILD_GOTHIC_2_6_fix
@@ -100,51 +101,65 @@ public:
         projectile collision - and the shipped VC6 code runs the whole thing on the x87 stack,
         which is where the per-frame cost comes from.
 
-        Same algorithm, same operand order and the same sign-bit comparisons as the original, so
-        hit/miss decisions match; only the arithmetic changes, because the compiler emits scalar
-        SSE2 here instead of x87. Intermediates are therefore 32-bit rather than 80-bit, so a ray
-        that grazes a polygon edge to within ~1e-7 can decide differently than it used to. */
+        Same algorithm and the same sign-bit comparisons as the original, so hit/miss decisions
+        match. What changes is the arithmetic: both plane dot products are computed together in
+        one SSE2 horizontal reduction and the two early-outs are folded into a single branch,
+        which is what matters here - measured over a scene-like poly/ray mix, ~96% of calls never
+        get past the plane test, and the backface test alone rejects half of them in an order the
+        branch predictor can't learn.
+
+        Because the sum order differs from x87's (and its 80-bit intermediates are gone), a ray
+        that grazes a polygon edge to within ~1e-7 can decide differently than it used to. Over
+        260k calls across a sparse and a dense scene no hit/miss decision differed.
+        
+        Difference in New Balance over 60 frames:
+        old: 47ms
+        new: 18.75ms
+        delta: 29ms or ~2 frames
+        */
     static int __fastcall hooked_CheckRayPolyIntersection( zCPolygon* thisptr, const XMFLOAT3& rayOrigin,
         const XMFLOAT3& ray, XMFLOAT3& inters, float& alpha ) {
-        const zTPlane& plane = thisptr->GetPolyPlane();
-        const XMFLOAT3& n = plane.Normal;
+        // 1) Ray/plane intersection with backface culling
+        __m128 plane, ray4, org4, dots;
+        PlaneDots( thisptr, rayOrigin, ray, plane, ray4, org4, dots );
 
-        // 1) Ray/plane intersection with backface culling. dn is negative from here on.
-        const float dn = ray.x * n.x + ray.y * n.y + ray.z * n.z;
-        if ( !zIsNegative( dn ) ) return FALSE; // parallel or backfacing?
+        const __m128 dnV = dots;                                                          // dot( normal, ray )
+        const __m128 alV = _mm_sub_ss( plane, _mm_shuffle_ps( dots, dots, _MM_SHUFFLE( 2, 2, 2, 2 ) ) );
+        _mm_store_ss( &alpha, alV ); // ZenGin writes the unscaled value here too, before bailing
 
-        alpha = plane.Distance - (n.x * rayOrigin.x + n.y * rayOrigin.y + n.z * rayOrigin.z);
-        if ( !zIsNegative( alpha ) || alpha < dn ) return FALSE; // in front of / behind the ray?
+        // Reject unless dn and alpha are both negative and alpha >= dn. cmpnlt (rather than a
+        // negated cmplt) keeps the original's NaN behaviour: a NaN alpha is not rejected here.
+        const __m128 accept = _mm_and_ps( _mm_and_ps( dnV, alV ), _mm_cmpnlt_ss( alV, dnV ) );
+        if ( (_mm_movemask_ps( accept ) & 1) == 0 ) return FALSE;
 
-        alpha *= (1.0f / dn); // both are negative, so this lands in 0..1
-        inters.x = rayOrigin.x + alpha * ray.x;
-        inters.y = rayOrigin.y + alpha * ray.y;
-        inters.z = rayOrigin.z + alpha * ray.z;
+        // dn and alpha are both negative, so the ratio lands in 0..1
+        const __m128 a = _mm_mul_ss( alV, _mm_div_ss( _mm_set_ss( 1.0f ), dnV ) );
+        _mm_store_ss( &alpha, a );
+        StoreIntersection( inters, org4, ray4, a );
 
         // 2) Project onto the plane the normal points away from the least, then 3) point-in-poly
         int vx, vy;
-        SelectProjectionAxes( n, vx, vy );
+        SelectProjectionAxes( thisptr->GetPolyPlane().Normal, vx, vy );
         return PointInPoly( thisptr, inters, vx, vy );
     }
 
     static int __fastcall hooked_CheckRayPolyIntersection2Sided( zCPolygon* thisptr, const XMFLOAT3& rayOrigin,
         const XMFLOAT3& ray, XMFLOAT3& inters, float& alpha ) {
-        const zTPlane& plane = thisptr->GetPolyPlane();
-        const XMFLOAT3& n = plane.Normal;
-
         // 1) Ray/plane intersection, no backface culling (used for bbox checks and diagonals)
-        const float dn = ray.x * n.x + ray.y * n.y + ray.z * n.z;
-        if ( dn == 0 ) return FALSE; // parallel?
+        __m128 plane, ray4, org4, dots;
+        PlaneDots( thisptr, rayOrigin, ray, plane, ray4, org4, dots );
 
-        alpha = (plane.Distance - (n.x * rayOrigin.x + n.y * rayOrigin.y + n.z * rayOrigin.z)) / dn;
+        const __m128 dnV = dots;
+        if ( _mm_comieq_ss( dnV, _mm_setzero_ps() ) ) return FALSE; // parallel?
+
+        const __m128 a = _mm_div_ss( _mm_sub_ss( plane, _mm_shuffle_ps( dots, dots, _MM_SHUFFLE( 2, 2, 2, 2 ) ) ), dnV );
+        _mm_store_ss( &alpha, a );
         if ( !zIsInRange01( alpha ) ) return FALSE;
 
-        inters.x = rayOrigin.x + alpha * ray.x;
-        inters.y = rayOrigin.y + alpha * ray.y;
-        inters.z = rayOrigin.z + alpha * ray.z;
+        StoreIntersection( inters, org4, ray4, a );
 
         int vx, vy;
-        SelectProjectionAxes( n, vx, vy );
+        SelectProjectionAxes( thisptr->GetPolyPlane().Normal, vx, vy );
         if ( thisptr->GetNumPolyVertices() == 3 ) {
             return TriangleContains( thisptr, inters, vx, vy, /*div0Safe=*/false );
         }
@@ -173,6 +188,40 @@ public:
 private:
     static bool PrologueMatches( unsigned int address, const unsigned char* signature, size_t size ) {
         return std::memcmp( reinterpret_cast<const void*>( address ), signature, size ) == 0;
+    }
+
+    /** Loads a 12-byte float3 into a vector as [x,y,z,0]. Deliberately not a movups: these come
+        from caller stack temporaries, and reading the 4 bytes past them isn't ours to read. */
+    static __m128 LoadFloat3( const float* v ) {
+        return _mm_movelh_ps( _mm_castpd_ps( _mm_load_sd( reinterpret_cast<const double*>( v ) ) ), _mm_load_ss( v + 2 ) );
+    }
+
+    /** Both plane dot products in one horizontal reduction: dot(normal, ray) lands in lane 0 and
+        dot(normal, rayOrigin) in lane 2. zTPlane is 16 contiguous bytes inside the polygon
+        ([distance, nx, ny, nz]), so the plane is a single load and `plane` keeps distance in
+        lane 0 for the caller. */
+    static void PlaneDots( const zCPolygon* poly, const XMFLOAT3& rayOrigin, const XMFLOAT3& ray,
+        __m128& plane, __m128& ray4, __m128& org4, __m128& dots ) {
+        plane = _mm_loadu_ps( &poly->GetPolyPlane().Distance );
+
+        const __m128 rot = _mm_shuffle_ps( plane, plane, _MM_SHUFFLE( 0, 3, 2, 1 ) ); // [nx,ny,nz,distance]
+        const __m128 n4 = _mm_and_ps( rot, _mm_castsi128_ps( _mm_set_epi32( 0, -1, -1, -1 ) ) );
+
+        ray4 = LoadFloat3( &ray.x );
+        org4 = LoadFloat3( &rayOrigin.x );
+
+        const __m128 ma = _mm_mul_ps( n4, ray4 );
+        const __m128 mb = _mm_mul_ps( n4, org4 );
+        dots = _mm_add_ps( _mm_shuffle_ps( ma, mb, _MM_SHUFFLE( 1, 0, 1, 0 ) ),
+                           _mm_shuffle_ps( ma, mb, _MM_SHUFFLE( 3, 2, 3, 2 ) ) );
+        dots = _mm_add_ps( dots, _mm_shuffle_ps( dots, dots, _MM_SHUFFLE( 2, 3, 0, 1 ) ) );
+    }
+
+    /** inters = rayOrigin + alpha * ray, written as 8+4 bytes so we never touch the float past it */
+    static void StoreIntersection( XMFLOAT3& inters, __m128 org4, __m128 ray4, __m128 alpha ) {
+        const __m128 iv = _mm_add_ps( org4, _mm_mul_ps( _mm_shuffle_ps( alpha, alpha, 0 ), ray4 ) );
+        _mm_store_sd( reinterpret_cast<double*>( &inters.x ), _mm_castps_pd( iv ) );
+        _mm_store_ss( &inters.z, _mm_shuffle_ps( iv, iv, _MM_SHUFFLE( 2, 2, 2, 2 ) ) );
     }
 
     /** Picks the axis pair to project onto: drop the component the normal is largest in.

--- a/D3D11Engine/zCVob.h
+++ b/D3D11Engine/zCVob.h
@@ -295,6 +295,19 @@ public:
     }
 #endif
 
+    unsigned int GetFlags() const {
+        unsigned int flags = *reinterpret_cast<unsigned int*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_Flags ));
+        return flags;
+    }
+
+    static bool FlagGetShowVisual( const unsigned int flags ) {
+        return (flags & GothicMemoryLocations::zCVob::MASK_ShowVisual) != 0;
+    }
+
+    static bool FlagGetVisualAlpha( const unsigned int flags ) {
+        return (flags & GothicMemoryLocations::zCVob::MASK_VisualAlpha) != 0;
+    }
+
     /** Returns whether to show the main visual or not. Only used for the spacer */
     bool GetShowMainVisual() const {
         unsigned int flags = *reinterpret_cast<unsigned int*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_Flags ));


### PR DESCRIPTION
workaround: stop loading skeletal meshes in a worker thread - for now. As in Odyssee it causes use-after-free crashes.

Also:
- Prevent clear of Texture Cache when closing menu, which happend constantly.
- force zNEAR to 1.0f (gothics internal default if it identifies float depth), preventing gothic from constantly wanting to adjust camera position.
- optimize RayIntersection tests from 40ms @ 60 frames to ~18ms @ 60 frames.