### PR TITLE
(2/7) dx12: Use `versioned` Root signatures (with fallback), cache PipelineState using CommandList wrapper, Improve Light culling performance, Submit depth early, ...

### DIFF
--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -154,6 +154,7 @@ public:
         installed, falling back to OnBeginFrame otherwise (see g_MainLoopFramePacingInstalled). */
     void WaitForFrameLatencyWaitable() {
         if ( HANDLE waitable = GetFrameLatencyWaitableObject() ) {
+            ZoneScoped;
             WaitForSingleObjectEx( waitable, 1000, TRUE );
         }
     }

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -942,6 +942,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="D3D11TracyDebug.h" />
     <ClInclude Include="D3D12Engine\D3D12PipelineState.h" />
     <ClInclude Include="D3D12Engine\D3D12ShaderBackend.h" />
+    <ClInclude Include="D3D12Engine\D3D12StateCache.h" />
     <ClInclude Include="D3D12Engine\D3D12RenderQueue.h" />
     <ClInclude Include="D3D12Engine\D3D12ShadowMap.h" />
     <ClInclude Include="D3D12Engine\D3D12PointShadows.h" />

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -918,6 +918,9 @@
     <ClInclude Include="D3D12Engine\D3D12ShaderBackend.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
+    <ClInclude Include="D3D12Engine\D3D12StateCache.h">
+      <Filter>Engine\D3D12</Filter>
+    </ClInclude>
     <ClInclude Include="D3D12Engine\InstancingUtils.h" />
     <ClInclude Include="D3D12Engine\D3D12RenderQueue.h">
       <Filter>Engine\D3D12</Filter>
@@ -925,6 +928,7 @@
     <ClInclude Include="D3D12Engine\D3D12TracyDebug.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
+    <ClInclude Include="BspPortalCuller.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -1323,6 +1327,9 @@
       <Filter>Engine\D3D12</Filter>
     </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12SkyIbl.cpp" />
+    <ClCompile Include="D3D12Engine\D3D12RootLayout.cpp" />
+    <ClCompile Include="BspPortalCuller.cpp" />
+    <ClCompile Include="D3D12Engine\D3D12Sky.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ddraw.def">

--- a/D3D11Engine/D3D12Engine/D3D12AO.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12AO.cpp
@@ -188,7 +188,7 @@ void D3D12GraphicsEngine::RenderSimpleSSAO() {
         || !m_Pipelines.AO.BlurPSO || !m_Pipelines.AO.BlurRootSig )
         return;
 
-    DX_ZONE( m_CmdList, "SSAO" );
+    DX_ZONE( m_CmdList.Get(), "SSAO" );
 
     const auto& sao = settings.SaoSettings;
     // This frame's projection — the same one the prepass depth below was rasterized with. Its _13/_23 carry the

--- a/D3D11Engine/D3D12Engine/D3D12Cull.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Cull.cpp
@@ -209,7 +209,7 @@ void D3D12GraphicsEngine::BuildHiZ() {
     if ( !m_FrameOpen || !m_HiZReady || !m_HiZ || !m_DepthBuffer || m_DepthSrvSlot == UINT_MAX ) return;
     if ( !m_Pipelines.Cull.HiZCopyPSO || !m_Pipelines.Cull.HiZReducePSO || !m_Pipelines.Cull.HiZRootSig ) return;
 
-    DX_ZONE( m_CmdList, "Hi-Z build" );
+    DX_ZONE( m_CmdList.Get(), "Hi-Z build" );
 
     D3D12_RESOURCE_BARRIER pre[2] = {};
     UINT preCount = 0;
@@ -267,7 +267,7 @@ void D3D12GraphicsEngine::CullVobsGPU() {
     if ( !m_GpuVobCullActive || !m_FrameOpen ) return;
     if ( !m_VobCullVisuals[m_FrameIndex] || !m_VobInstanceBuffer[m_FrameIndex] ) return;
 
-    DX_ZONE( m_CmdList, "VOB cull (compute)" );
+    DX_ZONE( m_CmdList.Get(), "VOB cull (compute)" );
 
     // --- Restore rest states the previous frame's draws left behind (same pattern as m_LightGridInPixelState) ---
     {

--- a/D3D11Engine/D3D12Engine/D3D12DoF.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12DoF.cpp
@@ -150,7 +150,7 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
         : m_Pipelines.DoF.BlurPSO.Get();
     if ( !blurPso ) return;
 
-    DX_ZONE( m_CmdList, "Depth of Field" );
+    DX_ZONE( m_CmdList.Get(), "Depth of Field" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth of Field" );
 
     const UINT prevIdx = m_DoFFocusIndex;

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -58,12 +58,16 @@ struct FrameSkelDraw {
 // reason — the attachment passes are fully bindless (b6 MaterialCB, no t0 table), so what the recorder needs
 // is the heap index, not a table handle. The main-view prepass/color paths still resolve `tex` themselves
 // (they CacheIn, which the shadow paths deliberately don't), so both fields stay live.
+// alphaTested = can the depth/caster PS' `clip(diffuse.a - 0.5)` ever discard for this attachment? Resolved on
+// the main thread with srvSlot (a pool-thread recorder must not read Gothic texture state), and used by every
+// depth-only consumer to route the attachment through a no-pixel-shader PSO when it can't.
 struct FrameAttachDraw {
     MeshInfo*                   mesh;
     zCTexture*                  tex;
     D3D12_VERTEX_BUFFER_VIEW    instView;
     const zCVob*                owner;
     UINT                        srvSlot;
+    bool                        alphaTested;
 };
 
 // Per-frame GPU point light. Filled by BuildFrameLightBuffer (D3D12Scene.cpp); the point-shadow slot
@@ -117,7 +121,14 @@ extern std::vector<VobInfo*> g_FrameVobs;
 // still appending to it — the point-shadow prepare runs its own PrepareFrameSkeletals after the cascade jobs
 // have launched. A vector's push_back would reallocate and turn those pointers into use-after-free; deque
 // guarantees references to existing elements survive a push_back.
-extern std::deque<std::vector<UINT>> g_SkelMatSrvs;
+// alphaTested rides along for the same reason it does on FrameAttachDraw: the shadow/depth casters want to skip
+// the alpha-clip pixel shader entirely for a material whose diffuse has no alpha channel, and only the main
+// thread may ask Gothic that question.
+struct SkelMatSlot {
+    UINT slot;
+    bool alphaTested;
+};
+extern std::deque<std::vector<SkelMatSlot>> g_SkelMatSrvs;
 extern size_t g_SkelMatSrvCount;
 
 // Water surfaces peeled out of the opaque world pass (BuildWorldDrawCommands, D3D12Scene.cpp) and drawn

--- a/D3D11Engine/D3D12Engine/D3D12Fog.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Fog.cpp
@@ -246,7 +246,7 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
 
     if ( !heightFog && !godRays ) return;
 
-    DX_ZONE( m_CmdList, "Height fog + god rays" );
+    DX_ZONE( m_CmdList.Get(), "Height fog + god rays" );
 
     // The depth buffer is still bound as the DSV from the geometry passes — drop it (color target only)
     // before transitioning it to a shader-resource state. Combined NON_PIXEL|PIXEL because the god-ray mask

--- a/D3D11Engine/D3D12Engine/D3D12Fx.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Fx.cpp
@@ -242,7 +242,7 @@ void D3D12GraphicsEngine::DrawMQuadMarks() {
     if ( g_MulQuadMarks.empty() ) return;
     if ( !m_FrameOpen || !m_Pipelines.Fx.RootSig ) { g_MulQuadMarks.clear(); return; }
 
-    DX_ZONE( m_CmdList, "Draw quad marks (modulate)" );
+    DX_ZONE( m_CmdList.Get(), "Draw quad marks (modulate)" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw quad marks (modulate)" );
 
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
@@ -331,7 +331,7 @@ XRESULT D3D12GraphicsEngine::DrawPolyStrips( bool noTextures ) {
     if ( polyStripInfos.empty() ) return XR_SUCCESS;
     if ( !m_FrameOpen || !m_Pipelines.Fx.RootSig || !m_FxVertexBuffer[m_FrameIndex] ) return XR_SUCCESS;
 
-    DX_ZONE( m_CmdList, "Draw poly strips" );
+    DX_ZONE( m_CmdList.Get(), "Draw poly strips" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw poly strips" );
 
     // Strip vertices are already in world space (GothicAPI builds them that way), so the world matrix is
@@ -435,7 +435,7 @@ void D3D12GraphicsEngine::DrawFrameParticleMeshes( std::unordered_map<zCVob*, st
     if ( progMeshes.empty() ) return;
     if ( !m_FrameOpen || !m_Pipelines.Fx.RootSig || !m_DepthBuffer ) return;
 
-    DX_ZONE( m_CmdList, "Draw particle meshes" );
+    DX_ZONE( m_CmdList.Get(), "Draw particle meshes" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw particle meshes" );
 
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();

--- a/D3D11Engine/D3D12Engine/D3D12GTAO.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GTAO.cpp
@@ -240,7 +240,7 @@ bool D3D12GraphicsEngine::IsGtaoEnabled() const {
 void D3D12GraphicsEngine::RenderGTAO() {
     if ( !m_FrameOpen || !m_CmdList ) return;
 
-    DX_ZONE( m_CmdList, "XeGTAO" );
+    DX_ZONE( m_CmdList.Get(), "XeGTAO" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "XeGTAO" );
 
     const auto& settings = Engine::GAPI->GetRendererState().RendererSettings;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -1048,6 +1048,7 @@ bool D3D12GraphicsEngine::CreateDepthBuffer( INT2 size ) {
 	dsv.Format = DXGI_FORMAT_D32_FLOAT;   // typeless resource viewed as depth here
 	dsv.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
 	device->CreateDepthStencilView( m_DepthBuffer.Get(), &dsv, m_DsvHeap->GetCPUDescriptorHandleForHeapStart() );
+	m_CmdList.InvalidateRenderTargets();   // descriptor rewritten in place — see D3D12StateCache.h
 
 	// R32_FLOAT SRV of the same texels for the light cull's per-tile far-Z read. Slot allocated once; the view is
 	// (re)created every call so it always points at the current (post-resize) resource.
@@ -1109,6 +1110,7 @@ bool D3D12GraphicsEngine::CreateSceneColorTarget( INT2 size ) {
 	m_SceneColorRtv = m_RtvHeap->GetCPUDescriptorHandleForHeapStart();
 	m_SceneColorRtv.ptr += static_cast<SIZE_T>(kBackBufferMax) * m_RtvDescriptorSize;
 	device->CreateRenderTargetView( m_SceneColor.Get(), nullptr, m_SceneColorRtv );
+	m_CmdList.InvalidateRenderTargets();
 
 	// SRV for the tonemap resolve (slot allocated once; view re-created each call to point at the current resource).
 	if ( m_SceneColorSrvSlot == UINT_MAX ) {
@@ -1179,7 +1181,7 @@ void D3D12GraphicsEngine::ResolveSceneToBackBuffer() {
 	// Tonemap the finished HDR scene onto the display target, then leave it bound so the 2D UI (drawn after
 	// OnStartWorldRendering) composites on top. If HDR is unavailable, no-op (nothing to show).
 	if ( !m_SceneColor || !m_Pipelines.Tonemap.PSO || !m_Pipelines.Tonemap.RootSig || !m_CmdList ) return;
-	DX_ZONE( m_CmdList, "Tonemap resolve (HDR->display)" );
+	DX_ZONE( m_CmdList.Get(), "Tonemap resolve (HDR->display)" );
 
 	if ( !m_SceneColorInPixelState ) {
 		auto toSrv = TransitionBarrier( m_SceneColor.Get(),
@@ -1372,6 +1374,7 @@ bool D3D12GraphicsEngine::CreateHdrDisplayTarget( INT2 size ) {
 	m_HdrDisplayRtv = m_RtvHeap->GetCPUDescriptorHandleForHeapStart();
 	m_HdrDisplayRtv.ptr += static_cast<SIZE_T>( kBackBufferMax + 3 ) * m_RtvDescriptorSize;
 	device->CreateRenderTargetView( m_HdrDisplay.Get(), nullptr, m_HdrDisplayRtv );
+	m_CmdList.InvalidateRenderTargets();
 
 	if ( m_HdrDisplaySrvSlot == UINT_MAX ) m_HdrDisplaySrvSlot = AllocateSrvSlot();
 	if ( m_HdrDisplaySrvSlot == UINT_MAX ) return false;
@@ -1392,7 +1395,7 @@ bool D3D12GraphicsEngine::CreateHdrDisplayTarget( INT2 size ) {
 void D3D12GraphicsEngine::EncodeHdrDisplayToBackBuffer() {
 	if ( !m_HdrOutputActive || !m_HdrDisplay || !m_CmdList ) return;
 	if ( !m_Pipelines.HdrEncode.PSO || !m_Pipelines.HdrEncode.RootSig || m_HdrDisplaySrvSlot == UINT_MAX ) return;
-	DX_ZONE( m_CmdList, "HDR scanout encode (display->swapchain)" );
+	DX_ZONE( m_CmdList.Get(), "HDR scanout encode (display->swapchain)" );
 
 	auto toSrv = TransitionBarrier( m_HdrDisplay.Get(),
 		D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
@@ -1691,6 +1694,7 @@ bool D3D12GraphicsEngine::AcquireBackBufferRTVs() {
             return false;
         m_BackBuffers[i]->SetName( i == 0 ? L"BackBuffer0" : L"BackBuffer1" );
         device->CreateRenderTargetView( m_BackBuffers[i].Get(), nullptr, rtvHandle );
+        m_CmdList.InvalidateRenderTargets();
         rtvHandle.ptr += m_RtvDescriptorSize;
     }
     return true;
@@ -1754,9 +1758,12 @@ XRESULT D3D12GraphicsEngine::OnBeginFrame() {
         hr = m_CmdAllocators[m_FrameIndex]->Reset();
         if ( FAILED( hr ) ) return XR_FAILED;
     }
-    hr = m_CmdList->Reset( m_CmdAllocators[m_FrameIndex].Get(), nullptr );
+    // Goes through the state cache, which drops its shadow with the list state Reset just discarded.
+    hr = m_CmdList.Reset( m_CmdAllocators[m_FrameIndex].Get(), nullptr );
     if ( FAILED( hr ) ) return XR_FAILED;
     ResetCpuContextTracker();
+    m_CmdList.ResetStats();
+    for ( UINT s = 0; s < kShadowRecordSlots; ++s ) m_ShadowCmdLists[s][m_FrameIndex].ResetStats();
 
     auto toRT = TransitionBarrier( m_BackBuffers[m_FrameIndex].Get(),
         D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET );
@@ -1975,12 +1982,33 @@ static void DiagnoseErrors(ID3D12Device* device) {
 XRESULT D3D12GraphicsEngine::Present() {
     if ( !m_SwapChainReady || !m_FrameOpen ) return XR_SUCCESS;
 
+    // Publish this frame's state-cache tally into the shared stats block the ImGui overlay reads
+    // ("StateChanges"). Issued = binds that actually reached the driver, across the main list and every
+    // shadow-recording list; the filtered count is what the cache saved. Written here, immediately before
+    // the overlay draws, because GothicAPI::OnWorldUpdate zeroes RendererInfo at the top of each frame.
+    {
+        UINT issued = m_CmdList.GetStats().Issued;
+        UINT filtered = m_CmdList.GetStats().Filtered;
+        for ( UINT s = 0; s < kShadowRecordSlots; ++s ) {
+            issued += m_ShadowCmdLists[s][m_FrameIndex].GetStats().Issued;
+            filtered += m_ShadowCmdLists[s][m_FrameIndex].GetStats().Filtered;
+        }
+        GothicRendererInfo& info = Engine::GAPI->GetRendererState().RendererInfo;
+        info.StateChanges = issued;
+        info.FramePipelineStates = filtered;   // "SC_PipelineStates" row — redundant binds dropped
+    }
+
     // Draw the ImGui overlay last, on top of the 2D UI, while the backbuffer is still a render target.
     // The SRV heap is bound (OnBeginFrame); re-bind the RTV defensively in case a draw changed it.
     if ( Engine::ImGuiHandle && Engine::ImGuiHandle->Initiated ) {
+        TracyD3D12ZoneCGX( m_CmdList.Get(), "ImGui" );
         D3D12_CPU_DESCRIPTOR_HANDLE rtv = GetDisplayRtv();
         m_CmdList->OMSetRenderTargets( 1, &rtv, FALSE, nullptr );
         Engine::ImGuiHandle->RenderLoopD3D12( m_CmdList.Get() );
+        // imgui_impl_dx12 records on the RAW list: its own PSO, root signature, descriptor heaps, RTV,
+        // viewport, scissor, topology, blend factor and vertex/index buffers. The state cache cannot see
+        // any of it, so drop the whole shadow — this is the one place in the backend that goes behind it.
+        m_CmdList.InvalidateAll();
     }
 
     // With real HDR output the frame so far lives in the FP16 display buffer; this is the one pass that turns
@@ -2364,6 +2392,7 @@ void D3D12GraphicsEngine::GetBackbufferData( bool thumbnail, byte** data, INT2& 
     }
     D3D12_CPU_DESCRIPTOR_HANDLE captureRtv = captureRtvHeap->GetCPUDescriptorHandleForHeapStart();
     device->CreateRenderTargetView( captureTex.Get(), nullptr, captureRtv );
+    m_CmdList.InvalidateRenderTargets();
 
     // m_SceneColor was left in PIXEL_SHADER_RESOURCE state by OnStartWorldRendering's ResolveSceneToBackBuffer
     // call (now genuinely true on the GPU after the flush above) — safe to sample without re-transitioning.

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -14,6 +14,7 @@
 
 #include "D3D12Texture.h"
 #include "D3D12ShaderBackend.h"
+#include "D3D12StateCache.h"
 #include "D3D12PipelineState.h"
 #include "D3D12ShadowMap.h"
 #include "D3D12PointShadows.h"
@@ -53,7 +54,7 @@ public:
     /** Actual configured frame-in-flight count (<= kBackBufferMax). Set once in the constructor from
         RendererSettings.LowLatency, before D3D12ShadowMap::Attach/D3D12PointShadows::Attach copy it -
         never changes afterwards (switching it requires a restart, like D3D11's swapchain waitable flag). */
-    UINT kBackBufferCount = 2;
+    UINT kBackBufferCount = 3;
 
     D3D12GraphicsEngine();
     ~D3D12GraphicsEngine() override;
@@ -456,7 +457,10 @@ private:
 
     Microsoft::WRL::ComPtr<ID3D12Resource>         m_BackBuffers[kBackBufferMax];
     Microsoft::WRL::ComPtr<ID3D12CommandAllocator> m_CmdAllocators[kBackBufferMax];
-    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> m_CmdList;
+    // The frame's direct command list, behind the engine-wide redundant-state filter (D3D12StateCache.h).
+    // Reads exactly like the ComPtr it replaces (`m_CmdList->Foo()`, `.Get()`, `if (!m_CmdList)`), but every
+    // PSO / root-signature / root-argument / IA / RS / OM bind now goes through the shadow first.
+    D3D12CmdList m_CmdList;
 
     Microsoft::WRL::ComPtr<ID3D12Fence> m_Fence;
     UINT64 m_FenceValues[kBackBufferMax] = {};
@@ -906,7 +910,10 @@ private:
     static constexpr UINT kRainShadowListIndex  = kShadowCascades + 1;
     static constexpr UINT kShadowRecordSlots    = kShadowCascades + 2;
     Microsoft::WRL::ComPtr<ID3D12CommandAllocator>    m_ShadowCmdAllocators[kShadowRecordSlots][kBackBufferMax];
-    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> m_ShadowCmdLists[kShadowRecordSlots][kBackBufferMax];
+    // Each recording slot owns its OWN state cache: a D3D12CmdList shadow is per-list and unsynchronized, and
+    // these lists are recorded concurrently on pool threads (one slot per thread) while the main thread records
+    // m_CmdList. Sharing one cache across them would race; per-slot wrappers can't.
+    D3D12CmdList m_ShadowCmdLists[kShadowRecordSlots][kBackBufferMax];
     bool m_ShadowCmdListsReady = false;
     bool CreateShadowRecordCommandLists();
     // Closes + submits whatever is currently recorded in m_CmdList and immediately reopens it on the SAME
@@ -933,7 +940,7 @@ private:
     void FinishShadowPasses();
     // Resets one (slot x frame-in-flight) allocator/list pair and hands back the open list, or nullptr on
     // failure. Public to the recording lambdas only in the sense that they are defined inside member functions.
-    ID3D12GraphicsCommandList* BeginShadowList( UINT slot );
+    D3D12CmdList* BeginShadowList( UINT slot );
     bool m_ShadowListRecorded[kShadowRecordSlots] = {};   // per slot: recorded AND closed successfully this frame
     bool m_ShadowThreadedRecord = false;   // this frame's BeginShadowRecording took the pooled-recording path
     bool m_RainShadowPassReady = false;   // PrepareRainShadowmap produced a valid camera + caster set this frame
@@ -1562,7 +1569,7 @@ private:
     // list it is handed.
     void PrepareRainShadowmap();
     void CollectRainShadowVobs();   // the VOB half of PrepareRainShadowmap (cull -> instance upload -> arg build)
-    void RecordRainShadowmap( ID3D12GraphicsCommandList* cmdList );
+    void RecordRainShadowmap( D3D12CmdList& cmdList );
 
     // Scene wetness ("wet ground"): the port of D3D11's deferred ApplySceneWettness into the Forward+ lit
     // pixel shaders (Shaders/D3D12/include/Wetness.hlsl). All of its inputs ride in the TAIL of the shared

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -282,20 +282,14 @@ private:
     // Skeletal (animated NPC/monster) pipeline creation now lives in m_Pipelines.CreateSkeletal (root sig + lit +
     // depth-prepass PSOs). The per-frame skeletal CB ring stays here:
     bool CreateSkeletalConstantBuffers(); // per-frame dynamic (upload-heap) skeletal CB ring (instance + bones)
-    // once/frame anim update + upload bone/inst CBs + attachment instances (pre-cull). cullFrustum (if given)
-    // rejects vobs whose bbox misses it — used by the shadow cascades to cull against the CASCADE frustum
-    // instead of the player's view frustum (a caster invisible to the player can still cast a visible shadow).
-    // sphereCenter/sphereRange (if given, sphereCenter != nullptr) instead cull by distance from that point —
-    // used by point-light shadows to cull against the LIGHT's sphere instead of the player's camera radius;
-    // cullFrustum and sphereCenter are mutually exclusive per call (cascades pass a frustum, point lights pass
-    // a sphere). shadowCascade >= 0 routes the (filtered) records into that cascade's own list, -2 routes into
-    // the point-shadow scratch list (g_PointShadowSkelDraws/g_PointShadowAttachDraws), else the main-view
-    // g_FrameSkelDraws/g_FrameAttachDraws; the per-vob CB/attachment ring upload itself is still cached once per
-    // frame (see g_SkelUploadCache) regardless of how many cull passes touch that vob.
-    // Beyond this camera distance an .MMS node attachment (facial morph head, bow/crossbow draw mesh) stops
-    // morphing and renders as its undeformed rest mesh — the literal D3D11 threshold (GothicAPI.cpp's
-    // `dist < 1000` split into drawAsMorphMesh/drawRegular, plus DrawSkeletalMeshVobs' `distance < 1000`
-    // morph branch). Morphing costs a CPU vertex re-upload per animation frame, so this bounds crowd cost.
+    // Once/frame anim update + upload bone/inst CBs + attachment instances (pre-cull).
+    // cullFrustum / sphereCenter+sphereRange are mutually exclusive: the cascades cull against the CASCADE
+    // frustum (a caster invisible to the player can still cast a visible shadow), point lights against the
+    // LIGHT's sphere. shadowCascade >= 0 routes the records into that cascade's list, -2 into the
+    // point-shadow scratch lists, else the main-view ones. The per-vob upload itself stays cached once per
+    // frame (g_SkelUploadCache) however many cull passes touch the vob.
+    // Beyond this camera distance an .MMS node attachment stops morphing and renders as its undeformed rest
+    // mesh. Same threshold D3D11 uses (GothicAPI.cpp's `dist < 1000`).
     static constexpr float kMorphMeshMaxDistance = 1000.0f;
     // cascadeCount > 1 (only valid with shadowCascade >= 0) switches to the MULTI-cascade mode: cullFrustum is
     // read as an ARRAY of cascadeCount frusta (i.e. D3D12ShadowMap::CascadeFrusta()) and each prepared vob is appended to
@@ -690,19 +684,16 @@ private:
     uint8_t* m_WorldDrawArgsPtr[kBackBufferMax] = {};
     D3D12_GPU_VIRTUAL_ADDRESS m_WorldDrawArgsGpu[kBackBufferMax] = {};
     UINT m_WorldDrawCount = 0;                       // commands built this frame (shared by both world passes)
-    // Alpha-test partition. BuildWorldDrawCommands orders the command set so [0, m_WorldOpaqueDrawCount) is
-    // every material that needs NO alpha cutout and [m_WorldOpaqueDrawCount, m_WorldDrawCount) is the ones that
-    // do. Only the depth prepass cares: it submits the prefix through a PS-less PSO (double-rate Z) and the
-    // suffix through the clipping one. The color pass draws the whole range as before — opaque geometry is
-    // order-independent, so the reordering is invisible to it.
+    // Alpha-test partition. BuildWorldDrawCommands orders the command set so [0, m_WorldOpaqueDrawCount)
+    // needs NO alpha cutout and the rest does. Only the depth prepass cares: it submits the prefix through a
+    // PS-less PSO (double-rate Z) and the suffix through the clipping one. The color pass draws the whole
+    // range — opaque geometry is order-independent, so the reordering is invisible to it.
     UINT m_WorldOpaqueDrawCount = 0;
-    // Coalesced mirror of the opaque prefix, appended at [m_WorldDepthMergedFirst, +m_WorldDepthMergedCount)
-    // — i.e. PAST m_WorldDrawCount, so the color pass' view of the ring is untouched. The wrapped world index
-    // buffer is packed section-major (WorldConverter::WrapVertexBuffers), so a visible section's opaque
-    // materials land in one contiguous index run; with no pixel shader bound their per-material b6 constants
-    // are dead, which makes those N commands one DrawIndexed over the merged range. Only the depth-only
-    // submits (this prepass + every CSM cascade's world casters) may use it. 0 = not built this frame (ring
-    // had no tail room), callers fall back to the per-material prefix.
+    // Coalesced mirror of the opaque prefix, appended PAST m_WorldDrawCount so the color pass' view of the
+    // ring is untouched. The wrapped world index buffer is packed section-major, so a visible section's
+    // opaque materials form one contiguous index run, and with no pixel shader bound their per-material b6
+    // constants are dead — so those N commands become one DrawIndexed. Only the depth-only submits may use
+    // it. 0 = not built this frame (no ring tail room), callers fall back to the per-material prefix.
     UINT m_WorldDepthMergedFirst = 0;
     UINT m_WorldDepthMergedCount = 0;
     unsigned int m_WorldDrawnIndices = 0;            // total indices in this frame's command set (triangle counter)
@@ -804,20 +795,15 @@ private:
         int shadowCascade = kVobIndicesMainView, UINT* outOpaqueCount = nullptr );
 
     // ---- GPU-driven skeletal meshes + node attachments (T9): ExecuteIndirect + bindless materials ----------
-    // The prerequisite was the bindless-skeletal / bindless-attachment work: neither Skeletal.RootSig nor the
-    // attachment PSOs bind a t0 descriptor table any more, and ExecuteIndirect can set root constants and root
-    // DESCRIPTORS but never a descriptor table. With that gone, both skeletal passes collapse the same way the
-    // world/VOB ones did (P2.11/P2.12): the per-mesh CPU work (UpdateMeshLibTexAniState, CacheIn, the b6
-    // material push, IASetVertexBuffers/IASetIndexBuffer, DrawIndexedInstanced) happens ONCE per frame in
-    // BuildSkeletalDrawCommands, and the depth prepass + the lit color pass each become one submit over the
-    // very same argument buffer (the prepass' clip-only PS simply ignores the normal/ORM constants).
+    // Possible because neither Skeletal.RootSig nor the attachment PSOs bind a t0 descriptor table any more,
+    // and ExecuteIndirect can set root constants and root DESCRIPTORS but never a table. The per-mesh CPU
+    // work happens ONCE per frame in BuildSkeletalDrawCommands, and the depth prepass and the lit pass each
+    // become one submit over the same argument buffer.
     //
-    // Base meshes need their own signature because each command also has to rebind the per-vob root CBVs (b1
-    // instance, b2 bone palette — root descriptors, so legal indirect arguments) that the shared skinning VS
-    // reads. Node attachments do NOT: they already draw through World.RootSig with exactly the VBVx2 + IBV +
-    // b6 shape m_VobIndirectCmdSig describes, so they reuse that signature and VobDrawCommand verbatim (their
-    // VSMainAttach/VSDepthAttach never read the b4 wind min/max the signature also writes — the instance
-    // stream's wind fields are reinterpreted as Fatness/Scaling instead — so those two floats go out as 0).
+    // Base meshes need their own signature because each command also rebinds the per-vob root CBVs (b1
+    // instance, b2 bone palette) the shared skinning VS reads. Node attachments do not — they already draw
+    // through World.RootSig with exactly the shape m_VobIndirectCmdSig describes, so they reuse it and
+    // VobDrawCommand verbatim.
     struct SkeletalDrawCommand {                     // 80 bytes; UINT64 members force 8-byte align, 80 % 8 == 0
         D3D12_GPU_VIRTUAL_ADDRESS InstCB;            // @0  root param 1 -> b1 InstanceCB (world/color/fatness)
         D3D12_GPU_VIRTUAL_ADDRESS BoneCB;            // @8  root param 2 -> b2 BonesCB (bone palette)
@@ -937,17 +923,15 @@ private:
     static constexpr UINT kRainShadowListIndex  = kShadowCascades + 1;
     static constexpr UINT kShadowRecordSlots    = kShadowCascades + 2;
     Microsoft::WRL::ComPtr<ID3D12CommandAllocator>    m_ShadowCmdAllocators[kShadowRecordSlots][kBackBufferMax];
-    // Each recording slot owns its OWN state cache: a D3D12CmdList shadow is per-list and unsynchronized, and
-    // these lists are recorded concurrently on pool threads (one slot per thread) while the main thread records
-    // m_CmdList. Sharing one cache across them would race; per-slot wrappers can't.
+    // Each slot owns its OWN state cache: a D3D12CmdList shadow is per-list and unsynchronized, and these
+    // lists are recorded concurrently on pool threads while the main thread records m_CmdList.
     D3D12CmdList m_ShadowCmdLists[kShadowRecordSlots][kBackBufferMax];
     bool m_ShadowCmdListsReady = false;
     bool CreateShadowRecordCommandLists();
     // Closes + submits whatever is currently recorded in m_CmdList and immediately reopens it on the SAME
     // frame allocator (no allocator Reset, no GPU wait) so a batch of independently-recorded lists can be
     // slotted into the queue at this exact point in the frame — or simply so the GPU can start on what is
-    // already recorded instead of idling until Present. Used by BeginShadowRecording and, again, right before
-    // FinishShadowPasses.
+    // already recorded instead of idling until Present.
     void SubmitRecordedCommandsAndReopen();
 
     // ---- The deferred shadow driver, called from OnStartWorldRendering (see D3D12Scene.cpp for the rationale).
@@ -959,9 +943,8 @@ private:
     //   BeginShadowRecording — submit m_CmdList "part A", fan the pure-D3D12 recording out to the pool and
     //                          RETURN IMMEDIATELY. The main thread then records the depth prepass, the GPU VOB
     //                          cull, the light cull and SSAO into the reopened m_CmdList while the pool works.
-    //   FinishShadowPasses   — join, execute the finished lists (they land in the queue ahead of the still-open
-    //                          part B2 — the lit passes — because the caller submits part B1 immediately before
-    //                          calling this), re-record any slot that failed, then the post-barriers + RT rebind.
+    //   FinishShadowPasses   — join, execute the finished lists (they land ahead of the still-open part B2,
+    //                          the lit passes), re-record any failed slot, then post-barriers + RT rebind.
     // NOTE the CSM cascades do NOT go through this driver: each cascade is one self-contained job (cull ->
     // build -> record -> close) launched by D3D12ShadowMap::Prepare, far earlier in the frame. Only the join
     // is shared, in FinishShadowPasses. See the phase table in D3D12ShadowMap.h.
@@ -1118,31 +1101,18 @@ private:
     // 63 of its 64 DWORDs, so two more root constants would not fit there.
     UINT m_ActiveAOMaskSrvSlot = UINT_MAX;
     bool m_AOResourcesReady = false;
-    // m_AOMask rests in UNORDERED_ACCESS between RenderSSAO runs (its creation state) except right after a
-    // successful run, which leaves it PIXEL_SHADER_RESOURCE for the lit passes' bindless read — tracks that so
-    // the NEXT run knows whether it must flip it back to UNORDERED_ACCESS before the main pass writes it (mirrors
-    // m_SceneColorInPixelState/m_LightGridInPixelState). Toggling AO off skips RenderSSAO entirely, so without
-    // this the resource would still show PIXEL_SHADER_RESOURCE if AO is re-enabled a frame later.
+    // m_AOMask rests in UNORDERED_ACCESS between RenderSSAO runs, except right after a successful one, which
+    // leaves it PIXEL_SHADER_RESOURCE for the lit passes. Toggling AO off skips RenderSSAO entirely, so the
+    // flag is what tells the next run whether to flip it back.
     bool m_AOMaskInPixelState = false;
     // --- The AO depth source ---------------------------------------------------------------------------------
-    // THIS frame's m_DepthBuffer, read straight after the Forward+ depth prepass and before any lit pass. The
-    // mask is therefore in this frame's screen space and the lit shaders read it at their own pixel — no
-    // reprojection, no lag (see Shaders/D3D12/include/ScreenSpaceAO.hlsl).
-    //
-    // This used to be a full-frame COPY of the PREVIOUS frame's completed depth (m_PrevDepth + CopyDepthForAO),
-    // because the prepass omitted grass — a grass pixel would then sample the AO of the terrain behind it, and
-    // the blades cast no AO of their own. Folding vegetation into the prepass (DrawVegetationDepthPrepass) fixed
-    // the cause, so the snapshot, its depth-sized allocation, the per-frame CopyResource and the per-pixel
-    // reprojection in five pixel shaders are all gone. Water/decals/particles still write depth after the
-    // prepass and are still not occluders; that was true of the whole scheme's near field anyway.
-    //
-    // Cost: RenderSSAO now has to round-trip m_DepthBuffer DEPTH_WRITE <-> NON_PIXEL_SHADER_RESOURCE and
-    // therefore serialises against the prepass, exactly like BuildHiZ does a few calls earlier.
+    // THIS frame's m_DepthBuffer, read after the Forward+ depth prepass and before any lit pass, so the mask is
+    // in this frame's screen space and needs no reprojection. In exchange RenderSSAO round-trips the depth
+    // buffer DEPTH_WRITE <-> NON_PIXEL_SHADER_RESOURCE and serialises against the prepass, as BuildHiZ does.
     //
     // 80 bytes of the shared shadow CB, between the wetness block and the sky-IBL tail. Only the leading float2
-    // is live (1/screen-size, so the lit shaders can turn SV_Position into a mask UV); the rest is the hole the
-    // reprojection constants used to occupy, kept because the offsets of everything after it are baked into
-    // five HLSL cbuffer layouts.
+    // is live (1/screen-size, to turn SV_Position into a mask UV); the rest is the hole the old reprojection
+    // constants left, kept because five HLSL cbuffer layouts bake in the offsets after it.
     static constexpr UINT kAoReprojCbOffset = 352;
     static constexpr UINT kAoReprojCbReservedBytes = 80;
     struct AoScreenCBData { float InvResX; float InvResY; float _pad[2]; };

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -696,10 +696,24 @@ private:
     // suffix through the clipping one. The color pass draws the whole range as before — opaque geometry is
     // order-independent, so the reordering is invisible to it.
     UINT m_WorldOpaqueDrawCount = 0;
+    // Coalesced mirror of the opaque prefix, appended at [m_WorldDepthMergedFirst, +m_WorldDepthMergedCount)
+    // — i.e. PAST m_WorldDrawCount, so the color pass' view of the ring is untouched. The wrapped world index
+    // buffer is packed section-major (WorldConverter::WrapVertexBuffers), so a visible section's opaque
+    // materials land in one contiguous index run; with no pixel shader bound their per-material b6 constants
+    // are dead, which makes those N commands one DrawIndexed over the merged range. Only the depth-only
+    // submits (this prepass + every CSM cascade's world casters) may use it. 0 = not built this frame (ring
+    // had no tail room), callers fall back to the per-material prefix.
+    UINT m_WorldDepthMergedFirst = 0;
+    UINT m_WorldDepthMergedCount = 0;
     unsigned int m_WorldDrawnIndices = 0;            // total indices in this frame's command set (triangle counter)
     bool m_WorldDrawArgsOverflowLogged = false;
     bool CreateWorldIndirect();                      // command signature + per-frame arg ring (once, at init)
     void BuildWorldDrawCommands();                   // collect visible sections + fill arg ring (once/frame, pre-prepass)
+    // Merges the opaque world commands in `opaque` (sorted in place) into the fewest DrawIndexed commands
+    // covering the EXACT same index ranges, written to `out`. Shared by BuildWorldDrawCommands and
+    // D3D12ShadowMap::CullCascade. Returns the merged count, or 0 if `out` could not hold the result.
+    static UINT CoalesceWorldDepthCommands( std::vector<WorldDrawCommand>& opaque,
+        WorldDrawCommand* out, UINT outCapacity );
 
     // ---- Alpha-blended world-mesh surfaces (D3D12Transparency.cpp) — port of D3D11's
     // DrawMeshInfoListAlphablended. BuildWorldDrawCommands peels these out of the opaque command set into

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -690,6 +690,12 @@ private:
     uint8_t* m_WorldDrawArgsPtr[kBackBufferMax] = {};
     D3D12_GPU_VIRTUAL_ADDRESS m_WorldDrawArgsGpu[kBackBufferMax] = {};
     UINT m_WorldDrawCount = 0;                       // commands built this frame (shared by both world passes)
+    // Alpha-test partition. BuildWorldDrawCommands orders the command set so [0, m_WorldOpaqueDrawCount) is
+    // every material that needs NO alpha cutout and [m_WorldOpaqueDrawCount, m_WorldDrawCount) is the ones that
+    // do. Only the depth prepass cares: it submits the prefix through a PS-less PSO (double-rate Z) and the
+    // suffix through the clipping one. The color pass draws the whole range as before — opaque geometry is
+    // order-independent, so the reordering is invisible to it.
+    UINT m_WorldOpaqueDrawCount = 0;
     unsigned int m_WorldDrawnIndices = 0;            // total indices in this frame's command set (triangle counter)
     bool m_WorldDrawArgsOverflowLogged = false;
     bool CreateWorldIndirect();                      // command signature + per-frame arg ring (once, at init)
@@ -749,6 +755,7 @@ private:
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_VobDrawArgsAlloc[kBackBufferMax];
     uint8_t* m_VobDrawArgsPtr[kBackBufferMax] = {};
     UINT m_VobDrawCount = 0;                          // commands built this frame (shared by both main-view VOB passes)
+    UINT m_VobOpaqueDrawCount = 0;                    // alpha-test partition of the above — see m_WorldOpaqueDrawCount
     unsigned int m_VobDrawnTriangles = 0;            // triangles in this frame's main-view VOB command set (stats)
     bool m_VobDrawArgsOverflowLogged = false;
     // The shadow-caster variant of this pipeline (VSDepth + PSShadowClipBindless) and the per-cascade arg rings
@@ -774,9 +781,13 @@ private:
     // self-shadows the full-detail surface black. See the constant's comment for the failure mode.
     static constexpr int kVobIndicesMainView = -1;
     static constexpr int kFirstLodShadowCascade = SHADOW_LOD_FIRST_CASCADE;
+    // outOpaqueCount (optional): how many of the returned commands form the leading no-alpha-cutout run. The
+    // build always partitions — opaque materials first, alpha-tested ones after — so the depth prepass can
+    // submit the prefix through a PS-less PSO. Callers that don't split (the color pass, the shadow cascades)
+    // just pass nullptr and draw the whole range. See m_WorldOpaqueDrawCount.
     UINT BuildVobDrawCommands( const std::vector<FrameVobUpload>& uploads, uint8_t* argPtr, bool resolveMaps,
         UINT maxCommands, bool culled = false, bool cacheIn = true,
-        int shadowCascade = kVobIndicesMainView );
+        int shadowCascade = kVobIndicesMainView, UINT* outOpaqueCount = nullptr );
 
     // ---- GPU-driven skeletal meshes + node attachments (T9): ExecuteIndirect + bindless materials ----------
     // The prerequisite was the bindless-skeletal / bindless-attachment work: neither Skeletal.RootSig nor the
@@ -813,10 +824,12 @@ private:
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_SkeletalDrawArgsAlloc[kBackBufferMax];
     uint8_t* m_SkeletalDrawArgsPtr[kBackBufferMax] = {};
     UINT m_SkeletalDrawCount = 0;                    // commands built this frame (prepass + color share them)
+    UINT m_SkeletalOpaqueDrawCount = 0;              // alpha-test partition — see m_WorldOpaqueDrawCount
     Microsoft::WRL::ComPtr<ID3D12Resource> m_AttachDrawArgs[kBackBufferMax];
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_AttachDrawArgsAlloc[kBackBufferMax];
     uint8_t* m_AttachDrawArgsPtr[kBackBufferMax] = {};
     UINT m_AttachDrawCount = 0;                      // VobDrawCommands built this frame (prepass + color share them)
+    UINT m_AttachOpaqueDrawCount = 0;                // alpha-test partition — see m_WorldOpaqueDrawCount
     unsigned int m_SkeletalDrawnTriangles = 0;       // triangles in this frame's skeletal+attachment command set (stats)
     bool m_SkeletalDrawArgsOverflowLogged = false;
     bool CreateSkeletalIndirect();                   // command signature + both per-frame arg rings (once, at init)
@@ -1226,6 +1239,7 @@ private:
     // the tail of CreateSkeletal), so a partial success is genuinely reachable — hence one gate, tested by
     // BeginMotionGBuffer and by each of the three prepass draws.
     bool MotionGBufferActive() const;
+    bool MotionGBufferNeeded() const;   // does any pass actually read velocity/normals this frame? see the impl
 
     // ---- Temporal anti-aliasing (D3D12Taa.cpp) --------------------------------------------------------------
     // Port of Intel's Graphics Optimized TAA (MIT; Shaders/D3D12/TAAResolve.hlsl carries the attribution). The
@@ -1558,6 +1572,7 @@ private:
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_RainVobDrawArgsAlloc[kBackBufferMax];
     uint8_t* m_RainVobDrawArgsPtr[kBackBufferMax] = {};
     UINT     m_RainVobDrawCount = 0;   // built by PrepareRainShadowmap, consumed by RecordRainShadowmap
+    UINT     m_RainVobOpaqueDrawCount = 0;   // alpha-test partition — see m_WorldOpaqueDrawCount
     // Bucket-per-visual collection target; grown by OnAddVob and reset by OnLoadWorld alongside the
     // main-view / per-cascade views, since the bucket index IS the visual index.
     RenderView m_RainShadowVobs;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -931,7 +931,9 @@ private:
     bool CreateShadowRecordCommandLists();
     // Closes + submits whatever is currently recorded in m_CmdList and immediately reopens it on the SAME
     // frame allocator (no allocator Reset, no GPU wait) so a batch of independently-recorded lists can be
-    // slotted into the queue at this exact point in the frame. Used by BeginShadowRecording.
+    // slotted into the queue at this exact point in the frame — or simply so the GPU can start on what is
+    // already recorded instead of idling until Present. Used by BeginShadowRecording and, again, right before
+    // FinishShadowPasses.
     void SubmitRecordedCommandsAndReopen();
 
     // ---- The deferred shadow driver, called from OnStartWorldRendering (see D3D12Scene.cpp for the rationale).
@@ -944,7 +946,8 @@ private:
     //                          RETURN IMMEDIATELY. The main thread then records the depth prepass, the GPU VOB
     //                          cull, the light cull and SSAO into the reopened m_CmdList while the pool works.
     //   FinishShadowPasses   — join, execute the finished lists (they land in the queue ahead of the still-open
-    //                          part B), re-record any slot that failed, then the post-barriers + RT rebind.
+    //                          part B2 — the lit passes — because the caller submits part B1 immediately before
+    //                          calling this), re-record any slot that failed, then the post-barriers + RT rebind.
     // NOTE the CSM cascades do NOT go through this driver: each cascade is one self-contained job (cull ->
     // build -> record -> close) launched by D3D12ShadowMap::Prepare, far earlier in the frame. Only the join
     // is shared, in FinishShadowPasses. See the phase table in D3D12ShadowMap.h.

--- a/D3D11Engine/D3D12Engine/D3D12LineRenderer.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12LineRenderer.cpp
@@ -126,7 +126,7 @@ void D3D12GraphicsEngine::DrawLines( const std::vector<LineVertex>& lines, bool 
     ID3D12PipelineState* pso = screenSpace ? m_Pipelines.Lines.ScreenPSO.Get() : m_Pipelines.Lines.WorldPSO.Get();
     if ( !pso ) return;
 
-    DX_ZONE( m_CmdList, "Draw debug lines" );
+    DX_ZONE( m_CmdList.Get(), "Draw debug lines" );
 
     const UINT frame = m_FrameIndex;
     const UINT bytes = static_cast<UINT>( lines.size() * sizeof( LineVertex ) );

--- a/D3D11Engine/D3D12Engine/D3D12Motion.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Motion.cpp
@@ -213,11 +213,27 @@ void D3D12GraphicsEngine::UploadMotionConstants() {
     memcpy( m_MotionCBMapped[m_FrameIndex], &cb, sizeof( cb ) );
 }
 
-/** Clears both G-buffer targets and makes them the depth prepass's render targets (replacing the scene-color
-    RTV the prepass used to bind with an all-zero write mask). The depth buffer stays bound — the prepass's whole
-    point is still laying down depth. */
+bool D3D12GraphicsEngine::MotionGBufferNeeded() const {
+    // Does ANYTHING downstream read the velocity or normal target this frame?
+    //   velocity -> RenderTAA (the only consumer; D3D12Taa.cpp) and the debug overlay
+    //   normals  -> XeGTAO (D3D12GTAO.cpp; it has a depth-derived fallback and is happy without them)
+    // Neither is on in a stock config (AntiAliasingMode defaults to AA_SMAA, AoMode to AO_HBAO), and writing
+    // two extra full-screen render targets across every opaque prepass draw for nobody is the single most
+    // expensive thing the D3D12 prepass was doing. Gate the whole G-buffer on an actual reader.
+    //
+    // Everything that touches the two targets keys off MotionGBufferActive(), so this one predicate turns off
+    // the MRT binding, both clears, the G-buffer PSO variants AND FillCameraVelocity together — which also
+    // keeps the velocity/normal barrier state machine paired (BeginMotionGBuffer flips them to RENDER_TARGET,
+    // FillCameraVelocity flips them back; running one without the other transitions from the wrong state).
+    if ( IsTaaEnabled() ) return true;
+    if ( IsGtaoEnabled() ) return true;   // wants the real normals over its depth-derived fallback
+    const auto& taa = Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.TAA;
+    return taa.DisplayVelocity || taa.DisplayNormals;
+}
+
 bool D3D12GraphicsEngine::MotionGBufferActive() const {
-    return m_MotionResourcesReady
+    return MotionGBufferNeeded()
+        && m_MotionResourcesReady
         && m_MotionCB[m_FrameIndex]
         && m_Pipelines.World.DepthPrepassGBufPSO
         && m_Pipelines.World.DepthPrepassVobGBufPSO
@@ -225,6 +241,10 @@ bool D3D12GraphicsEngine::MotionGBufferActive() const {
         && m_Pipelines.Skeletal.DepthPrepassGBufPSO;
 }
 
+/** Clears both G-buffer targets and makes them the depth prepass's render targets (replacing the scene-color
+    RTV the prepass used to bind with an all-zero write mask). The depth buffer stays bound — the prepass's whole
+    point is still laying down depth. No-op when nothing reads the two targets (MotionGBufferNeeded), in which
+    case the prepass keeps the masked-off scene-color RTV and its PS-less/depth-only PSOs. */
 void D3D12GraphicsEngine::BeginMotionGBuffer() {
     if ( !MotionGBufferActive() || !m_CmdList || !m_FrameOpen ) return;
 
@@ -269,7 +289,11 @@ void D3D12GraphicsEngine::EndMotionGBuffer() {
     of world rendering because it needs the FINAL depth buffer (water, decals and the transparents have all
     written by then). */
 void D3D12GraphicsEngine::FillCameraVelocity() {
-    if ( !m_FrameOpen || !m_MotionResourcesReady || !m_CmdList ) return;
+    if ( !m_FrameOpen || !m_CmdList ) return;
+    // MUST use the same predicate BeginMotionGBuffer does: this pass' opening barrier assumes velocity is in
+    // RENDER_TARGET, which is only true when BeginMotionGBuffer put it there. Running one without the other
+    // transitions from a state the resource isn't in.
+    if ( !MotionGBufferActive() ) return;
     if ( !m_Pipelines.Motion.FillPSO || !m_Pipelines.Motion.FillRootSig ) return;
     if ( !m_DepthBuffer || m_DepthSrvSlot == UINT_MAX ) return;
     const D3D12_GPU_VIRTUAL_ADDRESS motionCb = GetMotionCbAddress();

--- a/D3D11Engine/D3D12Engine/D3D12Motion.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Motion.cpp
@@ -109,6 +109,7 @@ bool D3D12GraphicsEngine::CreateMotionResources( INT2 size ) {
     m_NormalRtv.ptr += static_cast<SIZE_T>( kBackBufferMax + 5 ) * m_RtvDescriptorSize;
     device->CreateRenderTargetView( m_VelocityBuffer.Get(), nullptr, m_VelocityRtv );
     device->CreateRenderTargetView( m_NormalBuffer.Get(), nullptr, m_NormalRtv );
+    m_CmdList.InvalidateRenderTargets();   // descriptors rewritten in place — see D3D12StateCache.h
 
     auto ensureSlot = [&]( UINT& slot ) -> bool {
         if ( slot == UINT_MAX ) slot = AllocateSrvSlot();
@@ -274,7 +275,7 @@ void D3D12GraphicsEngine::FillCameraVelocity() {
     const D3D12_GPU_VIRTUAL_ADDRESS motionCb = GetMotionCbAddress();
     if ( !motionCb ) return;
 
-    DX_ZONE( m_CmdList, "Camera velocity fill" );
+    DX_ZONE( m_CmdList.Get(), "Camera velocity fill" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Camera velocity fill" );
 
     // Velocity RENDER_TARGET -> UAV (the compute pass writes it), depth DEPTH_WRITE -> shader-read. The DSV must
@@ -375,7 +376,7 @@ void D3D12GraphicsEngine::RenderMotionDebugOverlay() {
     // target and reading it would be invalid. Bail rather than emit a mismatched-state read.
     if ( !m_VelocityInPixelState ) return;
 
-    DX_ZONE( m_CmdList, "Motion debug overlay" );
+    DX_ZONE( m_CmdList.Get(), "Motion debug overlay" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Motion debug overlay" );
 
     D3D12_CPU_DESCRIPTOR_HANDLE rtv = GetDisplayRtv();

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -234,9 +234,25 @@ bool D3D12PipelineState::CreateWorld() {
 
     pso.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
 
-    // Reversed-Z: test + write depth, pass on GREATER_EQUAL (matches Gothic's infinite-far projection).
+    // Reversed-Z: test depth, pass on GREATER_EQUAL (matches Gothic's infinite-far projection).
+    //
+    // Depth write is OFF. The Forward+ depth prepass already laid down this exact geometry's depth, so every
+    // write here would only restore the value that is already in the buffer. Dropping it (a) removes a
+    // full-resolution depth write per opaque pixel, (b) leaves the depth surface clean for the many passes
+    // that read it later (AO, GPU cull, fog, DoF, TAA) instead of dirtying it again, and (c) lets an
+    // alpha-clipping lit shader take the plain early-Z path rather than Re-Z, since with no write there is
+    // nothing for a `discard` to invalidate.
+    //
+    // GREATER_EQUAL is kept rather than tightened to EQUAL on purpose. The prepass and this pass run DIFFERENT
+    // vertex shaders (DepthPrepass.hlsl:VSWorld vs World.hlsl:VSMain), and HLSL guarantees no cross-shader
+    // invariance for SV_Position — one ULP of difference under EQUAL makes the whole surface vanish, while
+    // under GREATER_EQUAL it still draws. The set of fragments that pass is identical to before this change;
+    // only the redundant write is gone. Same reasoning at the VOB/attachment/skeletal color PSOs.
+    //
+    // Does NOT apply to vegetation: DrawVegetationDepthPrepass is range-limited (kVegetationPrepassRange), so
+    // distant grass has no prepass depth and must keep writing its own or it stops occluding other grass.
     pso.DepthStencilState.DepthEnable = TRUE;
-    pso.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+    pso.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
     pso.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_GREATER_EQUAL;
     pso.DepthStencilState.StencilEnable = FALSE;
 
@@ -1197,7 +1213,11 @@ bool D3D12PipelineState::CreateVob() {
     pso.RasterizerState.DepthClipEnable = TRUE;
     pso.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
     pso.DepthStencilState.DepthEnable = TRUE;
-    pso.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+    // Depth write OFF — DrawVobDepthPrepass already wrote this geometry's depth. See the long note at the
+    // world color PSO (CreateWorld) for why, and for why the test stays GREATER_EQUAL instead of EQUAL.
+    // Inherited by VobAttachPSO and VobIndirectPSO below, which draw the same prepassed geometry; the two
+    // alpha-BLENDED VOB PSOs after them set the mask themselves (they were never in the prepass at all).
+    pso.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
     pso.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_GREATER_EQUAL;  // reversed-Z
     pso.DepthStencilState.StencilEnable = FALSE;
 
@@ -1782,7 +1802,9 @@ bool D3D12PipelineState::CreateSkeletal() {
     pso.RasterizerState.DepthClipEnable = TRUE;
     pso.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
     pso.DepthStencilState.DepthEnable = TRUE;
-    pso.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+    // Depth write OFF — DrawSkeletalDepthPrepass already wrote it. See the world color PSO (CreateWorld).
+    // NOTE: the depth-prepass PSO built further down re-enables the write; it is the one that lays the depth.
+    pso.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
     pso.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_GREATER_EQUAL;  // reversed-Z
     pso.DepthStencilState.StencilEnable = FALSE;
 
@@ -1811,6 +1833,10 @@ bool D3D12PipelineState::CreateSkeletal() {
     pso.VS = { Skeletal.DepthPrepassVsBlob->GetBufferPointer(), Skeletal.DepthPrepassVsBlob->GetBufferSize() };
     pso.PS = { Skeletal.DepthPrepassPsBlob->GetBufferPointer(), Skeletal.DepthPrepassPsBlob->GetBufferSize() };
     pso.BlendState.RenderTarget[0].RenderTargetWriteMask = 0;   // DEPTH ONLY — discard color
+    // ...and depth write back ON. The color PSO above deliberately leaves it OFF (it re-passes over depth this
+    // pass lays down); inheriting that here would make the prepass write nothing at all. Every PSO built from
+    // `pso` from here down is a prepass/G-buffer variant and wants the write.
+    pso.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
     if ( FAILED( device->CreateGraphicsPipelineState( &pso, IID_PPV_ARGS( Skeletal.DepthPrepassPSO.ReleaseAndGetAddressOf() ) ) ) ) {
         LogWarn() << "D3D12: CreateGraphicsPipelineState failed (skeletal depth prepass).";
         return false;

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -97,11 +97,9 @@ bool D3D12PipelineState::CreateWorld() {
     // a 64-bit mask in LightGrid itself, so t3 is no longer declared by any shader and this slot is now
     // PERMANENTLY UNBOUND — left in place (rather than renumbering every later param + BindFrameLights
     // call site) since nothing ever reads register(t3) any more. Same pattern as the WindCB param below.
-    // RootDataStatic on t1/t2: both are read per-pixel by the light loop, so letting the driver hoist
-    // the buffer load out of the shader is worth the promise. It holds — BuildFrameLightBuffer fills
-    // m_LightBuffer[frameIndex] at the top of OnStartWorldRendering and DispatchLightCulling writes the
-    // cluster grid, BOTH before any pass binds this root signature, and neither is touched again for the
-    // rest of the frame. The next frame writes a different frame-index slice behind the frame fence.
+    // RootDataStatic on t1/t2: BuildFrameLightBuffer and DispatchLightCulling both write at the top of
+    // OnStartWorldRendering, before any pass binds this root signature, and neither is touched again this
+    // frame. Lets the driver hoist the per-pixel buffer load out of the light loop.
     rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 3: t1 light StructuredBuffer
     // LightCB { LightCount, NumTilesX, LimitLightIntensity, PointShadowLowIndex, PointShadowDynIndex,
     //           ProjA, ProjB, NearZ, FarZ } — the last 4 feed PBRLighting.hlsl's ComputeZSlice.
@@ -114,16 +112,13 @@ bool D3D12PipelineState::CreateWorld() {
     // SRV heap. Both are read only by the lit world PS (PSMain); the depth-prepass/caster PSOs sharing
     // this root sig don't reference them, so those draws simply leave the slots unbound.
     // 9 = t5 point-light shadow cube array SRV (P2.10d), sampled by the tiled point-light loop.
-    // RootDataStatic on b3: every writer of the shared shadow CB — D3D12ShadowMap::Prepare,
-    // UploadWetnessConstants, UploadAoReprojConstants and RenderSkyIBL — runs earlier in
-    // OnStartWorldRendering than FinishShadowPasses, and every SetGraphicsRootConstantBufferView(7,...)
-    // site sits after it. Nothing writes the CB once a pass has bound it.
+    // RootDataStatic on b3: every writer of the shared shadow CB (D3D12ShadowMap::Prepare,
+    // UploadWetnessConstants, UploadAoReprojConstants, RenderSkyIBL) runs before FinishShadowPasses, and
+    // every bind site sits after it.
     rs.AddCBV( 3, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 7: b3 shadow CB (cascade view-projs + sun + strength)
-    // RangeStatic on t4/t5: both SRV slots are engine-owned, allocated once by D3D12ShadowMap /
-    // D3D12PointShadows and only ever rewritten from their Create* paths, which run behind a
-    // WaitForGpuIdle — so no in-flight list can be referencing the old descriptor. The maps themselves
-    // are rendered by the shadow command lists, which FinishShadowPasses executes AHEAD of the main
-    // list, so their contents are already final by the time this list sets the table.
+    // RangeStatic on t4/t5: engine-owned slots, only rewritten from Create* paths that run behind a
+    // WaitForGpuIdle, and their contents are final because FinishShadowPasses executes the shadow lists
+    // ahead of this one.
     rs.AddTable( D3D12RootLayout::SRVRange( 4, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_PIXEL );  // 8: t4 CSM array
     rs.AddTable( D3D12RootLayout::SRVRange( 5, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_PIXEL );  // 9: t5 point-shadow cube array
 
@@ -236,18 +231,14 @@ bool D3D12PipelineState::CreateWorld() {
 
     // Reversed-Z: test depth, pass on GREATER_EQUAL (matches Gothic's infinite-far projection).
     //
-    // Depth write is OFF. The Forward+ depth prepass already laid down this exact geometry's depth, so every
-    // write here would only restore the value that is already in the buffer. Dropping it (a) removes a
-    // full-resolution depth write per opaque pixel, (b) leaves the depth surface clean for the many passes
-    // that read it later (AO, GPU cull, fog, DoF, TAA) instead of dirtying it again, and (c) lets an
-    // alpha-clipping lit shader take the plain early-Z path rather than Re-Z, since with no write there is
-    // nothing for a `discard` to invalidate.
+    // Depth write is OFF: the Forward+ depth prepass already laid down this geometry's depth, so a write here
+    // only restores the value already in the buffer. It also lets an alpha-clipping lit shader take plain
+    // early-Z rather than Re-Z, since a `discard` has nothing left to invalidate.
     //
-    // GREATER_EQUAL is kept rather than tightened to EQUAL on purpose. The prepass and this pass run DIFFERENT
-    // vertex shaders (DepthPrepass.hlsl:VSWorld vs World.hlsl:VSMain), and HLSL guarantees no cross-shader
-    // invariance for SV_Position — one ULP of difference under EQUAL makes the whole surface vanish, while
-    // under GREATER_EQUAL it still draws. The set of fragments that pass is identical to before this change;
-    // only the redundant write is gone. Same reasoning at the VOB/attachment/skeletal color PSOs.
+    // The test stays GREATER_EQUAL rather than EQUAL: the prepass runs a DIFFERENT vertex shader
+    // (DepthPrepass.hlsl:VSWorld vs World.hlsl:VSMain) and HLSL guarantees no cross-shader SV_Position
+    // invariance, so one ULP under EQUAL makes a whole surface vanish. Same at the VOB/attachment/skeletal
+    // color PSOs.
     //
     // Does NOT apply to vegetation: DrawVegetationDepthPrepass is range-limited (kVegetationPrepassRange), so
     // distant grass has no prepass depth and must keep writing its own or it stops occluding other grass.
@@ -961,10 +952,9 @@ bool D3D12PipelineState::CreateDepthPrepass() {
         return false;
     }
 
-    // ...and the same thing with NO pixel shader, for the materials that don't need the cutout (the large
-    // majority of the world). PSClip can `discard`, which forces the whole draw onto the late-Z path; with no
-    // PS bound at all the rasterizer runs depth-only at double rate. See DepthPrepassNoAlphaPSO's declaration.
-    // Non-fatal: DrawDepthPrepass falls back to submitting everything through the clipping PSO if this is null.
+    // ...and the same with NO pixel shader, for the majority of materials that don't need the cutout. PSClip
+    // can `discard`, forcing the draw onto the late-Z path; with no PS the rasterizer runs depth-only at
+    // double rate. Non-fatal: DrawDepthPrepass falls back to the clipping PSO for everything.
     {
         D3D12_GRAPHICS_PIPELINE_STATE_DESC noAlpha = pso;
         noAlpha.PS = {};
@@ -1213,10 +1203,9 @@ bool D3D12PipelineState::CreateVob() {
     pso.RasterizerState.DepthClipEnable = TRUE;
     pso.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
     pso.DepthStencilState.DepthEnable = TRUE;
-    // Depth write OFF — DrawVobDepthPrepass already wrote this geometry's depth. See the long note at the
-    // world color PSO (CreateWorld) for why, and for why the test stays GREATER_EQUAL instead of EQUAL.
-    // Inherited by VobAttachPSO and VobIndirectPSO below, which draw the same prepassed geometry; the two
-    // alpha-BLENDED VOB PSOs after them set the mask themselves (they were never in the prepass at all).
+    // Depth write OFF — DrawVobDepthPrepass already wrote this geometry's depth; see the note at the world
+    // color PSO (CreateWorld). Inherited by VobAttachPSO/VobIndirectPSO below, which draw the same prepassed
+    // geometry; the alpha-BLENDED VOB PSOs after them set the mask themselves.
     pso.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
     pso.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_GREATER_EQUAL;  // reversed-Z
     pso.DepthStencilState.StencilEnable = FALSE;
@@ -1711,10 +1700,8 @@ bool D3D12PipelineState::CreateSkeletal() {
     // CreateGhostSkeletal.
     D3D12RootLayout& rs = Layout( "Skeletal" );
     rs.AddConstants( 0, 16, D3D12_SHADER_VISIBILITY_VERTEX );  // 0: b0 ViewProj
-    // RootDataStatic on b1/b2: both point into the per-frame skeletal ring, whose cursor
-    // (m_SkeletalCBBufferOffset) only ever ADVANCES within a frame — PrepareFrameSkeletals writes each
-    // entry once and hands out its address; a later PrepareFrameSkeletals call (shadow casters) appends
-    // at a fresh offset and never rewrites an address already handed out.
+    // RootDataStatic on b1/b2: both point into the per-frame skeletal ring, whose cursor only ADVANCES within
+    // a frame — PrepareFrameSkeletals writes each entry once and never rewrites a handed-out address.
     rs.AddCBV( 1, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 1: b1 per-instance
     rs.AddCBV( 2, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 2: b2 bone palette
     // 3: b3 fog — FogConstants (8 DWORDs); VS: CamPosWS; PS: color/near/far
@@ -1833,9 +1820,8 @@ bool D3D12PipelineState::CreateSkeletal() {
     pso.VS = { Skeletal.DepthPrepassVsBlob->GetBufferPointer(), Skeletal.DepthPrepassVsBlob->GetBufferSize() };
     pso.PS = { Skeletal.DepthPrepassPsBlob->GetBufferPointer(), Skeletal.DepthPrepassPsBlob->GetBufferSize() };
     pso.BlendState.RenderTarget[0].RenderTargetWriteMask = 0;   // DEPTH ONLY — discard color
-    // ...and depth write back ON. The color PSO above deliberately leaves it OFF (it re-passes over depth this
-    // pass lays down); inheriting that here would make the prepass write nothing at all. Every PSO built from
-    // `pso` from here down is a prepass/G-buffer variant and wants the write.
+    // ...and depth write back ON: the color PSO above leaves it OFF, and inheriting that would make the
+    // prepass write nothing. Every PSO built from `pso` from here down is a prepass/G-buffer variant.
     pso.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
     if ( FAILED( device->CreateGraphicsPipelineState( &pso, IID_PPV_ARGS( Skeletal.DepthPrepassPSO.ReleaseAndGetAddressOf() ) ) ) ) {
         LogWarn() << "D3D12: CreateGraphicsPipelineState failed (skeletal depth prepass).";

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -97,21 +97,35 @@ bool D3D12PipelineState::CreateWorld() {
     // a 64-bit mask in LightGrid itself, so t3 is no longer declared by any shader and this slot is now
     // PERMANENTLY UNBOUND — left in place (rather than renumbering every later param + BindFrameLights
     // call site) since nothing ever reads register(t3) any more. Same pattern as the WindCB param below.
-    rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_PIXEL );        // 3: t1 light StructuredBuffer
+    // RootDataStatic on t1/t2: both are read per-pixel by the light loop, so letting the driver hoist
+    // the buffer load out of the shader is worth the promise. It holds — BuildFrameLightBuffer fills
+    // m_LightBuffer[frameIndex] at the top of OnStartWorldRendering and DispatchLightCulling writes the
+    // cluster grid, BOTH before any pass binds this root signature, and neither is touched again for the
+    // rest of the frame. The next frame writes a different frame-index slice behind the frame fence.
+    rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 3: t1 light StructuredBuffer
     // LightCB { LightCount, NumTilesX, LimitLightIntensity, PointShadowLowIndex, PointShadowDynIndex,
     //           ProjA, ProjB, NearZ, FarZ } — the last 4 feed PBRLighting.hlsl's ComputeZSlice.
     rs.AddConstants( 2, 9, D3D12_SHADER_VISIBILITY_PIXEL );  // 4: b2 LightCB
-    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL );        // 5: t2 per-cluster LightGrid (64-bit mask)
-    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );        // 6: t3 UNUSED/dead (see above)
+    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 5: t2 per-cluster LightGrid (64-bit mask)
+    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );        // 6: t3 UNUSED/dead — never bound, so left volatile
 
     // 7 = shadow-sampling CB (b3) as a ROOT CBV (cascade view-projs are too big for root constants).
     // 8 = the CSM shadow-map Texture2DArray SRV (t4) via a one-entry descriptor table off the shared
     // SRV heap. Both are read only by the lit world PS (PSMain); the depth-prepass/caster PSOs sharing
     // this root sig don't reference them, so those draws simply leave the slots unbound.
     // 9 = t5 point-light shadow cube array SRV (P2.10d), sampled by the tiled point-light loop.
-    rs.AddCBV( 3, D3D12_SHADER_VISIBILITY_PIXEL );        // 7: b3 shadow CB (cascade view-projs + sun + strength)
-    rs.AddTable( D3D12RootLayout::SRVRange( 4 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 8: t4 CSM array
-    rs.AddTable( D3D12RootLayout::SRVRange( 5 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 9: t5 point-shadow cube array
+    // RootDataStatic on b3: every writer of the shared shadow CB — D3D12ShadowMap::Prepare,
+    // UploadWetnessConstants, UploadAoReprojConstants and RenderSkyIBL — runs earlier in
+    // OnStartWorldRendering than FinishShadowPasses, and every SetGraphicsRootConstantBufferView(7,...)
+    // site sits after it. Nothing writes the CB once a pass has bound it.
+    rs.AddCBV( 3, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 7: b3 shadow CB (cascade view-projs + sun + strength)
+    // RangeStatic on t4/t5: both SRV slots are engine-owned, allocated once by D3D12ShadowMap /
+    // D3D12PointShadows and only ever rewritten from their Create* paths, which run behind a
+    // WaitForGpuIdle — so no in-flight list can be referencing the old descriptor. The maps themselves
+    // are rendered by the shadow command lists, which FinishShadowPasses executes AHEAD of the main
+    // list, so their contents are already final by the time this list sets the table.
+    rs.AddTable( D3D12RootLayout::SRVRange( 4, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_PIXEL );  // 8: t4 CSM array
+    rs.AddTable( D3D12RootLayout::SRVRange( 5, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_PIXEL );  // 9: t5 point-shadow cube array
 
     // 10 = per-material bindless indices { normalSrvIndex, ormSrvIndex } as root constants (b6). The PS
     // reads the normal/ORM maps via ResourceDescriptorHeap[...] (SM6.6 bindless) — no per-material descriptor
@@ -138,7 +152,9 @@ bool D3D12PipelineState::CreateWorld() {
     // signature — including the CSM cascade casters built from the non-GBuf blobs — simply leaves it unbound.
     // Appended LAST on purpose: parameter index is Add*() call order, so inserting it anywhere earlier would
     // silently renumber every existing bind site and both ExecuteIndirect command signatures anchored here.
-    rs.AddCBV( 5, D3D12_SHADER_VISIBILITY_VERTEX );            // 13: b5 MotionCB
+    // RootDataStatic: UploadMotionConstants writes this once per frame, well before the G-buffer
+    // prepass — the only consumer — records anything.
+    rs.AddCBV( 5, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 13: b5 MotionCB
 
     // s0 diffuse: 16x anisotropic (matches D3D11's main texture sampler) — sharpens surfaces at grazing
     // angles and in the distance, which trilinear alone smears badly.
@@ -550,8 +566,9 @@ bool D3D12PipelineState::CreateGhostSkeletal() {
 
     D3D12RootLayout& rs = Layout( "GhostSkeletal" );
     rs.AddConstants( 0, 16, D3D12_SHADER_VISIBILITY_VERTEX );  // 0: b0 ViewProj
-    rs.AddCBV( 1, D3D12_SHADER_VISIBILITY_VERTEX );            // 1: b1 per-instance (World/ModelColor/Fatness)
-    rs.AddCBV( 2, D3D12_SHADER_VISIBILITY_VERTEX );            // 2: b2 bone palette
+    // Same advance-only per-frame skeletal ring as Skeletal.RootSig's b1/b2 — see there.
+    rs.AddCBV( 1, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 1: b1 per-instance (World/ModelColor/Fatness)
+    rs.AddCBV( 2, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 2: b2 bone palette
     // 3: b7 GhostAlpha (Skeletal.hlsl's b0..b6 are all spoken for)
     rs.AddConstants( 7, 1, D3D12_SHADER_VISIBILITY_PIXEL );
     // 4: b6 MaterialCB { normal, ORM, DIFFUSE } — the same bindless material block Skeletal.RootSig uses, so
@@ -645,15 +662,16 @@ bool D3D12PipelineState::CreateGrass() {
     // VS: all of it; PS: none currently, but cheap to keep visible.
     rs.AddConstants( 1, 8, D3D12_SHADER_VISIBILITY_ALL );
     rs.AddConstants( 2, 8, D3D12_SHADER_VISIBILITY_ALL );      // 4: b2 fog — VS: CamPosWS; PS: color/near/far
-    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL );             // 5: t2 light StructuredBuffer (root SRV)
+    // t2/t3 + b4 carry World.RootSig's RootDataStatic promises — same buffers, same frame ordering.
+    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 5: t2 light StructuredBuffer (root SRV)
     // 6: b3 LightCB, grown 5->9 for clustered Forward+ (P2.14): +ProjA/ProjB/NearZ/FarZ (ComputeZSlice).
     rs.AddConstants( 3, 9, D3D12_SHADER_VISIBILITY_PIXEL );   // b3 LightCB
-    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 7: t3 per-cluster LightGrid (64-bit mask)
-    rs.AddSRV( 4, D3D12_SHADER_VISIBILITY_PIXEL );             // 8: t4 UNUSED/dead (formerly the per-tile light-index list — see World.RootSig)
-    rs.AddCBV( 4, D3D12_SHADER_VISIBILITY_PIXEL );             // 9: b4 shadow-sampling CB (root CBV)
-    rs.AddTable( D3D12RootLayout::SRVRange( 5 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 10: t5 CSM shadow-map array
+    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 7: t3 per-cluster LightGrid (64-bit mask)
+    rs.AddSRV( 4, D3D12_SHADER_VISIBILITY_PIXEL );             // 8: t4 UNUSED/dead — never bound, so left volatile
+    rs.AddCBV( 4, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 9: b4 shadow-sampling CB (root CBV)
+    rs.AddTable( D3D12RootLayout::SRVRange( 5, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_PIXEL );  // 10: t5 CSM shadow-map array
     // 11: t6 point-shadow cube array (PBRLighting.hlsl requires this symbol)
-    rs.AddTable( D3D12RootLayout::SRVRange( 6 ), D3D12_SHADER_VISIBILITY_PIXEL );
+    rs.AddTable( D3D12RootLayout::SRVRange( 6, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_PIXEL );
     // 12 = simple-SSAO mask bindless SRV-heap index (b5 AOCB, PS only), set once per frame by DrawVegetation.
     // Grass gets real AO now that it joins the depth prepass RenderSSAO builds the mask from — see
     // Vegetation.hlsl's PSMain. The grass shadow CASTER (D3D12ShadowMap::CreateGrassCaster) shares this root sig
@@ -663,7 +681,7 @@ bool D3D12PipelineState::CreateGrass() {
     // because b0..b5 above are all spoken for; a root CBV rather than constants because it is three matrices.
     // Every other PSO on this root signature leaves the parameter unbound, which is legal for a parameter no
     // bound shader statically references.
-    rs.AddCBV( 6, D3D12_SHADER_VISIBILITY_VERTEX );            // 13: b6 MotionCB
+    rs.AddCBV( 6, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 13: b6 MotionCB (see World's b5)
 
     rs.AddStaticSampler( D3D12RootLayout::SamplerAniso( 0, D3D12_SHADER_VISIBILITY_PIXEL ) );      // s0 diffuse
     // s2 PCF, matches World/Vob/Skeletal.
@@ -1503,15 +1521,17 @@ bool D3D12PipelineState::CreateDecal() {
     rs.AddConstants( 0, 16, D3D12_SHADER_VISIBILITY_VERTEX );  // 0: b0 ViewProj
     rs.AddTable( D3D12RootLayout::SRVRange( 0 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 1: t0 diffuse
     rs.AddConstants( 1, 8, D3D12_SHADER_VISIBILITY_ALL );      // 2: b1 fog — VS: CamPosWS; PS: color/near/far
-    rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_PIXEL );             // 3: t1 light StructuredBuffer
+    // t1/t2 + b3 + t4/t5 carry World.RootSig's promises verbatim — same buffers, same frame ordering
+    // (DrawDecalList runs well after the light cull and FinishShadowPasses).
+    rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 3: t1 light StructuredBuffer
     // LightCB grew 5->9 for clustered Forward+ (P2.14): +ProjA/ProjB/NearZ/FarZ (PBRLighting.hlsl's
     // ComputeZSlice). Param 6 (t3, formerly the per-tile light-index list) is now dead/unbound — see World.RootSig.
     rs.AddConstants( 2, 9, D3D12_SHADER_VISIBILITY_PIXEL );    // 4: b2 LightCB
-    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL );             // 5: t2 per-cluster LightGrid (64-bit mask)
-    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 6: t3 UNUSED/dead
-    rs.AddCBV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 7: b3 shadow CB
-    rs.AddTable( D3D12RootLayout::SRVRange( 4 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 8: t4 CSM array
-    rs.AddTable( D3D12RootLayout::SRVRange( 5 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 9: t5 point-shadow cubes
+    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 5: t2 per-cluster LightGrid (64-bit mask)
+    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 6: t3 UNUSED/dead — never bound, so left volatile
+    rs.AddCBV( 3, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 7: b3 shadow CB
+    rs.AddTable( D3D12RootLayout::SRVRange( 4, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_PIXEL );  // 8: t4 CSM array
+    rs.AddTable( D3D12RootLayout::SRVRange( 5, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_PIXEL );  // 9: t5 point-shadow cubes
     rs.AddConstants( 7, 1, D3D12_SHADER_VISIBILITY_PIXEL );    // 10: b7 AOCB { AoMaskIndex }
     rs.AddStaticSampler( D3D12RootLayout::SamplerLinear( 0, D3D12_SHADER_VISIBILITY_PIXEL ) );  // s0
     // s2 PCF comparison for the CSM, s1 point-clamp for the SSAO mask — same roles as in the World layout;
@@ -1641,23 +1661,28 @@ bool D3D12PipelineState::CreateSkeletal() {
     // CreateGhostSkeletal.
     D3D12RootLayout& rs = Layout( "Skeletal" );
     rs.AddConstants( 0, 16, D3D12_SHADER_VISIBILITY_VERTEX );  // 0: b0 ViewProj
-    rs.AddCBV( 1, D3D12_SHADER_VISIBILITY_VERTEX );            // 1: b1 per-instance
-    rs.AddCBV( 2, D3D12_SHADER_VISIBILITY_VERTEX );            // 2: b2 bone palette
+    // RootDataStatic on b1/b2: both point into the per-frame skeletal ring, whose cursor
+    // (m_SkeletalCBBufferOffset) only ever ADVANCES within a frame — PrepareFrameSkeletals writes each
+    // entry once and hands out its address; a later PrepareFrameSkeletals call (shadow casters) appends
+    // at a fresh offset and never rewrites an address already handed out.
+    rs.AddCBV( 1, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 1: b1 per-instance
+    rs.AddCBV( 2, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 2: b2 bone palette
     // 3: b3 fog — FogConstants (8 DWORDs); VS: CamPosWS; PS: color/near/far
     rs.AddConstants( 3, 8, D3D12_SHADER_VISIBILITY_ALL );
     // Forward+ point lights (mirrors World.RootSig params 3/4/5/6, here at 4..7 — see BindFrameLights). All
     // MUST be bound at every skeletal draw or the PS light-loop bound/grid is undefined → GPU hang.
-    rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_PIXEL );             // 4: t1 light StructuredBuffer (root SRV)
+    // t1/t2 carry World.RootSig's RootDataStatic promise for the same reason (see there).
+    rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 4: t1 light StructuredBuffer (root SRV)
     // LightCB grew 5->9 for clustered Forward+ (P2.14): +ProjA/ProjB/NearZ/FarZ (ComputeZSlice).
     rs.AddConstants( 4, 9, D3D12_SHADER_VISIBILITY_PIXEL );    // 5: b4 LightCB
-    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL );             // 6: t2 per-cluster LightGrid (64-bit mask)
-    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 7: t3 UNUSED/dead (formerly the per-tile light-index list — see World.RootSig)
-    // 8: b5 shadow-sampling CB (skeletal's b3/b4 are fog/light count)
-    rs.AddCBV( 5, D3D12_SHADER_VISIBILITY_PIXEL );
+    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 6: t2 per-cluster LightGrid (64-bit mask)
+    rs.AddSRV( 3, D3D12_SHADER_VISIBILITY_PIXEL );             // 7: t3 UNUSED/dead — never bound, so left volatile
+    // 8: b5 shadow-sampling CB (skeletal's b3/b4 are fog/light count) — same shared CB, same promise as World's b3.
+    rs.AddCBV( 5, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );
     // CSM sampling (P2.9c-4b): shadow-map array SRV at t4 (skeletal PS samples it like world/VOB);
-    // point-light shadow cube array SRV at t5 (P2.10d).
-    rs.AddTable( D3D12RootLayout::SRVRange( 4 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 9: t4 CSM array
-    rs.AddTable( D3D12RootLayout::SRVRange( 5 ), D3D12_SHADER_VISIBILITY_PIXEL );  // 10: t5 point-shadow cube array
+    // point-light shadow cube array SRV at t5 (P2.10d). RangeStatic — see World.RootSig params 8/9.
+    rs.AddTable( D3D12RootLayout::SRVRange( 4, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_PIXEL );  // 9: t4 CSM array
+    rs.AddTable( D3D12RootLayout::SRVRange( 5, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_PIXEL );  // 10: t5 point-shadow cube array
     // 11: b6 MaterialCB { MatNormalIndex, MatOrmIndex, MatDiffuseIndex } — bindless indices. The diffuse index
     // is the third constant, matching World.RootSig's b6 layout so BindMaterialMaps serves both.
     rs.AddConstants( 6, 3, D3D12_SHADER_VISIBILITY_PIXEL );
@@ -1668,7 +1693,7 @@ bool D3D12PipelineState::CreateSkeletal() {
     // 13 = motion-vector CB (b9 here — b5 is the shadow CB on this signature; World.RootSig uses b5 for the same
     // struct). Root CBV, VS only, read ONLY by Skeletal.hlsl's VSDepthGBuf. Appended last for the same
     // parameter-renumbering reason as World's: SkeletalDrawCommand's indirect signature pushes param 11.
-    rs.AddCBV( 9, D3D12_SHADER_VISIBILITY_VERTEX );            // 13: b9 MotionCB
+    rs.AddCBV( 9, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 13: b9 MotionCB (see World's b5)
 
     // s0 diffuse: 16x anisotropic (matches D3D11's main texture sampler) — sharpens surfaces at grazing
     // angles and in the distance, which trilinear alone smears badly.
@@ -1800,7 +1825,9 @@ bool D3D12PipelineState::CreatePointShadow() {
     // --- Root signature: b0 = the 6 face view-projs as a root CBV (VS); t0 = diffuse SRV table (PS alpha-clip);
     // static linear sampler s0. (b0 is a CBV not root consts — 6 matrices = 384B exceed the root-const budget.)
     D3D12RootLayout& rs = Layout( "PointShadow" );
-    rs.AddCBV( 0, D3D12_SHADER_VISIBILITY_VERTEX );   // 0: b0 PCR_ViewProj[6]
+    // PrepareShadowPasses resolves every face CB into the per-frame ring BEFORE BeginShadowRecording
+    // launches the recorders that bind them; the recorders only ever replay already-final addresses.
+    rs.AddCBV( 0, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 0: b0 PCR_ViewProj[6]
     rs.AddTable( D3D12RootLayout::SRVRange( 0 ), D3D12_SHADER_VISIBILITY_PIXEL );   // 1: t0 diffuse
     rs.AddStaticSampler( D3D12RootLayout::SamplerLinear( 0, D3D12_SHADER_VISIBILITY_PIXEL,
         D3D12_TEXTURE_ADDRESS_MODE_WRAP ) );   // s0
@@ -1890,9 +1917,11 @@ bool D3D12PipelineState::CreatePointShadow() {
     // face CBV at b0 instead of the single-matrix root const. Reuses the per-frame d.instCb/d.boneCb.
     {
         D3D12RootLayout& skelRs = Layout( "PointShadowSkeletal" );
-        skelRs.AddCBV( 0, D3D12_SHADER_VISIBILITY_VERTEX );   // 0: b0 PCR_ViewProj[6]
-        skelRs.AddCBV( 1, D3D12_SHADER_VISIBILITY_VERTEX );   // 1: b1 instance (M_World/Fatness)
-        skelRs.AddCBV( 2, D3D12_SHADER_VISIBILITY_VERTEX );   // 2: b2 bones
+        // All three are pre-resolved per-frame ring addresses — see PointShadow.RootSig's b0 and
+        // Skeletal.RootSig's b1/b2 for why they are final by the time a recorder binds them.
+        skelRs.AddCBV( 0, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 0: b0 PCR_ViewProj[6]
+        skelRs.AddCBV( 1, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 1: b1 instance (M_World/Fatness)
+        skelRs.AddCBV( 2, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 2: b2 bones
         skelRs.AddTable( D3D12RootLayout::SRVRange( 0 ), D3D12_SHADER_VISIBILITY_PIXEL );   // 3: t0 diffuse
         skelRs.AddStaticSampler( D3D12RootLayout::SamplerLinear( 0, D3D12_SHADER_VISIBILITY_PIXEL,
             D3D12_TEXTURE_ADDRESS_MODE_WRAP ) );   // s0 — same as the world/VOB caster sig above
@@ -1941,7 +1970,9 @@ bool D3D12PipelineState::CreateTonemap() {
     if ( !device ) return false;
 
     D3D12RootLayout& rs = Layout( "Tonemap" );
-    rs.AddTable( D3D12RootLayout::SRVRange( 0 ), D3D12_SHADER_VISIBILITY_PIXEL );   // 0: t0 scene HDR
+    // RangeStatic: m_SceneColorSrvSlot is engine-owned, allocated once per swapchain size, and the whole
+    // 3D scene has finished rendering into it by the time this resolve binds the table.
+    rs.AddTable( D3D12RootLayout::SRVRange( 0, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_PIXEL );   // 0: t0 scene HDR
     // 1: b0 { Exposure, LumWhite, ToneMapMode, HdrOutput, DisplayHeadroom, MiddleGray, AutoExposureStrength,
     // AutoExposureMin, AutoExposureMax, pad[3] }. HdrOutput switches the PS off the SDR operators entirely and
     // onto the highlight roll-off for a real HDR scanout; a runtime branch rather than a PSO variant, since it
@@ -1949,7 +1980,8 @@ bool D3D12PipelineState::CreateTonemap() {
     // D3D12GraphicsEngine::TonemapRootConstants at the SetGraphicsRoot32BitConstants call site (that struct is
     // private, so it can't be named from here).
     rs.AddConstants( 0, 12, D3D12_SHADER_VISIBILITY_PIXEL );
-    rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_PIXEL );   // 2: t1 AdaptedLum
+    // RenderLuminanceAdapt's CS_LumAdapt writes AdaptedLum earlier in this same list, behind a barrier.
+    rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 2: t1 AdaptedLum
     rs.AddStaticSampler( D3D12RootLayout::SamplerLinear( 0, D3D12_SHADER_VISIBILITY_PIXEL ) );   // s0
 
     if ( !rs.Build( device, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT ) )
@@ -2070,7 +2102,8 @@ bool D3D12PipelineState::CreateLumAdapt() {
     // --- LumReduce root sig: b0 4x32-bit consts, t0 SRV table (scene color), u0 UAV root descriptor ---
     D3D12RootLayout& reduceRs = Layout( "LumReduce" );
     reduceRs.AddConstants( 0, 4, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 LumReduceCB
-    reduceRs.AddTable( D3D12RootLayout::SRVRange( 0 ), D3D12_SHADER_VISIBILITY_ALL );   // 1: t0 SceneHDR
+    // RangeStatic: engine-owned scene-colour slot (see Tonemap), scene already final at this point.
+    reduceRs.AddTable( D3D12RootLayout::SRVRange( 0, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_ALL );   // 1: t0 SceneHDR
     reduceRs.AddUAV( 0, D3D12_SHADER_VISIBILITY_ALL );            // 2: u0 PartialSums
     if ( !reduceRs.Build( device ) )
         return false;
@@ -2092,7 +2125,8 @@ bool D3D12PipelineState::CreateLumAdapt() {
     // --- LumAdapt root sig: b0 4x32-bit consts, t0 SRV root descriptor (PartialSums), u0 UAV root descriptor ---
     D3D12RootLayout& adaptRs = Layout( "LumAdapt" );
     adaptRs.AddConstants( 0, 4, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 LumAdaptCB
-    adaptRs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL );            // 1: t0 PartialSums
+    // CS_LumReduce wrote PartialSums immediately before this dispatch, behind a UAV barrier.
+    adaptRs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 1: t0 PartialSums
     adaptRs.AddUAV( 0, D3D12_SHADER_VISIBILITY_ALL );            // 2: u0 AdaptedLum
     if ( !adaptRs.Build( device ) )
         return false;
@@ -2128,9 +2162,10 @@ bool D3D12PipelineState::CreateWater() {
     D3D12RootLayout& rs = Layout( "Water" );
     rs.AddConstants( 0, 16, D3D12_SHADER_VISIBILITY_VERTEX );   // 0: b0 ViewProj
     rs.AddTable( D3D12RootLayout::SRVRange( 0 ), D3D12_SHADER_VISIBILITY_PIXEL );   // 1: t0 diffuse
-    // 2: b2 WaterCB (projection/view/params/bindless indices)
-    rs.AddCBV( 2, D3D12_SHADER_VISIBILITY_ALL );
-    rs.AddCBV( 1, D3D12_SHADER_VISIBILITY_PIXEL );              // 3: b1 AtmosphereConstantBuffer
+    // 2: b2 WaterCB (projection/view/params/bindless indices). Both CBs are per-frame ring writes that
+    // DrawWaterSurfaces completes before it binds them, and no later pass rewrites them this frame.
+    rs.AddCBV( 2, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );
+    rs.AddCBV( 1, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 3: b1 AtmosphereConstantBuffer
 
     // s0 — diffuse + the world-space distortion lookups.
     rs.AddStaticSampler( D3D12RootLayout::SamplerLinear( 0, D3D12_SHADER_VISIBILITY_PIXEL,
@@ -2250,7 +2285,9 @@ bool D3D12PipelineState::CreateLightCull() {
     D3D12RootLayout& rs = Layout( "LightCull" );
     // 0: b0 CullCB — ProjScale(2) + ScreenDim(2) + TotalLights + NumTilesX + NearZ + FarZ
     rs.AddConstants( 0, 8, D3D12_SHADER_VISIBILITY_ALL );
-    rs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL );   // 1: t0 SB_Lights
+    // t0: the same per-frame light buffer the lit passes read, filled by BuildFrameLightBuffer long
+    // before this dispatch — final from the bind. u0 is GPU-written and stays volatile by construction.
+    rs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 1: t0 SB_Lights
     rs.AddUAV( 0, D3D12_SHADER_VISIBILITY_ALL );   // 2: u0 RW_LightGrid (per-cluster 64-bit mask)
 
     if ( !rs.Build( device ) )   // compute: no IA input layout
@@ -2284,7 +2321,8 @@ bool D3D12PipelineState::CreateAdvanceRain() {
 
     D3D12RootLayout& rs = Layout( "AdvanceRain" );
     rs.AddConstants( 0, 16, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 AdvanceRainCB
-    rs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL );             // 1: t0 StaticData
+    // t0 is the immutable per-particle static seed buffer, uploaded once at rain init.
+    rs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 1: t0 StaticData
     rs.AddUAV( 0, D3D12_SHADER_VISIBILITY_ALL );             // 2: u0 DynamicData
 
     if ( !rs.Build( device ) )   // compute: no IA input layout
@@ -2321,8 +2359,10 @@ bool D3D12PipelineState::CreateRainDraw() {
     rs.AddConstants( 0, 16, D3D12_SHADER_VISIBILITY_VERTEX );   // 0: b0 ViewProjCB
     // 1: b1 RainInfoCB — read by both VS (billboard construction) and PS (rainResponse eye/light vectors)
     rs.AddConstants( 1, 10, D3D12_SHADER_VISIBILITY_ALL );
-    rs.AddSRV( 0, D3D12_SHADER_VISIBILITY_VERTEX );             // 2: t0 DynamicData
-    rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_VERTEX );             // 3: t1 StaticData
+    // t0 was written by AdvanceRain's compute dispatch earlier in this same list (behind a barrier) and
+    // is not touched again this frame; t1 is the immutable static seed buffer.
+    rs.AddSRV( 0, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 2: t0 DynamicData
+    rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );   // 3: t1 StaticData
     rs.AddConstants( 2, 2, D3D12_SHADER_VISIBILITY_PIXEL );     // 4: b2 RainTexCB
     // 5: b3 RainShadowCB — VS-only (IsWet is called from the VS); 16 (float4x4) + 1 (heap slot index)
     rs.AddConstants( 3, 17, D3D12_SHADER_VISIBILITY_VERTEX );
@@ -2845,7 +2885,9 @@ bool D3D12PipelineState::CreateAO() {
     // --- Main pass root sig: b0 12x32-bit SSAOCB, t0 depth SRV table, u0 AO-output UAV table ---
     D3D12RootLayout& mainRs = Layout( "AOMain" );
     mainRs.AddConstants( 0, 12, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 SSAOCB
-    mainRs.AddTable( D3D12RootLayout::SRVRange( 0 ), D3D12_SHADER_VISIBILITY_ALL );   // 1: t0 DepthTex
+    // RangeStatic: m_DepthSrvSlot is engine-owned (recreated only on resize, behind WaitForGpuIdle) and
+    // the depth prepass has finished + barriered to SRV before RenderSSAO binds this.
+    mainRs.AddTable( D3D12RootLayout::SRVRange( 0, 1, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_ALL );   // 1: t0 DepthTex
     mainRs.AddTable( D3D12RootLayout::UAVRange( 0 ), D3D12_SHADER_VISIBILITY_ALL );   // 2: u0 OutputAO
     mainRs.AddStaticSampler( sampler );
     if ( !mainRs.Build( device ) )
@@ -2856,7 +2898,7 @@ bool D3D12PipelineState::CreateAO() {
     D3D12RootLayout& blurRs = Layout( "AOBlur" );
     blurRs.AddConstants( 0, 8, D3D12_SHADER_VISIBILITY_ALL );    // 0: b0 BlurCB
     // 1: t0 BlurAOTex, t1 BlurDepthTex
-    blurRs.AddTable( D3D12RootLayout::SRVRange( 0, 2 ), D3D12_SHADER_VISIBILITY_ALL );
+    blurRs.AddTable( D3D12RootLayout::SRVRange( 0, 2, 0, D3D12RootLayout::RangeStatic ), D3D12_SHADER_VISIBILITY_ALL );
     blurRs.AddTable( D3D12RootLayout::UAVRange( 0 ), D3D12_SHADER_VISIBILITY_ALL );   // 2: u0 OutputAO
     blurRs.AddStaticSampler( sampler );
     if ( !blurRs.Build( device ) )
@@ -2953,7 +2995,8 @@ bool D3D12PipelineState::CreateMotion() {
     // Fully bindless (SM6.6 ResourceDescriptorHeap) for both the depth SRV and the velocity UAV, so there is no
     // descriptor table and nothing to rebind per frame — same shape as the god-ray compute passes.
     D3D12RootLayout& fillRs = Layout( "MotionFill" );
-    fillRs.AddCBV( 0, D3D12_SHADER_VISIBILITY_ALL );            // 0: b0 MotionCB
+    // UploadMotionConstants wrote this at the top of the frame; FillCameraVelocity runs at the end.
+    fillRs.AddCBV( 0, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 0: b0 MotionCB
     fillRs.AddConstants( 1, 4, D3D12_SHADER_VISIBILITY_ALL );   // 1: b1 FillCB { depthIdx, velUavIdx, w, h }
     if ( !fillRs.Build( device, D3D12_ROOT_SIGNATURE_FLAG_CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED ) )
         return false;
@@ -3031,7 +3074,8 @@ bool D3D12PipelineState::CreateTaa() {
     // through ResourceDescriptorHeap, so there is no descriptor table at all — hence
     // CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED.
     D3D12RootLayout& rs = Layout( "Taa" );
-    rs.AddCBV( 0, D3D12_SHADER_VISIBILITY_ALL );             // 0: b0 MotionCB
+    // Same once-per-frame MotionCB the prepass reads — final long before the TAA resolve binds it.
+    rs.AddCBV( 0, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 0: b0 MotionCB
     rs.AddConstants( 1, 18, D3D12_SHADER_VISIBILITY_ALL );   // 1: b1 TaaCB
     // s0 linear-clamp: the bicubic/bilinear history fetches. s1 point-clamp: the depth gathers, which must not
     // filter across a depth discontinuity.
@@ -3120,8 +3164,9 @@ bool D3D12PipelineState::CreateSky() {
     D3D12RootLayout& rs = Layout( "Sky" );
     rs.AddConstants( 0, 16, D3D12_SHADER_VISIBILITY_VERTEX );   // 0: b0 ViewProj
     // 1: b1 Atmosphere — a real CBV, not root constants: AtmosphereConstantBuffer is 96 bytes (24 DWORDs) and
-    // it is the same struct D3D11 uploads, filled once per frame by GSky::RenderSky().
-    rs.AddCBV( 1, D3D12_SHADER_VISIBILITY_PIXEL );
+    // it is the same struct D3D11 uploads, filled once per frame by GSky::RenderSky() — i.e. final before
+    // DrawSky binds it, and untouched for the rest of the frame.
+    rs.AddCBV( 1, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );
     rs.AddConstants( 2, 16, D3D12_SHADER_VISIBILITY_VERTEX );   // 2: b2 World (dome scale + camera translation)
     // 3: b3 SkyMaterialCB — { cloud/night/moon SRV slots + pad, moon centre px, moon half-size px, moon colour }
     rs.AddConstants( 3, 12, D3D12_SHADER_VISIBILITY_PIXEL );
@@ -3277,8 +3322,9 @@ bool D3D12PipelineState::CreateFog() {
 
     // --- Composition graphics root sig: b0 height-fog CBV, b1 atmosphere CBV, b2 4 root consts ---
     D3D12RootLayout& compositeRs = Layout( "FogComposite" );
-    compositeRs.AddCBV( 0, D3D12_SHADER_VISIBILITY_PIXEL );   // 0: b0 PFXBuffer (HeightfogConstantBuffer)
-    compositeRs.AddCBV( 1, D3D12_SHADER_VISIBILITY_PIXEL );   // 1: b1 Atmosphere (AtmosphereConstantBuffer)
+    // Both are per-frame ring writes RenderFogAndGodRays completes before binding them.
+    compositeRs.AddCBV( 0, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 0: b0 PFXBuffer (HeightfogConstantBuffer)
+    compositeRs.AddCBV( 1, D3D12_SHADER_VISIBILITY_PIXEL, 0, D3D12RootLayout::RootDataStatic );   // 1: b1 Atmosphere (AtmosphereConstantBuffer)
     // 2: b2 FogCompositeCB { depthIdx, godRaysIdx, flags, pad }
     compositeRs.AddConstants( 2, 4, D3D12_SHADER_VISIBILITY_PIXEL );
     // s0: god-ray upscale (quarter -> full res); s1: depth (1:1, never filtered).
@@ -3398,8 +3444,10 @@ bool D3D12PipelineState::CreateCull() {
     // (no heap slots). Only the Hi-Z pyramid is a texture and it comes in bindlessly by heap index.
     D3D12RootLayout& vobCullRs = Layout( "CullVob" );
     vobCullRs.AddConstants( 0, 24, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 VobCullCB — float4x4 ViewProj + 8 uints
-    vobCullRs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL );             // 1: t0 Visuals
-    vobCullRs.AddSRV( 1, D3D12_SHADER_VISIBILITY_ALL );             // 2: t1 InInstances
+    // Both inputs are CPU-written once per frame by UploadFrameVobInstances / BuildVobDrawCommands,
+    // which complete before this dispatch is recorded and are not touched again this frame.
+    vobCullRs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 1: t0 Visuals
+    vobCullRs.AddSRV( 1, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 2: t1 InInstances
     vobCullRs.AddUAV( 0, D3D12_SHADER_VISIBILITY_ALL );             // 3: u0 OutInstances (compacted)
     vobCullRs.AddUAV( 1, D3D12_SHADER_VISIBILITY_ALL );             // 4: u1 VisibleCounts
     if ( !vobCullRs.Build( device, D3D12_ROOT_SIGNATURE_FLAG_CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED ) )
@@ -3412,7 +3460,9 @@ bool D3D12PipelineState::CreateCull() {
     // --- Indirect-arg patch root sig: b0 4 consts (count/stride/offsets), t0 counts SRV, u0 raw arg UAV ---
     D3D12RootLayout& patchRs = Layout( "CullPatch" );
     patchRs.AddConstants( 0, 4, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 VobPatchCB
-    patchRs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL );            // 1: t0 PatchCounts
+    // t0 is the VisibleCounts UAV the cull dispatch just finished writing, read back here behind a
+    // barrier: final from this bind onwards (the next write is next frame's cull, a later list).
+    patchRs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 1: t0 PatchCounts
     patchRs.AddUAV( 0, D3D12_SHADER_VISIBILITY_ALL );            // 2: u0 PatchArgs (RWByteAddressBuffer)
     if ( !patchRs.Build( device ) )
         return false;

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -945,6 +945,20 @@ bool D3D12PipelineState::CreateDepthPrepass() {
         return false;
     }
 
+    // ...and the same thing with NO pixel shader, for the materials that don't need the cutout (the large
+    // majority of the world). PSClip can `discard`, which forces the whole draw onto the late-Z path; with no
+    // PS bound at all the rasterizer runs depth-only at double rate. See DepthPrepassNoAlphaPSO's declaration.
+    // Non-fatal: DrawDepthPrepass falls back to submitting everything through the clipping PSO if this is null.
+    {
+        D3D12_GRAPHICS_PIPELINE_STATE_DESC noAlpha = pso;
+        noAlpha.PS = {};
+        if ( FAILED( device->CreateGraphicsPipelineState( &noAlpha, IID_PPV_ARGS( World.DepthPrepassNoAlphaPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+            LogWarn() << "D3D12: CreateGraphicsPipelineState failed (depth prepass, no-alpha) — "
+                         "the world prepass keeps alpha-clipping every material.";
+            World.DepthPrepassNoAlphaPSO.Reset();
+        }
+    }
+
     // Instanced-VOB depth prepass PSO (P2.9b-4a): same depth-only state, but the VOB two-stream input layout
     // (packed vertex slot 0 + per-instance world matrix slot 1) and the VOB shader's VSDepth/PSDepthClip.
     if ( !m_Shaders->CompileFromFile( "Vob.hlsl", "VSDepth", Shadermodel_VS, World.DepthPrepassVobVsBlob.ReleaseAndGetAddressOf() ) ) {
@@ -1010,6 +1024,14 @@ bool D3D12PipelineState::CreateDepthPrepass() {
         LogWarn() << "D3D12: CreateGraphicsPipelineState failed (VOB attachment depth prepass).";
         return false;
     }
+    {
+        D3D12_GRAPHICS_PIPELINE_STATE_DESC noAlpha = pso;
+        noAlpha.PS = {};
+        if ( FAILED( device->CreateGraphicsPipelineState( &noAlpha, IID_PPV_ARGS( World.DepthPrepassVobAttachNoAlphaPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+            LogWarn() << "D3D12: CreateGraphicsPipelineState failed (VOB attachment depth prepass, no-alpha).";
+            World.DepthPrepassVobAttachNoAlphaPSO.Reset();
+        }
+    }
 
     // Bindless-diffuse VOB depth-prepass PSO (ExecuteIndirect, P2.12): same VSDepth blob + wind-only vobLayout +
     // depth-only state as DepthPrepassVobPSO, only the PS swapped to PSDepthClipBindless (compiled above, shared
@@ -1020,6 +1042,14 @@ bool D3D12PipelineState::CreateDepthPrepass() {
     if ( FAILED( device->CreateGraphicsPipelineState( &pso, IID_PPV_ARGS( World.DepthPrepassVobIndirectPSO.ReleaseAndGetAddressOf() ) ) ) ) {
         LogWarn() << "D3D12: CreateGraphicsPipelineState failed (VOB depth prepass, indirect).";
         return false;
+    }
+    {
+        D3D12_GRAPHICS_PIPELINE_STATE_DESC noAlpha = pso;
+        noAlpha.PS = {};
+        if ( FAILED( device->CreateGraphicsPipelineState( &noAlpha, IID_PPV_ARGS( World.DepthPrepassVobNoAlphaPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+            LogWarn() << "D3D12: CreateGraphicsPipelineState failed (VOB depth prepass, no-alpha).";
+            World.DepthPrepassVobNoAlphaPSO.Reset();
+        }
     }
 
     if ( !CreateDepthPrepassGBuf() ) {
@@ -1785,6 +1815,14 @@ bool D3D12PipelineState::CreateSkeletal() {
         LogWarn() << "D3D12: CreateGraphicsPipelineState failed (skeletal depth prepass).";
         return false;
     }
+    {
+        D3D12_GRAPHICS_PIPELINE_STATE_DESC noAlpha = pso;
+        noAlpha.PS = {};
+        if ( FAILED( device->CreateGraphicsPipelineState( &noAlpha, IID_PPV_ARGS( Skeletal.DepthPrepassNoAlphaPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+            LogWarn() << "D3D12: CreateGraphicsPipelineState failed (skeletal depth prepass, no-alpha).";
+            Skeletal.DepthPrepassNoAlphaPSO.Reset();
+        }
+    }
 
     // G-buffer prepass variant: motion vectors + normals for skinned meshes (VSDepthGBuf skins the vertex TWICE,
     // once through the current pose and once through the previous one out of the same b2 palette). Optional —
@@ -1885,6 +1923,15 @@ bool D3D12PipelineState::CreatePointShadow() {
         LogWarn() << "D3D12: CreateGraphicsPipelineState failed (point-shadow world caster).";
         return false;
     }
+    // No-pixel-shader twin — see PointShadowPipeline::CasterWorldNoAlphaPSO. Non-fatal.
+    {
+        D3D12_GRAPHICS_PIPELINE_STATE_DESC noAlpha = pso;
+        noAlpha.PS = {};
+        if ( FAILED( device->CreateGraphicsPipelineState( &noAlpha, IID_PPV_ARGS( PointShadow.CasterWorldNoAlphaPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+            LogWarn() << "D3D12: CreateGraphicsPipelineState failed (point-shadow world caster, no-alpha).";
+            PointShadow.CasterWorldNoAlphaPSO.Reset();
+        }
+    }
 
     // --- VOB caster PSO (P2.10e): same root sig (per-instance world rides the vertex stream, not the root) + the
     // same caster state, but VSCubeVob and a two-stream layout whose instance rows carry InstanceDataStepRate=6 —
@@ -1909,6 +1956,14 @@ bool D3D12PipelineState::CreatePointShadow() {
         if ( FAILED( device->CreateGraphicsPipelineState( &pso, IID_PPV_ARGS( PointShadow.CasterVobPSO.ReleaseAndGetAddressOf() ) ) ) ) {
             LogWarn() << "D3D12: CreateGraphicsPipelineState failed (point-shadow VOB caster).";
             return false;
+        }
+        {
+            D3D12_GRAPHICS_PIPELINE_STATE_DESC noAlpha = pso;
+            noAlpha.PS = {};
+            if ( FAILED( device->CreateGraphicsPipelineState( &noAlpha, IID_PPV_ARGS( PointShadow.CasterVobNoAlphaPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+                LogWarn() << "D3D12: CreateGraphicsPipelineState failed (point-shadow VOB caster, no-alpha).";
+                PointShadow.CasterVobNoAlphaPSO.Reset();
+            }
         }
     }
 
@@ -1953,6 +2008,14 @@ bool D3D12PipelineState::CreatePointShadow() {
         if ( FAILED( device->CreateGraphicsPipelineState( &pso, IID_PPV_ARGS( PointShadow.CasterSkeletalPSO.ReleaseAndGetAddressOf() ) ) ) ) {
             LogWarn() << "D3D12: CreateGraphicsPipelineState failed (point-shadow skeletal caster).";
             return false;
+        }
+        {
+            D3D12_GRAPHICS_PIPELINE_STATE_DESC noAlpha = pso;
+            noAlpha.PS = {};
+            if ( FAILED( device->CreateGraphicsPipelineState( &noAlpha, IID_PPV_ARGS( PointShadow.CasterSkeletalNoAlphaPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+                LogWarn() << "D3D12: CreateGraphicsPipelineState failed (point-shadow skeletal caster, no-alpha).";
+                PointShadow.CasterSkeletalNoAlphaPSO.Reset();
+            }
         }
     }
     return true;

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.h
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.h
@@ -83,6 +83,22 @@ public:
         Microsoft::WRL::ComPtr<ID3DBlob>            VobIndirectPsBlob;         // PSMainBindless
         Microsoft::WRL::ComPtr<ID3D12PipelineState> DepthPrepassVobIndirectPSO;
         Microsoft::WRL::ComPtr<ID3DBlob>            DepthPrepassVobIndirectPsBlob; // PSDepthClipBindless
+        // NO-PIXEL-SHADER prepass variants. Byte-identical to the three *DepthPrepass* PSOs above except
+        // `PS = {}` — no alpha clip, and therefore no pixel shader at all. A bound PS that can `discard`
+        // forces late-Z for the whole draw, which costs the depth-only prepass the double-rate Z path the
+        // hardware would otherwise give it (this is what D3D11's Forward+ prepass gets for free by calling
+        // PSSetShader(nullptr) — see D3D11ForwardPlusRenderer.cpp).
+        //
+        // Only materials that actually need the cutout (diffuse HasAlphaChannel() or Material->HasAlphaTest())
+        // need the clipping PSOs. The Build*DrawCommands functions partition each frame's indirect command
+        // buffer so the opaque materials form a prefix and the alpha-tested ones a suffix; the prepass then
+        // issues two ExecuteIndirects, this PSO over the prefix and the clipping one over the suffix.
+        //
+        // Not built for the *GBuf variants: when the motion/normal G-buffer is on there IS a pixel shader by
+        // definition (it exports velocity + normals), so the split buys nothing there.
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> DepthPrepassNoAlphaPSO;           // world mesh
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> DepthPrepassVobNoAlphaPSO;        // instanced VOBs
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> DepthPrepassVobAttachNoAlphaPSO;  // node attachments
         // G-buffer prepass variants (motion vectors + octahedral normals — see D3D12Motion.cpp). Identical depth
         // state to the three PSOs above, but two real render targets (kVelocityFormat, kGBufferNormalFormat)
         // instead of the masked-off scene-color RTV, and the *GBuf shader entry points which additionally read
@@ -168,6 +184,8 @@ public:
         Microsoft::WRL::ComPtr<ID3D12PipelineState> DepthPrepassPSO;    // depth-only skinned (color write mask 0)
         Microsoft::WRL::ComPtr<ID3DBlob>            DepthPrepassVsBlob;  // also reused by the CSM skeletal shadow caster
         Microsoft::WRL::ComPtr<ID3DBlob>            DepthPrepassPsBlob;
+        // No-pixel-shader variant of the above — see World.DepthPrepassNoAlphaPSO for why and how it is selected.
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> DepthPrepassNoAlphaPSO;
         // G-buffer prepass variant (motion vectors + normals). Skinned twice — current pose and the previous
         // pose out of the same b2 palette — so a swung limb gets true per-vertex velocity. Optional: null falls
         // back to DepthPrepassPSO above.
@@ -189,6 +207,13 @@ public:
         Microsoft::WRL::ComPtr<ID3D12PipelineState> CasterWorldPSO;
         Microsoft::WRL::ComPtr<ID3D12PipelineState> CasterVobPSO;
         Microsoft::WRL::ComPtr<ID3D12PipelineState> CasterSkeletalPSO;
+        // No-pixel-shader twins (`PS = {}`) of the three above, for casters whose diffuse has no alpha channel
+        // and therefore cannot be cut out by PSCubeClip. Six faces per caster makes this the shadow pass with
+        // the most to gain from the hardware's depth-only fast path. Null => the recorder keeps clipping
+        // everything. See D3D12ShadowMap::m_CasterWorldNoAlphaPSO for the full rationale.
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> CasterWorldNoAlphaPSO;
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> CasterVobNoAlphaPSO;
+        Microsoft::WRL::ComPtr<ID3D12PipelineState> CasterSkeletalNoAlphaPSO;
     };
 
     // Bink video playback (zBinkPlayer): own root sig (b0 viewport consts, t0-t2 YUV planes SRV table, static

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -51,6 +51,11 @@ namespace {
 		D3D12_VERTEX_BUFFER_VIEW    instView = {};       // 2nd stream (VOBs/attachments); SizeInBytes 0 => single stream
 		D3D12_GPU_VIRTUAL_ADDRESS   instCb = 0;          // skeletal b1
 		D3D12_GPU_VIRTUAL_ADDRESS   boneCb = 0;          // skeletal b2
+		// Can PSCubeClip's `clip(diffuse.a - 0.5)` ever discard here? If not, the record is drawn by the
+		// caster PSO's no-pixel-shader twin — a PS that merely might discard costs the whole draw the
+		// hardware's double-rate depth path, and this pass rasterizes six faces per caster. Resolved by the
+		// builders below (main thread, Gothic-side reads); the recorder just reads the flag.
+		bool                        alphaTested = true;
 	};
 	// Per shadowed light: its cube slot, its 6-face view-proj CB, and the [begin,end) spans it owns in each
 	// of the four draw lists below.
@@ -775,6 +780,7 @@ void D3D12PointShadows::Prepare() {
 							d.startIndex = mesh->BaseIndexLocation;
 							d.instanceCount = 6;
 							d.srv = boundSrv;
+							d.alphaTested = ( tex && tex->HasAlphaChannel() ) || meshKey.Material->HasAlphaTest();
 							g_PsStaticWorldDraws.push_back( d );
 						}
 					}
@@ -816,7 +822,10 @@ void D3D12PointShadows::Prepare() {
 
 					const D3D12_VERTEX_BUFFER_VIEW instView = { viGpu + gatherStart, count * static_cast<UINT>(sizeof( XMFLOAT4X4 )), static_cast<UINT>(sizeof( XMFLOAT4X4 )) };
 					for ( auto const& [meshKey, meshList] : visual->MeshesByTexture ) {
-						const D3D12_GPU_DESCRIPTOR_HANDLE srv = resolveDiffuse( meshKey.Material->GetAniTexture() );
+						zCTexture* const matTex = meshKey.Material->GetAniTexture();
+						const D3D12_GPU_DESCRIPTOR_HANDLE srv = resolveDiffuse( matTex );
+						const bool matAlphaTested = ( matTex && matTex->HasAlphaChannel() )
+							|| meshKey.Material->HasAlphaTest();
 						for ( MeshInfo* mi : meshList ) {
 							if ( !mi || mi->Indices.empty() || !mi->GetMeshVertexBuffer() || !mi->GetMeshIndexBuffer() ) continue;
 							D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( mi->GetMeshVertexBuffer() );
@@ -830,6 +839,7 @@ void D3D12PointShadows::Prepare() {
 							d.instanceCount = count * 6;
 							d.srv = srv;
 							d.instView = instView;
+							d.alphaTested = matAlphaTested;
 							g_PsStaticVobDraws.push_back( d );
 						}
 					}
@@ -880,7 +890,10 @@ void D3D12PointShadows::Prepare() {
 				model->UpdateMeshLibTexAniState();
 
 				for ( auto const& [mat, meshList] : sd.visual->SkeletalMeshes ) {
-					const D3D12_GPU_DESCRIPTOR_HANDLE srv = resolveDiffuse( mat ? mat->GetAniTexture() : nullptr );
+					zCTexture* const matTex = mat ? mat->GetAniTexture() : nullptr;
+					const D3D12_GPU_DESCRIPTOR_HANDLE srv = resolveDiffuse( matTex );
+					const bool matAlphaTested = ( matTex && matTex->HasAlphaChannel() )
+						|| ( mat && mat->HasAlphaTest() );
 					for ( auto const& mesh : meshList ) {
 						if ( !mesh || mesh->Indices.empty() || !mesh->MeshVertexBuffer || !mesh->MeshIndexBuffer ) continue;
 						D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( mesh->MeshVertexBuffer.get() );
@@ -895,6 +908,7 @@ void D3D12PointShadows::Prepare() {
 						d.srv = srv;
 						d.instCb = sd.instCb;
 						d.boneCb = sd.boneCb;
+						d.alphaTested = matAlphaTested;
 						g_PsDynSkelDraws.push_back( d );
 					}
 				}
@@ -921,6 +935,7 @@ void D3D12PointShadows::Prepare() {
 					d.instanceCount = 6;
 					d.srv = resolveDiffuse( a.tex );
 					d.instView = a.instView;
+					d.alphaTested = a.alphaTested;   // resolved with a.srvSlot on the main thread
 					g_PsDynAttachDraws.push_back( d );
 				}
 			}
@@ -1042,6 +1057,18 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 		lastVb = nullptr; lastIb = nullptr; lastSrv = 0;
 		lastInstCb = 0; lastBoneCb = 0; lastInstVbAddr = 0; lastInstVbSize = 0;
 		};
+	// Alpha-clip PSO selection, per draw. Deliberately NOT part of resetBindCache: unlike descriptor tables and
+	// root CBVs, the bound PSO survives a root-signature change, so one filter spanning all four phases is both
+	// correct and the fewest switches. `noAlpha` falls back to the clipping PSO when the twin failed to build,
+	// which collapses the filter back to today's behaviour without a second code path.
+	ID3D12PipelineState* boundPso = nullptr;
+	auto bindCasterPso = [&]( ID3D12PipelineState* clip, ID3D12PipelineState* noAlpha, bool alphaTested ) {
+		ID3D12PipelineState* want = ( alphaTested || !noAlpha ) ? clip : noAlpha;
+		if ( want != boundPso ) {
+			cmdList->SetPipelineState( want );
+			boundPso = want;
+		}
+		};
 	auto emitGeometry = [&]( const PointShadowDraw& d ) {
 		const bool twoStreams = d.instView.SizeInBytes != 0;
 		if ( d.vb != lastVb || d.ib != lastIb
@@ -1095,12 +1122,12 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 			if ( L.staticWorldEnd > L.staticWorldBegin ) {
 				DX_ZONE( cmdList.Get(), "World Mesh" );
 				TracyD3D12ZoneCGX( cmdList.Get(), "World Mesh" );
-				cmdList->SetPipelineState( psPipe.CasterWorldPSO.Get() );
 				cmdList->SetGraphicsRootSignature( psPipe.RootSig.Get() );
 				cmdList->SetGraphicsRootConstantBufferView( 0, L.faceCb );
 				resetBindCache();
 				for ( UINT i = L.staticWorldBegin; i < L.staticWorldEnd; ++i ) {
 					const PointShadowDraw& d = g_PsStaticWorldDraws[i];
+					bindCasterPso( psPipe.CasterWorldPSO.Get(), psPipe.CasterWorldNoAlphaPSO.Get(), d.alphaTested );
 					if ( d.srv.ptr != lastSrv ) { cmdList->SetGraphicsRootDescriptorTable( 1, d.srv ); lastSrv = d.srv.ptr; }
 					emitGeometry( d );
 				}
@@ -1109,12 +1136,12 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 			if ( L.staticVobEnd > L.staticVobBegin ) {
 				DX_ZONE( cmdList.Get(), "Vobs" );
 				TracyD3D12ZoneCGX( cmdList.Get(), "Vobs" );
-				cmdList->SetPipelineState( psPipe.CasterVobPSO.Get() );
 				cmdList->SetGraphicsRootSignature( psPipe.RootSig.Get() );
 				cmdList->SetGraphicsRootConstantBufferView( 0, L.faceCb );
 				resetBindCache();
 				for ( UINT i = L.staticVobBegin; i < L.staticVobEnd; ++i ) {
 					const PointShadowDraw& d = g_PsStaticVobDraws[i];
+					bindCasterPso( psPipe.CasterVobPSO.Get(), psPipe.CasterVobNoAlphaPSO.Get(), d.alphaTested );
 					if ( d.srv.ptr != lastSrv ) { cmdList->SetGraphicsRootDescriptorTable( 1, d.srv ); lastSrv = d.srv.ptr; }
 					emitGeometry( d );
 				}
@@ -1171,12 +1198,12 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 				// smaller root signature), so the skeletal root sig/PSO can't be assumed still bound once we're
 				// past the first light (bug: 2nd+ shadowed light's instCb/boneCb/diffuse binds landed on the
 				// wrong root signature's parameter slots — GPU device hang, caught via D3D12 validation).
-				cmdList->SetPipelineState( psPipe.CasterSkeletalPSO.Get() );
 				cmdList->SetGraphicsRootSignature( psPipe.SkeletalRootSig.Get() );
 				cmdList->SetGraphicsRootConstantBufferView( 0, L.faceCb );
 				resetBindCache();
 				for ( UINT i = L.dynSkelBegin; i < L.dynSkelEnd; ++i ) {
 					const PointShadowDraw& d = g_PsDynSkelDraws[i];
+					bindCasterPso( psPipe.CasterSkeletalPSO.Get(), psPipe.CasterSkeletalNoAlphaPSO.Get(), d.alphaTested );
 					if ( d.instCb != lastInstCb ) { cmdList->SetGraphicsRootConstantBufferView( 1, d.instCb ); lastInstCb = d.instCb; }
 					if ( d.boneCb != lastBoneCb ) { cmdList->SetGraphicsRootConstantBufferView( 2, d.boneCb ); lastBoneCb = d.boneCb; }
 					if ( d.srv.ptr != lastSrv )   { cmdList->SetGraphicsRootDescriptorTable( 3, d.srv ); lastSrv = d.srv.ptr; }
@@ -1187,12 +1214,12 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 			if ( haveAttachDraws ) {
 				DX_ZONE( cmdList.Get(), "Skeletal Nodes" );
 				TracyD3D12ZoneCGX( cmdList.Get(), "Skeletal Nodes" );
-				cmdList->SetPipelineState( psPipe.CasterVobPSO.Get() );
 				cmdList->SetGraphicsRootSignature( psPipe.RootSig.Get() );
 				cmdList->SetGraphicsRootConstantBufferView( 0, L.faceCb );
 				resetBindCache();
 				for ( UINT i = L.dynAttachBegin; i < L.dynAttachEnd; ++i ) {
 					const PointShadowDraw& d = g_PsDynAttachDraws[i];
+					bindCasterPso( psPipe.CasterVobPSO.Get(), psPipe.CasterVobNoAlphaPSO.Get(), d.alphaTested );
 					if ( d.srv.ptr != lastSrv ) { cmdList->SetGraphicsRootDescriptorTable( 1, d.srv ); lastSrv = d.srv.ptr; }
 					emitGeometry( d );
 				}

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -971,7 +971,7 @@ void D3D12PointShadows::CommitStaticCache() {
 }
 
 
-void D3D12PointShadows::Record( ID3D12GraphicsCommandList* cmdList ) {
+void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 	// The pure-D3D12 half of the pass: no Gothic access whatsoever, so it is safe on a pool thread. Phases mirror
 	// Prepare()'s comment: A) static casters into m_Cube, C) the dynamic (skeletal + attachment) overlay into its
 	// own m_DynCube, cleared per slot, D) hand the touched slots of BOTH arrays back to the lit pass as
@@ -987,8 +987,8 @@ void D3D12PointShadows::Record( ID3D12GraphicsCommandList* cmdList ) {
 		cmdList->SetDescriptorHeaps( 1, heaps );
 	}
 
-	DX_ZONE( cmdList, "Point Shadows (cubes)" );
-	TracyD3D12ZoneCGX( cmdList, "Point Shadows (cubes)" );
+	DX_ZONE( cmdList.Get(), "Point Shadows (cubes)" );
+	TracyD3D12ZoneCGX( cmdList.Get(), "Point Shadows (cubes)" );
 
 	// Face size differs per tier, so the viewport is (re)set per record in Phase A rather than once here. Phases
 	// B-D issue no draws, so they need none. Both tiers share the PSOs — same D16 target format, same topology.
@@ -1069,8 +1069,8 @@ void D3D12PointShadows::Record( ID3D12GraphicsCommandList* cmdList ) {
 	// long as Slot::staticValid says it does. The dynamic overlay lives in its own array (Phase C) and the lit pass
 	// mins the two. This is what used to be the `useAside` split plus a per-slot copy every frame.
 	if ( g_PsAnyStatic ) {
-		DX_ZONE( cmdList, "Static Pass" );
-		TracyD3D12ZoneCGX( cmdList, "Static Pass" );
+		DX_ZONE( cmdList.Get(), "Static Pass" );
+		TracyD3D12ZoneCGX( cmdList.Get(), "Static Pass" );
 		for ( const PointShadowLightRecord& L : g_PsLights ) {
 			if ( !L.renderStatic ) continue;
 			if ( L.lowRes ) pushSlot( m_LowCube.Get(), m_LowSlotState,    LowIndex( L.slot ), D3D12_RESOURCE_STATE_DEPTH_WRITE );
@@ -1093,8 +1093,8 @@ void D3D12PointShadows::Record( ID3D12GraphicsCommandList* cmdList ) {
 			cmdList->ClearDepthStencilView( dsv, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr );
 
 			if ( L.staticWorldEnd > L.staticWorldBegin ) {
-				DX_ZONE( cmdList, "World Mesh" );
-				TracyD3D12ZoneCGX( cmdList, "World Mesh" );
+				DX_ZONE( cmdList.Get(), "World Mesh" );
+				TracyD3D12ZoneCGX( cmdList.Get(), "World Mesh" );
 				cmdList->SetPipelineState( psPipe.CasterWorldPSO.Get() );
 				cmdList->SetGraphicsRootSignature( psPipe.RootSig.Get() );
 				cmdList->SetGraphicsRootConstantBufferView( 0, L.faceCb );
@@ -1107,8 +1107,8 @@ void D3D12PointShadows::Record( ID3D12GraphicsCommandList* cmdList ) {
 			}
 
 			if ( L.staticVobEnd > L.staticVobBegin ) {
-				DX_ZONE( cmdList, "Vobs" );
-				TracyD3D12ZoneCGX( cmdList, "Vobs" );
+				DX_ZONE( cmdList.Get(), "Vobs" );
+				TracyD3D12ZoneCGX( cmdList.Get(), "Vobs" );
 				cmdList->SetPipelineState( psPipe.CasterVobPSO.Get() );
 				cmdList->SetGraphicsRootSignature( psPipe.RootSig.Get() );
 				cmdList->SetGraphicsRootConstantBufferView( 0, L.faceCb );
@@ -1133,8 +1133,8 @@ void D3D12PointShadows::Record( ID3D12GraphicsCommandList* cmdList ) {
 	// static depth. SamplePointShadow takes min(static, dynamic), which is the same "occluded by either" result
 	// the composite used to produce.
 	{
-		DX_ZONE( cmdList, "Dynamic Overlay (skeletals)" );
-		TracyD3D12ZoneCGX( cmdList, "Dynamic Overlay (skeletals)" );
+		DX_ZONE( cmdList.Get(), "Dynamic Overlay (skeletals)" );
+		TracyD3D12ZoneCGX( cmdList.Get(), "Dynamic Overlay (skeletals)" );
 		// Phase A leaves whichever tier's viewport its LAST record used still bound. This phase only ever draws
 		// into the full-res active cube, so a low-res viewport surviving from Phase A would squeeze the whole
 		// dynamic overlay into the top-left 32x32 of each 128^2 face — i.e. dynamic point-light shadows visibly
@@ -1185,8 +1185,8 @@ void D3D12PointShadows::Record( ID3D12GraphicsCommandList* cmdList ) {
 			}
 
 			if ( haveAttachDraws ) {
-				DX_ZONE( cmdList, "Skeletal Nodes" );
-				TracyD3D12ZoneCGX( cmdList, "Skeletal Nodes" );
+				DX_ZONE( cmdList.Get(), "Skeletal Nodes" );
+				TracyD3D12ZoneCGX( cmdList.Get(), "Skeletal Nodes" );
 				cmdList->SetPipelineState( psPipe.CasterVobPSO.Get() );
 				cmdList->SetGraphicsRootSignature( psPipe.RootSig.Get() );
 				cmdList->SetGraphicsRootConstantBufferView( 0, L.faceCb );

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.h
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.h
@@ -33,6 +33,7 @@
 #include <DirectXMath.h>
 
 #include "D3D12EngineCommon.h"
+#include "D3D12StateCache.h"
 
 class D3D12GraphicsEngine;
 class zCVobLight;
@@ -110,7 +111,7 @@ public:
     void SelectShadowedLights( GPULight* lights, UINT count, const std::vector<LightShadowKey>& keys );
 
     void Prepare();
-    void Record( ID3D12GraphicsCommandList* cmdList );
+    void Record( D3D12CmdList& cmdList );
 
     // Commits the static-cube cache stamps Prepare() resolved this frame. MUST be called only once the pass is
     // known to have been recorded AND submitted (end of FinishShadowPasses) — never from Prepare().

--- a/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
@@ -165,7 +165,7 @@ void D3D12GraphicsEngine::RenderBloom() {
 		|| !m_Pipelines.Bloom.UpsamplePSO || !m_Pipelines.Bloom.CompositePSO || !m_SceneColor )
 		return;
 
-	DX_ZONE( m_CmdList, "Bloom" );
+	DX_ZONE( m_CmdList.Get(), "Bloom" );
 	const int mipCount = m_BloomMipCount;
 
 	struct BloomCB { float texelSizeX, texelSizeY, threshold, knee, intensity, filterRadius, padX, padY; };
@@ -383,7 +383,7 @@ void D3D12GraphicsEngine::RenderLuminanceAdapt() {
 		|| m_LumGroupsX == 0 || m_LumGroupsY == 0 )
 		return;
 
-	DX_ZONE( m_CmdList, "Dynamic Exposure (luminance reduce+adapt)" );
+	DX_ZONE( m_CmdList.Get(), "Dynamic Exposure (luminance reduce+adapt)" );
 
 	if ( !m_SceneColorInPixelState ) {
 		auto toSrv = TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
@@ -586,6 +586,7 @@ bool D3D12GraphicsEngine::CreateSmaaResources( INT2 size ) {
 	m_SmaaBlendRtv = m_RtvHeap->GetCPUDescriptorHandleForHeapStart();
 	m_SmaaBlendRtv.ptr += static_cast<SIZE_T>( kBackBufferMax + 2 ) * m_RtvDescriptorSize;
 	device->CreateRenderTargetView( m_SmaaBlend.Get(), &rtvDesc, m_SmaaBlendRtv );
+	m_CmdList.InvalidateRenderTargets();   // descriptors rewritten in place — see D3D12StateCache.h
 
 	m_SmaaResourcesReady = true;
 	return true;
@@ -604,7 +605,7 @@ void D3D12GraphicsEngine::RenderSMAA() {
 		|| !m_Pipelines.Smaa.RootSig || !m_Pipelines.Smaa.EdgePSO || !m_Pipelines.Smaa.BlendPSO || !m_Pipelines.Smaa.NeighborPSO )
 		return;
 
-	DX_ZONE( m_CmdList, "SMAA" );
+	DX_ZONE( m_CmdList.Get(), "SMAA" );
 
 	ID3D12Resource* backBuffer = GetDisplayTarget();
 	D3D12_CPU_DESCRIPTOR_HANDLE backRtv = GetDisplayRtv();
@@ -703,7 +704,7 @@ void D3D12GraphicsEngine::RenderSharpen() {
 		: m_Pipelines.Sharpen.SimplePSO.Get();
 	if ( !pso ) return;
 
-	DX_ZONE( m_CmdList, "Sharpen" );
+	DX_ZONE( m_CmdList.Get(), "Sharpen" );
 
 	ID3D12Resource* backBuffer = GetDisplayTarget();
 	D3D12_CPU_DESCRIPTOR_HANDLE backRtv = GetDisplayRtv();

--- a/D3D11Engine/D3D12Engine/D3D12Rain.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Rain.cpp
@@ -183,7 +183,7 @@ void D3D12GraphicsEngine::AdvanceRain() {
     }
     if ( !m_RainBuffersReady ) return;
 
-    DX_ZONE( m_CmdList, "AdvanceRain" );
+    DX_ZONE( m_CmdList.Get(), "AdvanceRain" );
 
     // Establish the invariant DrawRainParticles relies on — by the time AdvanceRain returns (buffers
     // ready), m_RainBufferDynamic is always in UNORDERED_ACCESS, whether or not the CS actually dispatched
@@ -247,7 +247,7 @@ void D3D12GraphicsEngine::DrawRainParticles() {
     const UINT texArraySlot = isSnow ? m_SnowTextureArraySrvSlot : m_RainTextureArraySrvSlot;
     if ( texArraySlot == UINT_MAX ) return;
 
-    DX_ZONE( m_CmdList, "DrawRainParticles" );
+    DX_ZONE( m_CmdList.Get(), "DrawRainParticles" );
 
     // Flip the dynamic buffer UAV -> NON_PIXEL_SHADER_RESOURCE for the VS's root-SRV read (AdvanceRain
     // guarantees it's in UNORDERED_ACCESS by the time it returns, whether or not it actually dispatched).
@@ -475,6 +475,7 @@ bool D3D12GraphicsEngine::CreateRainShadowResources() {
     dsv.Format = DXGI_FORMAT_D32_FLOAT;
     dsv.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
     device->CreateDepthStencilView( m_RainShadowMap.Get(), &dsv, m_RainShadowDsv );
+    m_CmdList.InvalidateRenderTargets();   // descriptor rewritten in place — see D3D12StateCache.h
 
     D3D12_SHADER_RESOURCE_VIEW_DESC srv = {};
     srv.Format = DXGI_FORMAT_R32_FLOAT;
@@ -761,7 +762,7 @@ void D3D12GraphicsEngine::PrepareRainShadowmap() {
 }
 
 
-void D3D12GraphicsEngine::RecordRainShadowmap( ID3D12GraphicsCommandList* cmdList ) {
+void D3D12GraphicsEngine::RecordRainShadowmap( D3D12CmdList& cmdList ) {
     // The pure-D3D12 half: no Gothic access, so it is safe on a pool thread.
     if ( !cmdList || !m_RainShadowPassReady ) return;
 
@@ -771,8 +772,8 @@ void D3D12GraphicsEngine::RecordRainShadowmap( ID3D12GraphicsCommandList* cmdLis
         cmdList->SetDescriptorHeaps( 1, heaps );
     }
 
-    DX_ZONE( cmdList, "RainShadowmap" );
-    TracyD3D12ZoneCGX( cmdList, "RainShadowmap" );
+    DX_ZONE( cmdList.Get(), "RainShadowmap" );
+    TracyD3D12ZoneCGX( cmdList.Get(), "RainShadowmap" );
 
     // Return the map to DEPTH_WRITE if last frame's readers left it in ALL_SHADER_RESOURCE.
     if ( m_RainShadowInReadState ) {
@@ -811,8 +812,8 @@ void D3D12GraphicsEngine::RecordRainShadowmap( ID3D12GraphicsCommandList* cmdLis
     // world had no casters), so re-establish them here rather than depending on that branch having run.
     if ( m_RainVobDrawCount > 0 && m_ShadowMap.GetVobIndirectCasterPSO() && m_VobIndirectCmdSig
         && m_RainVobDrawArgs[m_FrameIndex] ) {
-        DX_ZONE( cmdList, "Vobs" );
-        TracyD3D12ZoneCGX( cmdList, "Vobs" );
+        DX_ZONE( cmdList.Get(), "Vobs" );
+        TracyD3D12ZoneCGX( cmdList.Get(), "Vobs" );
 
         const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>(kRainShadowMapSize), static_cast<float>(kRainShadowMapSize), 0.0f, 1.0f };
         const D3D12_RECT     sc = { 0, 0, static_cast<LONG>(kRainShadowMapSize), static_cast<LONG>(kRainShadowMapSize) };

--- a/D3D11Engine/D3D12Engine/D3D12Rain.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Rain.cpp
@@ -524,6 +524,7 @@ namespace {
         UINT indexCount = 0;
         UINT startIndex = 0;
         UINT NormalIdx = 0xFFFFFFFFu, OrmIdx = 0, DiffuseIdx = 0;   // b6 MaterialCB (PSShadowClip reads Diffuse)
+        bool alphaTested = true;   // false => drawn by the no-pixel-shader caster PSO (see m_CasterWorldNoAlphaPSO)
     };
     std::vector<RainShadowDraw> g_RainShadowDraws;
     D3D12VertexBuffer* g_RainShadowVb = nullptr;
@@ -605,7 +606,7 @@ void D3D12GraphicsEngine::CollectRainShadowVobs() {
     // the wetness map is one coarse projection over the whole scene rather than a distance band, so there
     // is no near/far split here that would justify dropping caster detail.
     m_RainVobDrawCount = BuildVobDrawCommands( rainUploads, m_RainVobDrawArgsPtr[frame], false,
-        kMaxRainVobDrawCommands, false, true, 0 );
+        kMaxRainVobDrawCommands, false, true, 0, &m_RainVobOpaqueDrawCount );
 }
 
 
@@ -739,7 +740,8 @@ void D3D12GraphicsEngine::PrepareRainShadowmap() {
             }
 
             uint32_t diffuseIdx = m_BlackTexture->GetSrvSlot();
-            if ( zCTexture* tex = meshKey.Material->GetAniTexture() ) {
+            zCTexture* tex = meshKey.Material->GetAniTexture();
+            if ( tex ) {
                 if ( tex->GetCacheState() == zRES_CACHED_IN ) {
                     if ( MyDirectDrawSurface7* s = tex->GetSurface() ) {
                         if ( GfxTexture* gfx = s->GetEngineTexture() ) {
@@ -756,6 +758,8 @@ void D3D12GraphicsEngine::PrepareRainShadowmap() {
             d.NormalIdx = 0xFFFFFFFFu;
             d.OrmIdx = GetDefaultOrmSrvSlot();
             d.DiffuseIdx = diffuseIdx;
+            // Resolved here (main thread) so RecordRainShadowmap can pick the PSO without touching Gothic.
+            d.alphaTested = ( tex && tex->HasAlphaChannel() ) || meshKey.Material->HasAlphaTest();
             g_RainShadowDraws.push_back( d );
         }
     }
@@ -792,7 +796,13 @@ void D3D12GraphicsEngine::RecordRainShadowmap( D3D12CmdList& cmdList ) {
         cmdList->RSSetScissorRects( 1, &sc );
         cmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
-        cmdList->SetPipelineState( m_ShadowMap.GetWorldCasterPSO() );
+        // Per-draw PSO choice (this is a CPU draw loop, not an ExecuteIndirect): the casters whose diffuse has
+        // no alpha channel can't be clipped, so they run with no pixel shader bound. See m_CasterWorldNoAlphaPSO.
+        ID3D12PipelineState* const clipPso = m_ShadowMap.GetWorldCasterPSO();
+        ID3D12PipelineState* const noAlphaPso = m_ShadowMap.GetWorldCasterNoAlphaPSO()
+            ? m_ShadowMap.GetWorldCasterNoAlphaPSO() : clipPso;
+        ID3D12PipelineState* boundPso = nullptr;
+
         cmdList->SetGraphicsRootSignature( m_Pipelines.World.RootSig.Get() );
         cmdList->SetGraphicsRoot32BitConstants( 0, 16, &m_RainShadowViewProj, 0 );
 
@@ -802,6 +812,11 @@ void D3D12GraphicsEngine::RecordRainShadowmap( D3D12CmdList& cmdList ) {
         cmdList->IASetIndexBuffer( &ibv );
 
         for ( const RainShadowDraw& d : g_RainShadowDraws ) {
+            ID3D12PipelineState* wantPso = d.alphaTested ? clipPso : noAlphaPso;
+            if ( wantPso != boundPso ) {
+                cmdList->SetPipelineState( wantPso );
+                boundPso = wantPso;
+            }
             cmdList->SetGraphicsRoot32BitConstants( 10, 3, &d.NormalIdx, 0 );
             cmdList->DrawIndexedInstanced( d.indexCount, 1, d.startIndex, 0, 0 );
         }
@@ -821,12 +836,28 @@ void D3D12GraphicsEngine::RecordRainShadowmap( D3D12CmdList& cmdList ) {
         cmdList->RSSetScissorRects( 1, &sc );
         cmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
-        cmdList->SetPipelineState( m_ShadowMap.GetVobIndirectCasterPSO() );
+        // BuildVobDrawCommands partitioned this command set opaque-first (m_RainVobOpaqueDrawCount), so the
+        // leading run draws with no pixel shader — same split the CSM cascades do.
+        ID3D12PipelineState* const vobNoAlphaPso = m_ShadowMap.GetVobIndirectCasterNoAlphaPSO();
+        cmdList->SetPipelineState( vobNoAlphaPso ? vobNoAlphaPso : m_ShadowMap.GetVobIndirectCasterPSO() );
         cmdList->SetGraphicsRootSignature( m_Pipelines.World.RootSig.Get() );
         cmdList->SetGraphicsRoot32BitConstants( 0, 16, &m_RainShadowViewProj, 0 );
         cmdList->SetGraphicsRoot32BitConstants( 11, 12, &m_WindBuffer, 0 );   // b4 frame-global wind baseline
-        cmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_RainVobDrawCount,
-            m_RainVobDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
+        if ( !vobNoAlphaPso ) {
+            cmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_RainVobDrawCount,
+                m_RainVobDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
+        } else {
+            if ( m_RainVobOpaqueDrawCount > 0 ) {
+                cmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_RainVobOpaqueDrawCount,
+                    m_RainVobDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
+            }
+            if ( m_RainVobDrawCount > m_RainVobOpaqueDrawCount ) {
+                cmdList->SetPipelineState( m_ShadowMap.GetVobIndirectCasterPSO() );
+                cmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(),
+                    m_RainVobDrawCount - m_RainVobOpaqueDrawCount, m_RainVobDrawArgs[m_FrameIndex].Get(),
+                    static_cast<UINT64>( m_RainVobOpaqueDrawCount ) * sizeof( VobDrawCommand ), nullptr, 0 );
+            }
+        }
     }
 
     // Unbind before the transition: a DSV that is still the command list's "current" render target when its

--- a/D3D11Engine/D3D12Engine/D3D12RootLayout.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12RootLayout.cpp
@@ -7,20 +7,50 @@
 using Microsoft::WRL::ComPtr;
 
 namespace {
-    // D3D12SerializeRootSignature is exported from the already-loaded d3d12.dll (we don't link
+    // Both serialize entry points are exported from the already-loaded d3d12.dll (we don't link
     // d3d12.lib — see D3D12Device.cpp). Resolved once for the process rather than per root signature.
     typedef HRESULT( WINAPI* PFN_SERIALIZE_ROOT_SIG )( const D3D12_ROOT_SIGNATURE_DESC*, D3D_ROOT_SIGNATURE_VERSION, ID3DBlob**, ID3DBlob** );
+    typedef HRESULT( WINAPI* PFN_SERIALIZE_VERSIONED_ROOT_SIG )( const D3D12_VERSIONED_ROOT_SIGNATURE_DESC*, ID3DBlob**, ID3DBlob** );
+
+    HMODULE D3D12Module() {
+        static HMODULE s_module = LoadLibraryA( "d3d12.dll" );
+        return s_module;
+    }
 
     PFN_SERIALIZE_ROOT_SIG SerializeRootSignatureProc() {
-        static PFN_SERIALIZE_ROOT_SIG s_pfn = nullptr;
-        static bool s_attempted = false;
-        if ( s_attempted ) return s_pfn;
-        s_attempted = true;
-
-        HMODULE d3d12 = LoadLibraryA( "d3d12.dll" );
-        if ( !d3d12 ) return nullptr;
-        s_pfn = reinterpret_cast<PFN_SERIALIZE_ROOT_SIG>( GetProcAddress( d3d12, "D3D12SerializeRootSignature" ) );
+        static PFN_SERIALIZE_ROOT_SIG s_pfn = D3D12Module()
+            ? reinterpret_cast<PFN_SERIALIZE_ROOT_SIG>( GetProcAddress( D3D12Module(), "D3D12SerializeRootSignature" ) )
+            : nullptr;
         return s_pfn;
+    }
+
+    // Present since the 1.1 root signature was introduced (Win10 1511 / any Agility SDK d3d12.dll).
+    // Absent only on a d3d12.dll old enough that 1.1 doesn't exist at all, which the version query
+    // below independently reports as 1_0 — either check alone is enough to force the fallback.
+    PFN_SERIALIZE_VERSIONED_ROOT_SIG SerializeVersionedRootSignatureProc() {
+        static PFN_SERIALIZE_VERSIONED_ROOT_SIG s_pfn = D3D12Module()
+            ? reinterpret_cast<PFN_SERIALIZE_VERSIONED_ROOT_SIG>( GetProcAddress( D3D12Module(), "D3D12SerializeVersionedRootSignature" ) )
+            : nullptr;
+        return s_pfn;
+    }
+
+    // Highest root-signature version this device accepts. Cached per process: the backend only ever
+    // drives one D3D12 device, and every layout is built against it during Init.
+    D3D_ROOT_SIGNATURE_VERSION HighestRootSignatureVersion( ID3D12Device* device ) {
+        static D3D_ROOT_SIGNATURE_VERSION s_version = [device] {
+            D3D12_FEATURE_DATA_ROOT_SIGNATURE feature = {};
+            feature.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+            if ( !device || FAILED( device->CheckFeatureSupport( D3D12_FEATURE_ROOT_SIGNATURE, &feature, sizeof( feature ) ) ) ) {
+                // CheckFeatureSupport rejects the struct outright when the runtime predates 1.1.
+                LogInfo() << "D3D12: root signature 1.1 unavailable; falling back to 1.0 (all root "
+                             "parameters stay fully volatile — no descriptor/data preload).";
+                return D3D_ROOT_SIGNATURE_VERSION_1_0;
+            }
+            if ( feature.HighestVersion < D3D_ROOT_SIGNATURE_VERSION_1_1 )
+                LogInfo() << "D3D12: driver reports root signature 1.0 only; static-data promises will be dropped.";
+            return feature.HighestVersion;
+        }();
+        return s_version;
     }
 
     D3D12_STATIC_SAMPLER_DESC MakeSampler( UINT shaderRegister, D3D12_SHADER_VISIBILITY vis,
@@ -37,17 +67,21 @@ namespace {
 
 // ---- Declaration ------------------------------------------------------------------------------
 
-D3D12RootLayout::Range D3D12RootLayout::SRVRange( UINT baseRegister, UINT numDescriptors, UINT space ) {
-    return { D3D12_DESCRIPTOR_RANGE_TYPE_SRV, baseRegister, numDescriptors, space };
+D3D12RootLayout::Range D3D12RootLayout::SRVRange( UINT baseRegister, UINT numDescriptors, UINT space,
+    D3D12_DESCRIPTOR_RANGE_FLAGS flags ) {
+    return { D3D12_DESCRIPTOR_RANGE_TYPE_SRV, baseRegister, numDescriptors, space, flags };
 }
-D3D12RootLayout::Range D3D12RootLayout::UAVRange( UINT baseRegister, UINT numDescriptors, UINT space ) {
-    return { D3D12_DESCRIPTOR_RANGE_TYPE_UAV, baseRegister, numDescriptors, space };
+D3D12RootLayout::Range D3D12RootLayout::UAVRange( UINT baseRegister, UINT numDescriptors, UINT space,
+    D3D12_DESCRIPTOR_RANGE_FLAGS flags ) {
+    return { D3D12_DESCRIPTOR_RANGE_TYPE_UAV, baseRegister, numDescriptors, space, flags };
 }
-D3D12RootLayout::Range D3D12RootLayout::CBVRange( UINT baseRegister, UINT numDescriptors, UINT space ) {
-    return { D3D12_DESCRIPTOR_RANGE_TYPE_CBV, baseRegister, numDescriptors, space };
+D3D12RootLayout::Range D3D12RootLayout::CBVRange( UINT baseRegister, UINT numDescriptors, UINT space,
+    D3D12_DESCRIPTOR_RANGE_FLAGS flags ) {
+    return { D3D12_DESCRIPTOR_RANGE_TYPE_CBV, baseRegister, numDescriptors, space, flags };
 }
-D3D12RootLayout::Range D3D12RootLayout::SamplerRange( UINT baseRegister, UINT numDescriptors, UINT space ) {
-    return { D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, baseRegister, numDescriptors, space };
+D3D12RootLayout::Range D3D12RootLayout::SamplerRange( UINT baseRegister, UINT numDescriptors, UINT space,
+    D3D12_DESCRIPTOR_RANGE_FLAGS flags ) {
+    return { D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, baseRegister, numDescriptors, space, flags };
 }
 
 UINT D3D12RootLayout::AddConstants( UINT shaderRegister, UINT num32BitValues, D3D12_SHADER_VISIBILITY vis, UINT space ) {
@@ -62,24 +96,28 @@ UINT D3D12RootLayout::AddConstants( UINT shaderRegister, UINT num32BitValues, D3
 }
 
 UINT D3D12RootLayout::AddDescriptorParam( D3D12_ROOT_PARAMETER_TYPE type, UINT shaderRegister,
-    D3D12_SHADER_VISIBILITY vis, UINT space ) {
+    D3D12_SHADER_VISIBILITY vis, UINT space, D3D12_ROOT_DESCRIPTOR_FLAGS flags ) {
     ParamInfo p = {};
     p.Type = type;
     p.Visibility = vis;
     p.ShaderRegister = shaderRegister;
     p.Space = space;
+    p.DescriptorFlags = flags;
     m_Params.push_back( p );
     return static_cast<UINT>( m_Params.size() - 1 );
 }
 
-UINT D3D12RootLayout::AddCBV( UINT shaderRegister, D3D12_SHADER_VISIBILITY vis, UINT space ) {
-    return AddDescriptorParam( D3D12_ROOT_PARAMETER_TYPE_CBV, shaderRegister, vis, space );
+UINT D3D12RootLayout::AddCBV( UINT shaderRegister, D3D12_SHADER_VISIBILITY vis, UINT space,
+    D3D12_ROOT_DESCRIPTOR_FLAGS flags ) {
+    return AddDescriptorParam( D3D12_ROOT_PARAMETER_TYPE_CBV, shaderRegister, vis, space, flags );
 }
-UINT D3D12RootLayout::AddSRV( UINT shaderRegister, D3D12_SHADER_VISIBILITY vis, UINT space ) {
-    return AddDescriptorParam( D3D12_ROOT_PARAMETER_TYPE_SRV, shaderRegister, vis, space );
+UINT D3D12RootLayout::AddSRV( UINT shaderRegister, D3D12_SHADER_VISIBILITY vis, UINT space,
+    D3D12_ROOT_DESCRIPTOR_FLAGS flags ) {
+    return AddDescriptorParam( D3D12_ROOT_PARAMETER_TYPE_SRV, shaderRegister, vis, space, flags );
 }
 UINT D3D12RootLayout::AddUAV( UINT shaderRegister, D3D12_SHADER_VISIBILITY vis, UINT space ) {
-    return AddDescriptorParam( D3D12_ROOT_PARAMETER_TYPE_UAV, shaderRegister, vis, space );
+    // A root UAV is written by the GPU; DATA_VOLATILE is the only legal choice, so it isn't exposed.
+    return AddDescriptorParam( D3D12_ROOT_PARAMETER_TYPE_UAV, shaderRegister, vis, space, RootVolatile );
 }
 
 UINT D3D12RootLayout::AddTable( std::initializer_list<Range> ranges, D3D12_SHADER_VISIBILITY vis ) {
@@ -138,15 +176,23 @@ void D3D12RootLayout::Reset( const char* debugName ) {
 }
 
 bool D3D12RootLayout::Build( ID3D12Device* device, D3D12_ROOT_SIGNATURE_FLAGS flags ) {
-    PFN_SERIALIZE_ROOT_SIG serialize = SerializeRootSignatureProc();
-    if ( !serialize ) {
-        LogWarn() << "D3D12: D3D12SerializeRootSignature unavailable (" << m_DebugName << ").";
+    // Serialize as 1.1 when both the runtime export and the device support it, so the per-parameter
+    // DATA_STATIC*/DESCRIPTORS_* promises declared above actually reach the driver. Otherwise fall
+    // back to 1.0, which simply drops them — every layout stays valid under 1.0 semantics by
+    // construction (the flags only ever *narrow* what the layout is allowed to do, never widen it).
+    const bool useVersioned = SerializeVersionedRootSignatureProc() != nullptr
+        && HighestRootSignatureVersion( device ) >= D3D_ROOT_SIGNATURE_VERSION_1_1;
+
+    if ( !useVersioned && !SerializeRootSignatureProc() ) {
+        LogWarn() << "D3D12: no root signature serialize entry point available (" << m_DebugName << ").";
         return false;
     }
 
     // Materialize the retained declaration into the flat D3D12 structs. Ranges point into m_Ranges,
-    // which is stable for the lifetime of this object.
+    // which is stable for the lifetime of this object. Both version layouts are built — they are
+    // small, and it keeps the two serialize paths from each re-walking the declaration.
     std::vector<D3D12_DESCRIPTOR_RANGE> ranges( m_Ranges.size() );
+    std::vector<D3D12_DESCRIPTOR_RANGE1> ranges1( m_Ranges.size() );
     for ( size_t i = 0; i < m_Ranges.size(); ++i ) {
         const Range& r = m_Ranges[i];
         ranges[i] = {};
@@ -155,41 +201,69 @@ bool D3D12RootLayout::Build( ID3D12Device* device, D3D12_ROOT_SIGNATURE_FLAGS fl
         ranges[i].BaseShaderRegister = r.BaseRegister;
         ranges[i].RegisterSpace = r.Space;
         ranges[i].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+        ranges1[i] = {};
+        ranges1[i].RangeType = r.Type;
+        ranges1[i].NumDescriptors = r.NumDescriptors;
+        ranges1[i].BaseShaderRegister = r.BaseRegister;
+        ranges1[i].RegisterSpace = r.Space;
+        ranges1[i].Flags = r.Flags;
+        ranges1[i].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
     }
 
     std::vector<D3D12_ROOT_PARAMETER> params( m_Params.size() );
+    std::vector<D3D12_ROOT_PARAMETER1> params1( m_Params.size() );
     for ( size_t i = 0; i < m_Params.size(); ++i ) {
         const ParamInfo& src = m_Params[i];
         D3D12_ROOT_PARAMETER& dst = params[i];
+        D3D12_ROOT_PARAMETER1& dst1 = params1[i];
         dst = {};
-        dst.ParameterType = src.Type;
-        dst.ShaderVisibility = src.Visibility;
+        dst1 = {};
+        dst.ParameterType = dst1.ParameterType = src.Type;
+        dst.ShaderVisibility = dst1.ShaderVisibility = src.Visibility;
         switch ( src.Type ) {
         case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
-            dst.Constants.ShaderRegister = src.ShaderRegister;
-            dst.Constants.RegisterSpace = src.Space;
-            dst.Constants.Num32BitValues = src.Num32BitValues;
+            dst.Constants.ShaderRegister = dst1.Constants.ShaderRegister = src.ShaderRegister;
+            dst.Constants.RegisterSpace = dst1.Constants.RegisterSpace = src.Space;
+            dst.Constants.Num32BitValues = dst1.Constants.Num32BitValues = src.Num32BitValues;
             break;
         case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
             dst.DescriptorTable.NumDescriptorRanges = static_cast<UINT>( src.RangeCount );
             dst.DescriptorTable.pDescriptorRanges = src.RangeCount ? &ranges[src.FirstRange] : nullptr;
+            dst1.DescriptorTable.NumDescriptorRanges = static_cast<UINT>( src.RangeCount );
+            dst1.DescriptorTable.pDescriptorRanges = src.RangeCount ? &ranges1[src.FirstRange] : nullptr;
             break;
         default:   // CBV / SRV / UAV root descriptors
-            dst.Descriptor.ShaderRegister = src.ShaderRegister;
-            dst.Descriptor.RegisterSpace = src.Space;
+            dst.Descriptor.ShaderRegister = dst1.Descriptor.ShaderRegister = src.ShaderRegister;
+            dst.Descriptor.RegisterSpace = dst1.Descriptor.RegisterSpace = src.Space;
+            dst1.Descriptor.Flags = src.DescriptorFlags;   // 1.1 only — 1.0 is implicitly volatile
             break;
         }
     }
 
-    D3D12_ROOT_SIGNATURE_DESC rsDesc = {};
-    rsDesc.NumParameters = static_cast<UINT>( params.size() );
-    rsDesc.pParameters = params.empty() ? nullptr : params.data();
-    rsDesc.NumStaticSamplers = static_cast<UINT>( m_StaticSamplers.size() );
-    rsDesc.pStaticSamplers = m_StaticSamplers.empty() ? nullptr : m_StaticSamplers.data();
-    rsDesc.Flags = flags;
-
     ComPtr<ID3DBlob> rsBlob, rsErr;
-    if ( FAILED( serialize( &rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, rsBlob.GetAddressOf(), rsErr.GetAddressOf() ) ) ) {
+    HRESULT serializeHr = E_FAIL;
+    if ( useVersioned ) {
+        D3D12_VERSIONED_ROOT_SIGNATURE_DESC versioned = {};
+        versioned.Version = D3D_ROOT_SIGNATURE_VERSION_1_1;
+        versioned.Desc_1_1.NumParameters = static_cast<UINT>( params1.size() );
+        versioned.Desc_1_1.pParameters = params1.empty() ? nullptr : params1.data();
+        versioned.Desc_1_1.NumStaticSamplers = static_cast<UINT>( m_StaticSamplers.size() );
+        versioned.Desc_1_1.pStaticSamplers = m_StaticSamplers.empty() ? nullptr : m_StaticSamplers.data();
+        versioned.Desc_1_1.Flags = flags;
+        serializeHr = SerializeVersionedRootSignatureProc()( &versioned, rsBlob.GetAddressOf(), rsErr.GetAddressOf() );
+    } else {
+        D3D12_ROOT_SIGNATURE_DESC rsDesc = {};
+        rsDesc.NumParameters = static_cast<UINT>( params.size() );
+        rsDesc.pParameters = params.empty() ? nullptr : params.data();
+        rsDesc.NumStaticSamplers = static_cast<UINT>( m_StaticSamplers.size() );
+        rsDesc.pStaticSamplers = m_StaticSamplers.empty() ? nullptr : m_StaticSamplers.data();
+        rsDesc.Flags = flags;
+        serializeHr = SerializeRootSignatureProc()( &rsDesc, D3D_ROOT_SIGNATURE_VERSION_1,
+            rsBlob.GetAddressOf(), rsErr.GetAddressOf() );
+    }
+
+    if ( FAILED( serializeHr ) ) {
         if ( rsErr )
             LogWarn() << "D3D12: root signature '" << m_DebugName << "' serialize error: "
                       << static_cast<const char*>( rsErr->GetBufferPointer() );

--- a/D3D11Engine/D3D12Engine/D3D12RootLayout.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12RootLayout.cpp
@@ -252,15 +252,72 @@ bool D3D12RootLayout::Build( ID3D12Device* device, D3D12_ROOT_SIGNATURE_FLAGS fl
         versioned.Desc_1_1.pStaticSamplers = m_StaticSamplers.empty() ? nullptr : m_StaticSamplers.data();
         versioned.Desc_1_1.Flags = flags;
         serializeHr = SerializeVersionedRootSignatureProc()( &versioned, rsBlob.GetAddressOf(), rsErr.GetAddressOf() );
-    } else {
-        D3D12_ROOT_SIGNATURE_DESC rsDesc = {};
-        rsDesc.NumParameters = static_cast<UINT>( params.size() );
-        rsDesc.pParameters = params.empty() ? nullptr : params.data();
-        rsDesc.NumStaticSamplers = static_cast<UINT>( m_StaticSamplers.size() );
-        rsDesc.pStaticSamplers = m_StaticSamplers.empty() ? nullptr : m_StaticSamplers.data();
-        rsDesc.Flags = flags;
-        serializeHr = SerializeRootSignatureProc()( &rsDesc, D3D_ROOT_SIGNATURE_VERSION_1,
-            rsBlob.GetAddressOf(), rsErr.GetAddressOf() );
+
+        if ( FAILED( serializeHr ) ) {
+            LogWarn() << "D3D12: root signature '" << m_DebugName << "' 1.1 serialize failed (flags 0x"
+                      << std::hex << flags << std::dec << "); retrying unversioned 1.0.";
+            if ( rsErr )
+                LogWarn() << "D3D12: root signature '" << m_DebugName << "' serialize error: "
+                          << static_cast<const char*>( rsErr->GetBufferPointer() );
+        }
+    }
+
+    // Unversioned 1.0 fallback — used both when 1.1 is unavailable and when its serializer rejected
+    // the desc. The case that matters in practice is a serializer older than the flag bits we ask for:
+    // the exported serialize entry points live in the *global* D3D12 state, which can be older than
+    // the Agility core the device itself came from (see D3D12Device.cpp), and such a serializer
+    // rejects the whole desc over one flag bit it doesn't recognize. The parameter layout is always
+    // valid under 1.0 by construction (1.1's per-parameter promises only ever narrow what a layout may
+    // do), but the *flags* are not, so the retry first keeps only the flag bits the original D3D12
+    // release defined and then drops the flags entirely.
+    if ( FAILED( serializeHr ) && SerializeRootSignatureProc() ) {
+        // The bits that shipped with D3D12 itself. Everything above them (LOCAL_ROOT_SIGNATURE,
+        // DENY_AMPLIFICATION/MESH, the two *_HEAP_DIRECTLY_INDEXED bindless bits) arrived in later
+        // runtimes and is what an old serializer chokes on.
+        constexpr D3D12_ROOT_SIGNATURE_FLAGS legacyMask =
+            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT
+            | D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS
+            | D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS
+            | D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS
+            | D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS
+            | D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS
+            | D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT;
+
+        const D3D12_ROOT_SIGNATURE_FLAGS attempts[] = { flags, flags & legacyMask, D3D12_ROOT_SIGNATURE_FLAG_NONE };
+        D3D12_ROOT_SIGNATURE_FLAGS tried = static_cast<D3D12_ROOT_SIGNATURE_FLAGS>( ~0u );   // no legal flag set
+        for ( D3D12_ROOT_SIGNATURE_FLAGS attempt : attempts ) {
+            if ( attempt == tried ) continue;   // identical to the previous try — nothing new to learn
+            tried = attempt;
+
+            D3D12_ROOT_SIGNATURE_DESC rsDesc = {};
+            rsDesc.NumParameters = static_cast<UINT>( params.size() );
+            rsDesc.pParameters = params.empty() ? nullptr : params.data();
+            rsDesc.NumStaticSamplers = static_cast<UINT>( m_StaticSamplers.size() );
+            rsDesc.pStaticSamplers = m_StaticSamplers.empty() ? nullptr : m_StaticSamplers.data();
+            rsDesc.Flags = attempt;
+
+            rsBlob.Reset();
+            rsErr.Reset();
+            serializeHr = SerializeRootSignatureProc()( &rsDesc, D3D_ROOT_SIGNATURE_VERSION_1,
+                rsBlob.GetAddressOf(), rsErr.GetAddressOf() );
+            if ( SUCCEEDED( serializeHr ) ) {
+                if ( attempt != flags ) {
+                    // Loud on purpose: a layout that lost CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED here still
+                    // serializes, but any SM6.6 ResourceDescriptorHeap[...] shader bound to it will be
+                    // rejected at PSO creation. D3D12Device::IsAvailable() gates on SM6.6/tier-3 up
+                    // front so we normally never get here; if we do, the log says which bits went.
+                    LogWarn() << "D3D12: root signature '" << m_DebugName << "' serialized as 1.0 with reduced flags 0x"
+                              << std::hex << attempt << " (dropped 0x" << ( flags & ~attempt ) << std::dec
+                              << ") — this runtime's serializer is older than the flags requested.";
+                } else if ( useVersioned ) {
+                    LogInfo() << "D3D12: root signature '" << m_DebugName << "' serialized as 1.0 (1.1 rejected it).";
+                }
+                break;
+            }
+            if ( rsErr )
+                LogInfo() << "D3D12: root signature '" << m_DebugName << "' 1.0 serialize (flags 0x" << std::hex
+                          << attempt << std::dec << ") failed: " << static_cast<const char*>( rsErr->GetBufferPointer() );
+        }
     }
 
     if ( FAILED( serializeHr ) ) {

--- a/D3D11Engine/D3D12Engine/D3D12RootLayout.h
+++ b/D3D11Engine/D3D12Engine/D3D12RootLayout.h
@@ -24,18 +24,13 @@
 // for the process instead of re-resolving it per root signature.
 //
 // ---- Root signature 1.1 -----------------------------------------------------------------------
-// Layouts are serialized as VERSION_1_1 when the driver supports it (falling back to 1_0 otherwise —
-// see Build()). 1.1's whole point is that the declaration can PROMISE the driver that a descriptor or
-// its referenced data won't change between the bind and the end of execution, which is what lets the
-// driver preload the descriptor / the constant data into SGPRs at the Set call instead of re-reading
-// it per shader invocation. Under 1.0 every parameter is implicitly fully volatile and no such
-// promotion is legal.
+// Layouts are serialized as VERSION_1_1 when the driver supports it (falling back to 1_0 — see Build()).
+// 1.1 lets a declaration PROMISE that a descriptor or its data won't change between the bind and the end
+// of execution, so the driver can preload it at the Set call instead of re-reading it per invocation.
 //
-// Those promises are UNCHECKED by the runtime outside the debug layer: breaking one reads stale or
-// garbage data on the GPU. So the flag arguments below all DEFAULT to the fully-volatile values,
-// which are exactly 1.0's semantics — a layout that says nothing behaves precisely as it did before
-// the 1.1 migration. Tightening is opt-in, per parameter, at the declaration site, and the reason it
-// is safe belongs in a comment there. See the Volatile/Static constants right below for the vocabulary.
+// Those promises are UNCHECKED outside the debug layer: breaking one reads garbage on the GPU. So the flag
+// arguments below all DEFAULT to the fully-volatile values, i.e. 1.0 semantics. Tightening is opt-in, per
+// parameter, at the declaration site, and the reason it is safe belongs in a comment there.
 class D3D12RootLayout {
 public:
     // ---- Descriptor-range flag vocabulary -----------------------------------------------------

--- a/D3D11Engine/D3D12Engine/D3D12RootLayout.h
+++ b/D3D11Engine/D3D12Engine/D3D12RootLayout.h
@@ -20,10 +20,53 @@
 //     see below.
 //
 // d3d12.dll is loaded dynamically (no d3d12.lib link, to keep the D3D11 path's Windows 7 floor), so
-// D3D12SerializeRootSignature is resolved by GetProcAddress. The builder caches that resolution once
+// the serialize entry point is resolved by GetProcAddress. The builder caches that resolution once
 // for the process instead of re-resolving it per root signature.
+//
+// ---- Root signature 1.1 -----------------------------------------------------------------------
+// Layouts are serialized as VERSION_1_1 when the driver supports it (falling back to 1_0 otherwise —
+// see Build()). 1.1's whole point is that the declaration can PROMISE the driver that a descriptor or
+// its referenced data won't change between the bind and the end of execution, which is what lets the
+// driver preload the descriptor / the constant data into SGPRs at the Set call instead of re-reading
+// it per shader invocation. Under 1.0 every parameter is implicitly fully volatile and no such
+// promotion is legal.
+//
+// Those promises are UNCHECKED by the runtime outside the debug layer: breaking one reads stale or
+// garbage data on the GPU. So the flag arguments below all DEFAULT to the fully-volatile values,
+// which are exactly 1.0's semantics — a layout that says nothing behaves precisely as it did before
+// the 1.1 migration. Tightening is opt-in, per parameter, at the declaration site, and the reason it
+// is safe belongs in a comment there. See the Volatile/Static constants right below for the vocabulary.
 class D3D12RootLayout {
 public:
+    // ---- Descriptor-range flag vocabulary -----------------------------------------------------
+    // DEFAULT. Both the descriptor in the heap and the data it points at may change after this table
+    // is recorded into a command list. Identical to root signature 1.0 behaviour; always correct,
+    // never optimal. Right for any table whose SRV slot is owned by the Gothic texture cache (slots
+    // are recycled) or whose contents a later pass in the same list rewrites.
+    static constexpr D3D12_DESCRIPTOR_RANGE_FLAGS RangeVolatile =
+        D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE | D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE;
+    // The heap slot may still be rewritten, but the RESOURCE CONTENTS are final from the moment the
+    // table is set until the command list finishes. The common upgrade: a render target another pass
+    // (or another command list executed earlier) already finished writing.
+    static constexpr D3D12_DESCRIPTOR_RANGE_FLAGS RangeDataStatic =
+        D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE | D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE;
+    // Descriptor AND data are both final from the set. Engine-owned, long-lived resources whose SRV
+    // slot is allocated once at create time and only ever rewritten behind a WaitForGpuIdle (resize).
+    static constexpr D3D12_DESCRIPTOR_RANGE_FLAGS RangeStatic = D3D12_DESCRIPTOR_RANGE_FLAG_NONE;
+    // A UAV range is written BY the GPU, so its data is volatile by definition. Never upgrade one.
+    static constexpr D3D12_DESCRIPTOR_RANGE_FLAGS RangeUavVolatile =
+        D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE | D3D12_DESCRIPTOR_RANGE_FLAG_DATA_VOLATILE;
+
+    // ---- Root-descriptor flag vocabulary ------------------------------------------------------
+    // DEFAULT: 1.0 semantics — the buffer behind this root CBV/SRV/UAV may change at any point.
+    static constexpr D3D12_ROOT_DESCRIPTOR_FLAGS RootVolatile = D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE;
+    // The buffer contents are final from the moment this root descriptor is SET until the command
+    // list finishes executing. This is the flag that matters for the Forward+ hot path: the per-frame
+    // light buffer / cluster grid / shadow CB are all written to their frame-index slice long before
+    // any pass binds them, and nothing rewrites them afterwards within the frame.
+    static constexpr D3D12_ROOT_DESCRIPTOR_FLAGS RootDataStatic =
+        D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE;
+
     // ---- Declaration --------------------------------------------------------------------------
     // One range inside a descriptor table. Use the SRV/UAV/CBV/Sampler factories below.
     struct Range {
@@ -31,17 +74,27 @@ public:
         UINT BaseRegister;
         UINT NumDescriptors;   // UINT_MAX = unbounded
         UINT Space;
+        D3D12_DESCRIPTOR_RANGE_FLAGS Flags;   // 1.1 only; ignored when serializing as 1.0
     };
-    static Range SRVRange( UINT baseRegister, UINT numDescriptors = 1, UINT space = 0 );
-    static Range UAVRange( UINT baseRegister, UINT numDescriptors = 1, UINT space = 0 );
-    static Range CBVRange( UINT baseRegister, UINT numDescriptors = 1, UINT space = 0 );
-    static Range SamplerRange( UINT baseRegister, UINT numDescriptors = 1, UINT space = 0 );
+    static Range SRVRange( UINT baseRegister, UINT numDescriptors = 1, UINT space = 0,
+        D3D12_DESCRIPTOR_RANGE_FLAGS flags = RangeVolatile );
+    static Range UAVRange( UINT baseRegister, UINT numDescriptors = 1, UINT space = 0,
+        D3D12_DESCRIPTOR_RANGE_FLAGS flags = RangeUavVolatile );
+    static Range CBVRange( UINT baseRegister, UINT numDescriptors = 1, UINT space = 0,
+        D3D12_DESCRIPTOR_RANGE_FLAGS flags = RangeVolatile );
+    // Sampler ranges take no data flags (there is no data behind a sampler); only the DESCRIPTORS_*
+    // bits are meaningful, and D3D12 rejects any DATA_* flag on one.
+    static Range SamplerRange( UINT baseRegister, UINT numDescriptors = 1, UINT space = 0,
+        D3D12_DESCRIPTOR_RANGE_FLAGS flags = D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE );
 
     // Each returns the root-parameter index it was assigned (i.e. the value to pass to
     // SetGraphicsRoot*/SetComputeRoot* at bind time). Parameters are assigned in call order.
     UINT AddConstants( UINT shaderRegister, UINT num32BitValues, D3D12_SHADER_VISIBILITY vis, UINT space = 0 );
-    UINT AddCBV( UINT shaderRegister, D3D12_SHADER_VISIBILITY vis, UINT space = 0 );
-    UINT AddSRV( UINT shaderRegister, D3D12_SHADER_VISIBILITY vis, UINT space = 0 );
+    UINT AddCBV( UINT shaderRegister, D3D12_SHADER_VISIBILITY vis, UINT space = 0,
+        D3D12_ROOT_DESCRIPTOR_FLAGS flags = RootVolatile );
+    UINT AddSRV( UINT shaderRegister, D3D12_SHADER_VISIBILITY vis, UINT space = 0,
+        D3D12_ROOT_DESCRIPTOR_FLAGS flags = RootVolatile );
+    // No flags argument: a root UAV is GPU-written, so DATA_VOLATILE is the only correct choice.
     UINT AddUAV( UINT shaderRegister, D3D12_SHADER_VISIBILITY vis, UINT space = 0 );
     UINT AddTable( std::initializer_list<Range> ranges, D3D12_SHADER_VISIBILITY vis );
     // Convenience for the overwhelmingly common single-range table.
@@ -107,10 +160,12 @@ private:
         UINT Num32BitValues;      // Constants only
         size_t FirstRange;        // Table only: index into m_Ranges
         size_t RangeCount;
+        D3D12_ROOT_DESCRIPTOR_FLAGS DescriptorFlags;   // CBV/SRV/UAV only; 1.1, ignored when serializing as 1.0
     };
 
     UINT AddDescriptorParam( D3D12_ROOT_PARAMETER_TYPE type, UINT shaderRegister,
-                             D3D12_SHADER_VISIBILITY vis, UINT space );
+                             D3D12_SHADER_VISIBILITY vis, UINT space,
+                             D3D12_ROOT_DESCRIPTOR_FLAGS flags );
 
     std::vector<ParamInfo> m_Params;
     std::deque<Range> m_Ranges;                 // stable storage; tables index into this

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -591,11 +591,13 @@ void D3D12GraphicsEngine::BeginShadowRecording() {
 	// and return immediately. The caller then records the depth prepass, the GPU VOB cull, the tiled light cull
 	// and SSAO into m_CmdList while the pool records shadows into its own lists.
 	//
-	// Queue ordering: the finished lists must land BETWEEN what is already recorded this frame (OnBeginFrame's
-	// clears, DrawSky, AdvanceRain, the indirect-arg builds) and everything recorded after this point. So
-	// close+submit m_CmdList here and reopen it on the SAME frame allocator; FinishShadowPasses then executes
-	// the shadow lists while the reopened list is still open and unsubmitted, which gives the GPU
-	// [part A][cascades][point cubes][rain map][part B] even though the CPU recorded part B first.
+	// Queue ordering: the finished lists must land AHEAD of the lit geometry passes (the first readers of the
+	// cascade map / point cubes). So close+submit m_CmdList here and reopen it on the SAME frame allocator;
+	// FinishShadowPasses then executes the shadow lists while the reopened list is still open and unsubmitted,
+	// which gives the GPU [part A][part B1][cascades][point cubes][rain map][part B2] even though the CPU
+	// recorded B1 first. (B1 — the depth prepass through sky IBL — is submitted by a second
+	// SubmitRecordedCommandsAndReopen right before FinishShadowPasses, purely so the GPU can start on it
+	// instead of idling until Present; it reads nothing the shadow passes write.)
 	m_ShadowRecordingPending = false;
 	m_ShadowThreadedRecord = false;
 	// ONLY the point/rain slots. The cascade slots belong to the per-cascade jobs launched way back in
@@ -669,8 +671,9 @@ void D3D12GraphicsEngine::FinishShadowPasses() {
 	//      gone (its Gothic-mutating half moved into Prepare, its per-cascade half into BuildCascade), so the
 	//      chains have been running since Prepare and this join should find them already finished.
 	//   2. Emit inline anything that could not record into its own list.
-	//   3. Execute every finished list. m_CmdList part B (prepass, culls, SSAO) is still OPEN and unsubmitted,
-	//      so the GPU order stays [part A][shadows][part B] even though the CPU recorded part B first.
+	//   3. Execute every finished list. The caller submitted part B1 (prepass, culls, SSAO, sky IBL) just before
+	//      calling us and reopened m_CmdList, so what is OPEN and unsubmitted here is part B2 — the lit passes
+	//      onwards. GPU order: [part A][part B1][shadows][part B2].
 	// Anything that failed to record is re-issued inline rather than dropped: skipping a pass would desync its
 	// cross-frame resource-state tracking (D3D12PointShadows' per-slot cube states, m_RainShadowInReadState).
 	if ( !m_FrameOpen ) return;
@@ -2415,9 +2418,28 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// run after D3D12ShadowMap::Prepare (it reads its sun direction) and before the lit passes below. No-op on an unchanged
 	// sky; the shaders fall back to the old flat ambient whenever the indices are the 0xFFFFFFFF sentinel.
 	RenderSkyIBL();
-	// Join the shadow recorders and slot their lists into the queue ahead of everything recorded above — the lit
-	// passes below are the first thing this frame that samples the cascade map / point-shadow cubes. Also
-	// re-establishes the scene-color RT + depth for them.
+
+	// Submit part B1 (prepass -> G-buffer -> HiZ/VOB cull -> light cull -> SSAO -> sky IBL) NOW instead of letting
+	// it ride along to Present. Without this the GPU sat idle from the shadow lists all the way to the end of the
+	// frame: everything above was recorded long ago but stayed in an open, unsubmitted list while the main thread
+	// went on recording the lit passes, transparency, particles and post-FX. Costs one extra ExecuteCommandLists
+	// (plus the RT/heap rebind Reset drops) and buys the GPU that whole span.
+	//
+	// The reorder this introduces is [A][B1][shadows][B2] rather than [A][shadows][B1+B2]: none of the passes in
+	// B1 read anything a shadow pass writes (the tile cull and SSAO consume only the prepass depth/normals, and
+	// the IBL compute is self-contained on its own cubes), so their new position ahead of the shadow lists is
+	// safe. What still must NOT move is FinishShadowPasses' TransitionToReadState and the lit passes below —
+	// both are recorded into the reopened list and therefore stay behind the shadow lists.
+	if ( m_FrameOpen ) {
+		SubmitRecordedCommandsAndReopen();
+		// The reopen Resets m_CmdList, dropping its render targets/viewport (FinishShadowPasses re-establishes
+		// them again at its tail, but a cascade re-issued inline records before that point).
+		BindSceneColorTarget();
+	}
+
+	// Join the shadow recorders and slot their lists into the queue between the block submitted just above and
+	// everything recorded from here on — the lit passes below are the first thing this frame that samples the
+	// cascade map / point-shadow cubes. Also re-establishes the scene-color RT + depth for them.
 	FinishShadowPasses();
     {
         DX_ZONE( m_CmdList.Get(), "Lit Geometry Pass" );

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2793,6 +2793,42 @@ namespace {
     }
 }
 
+UINT D3D12GraphicsEngine::CoalesceWorldDepthCommands(
+    std::vector<WorldDrawCommand>& opaque, WorldDrawCommand* out, UINT outCapacity ) {
+    // Draw-call merge for the depth-only world submits. Every command here indexes the SAME wrapped world
+    // VB/IB, so two commands whose index ranges touch are one DrawIndexed over the union. Strictly
+    // conservative: only EXACTLY adjacent ranges merge, so not one extra index is ever rasterized — bridging
+    // a gap would re-lay depth for geometry the color pass peeled out (water, portals, alpha-blended) or
+    // frustum-culled, and punch holes in the scene.
+    if ( opaque.empty() || !out || outCapacity == 0 ) return 0;
+
+    std::sort( opaque.begin(), opaque.end(),
+        []( const WorldDrawCommand& a, const WorldDrawCommand& b ) {
+            return a.Draw.StartIndexLocation < b.Draw.StartIndexLocation;
+        } );
+
+    // The surviving command keeps the FIRST constituent's b6 material constants. Nothing on a depth-only PSO
+    // reads them (the opaque run binds no pixel shader at all), but they stay a valid bindless slot rather
+    // than a stale ring value, so a future prepass shader that does read b6 degrades to "wrong texture on a
+    // merged run" instead of sampling a freed descriptor.
+    UINT n = 0;
+    WorldDrawCommand run = opaque[0];
+    for ( size_t i = 1; i < opaque.size(); ++i ) {
+        const WorldDrawCommand& c = opaque[i];
+        if ( c.Draw.StartIndexLocation == run.Draw.StartIndexLocation + run.Draw.IndexCountPerInstance ) {
+            run.Draw.IndexCountPerInstance += c.Draw.IndexCountPerInstance;
+            continue;
+        }
+        if ( n >= outCapacity ) return 0;   // no tail room — caller falls back to the per-material prefix
+        out[n++] = run;
+        run = c;
+    }
+    if ( n >= outCapacity ) return 0;
+    out[n++] = run;
+    return n;
+}
+
+
 void D3D12GraphicsEngine::BuildWorldDrawCommands() {
     // Build this frame's world-mesh ExecuteIndirect command set ONCE (P2.11): frustum-collect the visible sections,
     // then per non-water material append { bindless material indices, DrawIndexedArguments (its index range into
@@ -2828,6 +2864,12 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
     // capacity retained across frames (same idiom as `sections` above; no per-frame allocation).
     static std::vector<WorldDrawCommand> alphaCmds;
     alphaCmds.clear();
+
+    // Every opaque command as written, mirrored into normal RAM so CoalesceWorldDepthCommands can sort and
+    // scan it — the ring itself is UPLOAD (write-combined), where a read-back would cost far more than the
+    // copy. static for the same reason alphaCmds is: no per-frame allocation.
+    static std::vector<WorldDrawCommand> opaqueCmds;
+    opaqueCmds.clear();
 
     // Camera position for the alpha-blended peel's painter-order sort key (see the branch below).
     const XMVECTOR transparencyCamPos = Engine::GAPI->GetCameraPositionXM();
@@ -2946,8 +2988,8 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
             c.Draw.StartIndexLocation = mesh->BaseIndexLocation;
             c.Draw.BaseVertexLocation = 0;
             c.Draw.StartInstanceLocation = 0;
-            if ( alphaTested ) alphaCmds.push_back( c );
-            else               cmds[count++] = c;
+            if ( alphaTested ) { alphaCmds.push_back( c ); }
+            else               { cmds[count++] = c; opaqueCmds.push_back( c ); }
             m_WorldDrawnIndices += static_cast<unsigned int>( mesh->Indices.size() );
         }
     }
@@ -2959,6 +3001,15 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
         count += static_cast<UINT>( alphaCmds.size() );
     }
     m_WorldDrawCount = count;
+
+    // Coalesced opaque run for the depth prepass, appended PAST the color pass' set so that set is unchanged
+    // (see m_WorldDepthMergedFirst). Degrades to 0 — and the prepass to the per-material prefix — if the
+    // ring's tail can't hold it, so the overflow guard above needs no extra headroom.
+    m_WorldDepthMergedFirst = count;
+    m_WorldDepthMergedCount = ( count < kMaxWorldDrawCommands )
+        ? CoalesceWorldDepthCommands( opaqueCmds, cmds + count, kMaxWorldDrawCommands - count )
+        : 0;
+
     // Painter's order for the peeled alpha-blended surfaces (far -> near), once per frame.
     SortWorldTransparencyMeshes();
 }
@@ -3516,7 +3567,13 @@ void D3D12GraphicsEngine::DrawDepthPrepass() {
         return;
     }
     // Opaque prefix, no pixel shader bound at all (set above) — this is the run that gets double-rate Z.
-    if ( m_WorldOpaqueDrawCount > 0 ) {
+    // Prefer the coalesced mirror of that prefix (see m_WorldDepthMergedFirst): identical index coverage,
+    // far fewer commands, and with no PS bound the per-material constants it drops are dead anyway.
+    if ( m_WorldDepthMergedCount > 0 ) {
+        m_CmdList->ExecuteIndirect( m_WorldIndirectCmdSig.Get(), m_WorldDepthMergedCount,
+            m_WorldDrawArgs[m_FrameIndex].Get(),
+            static_cast<UINT64>( m_WorldDepthMergedFirst ) * sizeof( WorldDrawCommand ), nullptr, 0 );
+    } else if ( m_WorldOpaqueDrawCount > 0 ) {
         m_CmdList->ExecuteIndirect( m_WorldIndirectCmdSig.Get(), m_WorldOpaqueDrawCount,
             m_WorldDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
     }

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -714,8 +714,13 @@ void D3D12GraphicsEngine::FinishShadowPasses() {
 		// Only when the jobs were SUPPOSED to record into their own lists — otherwise 2a already emitted every
 		// cascade inline and re-issuing here would draw each of them twice.
 		if ( m_ShadowMap.IsPassReady() && m_ShadowMap.RecordedInJob() ) {
-			for ( UINT c = 0; c < kShadowCascades; ++c )
+			for ( UINT c = 0; c < kShadowCascades; ++c ) {
+				// A lazily-frozen cascade launched no job, so its slot is legitimately unrecorded — that is not a
+				// failure and must not be re-issued inline (RecordCascade would no-op anyway, but it would light
+				// up the "failed to record" warning below every third frame).
+				if ( !m_ShadowMap.ShouldUpdateCascade( c ) ) continue;
 				if ( !m_ShadowListRecorded[c] ) { m_ShadowMap.RecordCascade( c, m_CmdList, m_ShadowMap.IsSunUp() ); anyFailed = true; }
+		}
 		}
 		if ( m_PointShadows.IsPassReady() && !m_ShadowListRecorded[kPointShadowListIndex] ) {
 			m_PointShadows.Record( m_CmdList );

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -199,6 +199,10 @@ namespace {
     // MUST match MASK_WORDS in Shaders/D3D12/include/ForwardPlusTypes.hlsl (MAX_ACTIVE_LIGHTS / 32) — sizes the
     // per-cluster LightGrid.Mask array on the C++ side of CreateLightCullBuffers.
     constexpr UINT kMaskWordsPerCluster = kMaxFrameLights / 32;
+    // Total words per LightGrid entry: the mask array plus the leading WordOccupancy summary word the pixel
+    // shader bit-scans instead of walking all 32 mask words. Keep in lockstep with the HLSL struct — this is a
+    // StructuredBuffer, so a stride mismatch silently misindexes EVERY cluster.
+    constexpr UINT kWordsPerCluster = kMaskWordsPerCluster + 1;
     // Gothic's reversed-Z camera projection has no real far plane (infinite far), so the cluster Z grid needs a
     // chosen practical far distance to log-distribute its slices over. This is a FLOOR, not the actual value
     // used — GetClusterFarZ() below clamps it up to the user's VisualFXDrawRadius setting, which is the CPU-side
@@ -792,8 +796,9 @@ UINT D3D12GraphicsEngine::ResolveDiffuseSlotCacheIn( zCTexture* tex ) {
 
 bool D3D12GraphicsEngine::CreateLightCullBuffers( INT2 size ) {
 	// Per-resolution CLUSTERED Forward+ grid storage (P2.14; tiled P2.9b-2 predecessor). Recreated on resize
-	// alongside the depth buffer. RW_LightGrid: one MAX_ACTIVE_LIGHTS-bit membership mask (kMaskWordsPerCluster
-	// * 4 B) per (16x16 screen tile x Z slice) cluster — see LightCull.hlsl/PBRLighting.hlsl. There is no
+	// alongside the depth buffer. RW_LightGrid: one MAX_ACTIVE_LIGHTS-bit membership mask plus its WordOccupancy
+	// summary word (kWordsPerCluster * 4 B) per (16x16 screen tile x Z slice) cluster — see
+	// LightCull.hlsl/PBRLighting.hlsl. There is no
 	// separate index-list buffer: the mask itself IS the light list (bit i = light i). DEFAULT-heap UAV buffer
 	// created in UNORDERED_ACCESS; each frame DispatchLightCulling writes it (UAV) then transitions it to
 	// PIXEL_SHADER_RESOURCE for the lit geometry passes to read, then back.
@@ -833,7 +838,7 @@ bool D3D12GraphicsEngine::CreateLightCullBuffers( INT2 size ) {
 		return true;
 		};
 
-	if ( !makeUavBuffer( static_cast<UINT64>(numClusters) * kMaskWordsPerCluster * sizeof( uint32_t ), L"LightGrid", m_LightGridBuffer, m_LightGridBufferAlloc ) )
+	if ( !makeUavBuffer( static_cast<UINT64>(numClusters) * kWordsPerCluster * sizeof( uint32_t ), L"LightGrid", m_LightGridBuffer, m_LightGridBufferAlloc ) )
 		return false;
 	m_LightGridInPixelState = false;   // freshly created in UNORDERED_ACCESS (see DispatchLightCulling round-trip)
 	return true;

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -53,31 +53,20 @@ using Microsoft::WRL::ComPtr;
 // (DrawVobsInstanced) and the point-shadow static-VOB gather all draw from these — no second upload.
 std::vector<FrameVobUpload> g_FrameVobUploads;
 std::vector<VobInfo*> g_FrameVobs;
-// Per-vob snapshot of the diffuse SRV HEAP SLOT for each entry of visual->SkeletalMeshes, in that map's
-// (stable, unmutated-within-a-frame) iteration order. Taken by PrepareFrameSkeletals on the main thread
-// immediately after that vob's UpdateMeshLibTexAniState(), which is the only moment the shared per-MODEL texture
-// slots actually describe this instance. Grown monotonically and reused: only the live prefix
-// [0, g_SkelMatSrvCount) is valid each frame and the inner vectors keep their capacity, so this settles into
-// zero per-frame allocations. Indexed (never pointed into) by FrameSkelDraw::matSrvIndex so a rehash of
-// g_SkelUploadCache or a growth of this container can't dangle a record.
-// Deque rather than vector so that growing it cannot invalidate the element pointers the concurrent CSM
-// cascade recorders are holding — see the declaration in D3D12EngineCommon.h.
+// Per-vob snapshot of the diffuse SRV heap slot for each entry of visual->SkeletalMeshes. Taken by
+// PrepareFrameSkeletals right after that vob's UpdateMeshLibTexAniState(), the only moment the shared
+// per-MODEL texture slots describe this instance. Grown monotonically and reused: only [0, g_SkelMatSrvCount)
+// is live each frame. Indexed, never pointed into, by FrameSkelDraw::matSrvIndex, so neither a rehash of
+// g_SkelUploadCache nor a growth here can dangle a record. Deque so growth cannot invalidate the element
+// pointers the concurrent CSM cascade recorders hold.
 std::deque<std::vector<SkelMatSlot>> g_SkelMatSrvs;
 size_t g_SkelMatSrvCount = 0;
 
 namespace {
-    // Swapchain / final-output format. R10G10B10A2 (10-bit) instead of R8: the tonemapped output has much
-    // finer gradients (kills banding in sky/fog/soft shadows) at the same 32bpp. Also the format the 2D UI +
-    // ImGui + the tonemap resolve write to. Flip-model swapchains support R10G10B10A2_UNORM natively.
-    // HDR scene-color format: the 3D world/VOB/skeletal/water/decal/particle passes accumulate lighting here in
-    // linear-ish FLOAT (values may exceed 1.0 — bright sun + additive point lights no longer clip to white), then
-    // a fullscreen tonemap resolves it into the swapchain. R16F 4-channel = 64bpp intermediate (recreated on resize).
     constexpr UINT kVobInstanceBufferBytes = 8 * 1024 * 1024; // per-frame VOB instance ring (~58k instances @144B)
-    // Per-SLOT size of the separate shadow-caster instance ring (see m_ShadowVobInstanceBuffer). One slot per
-    // cascade plus one for the rain map, so the whole buffer is this x kShadowInstanceRingSlots per frame index.
-    // Deliberately smaller per slot than the main ring: a cascade collects one pass's casters, not the whole
-    // frame's geometry. Overflow is logged per slot (never silently truncated) — if that warning shows up in
-    // practice this is the number to raise, at 2 x kShadowInstanceRingSlots bytes of 32-bit VA per increment.
+    // Per-SLOT size of the shadow-caster instance ring (m_ShadowVobInstanceBuffer): one slot per cascade plus
+    // one for the rain map. Smaller than the main ring — a cascade collects one pass's casters, not the whole
+    // frame's geometry. Overflow is logged per slot rather than silently truncated.
     constexpr UINT kShadowInstanceSliceBytes = 2 * 1024 * 1024; // ~14k instances @144B, per cascade per frame
     constexpr UINT kParticleInstanceBufferBytes = 8 * 1024 * 1024; // per-frame particle instance ring (~150k @56B)
     constexpr UINT kDecalInstanceBufferBytes = 4 * 1024 * 1024; // per-frame decal instance ring (~52k decals @80B)
@@ -97,53 +86,10 @@ namespace {
 
 
 
-    // Inline HLSL for the 2D UI path. VS mirrors VS_TransformedEx (screen-space xyzrhw -> clip space,
-    // rhw packed in Normal.x). PS emulates the fixed-function texture-stage pipeline (mirrors
-    // Shaders/FixedFunctionPipeline.h): FF_Stages[0/1] color ops + args + diffuse-alpha test, driven by
-    // the FFPipelineConstantBuffer (b1) which receives Gothic's GraphicsState each draw. Per-draw BLEND
-    // modes (opaque/alpha/additive/modulate/...) are handled by selecting a matching PSO, not here.
-    // Limitation: only texture0 is bound, so a 2nd stage samples texture0 (menus use 1 stage -> exact;
-    // the world's 2-texture lightmap path is a Phase-2 concern).
-
-    // Phase-2 world shader (textured). The wrapped world mesh is the packed 36-byte ExVertexStructGPU;
-    // we bind Position (float3 @0), TexCoord0 (float2 @20) and Color (R8G8B8A8 @32), ignoring the packed
-    // normal/tangent/uv2 for now. World-mesh verts are already in world space, so the transform is just
-    // ViewProj (identity world) — matches D3D11 VS_ExPacked: mul(float4(pos,1), ViewProj), reversed-Z.
-    // PS samples the diffuse texture, modulates by the baked vertex color (Gothic packs a DWORD read as
-    // R8G8B8A8 -> .bgr recovers RGB), and does a fixed alpha-test cutout (foliage/fences). No G-buffer /
-    // no deferred lighting yet: the baked vertex color stands in for lighting.
-
-    // Phase-2 instanced VOB shader. Slot 0 = ExVertexStruct (Position@0, Normal@12, TexCoord0@24);
-    // slot 1 = per-instance data (world matrix as 4 rows + instance color) from VobInstanceInfo.
-
-    // Forward+ opaque DEPTH PREPASS shader (P2.9b-1). Lays down the opaque world-mesh depth before the
-    // lit color passes so the later tiled light-culling compute (P2.9b-2) has a per-pixel depth to tighten
-    // each tile's frustum. Writes DEPTH ONLY — the PSO sets the color write mask to 0, so the float4 the PS
-    // returns is discarded (it exists solely to run the alpha-test clip). The clip cutoff matches the opaque
-    // world PS's clip( t.a - 0.5 ) exactly, so cutout foliage/fence gaps do NOT write depth (otherwise the
-    // main pass would see background occluded through the gaps). Reuses m_Pipelines.World.RootSig: only b0 (ViewProj)
-    // and t0/s0 are referenced — fog/light params are NOT bound (no light loop here, so no hang risk).
-
-    // CLUSTERED Forward+ light-culling COMPUTE shader (P2.14; tiled P2.9b-2 predecessor). One thread group per
-    // (16x16 screen tile x Z slice) cluster; each group builds its cluster's view-space AABB analytically (a
-    // log-distributed Z slice over CullCB's NearZ/FarZ — no depth-buffer read at all, unlike the old per-tile
-    // scheme which bounded each tile's far-Z from the prepass depth) and tests up to MAX_ACTIVE_LIGHTS lights
-    // against it, one per thread. A pass sets that light's bit in a 64-bit groupshared mask (InterlockedOr),
-    // written out as the cluster's LightGrid.Mask — no index list, no global atomic counter, and no per-tile
-    // light cap: the cap is now a single global one (the frame's nearest MAX_ACTIVE_LIGHTS, see
-    // ForwardPlusTypes.hlsl), so it can never differ between clusters or flicker frame-to-frame the way the
-    // old per-tile InterlockedAdd race used to. See LightCull.hlsl's CSMain for the full rationale.
-    // PositionView is filled CPU-side in BuildFrameLightBuffer using the same transpose(view) transform the
-    // D3D11 CullLights uses, so this shader's view space matches. SM6.6: no ternary (use min()/select()).
-
-    // Water: the surfaces peeled out of the opaque world pass live in g_FrameWaterSurfaces (declared in
-    // D3D12EngineCommon.h, defined in D3D12Water.cpp, which owns the whole pass).
-
     // Per-frame visible-vob/light/mob collection, hoisted out of DrawVobsInstanced so ALL geometry passes
-    // (world, VOBs, skeletal) light against the same set. CollectVisibleVobs has side effects (fills each
-    // visual's Instances list) and must run EXACTLY ONCE per frame. Single-threaded within OnStartWorldRendering.
-    // g_FrameVobs sits at file scope above this namespace — StoreVobPreviousTransforms (D3D12Motion.cpp) walks
-    // it at frame end to snapshot each drawn vob's transform for next frame's motion vectors.
+    // light against the same set. CollectVisibleVobs fills each visual's Instances list, so it must run
+    // EXACTLY ONCE per frame. g_FrameVobs sits at file scope above this namespace — StoreVobPreviousTransforms
+    // walks it at frame end to snapshot each drawn vob's transform for next frame's motion vectors.
     std::vector<VobLightInfo*>    g_FrameLights;
     std::vector<SkeletalVobInfo*> g_FrameMobs;
 
@@ -175,45 +121,22 @@ namespace {
     };
     gtl::flat_hash_map<SkeletalVobInfo*, SkelUploadCache> g_SkelUploadCache;
 
-    // Per-vob snapshot of the diffuse descriptor handle for each entry of visual->SkeletalMeshes, in that map's
-    // (stable, unmutated-within-a-frame) iteration order. Taken by PrepareFrameSkeletals on the main thread
-    // immediately after that vob's UpdateMeshLibTexAniState(), which is the only moment the shared per-MODEL
-    // texture slots actually describe this instance. Grown monotonically and reused: only the live prefix
-    // [0, g_SkelMatSrvCount) is valid each frame and the inner vectors keep their capacity, so this settles into
-    // zero per-frame allocations. Indexed (never pointed into) by FrameSkelDraw so a rehash of g_SkelUploadCache
-    // or a growth of this vector can't dangle a record.
-    // Definitions sit at file scope above this namespace (the CSM cascade recorder reads them).
-
-
-    // Forward+ MVP light buffer (P2.9a): the whole visible-light list is rebuilt from offset 0 each frame,
-    // so the ring is just kBackBufferCount snapshots (no per-draw offset). MUST match MAX_ACTIVE_LIGHTS in
-    // Shaders/D3D12/include/ForwardPlusTypes.hlsl (raising one without the other either wastes cluster-mask
-    // capacity or silently drops lights past the smaller of the two — see that header's comment). Raised from
-    // the original 400 (D3D11 MAX_TILED_LIGHTS parity) to 1024 after in-game testing showed ambient-heavy scenes
-    // (static "atmospheric" fill lights stacking with dynamic torches/spells) regularly exceeding 400 visible
-    // point lights and clipping.
+    // Forward+ light buffer: the visible-light list is rebuilt from offset 0 each frame, so the ring is just
+    // kBackBufferCount snapshots. MUST match MAX_ACTIVE_LIGHTS in ForwardPlusTypes.hlsl. 1024 rather than
+    // D3D11's 400, which ambient-heavy scenes were clipping against.
     constexpr UINT kMaxFrameLights = 1024;
 
-    // Clustered Forward+ (P2.14). MUST match NUM_Z_SLICES in Shaders/D3D12/include/ForwardPlusTypes.hlsl.
+    // MUST match NUM_Z_SLICES / MASK_WORDS in Shaders/D3D12/include/ForwardPlusTypes.hlsl.
     constexpr UINT kNumZSlices = 16;
-    // MUST match MASK_WORDS in Shaders/D3D12/include/ForwardPlusTypes.hlsl (MAX_ACTIVE_LIGHTS / 32) — sizes the
-    // per-cluster LightGrid.Mask array on the C++ side of CreateLightCullBuffers.
     constexpr UINT kMaskWordsPerCluster = kMaxFrameLights / 32;
-    // Total words per LightGrid entry: the mask array plus the leading WordOccupancy summary word the pixel
-    // shader bit-scans instead of walking all 32 mask words. Keep in lockstep with the HLSL struct — this is a
-    // StructuredBuffer, so a stride mismatch silently misindexes EVERY cluster.
+    // Mask array plus the leading WordOccupancy summary word. Must match the HLSL LightGrid struct — this is a
+    // StructuredBuffer, so a stride mismatch misindexes every cluster.
     constexpr UINT kWordsPerCluster = kMaskWordsPerCluster + 1;
-    // Gothic's reversed-Z camera projection has no real far plane (infinite far), so the cluster Z grid needs a
-    // chosen practical far distance to log-distribute its slices over. This is a FLOOR, not the actual value
-    // used — GetClusterFarZ() below clamps it up to the user's VisualFXDrawRadius setting, which is the CPU-side
-    // distance point lights are even collected out to (up to 50000 in the ImGui slider). A fixed 4096 here used
-    // to hard-clip any light farther than that from the camera: BOTH the cull compute's cluster AABBs (Z capped
-    // at FarZ) and the lit pixel shaders' ComputeZSlice clamp to [NearZ,FarZ], so a light beyond FarZ could never
-    // intersect any cluster no matter how far the user's draw-distance setting said to collect it from — it just
-    // silently stopped lighting anything, which read as point lights vanishing at a short, seemingly arbitrary
-    // range regardless of VisualFXDrawRadius. Tying FarZ to that setting (with this constant only as a floor for
-    // very small settings) fixes that without costing extra memory: buffer size depends on tile/slice/mask
-    // counts, not on FarZ, which only changes how far apart the log-distributed Z slices land.
+    // Gothic's projection has no real far plane, so the cluster Z grid needs a practical far distance to
+    // log-distribute its slices over. A FLOOR only: GetClusterFarZ() raises it to VisualFXDrawRadius, the
+    // range lights are collected out to. A fixed value here hard-clips lights past it — the cull's cluster
+    // AABBs and the shaders' ComputeZSlice both clamp to [NearZ,FarZ], so such a light intersects no cluster
+    // and silently stops lighting anything. FarZ costs no memory; it only spaces the slices.
     constexpr float kClusterMinFarZ = 4096.0f;
     float GetClusterFarZ() {
         return std::max( kClusterMinFarZ, Engine::GAPI->GetRendererState().RendererSettings.VisualFXDrawRadius );
@@ -243,25 +166,10 @@ namespace {
     static_assert( offsetof( SkeletalInstanceCB, ModelColor ) == 64 && offsetof( SkeletalInstanceCB, Fatness ) == 80,
         "PointShadow.hlsl's SkelInstanceCB is a byte-compatible prefix of this struct — the motion tail must stay APPENDED" );
 
-    // Phase-2 skeletal (animated) mesh shader — NPCs, monsters, animated MOBs. Matrix-palette skinning:
-    // each vertex stores its position baked into up to 4 influencing bones' local spaces (half4 each),
-    // plus per-influence bone index + weight, so skinnedPos = sum_i weight_i * mul(pos_i, Bones[idx_i]).
-    // Mirrors VS_ExSkeletal.hlsl's ApplySkinningCurrent core (minus motion vectors / view-space normal /
-    // prev-frame bones). b0 = ViewProj (root consts), b1 = per-instance (world + color + fatness), b2 =
-    // bone-matrix palette (<=96). Default column-major packing: matrices are uploaded as row-major
-    // XMFLOAT4X4 and read the same way the D3D11 skeletal VS does, so mul() is byte-for-byte identical.
-
-    // Phase-2 particle (PFX) shader — instanced camera-facing billboards. One instance per live particle
-    // (ParticleInstanceInfo, 56B, all PER_INSTANCE); the VS expands a 4-vertex triangle strip from
-    // SV_VertexID, doing all billboard orientation itself (mirrors VS_ParticlePoint.hlsl). `type` encodes
-    // the alignment: >=10 => quad-poly (half size); the low digit selects camera / y-locked / plane /
-    // velocity-aligned. DIFFUSE is a full float4 here (unlike the packed DWORD paths) so no swizzle. b0 =
-    // ViewProj (root consts, default column-major packing, same as the world shader); b1 = camera world pos.
-
-    // Per-decal instance data (per-instance vertex stream, slot 1). World = world*offset*scale (view NOT
-    // baked in — unlike D3D11, the D3D12 decal VS applies the standard ViewProj, so the CPU only needs the
-    // model matrix). Color.a = the material's ghost alpha ((GetColor()>>24)/255); Color.r is the
-    // shade-lit flag (0 for the unlit ADD/MUL/MUL2 modes — see Decal.hlsl's PSMainBlend); .gb unused. 80 bytes.
+    // Per-decal instance data (per-instance vertex stream, slot 1). World = world*offset*scale; unlike D3D11
+    // the D3D12 decal VS applies the standard ViewProj, so the CPU only needs the model matrix. Color.a is
+    // the material's ghost alpha, Color.r the shade-lit flag (0 for the unlit ADD/MUL/MUL2 modes — see
+    // Decal.hlsl's PSMainBlend), .gb unused.
     struct DecalInstanceInfo {
         DirectX::XMFLOAT4X4 World;
         DirectX::XMFLOAT4   Color;
@@ -272,34 +180,19 @@ namespace {
     struct DecalQuadVertex { float px, py, pz; float u, v; };
     static_assert( sizeof( DecalQuadVertex ) == 20, "DecalQuadVertex must be tightly packed (stride 20)" );
 
-    // Decal shader. The quad is expanded by the per-instance world matrix (built on the CPU from the vob's
-    // world matrix + DecalOffset/DecalSize + camera-alignment, exactly like D3D11's DrawDecalList), then
-    // transformed by the standard ViewProj. Two pixel shaders: PSMainLit (opaque/alpha-test cutout — blood,
-    // arrows) and PSMainBlend (texture * material alpha; the PSO blend state does add/alpha/modulate).
-
-    // Round a ring offset up so the next allocation starts on a 256-byte boundary (D3D12 requires root
-    // CBV addresses to be 256-byte aligned).
+    // D3D12 requires root CBV addresses to be 256-byte aligned.
     UINT AlignCB( UINT offset ) { return ( offset + 255u ) & ~255u; }
 
-    // FogConstants now lives in D3D12EngineCommon.h — the split-out passes bind the same b1.
-
     // The color to clear/fill the sky and per-pixel distance-fog with, mirroring D3D11's background-clear
-    // formula (D3D11GraphicsEngine::OnStartWorldRendering, ~line 4180): GetFogColor() (== FogColorMod, a
-    // fixed user-configurable tint, weather-override aware) is only correct while AtmosphericScattering is
-    // on — that's the color the real scattering shader takes as its base input. With scattering OFF (the FF
-    // sky path), D3D11 instead uses GraphicsState.FF_FogColor, which GSky.cpp refreshes every frame from
-    // Gothic's own zCSkyController_Outdoor::GetMasterState()->FogColor — i.e. it actually tracks time of day/
-    // weather. D3D12 previously called GetFogColor() unconditionally here, so with scattering disabled the
-    // sky/fog stayed pinned to the static FogColorMod tint (default a light lavender-blue) regardless of time
-    // of day — the sky never darkened at night, matching the reported "always looks like fog color" bug.
+    // formula. FogColorMod is a fixed user tint and is only the right base while AtmosphericScattering is on;
+    // with it off the FF sky path must use GraphicsState.FF_FogColor, which GSky.cpp refreshes each frame
+    // from Gothic's sky controller and which is therefore the only one that tracks time of day.
     DirectX::XMVECTOR GetSceneFogColorXM() {
         const auto& rs = Engine::GAPI->GetRendererState();
 
-        // Indoor levels (mines, dungeons, ...) have no sky and no fog - ZenGin runs them with a
-        // zCSkyControler_Indoor and oCGame::EnvironmentInit never sets up the outdoor fog/farclip
-        // there. Both consumers of this color want black in that case: the sky fill (there is no sky
-        // to fade into) and the per-pixel distance fog in the lit shaders (which would otherwise wash
-        // the far end of a mine shaft in daylight).
+        // Indoor levels have no sky and no fog - ZenGin runs them with a zCSkyControler_Indoor and never sets
+        // up the outdoor fog/farclip. Both consumers want black: the sky fill has no sky to fade into, and
+        // the lit shaders' distance fog would otherwise wash the far end of a mine shaft in daylight.
         if ( Engine::GAPI->IsIndoorWorld() ) {
             return DirectX::XMVectorZero();
         }
@@ -338,20 +231,14 @@ namespace {
         return color;
     }
 
-    // Builds this frame's fog constants from Gothic's sky state. FogColor = GetSceneFogColorXM() (0..1,
-    // weather / sky-override / AtmosphericScattering-mode correct — the same color used to clear the sky);
-    // FogNear/FogFar = GraphicsState.FF_FogNear/FF_FogFar, the same values D3D11's ComputeFog() uses (set
-    // once per frame in GSky.cpp from sky->GetMasterState()->FogDist, with Gothic's hardcoded 0.3 near
-    // factor) — NOT GetFarZ(), which is an unrelated atmospheric-perspective far plane the height-fog PFX
-    // uses for its density falloff and is typically much smaller than FogDist, which was making the fog
-    // ramp in far too aggressively.
-    // Mirror of D3D12GraphicsEngine::m_HeightFogActive, refreshed from it once per frame at the top of
-    // OnStartWorldRendering — MakeFogConstants is a free function and can't reach the member. When the
-    // post-pass height fog runs (RenderFogAndGodRays), this cheap linear fog must NOT also be applied or the
-    // scene ends up fogged twice; D3D11's lit shaders never apply distance fog, the composition pass is the
-    // only fog there is.
+    // Mirror of D3D12GraphicsEngine::m_HeightFogActive (MakeFogConstants is a free function and can't reach
+    // the member), refreshed once per frame. When the post-pass height fog runs the cheap linear fog below
+    // must NOT also be applied, or the scene is fogged twice.
     bool g_HeightFogActive = false;
 
+    // FogNear/FogFar come from GraphicsState.FF_FogNear/FF_FogFar, the values D3D11's ComputeFog() uses —
+    // NOT GetFarZ(), an unrelated atmospheric-perspective far plane that is typically far smaller and made
+    // the fog ramp in much too aggressively.
     FogConstants MakeFogConstants() {
         FogConstants fog = {};
         DirectX::XMFLOAT3 fc;
@@ -360,8 +247,7 @@ namespace {
 
         if ( g_HeightFogActive ) {
             // Push the ramp past any reachable view distance instead of adding a shader permutation: the PS
-            // lerp weight saturate((d - near)/(far - near)) is then 0 everywhere, i.e. no fog, and the height
-            // fog composition owns the look. (Never near == far — that would divide by zero.)
+            // lerp weight is then 0 everywhere. Never near == far — that would divide by zero.
             fog.FogNear = 1.0e9f;
             fog.FogFar = 2.0e9f;
             DirectX::XMFLOAT3 camPos;
@@ -566,7 +452,7 @@ D3D12CmdList* D3D12GraphicsEngine::BeginShadowList( UINT slot ) {
 	D3D12CmdList&           cl    = m_ShadowCmdLists[slot][m_FrameIndex];
 	if ( !alloc || !cl ) return nullptr;
 	if ( FAILED( alloc->Reset() ) ) return nullptr;
-	// Goes through the wrapper, so this slot's state shadow is dropped with the list state it describes.
+	// Through the wrapper, so this slot's state shadow is dropped with the list state it describes.
 	if ( FAILED( cl.Reset( alloc, nullptr ) ) ) return nullptr;
 	ResetCpuContextTracker();   // per-thread breadcrumb ring — see D3D12EngineCommon.h
 	return &cl;
@@ -590,18 +476,14 @@ void D3D12GraphicsEngine::PrepareShadowPasses() {
 
 
 void D3D12GraphicsEngine::BeginShadowRecording() {
-	// Step 2. The three shadow passes write resources that NOTHING between here and the lit geometry passes
-	// reads, so their command recording has no business sitting on the main thread's critical path: fan it out
-	// and return immediately. The caller then records the depth prepass, the GPU VOB cull, the tiled light cull
-	// and SSAO into m_CmdList while the pool records shadows into its own lists.
+	// Step 2. Nothing between here and the lit geometry passes reads what the three shadow passes write, so
+	// their recording is fanned out and this returns immediately; the caller records the depth prepass, the
+	// GPU VOB cull, the light cull and SSAO into m_CmdList while the pool records shadows into its own lists.
 	//
 	// Queue ordering: the finished lists must land AHEAD of the lit geometry passes (the first readers of the
 	// cascade map / point cubes). So close+submit m_CmdList here and reopen it on the SAME frame allocator;
-	// FinishShadowPasses then executes the shadow lists while the reopened list is still open and unsubmitted,
-	// which gives the GPU [part A][part B1][cascades][point cubes][rain map][part B2] even though the CPU
-	// recorded B1 first. (B1 — the depth prepass through sky IBL — is submitted by a second
-	// SubmitRecordedCommandsAndReopen right before FinishShadowPasses, purely so the GPU can start on it
-	// instead of idling until Present; it reads nothing the shadow passes write.)
+	// FinishShadowPasses then executes the shadow lists while the reopened list is still open, giving the GPU
+	// [part A][part B1][cascades][point cubes][rain map][part B2] even though the CPU recorded B1 first.
 	m_ShadowRecordingPending = false;
 	m_ShadowThreadedRecord = false;
 	// ONLY the point/rain slots. The cascade slots belong to the per-cascade jobs launched way back in
@@ -670,23 +552,18 @@ void D3D12GraphicsEngine::FinishShadowPasses() {
 	// Step 3, run immediately before the lit geometry pass — which samples the cascade array and the point-light
 	// cubes, so this is the last possible moment. Three things happen here, in order:
 	//   1. Join the per-cascade cull -> build -> record chains (D3D12ShadowMap::WaitCascadeJobs) and the
-	//      point/rain recorders launched in BeginShadowRecording. This USED to be where the cascades were first
-	//      recorded, because a main-thread-only Phase C sat between their cull and their draws; that step is
-	//      gone (its Gothic-mutating half moved into Prepare, its per-cascade half into BuildCascade), so the
-	//      chains have been running since Prepare and this join should find them already finished.
+	//      point/rain recorders launched in BeginShadowRecording. They have been running since Prepare, so
+	//      this join should find them finished.
 	//   2. Emit inline anything that could not record into its own list.
-	//   3. Execute every finished list. The caller submitted part B1 (prepass, culls, SSAO, sky IBL) just before
-	//      calling us and reopened m_CmdList, so what is OPEN and unsubmitted here is part B2 — the lit passes
-	//      onwards. GPU order: [part A][part B1][shadows][part B2].
+	//   3. Execute every finished list. The caller already submitted part B1 (prepass, culls, SSAO, sky IBL)
+	//      and reopened m_CmdList, so GPU order ends up [part A][part B1][shadows][part B2].
 	// Anything that failed to record is re-issued inline rather than dropped: skipping a pass would desync its
 	// cross-frame resource-state tracking (D3D12PointShadows' per-slot cube states, m_RainShadowInReadState).
 	if ( !m_FrameOpen ) return;
 
 	// --- 1. join the per-cascade cull -> build -> record chains ---
-	// These were launched all the way back in D3D12ShadowMap::Prepare and have had DrawSky, the point/rain
-	// prepares, the indirect-arg builds and the whole prepass/cull/SSAO recording block to run in — so unlike
-	// the old split (where recording could not start until the main thread got here) this should return without
-	// blocking. It cannot move any later regardless: the lit geometry pass below samples the cascade array.
+	// Launched in D3D12ShadowMap::Prepare, so they should already be finished. This cannot move any later
+	// regardless: the lit geometry pass below samples the cascade array.
 	m_ShadowMap.WaitCascadeJobs();
 
 	// --- 2a. cascades that could NOT record inside their job (threading off, sun down, or the per-slot command
@@ -722,9 +599,7 @@ void D3D12GraphicsEngine::FinishShadowPasses() {
 		// cascade inline and re-issuing here would draw each of them twice.
 		if ( m_ShadowMap.IsPassReady() && m_ShadowMap.RecordedInJob() ) {
 			for ( UINT c = 0; c < kShadowCascades; ++c ) {
-				// A lazily-frozen cascade launched no job, so its slot is legitimately unrecorded — that is not a
-				// failure and must not be re-issued inline (RecordCascade would no-op anyway, but it would light
-				// up the "failed to record" warning below every third frame).
+				// A lazily-frozen cascade launched no job, so its unrecorded slot is not a failure.
 				if ( !m_ShadowMap.ShouldUpdateCascade( c ) ) continue;
 				if ( !m_ShadowListRecorded[c] ) { m_ShadowMap.RecordCascade( c, m_CmdList, m_ShadowMap.IsSunUp() ); anyFailed = true; }
 			}
@@ -797,8 +672,7 @@ UINT D3D12GraphicsEngine::ResolveDiffuseSlotCacheIn( zCTexture* tex ) {
 bool D3D12GraphicsEngine::CreateLightCullBuffers( INT2 size ) {
 	// Per-resolution CLUSTERED Forward+ grid storage (P2.14; tiled P2.9b-2 predecessor). Recreated on resize
 	// alongside the depth buffer. RW_LightGrid: one MAX_ACTIVE_LIGHTS-bit membership mask plus its WordOccupancy
-	// summary word (kWordsPerCluster * 4 B) per (16x16 screen tile x Z slice) cluster — see
-	// LightCull.hlsl/PBRLighting.hlsl. There is no
+	// summary word (kWordsPerCluster * 4 B) per (16x16 screen tile x Z slice) cluster. There is no
 	// separate index-list buffer: the mask itself IS the light list (bit i = light i). DEFAULT-heap UAV buffer
 	// created in UNORDERED_ACCESS; each frame DispatchLightCulling writes it (UAV) then transitions it to
 	// PIXEL_SHADER_RESOURCE for the lit geometry passes to read, then back.
@@ -895,19 +769,15 @@ bool D3D12GraphicsEngine::CreateVobInstanceBuffers() {
 
 
 // ---- Static point-light clustering ------------------------------------------------------------------------
-// Gothic lights a room or cave with 10-30 co-located STATIC "atmospheric" lights whose only job is to raise the
-// ambient level. Giving each one a shadow cube is impossible (there aren't that many cubes) and giving none of
-// them a cube means the whole set bleeds through the walls. Since they are all in the same room, ONE cube placed
-// between them occludes them all about equally well — so static lights are bucketed by a coarse world-space grid
-// and every member of a bucket shares its cube. Each light still shades from its OWN position/colour/range; only
-// the cube lookup (GPULight::ShadowOrigin/ShadowRange) is redirected to the cluster.
+// Gothic lights a room with 10-30 co-located static "atmospheric" lights. There are not enough shadow cubes to
+// give each one its own, and giving none a cube lets the whole set bleed through walls — but since they share a
+// room, ONE cube between them occludes them all about equally. So static lights are bucketed by a coarse
+// world-space grid and share their bucket's cube; each still shades from its own position/colour/range, only
+// the cube lookup (GPULight::ShadowOrigin/ShadowRange) is redirected.
 //
-// EVERYTHING about a cluster is derived from the CELL and only ever grows, never shrinks. That is deliberate and
-// load-bearing: the cluster is the identity that owns a cube slot, and the point-shadow static cache re-renders a
-// slot whenever its origin or range changes. Deriving either from the currently VISIBLE members would make both
-// churn every time the camera turned (members enter and leave the frustum constantly), re-rendering the static
-// cube every frame and defeating the cache entirely. Grow-only means a cluster settles within a few frames of
-// first being seen and then never invalidates again.
+// A cluster is derived from its CELL and only ever grows. That is load-bearing: the point-shadow static cache
+// re-renders a slot whenever its origin or range changes, so deriving either from the currently VISIBLE members
+// would invalidate the cube every time the camera turned.
 namespace {
 	// One visible point light on its way into the GPU light buffer. Built and distance-sorted by
 	// BuildFrameLightBuffer, then clustered here; it stays parallel to the filled GPULight array so the
@@ -1060,29 +930,19 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 	// so the view space this fills matches what the cull shader's frustum is built in.
 	const XMMATRIX view = XMMatrixTranspose( Engine::GAPI->GetViewMatrixXM() );
 
-	// ================= Static-light policy ==========================================================
-	// A point light that wins no shadow cube is shaded UNSHADOWED: it lights straight through walls and fights
-	// the tiled cull with contributions that should have been occluded. Forward+ makes MANY lights cheap, but it
-	// says nothing about visibility — cubes do, and they are the scarce resource. Gothic makes this acute by
-	// lighting a room or cave with 10-30 co-located STATIC "atmospheric" lights that exist only to raise the
-	// ambient level. Four mechanisms, in the order they apply:
+	// Static-light policy. A point light with no shadow cube shades UNSHADOWED and lights through walls, and
+	// cubes are the scarce resource. Four mechanisms, in the order they apply:
+	//   1. DisableStaticPointlights — drop static lights outright; under HDR they stack into an over-bright
+	//      interior.
+	//   2. CLUSTERING (above) — one cube per grid cell instead of one per light.
+	//   3. The LOW-RES TIER — static/clustered cubes come from the 32^2 pool, never the 128^2 one, so they
+	//      cannot starve a dynamic torch. Static visibility is static, so they are cached forever.
+	//   4. RANGE CLAMPING (below) — a static light that still gets no cube keeps its slot but has its shading
+	//      range cut, so it lights its alcove instead of reaching through a wall. An absent light is a visible
+	//      hole; a range-limited one is not.
 	//
-	//   1. DisableStaticPointlights — drop every static light outright. Under HDR output those fill lights stack
-	//      into a badly over-bright interior, and some players simply want them gone.
-	//   2. CLUSTERING — static lights are grouped by a world-space grid cell and share ONE cube per cell, so a
-	//      30-torch room costs one cube instead of 30 (or instead of bleeding). Each light still shades with its
-	//      own position/colour/range; only the cube lookup (ShadowOrigin/ShadowRange) is the cluster's.
-	//   3. The LOW-RES TIER — every static/clustered cube comes from the 32^2 pool, never the 128^2 one, so
-	//      static lights can never starve a dynamic torch of a full-res cube. Static visibility is static, so
-	//      those cubes are rendered once and cached forever; they exist to stop room-to-room bleed, not to
-	//      resolve detail. See D3D12PointShadows' kStaticCubeSize block.
-	//   4. RANGE CLAMPING (after selection, below) — a static light that still ends up without a cube keeps its
-	//      slot in the buffer but has its shading range cut, so it lights its own alcove instead of reaching
-	//      through a wall. Clamping beats deleting it: an absent light is a visible hole, a range-limited one
-	//      is not.
-	//
-	// Sorting by distance also fixes the overflow case: the buffer now keeps the NEAREST m_LightBufferCapacity
-	// lights rather than whatever BSP order CollectVisibleVobs happened to emit first.
+	// Sorting by distance also fixes the overflow case: the buffer keeps the NEAREST lights rather than
+	// whatever BSP order CollectVisibleVobs emitted first.
 	const GothicRendererSettings& lightSettings = Engine::GAPI->GetRendererState().RendererSettings;
 	const bool dropStaticLights = lightSettings.DisableStaticPointlights;
 	const bool pointShadowsOn = lightSettings.EnablePointlightShadows != GothicRendererSettings::PLS_DISABLED;
@@ -1191,16 +1051,9 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 
 
 void D3D12GraphicsEngine::BindFrameLights( UINT srvParam, UINT countParam, UINT gridParam ) {
-	// Bind the CLUSTERED Forward+ point-light root params: srvParam = the light StructuredBuffer as a root SRV
-	// (t1), countParam = LightCB { LightCount, NumTilesX, LimitLightIntensity, PointShadowLowIndex,
-	// PointShadowDynIndex, ProjA, ProjB, NearZ, FarZ }, gridParam = the per-cluster 64-bit mask root SRV (t2)
-	// produced by DispatchLightCulling. EVERY draw whose bound PSO reads the tiled light loop MUST call this
-	// after setting its root signature, or the loop bound (Count) and grid are UNDEFINED root values and can
-	// run billions of iterations → GPU timeout/removal. Root args are cleared on every SetGraphicsRootSignature.
-	// The param indices differ per root sig: m_Pipelines.World.RootSig uses (3,4,5) — the default — for the
-	// world mesh / instanced VOBs / node attachments; m_Pipelines.Skeletal.RootSig uses (4,5,6);
-	// m_Pipelines.Grass.RootSig uses (5,6,7). (Param 6/7/8, formerly the light-index-list SRV, is now dead —
-	// see the root-sig comments in D3D12PipelineState.cpp.)
+	// EVERY draw whose PSO reads the light loop MUST call this after setting its root signature — root args are
+	// cleared by SetGraphicsRootSignature, and an undefined loop bound runs billions of iterations into a GPU
+	// timeout. Param indices differ per root sig: World (3,4,5), Skeletal (4,5,6), Grass (5,6,7).
 	m_CmdList->SetGraphicsRootShaderResourceView( srvParam, m_LightBuffer[m_FrameIndex]->GetGPUVirtualAddress() );
 	m_CmdList->SetGraphicsRoot32BitConstant( countParam, m_FrameLightCount, 0 );   // LightCount @ b*.x
 	m_CmdList->SetGraphicsRoot32BitConstant( countParam, m_NumTilesX, 1 );         // NumTilesX  @ b*.y
@@ -1821,18 +1674,14 @@ void D3D12GraphicsEngine::DrawGhostVobs() {
 			}
 			}   // end base skinned mesh
 
-			// --- Node attachments (HEADS, weapons, held items, lamps). An NPC's head is a .MMS node attachment,
-			// not part of the soft-skin body, so without this a ghost NPC renders headless and unarmed.
+			// --- Node attachments (heads, weapons, held items, lamps). An NPC's head is a .MMS node
+			// attachment, not part of the soft-skin body, so without this a ghost NPC renders headless.
 			//
-			// Drawn through the NON-skeletal m_Pipelines.Ghost, which fits exactly: attachments are RIGID
-			// ExVertexStruct meshes (POSITION@0 + TEXCOORD@24 — its input layout) whose world matrix is
-			// modelWorld * boneMatrix[node], and that pipeline takes World as a b1 root constant. So no new PSO,
-			// no new shader and no VOB instance-ring traffic — unlike the lit path (DrawSkeletalColor), which
-			// must use the instanced VobAttach PSO because it batches. Ghosts are a handful of objects; a root
-			// constant per attachment is cheaper than a ring allocation.
-			//
-			// Fatness/Scaling (the VobAttach PSO's morph inflate) are deliberately NOT applied: Preview.hlsl's
-			// VSMain has no such input, and D3D11's ghost path goes through DrawSkeletalMeshVob the same way.
+			// Drawn through the NON-skeletal m_Pipelines.Ghost: attachments are rigid ExVertexStruct meshes
+			// matching its input layout, and it takes World as a b1 root constant, so no new PSO and no
+			// instance-ring traffic. Ghosts are a handful of objects, so a root constant per attachment beats
+			// the ring allocation the batching lit path needs. Fatness/Scaling are deliberately not applied —
+			// Preview.hlsl's VSMain has no such input, and D3D11's ghost path behaves the same.
 			if ( m_Pipelines.Ghost.PSO && m_Pipelines.Ghost.RootSig ) {
 				zCArray<zCModelNodeInst*>* nodeList = model->GetNodeList();
 				const int nodeCount = nodeList
@@ -1993,11 +1842,10 @@ void D3D12GraphicsEngine::DrawVegetationDepthPrepass() {
 	// Grass into the Forward+ depth prepass — see the header comment on kVegetationPrepassRange for why, and for
 	// why the range is capped independently of the lit pass's OutdoorSmallVobDrawRadius.
 	//
-	// Deliberately a near-clone of DrawVegetation's cull + bind + draw loop rather than a shared helper: the two
-	// differ in the PSO, the cull radius, the root arguments they bind (this one touches neither lights, shadows,
-	// the ground texture nor the AO mask) and, in the G-buffer case, the extra MotionCB — which is most of what
-	// that loop is. What they MUST share is the vertex-position math, and that lives in the shader
-	// (GrassWorldPos) plus MakeGrassConstants, both of which they do share.
+	// Deliberately a near-clone of DrawVegetation's loop rather than a shared helper: they differ in the PSO,
+	// the cull radius, the root arguments bound and the G-buffer MotionCB, which is most of that loop. What
+	// they must share is the vertex-position math, and that lives in the shader (GrassWorldPos) plus
+	// MakeGrassConstants.
 	if ( !m_FrameOpen || !m_Pipelines.Grass.RootSig || !m_DepthBuffer ) return;
 
 	// The prepass is all-or-nothing about its render targets (see MotionGBufferActive): whichever variant the
@@ -2800,11 +2648,10 @@ namespace {
 
 UINT D3D12GraphicsEngine::CoalesceWorldDepthCommands(
     std::vector<WorldDrawCommand>& opaque, WorldDrawCommand* out, UINT outCapacity ) {
-    // Draw-call merge for the depth-only world submits. Every command here indexes the SAME wrapped world
-    // VB/IB, so two commands whose index ranges touch are one DrawIndexed over the union. Strictly
-    // conservative: only EXACTLY adjacent ranges merge, so not one extra index is ever rasterized — bridging
-    // a gap would re-lay depth for geometry the color pass peeled out (water, portals, alpha-blended) or
-    // frustum-culled, and punch holes in the scene.
+    // Draw-call merge for the depth-only world submits. Every command indexes the SAME wrapped world VB/IB,
+    // so two commands with adjacent index ranges become one DrawIndexed. Only EXACTLY adjacent ranges merge:
+    // bridging a gap would re-lay depth for geometry the color pass peeled out (water, portals, blended) or
+    // frustum-culled, punching holes in the scene.
     if ( opaque.empty() || !out || outCapacity == 0 ) return 0;
 
     std::sort( opaque.begin(), opaque.end(),
@@ -2812,10 +2659,8 @@ UINT D3D12GraphicsEngine::CoalesceWorldDepthCommands(
             return a.Draw.StartIndexLocation < b.Draw.StartIndexLocation;
         } );
 
-    // The surviving command keeps the FIRST constituent's b6 material constants. Nothing on a depth-only PSO
-    // reads them (the opaque run binds no pixel shader at all), but they stay a valid bindless slot rather
-    // than a stale ring value, so a future prepass shader that does read b6 degrades to "wrong texture on a
-    // merged run" instead of sampling a freed descriptor.
+    // The surviving command keeps the first constituent's b6 material constants. Nothing on a depth-only PSO
+    // reads them, but they stay a valid bindless slot rather than a stale ring value.
     UINT n = 0;
     WorldDrawCommand run = opaque[0];
     for ( size_t i = 1; i < opaque.size(); ++i ) {
@@ -2863,16 +2708,14 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
     UINT count = 0;
 
     // Alpha-test partition (see m_WorldOpaqueDrawCount): opaque materials go straight into the arg ring, the
-    // alpha-tested minority is staged here and appended after the loop. Staged rather than written straight
-    // into the ring's tail because the ring is UPLOAD (write-combined) memory — compacting the two runs by
-    // reading it back would be far slower than one forward copy out of normal RAM. static: main thread only,
-    // capacity retained across frames (same idiom as `sections` above; no per-frame allocation).
+    // alpha-tested minority is staged here and appended after the loop. Staged in normal RAM because the ring
+    // is UPLOAD (write-combined) and compacting it in place would mean reading it back. static: main thread
+    // only, capacity retained across frames.
     static std::vector<WorldDrawCommand> alphaCmds;
     alphaCmds.clear();
 
-    // Every opaque command as written, mirrored into normal RAM so CoalesceWorldDepthCommands can sort and
-    // scan it — the ring itself is UPLOAD (write-combined), where a read-back would cost far more than the
-    // copy. static for the same reason alphaCmds is: no per-frame allocation.
+    // Mirror of every opaque command in normal RAM, so CoalesceWorldDepthCommands can sort and scan it without
+    // reading back the write-combined ring. static for the same reason alphaCmds is.
     static std::vector<WorldDrawCommand> opaqueCmds;
     opaqueCmds.clear();
 
@@ -2977,9 +2820,8 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
                 normalStrength = kWetDistortionNormalStrength;
             }
 
-            // Does this material actually need the depth prepass' alpha cutout? Same predicate D3D11 uses to
-            // decide between PS_DiffuseAlphaTestShadows and no pixel shader at all in its Z-prepass / shadow
-            // batch loop (D3D11GraphicsEngine.cpp, `batch.NeedAlpha`).
+            // Same predicate D3D11 uses to pick between PS_DiffuseAlphaTestShadows and no pixel shader at all
+            // in its Z-prepass / shadow batch loop (D3D11GraphicsEngine.cpp, `batch.NeedAlpha`).
             const bool alphaTested = ( tex && tex->HasAlphaChannel() )
                 || ( meshKey.Material && meshKey.Material->HasAlphaTest() );
 
@@ -3009,7 +2851,7 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
 
     // Coalesced opaque run for the depth prepass, appended PAST the color pass' set so that set is unchanged
     // (see m_WorldDepthMergedFirst). Degrades to 0 — and the prepass to the per-material prefix — if the
-    // ring's tail can't hold it, so the overflow guard above needs no extra headroom.
+    // ring's tail can't hold it.
     m_WorldDepthMergedFirst = count;
     m_WorldDepthMergedCount = ( count < kMaxWorldDrawCommands )
         ? CoalesceWorldDepthCommands( opaqueCmds, cmds + count, kMaxWorldDrawCommands - count )
@@ -3498,16 +3340,8 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
 
 
 void D3D12GraphicsEngine::DrawDepthPrepass() {
-    // Forward+ opaque depth prepass (P2.9b-1). Lays down the opaque WORLD-MESH depth before the lit color
-    // passes, so the tiled light-culling compute (P2.9b-2) can read a populated depth buffer to tighten each
-    // tile's frustum. Writes depth only (color write mask 0). Runs after DrawSky (color cleared, depth still
-    // at the OnBeginFrame clear of 0.0) and before DrawWorldMesh. The main opaque passes keep GREATER_EQUAL +
-    // depth-write, so they re-pass on equal depth and rewrite the same value — the frame is visually identical.
-    //
-    // Scope: WORLD MESH ONLY this increment. Instanced VOBs + skeletal NPCs still get their depth from their
-    // own (unchanged) color passes; they'll be added to the prepass alongside the cull consumer (P2.9b-2),
-    // where the VOB instance-ring offset sharing gets designed together with the tile grid. Water is skipped
-    // (transparent — it never writes depth, same as the opaque pass peels it out).
+    // Forward+ opaque WORLD-MESH depth prepass, before the lit color passes. Writes depth only (color write
+    // mask 0). Water is skipped: it is transparent and never writes depth, same as in the opaque pass.
     if ( !m_FrameOpen || !m_Pipelines.World.DepthPrepassPSO || !m_Pipelines.World.RootSig || !m_DepthBuffer )
         return;
 
@@ -3538,9 +3372,9 @@ void D3D12GraphicsEngine::DrawDepthPrepass() {
     XMFLOAT4X4 viewProj;
     XMStoreFloat4x4( &viewProj, XMMatrixMultiply( XMLoadFloat4x4( &projM ), XMLoadFloat4x4( &viewM ) ) );
 
-    // Split the submit whenever the no-alpha PSO exists and the G-buffer is off (with the G-buffer on there is
-    // a pixel shader either way, so the split buys nothing). BuildWorldDrawCommands ordered the command set
-    // opaque-prefix / alpha-tested-suffix precisely for this. See World.DepthPrepassNoAlphaPSO.
+    // Split the submit when the no-alpha PSO exists and the G-buffer is off (with it on there is a pixel
+    // shader either way). BuildWorldDrawCommands ordered the command set opaque-prefix / alpha-tested-suffix
+    // for this. See World.DepthPrepassNoAlphaPSO.
     const bool splitAlpha = !gbuf && m_Pipelines.World.DepthPrepassNoAlphaPSO != nullptr;
 
     m_CmdList->SetPipelineState( gbuf ? m_Pipelines.World.DepthPrepassGBufPSO.Get()
@@ -3571,9 +3405,9 @@ void D3D12GraphicsEngine::DrawDepthPrepass() {
             m_WorldDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
         return;
     }
-    // Opaque prefix, no pixel shader bound at all (set above) — this is the run that gets double-rate Z.
-    // Prefer the coalesced mirror of that prefix (see m_WorldDepthMergedFirst): identical index coverage,
-    // far fewer commands, and with no PS bound the per-material constants it drops are dead anyway.
+    // Opaque prefix, no pixel shader bound — the run that gets double-rate Z. Prefer the coalesced mirror of
+    // it (m_WorldDepthMergedFirst): identical index coverage, far fewer commands, and the per-material
+    // constants it drops are dead with no PS bound.
     if ( m_WorldDepthMergedCount > 0 ) {
         m_CmdList->ExecuteIndirect( m_WorldIndirectCmdSig.Get(), m_WorldDepthMergedCount,
             m_WorldDrawArgs[m_FrameIndex].Get(),
@@ -3596,9 +3430,7 @@ void D3D12GraphicsEngine::DispatchLightCulling() {
     // CLUSTERED Forward+ light cull (P2.14; tiled P2.9b-2 predecessor). One thread group per 16x16 screen tile
     // writes that tile's whole column of kNumZSlices light-membership masks into m_LightGridBuffer — see
     // Shaders/D3D12/LightCull.hlsl. Cluster Z bounds are analytic (log-distributed over CullCB's NearZ/FarZ),
-    // so unlike the old per-tile scheme this pass never touches the depth buffer: no prepass ordering
-    // dependency, no depth-SRV round-trip. Verify in RenderDoc: m_LightGridBuffer's Mask should be non-zero for
-    // clusters torches/spells occupy, zero elsewhere.
+    // so this pass never touches the depth buffer: no prepass ordering dependency, no depth-SRV round-trip.
     if ( !m_FrameOpen || !m_Pipelines.LightCull.PSO || !m_Pipelines.LightCull.RootSig || !m_LightGridBuffer )
         return;
     if ( !m_LightBuffer[m_FrameIndex] || m_NumTilesX == 0 || m_NumTilesY == 0 )
@@ -3643,9 +3475,8 @@ void D3D12GraphicsEngine::DispatchLightCulling() {
     m_CmdList->SetComputeRoot32BitConstants( 0, 8, &cb, 0 );
     m_CmdList->SetComputeRootShaderResourceView( 1, m_LightBuffer[m_FrameIndex]->GetGPUVirtualAddress() );
     m_CmdList->SetComputeRootUnorderedAccessView( 2, m_LightGridBuffer->GetGPUVirtualAddress() );
-    // One group per SCREEN TILE — the shader bins all kNumZSlices clusters of the tile column itself (the 16
-    // clusters share their XY bounds, so culling once per column and Z-binning the survivors is ~16x less work
-    // than the old group-per-cluster dispatch). Do NOT re-add the Z dimension without changing LightCull.hlsl.
+    // One group per SCREEN TILE — the shader bins the whole column of clusters itself, since they share their
+    // XY bounds. Do NOT re-add the Z dimension without changing LightCull.hlsl.
     m_CmdList->Dispatch( m_NumTilesX, m_NumTilesY, 1 );
 
     D3D12_RESOURCE_BARRIER post = TransitionBarrier( m_LightGridBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
@@ -4077,18 +3908,12 @@ XRESULT D3D12GraphicsEngine::DrawVobsInstanced() {
 
 void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& vobs, const Frustum* cullFrustum, int shadowCascade,
     const DirectX::XMFLOAT3* sphereCenter, float sphereRange, UINT cascadeCount, bool collectGhosts ) {
-    // P2.9b-4b (pre-cull) + shadow-cascade/point-shadow parity: run each candidate skeletal vob's once-per-frame
-    // animation update, upload its instance + bone CBs (base meshes) and its node attachments' VOB-instance data
-    // into the per-frame rings ONCE (cached in g_SkelUploadCache — the pose data is view-independent), and
-    // RECORD the (possibly cached) GPU addresses into the caller's destination list: g_FrameSkelDraws/
-    // g_FrameAttachDraws for the main view (shadowCascade < 0, default), D3D12ShadowMap::SkelDraws[c]/
-    // AttachDraws[c] for CSM cascade c (shadowCascade >= 0), or D3D12PointShadows::SkelScratch/
-    // AttachScratch for a point light (shadowCascade == -2) — mirrors D3D11's
-    // Shadows::DrawSkeletalMeshes, which culls the FULL registered skeletal-vob list against the shadow's OWN
-    // frustum/sphere rather than reusing the player's view-frustum-culled list (a caster invisible to the
-    // player can still cast a visible shadow). NO draws here — DrawSkeletalDepthPrepass/DrawSkeletalColor read
-    // g_FrameSkelDraws/g_FrameAttachDraws; D3D12ShadowMap::RecordCascade reads its own SkelDraws[c]/
-    // AttachDraws[c]; D3D12PointShadows::Prepare reads its SkelScratch/AttachScratch.
+    // Run each candidate skeletal vob's once-per-frame animation update, upload its instance + bone CBs and
+    // its attachments' VOB-instance data ONCE (cached in g_SkelUploadCache — the pose is view-independent),
+    // and record the resulting GPU addresses into the caller's list: the main view's g_FrameSkelDraws/
+    // g_FrameAttachDraws, a cascade's SkelDraws[c]/AttachDraws[c] (shadowCascade >= 0), or the point-shadow
+    // scratch lists (-2). No draws here. Like D3D11's Shadows::DrawSkeletalMeshes, each shadow caller culls
+    // the FULL registered vob list against its OWN frustum/sphere rather than the player's.
     if ( !m_FrameOpen || !m_SkeletalCBBuffer[m_FrameIndex] || !m_SkeletalCBBufferPtr[m_FrameIndex] )
         return;
     GothicRendererState& rs = Engine::GAPI->GetRendererState();
@@ -4125,17 +3950,13 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
         if ( !vi || !vi->Vob || !vi->VisualInfo ) continue;
         if ( !vi->Vob->GetShowVisual() ) continue;
 
-        // Ghost vobs (invisible-potion NPCs, fading spawns, spirits) never join the regular skinned draw on
-        // either backend. What happens to them instead depends on the caller:
-        //   - shadow callers (collectGhosts == false): dropped outright. D3D11 skips them the same way in
-        //     Shadows::DrawSkeletalMeshes (D3D11GraphicsEngine.cpp:5909/6275/7004) — ghosts cast no shadows.
-        //   - the main view (collectGhosts == true): rerouted into GothicAPI::TransparencyVobs below, so
-        //     DrawGhostVobs draws them unlit+blended later in the frame. Handled after the cull/extract work
-        //     rather than here, because the ghost pass needs a culled vob with its geometry actually built.
-        // NOTE the deliberately different conditions: D3D11's shadow skips test
-        // `GetVisualAlpha() && GetVobTransparency() < 0.7f`, but its main-view reroute
-        // (GothicAPI::DrawWorldMeshNaive:1394) tests `GetVisualAlpha()` ALONE. A ghost at transparency >= 0.7
-        // therefore draws as a ghost AND casts a normal shadow. Faithful, not an oversight.
+        // Ghost vobs (invisible-potion NPCs, fading spawns, spirits) never join the regular skinned draw:
+        //   - shadow callers (collectGhosts == false): dropped outright — ghosts cast no shadows, as D3D11.
+        //   - the main view: rerouted into GothicAPI::TransparencyVobs below, so DrawGhostVobs draws them
+        //     unlit+blended later. Done after the cull/extract work, since the ghost pass needs a culled vob
+        //     with its geometry actually built.
+        // The two conditions differ deliberately, matching D3D11: its shadow skip tests transparency < 0.7,
+        // its main-view reroute tests GetVisualAlpha() alone, so a ghost at >= 0.7 both draws and casts.
         const bool isGhost = vi->Vob->GetVisualAlpha();
         if ( isGhost && !collectGhosts && vi->Vob->GetVobTransparency() < 0.7f ) continue;
 
@@ -4170,16 +3991,13 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
         if ( visual->SkeletalMeshes.empty() && model->GetMeshSoftSkinList()->NumInArray > 0 )
             WorldConverter::ExtractSkeletalMeshFromVob( model, visual );
 
-        // Main-view ghost reroute (see the isGhost note above). This is the D3D12 equivalent of the branch
-        // GothicAPI::DrawWorldMeshNaive (:1394) takes on D3D11 — that function is the D3D11 collection path and
-        // is never called on this backend, so nothing else has ever pushed a SKELETAL entry into
-        // TransparencyVobs here. Static ghost VOBs already arrive via CVVH_AddNotDrawnVobToList
-        // (GothicAPI.cpp:4698/6771, the `normalVob` branch), which is why DrawGhostVobs' skeletal half existed
-        // but was unreachable: ghost NPCs simply rendered as nothing.
+        // Main-view ghost reroute (see the isGhost note above), the D3D12 equivalent of the branch
+        // GothicAPI::DrawWorldMeshNaive takes on D3D11 — that path never runs on this backend, so nothing
+        // else pushes a SKELETAL entry into TransparencyVobs. Static ghost VOBs already arrive via
+        // CVVH_AddNotDrawnVobToList.
         //
-        // Placed AFTER the distance/frustum cull and the lazy ExtractSkeletalMeshFromVob above (D3D11 pushes
-        // slightly earlier, before the mesh work) so the ghost pass receives a culled vob whose geometry is
-        // actually built — DrawGhostVobs skips entries with an empty SkeletalMeshes list.
+        // After the cull and the lazy ExtractSkeletalMeshFromVob above, so the ghost pass receives a vob whose
+        // geometry is built — DrawGhostVobs skips entries with an empty SkeletalMeshes list.
         if ( isGhost ) {
             if ( collectGhosts ) {
                 // Gothic lerps its animations only when this is set and below ~2000. The regular path below
@@ -4398,15 +4216,10 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
                     // to right now, so skip this attachment entirely for this frame rather than race them.
                     if ( !mvi->Ready.load( std::memory_order_acquire ) || !mvi->Visual ) continue;
                     const bool isMMS = strcmp( mvi->Visual->GetFileExtension( 0 ), ".MMS" ) == 0;
-                    // MMS attachments only MORPH within kMorphMeshMaxDistance of the camera — beyond that they
-                    // render as their undeformed rest mesh. This mirrors D3D11 exactly: GothicAPI::
-                    // DrawWorldMeshNaive splits the skeletal vobs into a `drawAsMorphMesh` list (dist < 1000, has
-                    // an MMS attachment) drawn with distance=500 and a `drawRegular` list drawn with FLT_MAX, and
-                    // DrawSkeletalMeshVobs' morph branch is gated on `isMMS && distance < 1000` — so far-away MMS
-                    // attachments fall through to its plain instanced attachment path, which carries no
-                    // Fatness/Scaling at all. Morphing is CPU-side (Gothic's own zCMorphMesh::AdvanceAnis +
-                    // CalcVertexPositions, then a full vertex-buffer re-upload per animation frame), so this gate
-                    // is a real per-frame CPU/bandwidth saving on crowds, not just a visual nicety.
+                    // MMS attachments only MORPH within kMorphMeshMaxDistance; beyond it they render as their
+                    // undeformed rest mesh and carry no Fatness/Scaling, mirroring D3D11's `isMMS &&
+                    // distance < 1000` morph branch. A real CPU/bandwidth saving on crowds, not just a
+                    // visual nicety, whenever the deform still runs on the CPU.
                     const bool morphActive = isMMS && inMorphMeshRange;
                     // Fatness/Scaling inflate-along-normal (mirrors D3D11's VS_ExConstantBuffer_PerInstanceNode,
                     // VS_ExNode.hlsl: localPos = (pos + Fatness*normal) * Scaling). Only actively-morphing MMS

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -62,7 +62,7 @@ std::vector<VobInfo*> g_FrameVobs;
 // g_SkelUploadCache or a growth of this container can't dangle a record.
 // Deque rather than vector so that growing it cannot invalidate the element pointers the concurrent CSM
 // cascade recorders are holding — see the declaration in D3D12EngineCommon.h.
-std::deque<std::vector<UINT>> g_SkelMatSrvs;
+std::deque<std::vector<SkelMatSlot>> g_SkelMatSrvs;
 size_t g_SkelMatSrvCount = 0;
 
 namespace {
@@ -2358,9 +2358,10 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// vertex/index binds happen once/frame instead of per-pass, and neither pass issues per-mesh CPU draw calls).
 	if ( Engine::GAPI->GetRendererState().RendererSettings.DrawVOBs && m_VobDrawArgsPtr[m_FrameIndex] ) {
 		m_VobDrawCount = BuildVobDrawCommands( g_FrameVobUploads, m_VobDrawArgsPtr[m_FrameIndex], true,
-			kMaxVobDrawCommands, m_GpuVobCullActive );
+			kMaxVobDrawCommands, m_GpuVobCullActive, true, kVobIndicesMainView, &m_VobOpaqueDrawCount );
 	} else {
 		m_VobDrawCount = 0;
+		m_VobOpaqueDrawCount = 0;
 	}
 	// Build the skeletal + node-attachment ExecuteIndirect command sets ONCE (T9) from g_FrameSkelDraws/
 	// g_FrameAttachDraws, resolving each material's full bindless index set — the depth prepass ignores the
@@ -2776,6 +2777,7 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
     // the shared world VB/IB) }. Water is peeled here into g_FrameWaterSurfaces (drawn later, alpha-blended). Both
     // world passes then consume the result, so the BSP walk + per-material CacheIn happen once/frame (was 2-3x).
     m_WorldDrawCount = 0;
+    m_WorldOpaqueDrawCount = 0;
     m_WorldDrawnIndices = 0;
     g_FrameWaterSurfaces.clear();
     g_FrameWorldTransparency.clear();
@@ -2796,6 +2798,14 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
 
     WorldDrawCommand* cmds = reinterpret_cast<WorldDrawCommand*>( m_WorldDrawArgsPtr[m_FrameIndex] );
     UINT count = 0;
+
+    // Alpha-test partition (see m_WorldOpaqueDrawCount): opaque materials go straight into the arg ring, the
+    // alpha-tested minority is staged here and appended after the loop. Staged rather than written straight
+    // into the ring's tail because the ring is UPLOAD (write-combined) memory — compacting the two runs by
+    // reading it back would be far slower than one forward copy out of normal RAM. static: main thread only,
+    // capacity retained across frames (same idiom as `sections` above; no per-frame allocation).
+    static std::vector<WorldDrawCommand> alphaCmds;
+    alphaCmds.clear();
 
     // Camera position for the alpha-blended peel's painter-order sort key (see the branch below).
     const XMVECTOR transparencyCamPos = Engine::GAPI->GetCameraPositionXM();
@@ -2857,7 +2867,7 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
                 g_FrameWorldTransparency.push_back( { meshKey.Material, mesh, transparencyDistanceSq() } );
                 continue;
             }
-            if ( count >= kMaxWorldDrawCommands ) {
+            if ( count + alphaCmds.size() >= kMaxWorldDrawCommands ) {
                 if ( !m_WorldDrawArgsOverflowLogged ) {
                     LogWarn() << "D3D12: world draw-command ring overflow (" << kMaxWorldDrawCommands
                         << " draws/frame); some world materials dropped this frame.";
@@ -2898,7 +2908,13 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
                 normalStrength = kWetDistortionNormalStrength;
             }
 
-            WorldDrawCommand& c = cmds[count];
+            // Does this material actually need the depth prepass' alpha cutout? Same predicate D3D11 uses to
+            // decide between PS_DiffuseAlphaTestShadows and no pixel shader at all in its Z-prepass / shadow
+            // batch loop (D3D11GraphicsEngine.cpp, `batch.NeedAlpha`).
+            const bool alphaTested = ( tex && tex->HasAlphaChannel() )
+                || ( meshKey.Material && meshKey.Material->HasAlphaTest() );
+
+            WorldDrawCommand c{};
             c.MatNormalIndex     = normalIdx;
             c.MatOrmIndex        = ormIdx;
             c.MatDiffuseIndex    = diffuseIdx;
@@ -2908,9 +2924,17 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
             c.Draw.StartIndexLocation = mesh->BaseIndexLocation;
             c.Draw.BaseVertexLocation = 0;
             c.Draw.StartInstanceLocation = 0;
-            ++count;
+            if ( alphaTested ) alphaCmds.push_back( c );
+            else               cmds[count++] = c;
             m_WorldDrawnIndices += static_cast<unsigned int>( mesh->Indices.size() );
         }
+    }
+    // Append the alpha-tested run behind the opaque one, so the prepass can draw [0, opaque) with no pixel
+    // shader and [opaque, total) with the clipping one.
+    m_WorldOpaqueDrawCount = count;
+    if ( !alphaCmds.empty() ) {
+        std::memcpy( cmds + count, alphaCmds.data(), alphaCmds.size() * sizeof( WorldDrawCommand ) );
+        count += static_cast<UINT>( alphaCmds.size() );
     }
     m_WorldDrawCount = count;
     // Painter's order for the peeled alpha-blended surfaces (far -> near), once per frame.
@@ -2996,14 +3020,30 @@ bool D3D12GraphicsEngine::CreateVobIndirect() {
 
 
 UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload>& uploads, uint8_t* argPtr, bool resolveMaps,
-    UINT maxCommands, bool culled, bool cacheIn, int shadowCascade ) {
+    UINT maxCommands, bool culled, bool cacheIn, int shadowCascade, UINT* outOpaqueCount ) {
     // Fill an arg buffer with one command per (visual x material x sub-mesh): resolve the material's bindless
     // indices (diffuse always; normal/ORM only when resolveMaps — the depth/shadow passes just alpha-clip on
     // diffuse), pack the mesh + instance VB views + IB view, the per-visual wind min/max, and DrawIndexedInstanced.
     // Same CacheIn/From resolution the per-draw path did — but done ONCE per built buffer instead of per pass.
-    if ( !argPtr ) return 0;
+    if ( !argPtr ) { if ( outOpaqueCount ) *outOpaqueCount = 0; return 0; }
     VobDrawCommand* cmds = reinterpret_cast<VobDrawCommand*>( argPtr );
     UINT count = 0;
+    // Alpha-test partition staging — see the identical block in BuildWorldDrawCommands for why the tail is
+    // staged in normal RAM instead of compacted inside the write-combined UPLOAD ring. thread_local, not
+    // static: the shadow cascades call this concurrently on the worker pool (cacheIn=false).
+    thread_local std::vector<VobDrawCommand> alphaCmds;
+    alphaCmds.clear();
+    // Appends the staged alpha-tested run behind the opaque one and reports the partition point. Both exits
+    // below (ring overflow and normal completion) go through this, or an overflowing frame would silently
+    // drop every alpha-tested draw instead of just the ones past the cap.
+    auto finish = [&]() -> UINT {
+        if ( outOpaqueCount ) *outOpaqueCount = count;
+        if ( !alphaCmds.empty() ) {
+            std::memcpy( cmds + count, alphaCmds.data(), alphaCmds.size() * sizeof( VobDrawCommand ) );
+            count += static_cast<UINT>( alphaCmds.size() );
+        }
+        return count;
+        };
     const uint32_t whiteSlot   = m_BlackTexture->GetSrvSlot();
     const uint32_t defaultOrm  = GetDefaultOrmSrvSlot();
     // Attribute the triangle stat to the main-view build only (resolveMaps): the shadow cascades build the same
@@ -3089,13 +3129,13 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                     continue;
                 }
 
-                if ( count >= maxCommands ) {
+                if ( count + alphaCmds.size() >= maxCommands ) {
                     if ( !m_VobDrawArgsOverflowLogged ) {
                         LogWarn() << "D3D12: VOB draw-command ring overflow (" << maxCommands
                             << " draws/frame); some VOBs dropped this frame.";
                         m_VobDrawArgsOverflowLogged = true;
                     }
-                    return count;
+                    return finish();
                 }
 
                 // Pick this command's index buffer. A missing level just falls through to the next-best one,
@@ -3121,7 +3161,7 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                     }
                 }
 
-                VobDrawCommand& c = cmds[count++];
+                VobDrawCommand c{};
                 c.MeshVBV = { mvb->GetGpuVirtualAddress(), mvb->GetSizeInBytes(), sizeof( ExVertexStruct ) };
                 // GPU-culled: draw from the compacted buffer CSCull writes (same byte range, different base)
                 // and let CSPatchArgs replace InstanceCount below with the surviving count for this visual.
@@ -3139,12 +3179,17 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 c.Draw.StartIndexLocation    = 0;
                 c.Draw.BaseVertexLocation    = 0;
                 c.Draw.StartInstanceLocation = 0;
+                // Partition by alpha cutout (see m_WorldOpaqueDrawCount): opaque first, alpha-tested appended
+                // by finish(). `alphaTested` is the same flag that already gates the reduced shadow index
+                // buffers above, so there is nothing new to compute here.
+                if ( alphaTested ) alphaCmds.push_back( c );
+                else               cmds[count++] = c;
                 if ( resolveMaps )
                     m_VobDrawnTriangles += (cmdIndexCount / 3) * up.numInstances;
             }
         }
     }
-    return count;
+    return finish();
 }
 
 
@@ -3238,9 +3283,16 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
     // submits: they used to do this work after the fan-out.
     m_SkeletalDrawCount = 0;
     m_AttachDrawCount = 0;
+    m_SkeletalOpaqueDrawCount = 0;
+    m_AttachOpaqueDrawCount = 0;
     m_SkeletalDrawnTriangles = 0;
     if ( !m_FrameOpen ) return;
     const UINT frame = m_FrameIndex;
+
+    // Alpha-test partition staging for both command sets below — see BuildWorldDrawCommands for the rationale.
+    // Main thread only (this runs before BeginShadowRecording fans anything out), so plain statics.
+    static std::vector<SkeletalDrawCommand> alphaSkelCmds;
+    static std::vector<VobDrawCommand>      alphaAttachCmds;
 
     auto logOverflow = [this]( const char* what, UINT cap ) {
         if ( !m_SkeletalDrawArgsOverflowLogged ) {
@@ -3254,6 +3306,7 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
     if ( !g_FrameSkelDraws.empty() && m_SkeletalDrawArgsPtr[frame] ) {
         SkeletalDrawCommand* cmds = reinterpret_cast<SkeletalDrawCommand*>( m_SkeletalDrawArgsPtr[frame] );
         UINT count = 0;
+        alphaSkelCmds.clear();
         for ( const FrameSkelDraw& d : g_FrameSkelDraws ) {
             if ( !d.visual || !d.vobInfo || !d.vobInfo->Vob ) continue;
             zCModel* model = static_cast<zCModel*>( d.vobInfo->Vob->GetVisual() );
@@ -3270,6 +3323,8 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
                 UINT mats[3];
                 ResolveMaterialMapSlots( tex, mats );
                 mats[2] = ResolveDiffuseSlotCacheIn( tex );
+                // Alpha-test partition — same predicate as the world/VOB builds (see m_WorldOpaqueDrawCount).
+                const bool alphaTested = ( tex && tex->HasAlphaChannel() ) || ( mat && mat->HasAlphaTest() );
 
                 for ( auto const& mesh : meshList ) {
                     if ( !mesh || mesh->Indices.empty() || !mesh->MeshVertexBuffer || !mesh->MeshIndexBuffer )
@@ -3277,9 +3332,9 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
                     D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( mesh->MeshVertexBuffer.get() );
                     D3D12VertexBuffer* mib = D3D12VertexBuffer::From( mesh->MeshIndexBuffer.get() );
                     if ( !mvb->GetResource() || !mib->GetResource() ) continue;
-                    if ( count >= kMaxSkeletalDrawCommands ) { logOverflow( "base-mesh", kMaxSkeletalDrawCommands ); break; }
+                    if ( count + alphaSkelCmds.size() >= kMaxSkeletalDrawCommands ) { logOverflow( "base-mesh", kMaxSkeletalDrawCommands ); break; }
 
-                    SkeletalDrawCommand& c = cmds[count++];
+                    SkeletalDrawCommand c{};
                     c.InstCB  = d.instCb;
                     c.BoneCB  = d.boneCb;
                     c.MeshVBV = { mvb->GetGpuVirtualAddress(), mvb->GetSizeInBytes(), sizeof( ExSkelVertexStruct ) };
@@ -3292,11 +3347,19 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
                     c.Draw.StartIndexLocation    = 0;
                     c.Draw.BaseVertexLocation    = 0;
                     c.Draw.StartInstanceLocation = 0;
+                    if ( alphaTested ) alphaSkelCmds.push_back( c );
+                    else               cmds[count++] = c;
                     m_SkeletalDrawnTriangles += static_cast<unsigned int>( mesh->Indices.size() ) / 3;
                 }
-                if ( count >= kMaxSkeletalDrawCommands ) break;
+                if ( count + alphaSkelCmds.size() >= kMaxSkeletalDrawCommands ) break;
             }
-            if ( count >= kMaxSkeletalDrawCommands ) break;
+            if ( count + alphaSkelCmds.size() >= kMaxSkeletalDrawCommands ) break;
+        }
+        // Alpha-tested run appended behind the opaque one — see m_WorldOpaqueDrawCount.
+        m_SkeletalOpaqueDrawCount = count;
+        if ( !alphaSkelCmds.empty() ) {
+            std::memcpy( cmds + count, alphaSkelCmds.data(), alphaSkelCmds.size() * sizeof( SkeletalDrawCommand ) );
+            count += static_cast<UINT>( alphaSkelCmds.size() );
         }
         m_SkeletalDrawCount = count;
     }
@@ -3308,19 +3371,25 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
     if ( !g_FrameAttachDraws.empty() && m_AttachDrawArgsPtr[frame] ) {
         VobDrawCommand* cmds = reinterpret_cast<VobDrawCommand*>( m_AttachDrawArgsPtr[frame] );
         UINT count = 0;
+        alphaAttachCmds.clear();
         for ( const FrameAttachDraw& a : g_FrameAttachDraws ) {
             if ( !a.mesh || a.mesh->Indices.empty() || !a.mesh->GetMeshVertexBuffer() || !a.mesh->GetMeshIndexBuffer() )
                 continue;
             D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( a.mesh->GetMeshVertexBuffer() );
             D3D12VertexBuffer* mib = D3D12VertexBuffer::From( a.mesh->GetMeshIndexBuffer() );
             if ( !mvb->GetResource() || !mib->GetResource() ) continue;
-            if ( count >= kMaxAttachDrawCommands ) { logOverflow( "attachment", kMaxAttachDrawCommands ); break; }
+            if ( count + alphaAttachCmds.size() >= kMaxAttachDrawCommands ) { logOverflow( "attachment", kMaxAttachDrawCommands ); break; }
 
             UINT mats[3];
             ResolveMaterialMapSlots( a.tex, mats );
             mats[2] = ResolveDiffuseSlotCacheIn( a.tex );
+            // Alpha-test partition. FrameAttachDraw carries only the texture, not the material — but that
+            // costs nothing here: the prepass cutout is `clip(diffuse.a - 0.5)`, which can only ever discard
+            // when the diffuse actually HAS an alpha channel. The material's HasAlphaTest() flag that the
+            // other three builds also test is pure conservatism (a=1 everywhere never clips).
+            const bool alphaTested = a.tex && a.tex->HasAlphaChannel();
 
-            VobDrawCommand& c = cmds[count++];
+            VobDrawCommand c{};
             c.MeshVBV = { mvb->GetGpuVirtualAddress(), mvb->GetSizeInBytes(), sizeof( ExVertexStruct ) };
             c.InstVBV = a.instView;
             c.IBV     = { mib->GetGpuVirtualAddress(), mib->GetSizeInBytes(), DXGI_FORMAT_R16_UINT };
@@ -3336,7 +3405,14 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
             c.Draw.StartInstanceLocation = 0;
             c.VisualIndex = 0xFFFFFFFFu;   // never GPU-culled: "leave the CPU's instance count alone"
             c._cmdPad     = 0;
+            if ( alphaTested ) alphaAttachCmds.push_back( c );
+            else               cmds[count++] = c;
             m_SkeletalDrawnTriangles += static_cast<unsigned int>( a.mesh->Indices.size() ) / 3;
+        }
+        m_AttachOpaqueDrawCount = count;
+        if ( !alphaAttachCmds.empty() ) {
+            std::memcpy( cmds + count, alphaAttachCmds.data(), alphaAttachCmds.size() * sizeof( VobDrawCommand ) );
+            count += static_cast<UINT>( alphaAttachCmds.size() );
         }
         m_AttachDrawCount = count;
     }
@@ -3384,8 +3460,14 @@ void D3D12GraphicsEngine::DrawDepthPrepass() {
     XMFLOAT4X4 viewProj;
     XMStoreFloat4x4( &viewProj, XMMatrixMultiply( XMLoadFloat4x4( &projM ), XMLoadFloat4x4( &viewM ) ) );
 
+    // Split the submit whenever the no-alpha PSO exists and the G-buffer is off (with the G-buffer on there is
+    // a pixel shader either way, so the split buys nothing). BuildWorldDrawCommands ordered the command set
+    // opaque-prefix / alpha-tested-suffix precisely for this. See World.DepthPrepassNoAlphaPSO.
+    const bool splitAlpha = !gbuf && m_Pipelines.World.DepthPrepassNoAlphaPSO != nullptr;
+
     m_CmdList->SetPipelineState( gbuf ? m_Pipelines.World.DepthPrepassGBufPSO.Get()
-                                      : m_Pipelines.World.DepthPrepassPSO.Get() );
+                                      : ( splitAlpha ? m_Pipelines.World.DepthPrepassNoAlphaPSO.Get()
+                                                     : m_Pipelines.World.DepthPrepassPSO.Get() ) );
     m_CmdList->SetGraphicsRootSignature( m_Pipelines.World.RootSig.Get() );
     m_CmdList->SetGraphicsRoot32BitConstants( 0, 16, &viewProj, 0 );   // b0 ViewProj (fog/lights not referenced)
     if ( gbuf ) m_CmdList->SetGraphicsRootConstantBufferView( 13, motionCb );   // b5 MotionCB (VSWorldGBuf)
@@ -3406,8 +3488,23 @@ void D3D12GraphicsEngine::DrawDepthPrepass() {
     // sets the b6 diffuse index (PSClip alpha-clips bindless) then draws its material's index range. Replaces the
     // per-material descriptor-table binds + DrawIndexedInstanced calls (the CPU cost this optimization targets).
     if ( m_WorldDrawCount == 0 ) return;
-    m_CmdList->ExecuteIndirect( m_WorldIndirectCmdSig.Get(), m_WorldDrawCount,
-        m_WorldDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
+    if ( !splitAlpha ) {
+        m_CmdList->ExecuteIndirect( m_WorldIndirectCmdSig.Get(), m_WorldDrawCount,
+            m_WorldDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
+        return;
+    }
+    // Opaque prefix, no pixel shader bound at all (set above) — this is the run that gets double-rate Z.
+    if ( m_WorldOpaqueDrawCount > 0 ) {
+        m_CmdList->ExecuteIndirect( m_WorldIndirectCmdSig.Get(), m_WorldOpaqueDrawCount,
+            m_WorldDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
+    }
+    // Alpha-tested suffix through the clipping PSO, starting at the partition point.
+    if ( m_WorldDrawCount > m_WorldOpaqueDrawCount ) {
+        m_CmdList->SetPipelineState( m_Pipelines.World.DepthPrepassPSO.Get() );
+        m_CmdList->ExecuteIndirect( m_WorldIndirectCmdSig.Get(), m_WorldDrawCount - m_WorldOpaqueDrawCount,
+            m_WorldDrawArgs[m_FrameIndex].Get(),
+            static_cast<UINT64>( m_WorldOpaqueDrawCount ) * sizeof( WorldDrawCommand ), nullptr, 0 );
+    }
 }
 
 
@@ -3782,8 +3879,12 @@ void D3D12GraphicsEngine::DrawVobDepthPrepass() {
     const D3D12_GPU_VIRTUAL_ADDRESS motionCb = GetMotionCbAddress();
     const bool gbuf = motionCb && MotionGBufferActive();
 
+    // See DrawDepthPrepass: opaque prefix with no pixel shader, alpha-tested suffix with the clipping one.
+    const bool splitAlpha = !gbuf && m_Pipelines.World.DepthPrepassVobNoAlphaPSO != nullptr;
+
     m_CmdList->SetPipelineState( gbuf ? m_Pipelines.World.DepthPrepassVobGBufPSO.Get()
-                                      : m_Pipelines.World.DepthPrepassVobIndirectPSO.Get() );
+                                      : ( splitAlpha ? m_Pipelines.World.DepthPrepassVobNoAlphaPSO.Get()
+                                                     : m_Pipelines.World.DepthPrepassVobIndirectPSO.Get() ) );
     m_CmdList->SetGraphicsRootSignature( m_Pipelines.World.RootSig.Get() );
     m_CmdList->SetGraphicsRoot32BitConstants( 0, 16, &viewProj, 0 );   // b0 ViewProj (fog/lights not referenced)
     if ( gbuf ) m_CmdList->SetGraphicsRootConstantBufferView( 13, motionCb );   // b5 MotionCB (VSDepthGBuf)
@@ -3802,7 +3903,21 @@ void D3D12GraphicsEngine::DrawVobDepthPrepass() {
     // wind, then DrawIndexedInstanced — replacing the per-mesh IASetVertexBuffers/table/draw the CPU path issued.
     // drawArgs (GetVobDrawArgsBuffer): the GPU-culled DEFAULT copy (instance counts patched by CullVobsGPU) when
     // culling is active, else the CPU-written UPLOAD ring.
-    m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_VobDrawCount, drawArgs, 0, nullptr, 0 );
+    if ( !splitAlpha ) {
+        m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_VobDrawCount, drawArgs, 0, nullptr, 0 );
+        return;
+    }
+    // drawArgs may be the GPU-culled DEFAULT copy — but CSPatchArgs only rewrites each command's
+    // InstanceCount in place (keyed on the VisualIndex embedded in the command itself), so the opaque/
+    // alpha-tested partition the CPU build laid out survives the cull byte-for-byte. See D3D12Cull.cpp.
+    if ( m_VobOpaqueDrawCount > 0 ) {
+        m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_VobOpaqueDrawCount, drawArgs, 0, nullptr, 0 );
+    }
+    if ( m_VobDrawCount > m_VobOpaqueDrawCount ) {
+        m_CmdList->SetPipelineState( m_Pipelines.World.DepthPrepassVobIndirectPSO.Get() );
+        m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_VobDrawCount - m_VobOpaqueDrawCount, drawArgs,
+            static_cast<UINT64>( m_VobOpaqueDrawCount ) * sizeof( VobDrawCommand ), nullptr, 0 );
+    }
 }
 
 
@@ -4034,10 +4149,13 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
             if ( g_SkelMatSrvCount >= g_SkelMatSrvs.size() )
                 g_SkelMatSrvs.emplace_back();
             {
-                std::vector<UINT>& matSrvs = g_SkelMatSrvs[g_SkelMatSrvCount];
+                std::vector<SkelMatSlot>& matSrvs = g_SkelMatSrvs[g_SkelMatSrvCount];
                 matSrvs.clear();
-                for ( auto const& [mat, meshList] : visual->SkeletalMeshes )
-                    matSrvs.push_back( ResolveShadowDiffuseSlot( mat ? mat->GetAniTexture() : nullptr ) );
+                for ( auto const& [mat, meshList] : visual->SkeletalMeshes ) {
+                    zCTexture* matTex = mat ? mat->GetAniTexture() : nullptr;
+                    matSrvs.push_back( { ResolveShadowDiffuseSlot( matTex ),
+                        ( matTex && matTex->HasAlphaChannel() ) || ( mat && mat->HasAlphaTest() ) } );
+                }
                 entry.matSrvIndex = static_cast<uint32_t>( g_SkelMatSrvCount++ );
             }
 
@@ -4260,7 +4378,8 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
                             // attTex directly because they CacheIn, which a shadow-only alpha cutout deliberately
                             // must not do.
                             entry.attachments.push_back( { attMesh.get(), attTex, attInstView, vi->Vob,
-                                ResolveShadowDiffuseSlot( attTex ) } );
+                                ResolveShadowDiffuseSlot( attTex ),
+                                attTex && attTex->HasAlphaChannel() } );
                         }
                     }
                 }
@@ -4322,8 +4441,11 @@ void D3D12GraphicsEngine::DrawSkeletalDepthPrepass() {
         // Motion vectors + normals — see DrawDepthPrepass. VSDepthGBuf skins each vertex twice (current pose and
         // the previous pose out of the same b2 palette), so NPCs get true per-vertex velocity on limbs.
         const bool skelGbuf = motionCb && MotionGBufferActive();
+        // See DrawDepthPrepass: opaque prefix with no pixel shader, alpha-tested suffix with the clipping one.
+        const bool splitAlpha = !skelGbuf && m_Pipelines.Skeletal.DepthPrepassNoAlphaPSO != nullptr;
         m_CmdList->SetPipelineState( skelGbuf ? m_Pipelines.Skeletal.DepthPrepassGBufPSO.Get()
-                                              : m_Pipelines.Skeletal.DepthPrepassPSO.Get() );
+                                              : ( splitAlpha ? m_Pipelines.Skeletal.DepthPrepassNoAlphaPSO.Get()
+                                                             : m_Pipelines.Skeletal.DepthPrepassPSO.Get() ) );
         m_CmdList->SetGraphicsRootSignature( m_Pipelines.Skeletal.RootSig.Get() );
         m_CmdList->SetGraphicsRoot32BitConstants( 0, 16, &viewProj, 0 );
         if ( skelGbuf ) m_CmdList->SetGraphicsRootConstantBufferView( 13, motionCb );   // b9 MotionCB
@@ -4332,8 +4454,21 @@ void D3D12GraphicsEngine::DrawSkeletalDepthPrepass() {
         m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
         // Each command sets its own b1 instance CBV + b2 bone CBV + skinned VBV + IBV + b6 material consts,
         // then DrawIndexed — replacing the per-vob root-CBV sets and per-mesh IA binds the CPU path issued.
-        m_CmdList->ExecuteIndirect( m_SkeletalIndirectCmdSig.Get(), m_SkeletalDrawCount,
-            m_SkeletalDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
+        if ( !splitAlpha ) {
+            m_CmdList->ExecuteIndirect( m_SkeletalIndirectCmdSig.Get(), m_SkeletalDrawCount,
+                m_SkeletalDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
+        } else {
+            if ( m_SkeletalOpaqueDrawCount > 0 ) {
+                m_CmdList->ExecuteIndirect( m_SkeletalIndirectCmdSig.Get(), m_SkeletalOpaqueDrawCount,
+                    m_SkeletalDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
+            }
+            if ( m_SkeletalDrawCount > m_SkeletalOpaqueDrawCount ) {
+                m_CmdList->SetPipelineState( m_Pipelines.Skeletal.DepthPrepassPSO.Get() );
+                m_CmdList->ExecuteIndirect( m_SkeletalIndirectCmdSig.Get(),
+                    m_SkeletalDrawCount - m_SkeletalOpaqueDrawCount, m_SkeletalDrawArgs[m_FrameIndex].Get(),
+                    static_cast<UINT64>( m_SkeletalOpaqueDrawCount ) * sizeof( SkeletalDrawCommand ), nullptr, 0 );
+            }
+        }
     }
 
     // Node attachments (depth only) through the VOB attachment depth PSO (Fatness/Scaling variant — see
@@ -4344,8 +4479,11 @@ void D3D12GraphicsEngine::DrawSkeletalDepthPrepass() {
         DX_ZONE( m_CmdList.Get(), "Depth Prepass (attachments)" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth Prepass (attachments)" );
         const bool attachGbuf = motionCb && MotionGBufferActive();
+        // See DrawDepthPrepass: opaque prefix with no pixel shader, alpha-tested suffix with the clipping one.
+        const bool attachSplit = !attachGbuf && m_Pipelines.World.DepthPrepassVobAttachNoAlphaPSO != nullptr;
         m_CmdList->SetPipelineState( attachGbuf ? m_Pipelines.World.DepthPrepassVobAttachGBufPSO.Get()
-                                                : m_Pipelines.World.DepthPrepassVobAttachPSO.Get() );
+                                                : ( attachSplit ? m_Pipelines.World.DepthPrepassVobAttachNoAlphaPSO.Get()
+                                                                : m_Pipelines.World.DepthPrepassVobAttachPSO.Get() ) );
         m_CmdList->SetGraphicsRootSignature( m_Pipelines.World.RootSig.Get() );
         m_CmdList->SetGraphicsRoot32BitConstants( 0, 16, &viewProj, 0 );
         if ( attachGbuf ) m_CmdList->SetGraphicsRootConstantBufferView( 13, motionCb );   // b5 MotionCB
@@ -4355,8 +4493,21 @@ void D3D12GraphicsEngine::DrawSkeletalDepthPrepass() {
         m_CmdList->RSSetViewports( 1, &vp );
         m_CmdList->RSSetScissorRects( 1, &sc );
         m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
-        m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_AttachDrawCount,
-            m_AttachDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
+        if ( !attachSplit ) {
+            m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_AttachDrawCount,
+                m_AttachDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
+        } else {
+            if ( m_AttachOpaqueDrawCount > 0 ) {
+                m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_AttachOpaqueDrawCount,
+                    m_AttachDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
+            }
+            if ( m_AttachDrawCount > m_AttachOpaqueDrawCount ) {
+                m_CmdList->SetPipelineState( m_Pipelines.World.DepthPrepassVobAttachPSO.Get() );
+                m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(),
+                    m_AttachDrawCount - m_AttachOpaqueDrawCount, m_AttachDrawArgs[m_FrameIndex].Get(),
+                    static_cast<UINT64>( m_AttachOpaqueDrawCount ) * sizeof( VobDrawCommand ), nullptr, 0 );
+            }
+        }
     }
 }
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -720,7 +720,7 @@ void D3D12GraphicsEngine::FinishShadowPasses() {
 				// up the "failed to record" warning below every third frame).
 				if ( !m_ShadowMap.ShouldUpdateCascade( c ) ) continue;
 				if ( !m_ShadowListRecorded[c] ) { m_ShadowMap.RecordCascade( c, m_CmdList, m_ShadowMap.IsSunUp() ); anyFailed = true; }
-		}
+			}
 		}
 		if ( m_PointShadows.IsPassReady() && !m_ShadowListRecorded[kPointShadowListIndex] ) {
 			m_PointShadows.Record( m_CmdList );
@@ -3412,8 +3412,8 @@ void D3D12GraphicsEngine::DrawDepthPrepass() {
 
 
 void D3D12GraphicsEngine::DispatchLightCulling() {
-    // CLUSTERED Forward+ light cull (P2.14; tiled P2.9b-2 predecessor). One thread group per (16x16 screen
-    // tile x Z slice) cluster writes a 64-bit light-membership mask into m_LightGridBuffer — see
+    // CLUSTERED Forward+ light cull (P2.14; tiled P2.9b-2 predecessor). One thread group per 16x16 screen tile
+    // writes that tile's whole column of kNumZSlices light-membership masks into m_LightGridBuffer — see
     // Shaders/D3D12/LightCull.hlsl. Cluster Z bounds are analytic (log-distributed over CullCB's NearZ/FarZ),
     // so unlike the old per-tile scheme this pass never touches the depth buffer: no prepass ordering
     // dependency, no depth-SRV round-trip. Verify in RenderDoc: m_LightGridBuffer's Mask should be non-zero for
@@ -3462,7 +3462,10 @@ void D3D12GraphicsEngine::DispatchLightCulling() {
     m_CmdList->SetComputeRoot32BitConstants( 0, 8, &cb, 0 );
     m_CmdList->SetComputeRootShaderResourceView( 1, m_LightBuffer[m_FrameIndex]->GetGPUVirtualAddress() );
     m_CmdList->SetComputeRootUnorderedAccessView( 2, m_LightGridBuffer->GetGPUVirtualAddress() );
-    m_CmdList->Dispatch( m_NumTilesX, m_NumTilesY, kNumZSlices );
+    // One group per SCREEN TILE — the shader bins all kNumZSlices clusters of the tile column itself (the 16
+    // clusters share their XY bounds, so culling once per column and Z-binning the survivors is ~16x less work
+    // than the old group-per-cluster dispatch). Do NOT re-add the Z dimension without changing LightCull.hlsl.
+    m_CmdList->Dispatch( m_NumTilesX, m_NumTilesY, 1 );
 
     D3D12_RESOURCE_BARRIER post = TransitionBarrier( m_LightGridBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
     m_CmdList->ResourceBarrier( 1, &post );

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -553,18 +553,19 @@ namespace {
 }
 
 
-ID3D12GraphicsCommandList* D3D12GraphicsEngine::BeginShadowList( UINT slot ) {
+D3D12CmdList* D3D12GraphicsEngine::BeginShadowList( UINT slot ) {
 	// Resets one deferred-shadow (slot x frame-in-flight) allocator/list pair for recording, and returns the
 	// open list (nullptr on failure — the caller then leaves that slot unrecorded and FinishShadowPasses
 	// re-issues the pass inline). Safe without a GPU wait: this pair was last used kBackBufferCount frames ago
 	// and Present() already fenced on that frame.
-	ID3D12CommandAllocator*    alloc = m_ShadowCmdAllocators[slot][m_FrameIndex].Get();
-	ID3D12GraphicsCommandList* cl    = m_ShadowCmdLists[slot][m_FrameIndex].Get();
+	ID3D12CommandAllocator* alloc = m_ShadowCmdAllocators[slot][m_FrameIndex].Get();
+	D3D12CmdList&           cl    = m_ShadowCmdLists[slot][m_FrameIndex];
 	if ( !alloc || !cl ) return nullptr;
 	if ( FAILED( alloc->Reset() ) ) return nullptr;
-	if ( FAILED( cl->Reset( alloc, nullptr ) ) ) return nullptr;
+	// Goes through the wrapper, so this slot's state shadow is dropped with the list state it describes.
+	if ( FAILED( cl.Reset( alloc, nullptr ) ) ) return nullptr;
 	ResetCpuContextTracker();   // per-thread breadcrumb ring — see D3D12EngineCommon.h
-	return cl;
+	return &cl;
 }
 
 
@@ -616,8 +617,8 @@ void D3D12GraphicsEngine::BeginShadowRecording() {
 		// Degrade to the original single-threaded driver: record inline, right here. Same output, same queue
 		// order — just no overlap with the prepass. (The cascades still record in FinishShadowPasses, since
 		// their caster data does not exist until the concurrent cull is joined there.)
-		m_PointShadows.Record( m_CmdList.Get() );
-		RecordRainShadowmap( m_CmdList.Get() );
+		m_PointShadows.Record( m_CmdList );
+		RecordRainShadowmap( m_CmdList );
 		// Those passes leave no render target bound (their DSVs have just left DEPTH_WRITE) and the depth
 		// prepass the caller records next does not bind its own — re-establish the scene-color RT + depth.
 		BindSceneColorTarget();
@@ -638,9 +639,9 @@ void D3D12GraphicsEngine::BeginShadowRecording() {
 			[]( const std::stop_token& token, D3D12GraphicsEngine* self ) {
 				if ( token.stop_requested() ) return;
 				ZoneScopedN( "Record point shadows" );
-				ID3D12GraphicsCommandList* cl = self->BeginShadowList( kPointShadowListIndex );
+				D3D12CmdList* cl = self->BeginShadowList( kPointShadowListIndex );
 				if ( !cl ) return;
-				self->m_PointShadows.Record( cl );
+				self->m_PointShadows.Record( *cl );
 				self->m_ShadowListRecorded[kPointShadowListIndex] = SUCCEEDED( cl->Close() );
 			}, this ).future );
 	}
@@ -649,9 +650,9 @@ void D3D12GraphicsEngine::BeginShadowRecording() {
 			[]( const std::stop_token& token, D3D12GraphicsEngine* self ) {
 				if ( token.stop_requested() ) return;
 				ZoneScopedN( "Record rain shadowmap" );
-				ID3D12GraphicsCommandList* cl = self->BeginShadowList( kRainShadowListIndex );
+				D3D12CmdList* cl = self->BeginShadowList( kRainShadowListIndex );
 				if ( !cl ) return;
-				self->RecordRainShadowmap( cl );
+				self->RecordRainShadowmap( *cl );
 				self->m_ShadowListRecorded[kRainShadowListIndex] = SUCCEEDED( cl->Close() );
 			}, this ).future );
 	}
@@ -689,7 +690,7 @@ void D3D12GraphicsEngine::FinishShadowPasses() {
 			m_ShadowRecordingPending = true;   // there is now at least one own-list batch to execute below
 		} else {
 			for ( UINT c = 0; c < kShadowCascades; ++c )
-				m_ShadowMap.RecordCascade( c, m_CmdList.Get(), m_ShadowMap.IsSunUp() );
+				m_ShadowMap.RecordCascade( c, m_CmdList, m_ShadowMap.IsSunUp() );
 		}
 	}
 
@@ -714,14 +715,14 @@ void D3D12GraphicsEngine::FinishShadowPasses() {
 		// cascade inline and re-issuing here would draw each of them twice.
 		if ( m_ShadowMap.IsPassReady() && m_ShadowMap.RecordedInJob() ) {
 			for ( UINT c = 0; c < kShadowCascades; ++c )
-				if ( !m_ShadowListRecorded[c] ) { m_ShadowMap.RecordCascade( c, m_CmdList.Get(), m_ShadowMap.IsSunUp() ); anyFailed = true; }
+				if ( !m_ShadowListRecorded[c] ) { m_ShadowMap.RecordCascade( c, m_CmdList, m_ShadowMap.IsSunUp() ); anyFailed = true; }
 		}
 		if ( m_PointShadows.IsPassReady() && !m_ShadowListRecorded[kPointShadowListIndex] ) {
-			m_PointShadows.Record( m_CmdList.Get() );
+			m_PointShadows.Record( m_CmdList );
 			anyFailed = true;
 		}
 		if ( m_RainShadowPassReady && !m_ShadowListRecorded[kRainShadowListIndex] ) {
-			RecordRainShadowmap( m_CmdList.Get() );
+			RecordRainShadowmap( m_CmdList );
 			anyFailed = true;
 		}
 		if ( anyFailed && !m_ShadowRecordFailureLogged ) {
@@ -734,7 +735,7 @@ void D3D12GraphicsEngine::FinishShadowPasses() {
 	// Hand the cascade array to PIXEL_SHADER_RESOURCE for the lit-pass PCF sampling; reverted at the top of next
 	// frame's D3D12ShadowMap::Prepare. (The point-shadow cube and the rain map do their own transition inside
 	// their own pass, which is self-contained in one list.)
-	m_ShadowMap.TransitionToReadState( m_CmdList.Get() );
+	m_ShadowMap.TransitionToReadState( m_CmdList );
 
 	// Every shadow list for this frame is now recorded and submitted (or was re-issued inline above), so the
 	// point-shadow static cubes this frame (re)rendered have actually reached the GPU — only now may their slots
@@ -1997,7 +1998,7 @@ void D3D12GraphicsEngine::DrawVegetationDepthPrepass() {
 	const auto& vegetationBoxes = Engine::GAPI->GetVegetationBoxes();
 	if ( vegetationBoxes.empty() ) return;
 
-	DX_ZONE( m_CmdList, "Depth Prepass (vegetation)" );
+	DX_ZONE( m_CmdList.Get(), "Depth Prepass (vegetation)" );
 	TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth Prepass (vegetation)" );
 
 	// ViewProj — identical derivation to DrawVegetation, so the depth laid down here is what the lit pass
@@ -2094,7 +2095,7 @@ void D3D12GraphicsEngine::DrawVegetation() {
 	const auto& vegetationBoxes = Engine::GAPI->GetVegetationBoxes();
 	if ( vegetationBoxes.empty() ) return;
 
-	DX_ZONE( m_CmdList, "Draw vegetation" );
+	DX_ZONE( m_CmdList.Get(), "Draw vegetation" );
 	TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw vegetation" );
 
 	XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
@@ -2366,7 +2367,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// specifically NOT safe to move any Gothic read INTO a recorder for the same reason.
 	BuildSkeletalDrawCommands();
     {
-        DX_ZONE( m_CmdList, "Depth Prepass" );
+        DX_ZONE( m_CmdList.Get(), "Depth Prepass" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth Prepass" );
 		// Swap the (write-masked-off) scene-color RTV the prepass used to bind for the two motion/normal
 		// G-buffer targets, and clear velocity to its sentinel. The three prepass passes below then run their
@@ -2413,11 +2414,11 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// re-establishes the scene-color RT + depth for them.
 	FinishShadowPasses();
     {
-        DX_ZONE( m_CmdList, "Lit Geometry Pass" );
+        DX_ZONE( m_CmdList.Get(), "Lit Geometry Pass" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Lit Geometry Pass" );
 	    DrawWorldMesh();
 	    {
-		    DX_ZONE( m_CmdList, "Draw skeletal (color)" );
+		    DX_ZONE( m_CmdList.Get(), "Draw skeletal (color)" );
 		    TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw skeletal (color)" );
 		    DrawSkeletalColor();   // base meshes + node attachments, lit through the tile grid (both lists)
 	    }
@@ -2438,7 +2439,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	decals.clear();
 	Engine::GAPI->GetVisibleDecalList( decals );
 	{
-		DX_ZONE( m_CmdList, "Draw decals (opaque)" );
+		DX_ZONE( m_CmdList.Get(), "Draw decals (opaque)" );
 		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw decals (opaque)" );
 		DrawDecalList( decals, true );
 	}
@@ -2457,7 +2458,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	DrawWorldTransparencyMeshes();
 
 	{
-		DX_ZONE( m_CmdList, "Draw decals (transparent)" );
+		DX_ZONE( m_CmdList.Get(), "Draw decals (transparent)" );
 		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw decals (transparent)" );
 		DrawDecalList( decals, false );
 	}
@@ -2469,7 +2470,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// Particles last: billboarded PFX (fire, smoke, magic, dust) blended over everything, depth-tested
 	// against the opaque scene but not writing depth. Mirrors D3D11's late DrawParticlesSimple pass.
 	{
-		DX_ZONE( m_CmdList, "Draw particles" );
+		DX_ZONE( m_CmdList.Get(), "Draw particles" );
 		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw particles" );
 		DrawParticleEffects();
 	}
@@ -2477,7 +2478,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// Rain/snow (D3D12 rain parity, step 2): unlit placeholder billboards, always "wet" — see
 	// DrawRainParticles. Same late-transparency slot D3D11 draws rain in.
 	{
-		DX_ZONE( m_CmdList, "Draw rain" );
+		DX_ZONE( m_CmdList.Get(), "Draw rain" );
 		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw rain" );
 		DrawRainParticles();
 	}
@@ -2491,7 +2492,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// pass placement (after the transparency waterfall/decals, before post-FX). MUST run every frame even if
 	// EnableBloom/etc. are off — it also drains GothicAPI::TransparencyVobs, which nothing else consumes.
 	{
-		DX_ZONE( m_CmdList, "Draw ghosts" );
+		DX_ZONE( m_CmdList.Get(), "Draw ghosts" );
 		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw ghosts" );
 		DrawGhostVobs();
 	}
@@ -2560,7 +2561,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// pass (after post-FX, before Gothic's 2D UI composites on top). Both calls also CLEAR their cache, so this
 	// is what keeps the line lists from growing unbounded across frames.
 	{
-		DX_ZONE( m_CmdList, "Draw debug lines" );
+		DX_ZONE( m_CmdList.Get(), "Draw debug lines" );
 		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw debug lines" );
 		m_LineRenderer->Flush();
 		m_LineRenderer->FlushScreenSpace();
@@ -2580,7 +2581,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 
 XRESULT D3D12GraphicsEngine::DrawSky() {
 	if ( !m_FrameOpen ) return XR_SUCCESS;
-	DX_ZONE( m_CmdList, "Draw sky" );
+	DX_ZONE( m_CmdList.Get(), "Draw sky" );
 	TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw sky" );
 
 	// Base fallback fill: Gothic's current sky/fog color (see GetSceneFogColorXM — tracks time of day when
@@ -3366,7 +3367,7 @@ void D3D12GraphicsEngine::DrawDepthPrepass() {
     if ( !vb->GetResource() || !ib->GetResource() ) return;
     if ( ib->GetSizeInBytes() / sizeof( uint32_t ) == 0 ) return;
 
-    DX_ZONE( m_CmdList, "Depth Prepass (world)" );
+    DX_ZONE( m_CmdList.Get(), "Depth Prepass (world)" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth Prepass (world)" );
 
     // ViewProj — identical derivation to DrawWorldMesh so the prepass depth matches the opaque pass exactly.
@@ -3417,7 +3418,7 @@ void D3D12GraphicsEngine::DispatchLightCulling() {
     if ( !m_LightBuffer[m_FrameIndex] || m_NumTilesX == 0 || m_NumTilesY == 0 )
         return;
 
-    DX_ZONE( m_CmdList, "Light Culling (compute)" );
+    DX_ZONE( m_CmdList.Get(), "Light Culling (compute)" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Light Culling (compute)" );
 
     // The lit geometry passes left the grid buffer in PIXEL_SHADER_RESOURCE last frame; transition it back to
@@ -3541,7 +3542,7 @@ XRESULT D3D12GraphicsEngine::DrawWorldMesh( bool /*noTextures*/ ) {
     const UINT numIndices = ib->GetSizeInBytes() / sizeof( uint32_t );
     if ( numIndices == 0 ) return XR_SUCCESS;
 
-    DX_ZONE( m_CmdList, "Draw World Mesh" );
+    DX_ZONE( m_CmdList.Get(), "Draw World Mesh" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw World Mesh" );
 
     // Camera matrices — replicate the D3D11 DrawWorldMesh setup exactly so ViewProj is byte-identical:
@@ -3755,7 +3756,7 @@ void D3D12GraphicsEngine::DrawVobDepthPrepass() {
     ID3D12Resource* drawArgs = GetVobDrawArgsBuffer();
     if ( m_VobDrawCount == 0 || !drawArgs ) return;
 
-    DX_ZONE( m_CmdList, "Depth Prepass (vobs)" );
+    DX_ZONE( m_CmdList.Get(), "Depth Prepass (vobs)" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth Prepass (vobs)" );
 
     // ViewProj — identical derivation to DrawVobsInstanced so the prepass depth matches the color pass exactly.
@@ -3847,7 +3848,7 @@ XRESULT D3D12GraphicsEngine::DrawVobsInstanced() {
     static_assert( sizeof( VS_ExConstantBuffer_Wind ) == 48, "WindCB (b4) layout must match Vob.hlsl's WindCB" );
 
     {
-        DX_ZONE( m_CmdList, "Draw Vobs" );
+        DX_ZONE( m_CmdList.Get(), "Draw Vobs" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw Vobs" );
         // One GPU-driven submit over the command set BuildVobDrawCommands filled: each command sets its mesh/
         // instance VBVs + IBV, b6 { normal, orm, diffuse } bindless indices (PSMainBindless samples all three),
@@ -4308,7 +4309,7 @@ void D3D12GraphicsEngine::DrawSkeletalDepthPrepass() {
     // cutout and ignores the normal/ORM constants each command also carries).
     if ( m_SkeletalDrawCount > 0 && m_SkeletalIndirectCmdSig && m_SkeletalDrawArgs[m_FrameIndex]
         && m_Pipelines.Skeletal.DepthPrepassPSO && m_Pipelines.Skeletal.RootSig ) {
-        DX_ZONE( m_CmdList, "Depth Prepass (skeletal)" );
+        DX_ZONE( m_CmdList.Get(), "Depth Prepass (skeletal)" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth Prepass (skeletal)" );
         // Motion vectors + normals — see DrawDepthPrepass. VSDepthGBuf skins each vertex twice (current pose and
         // the previous pose out of the same b2 palette), so NPCs get true per-vertex velocity on limbs.
@@ -4332,7 +4333,7 @@ void D3D12GraphicsEngine::DrawSkeletalDepthPrepass() {
     // won't reflect the same inflate/scale as the color pass, the same class of bug the wind fix addressed).
     if ( m_AttachDrawCount > 0 && m_VobIndirectCmdSig && m_AttachDrawArgs[m_FrameIndex]
         && m_Pipelines.World.DepthPrepassVobAttachPSO && m_Pipelines.World.RootSig ) {
-        DX_ZONE( m_CmdList, "Depth Prepass (attachments)" );
+        DX_ZONE( m_CmdList.Get(), "Depth Prepass (attachments)" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth Prepass (attachments)" );
         const bool attachGbuf = motionCb && MotionGBufferActive();
         m_CmdList->SetPipelineState( attachGbuf ? m_Pipelines.World.DepthPrepassVobAttachGBufPSO.Get()
@@ -4376,7 +4377,7 @@ void D3D12GraphicsEngine::DrawSkeletalColor() {
 
     // Base skinned meshes (lit) — one ExecuteIndirect over the shared command set (see the prepass).
     if ( m_SkeletalDrawCount > 0 && m_SkeletalIndirectCmdSig && m_SkeletalDrawArgs[m_FrameIndex] ) {
-        DX_ZONE( m_CmdList, "Draw skeletal" );
+        DX_ZONE( m_CmdList.Get(), "Draw skeletal" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw skeletal" );
         m_CmdList->SetPipelineState( m_Pipelines.Skeletal.PSO.Get() );
         m_CmdList->SetGraphicsRootSignature( m_Pipelines.Skeletal.RootSig.Get() );
@@ -4400,7 +4401,7 @@ void D3D12GraphicsEngine::DrawSkeletalColor() {
     // unbound count would run the loop on garbage → GPU TDR hang.
     if ( m_AttachDrawCount > 0 && m_VobIndirectCmdSig && m_AttachDrawArgs[m_FrameIndex]
         && m_Pipelines.World.VobAttachPSO && m_Pipelines.World.RootSig ) {
-        DX_ZONE( m_CmdList, "Draw attachments" );
+        DX_ZONE( m_CmdList.Get(), "Draw attachments" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw attachments" );
         m_CmdList->SetPipelineState( m_Pipelines.World.VobAttachPSO.Get() );
         m_CmdList->SetGraphicsRootSignature( m_Pipelines.World.RootSig.Get() );

--- a/D3D11Engine/D3D12Engine/D3D12ShaderBackend.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShaderBackend.cpp
@@ -181,6 +181,7 @@ namespace {
         arguments.push_back( DXC_ARG_OPTIMIZATION_LEVEL3 );   // -O3 (Maximum optimization for release)
 #endif
         arguments.push_back( L"-enable-16bit-types" ); // Enable 16-bit types for SM6+ (half, min16float, etc.)
+        arguments.push_back( L"-all-resources-bound" ); // Let the GPU know that we ensure all resources exist.
 
         // Translate any legacy macro preprocessors into modern DXC -D parameters
         std::vector<std::wstring> wDefinesStore;

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -869,6 +869,7 @@ void D3D12ShadowMap::Prepare() {
 		m_CascadeMatricesValid = false;   // the frozen matrices no longer describe any rendered slice
 		for ( UINT c = 0; c < kShadowCascades; ++c ) {
 			m_WorldDrawCount[c] = 0;
+			m_WorldDepthMergedCount[c] = 0;
 			m_VobDrawCount[c] = 0;
 			g_GrassBoxes[c].clear();
 			SkelDraws[c].clear();
@@ -1021,6 +1022,8 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
 	// --- World mesh: bbox-test the pre-resolved caster set into this cascade's ExecuteIndirect arg buffer ---
 	m_WorldDrawCount[c] = 0;
 	m_WorldOpaqueDrawCount[c] = 0;
+	m_WorldDepthMergedFirst[c] = 0;
+	m_WorldDepthMergedCount[c] = 0;
 	if ( uint8_t* argPtr = m_WorldDrawArgsPtr[c][m_E->m_FrameIndex] ) {
 		auto* cmds = reinterpret_cast<D3D12GraphicsEngine::WorldDrawCommand*>( argPtr );
 		UINT drawCount = 0;
@@ -1031,6 +1034,10 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
 		// staged in normal RAM rather than compacted inside the write-combined UPLOAD ring.)
 		thread_local std::vector<D3D12GraphicsEngine::WorldDrawCommand> alphaCmds;
 		alphaCmds.clear();
+		// Opaque commands mirrored into normal RAM for the depth-only draw-call merge below — see
+		// D3D12GraphicsEngine::CoalesceWorldDepthCommands. thread_local for the same reason alphaCmds is.
+		thread_local std::vector<D3D12GraphicsEngine::WorldDrawCommand> opaqueCmds;
+		opaqueCmds.clear();
 		for ( const ShadowWorldCaster& caster : g_WorldCasters ) {
 			if ( !Engine::GAPI->IsWorldMeshVisibleInFrustum( caster.mesh, frustum ) ) continue;
 			if ( drawCount + alphaCmds.size() >= D3D12GraphicsEngine::kMaxWorldDrawCommands ) break;
@@ -1047,8 +1054,8 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
 			cmd.Draw.StartIndexLocation = caster.startIndex;
 			cmd.Draw.BaseVertexLocation = 0;
 			cmd.Draw.StartInstanceLocation = 0;
-			if ( caster.alphaTested ) alphaCmds.push_back( cmd );
-			else                      cmds[drawCount++] = cmd;
+			if ( caster.alphaTested ) { alphaCmds.push_back( cmd ); }
+			else                      { cmds[drawCount++] = cmd; opaqueCmds.push_back( cmd ); }
 		}
 		m_WorldOpaqueDrawCount[c] = drawCount;
 		if ( !alphaCmds.empty() ) {
@@ -1057,6 +1064,16 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
 			drawCount += static_cast<UINT>( alphaCmds.size() );
 		}
 		m_WorldDrawCount[c] = drawCount;
+
+		// Coalesce the opaque prefix for this cascade's PS-less caster run, appended past the per-material
+		// set (see m_WorldDepthMergedFirst). Same wrapped world IB as the main view, so the same merge holds;
+		// the far cascade is where it pays most (it accepts nearly every section, so its opaque casters are
+		// long contiguous index runs). Pool-thread safe: touches only this cascade's ring and counters.
+		m_WorldDepthMergedFirst[c] = drawCount;
+		m_WorldDepthMergedCount[c] = ( drawCount < D3D12GraphicsEngine::kMaxWorldDrawCommands )
+			? D3D12GraphicsEngine::CoalesceWorldDepthCommands( opaqueCmds, cmds + drawCount,
+				D3D12GraphicsEngine::kMaxWorldDrawCommands - drawCount )
+			: 0;
 	}
 
 	// --- Instanced VOBs: collect this cascade's visible set. The instance-ring upload + indirect-arg build
@@ -1191,7 +1208,15 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 			cmdList->ExecuteIndirect( m_E->m_WorldIndirectCmdSig.Get(), m_WorldDrawCount[c],
 				m_WorldDrawArgs[c][frame].Get(), 0, nullptr, 0 );
 		} else {
-			if ( m_WorldOpaqueDrawCount[c] > 0 ) {
+			// Prefer the coalesced mirror of the opaque prefix (see m_WorldDepthMergedFirst): identical index
+			// coverage in far fewer commands, and this run binds no pixel shader, so the per-material b6
+			// constants it drops are dead.
+			if ( m_WorldDepthMergedCount[c] > 0 ) {
+				cmdList->ExecuteIndirect( m_E->m_WorldIndirectCmdSig.Get(), m_WorldDepthMergedCount[c],
+					m_WorldDrawArgs[c][frame].Get(),
+					static_cast<UINT64>( m_WorldDepthMergedFirst[c] ) * sizeof( D3D12GraphicsEngine::WorldDrawCommand ),
+					nullptr, 0 );
+			} else if ( m_WorldOpaqueDrawCount[c] > 0 ) {
 				cmdList->ExecuteIndirect( m_E->m_WorldIndirectCmdSig.Get(), m_WorldOpaqueDrawCount[c],
 					m_WorldDrawArgs[c][frame].Get(), 0, nullptr, 0 );
 			}

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -52,6 +52,10 @@ namespace {
         uint32_t diffuseIdx;          // bindless SRV slot for PSShadowClip's alpha cutout
         UINT     indexCount;
         UINT     startIndex;
+        // Can PSShadowClip's `clip(diffuse.a - 0.5)` ever discard for this material? If not, the caster is
+        // drawn by the no-pixel-shader PSO instead (double-rate depth). Resolved on the main thread in
+        // Phase A alongside diffuseIdx; CullCascade uses it to partition each cascade's command set.
+        bool     alphaTested;
     };
     std::vector<ShadowWorldCaster> g_WorldCasters;
 
@@ -227,6 +231,17 @@ bool D3D12ShadowMap::Init() {
 		LogWarn() << "D3D12: CreateGraphicsPipelineState failed (shadow caster).";
 		return false;
 	}
+	// No-pixel-shader twin for the casters that need no cutout — see m_CasterWorldNoAlphaPSO. These are already
+	// NumRenderTargets=0 / void-PS PSOs, so dropping the PS entirely is a one-field change. Non-fatal.
+	{
+		D3D12_GRAPHICS_PIPELINE_STATE_DESC noAlpha = pso;
+		noAlpha.PS = {};
+		if ( FAILED( device->CreateGraphicsPipelineState( &noAlpha, IID_PPV_ARGS( m_CasterWorldNoAlphaPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+			LogWarn() << "D3D12: CreateGraphicsPipelineState failed (shadow caster, no-alpha) — "
+			             "world casters keep alpha-clipping every material.";
+			m_CasterWorldNoAlphaPSO.Reset();
+		}
+	}
 
 	// VOB caster PSO (P2.9c-2): reuse the VOB depth-prepass VSDepth (two-stream: packed vertex + per-instance
 	// world matrix) + m_Pipelines.World.RootSig, with the same caster state (front cull, bias, LESS_EQUAL, no RTV). Also
@@ -269,6 +284,14 @@ bool D3D12ShadowMap::Init() {
 			LogWarn() << "D3D12: CreateGraphicsPipelineState failed (VOB shadow caster, indirect).";
 			return false;
 		}
+		{
+			D3D12_GRAPHICS_PIPELINE_STATE_DESC noAlpha = pso;
+			noAlpha.PS = {};
+			if ( FAILED( device->CreateGraphicsPipelineState( &noAlpha, IID_PPV_ARGS( m_CasterVobIndirectNoAlphaPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+				LogWarn() << "D3D12: CreateGraphicsPipelineState failed (VOB shadow caster, no-alpha).";
+				m_CasterVobIndirectNoAlphaPSO.Reset();
+			}
+		}
 	}
 
 	// Node-attachment CSM caster variant (VSDepthAttach: Fatness/Scaling inflate-along-normal instead of wind —
@@ -297,6 +320,14 @@ bool D3D12ShadowMap::Init() {
 			LogWarn() << "D3D12: CreateGraphicsPipelineState failed (VOB attachment shadow caster).";
 			return false;
 		}
+		{
+			D3D12_GRAPHICS_PIPELINE_STATE_DESC noAlpha = pso;
+			noAlpha.PS = {};
+			if ( FAILED( device->CreateGraphicsPipelineState( &noAlpha, IID_PPV_ARGS( m_CasterVobAttachNoAlphaPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+				LogWarn() << "D3D12: CreateGraphicsPipelineState failed (VOB attachment shadow caster, no-alpha).";
+				m_CasterVobAttachNoAlphaPSO.Reset();
+			}
+		}
 	}
 
 	// Skeletal caster PSO (P2.9c-2): reuse the skeletal depth-prepass VSDepth (matrix-palette skinning) +
@@ -322,6 +353,14 @@ bool D3D12ShadowMap::Init() {
 		if ( FAILED( device->CreateGraphicsPipelineState( &pso, IID_PPV_ARGS( m_CasterSkeletalPSO.ReleaseAndGetAddressOf() ) ) ) ) {
 			LogWarn() << "D3D12: CreateGraphicsPipelineState failed (skeletal shadow caster).";
 			return false;
+		}
+		{
+			D3D12_GRAPHICS_PIPELINE_STATE_DESC noAlpha = pso;
+			noAlpha.PS = {};
+			if ( FAILED( device->CreateGraphicsPipelineState( &noAlpha, IID_PPV_ARGS( m_CasterSkeletalNoAlphaPSO.ReleaseAndGetAddressOf() ) ) ) ) {
+				LogWarn() << "D3D12: CreateGraphicsPipelineState failed (skeletal shadow caster, no-alpha).";
+				m_CasterSkeletalNoAlphaPSO.Reset();
+			}
 		}
 	}
 	return true;
@@ -799,8 +838,11 @@ void D3D12ShadowMap::Prepare() {
 					}
 				}
 
+				const bool alphaTested = ( tex && tex->HasAlphaChannel() )
+					|| meshKey.Material->HasAlphaTest();
+
 				g_WorldCasters.push_back( { mesh, diffuseIdx,
-					static_cast<UINT>( mesh->Indices.size() ), mesh->BaseIndexLocation } );
+					static_cast<UINT>( mesh->Indices.size() ), mesh->BaseIndexLocation, alphaTested } );
 			}
 		}
 	}
@@ -957,7 +999,8 @@ void D3D12ShadowMap::BuildCascade( UINT cascade ) {
 	// shadowCascade=c: cascade 0 keeps full-detail casters (it covers what the player is standing in),
 	// the outer cascades draw the baked progressive-mesh LOD instead — same command count, fewer triangles.
 	m_VobDrawCount[c] = m_E->BuildVobDrawCommands( cascadeUploads, m_VobDrawArgsPtr[c][frame], false,
-		D3D12GraphicsEngine::kMaxShadowVobDrawCommands, false, false, static_cast<int>( c ) );
+		D3D12GraphicsEngine::kMaxShadowVobDrawCommands, false, false, static_cast<int>( c ),
+		&m_VobOpaqueDrawCount[c] );
 }
 
 
@@ -977,15 +1020,22 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
 
 	// --- World mesh: bbox-test the pre-resolved caster set into this cascade's ExecuteIndirect arg buffer ---
 	m_WorldDrawCount[c] = 0;
+	m_WorldOpaqueDrawCount[c] = 0;
 	if ( uint8_t* argPtr = m_WorldDrawArgsPtr[c][m_E->m_FrameIndex] ) {
 		auto* cmds = reinterpret_cast<D3D12GraphicsEngine::WorldDrawCommand*>( argPtr );
 		UINT drawCount = 0;
 		const uint32_t defaultOrm = m_E->GetDefaultOrmSrvSlot();
+		// Alpha-test partition: no-cutout casters go straight into the ring, the rest are staged and appended
+		// after the loop so RecordCascade can draw the leading run with no pixel shader bound. thread_local —
+		// one CullCascade per cascade runs concurrently on the pool. (Same scheme as BuildWorldDrawCommands;
+		// staged in normal RAM rather than compacted inside the write-combined UPLOAD ring.)
+		thread_local std::vector<D3D12GraphicsEngine::WorldDrawCommand> alphaCmds;
+		alphaCmds.clear();
 		for ( const ShadowWorldCaster& caster : g_WorldCasters ) {
 			if ( !Engine::GAPI->IsWorldMeshVisibleInFrustum( caster.mesh, frustum ) ) continue;
-			if ( drawCount >= D3D12GraphicsEngine::kMaxWorldDrawCommands ) break;
+			if ( drawCount + alphaCmds.size() >= D3D12GraphicsEngine::kMaxWorldDrawCommands ) break;
 
-			auto& cmd = cmds[drawCount++];
+			D3D12GraphicsEngine::WorldDrawCommand cmd{};
 			cmd.MatNormalIndex = 0xFFFFFFFFu;
 			cmd.MatOrmIndex = defaultOrm;
 			cmd.MatDiffuseIndex = caster.diffuseIdx;
@@ -997,6 +1047,14 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
 			cmd.Draw.StartIndexLocation = caster.startIndex;
 			cmd.Draw.BaseVertexLocation = 0;
 			cmd.Draw.StartInstanceLocation = 0;
+			if ( caster.alphaTested ) alphaCmds.push_back( cmd );
+			else                      cmds[drawCount++] = cmd;
+		}
+		m_WorldOpaqueDrawCount[c] = drawCount;
+		if ( !alphaCmds.empty() ) {
+			std::memcpy( cmds + drawCount, alphaCmds.data(),
+				alphaCmds.size() * sizeof( D3D12GraphicsEngine::WorldDrawCommand ) );
+			drawCount += static_cast<UINT>( alphaCmds.size() );
 		}
 		m_WorldDrawCount[c] = drawCount;
 	}
@@ -1111,7 +1169,11 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 		DX_ZONE( cmdList.Get(), "World Mesh" );
 		TracyD3D12ZoneCGX( cmdList.Get(), "World Mesh" );
 
-		cmdList->SetPipelineState( m_CasterWorldPSO.Get() );
+		// Split at the alpha-test partition CullCascade laid out: the leading opaque run needs no cutout, so it
+		// draws with no pixel shader bound (double-rate depth); only the tail pays for PSShadowClip.
+		const bool splitAlpha = m_CasterWorldNoAlphaPSO != nullptr;
+
+		cmdList->SetPipelineState( splitAlpha ? m_CasterWorldNoAlphaPSO.Get() : m_CasterWorldPSO.Get() );
 		cmdList->SetGraphicsRootSignature( m_E->m_Pipelines.World.RootSig.Get() );
 		cmdList->SetGraphicsRoot32BitConstants( 0, 16, &m_CascadeViewProj[c], 0 );
 
@@ -1120,8 +1182,22 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 		cmdList->IASetVertexBuffers( 0, 1, &vbv );
 		cmdList->IASetIndexBuffer( &ibv );
 
-		cmdList->ExecuteIndirect( m_E->m_WorldIndirectCmdSig.Get(), m_WorldDrawCount[c],
-			m_WorldDrawArgs[c][frame].Get(), 0, nullptr, 0 );
+		if ( !splitAlpha ) {
+			cmdList->ExecuteIndirect( m_E->m_WorldIndirectCmdSig.Get(), m_WorldDrawCount[c],
+				m_WorldDrawArgs[c][frame].Get(), 0, nullptr, 0 );
+		} else {
+			if ( m_WorldOpaqueDrawCount[c] > 0 ) {
+				cmdList->ExecuteIndirect( m_E->m_WorldIndirectCmdSig.Get(), m_WorldOpaqueDrawCount[c],
+					m_WorldDrawArgs[c][frame].Get(), 0, nullptr, 0 );
+			}
+			if ( m_WorldDrawCount[c] > m_WorldOpaqueDrawCount[c] ) {
+				cmdList->SetPipelineState( m_CasterWorldPSO.Get() );
+				cmdList->ExecuteIndirect( m_E->m_WorldIndirectCmdSig.Get(),
+					m_WorldDrawCount[c] - m_WorldOpaqueDrawCount[c], m_WorldDrawArgs[c][frame].Get(),
+					static_cast<UINT64>( m_WorldOpaqueDrawCount[c] ) * sizeof( D3D12GraphicsEngine::WorldDrawCommand ),
+					nullptr, 0 );
+			}
+		}
 	}
 
 	// --- Instanced VOBs: one ExecuteIndirect over the command set Phase C built for this cascade ---
@@ -1129,12 +1205,29 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 		&& m_VobDrawArgs[c][frame] ) {
 		DX_ZONE( cmdList.Get(), "Vobs" );
 		TracyD3D12ZoneCGX( cmdList.Get(), "Vobs" );
-		cmdList->SetPipelineState( m_CasterVobIndirectPSO.Get() );
+		// Same alpha-test split as the world casters above — BuildVobDrawCommands partitioned this cascade's
+		// command set (its outOpaqueCount landed in m_VobOpaqueDrawCount[c]).
+		const bool splitAlpha = m_CasterVobIndirectNoAlphaPSO != nullptr;
+		cmdList->SetPipelineState( splitAlpha ? m_CasterVobIndirectNoAlphaPSO.Get() : m_CasterVobIndirectPSO.Get() );
 		cmdList->SetGraphicsRootSignature( m_E->m_Pipelines.World.RootSig.Get() );
 		cmdList->SetGraphicsRoot32BitConstants( 0, 16, &m_CascadeViewProj[c], 0 );
 		cmdList->SetGraphicsRoot32BitConstants( 11, 12, &m_E->m_WindBuffer, 0 );   // b4 frame-global wind baseline
-		cmdList->ExecuteIndirect( m_E->m_VobIndirectCmdSig.Get(), m_VobDrawCount[c],
-			m_VobDrawArgs[c][frame].Get(), 0, nullptr, 0 );
+		if ( !splitAlpha ) {
+			cmdList->ExecuteIndirect( m_E->m_VobIndirectCmdSig.Get(), m_VobDrawCount[c],
+				m_VobDrawArgs[c][frame].Get(), 0, nullptr, 0 );
+		} else {
+			if ( m_VobOpaqueDrawCount[c] > 0 ) {
+				cmdList->ExecuteIndirect( m_E->m_VobIndirectCmdSig.Get(), m_VobOpaqueDrawCount[c],
+					m_VobDrawArgs[c][frame].Get(), 0, nullptr, 0 );
+			}
+			if ( m_VobDrawCount[c] > m_VobOpaqueDrawCount[c] ) {
+				cmdList->SetPipelineState( m_CasterVobIndirectPSO.Get() );
+				cmdList->ExecuteIndirect( m_E->m_VobIndirectCmdSig.Get(),
+					m_VobDrawCount[c] - m_VobOpaqueDrawCount[c], m_VobDrawArgs[c][frame].Get(),
+					static_cast<UINT64>( m_VobOpaqueDrawCount[c] ) * sizeof( D3D12GraphicsEngine::VobDrawCommand ),
+					nullptr, 0 );
+			}
+		}
 	}
 
 	// --- Skinned skeletals (root sig: m_Pipelines.Skeletal.RootSig; b0 cascade view-proj, b1 instance, b2 bones) ---
@@ -1142,7 +1235,14 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 		DX_ZONE( cmdList.Get(), "Skeletals" );
 		TracyD3D12ZoneCGX( cmdList.Get(), "Skeletals" );
 
-		cmdList->SetPipelineState( m_CasterSkeletalPSO.Get() );
+		// Per-material PSO choice rather than a partitioned command set: this is a CPU draw loop, not an
+		// ExecuteIndirect, so switching only when the flag actually flips is cheaper than reordering the
+		// records. boundPso tracks which of the two is currently set (nothing assumed bound at the start).
+		ID3D12PipelineState* const skelClipPso = m_CasterSkeletalPSO.Get();
+		ID3D12PipelineState* const skelNoAlphaPso = m_CasterSkeletalNoAlphaPSO ? m_CasterSkeletalNoAlphaPSO.Get()
+		                                                                      : skelClipPso;
+		ID3D12PipelineState* boundPso = nullptr;
+
 		cmdList->SetGraphicsRootSignature( m_E->m_Pipelines.Skeletal.RootSig.Get() );
 		cmdList->SetGraphicsRoot32BitConstants( 0, 16, &m_CascadeViewProj[c], 0 );
 		for ( const FrameSkelDraw& d : SkelDraws[c] ) {
@@ -1151,16 +1251,24 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 			// snapshotted on the main thread right after ITS UpdateMeshLibTexAniState (see
 			// [[skeletal-texani-shared-slots]] and g_SkelMatSrvs) — calling it here would both be wrong for a
 			// second instance of the same model and unsafe from a pool thread.
-			const std::vector<UINT>* matSrvs =
+			const std::vector<SkelMatSlot>* matSrvs =
 				(d.matSrvIndex < g_SkelMatSrvCount) ? &g_SkelMatSrvs[d.matSrvIndex] : nullptr;
 
 			cmdList->SetGraphicsRootConstantBufferView( 1, d.instCb );
 			cmdList->SetGraphicsRootConstantBufferView( 2, d.boneCb );
 			size_t matIdx = 0;
 			for ( auto const& [mat, meshList] : d.visual->SkeletalMeshes ) {
-				const UINT diffuseSlot = (matSrvs && matIdx < matSrvs->size())
-					? (*matSrvs)[matIdx] : blackSlot;
+				const bool haveSlot = matSrvs && matIdx < matSrvs->size();
+				const UINT diffuseSlot = haveSlot ? (*matSrvs)[matIdx].slot : blackSlot;
+				// No snapshot for this material -> assume it clips (the conservative side: a missed cutout is a
+				// visible solid shadow, a needless clip is only slower).
+				const bool alphaTested = !haveSlot || (*matSrvs)[matIdx].alphaTested;
 				++matIdx;
+				ID3D12PipelineState* wantPso = alphaTested ? skelClipPso : skelNoAlphaPso;
+				if ( wantPso != boundPso ) {
+					cmdList->SetPipelineState( wantPso );
+					boundPso = wantPso;
+				}
 				// PSShadowClip reads only MatDiffuseIndex, the THIRD constant of the b6 MaterialCB (param 11) —
 				// push just that one at offset 2 rather than resolving normal/ORM maps the caster never samples.
 				cmdList->SetGraphicsRoot32BitConstant( 11, diffuseSlot, 2 );
@@ -1186,11 +1294,21 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 
 		// Attachment variant (Fatness/Scaling instead of wind, needs NORMAL) — must match the depth prepass/
 		// color pass PSO choice for the same reason the wind fix required it (bit-identical transform).
-		cmdList->SetPipelineState( m_CasterVobAttachPSO.Get() );
+		// Per-attachment PSO choice, same scheme as the skeletal loop above (CPU draw loop, so switch on flip).
+		ID3D12PipelineState* const attClipPso = m_CasterVobAttachPSO.Get();
+		ID3D12PipelineState* const attNoAlphaPso = m_CasterVobAttachNoAlphaPSO ? m_CasterVobAttachNoAlphaPSO.Get()
+		                                                                      : attClipPso;
+		ID3D12PipelineState* boundAttachPso = nullptr;
+
 		cmdList->SetGraphicsRootSignature( m_E->m_Pipelines.World.RootSig.Get() );
 		cmdList->SetGraphicsRoot32BitConstants( 0, 16, &m_CascadeViewProj[c], 0 );
 		for ( const FrameAttachDraw& a : AttachDraws[c] ) {
 			if ( !a.mesh || !a.mesh->GetMeshVertexBuffer() || !a.mesh->GetMeshIndexBuffer() ) continue;
+			ID3D12PipelineState* wantPso = a.alphaTested ? attClipPso : attNoAlphaPso;
+			if ( wantPso != boundAttachPso ) {
+				cmdList->SetPipelineState( wantPso );
+				boundAttachPso = wantPso;
+			}
 			D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( a.mesh->GetMeshVertexBuffer() );
 			D3D12VertexBuffer* mib = D3D12VertexBuffer::From( a.mesh->GetMeshIndexBuffer() );
 			if ( !mvb->GetResource() || !mib->GetResource() ) continue;

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -866,9 +866,9 @@ void D3D12ShadowMap::Prepare() {
 					{ ZoneScopedN( "Build shadow cascade" ); self->BuildCascade( cascade ); }
 					if ( !record ) return;
 					ZoneScopedN( "Record shadow cascade" );
-					ID3D12GraphicsCommandList* cl = self->m_E->BeginShadowList( cascade );
+					D3D12CmdList* cl = self->m_E->BeginShadowList( cascade );
 					if ( !cl ) return;   // slot unusable — FinishShadowPasses re-issues this cascade inline
-					self->RecordCascade( cascade, cl, self->m_SunUp );
+					self->RecordCascade( cascade, *cl, self->m_SunUp );
 					// Only a successfully closed list may be executed; a failed Close leaves it unusable.
 					self->m_E->m_ShadowListRecorded[cascade] = SUCCEEDED( cl->Close() );
 				}, this, c, recordInJob ).future );
@@ -1032,7 +1032,7 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
 }
 
 
-void D3D12ShadowMap::RecordCascade( UINT cascade, ID3D12GraphicsCommandList* cmdList, bool sunUp ) {
+void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool sunUp ) {
 	// Issues one cascade's caster draws into the command list it is handed (m_CmdList on the serial path, that
 	// cascade's own list on the MT path). Pool-thread safe for the same reason CullCascade is: it reads ONLY
 	// per-cascade state and values already resolved on the main thread — the arg buffers + counts, the
@@ -1052,8 +1052,8 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, ID3D12GraphicsCommandList* cmd
 		cmdList->SetDescriptorHeaps( 1, heaps );
 	}
 
-	DX_ZONE( cmdList, "Sun Shadow Cascade" );
-	TracyD3D12ZoneCGX( cmdList, "Sun Shadow Cascade" );
+	DX_ZONE( cmdList.Get(), "Sun Shadow Cascade" );
+	TracyD3D12ZoneCGX( cmdList.Get(), "Sun Shadow Cascade" );
 
 	cmdList->OMSetRenderTargets( 0, nullptr, FALSE, &dsv );   // DSV stays bound across the PSO switches below
 	cmdList->ClearDepthStencilView( dsv, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr );   // normal-Z far
@@ -1077,8 +1077,8 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, ID3D12GraphicsCommandList* cmd
 
 	// --- World mesh (root sig: m_Pipelines.World.RootSig; b0 = cascade view-proj; b6 bindless material) ---
 	if ( m_WorldDrawCount[c] > 0 && vb && ib && m_WorldDrawArgs[c][frame] ) {
-		DX_ZONE( cmdList, "World Mesh" );
-		TracyD3D12ZoneCGX( cmdList, "World Mesh" );
+		DX_ZONE( cmdList.Get(), "World Mesh" );
+		TracyD3D12ZoneCGX( cmdList.Get(), "World Mesh" );
 
 		cmdList->SetPipelineState( m_CasterWorldPSO.Get() );
 		cmdList->SetGraphicsRootSignature( m_E->m_Pipelines.World.RootSig.Get() );
@@ -1096,8 +1096,8 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, ID3D12GraphicsCommandList* cmd
 	// --- Instanced VOBs: one ExecuteIndirect over the command set Phase C built for this cascade ---
 	if ( m_VobDrawCount[c] > 0 && m_CasterVobIndirectPSO && m_E->m_VobIndirectCmdSig
 		&& m_VobDrawArgs[c][frame] ) {
-		DX_ZONE( cmdList, "Vobs" );
-		TracyD3D12ZoneCGX( cmdList, "Vobs" );
+		DX_ZONE( cmdList.Get(), "Vobs" );
+		TracyD3D12ZoneCGX( cmdList.Get(), "Vobs" );
 		cmdList->SetPipelineState( m_CasterVobIndirectPSO.Get() );
 		cmdList->SetGraphicsRootSignature( m_E->m_Pipelines.World.RootSig.Get() );
 		cmdList->SetGraphicsRoot32BitConstants( 0, 16, &m_CascadeViewProj[c], 0 );
@@ -1108,8 +1108,8 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, ID3D12GraphicsCommandList* cmd
 
 	// --- Skinned skeletals (root sig: m_Pipelines.Skeletal.RootSig; b0 cascade view-proj, b1 instance, b2 bones) ---
 	if ( m_CasterSkeletalPSO && m_E->m_Pipelines.Skeletal.RootSig && !SkelDraws[c].empty() ) {
-		DX_ZONE( cmdList, "Skeletals" );
-		TracyD3D12ZoneCGX( cmdList, "Skeletals" );
+		DX_ZONE( cmdList.Get(), "Skeletals" );
+		TracyD3D12ZoneCGX( cmdList.Get(), "Skeletals" );
 
 		cmdList->SetPipelineState( m_CasterSkeletalPSO.Get() );
 		cmdList->SetGraphicsRootSignature( m_E->m_Pipelines.Skeletal.RootSig.Get() );
@@ -1150,8 +1150,8 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, ID3D12GraphicsCommandList* cmd
 
 	// --- Node attachments (weapons/heads) through the VOB caster PSO (packed vertex + single instance) ---
 	if ( m_CasterVobAttachPSO && m_E->m_Pipelines.World.RootSig && !AttachDraws[c].empty() ) {
-		DX_ZONE( cmdList, "Skeletal Nodes" );
-		TracyD3D12ZoneCGX( cmdList, "Skeletal Nodes" );
+		DX_ZONE( cmdList.Get(), "Skeletal Nodes" );
+		TracyD3D12ZoneCGX( cmdList.Get(), "Skeletal Nodes" );
 
 		// Attachment variant (Fatness/Scaling instead of wind, needs NORMAL) — must match the depth prepass/
 		// color pass PSO choice for the same reason the wind fix required it (bit-identical transform).
@@ -1180,8 +1180,8 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, ID3D12GraphicsCommandList* cmd
 	// applies, t0 grass texture for the alpha-clip) — CULL_NONE caster, see CreateGrassCaster. The boxes were
 	// culled against this cascade's frustum in CullCascade; the CB was filled in Phase A. ---
 	if ( !g_GrassBoxes[c].empty() && m_CasterGrassPSO && m_E->m_Pipelines.Grass.RootSig ) {
-		DX_ZONE( cmdList, "Grass" );
-		TracyD3D12ZoneCGX( cmdList, "Grass" );
+		DX_ZONE( cmdList.Get(), "Grass" );
+		TracyD3D12ZoneCGX( cmdList.Get(), "Grass" );
 
 		bool grassBound = false;
 		for ( GVegetationBox* box : g_GrassBoxes[c] ) {
@@ -1222,7 +1222,7 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, ID3D12GraphicsCommandList* cmd
 }
 
 
-void D3D12ShadowMap::TransitionToReadState( ID3D12GraphicsCommandList* cmdList ) {
+void D3D12ShadowMap::TransitionToReadState( D3D12CmdList& cmdList ) {
 	// Hand the cascade array to PIXEL_SHADER_RESOURCE for the lit-pass PCF sampling; reverted at the top of next
 	// frame's Prepare(). (The point-shadow cube and the rain map do their own transition inside their own pass,
 	// which is self-contained in one list.)

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -154,6 +154,9 @@ bool D3D12ShadowMap::Resize( UINT newSize ) {
 
 	m_MapSize = newSize;
 	if ( !CreateTextureAndViews( m_MapSize ) ) return false;
+	// Fresh texture -> every slice's depth is gone, and the texel-snap grid changed with the resolution. Nothing
+	// may be frozen next frame; force a full re-render of all cascades.
+	m_CascadeMatricesValid = false;
 
 	LogInfo() << "D3D12: shadow map resized to " << m_MapSize << "x" << m_MapSize;
 	return true;
@@ -527,7 +530,20 @@ void D3D12ShadowMap::ComputeCascadeMatrices() {
 	const float lightDotUp = std::max( fabsf( XMVectorGetX( XMVector3Dot( lightDir, worldUp ) ) ), 0.05f );
 	const float dynamicPullback = std::clamp( 4000.0f / lightDotUp, 2000.0f, 15000.0f );
 
+	// Lazy update decision for this frame (see kLazyLastCascadeInterval). Resolved HERE, ahead of the per-cascade
+	// loop, because a frozen cascade must keep its matrices as well as its depth — recomputing the view-proj of a
+	// slice we are not going to re-render would make the lit pass sample last frame's depth with this frame's
+	// transform. Mirrors D3D11ShadowMap's frameCount-modulo gate.
+	++m_LazyFrameCounter;
+	const bool lazyUpdate = shadowDirSettings.DebugSettings.ShadowCascades.LazyCascadeUpdate && m_CascadeMatricesValid;
+	for ( UINT c = 0; c < kShadowCascades; ++c ) m_ShouldUpdateCascade[c] = true;
+	if ( lazyUpdate && kShadowCascades > 1 )
+		m_ShouldUpdateCascade[kShadowCascades - 1] = (m_LazyFrameCounter % kLazyLastCascadeInterval) == 0;
+	m_CascadeMatricesValid = true;
+
 	for ( UINT c = 0; c < kShadowCascades; ++c ) {
+		if ( !m_ShouldUpdateCascade[c] ) continue;   // frozen: keep m_CascadeViewProj/m_CascadeFrustum/m_CascadeTexelWorld
+
 		// 8 world-space corners of the camera frustum slice [splits[c], splits[c+1]].
 		XMFLOAT3 corners[8];
 		int ci = 0;
@@ -804,6 +820,11 @@ void D3D12ShadowMap::Prepare() {
 	if ( !sunUp ) {
 		// Nothing casts; each cascade still gets its slice cleared to far (= unshadowed) at record time. No cull
 		// jobs are launched, so FinishPrepare has nothing to wait for and skips Phase C outright.
+		// The lazy gate is overridden here: a frozen cascade skips its RecordCascade entirely, so at dusk the
+		// last cascade would keep the daytime depth it was frozen with for up to two more frames and go on
+		// shadowing after the sun set. Clearing is cheap — always do it.
+		for ( UINT c = 0; c < kShadowCascades; ++c ) m_ShouldUpdateCascade[c] = true;
+		m_CascadeMatricesValid = false;   // the frozen matrices no longer describe any rendered slice
 		for ( UINT c = 0; c < kShadowCascades; ++c ) {
 			m_WorldDrawCount[c] = 0;
 			m_VobDrawCount[c] = 0;
@@ -858,6 +879,10 @@ void D3D12ShadowMap::Prepare() {
 	g_CullJobs.clear();
 	if ( threadedCull ) {
 		for ( UINT c = 0; c < kShadowCascades; ++c ) {
+			// Lazily-frozen cascade: no cull, no build, no record — its slice already holds the depth that its
+			// (equally frozen) matrices describe. m_ShadowListRecorded[c] stays false, and RecordCascade's own
+			// gate keeps FinishShadowPasses' inline fallback from re-issuing it.
+			if ( !m_ShouldUpdateCascade[c] ) continue;
 			// (The flags were cleared at the top of this function, before ANY early-out — see there.)
 			g_CullJobs.push_back( Engine::RenderingThreadPool->enqueue(
 				[]( const std::stop_token& token, D3D12ShadowMap* self, UINT cascade, bool record ) {
@@ -876,6 +901,7 @@ void D3D12ShadowMap::Prepare() {
 		m_CullingPending = true;
 	} else {
 		for ( UINT c = 0; c < kShadowCascades; ++c ) {
+			if ( !m_ShouldUpdateCascade[c] ) continue;   // frozen — see the threaded branch above
 			CullCascade( c );
 			BuildCascade( c );
 		}
@@ -1040,6 +1066,11 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 	// (g_SkelMatSrvs / FrameAttachDraw::srv). No Gothic mutation, no UpdateMeshLibTexAniState, no ring writes.
 	if ( !cmdList || !m_DsvHeap ) return;
 	const UINT c = cascade;
+	// Lazily frozen this frame (see kLazyLastCascadeInterval): its slice keeps the depth it already holds and
+	// must NOT even be cleared. Gated here rather than only at the call sites so that every path reaching this
+	// function — the job, FinishShadowPasses' "recording was off" loop and its "the list failed to close"
+	// fallback — agrees, and none of them re-renders a cascade that was never culled or built this frame.
+	if ( !m_ShouldUpdateCascade[c] ) return;
 	const UINT frame = m_E->m_FrameIndex;
 
 	D3D12_CPU_DESCRIPTOR_HANDLE dsv = m_DsvHeap->GetCPUDescriptorHandleForHeapStart();

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -1081,12 +1081,14 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
 	ctx.cameraPosition = Engine::GAPI->GetCameraPosition();
 	ctx.stage = RenderStage::STAGE_DRAW_SHADOWS;
 	ctx.drawDistances.OutdoorVobs = std::max( 20000.0f, shadowDistance );
-	ctx.drawDistances.OutdoorVobsSmall = std::max( 20000.0f, shadowDistance );
-	ctx.drawDistances.IndoorVobs = std::max( 20000.0f, shadowDistance );
+	ctx.drawDistances.OutdoorVobsSmall = (c == 2) 
+        ? 0.0f // last cascade gets nothing
+        : std::max( 18000.0f, shadowDistance );
+    ctx.drawDistances.IndoorVobs = 0.0f; // why would we WANT to include Indoor vobs in the shadows?
 	ctx.drawDistances.VisualFX = 0.0f;
 	ctx.drawDistancesSq.OutdoorVobs = ctx.drawDistances.OutdoorVobs * ctx.drawDistances.OutdoorVobs;
 	ctx.drawDistancesSq.OutdoorVobsSmall = ctx.drawDistances.OutdoorVobsSmall * ctx.drawDistances.OutdoorVobsSmall;
-	ctx.drawDistancesSq.IndoorVobs = ctx.drawDistances.IndoorVobs * ctx.drawDistances.IndoorVobs;
+    ctx.drawDistancesSq.IndoorVobs = ctx.drawDistances.IndoorVobs * ctx.drawDistances.IndoorVobs;
 	ctx.drawDistancesSq.VisualFX = 0.0f;
 
 	ctx.drawFlags.DrawVOBs = rs.DrawVOBs;
@@ -1109,7 +1111,10 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
 			if ( !box || box->GetSpotCount() == 0 ) continue;
 			XMFLOAT3 bbMin, bbMax;
 			box->GetBoundingBox( &bbMin, &bbMax );
+
+            if ( Toolbox::ComputePointAABBDistance( ctx.cameraPosition, bbMin, bbMax ) > ctx.drawDistances.OutdoorVobsSmall ) continue;
 			if ( !frustum.Intersects( zTBBox3D{ bbMin, bbMax } ) ) continue;
+
 			g_GrassBoxes[c].push_back( box );
 		}
 	}

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -1029,9 +1029,8 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
 		UINT drawCount = 0;
 		const uint32_t defaultOrm = m_E->GetDefaultOrmSrvSlot();
 		// Alpha-test partition: no-cutout casters go straight into the ring, the rest are staged and appended
-		// after the loop so RecordCascade can draw the leading run with no pixel shader bound. thread_local —
-		// one CullCascade per cascade runs concurrently on the pool. (Same scheme as BuildWorldDrawCommands;
-		// staged in normal RAM rather than compacted inside the write-combined UPLOAD ring.)
+		// after the loop so RecordCascade can draw the leading run with no pixel shader bound. Same scheme as
+		// BuildWorldDrawCommands. thread_local — one CullCascade per cascade runs concurrently on the pool.
 		thread_local std::vector<D3D12GraphicsEngine::WorldDrawCommand> alphaCmds;
 		alphaCmds.clear();
 		// Opaque commands mirrored into normal RAM for the depth-only draw-call merge below — see
@@ -1065,10 +1064,9 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
 		}
 		m_WorldDrawCount[c] = drawCount;
 
-		// Coalesce the opaque prefix for this cascade's PS-less caster run, appended past the per-material
-		// set (see m_WorldDepthMergedFirst). Same wrapped world IB as the main view, so the same merge holds;
-		// the far cascade is where it pays most (it accepts nearly every section, so its opaque casters are
-		// long contiguous index runs). Pool-thread safe: touches only this cascade's ring and counters.
+		// Coalesce the opaque prefix for this cascade's PS-less caster run, appended past the per-material set
+		// (see m_WorldDepthMergedFirst). Same wrapped world IB as the main view, so the same merge holds; it
+		// pays most in the far cascade. Pool-thread safe: touches only this cascade's ring and counters.
 		m_WorldDepthMergedFirst[c] = drawCount;
 		m_WorldDepthMergedCount[c] = ( drawCount < D3D12GraphicsEngine::kMaxWorldDrawCommands )
 			? D3D12GraphicsEngine::CoalesceWorldDepthCommands( opaqueCmds, cmds + drawCount,
@@ -1146,10 +1144,8 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 	// (g_SkelMatSrvs / FrameAttachDraw::srv). No Gothic mutation, no UpdateMeshLibTexAniState, no ring writes.
 	if ( !cmdList || !m_DsvHeap ) return;
 	const UINT c = cascade;
-	// Lazily frozen this frame (see kLazyLastCascadeInterval): its slice keeps the depth it already holds and
-	// must NOT even be cleared. Gated here rather than only at the call sites so that every path reaching this
-	// function — the job, FinishShadowPasses' "recording was off" loop and its "the list failed to close"
-	// fallback — agrees, and none of them re-renders a cascade that was never culled or built this frame.
+	// Lazily frozen this frame (see kLazyLastCascadeInterval): its slice keeps the depth it holds and must NOT
+	// even be cleared. Gated here rather than at the call sites so every path into this function agrees.
 	if ( !m_ShouldUpdateCascade[c] ) return;
 	const UINT frame = m_E->m_FrameIndex;
 
@@ -1266,8 +1262,7 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 		TracyD3D12ZoneCGX( cmdList.Get(), "Skeletals" );
 
 		// Per-material PSO choice rather than a partitioned command set: this is a CPU draw loop, not an
-		// ExecuteIndirect, so switching only when the flag actually flips is cheaper than reordering the
-		// records. boundPso tracks which of the two is currently set (nothing assumed bound at the start).
+		// ExecuteIndirect, so switching when the flag flips is cheaper than reordering the records.
 		ID3D12PipelineState* const skelClipPso = m_CasterSkeletalPSO.Get();
 		ID3D12PipelineState* const skelNoAlphaPso = m_CasterSkeletalNoAlphaPSO ? m_CasterSkeletalNoAlphaPSO.Get()
 		                                                                      : skelClipPso;

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
@@ -31,6 +31,7 @@
 
 #include "../Frustum.h"
 #include "D3D12EngineCommon.h"
+#include "D3D12StateCache.h"
 #include "InstancingUtils.h"   // RenderView — the per-cascade visible-VOB collection target
 
 class D3D12GraphicsEngine;
@@ -88,7 +89,7 @@ public:
     void Prepare();
     void CullCascade( UINT cascade );
     void BuildCascade( UINT cascade );
-    void RecordCascade( UINT cascade, ID3D12GraphicsCommandList* cmdList, bool sunUp );
+    void RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool sunUp );
     // The single join point for the concurrent per-cascade jobs (mirrors D3D11ShadowMap::WaitShadowCullingComplete).
     void WaitCascadeJobs();
     // True when this frame's cascades recorded into their OWN command lists inside their jobs. False whenever
@@ -97,7 +98,7 @@ public:
     bool RecordedInJob() const { return m_RecordedInJob; }
     // Hand the cascade array to PIXEL_SHADER_RESOURCE for the lit-pass sampling (reverted at the top of the
     // next Prepare()). Issued on the main command list, after every cascade list has been executed.
-    void TransitionToReadState( ID3D12GraphicsCommandList* cmdList );
+    void TransitionToReadState( D3D12CmdList& cmdList );
 
     bool IsPassReady() const { return m_PassReady; }
     bool IsSunUp() const { return m_SunUp; }

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
@@ -102,6 +102,10 @@ public:
 
     bool IsPassReady() const { return m_PassReady; }
     bool IsSunUp() const { return m_SunUp; }
+    // False for a cascade that is being re-used from an earlier frame this frame (lazy update, see
+    // m_ShouldUpdateCascade). Such a cascade is neither culled, built nor recorded — its slice keeps the depth
+    // it already holds and its matrices stay frozen so the lit pass keeps sampling it correctly.
+    bool ShouldUpdateCascade( UINT cascade ) const { return m_ShouldUpdateCascade[cascade]; }
     // World-space direction TOWARD the sun (this frame, temporally smoothed). Read by the sky-IBL pass.
     const DirectX::XMFLOAT3& GetSunDirWS() const { return m_SunDirWS; }
     const Frustum* CascadeFrusta() const { return m_CascadeFrustum; }
@@ -178,6 +182,19 @@ private:
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_VobDrawArgsAlloc[kShadowCascades][kBackBufferMax];
     uint8_t* m_VobDrawArgsPtr[kShadowCascades][kBackBufferMax] = {};
     UINT     m_VobDrawCount[kShadowCascades] = {};   // built by FinishPrepare, consumed by RecordCascade
+
+    // Lazy cascade update (parity with D3D11ShadowMap's RendererSettings.DebugSettings.ShadowCascades.
+    // LazyCascadeUpdate): the LAST cascade covers the whole world and is by far the most expensive to cull and
+    // record, while also being the one where a two-frame-old shadow is least visible (it starts thousands of
+    // units out, at a couple of texels per caster). So it only refreshes every kLazyLastCascadeInterval-th
+    // frame; on the other frames its matrices, its frustum and its depth slice are all left exactly as they
+    // were, and the whole cull -> build -> record chain for it is skipped. Only valid because each cascade owns
+    // its own array slice and clears it itself in RecordCascade — skipping the record simply preserves the
+    // contents (this is why D3D11 has to disable the same optimization on its atlas path, which clears wholesale).
+    static constexpr size_t kLazyLastCascadeInterval = 3;
+    size_t m_LazyFrameCounter = 0;
+    bool m_ShouldUpdateCascade[kShadowCascades] = {};   // resolved in ComputeCascadeMatrices, read everywhere else
+    bool m_CascadeMatricesValid = false;                // first frame (and after a Resize) nothing may be frozen
 
     bool m_CullingPending = false;   // cascade jobs are in flight and must be joined before the results are read
     bool m_RecordedInJob = false;    // this frame's jobs also RECORDED (not just culled/built) — see RecordedInJob()

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
@@ -114,6 +114,10 @@ public:
     // through the engine's shared VOB command signature, so the two passes are byte-compatible.
     ID3D12PipelineState* GetWorldCasterPSO() const { return m_CasterWorldPSO.Get(); }
     ID3D12PipelineState* GetVobIndirectCasterPSO() const { return m_CasterVobIndirectPSO.Get(); }
+    // ...and their no-pixel-shader twins, for the leading opaque run of a partitioned caster command set.
+    // Null when PSO creation failed, in which case the caller submits everything through the clipping PSO.
+    ID3D12PipelineState* GetWorldCasterNoAlphaPSO() const { return m_CasterWorldNoAlphaPSO.Get(); }
+    ID3D12PipelineState* GetVobIndirectCasterNoAlphaPSO() const { return m_CasterVobIndirectNoAlphaPSO.Get(); }
 
     // ---- Per-cascade caster records, filled by the engine's shared collectors ----
     // The skeletal/attachment records are written by D3D12GraphicsEngine::PrepareFrameSkeletals (multi-cascade
@@ -155,6 +159,16 @@ private:
     Microsoft::WRL::ComPtr<ID3D12PipelineState> m_CasterVobAttachPSO;
     Microsoft::WRL::ComPtr<ID3D12PipelineState> m_CasterSkeletalPSO;
     Microsoft::WRL::ComPtr<ID3DBlob>            m_CasterSkeletalPsBlob;
+    // NO-PIXEL-SHADER caster twins (`PS = {}`) of the four above. A caster whose diffuse has no alpha channel
+    // cannot be clipped by PSShadowClip's `clip(a - 0.5)` — binding a PS that merely *might* discard costs the
+    // whole draw the hardware's double-rate depth-only path, over three cascades plus the rain map plus the
+    // point-shadow cubes. Every caster list is partitioned opaque-first so each pass can submit the leading
+    // run through these and only the tail through the clipping PSOs. Mirror of the main-view
+    // World.DepthPrepassNoAlphaPSO family; likewise optional (null => no split, everything clips as before).
+    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_CasterWorldNoAlphaPSO;
+    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_CasterVobIndirectNoAlphaPSO;
+    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_CasterVobAttachNoAlphaPSO;
+    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_CasterSkeletalNoAlphaPSO;
     // CULL_NONE (not front-cull): grass cards are thin double-sided planes, matching Grass.PSO's own culling.
     Microsoft::WRL::ComPtr<ID3D12PipelineState> m_CasterGrassPSO;
     Microsoft::WRL::ComPtr<ID3DBlob>            m_CasterGrassVsBlob;   // VSDepth (Vegetation.hlsl)
@@ -177,11 +191,14 @@ private:
     uint8_t*                  m_WorldDrawArgsPtr[kShadowCascades][kBackBufferMax] = {};
     D3D12_GPU_VIRTUAL_ADDRESS m_WorldDrawArgsGpu[kShadowCascades][kBackBufferMax] = {};
     UINT                      m_WorldDrawCount[kShadowCascades] = {};
+    // Alpha-test partition point: [0, opaque) needs no cutout, [opaque, total) does. See m_CasterWorldNoAlphaPSO.
+    UINT                      m_WorldOpaqueDrawCount[kShadowCascades] = {};
     // Per-cascade instanced-VOB arg rings — the VOB analogue of the above (engine sig m_VobIndirectCmdSig).
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_VobDrawArgs[kShadowCascades][kBackBufferMax];
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_VobDrawArgsAlloc[kShadowCascades][kBackBufferMax];
     uint8_t* m_VobDrawArgsPtr[kShadowCascades][kBackBufferMax] = {};
     UINT     m_VobDrawCount[kShadowCascades] = {};   // built by FinishPrepare, consumed by RecordCascade
+    UINT     m_VobOpaqueDrawCount[kShadowCascades] = {};   // alpha-test partition — see m_WorldOpaqueDrawCount
 
     // Lazy cascade update (parity with D3D11ShadowMap's RendererSettings.DebugSettings.ShadowCascades.
     // LazyCascadeUpdate): the LAST cascade covers the whole world and is by far the most expensive to cull and

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
@@ -193,6 +193,12 @@ private:
     UINT                      m_WorldDrawCount[kShadowCascades] = {};
     // Alpha-test partition point: [0, opaque) needs no cutout, [opaque, total) does. See m_CasterWorldNoAlphaPSO.
     UINT                      m_WorldOpaqueDrawCount[kShadowCascades] = {};
+    // Coalesced mirror of that opaque prefix, appended past m_WorldDrawCount in the same ring — see
+    // D3D12GraphicsEngine::m_WorldDepthMergedFirst. Nothing else reads a cascade's ring, but keeping the
+    // per-material prefix intact keeps the two build sites identical and leaves the fallback available.
+    // 0 = not built (no tail room); RecordCascade then submits the per-material prefix instead.
+    UINT                      m_WorldDepthMergedFirst[kShadowCascades] = {};
+    UINT                      m_WorldDepthMergedCount[kShadowCascades] = {};
     // Per-cascade instanced-VOB arg rings — the VOB analogue of the above (engine sig m_VobIndirectCmdSig).
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_VobDrawArgs[kShadowCascades][kBackBufferMax];
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_VobDrawArgsAlloc[kShadowCascades][kBackBufferMax];

--- a/D3D11Engine/D3D12Engine/D3D12Sky.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Sky.cpp
@@ -248,7 +248,7 @@ bool D3D12GraphicsEngine::DrawAtmosphereSkyDome() {
 
     // Own marker inside DrawSky's — this is the pass whose cost is being compared against the
     // fixed-function sky it replaces, so it needs to be separable in a capture.
-    DX_ZONE( m_CmdList, "Sky dome (scattering)" );
+    DX_ZONE( m_CmdList.Get(), "Sky dome (scattering)" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Sky dome (scattering)" );
 
     const AtmosphereConstantBuffer& atmo = sky->GetAtmosphereCB();

--- a/D3D11Engine/D3D12Engine/D3D12SkyIbl.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12SkyIbl.cpp
@@ -334,7 +334,7 @@ void D3D12GraphicsEngine::RenderSkyIBL() {
         || std::fabs( p.SunIntensity - m_SkyLastParams.SunIntensity ) > 0.01f;
     if ( !dirty ) return;
 
-    DX_ZONE( m_CmdList, "Sky IBL" );
+    DX_ZONE( m_CmdList.Get(), "Sky IBL" );
 
     // --- Pass 1: analytic radiance -> env cube mip 0 -------------------------------------------------------
     // BOTH cubes go back to UNORDERED_ACCESS: the flag covers the pair because the tail of this function

--- a/D3D11Engine/D3D12Engine/D3D12StateCache.h
+++ b/D3D11Engine/D3D12Engine/D3D12StateCache.h
@@ -1,0 +1,506 @@
+#pragma once
+#include <d3d12.h>
+#include <wrl/client.h>
+#include <cstdint>
+#include <cstring>
+
+// Engine-wide redundant-state filter for the D3D12 backend.
+//
+// WHY THIS EXISTS
+// ---------------
+// Gothic's fixed-function draw stream (the D3D7 wrapper: 2D UI, HUD, sky, every DrawString glyph run)
+// funnels through SubmitUIDraw, which re-issued the FULL bind set per draw — PSO, root signature, 4+36
+// root 32-bit constants, a descriptor table, viewport, scissor, topology and the VB view — even when
+// nothing but the vertex buffer had changed between two consecutive draws. A Gothic menu frame is
+// hundreds of such draws, and this is a 32-bit, CPU-bound process where driver-side root-signature and
+// PSO changes are among the most expensive per-draw calls there are. The 3D passes have the same shape
+// (a per-material loop that re-binds the pass-constant set every iteration).
+//
+// D3D12CmdList wraps ONE ID3D12GraphicsCommandList and drops any state-setting call whose arguments
+// match what that list already carries. It is a drop-in replacement for the ComPtr it displaces:
+// `operator->` returns `this`, so every existing `m_CmdList->SetPipelineState(...)` call site keeps
+// compiling and silently becomes cached. That is deliberate — a cache that can be bypassed by an
+// un-migrated call site is a cache that goes stale and renders garbage, so the ONLY way to reach the
+// tracked methods is through the filter. Untracked calls (draws, dispatches, barriers, copies, clears)
+// are plain forwarders; none of them disturb pipeline state on D3D12.
+//
+// If a future call site needs a command-list method that isn't here, it won't compile — add a
+// forwarder (or, if it mutates tracked state, a cached setter). Do NOT reach around via Get().
+//
+// CORRECTNESS RULES ENCODED HERE (D3D12 spec)
+// -------------------------------------------
+//   * Reset() drops ALL command-list state -> the whole shadow is cleared.
+//   * Setting a root signature invalidates every root argument of that pipeline type. So a CHANGED
+//     root signature clears that space's root-argument shadow; an unchanged one is skipped outright
+//     and the shadow (correctly) survives.
+//   * Setting a PSO does NOT invalidate root arguments, and a PSO whose embedded root signature
+//     differs from the bound one does NOT implicitly change the bound root signature. PSO and root
+//     signature are therefore tracked independently.
+//   * Changing the bound descriptor heaps makes previously-set descriptor TABLES stale, so a heap
+//     change clears the table entries in both root-argument spaces (root CBV/SRV/UAVs and root
+//     constants are heap-independent and survive).
+//   * Rebinding an identical descriptor table / root descriptor is a true no-op even if the
+//     descriptor or the buffer contents changed in between: with volatile ranges the GPU reads both
+//     at execute time, and with the DATA_STATIC_WHILE_SET_AT_EXECUTE ranges D3D12RootLayout declares,
+//     mutating the data while the binding is set is already a contract violation independent of this
+//     cache. Nothing new is broken by skipping the second Set.
+//
+// ANYTHING THAT RECORDS STATE BEHIND THE WRAPPER'S BACK MUST CALL InvalidateAll(). In this backend
+// that is exactly one thing: imgui_impl_dx12, which sets its own PSO, root signature, heaps, RTs,
+// viewport and topology on the raw pointer (see D3D12GraphicsEngine::Present).
+//
+// THREADING: no locking. One wrapper belongs to one command list, and a command list may only ever be
+// recorded by one thread at a time — so the MT shadow-cascade recorders each get their own wrapper
+// (m_ShadowCmdLists) and never touch the main list's. Same rule the D3D12 API itself imposes.
+class D3D12CmdList {
+public:
+    // Root-parameter capacity. The widest layout in the backend uses index 13 (D3D12PipelineState.cpp);
+    // 20 leaves headroom without making the shadow big. Anything past it falls through UNCACHED rather
+    // than corrupting the shadow (see the bounds checks in the setters).
+    static constexpr UINT kMaxRootParams = 20;
+    // Widest root-constant block: GothicGraphicsState = 144 bytes = 36 DWORDs (the FF/UI pipe constants).
+    // 48 leaves headroom and keeps the valid-mask a single uint64_t. Sizing matters a little here: the
+    // constant shadow dominates the object (kMaxRootParams * kMaxRootConstDwords * 4 * 2 pipeline types
+    // ~= 7.7 KB), and one of these exists per shadow-recording slot per frame-in-flight — ~150 KB total,
+    // which is affordable under the 32-bit budget but not worth inflating for no reason.
+    static constexpr UINT kMaxRootConstDwords = 48;
+    static constexpr UINT kMaxVertexSlots = 4;
+    static constexpr UINT kMaxRenderTargets = 8;
+    static constexpr UINT kMaxDescriptorHeaps = 2;
+
+    // Redundant-call counters, for eyeballing the win in a debug overlay / log. Cheap enough to keep
+    // unconditional (one increment per filtered call, against a saved driver call).
+    struct Stats {
+        uint32_t Issued = 0;
+        uint32_t Filtered = 0;
+        void Reset() { Issued = 0; Filtered = 0; }
+    };
+
+    D3D12CmdList() = default;
+    D3D12CmdList( const D3D12CmdList& ) = delete;
+    D3D12CmdList& operator=( const D3D12CmdList& ) = delete;
+
+    // ---- ComPtr-compatible surface -------------------------------------------------------------
+    // Lets the member keep reading like the ComPtr<ID3D12GraphicsCommandList> it replaced.
+    ID3D12GraphicsCommandList* Get() const noexcept { return m_List.Get(); }
+    explicit operator bool() const noexcept { return m_List != nullptr; }
+    D3D12CmdList* operator->() noexcept { return this; }
+    const D3D12CmdList* operator->() const noexcept { return this; }
+
+    ID3D12GraphicsCommandList** ReleaseAndGetAddressOf() noexcept {
+        InvalidateAll();
+        return m_List.ReleaseAndGetAddressOf();
+    }
+    // Adopt a list created elsewhere (the per-slot shadow lists are created into ComPtrs by
+    // CreateShadowRecordCommandLists and handed here).
+    void Attach( ID3D12GraphicsCommandList* list ) noexcept {
+        InvalidateAll();
+        m_List = list;
+    }
+
+    const Stats& GetStats() const noexcept { return m_Stats; }
+    void ResetStats() noexcept { m_Stats.Reset(); }
+
+    // ---- Shadow control ------------------------------------------------------------------------
+    /** Forget everything the wrapper believes about this list. Call after ANY code path records
+        state on the raw pointer (imgui_impl_dx12 is the only one in this backend). */
+    void InvalidateAll() noexcept {
+        m_PSO = nullptr;
+        m_GfxRootSig = nullptr;
+        m_ComputeRootSig = nullptr;
+        m_NumHeaps = 0;
+        m_Heaps[0] = m_Heaps[1] = nullptr;
+        m_Topology = D3D_PRIMITIVE_TOPOLOGY_UNDEFINED;
+        m_NumViewports = kInvalidCount;
+        m_NumScissors = kInvalidCount;
+        m_RTValid = false;
+        m_IBValid = false;
+        for ( UINT i = 0; i < kMaxVertexSlots; ++i ) m_VBValid[i] = false;
+        InvalidateRootArgs( m_Gfx );
+        InvalidateRootArgs( m_Compute );
+    }
+
+    /** Forget only the OM render-target binding.
+
+        This is the ONE piece of state where "same arguments" is not the same as "same result".
+        OMSetRenderTargets takes CPU descriptor handles and the runtime snapshots the DESCRIPTOR
+        CONTENTS into the command list at RECORD time — unlike a descriptor table or a root
+        descriptor, which the GPU resolves at execute. So if an RTV/DSV descriptor is rewritten in
+        place (a lazily-created or resized target landing on the same heap slot) while the list is
+        open, an otherwise-identical rebind is NOT redundant: it is the only thing that would pick up
+        the new resource. Every site that writes an RTV/DSV descriptor calls this. */
+    void InvalidateRenderTargets() noexcept { m_RTValid = false; }
+
+    /** Forget everything a command signature is able to write from an indirect argument stream: the IA
+        vertex/index buffer views and every root argument of both pipeline types. Called by
+        ExecuteIndirect (see there for why), and available to any future path that hands the list to
+        something which can rewrite bindings without going through this wrapper. */
+    void InvalidateIndirectWritableState() noexcept {
+        m_IBValid = false;
+        for ( UINT i = 0; i < kMaxVertexSlots; ++i ) m_VBValid[i] = false;
+        InvalidateRootArgs( m_Gfx );
+        InvalidateRootArgs( m_Compute );
+    }
+
+    // ---- Lifetime ------------------------------------------------------------------------------
+    HRESULT Close() { return m_List->Close(); }
+
+    HRESULT Reset( ID3D12CommandAllocator* allocator, ID3D12PipelineState* initialState ) {
+        // Reset drops every bit of state the list carried, including the PSO — the shadow has to go
+        // with it. `initialState` is the one thing that survives, so seed the PSO shadow from it.
+        InvalidateAll();
+        HRESULT hr = m_List->Reset( allocator, initialState );
+        if ( SUCCEEDED( hr ) ) m_PSO = initialState;
+        return hr;
+    }
+
+    // ---- Tracked state -------------------------------------------------------------------------
+    void SetPipelineState( ID3D12PipelineState* pso ) {
+        if ( m_PSO == pso ) { ++m_Stats.Filtered; return; }
+        m_PSO = pso;
+        ++m_Stats.Issued;
+        m_List->SetPipelineState( pso );
+    }
+
+    void SetGraphicsRootSignature( ID3D12RootSignature* rs ) {
+        if ( m_GfxRootSig == rs ) { ++m_Stats.Filtered; return; }
+        m_GfxRootSig = rs;
+        InvalidateRootArgs( m_Gfx );   // a root-signature change invalidates every root argument
+        ++m_Stats.Issued;
+        m_List->SetGraphicsRootSignature( rs );
+    }
+
+    void SetComputeRootSignature( ID3D12RootSignature* rs ) {
+        if ( m_ComputeRootSig == rs ) { ++m_Stats.Filtered; return; }
+        m_ComputeRootSig = rs;
+        InvalidateRootArgs( m_Compute );
+        ++m_Stats.Issued;
+        m_List->SetComputeRootSignature( rs );
+    }
+
+    void SetDescriptorHeaps( UINT numHeaps, ID3D12DescriptorHeap* const* heaps ) {
+        if ( numHeaps <= kMaxDescriptorHeaps && numHeaps == m_NumHeaps ) {
+            bool same = true;
+            for ( UINT i = 0; i < numHeaps; ++i ) if ( m_Heaps[i] != heaps[i] ) { same = false; break; }
+            if ( same ) { ++m_Stats.Filtered; return; }
+        }
+        if ( numHeaps <= kMaxDescriptorHeaps ) {
+            m_NumHeaps = numHeaps;
+            for ( UINT i = 0; i < numHeaps; ++i ) m_Heaps[i] = heaps[i];
+        } else {
+            m_NumHeaps = 0;   // more heaps than we shadow — never claim a hit again until re-set
+        }
+        // Descriptor tables recorded against the old heaps are stale; root descriptors/constants aren't.
+        InvalidateTables( m_Gfx );
+        InvalidateTables( m_Compute );
+        ++m_Stats.Issued;
+        m_List->SetDescriptorHeaps( numHeaps, heaps );
+    }
+
+    void IASetPrimitiveTopology( D3D12_PRIMITIVE_TOPOLOGY topology ) {
+        if ( m_Topology == topology ) { ++m_Stats.Filtered; return; }
+        m_Topology = topology;
+        ++m_Stats.Issued;
+        m_List->IASetPrimitiveTopology( topology );
+    }
+
+    void RSSetViewports( UINT num, const D3D12_VIEWPORT* viewports ) {
+        if ( num == m_NumViewports && num <= kMaxViewports
+            && std::memcmp( m_Viewports, viewports, num * sizeof( D3D12_VIEWPORT ) ) == 0 ) {
+            ++m_Stats.Filtered; return;
+        }
+        if ( num <= kMaxViewports ) {
+            m_NumViewports = num;
+            std::memcpy( m_Viewports, viewports, num * sizeof( D3D12_VIEWPORT ) );
+        } else {
+            m_NumViewports = kInvalidCount;
+        }
+        ++m_Stats.Issued;
+        m_List->RSSetViewports( num, viewports );
+    }
+
+    void RSSetScissorRects( UINT num, const D3D12_RECT* rects ) {
+        if ( num == m_NumScissors && num <= kMaxViewports
+            && std::memcmp( m_Scissors, rects, num * sizeof( D3D12_RECT ) ) == 0 ) {
+            ++m_Stats.Filtered; return;
+        }
+        if ( num <= kMaxViewports ) {
+            m_NumScissors = num;
+            std::memcpy( m_Scissors, rects, num * sizeof( D3D12_RECT ) );
+        } else {
+            m_NumScissors = kInvalidCount;
+        }
+        ++m_Stats.Issued;
+        m_List->RSSetScissorRects( num, rects );
+    }
+
+    void OMSetRenderTargets( UINT numRTs, const D3D12_CPU_DESCRIPTOR_HANDLE* rtvs,
+        BOOL singleHandleToRange, const D3D12_CPU_DESCRIPTOR_HANDLE* dsv ) {
+        const bool haveDsv = dsv != nullptr;
+        if ( m_RTValid && numRTs == m_NumRTs && singleHandleToRange == m_RTSingleHandle
+            && haveDsv == m_HaveDsv && ( !haveDsv || dsv->ptr == m_Dsv.ptr ) ) {
+            // singleHandleToRange==TRUE means only rtvs[0] is read (it describes a contiguous range).
+            const UINT compare = ( singleHandleToRange && numRTs > 0 ) ? 1u : numRTs;
+            bool same = true;
+            for ( UINT i = 0; i < compare; ++i ) if ( m_Rtvs[i].ptr != rtvs[i].ptr ) { same = false; break; }
+            if ( same ) { ++m_Stats.Filtered; return; }
+        }
+        if ( numRTs <= kMaxRenderTargets ) {
+            m_RTValid = true;
+            m_NumRTs = numRTs;
+            m_RTSingleHandle = singleHandleToRange;
+            const UINT store = ( singleHandleToRange && numRTs > 0 ) ? 1u : numRTs;
+            for ( UINT i = 0; i < store; ++i ) m_Rtvs[i] = rtvs[i];
+            m_HaveDsv = haveDsv;
+            if ( haveDsv ) m_Dsv = *dsv;
+        } else {
+            m_RTValid = false;
+        }
+        ++m_Stats.Issued;
+        m_List->OMSetRenderTargets( numRTs, rtvs, singleHandleToRange, dsv );
+    }
+
+    void IASetIndexBuffer( const D3D12_INDEX_BUFFER_VIEW* view ) {
+        if ( m_IBValid ) {
+            if ( !view ) {
+                if ( !m_IBBound ) { ++m_Stats.Filtered; return; }
+            } else if ( m_IBBound && std::memcmp( &m_IB, view, sizeof( D3D12_INDEX_BUFFER_VIEW ) ) == 0 ) {
+                ++m_Stats.Filtered; return;
+            }
+        }
+        m_IBValid = true;
+        m_IBBound = view != nullptr;
+        if ( view ) m_IB = *view;
+        ++m_Stats.Issued;
+        m_List->IASetIndexBuffer( view );
+    }
+
+    void IASetVertexBuffers( UINT startSlot, UINT numViews, const D3D12_VERTEX_BUFFER_VIEW* views ) {
+        // A null `views` unbinds the range; model that as an all-zero view so the compare below works.
+        static constexpr D3D12_VERTEX_BUFFER_VIEW kNullView = {};
+        if ( startSlot + numViews <= kMaxVertexSlots ) {
+            bool same = true;
+            for ( UINT i = 0; i < numViews; ++i ) {
+                const D3D12_VERTEX_BUFFER_VIEW& v = views ? views[i] : kNullView;
+                const UINT slot = startSlot + i;
+                if ( !m_VBValid[slot] || std::memcmp( &m_VBs[slot], &v, sizeof( v ) ) != 0 ) { same = false; break; }
+            }
+            if ( same && numViews > 0 ) { ++m_Stats.Filtered; return; }
+            for ( UINT i = 0; i < numViews; ++i ) {
+                const UINT slot = startSlot + i;
+                m_VBs[slot] = views ? views[i] : kNullView;
+                m_VBValid[slot] = true;
+            }
+        } else {
+            for ( UINT i = 0; i < kMaxVertexSlots; ++i ) m_VBValid[i] = false;
+        }
+        ++m_Stats.Issued;
+        m_List->IASetVertexBuffers( startSlot, numViews, views );
+    }
+
+    // ---- Root arguments ------------------------------------------------------------------------
+    void SetGraphicsRoot32BitConstant( UINT param, UINT value, UINT destOffset ) {
+        if ( FilterConstants( m_Gfx, param, 1, &value, destOffset ) ) return;
+        m_List->SetGraphicsRoot32BitConstant( param, value, destOffset );
+    }
+
+    void SetGraphicsRoot32BitConstants( UINT param, UINT num, const void* data, UINT destOffset ) {
+        if ( FilterConstants( m_Gfx, param, num, data, destOffset ) ) return;
+        m_List->SetGraphicsRoot32BitConstants( param, num, data, destOffset );
+    }
+
+    void SetComputeRoot32BitConstants( UINT param, UINT num, const void* data, UINT destOffset ) {
+        if ( FilterConstants( m_Compute, param, num, data, destOffset ) ) return;
+        m_List->SetComputeRoot32BitConstants( param, num, data, destOffset );
+    }
+
+    void SetGraphicsRootDescriptorTable( UINT param, D3D12_GPU_DESCRIPTOR_HANDLE handle ) {
+        if ( FilterTable( m_Gfx, param, handle ) ) return;
+        m_List->SetGraphicsRootDescriptorTable( param, handle );
+    }
+
+    void SetComputeRootDescriptorTable( UINT param, D3D12_GPU_DESCRIPTOR_HANDLE handle ) {
+        if ( FilterTable( m_Compute, param, handle ) ) return;
+        m_List->SetComputeRootDescriptorTable( param, handle );
+    }
+
+    void SetGraphicsRootConstantBufferView( UINT param, D3D12_GPU_VIRTUAL_ADDRESS address ) {
+        if ( FilterRootDescriptor( m_Gfx, param, RootArgKind::CBV, address ) ) return;
+        m_List->SetGraphicsRootConstantBufferView( param, address );
+    }
+
+    void SetComputeRootConstantBufferView( UINT param, D3D12_GPU_VIRTUAL_ADDRESS address ) {
+        if ( FilterRootDescriptor( m_Compute, param, RootArgKind::CBV, address ) ) return;
+        m_List->SetComputeRootConstantBufferView( param, address );
+    }
+
+    void SetGraphicsRootShaderResourceView( UINT param, D3D12_GPU_VIRTUAL_ADDRESS address ) {
+        if ( FilterRootDescriptor( m_Gfx, param, RootArgKind::SRV, address ) ) return;
+        m_List->SetGraphicsRootShaderResourceView( param, address );
+    }
+
+    void SetComputeRootShaderResourceView( UINT param, D3D12_GPU_VIRTUAL_ADDRESS address ) {
+        if ( FilterRootDescriptor( m_Compute, param, RootArgKind::SRV, address ) ) return;
+        m_List->SetComputeRootShaderResourceView( param, address );
+    }
+
+    void SetComputeRootUnorderedAccessView( UINT param, D3D12_GPU_VIRTUAL_ADDRESS address ) {
+        if ( FilterRootDescriptor( m_Compute, param, RootArgKind::UAV, address ) ) return;
+        m_List->SetComputeRootUnorderedAccessView( param, address );
+    }
+
+    // ---- Untracked passthrough -----------------------------------------------------------------
+    // None of these mutate the pipeline state the shadow tracks.
+    void ResourceBarrier( UINT num, const D3D12_RESOURCE_BARRIER* barriers ) { m_List->ResourceBarrier( num, barriers ); }
+    void DrawInstanced( UINT vertexCount, UINT instanceCount, UINT startVertex, UINT startInstance ) {
+        m_List->DrawInstanced( vertexCount, instanceCount, startVertex, startInstance );
+    }
+    void DrawIndexedInstanced( UINT indexCount, UINT instanceCount, UINT startIndex, INT baseVertex, UINT startInstance ) {
+        m_List->DrawIndexedInstanced( indexCount, instanceCount, startIndex, baseVertex, startInstance );
+    }
+    void Dispatch( UINT x, UINT y, UINT z ) { m_List->Dispatch( x, y, z ); }
+    void ExecuteIndirect( ID3D12CommandSignature* sig, UINT maxCount, ID3D12Resource* argBuffer,
+        UINT64 argOffset, ID3D12Resource* countBuffer, UINT64 countOffset ) {
+        m_List->ExecuteIndirect( sig, maxCount, argBuffer, argOffset, countBuffer, countOffset );
+        // NOT a passthrough: a command signature can WRITE bindings from the argument stream — vertex
+        // buffer views, the index buffer view, root constants, root CBV/SRV/UAVs (this backend's
+        // signatures use all four; see the D3D12_INDIRECT_ARGUMENT_TYPE_* tables in D3D12Scene.cpp) —
+        // and D3D12 leaves every one of them UNDEFINED once the call returns. Anything the shadow still
+        // claims about them is a lie, and the next pass's "redundant" rebind is the only thing that would
+        // restore it. Getting this wrong is not subtle: the world mesh vanished unless a vegetation pass
+        // happened to rebind different buffers in between.
+        //
+        // Deliberately conservative — the signature could be interrogated for exactly which parameters it
+        // touches, but ExecuteIndirect is issued once per BATCH, not per draw, so a few extra rebinds cost
+        // nothing next to the fragility of keeping that analysis in sync with the signature declarations.
+        // PSO, root signature, descriptor heaps, render targets, viewport, scissor and topology are NOT
+        // writable from an argument stream and stay valid.
+        InvalidateIndirectWritableState();
+    }
+    void ClearRenderTargetView( D3D12_CPU_DESCRIPTOR_HANDLE rtv, const FLOAT color[4], UINT numRects, const D3D12_RECT* rects ) {
+        m_List->ClearRenderTargetView( rtv, color, numRects, rects );
+    }
+    void ClearDepthStencilView( D3D12_CPU_DESCRIPTOR_HANDLE dsv, D3D12_CLEAR_FLAGS flags, FLOAT depth,
+        UINT8 stencil, UINT numRects, const D3D12_RECT* rects ) {
+        m_List->ClearDepthStencilView( dsv, flags, depth, stencil, numRects, rects );
+    }
+    void CopyResource( ID3D12Resource* dst, ID3D12Resource* src ) { m_List->CopyResource( dst, src ); }
+    void CopyBufferRegion( ID3D12Resource* dst, UINT64 dstOffset, ID3D12Resource* src, UINT64 srcOffset, UINT64 bytes ) {
+        m_List->CopyBufferRegion( dst, dstOffset, src, srcOffset, bytes );
+    }
+    void CopyTextureRegion( const D3D12_TEXTURE_COPY_LOCATION* dst, UINT dstX, UINT dstY, UINT dstZ,
+        const D3D12_TEXTURE_COPY_LOCATION* src, const D3D12_BOX* srcBox ) {
+        m_List->CopyTextureRegion( dst, dstX, dstY, dstZ, src, srcBox );
+    }
+
+private:
+    static constexpr UINT kMaxViewports = 4;
+    static constexpr UINT kInvalidCount = 0xFFFFFFFFu;
+
+    enum class RootArgKind : uint8_t { None, Constants, CBV, SRV, UAV, Table };
+
+    // One pipeline type's (graphics or compute) root-argument shadow. Kinds are tracked alongside the
+    // values so a parameter that flips from, say, a root CBV to a descriptor table can never produce a
+    // false hit on a numerically equal handle.
+    struct RootArgs {
+        RootArgKind               Kind[kMaxRootParams] = {};
+        D3D12_GPU_VIRTUAL_ADDRESS Address[kMaxRootParams] = {};   // CBV / SRV / UAV
+        UINT64                    Table[kMaxRootParams] = {};     // descriptor-table handle .ptr
+        // Root constants, shadowed per DWORD. ValidMask marks which DWORDs of a parameter are known —
+        // partial writes (destOffset != 0) leave the rest unknown, and a hit requires the whole
+        // requested range to be both known and equal.
+        uint32_t                  Consts[kMaxRootParams][kMaxRootConstDwords] = {};
+        uint64_t                  ValidMask[kMaxRootParams] = {};
+    };
+
+    static void InvalidateRootArgs( RootArgs& a ) noexcept {
+        for ( UINT i = 0; i < kMaxRootParams; ++i ) {
+            a.Kind[i] = RootArgKind::None;
+            a.ValidMask[i] = 0;
+        }
+    }
+    static void InvalidateTables( RootArgs& a ) noexcept {
+        for ( UINT i = 0; i < kMaxRootParams; ++i )
+            if ( a.Kind[i] == RootArgKind::Table ) a.Kind[i] = RootArgKind::None;
+    }
+
+    /** Returns true when the call can be dropped. Otherwise updates the shadow and returns false so
+        the caller issues it. Out-of-range parameters/offsets fall through uncached. */
+    bool FilterConstants( RootArgs& a, UINT param, UINT num, const void* data, UINT destOffset ) {
+        if ( param >= kMaxRootParams || destOffset + num > kMaxRootConstDwords || num == 0 ) {
+            if ( param < kMaxRootParams ) { a.Kind[param] = RootArgKind::None; a.ValidMask[param] = 0; }
+            ++m_Stats.Issued;
+            return false;
+        }
+        const uint64_t range = ( num >= 64 ) ? ~0ull : ( ( ( 1ull << num ) - 1ull ) << destOffset );
+        if ( a.Kind[param] == RootArgKind::Constants && ( a.ValidMask[param] & range ) == range
+            && std::memcmp( &a.Consts[param][destOffset], data, num * sizeof( uint32_t ) ) == 0 ) {
+            ++m_Stats.Filtered;
+            return true;
+        }
+        if ( a.Kind[param] != RootArgKind::Constants ) {
+            a.Kind[param] = RootArgKind::Constants;
+            a.ValidMask[param] = 0;
+        }
+        std::memcpy( &a.Consts[param][destOffset], data, num * sizeof( uint32_t ) );
+        a.ValidMask[param] |= range;
+        ++m_Stats.Issued;
+        return false;
+    }
+
+    bool FilterTable( RootArgs& a, UINT param, D3D12_GPU_DESCRIPTOR_HANDLE handle ) {
+        if ( param >= kMaxRootParams ) { ++m_Stats.Issued; return false; }
+        if ( a.Kind[param] == RootArgKind::Table && a.Table[param] == handle.ptr ) {
+            ++m_Stats.Filtered;
+            return true;
+        }
+        a.Kind[param] = RootArgKind::Table;
+        a.Table[param] = handle.ptr;
+        ++m_Stats.Issued;
+        return false;
+    }
+
+    bool FilterRootDescriptor( RootArgs& a, UINT param, RootArgKind kind, D3D12_GPU_VIRTUAL_ADDRESS address ) {
+        if ( param >= kMaxRootParams ) { ++m_Stats.Issued; return false; }
+        if ( a.Kind[param] == kind && a.Address[param] == address ) {
+            ++m_Stats.Filtered;
+            return true;
+        }
+        a.Kind[param] = kind;
+        a.Address[param] = address;
+        ++m_Stats.Issued;
+        return false;
+    }
+
+    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> m_List;
+
+    ID3D12PipelineState* m_PSO = nullptr;
+    ID3D12RootSignature* m_GfxRootSig = nullptr;
+    ID3D12RootSignature* m_ComputeRootSig = nullptr;
+    ID3D12DescriptorHeap* m_Heaps[kMaxDescriptorHeaps] = {};
+    UINT m_NumHeaps = 0;
+
+    D3D12_PRIMITIVE_TOPOLOGY m_Topology = D3D_PRIMITIVE_TOPOLOGY_UNDEFINED;
+
+    D3D12_VIEWPORT m_Viewports[kMaxViewports] = {};
+    UINT m_NumViewports = kInvalidCount;
+    D3D12_RECT m_Scissors[kMaxViewports] = {};
+    UINT m_NumScissors = kInvalidCount;
+
+    bool m_RTValid = false;
+    UINT m_NumRTs = 0;
+    BOOL m_RTSingleHandle = FALSE;
+    D3D12_CPU_DESCRIPTOR_HANDLE m_Rtvs[kMaxRenderTargets] = {};
+    bool m_HaveDsv = false;
+    D3D12_CPU_DESCRIPTOR_HANDLE m_Dsv = {};
+
+    bool m_IBValid = false;
+    bool m_IBBound = false;
+    D3D12_INDEX_BUFFER_VIEW m_IB = {};
+    D3D12_VERTEX_BUFFER_VIEW m_VBs[kMaxVertexSlots] = {};
+    bool m_VBValid[kMaxVertexSlots] = {};
+
+    RootArgs m_Gfx;
+    RootArgs m_Compute;
+    Stats m_Stats;
+};

--- a/D3D11Engine/D3D12Engine/D3D12StateCache.h
+++ b/D3D11Engine/D3D12Engine/D3D12StateCache.h
@@ -6,52 +6,34 @@
 
 // Engine-wide redundant-state filter for the D3D12 backend.
 //
-// WHY THIS EXISTS
-// ---------------
-// Gothic's fixed-function draw stream (the D3D7 wrapper: 2D UI, HUD, sky, every DrawString glyph run)
-// funnels through SubmitUIDraw, which re-issued the FULL bind set per draw — PSO, root signature, 4+36
-// root 32-bit constants, a descriptor table, viewport, scissor, topology and the VB view — even when
-// nothing but the vertex buffer had changed between two consecutive draws. A Gothic menu frame is
-// hundreds of such draws, and this is a 32-bit, CPU-bound process where driver-side root-signature and
-// PSO changes are among the most expensive per-draw calls there are. The 3D passes have the same shape
-// (a per-material loop that re-binds the pass-constant set every iteration).
+// D3D12CmdList wraps ONE ID3D12GraphicsCommandList and drops any state-setting call whose arguments match
+// what that list already carries. Gothic's fixed-function draw stream (SubmitUIDraw: 2D UI, HUD, sky, every
+// glyph run) re-issues the FULL bind set per draw, and the 3D per-material loops have the same shape — on a
+// CPU-bound 32-bit process, root-signature and PSO changes are the most expensive calls there are.
 //
-// D3D12CmdList wraps ONE ID3D12GraphicsCommandList and drops any state-setting call whose arguments
-// match what that list already carries. It is a drop-in replacement for the ComPtr it displaces:
-// `operator->` returns `this`, so every existing `m_CmdList->SetPipelineState(...)` call site keeps
-// compiling and silently becomes cached. That is deliberate — a cache that can be bypassed by an
-// un-migrated call site is a cache that goes stale and renders garbage, so the ONLY way to reach the
-// tracked methods is through the filter. Untracked calls (draws, dispatches, barriers, copies, clears)
-// are plain forwarders; none of them disturb pipeline state on D3D12.
-//
-// If a future call site needs a command-list method that isn't here, it won't compile — add a
-// forwarder (or, if it mutates tracked state, a cached setter). Do NOT reach around via Get().
+// It is a drop-in replacement for the ComPtr it displaces: `operator->` returns `this`, so existing call
+// sites keep compiling and silently become cached. That is deliberate — the only way to reach a tracked
+// method is through the filter, so no call site can bypass the cache and leave it stale. Untracked calls
+// (draws, dispatches, barriers, copies, clears) are plain forwarders. If a call site needs a method that
+// isn't here it won't compile: add a forwarder (or a cached setter), do NOT reach around via Get().
 //
 // CORRECTNESS RULES ENCODED HERE (D3D12 spec)
-// -------------------------------------------
 //   * Reset() drops ALL command-list state -> the whole shadow is cleared.
-//   * Setting a root signature invalidates every root argument of that pipeline type. So a CHANGED
-//     root signature clears that space's root-argument shadow; an unchanged one is skipped outright
-//     and the shadow (correctly) survives.
-//   * Setting a PSO does NOT invalidate root arguments, and a PSO whose embedded root signature
-//     differs from the bound one does NOT implicitly change the bound root signature. PSO and root
-//     signature are therefore tracked independently.
-//   * Changing the bound descriptor heaps makes previously-set descriptor TABLES stale, so a heap
-//     change clears the table entries in both root-argument spaces (root CBV/SRV/UAVs and root
-//     constants are heap-independent and survive).
-//   * Rebinding an identical descriptor table / root descriptor is a true no-op even if the
-//     descriptor or the buffer contents changed in between: with volatile ranges the GPU reads both
-//     at execute time, and with the DATA_STATIC_WHILE_SET_AT_EXECUTE ranges D3D12RootLayout declares,
-//     mutating the data while the binding is set is already a contract violation independent of this
-//     cache. Nothing new is broken by skipping the second Set.
+//   * Setting a root signature invalidates every root argument of that pipeline type, so a CHANGED root
+//     signature clears that space's shadow; an unchanged one is skipped and the shadow survives.
+//   * Setting a PSO does NOT invalidate root arguments, nor implicitly change the bound root signature.
+//     PSO and root signature are therefore tracked independently.
+//   * Changing the bound descriptor heaps makes previously-set descriptor TABLES stale, so a heap change
+//     clears the table entries in both spaces (root descriptors and constants are heap-independent).
+//   * Rebinding an identical table / root descriptor is a true no-op even if the descriptor or the buffer
+//     contents changed in between: volatile ranges are read at execute time, and mutating data behind a
+//     DATA_STATIC_WHILE_SET_AT_EXECUTE range is already a contract violation independent of this cache.
 //
-// ANYTHING THAT RECORDS STATE BEHIND THE WRAPPER'S BACK MUST CALL InvalidateAll(). In this backend
-// that is exactly one thing: imgui_impl_dx12, which sets its own PSO, root signature, heaps, RTs,
-// viewport and topology on the raw pointer (see D3D12GraphicsEngine::Present).
+// ANYTHING THAT RECORDS STATE BEHIND THE WRAPPER'S BACK MUST CALL InvalidateAll(). In this backend that is
+// exactly one thing: imgui_impl_dx12 (see D3D12GraphicsEngine::Present).
 //
-// THREADING: no locking. One wrapper belongs to one command list, and a command list may only ever be
-// recorded by one thread at a time — so the MT shadow-cascade recorders each get their own wrapper
-// (m_ShadowCmdLists) and never touch the main list's. Same rule the D3D12 API itself imposes.
+// THREADING: no locking. One wrapper per command list, and a list may only be recorded by one thread at a
+// time — so the MT shadow-cascade recorders each get their own wrapper (m_ShadowCmdLists).
 class D3D12CmdList {
 public:
     // Root-parameter capacity. The widest layout in the backend uses index 13 (D3D12PipelineState.cpp);
@@ -59,10 +41,8 @@ public:
     // than corrupting the shadow (see the bounds checks in the setters).
     static constexpr UINT kMaxRootParams = 20;
     // Widest root-constant block: GothicGraphicsState = 144 bytes = 36 DWORDs (the FF/UI pipe constants).
-    // 48 leaves headroom and keeps the valid-mask a single uint64_t. Sizing matters a little here: the
-    // constant shadow dominates the object (kMaxRootParams * kMaxRootConstDwords * 4 * 2 pipeline types
-    // ~= 7.7 KB), and one of these exists per shadow-recording slot per frame-in-flight — ~150 KB total,
-    // which is affordable under the 32-bit budget but not worth inflating for no reason.
+    // 48 leaves headroom and keeps the valid-mask a single uint64_t. Don't inflate: the constant shadow
+    // dominates the object (~7.7 KB), and one exists per shadow-recording slot per frame-in-flight.
     static constexpr UINT kMaxRootConstDwords = 48;
     static constexpr UINT kMaxVertexSlots = 4;
     static constexpr UINT kMaxRenderTargets = 8;
@@ -362,19 +342,12 @@ public:
     void ExecuteIndirect( ID3D12CommandSignature* sig, UINT maxCount, ID3D12Resource* argBuffer,
         UINT64 argOffset, ID3D12Resource* countBuffer, UINT64 countOffset ) {
         m_List->ExecuteIndirect( sig, maxCount, argBuffer, argOffset, countBuffer, countOffset );
-        // NOT a passthrough: a command signature can WRITE bindings from the argument stream — vertex
-        // buffer views, the index buffer view, root constants, root CBV/SRV/UAVs (this backend's
-        // signatures use all four; see the D3D12_INDIRECT_ARGUMENT_TYPE_* tables in D3D12Scene.cpp) —
-        // and D3D12 leaves every one of them UNDEFINED once the call returns. Anything the shadow still
-        // claims about them is a lie, and the next pass's "redundant" rebind is the only thing that would
-        // restore it. Getting this wrong is not subtle: the world mesh vanished unless a vegetation pass
-        // happened to rebind different buffers in between.
-        //
-        // Deliberately conservative — the signature could be interrogated for exactly which parameters it
-        // touches, but ExecuteIndirect is issued once per BATCH, not per draw, so a few extra rebinds cost
-        // nothing next to the fragility of keeping that analysis in sync with the signature declarations.
-        // PSO, root signature, descriptor heaps, render targets, viewport, scissor and topology are NOT
-        // writable from an argument stream and stay valid.
+        // NOT a passthrough: a command signature can WRITE bindings from the argument stream — VBVs, the
+        // IBV, root constants and root CBV/SRV/UAVs (this backend uses all four) — and D3D12 leaves every
+        // one of them UNDEFINED once the call returns, so anything the shadow still claims is a lie.
+        // Conservative on purpose: ExecuteIndirect is issued once per batch, so a few extra rebinds are
+        // cheaper than keeping a per-signature analysis in sync. PSO, root signature, descriptor heaps,
+        // render targets, viewport, scissor and topology are not writable this way and stay valid.
         InvalidateIndirectWritableState();
     }
     void ClearRenderTargetView( D3D12_CPU_DESCRIPTOR_HANDLE rtv, const FLOAT color[4], UINT numRects, const D3D12_RECT* rects ) {

--- a/D3D11Engine/D3D12Engine/D3D12Taa.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Taa.cpp
@@ -217,7 +217,7 @@ void D3D12GraphicsEngine::RenderTAA() {
     const D3D12_GPU_VIRTUAL_ADDRESS motionCb = GetMotionCbAddress();
     if ( !motionCb ) return;
 
-    DX_ZONE( m_CmdList, "TAA resolve" );
+    DX_ZONE( m_CmdList.Get(), "TAA resolve" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "TAA resolve" );
 
     const UINT writeIdx = m_TaaHistoryIndex;

--- a/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
@@ -283,7 +283,7 @@ void D3D12GraphicsEngine::DrawWorldTransparencyMeshes() {
     D3D12VertexBuffer* ib = D3D12VertexBuffer::From( wm->GetMeshIndexBuffer() );
     if ( !vb->GetResource() || !ib->GetResource() ) { clearLists(); return; }
 
-    DX_ZONE( m_CmdList, "DrawWorldTransparencyMeshes" );
+    DX_ZONE( m_CmdList.Get(), "DrawWorldTransparencyMeshes" );
 
     // ViewProj — identical derivation to DrawWorldMesh/DrawWaterSurfaces (world verts are world-space).
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
@@ -325,15 +325,15 @@ void D3D12GraphicsEngine::DrawWorldTransparencyMeshes() {
     // Sub-pass order is D3D11's render-graph order: blended surfaces, then the forest portals, then the
     // waterfall foam.
     {
-        DX_ZONE( m_CmdList, "World transparency (blended)" );
+        DX_ZONE( m_CmdList.Get(), "World transparency (blended)" );
         DrawWorldTransparencyList( g_FrameWorldTransparency, EKind::Simple, true );
     }
     if ( drawPortals ) {
-        DX_ZONE( m_CmdList, "World transparency (forest portals)" );
+        DX_ZONE( m_CmdList.Get(), "World transparency (forest portals)" );
         DrawWorldTransparencyList( g_FrameWorldTransparencyPortal, EKind::Portal, false );
     }
     {
-        DX_ZONE( m_CmdList, "World transparency (waterfall foam)" );
+        DX_ZONE( m_CmdList.Get(), "World transparency (waterfall foam)" );
         DrawWorldTransparencyList( g_FrameWorldTransparencyFoam, EKind::Foam, true );
     }
 
@@ -361,7 +361,7 @@ void D3D12GraphicsEngine::DrawVobAlphaMeshes() {
         return;
     }
 
-    DX_ZONE( m_CmdList, "DrawVobAlphaMeshes" );
+    DX_ZONE( m_CmdList.Get(), "DrawVobAlphaMeshes" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw Vobs (blended)" );
 
     // ViewProj — identical derivation to DrawVobsInstanced, so a peeled mesh lands on exactly the pixels it

--- a/D3D11Engine/D3D12Engine/D3D12Water.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Water.cpp
@@ -355,7 +355,7 @@ void D3D12GraphicsEngine::DrawWaterSurfaces() {
     if ( !m_FrameOpen || !m_Pipelines.Water.PSO || !m_Pipelines.Water.RootSig || !m_DepthBuffer || g_FrameWaterSurfaces.empty() )
         return;
 
-    DX_ZONE( m_CmdList, "DrawWaterSurfaces" );
+    DX_ZONE( m_CmdList.Get(), "DrawWaterSurfaces" );
 
     MeshInfo* wm = Engine::GAPI->GetWrappedWorldMesh();
     if ( !wm || !wm->GetMeshVertexBuffer() || !wm->GetMeshIndexBuffer() ) { g_FrameWaterSurfaces.clear(); return; }
@@ -381,7 +381,7 @@ void D3D12GraphicsEngine::DrawWaterSurfaces() {
     // ---------------------------------------------------------------------------------------------------
     const bool copiesReady = EnsureWaterCopyResources() && m_WaterCBMapped[m_FrameIndex];
     if ( copiesReady ) {
-        DX_ZONE( m_CmdList, "Water scene+depth copy" );
+        DX_ZONE( m_CmdList.Get(), "Water scene+depth copy" );
         // Both sources must leave their bound states, so drop the render targets first.
         m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
 
@@ -490,7 +490,7 @@ void D3D12GraphicsEngine::DrawWaterSurfaces() {
     // the fog visibly breaks at the ocean without this pass. Same VB/IB/root constants; only the PSO differs
     // (color writes masked, depth-write on).
     if ( m_Pipelines.Water.DepthPrepassPSO ) {
-        DX_ZONE( m_CmdList, "Water Z-Prepass" );
+        DX_ZONE( m_CmdList.Get(), "Water Z-Prepass" );
         m_CmdList->SetPipelineState( m_Pipelines.Water.DepthPrepassPSO.Get() );
         for ( auto const& [tex, meshes] : g_FrameWaterSurfaces ) {
             for ( MeshInfo* mesh : meshes ) {

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -2569,19 +2569,11 @@ SkeletalMeshVisualInfo* GothicAPI::ResolveSkeletalVisualInfo( zCModel* model ) {
     return skeletalMesh;
 }
 
-/** True if this emitter samples its spawn positions off a skeletal shape-mesh we cannot serve yet.
- *  ZENGIN's zCParticleEmitter::GetPosition falls back to (0,0,0) - the model's own origin - when
- *  GetLowestLODNumPolys returns 0, so the whole effect would visibly collapse onto the model's
- *  pivot. Skipping the emitter tick until the data is there is the lesser evil: the effect simply
- *  starts a few frames late instead of starting wrong. */
-/** ZENGIN's oCVisualFX::CalcPFXMesh (oVisFx.cpp:3961) points a zPFX_EMITTER_SHAPE_MESH emitter at
- *  the origin vob's visual exactly once - while the FX's own visual is being created. If the origin
- *  had no visual yet at that instant, none of its shpMesh/shpProgMesh/shpModel branches assign, and
- *  the pointer stays null for the whole life of the effect (oCNpc::StartEffect's follow-up
- *  SetPFXShapeVisual is likewise guarded by `if (GetVisual())`, oNpc.cpp:14437). ZENGIN's
- *  zCParticleEmitter::GetPosition then falls through its MESH case to `return zVEC3(0,0,0)`
- *  (zParticle.cpp:2460) and every particle spawns on the vob's pivot - the "fire beast burns at one
- *  point until re-spawned" bug. Re-run the assignment here once the visual does exist. */
+/** ZENGIN's oCVisualFX::CalcPFXMesh points a zPFX_EMITTER_SHAPE_MESH emitter at the origin vob's visual
+ *  exactly once, while the FX's own visual is being created. If the origin had no visual at that instant the
+ *  pointer stays null for the life of the effect, zCParticleEmitter::GetPosition falls through its MESH case
+ *  to (0,0,0), and every particle spawns on the vob's pivot - the "fire beast burns at one point until
+ *  re-spawned" bug. Re-run the assignment here once the visual does exist. */
 void GothicAPI::RepairShapeMeshEmitter( zCVob* source, zCParticleFX* fx ) {
 #ifndef BUILD_SPACER
     oCVisualFX* visFx = source ? source->As<oCVisualFX>() : nullptr;

--- a/D3D11Engine/Shaders/D3D12/LightCull.hlsl
+++ b/D3D11Engine/Shaders/D3D12/LightCull.hlsl
@@ -3,6 +3,10 @@
 #define MASK_WORDS (MAX_ACTIVE_LIGHTS / 32u)
 #define NUM_Z_SLICES 16u
 
+// One thread group per SCREEN TILE (not per cluster): the group culls once against the tile's infinite frustum
+// column, then bins the survivors into all NUM_Z_SLICES slices itself. See CSMain's header for why.
+#define CULL_GROUP_SIZE 64u
+
 // MUST stay layout-identical to GPULight (C++ D3D12EngineCommon.h / HLSL include/ForwardPlusTypes.hlsl) — this
 // is a StructuredBuffer, so a stride mismatch silently misindexes EVERY light. The cull only reads
 // PositionView/Range; the trailing fields are here purely to keep the 64-byte stride.
@@ -23,7 +27,7 @@ cbuffer CullCB : register(b0) {
     float2 ProjScale;    // (Proj._11, Proj._22): view->clip x/y scale (diagonal terms, layout-invariant)
     uint2  ScreenDim;    // render-target pixel size
     uint   TotalLights;  // valid light count in SB_Lights (may exceed MAX_ACTIVE_LIGHTS; only the first
-                          // MAX_ACTIVE_LIGHTS are ever tested — see the numthreads note below)
+                          // MAX_ACTIVE_LIGHTS are ever tested — the mask has exactly that many bits)
     uint   NumTilesX;    // ceil(ScreenDim.x / TILE_SIZE)
     float  NearZ;        // camera near plane (Engine::GAPI->GetNearPlane()) — inner bound of the cluster Z range
     float  FarZ;         // fixed practical cluster far distance (kClusterFarZ in D3D12Scene.cpp) — Gothic's
@@ -31,68 +35,133 @@ cbuffer CullCB : register(b0) {
                           // anything beyond it collapses into the last (coarsest) Z slice.
 };
 
-groupshared uint   gs_Mask[MASK_WORDS];
-groupshared float3 gs_AabbMin;
-groupshared float3 gs_AabbMax;
+// The whole tile column's output, built in LDS and flushed once: NUM_Z_SLICES consecutive LightGrid entries,
+// which is exactly RW_LightGrid[tileIndex*NUM_Z_SLICES .. +NUM_Z_SLICES). 512 words = 2 KB.
+groupshared uint gs_Mask[NUM_Z_SLICES * MASK_WORDS];
+// Lights that survived the column test, packed as: bit 0..9 = light index, bit 10..13 = first Z slice,
+// bit 14..17 = last Z slice. Capacity is MAX_ACTIVE_LIGHTS so an append can never overflow (4 KB).
+groupshared uint gs_Cand[MAX_ACTIVE_LIGHTS];
+groupshared uint gs_CandCount;
 
-// View-space XY at a given pixel and a KNOWN view-space Z (unlike the old per-tile cull, this Z comes from the
-// analytic cluster slice bounds below, not from sampling the depth buffer — that's what makes this CLUSTERED
-// rather than "tiled with scene-derived depth bounds": every cluster's shape is fixed by the camera projection
-// alone, so the cull no longer depends on the depth prepass having run first.
-float2 ViewXYAtZ( float2 pixel, float zView ) {
-    float2 ndc;
-    ndc.x = pixel.x / (float)ScreenDim.x * 2.0 - 1.0;
-    ndc.y = -(pixel.y / (float)ScreenDim.y * 2.0 - 1.0);
-    return float2( ndc.x / ProjScale.x * zView, ndc.y / ProjScale.y * zView );
+// Log-distributed slice index for a view-space Z. MUST stay identical to PBRLighting.hlsl's ComputeZSlice tail
+// (that one first inverts the hardware reversed-Z depth to viewZ, then does exactly this) or a pixel reads a
+// different cluster than the one culled for it.
+uint SliceOfViewZ( float zView, float invLogRatio ) {
+    float t = log2( max( zView, NearZ ) / NearZ ) * invLogRatio;
+    return (uint)clamp( floor( t * (float)NUM_Z_SLICES ), 0.0, (float)( NUM_Z_SLICES - 1 ) );
 }
 
-// Closest-point sphere/AABB overlap (view space). Keeps a light iff its sphere touches the box.
-bool SphereInsideAABB( float3 center, float radius, float3 aabbMin, float3 aabbMax ) {
-    float3 closest = clamp( center, aabbMin, aabbMax );
-    float3 delta = closest - center;
-    return dot( delta, delta ) <= radius * radius;
-}
-
-// One thread group per (tileX, tileY, zSlice) cluster; one thread per candidate light (thread ti tests light
-// ti — see MAX_ACTIVE_LIGHTS). Dispatch is (NumTilesX, NumTilesY, NUM_Z_SLICES); groupID.z is the Z slice.
-[numthreads( MAX_ACTIVE_LIGHTS, 1, 1 )]
+// One thread group per 16x16 SCREEN TILE — dispatch is (NumTilesX, NumTilesY, 1), and the group produces all
+// NUM_Z_SLICES clusters of that tile column itself.
+//
+// The predecessor dispatched one group per (tile x slice) with numthreads(MAX_ACTIVE_LIGHTS,1,1) — thread ti
+// tested light ti against that one cluster's AABB. At 1080p that is 130560 groups * 1024 threads = ~134M
+// threads to test a few dozen lights, i.e. the pass was ~entirely launch overhead and idle lanes. This version
+// costs (tiles * 64) threads instead — 16x fewer groups, 16x narrower — by exploiting the fact that the 16
+// clusters of a tile column share their XY bounds:
+//
+//   Phase 1  test each light ONCE against the tile's infinite frustum column (4 side planes) and, for the
+//            survivors, derive the slice span [s0,s1] its sphere covers analytically from its Z extent.
+//            Wave-compacted into gs_Cand — one LDS atomic per wave, not one per surviving light.
+//   Phase 2  OR each candidate's bit into only the slices it actually spans. A torch touches 1-3 slices, so
+//            this replaces 16 full sphere/AABB tests per light with a handful of LDS ORs.
+//   Phase 3  flush all 512 mask words with the full group, coalesced (the old code had thread 0 write 32
+//            words serially while 1023 lanes waited).
+//
+// Culling quality is equivalent-to-tighter: the old per-slice test used the AXIS-ALIGNED bound of the frustum
+// slab, which is a superset of the frustum column this now tests against, and the Z interval is exact.
+[numthreads( CULL_GROUP_SIZE, 1, 1 )]
 void CSMain( uint3 groupID : SV_GroupID, uint ti : SV_GroupIndex ) {
-    // Only the first MASK_WORDS threads need to clear the mask (one word each) — cheap even though the group
-    // has many more threads than that.
-    if ( ti < MASK_WORDS ) gs_Mask[ti] = 0;
+    // Clear the output mask + the candidate counter. 512 words / 64 threads = 8 each.
+    [unroll]
+    for ( uint c = 0; c < ( NUM_Z_SLICES * MASK_WORDS ) / CULL_GROUP_SIZE; ++c )
+        gs_Mask[c * CULL_GROUP_SIZE + ti] = 0;
+    if ( ti == 0 ) gs_CandCount = 0;
 
-    // Log-distributed cluster Z bounds (Doom/Olsson clustered shading): slice 0 is thinnest (nearest, where
-    // depth precision/occupancy is highest) and slices widen geometrically out to FarZ. This is pure view-space
-    // math and has nothing to do with the reversed-Z hardware depth encoding — that only matters where a hardware
-    // depth is converted back to a view-space Z (PBRLighting.hlsl's ComputeZSlice does that for the pixel shader
-    // side; this compute pass never touches hardware depth at all).
-    const uint slice = groupID.z;
-    const float sliceNearZ = NearZ * pow( FarZ / NearZ, (float)slice / (float)NUM_Z_SLICES );
-    const float sliceFarZ  = NearZ * pow( FarZ / NearZ, (float)( slice + 1 ) / (float)NUM_Z_SLICES );
+    // --- Tile frustum column, view space. Uniform over the group (depends on groupID only), so every lane
+    // computes it redundantly into scalar registers rather than paying a broadcast + barrier for it.
+    // ndc.x = viewX * ProjScale.x / viewZ  =>  the plane through the eye at tile edge ndcX is  viewX = t*viewZ.
+    const float2 tileMin = float2( groupID.xy ) * TILE_SIZE;
+    const float2 tileMax = float2( groupID.xy + uint2( 1, 1 ) ) * TILE_SIZE;
+    const float tx0 = ( tileMin.x / (float)ScreenDim.x * 2.0 - 1.0 ) / ProjScale.x;
+    const float tx1 = ( tileMax.x / (float)ScreenDim.x * 2.0 - 1.0 ) / ProjScale.x;
+    // ndc.y is flipped relative to pixel y, so tileMin.y gives the LARGER ndc/view y.
+    const float ty1 = -( tileMin.y / (float)ScreenDim.y * 2.0 - 1.0 ) / ProjScale.y;
+    const float ty0 = -( tileMax.y / (float)ScreenDim.y * 2.0 - 1.0 ) / ProjScale.y;
 
-    if ( ti == 0 ) {
-        const float2 tileMin = float2( groupID.xy ) * TILE_SIZE;
-        const float2 tileMax = float2( groupID.xy + uint2( 1, 1 ) ) * TILE_SIZE;
-        const float2 n0 = ViewXYAtZ( tileMin, sliceNearZ ), n1 = ViewXYAtZ( tileMax, sliceNearZ );
-        const float2 f0 = ViewXYAtZ( tileMin, sliceFarZ ),  f1 = ViewXYAtZ( tileMax, sliceFarZ );
-        gs_AabbMin = float3( min( min( n0, n1 ), min( f0, f1 ) ), sliceNearZ );
-        gs_AabbMax = float3( max( max( n0, n1 ), max( f0, f1 ) ), sliceFarZ );
-    }
-    GroupMemoryBarrierWithGroupSync();
+    // Inward-pointing unit normals (planes all pass through the origin, so the signed distance to a sphere
+    // centre is just dot(n, c) and the test is dot(n,c) >= -radius).
+    const float3 pL = float3(  1, 0, -tx0 ) * rsqrt( 1.0 + tx0 * tx0 );
+    const float3 pR = float3( -1, 0,  tx1 ) * rsqrt( 1.0 + tx1 * tx1 );
+    const float3 pB = float3( 0,  1, -ty0 ) * rsqrt( 1.0 + ty0 * ty0 );
+    const float3 pT = float3( 0, -1,  ty1 ) * rsqrt( 1.0 + ty1 * ty1 );
 
-    if ( ti < TotalLights ) {
-        TiledPointLight L = SB_Lights[ti];
-        if ( SphereInsideAABB( L.PositionView, L.Range * 1.05, gs_AabbMin, gs_AabbMax ) ) {
-            InterlockedOr( gs_Mask[ti / 32u], 1u << ( ti % 32u ) );
+    const float invLogRatio = 1.0 / log2( FarZ / NearZ );
+    const uint  lightCount  = min( TotalLights, MAX_ACTIVE_LIGHTS );
+
+    GroupMemoryBarrierWithGroupSync();   // gs_Mask cleared + gs_CandCount ready before any phase-1 append
+
+    // --- Phase 1: cull against the column, wave-compact the survivors ---
+    for ( uint base = 0; base < lightCount; base += CULL_GROUP_SIZE ) {
+        const uint li = base + ti;
+
+        bool hit = false;
+        uint packed = 0;
+        // NOTE: no early-out/continue here — every lane must reach the wave ops below with the same activity
+        // mask, so out-of-range lanes fall through with hit=false instead of exiting the loop.
+        if ( li < lightCount ) {
+            const TiledPointLight L = SB_Lights[li];
+            const float3 c = L.PositionView;
+            const float  r = L.Range * 1.05;
+
+            // Z extent first: it is the cheapest reject and it is what the slice span needs anyway.
+            const float zLo = c.z - r;
+            const float zHi = c.z + r;
+            if ( zHi >= NearZ && zLo <= FarZ &&
+                 dot( pL, c ) >= -r && dot( pR, c ) >= -r &&
+                 dot( pB, c ) >= -r && dot( pT, c ) >= -r ) {
+                const uint s0 = SliceOfViewZ( max( zLo, NearZ ), invLogRatio );
+                const uint s1 = SliceOfViewZ( min( zHi, FarZ ),  invLogRatio );
+                packed = li | ( s0 << 10 ) | ( s1 << 14 );
+                hit = true;
+            }
+        }
+
+        // One LDS atomic per wave instead of one per surviving light: the wave reserves its whole run and each
+        // lane takes its slot from the prefix popcount. Wave-size agnostic (no ballot-word assumptions).
+        const uint waveHits = WaveActiveCountBits( hit );
+        uint waveBase = 0;
+        if ( waveHits != 0 ) {
+            if ( WaveIsFirstLane() ) InterlockedAdd( gs_CandCount, waveHits, waveBase );
+            waveBase = WaveReadLaneFirst( waveBase );
+            if ( hit ) gs_Cand[waveBase + WavePrefixCountBits( hit )] = packed;
         }
     }
+
     GroupMemoryBarrierWithGroupSync();
 
-    if ( ti == 0 ) {
-        const uint tileIndex = groupID.y * NumTilesX + groupID.x;
-        const uint clusterIndex = tileIndex * NUM_Z_SLICES + slice;
-        [unroll]
-        for ( uint w = 0; w < MASK_WORDS; ++w )
-            RW_LightGrid[clusterIndex].Mask[w] = gs_Mask[w];
+    // --- Phase 2: bin each candidate into the slices its sphere actually spans ---
+    const uint candCount = gs_CandCount;
+    for ( uint ci = ti; ci < candCount; ci += CULL_GROUP_SIZE ) {
+        const uint packed = gs_Cand[ci];
+        const uint li = packed & 0x3FFu;
+        const uint s0 = ( packed >> 10 ) & 0xFu;
+        const uint s1 = ( packed >> 14 ) & 0xFu;
+        const uint word = li >> 5u;
+        const uint bit  = 1u << ( li & 31u );
+        for ( uint s = s0; s <= s1; ++s )
+            InterlockedOr( gs_Mask[s * MASK_WORDS + word], bit );
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+
+    // --- Phase 3: flush the whole column ---
+    // The tile's NUM_Z_SLICES clusters are contiguous in RW_LightGrid, so gs_Mask maps onto them flat and the
+    // 512-word store is fully coalesced across the group.
+    const uint clusterBase = ( groupID.y * NumTilesX + groupID.x ) * NUM_Z_SLICES;
+    [unroll]
+    for ( uint o = 0; o < ( NUM_Z_SLICES * MASK_WORDS ) / CULL_GROUP_SIZE; ++o ) {
+        const uint i = o * CULL_GROUP_SIZE + ti;
+        RW_LightGrid[clusterBase + ( i >> 5u )].Mask[i & 31u] = gs_Mask[i];
     }
 }

--- a/D3D11Engine/Shaders/D3D12/LightCull.hlsl
+++ b/D3D11Engine/Shaders/D3D12/LightCull.hlsl
@@ -18,7 +18,9 @@ struct TiledPointLight {
 };
 // Clustered Forward+ (P2.14): a MAX_ACTIVE_LIGHTS-bit membership mask, one bit per light in
 // SB_Lights[0..MAX_ACTIVE_LIGHTS). MASK_WORDS * 4 bytes, same layout as ForwardPlusTypes.hlsl's copy.
-struct LightGrid { uint Mask[MASK_WORDS]; };
+// WordOccupancy: bit w set iff Mask[w] != 0, so the pixel shader can skip the empty words instead of walking all
+// MASK_WORDS of them. See the fuller note on ForwardPlusTypes.hlsl's copy — the two MUST stay layout-identical.
+struct LightGrid { uint WordOccupancy; uint Mask[MASK_WORDS]; };
 
 StructuredBuffer<TiledPointLight> SB_Lights   : register(t0);
 RWStructuredBuffer<LightGrid>     RW_LightGrid : register(u0);
@@ -42,6 +44,8 @@ groupshared uint gs_Mask[NUM_Z_SLICES * MASK_WORDS];
 // bit 14..17 = last Z slice. Capacity is MAX_ACTIVE_LIGHTS so an append can never overflow (4 KB).
 groupshared uint gs_Cand[MAX_ACTIVE_LIGHTS];
 groupshared uint gs_CandCount;
+// One WordOccupancy summary per slice of the column, OR-reduced out of gs_Mask between phases 2 and 3.
+groupshared uint gs_Occ[NUM_Z_SLICES];
 
 // Log-distributed slice index for a view-space Z. MUST stay identical to PBRLighting.hlsl's ComputeZSlice tail
 // (that one first inverts the hardware reversed-Z depth to viewZ, then does exactly this) or a pixel reads a
@@ -77,6 +81,7 @@ void CSMain( uint3 groupID : SV_GroupID, uint ti : SV_GroupIndex ) {
     for ( uint c = 0; c < ( NUM_Z_SLICES * MASK_WORDS ) / CULL_GROUP_SIZE; ++c )
         gs_Mask[c * CULL_GROUP_SIZE + ti] = 0;
     if ( ti == 0 ) gs_CandCount = 0;
+    if ( ti < NUM_Z_SLICES ) gs_Occ[ti] = 0;   // 16 slices, group is 64 wide — one lane each, no loop
 
     // --- Tile frustum column, view space. Uniform over the group (depends on groupID only), so every lane
     // computes it redundantly into scalar registers rather than paying a broadcast + barrier for it.
@@ -155,6 +160,18 @@ void CSMain( uint3 groupID : SV_GroupID, uint ti : SV_GroupIndex ) {
 
     GroupMemoryBarrierWithGroupSync();
 
+    // --- Phase 2b: reduce gs_Mask into one WordOccupancy summary per slice ---
+    // MASK_WORDS is 32, so the flat gs_Mask index i splits as (slice = i >> 5, word = i & 31) — the same mapping
+    // phase 3 flushes with. Only non-empty words contribute, so the usual near-empty column costs 8 compares per
+    // lane and issues no atomics at all.
+    [unroll]
+    for ( uint u = 0; u < ( NUM_Z_SLICES * MASK_WORDS ) / CULL_GROUP_SIZE; ++u ) {
+        const uint i = u * CULL_GROUP_SIZE + ti;
+        if ( gs_Mask[i] != 0 ) InterlockedOr( gs_Occ[i >> 5u], 1u << ( i & 31u ) );
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+
     // --- Phase 3: flush the whole column ---
     // The tile's NUM_Z_SLICES clusters are contiguous in RW_LightGrid, so gs_Mask maps onto them flat and the
     // 512-word store is fully coalesced across the group.
@@ -164,4 +181,6 @@ void CSMain( uint3 groupID : SV_GroupID, uint ti : SV_GroupIndex ) {
         const uint i = o * CULL_GROUP_SIZE + ti;
         RW_LightGrid[clusterBase + ( i >> 5u )].Mask[i & 31u] = gs_Mask[i];
     }
+    // One summary word per slice — 16 lanes, alongside the mask flush above.
+    if ( ti < NUM_Z_SLICES ) RW_LightGrid[clusterBase + ti].WordOccupancy = gs_Occ[ti];
 }

--- a/D3D11Engine/Shaders/D3D12/LightCull.hlsl
+++ b/D3D11Engine/Shaders/D3D12/LightCull.hlsl
@@ -56,24 +56,16 @@ uint SliceOfViewZ( float zView, float invLogRatio ) {
 }
 
 // One thread group per 16x16 SCREEN TILE — dispatch is (NumTilesX, NumTilesY, 1), and the group produces all
-// NUM_Z_SLICES clusters of that tile column itself.
-//
-// The predecessor dispatched one group per (tile x slice) with numthreads(MAX_ACTIVE_LIGHTS,1,1) — thread ti
-// tested light ti against that one cluster's AABB. At 1080p that is 130560 groups * 1024 threads = ~134M
-// threads to test a few dozen lights, i.e. the pass was ~entirely launch overhead and idle lanes. This version
-// costs (tiles * 64) threads instead — 16x fewer groups, 16x narrower — by exploiting the fact that the 16
-// clusters of a tile column share their XY bounds:
+// NUM_Z_SLICES clusters of that tile column itself, exploiting the fact that they share their XY bounds:
 //
 //   Phase 1  test each light ONCE against the tile's infinite frustum column (4 side planes) and, for the
 //            survivors, derive the slice span [s0,s1] its sphere covers analytically from its Z extent.
 //            Wave-compacted into gs_Cand — one LDS atomic per wave, not one per surviving light.
-//   Phase 2  OR each candidate's bit into only the slices it actually spans. A torch touches 1-3 slices, so
-//            this replaces 16 full sphere/AABB tests per light with a handful of LDS ORs.
-//   Phase 3  flush all 512 mask words with the full group, coalesced (the old code had thread 0 write 32
-//            words serially while 1023 lanes waited).
+//   Phase 2  OR each candidate's bit into only the slices it actually spans. A torch touches 1-3 slices.
+//   Phase 3  flush all 512 mask words with the full group, coalesced.
 //
-// Culling quality is equivalent-to-tighter: the old per-slice test used the AXIS-ALIGNED bound of the frustum
-// slab, which is a superset of the frustum column this now tests against, and the Z interval is exact.
+// Culling quality is equivalent-to-tighter than a per-cluster AABB test: the frustum column is a subset of the
+// axis-aligned slab bound, and the Z interval is exact.
 [numthreads( CULL_GROUP_SIZE, 1, 1 )]
 void CSMain( uint3 groupID : SV_GroupID, uint ti : SV_GroupIndex ) {
     // Clear the output mask + the candidate counter. 512 words / 64 threads = 8 each.

--- a/D3D11Engine/Shaders/D3D12/include/ForwardPlusTypes.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/ForwardPlusTypes.hlsl
@@ -8,13 +8,10 @@
 #define TILE_SIZE 16u
 // Clustered Forward+ (P2.14): a global cap on SIMULTANEOUSLY-SHADED point lights, not a per-tile cap. The
 // frame's light buffer (kMaxFrameLights in D3D12Scene.cpp, sorted nearest-to-camera) feeds only its first
-// MAX_ACTIVE_LIGHTS entries into the cluster bitmask — the mask has exactly this many bits and bit i IS light i,
-// so the constant is load-bearing on BOTH sides, not just a cap. Lights beyond this rank in the sorted buffer
-// simply never light anything (same "farthest dropped first" policy the old per-tile prefix-sum cap used, just
-// applied once globally instead of independently per tile).
-// Must match kMaxFrameLights in D3D12Scene.cpp (raising one without the other either wastes capacity or
-// silently drops lights past the smaller of the two). LightCull.hlsl additionally packs a light index into 10
-// bits of its candidate list, so raising this past 1024 needs that packing widened too.
+// MAX_ACTIVE_LIGHTS entries into the cluster bitmask — bit i IS light i, so this is load-bearing on both
+// sides, not just a cap; lights past this rank in the sorted buffer never light anything. Must match
+// kMaxFrameLights in D3D12Scene.cpp. LightCull.hlsl also packs a light index into 10 bits of its candidate
+// list, so raising this past 1024 needs that packing widened too.
 // Raised from 64 (P2.14's initial cap clipped visibly in ambient-heavy scenes — Gothic can have 400+
 // simultaneously visible point lights once static "atmospheric" fill lights are counted) to 1024 = 32 * 32-bit
 // words. Each cluster's mask is MASK_WORDS * 4 bytes: at 1080p (~8160 16x16 tiles * NUM_Z_SLICES=16 slices =
@@ -47,13 +44,10 @@ struct GPULight {
 // i set = light i is visible in this cluster), NOT an {Offset,Count} index slice — see LightCull.hlsl/
 // PBRLighting.hlsl's AccumTiledPointLights. (MASK_WORDS + 1) * 4 bytes per cluster.
 //
-// WordOccupancy is a summary of Mask: bit w is set iff Mask[w] != 0. Without it every lit pixel had to load and
-// test all MASK_WORDS (32) words just to discover a cluster is empty, which is the common case — and because
-// BuildFrameLightBuffer sorts the frame's lights NEAREST-FIRST, the set bits bunch into the low words, so words
-// 2..31 are near-always zero and were pure loop overhead. Bit-scanning this one word instead touches only the
-// words that actually carry lights, and keeps the property that made the bitmask preferable to an {Offset,Count}
-// list in the first place: the loop bound is a popcount, so a corrupt grid entry can never spin away.
-// MASK_WORDS is 32, so the summary fits exactly one word — raising MAX_ACTIVE_LIGHTS past 1024 breaks that.
+// WordOccupancy is a summary of Mask: bit w is set iff Mask[w] != 0, so a lit pixel bit-scans one word instead
+// of testing all MASK_WORDS to discover an empty cluster (the common case — BuildFrameLightBuffer sorts
+// nearest-first, so the set bits bunch into the low words). The loop bound stays a popcount, so a corrupt grid
+// entry cannot spin away. MASK_WORDS is 32, so the summary fits exactly one word.
 struct LightGrid { uint WordOccupancy; uint Mask[MASK_WORDS]; };
 
 // ShadowCubeIndex encoding: -1 = unshadowed, else (slot | tier). Bit 30 selects the low-res static cube array

--- a/D3D11Engine/Shaders/D3D12/include/ForwardPlusTypes.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/ForwardPlusTypes.hlsl
@@ -45,8 +45,16 @@ struct GPULight {
 };
 // Clustered Forward+ grid cell: a MAX_ACTIVE_LIGHTS-bit membership mask over the frame's active light list (bit
 // i set = light i is visible in this cluster), NOT an {Offset,Count} index slice — see LightCull.hlsl/
-// PBRLighting.hlsl's AccumTiledPointLights. MASK_WORDS * 4 bytes per cluster.
-struct LightGrid { uint Mask[MASK_WORDS]; };
+// PBRLighting.hlsl's AccumTiledPointLights. (MASK_WORDS + 1) * 4 bytes per cluster.
+//
+// WordOccupancy is a summary of Mask: bit w is set iff Mask[w] != 0. Without it every lit pixel had to load and
+// test all MASK_WORDS (32) words just to discover a cluster is empty, which is the common case — and because
+// BuildFrameLightBuffer sorts the frame's lights NEAREST-FIRST, the set bits bunch into the low words, so words
+// 2..31 are near-always zero and were pure loop overhead. Bit-scanning this one word instead touches only the
+// words that actually carry lights, and keeps the property that made the bitmask preferable to an {Offset,Count}
+// list in the first place: the loop bound is a popcount, so a corrupt grid entry can never spin away.
+// MASK_WORDS is 32, so the summary fits exactly one word — raising MAX_ACTIVE_LIGHTS past 1024 breaks that.
+struct LightGrid { uint WordOccupancy; uint Mask[MASK_WORDS]; };
 
 // ShadowCubeIndex encoding: -1 = unshadowed, else (slot | tier). Bit 30 selects the low-res static cube array
 // over the full-res dynamic one, and keeps the value positive so "ShadowCubeIndex >= 0" still means shadowed.

--- a/D3D11Engine/Shaders/D3D12/include/ForwardPlusTypes.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/ForwardPlusTypes.hlsl
@@ -8,12 +8,13 @@
 #define TILE_SIZE 16u
 // Clustered Forward+ (P2.14): a global cap on SIMULTANEOUSLY-SHADED point lights, not a per-tile cap. The
 // frame's light buffer (kMaxFrameLights in D3D12Scene.cpp, sorted nearest-to-camera) feeds only its first
-// MAX_ACTIVE_LIGHTS entries into the cluster bitmask — thread ti of LightCull.hlsl's CSMain tests light ti, and
-// the mask has exactly this many bits, so the constant is load-bearing on BOTH sides, not just a cap. Lights
-// beyond this rank in the sorted buffer simply never light anything (same "farthest dropped first" policy the
-// old per-tile prefix-sum cap used, just applied once globally instead of independently per tile).
-// Must match LightCull.hlsl's numthreads(MAX_ACTIVE_LIGHTS,1,1) AND kMaxFrameLights in D3D12Scene.cpp (raising
-// one without the other either wastes capacity or silently drops lights past the smaller of the two).
+// MAX_ACTIVE_LIGHTS entries into the cluster bitmask — the mask has exactly this many bits and bit i IS light i,
+// so the constant is load-bearing on BOTH sides, not just a cap. Lights beyond this rank in the sorted buffer
+// simply never light anything (same "farthest dropped first" policy the old per-tile prefix-sum cap used, just
+// applied once globally instead of independently per tile).
+// Must match kMaxFrameLights in D3D12Scene.cpp (raising one without the other either wastes capacity or
+// silently drops lights past the smaller of the two). LightCull.hlsl additionally packs a light index into 10
+// bits of its candidate list, so raising this past 1024 needs that packing widened too.
 // Raised from 64 (P2.14's initial cap clipped visibly in ambient-heavy scenes — Gothic can have 400+
 // simultaneously visible point lights once static "atmospheric" fill lights are counted) to 1024 = 32 * 32-bit
 // words. Each cluster's mask is MASK_WORDS * 4 bytes: at 1080p (~8160 16x16 tiles * NUM_Z_SLICES=16 slices =

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -76,11 +76,20 @@ float SamplePointShadow( int encodedIndex, float3 wpos, float3 N, float3 lightPo
     float3 bt = cross( L, t );
     float  r  = ( 0.006 + 0.010 * saturate( zView / f ) ) * coarse;
     static const float2 kDisk[4] = { float2( 0.7, 0.7 ), float2( -0.7, 0.7 ), float2( 0.7, -0.7 ), float2( -0.7, -0.7 ) };
+
+    // The low-res static tier is deliberately blurry (see the header note): a 4x-coarse cube is there to stop
+    // room-to-room bleed, not to resolve edges, and its disk radius `r` is already scaled 4x to match. Four
+    // taps on it mostly re-average the same kStaticCubeSize^2 texel neighbourhood, so it takes a 2-tap
+    // diagonal (kDisk[0]/kDisk[3], opposite corners — the widest pair) for half the texture ops. The full-res
+    // tier keeps all four, and with it the optional dynamic-overlay min, where the resolution is actually
+    // there to be filtered.
+    const int  taps   = lowRes ? 2 : 4;
+    const int  stride = lowRes ? 3 : 1;
     float sh = 0.0;
-    [unroll]
-    for ( int s = 0; s < 4; ++s )
+    [loop]
+    for ( int s = 0; s < taps; ++s )
     {
-        float3 o = normalize( L + ( kDisk[s].x * t + kDisk[s].y * bt ) * r );
+        float3 o = normalize( L + ( kDisk[s * stride].x * t + kDisk[s * stride].y * bt ) * r );
         if ( lowRes )
         {
             TextureCubeArray lowCubes = ResourceDescriptorHeap[PointShadowLowIndex];
@@ -97,7 +106,7 @@ float SamplePointShadow( int encodedIndex, float3 wpos, float3 N, float3 lightPo
             sh += s;
         }
     }
-    return sh * 0.25;
+    return sh / (float)taps;
 }
 
 // PCF footprint, expressed as a WORLD radius rather than a texel count. The kernel used to step
@@ -125,6 +134,25 @@ float SampleCascadePCF( int c, float2 uv, float depth )
     float cascadeWorld = max( CascadeTexelWorld[c] * ShadowMapSize, 1e-4 );
     float pcfStep = clamp( kPcfWorldRadius / ( 2.0 * cascadeWorld ),
                            kPcfMinTexels * texel, kPcfMaxTexels * texel );
+
+    // Uniformity pre-test before committing to the full 5x5. Sample the kernel's centre and its four
+    // corners; when all five agree the footprint is entirely lit or entirely occluded, the remaining 20
+    // taps cannot return anything else, so bail with that value. Open sun and deep shade are the large
+    // majority of shaded pixels, so the common case becomes 5 taps instead of 25 and only transition
+    // pixels pay 30. shadowCmp is a COMPARISON_MIN_MAG_LINEAR sampler, so a tap that straddles a shadow
+    // edge comes back fractional and fails both tests — the predicate errs towards the full kernel.
+    //
+    // The pre-taps sit at the kernel's full extent, so fooling it needs an occluder that fits entirely
+    // between a corner and the centre, i.e. sub-2-texel detail. Dense sub-texel casters (grass — see the
+    // kPcfWorldRadius note above) are the one case that can read "solid" for a footprint the full kernel
+    // would have averaged to a partial value; that is the first thing to check if far-cascade vegetation
+    // shadows go back to looking like a flat black mask.
+    const float2 kPre[5] = { float2( 0, 0 ), float2( -2, -2 ), float2( 2, -2 ), float2( -2, 2 ), float2( 2, 2 ) };
+    float pre = 0.0;
+    [unroll] for ( int p = 0; p < 5; ++p )
+        pre += ShadowMap.SampleCmpLevelZero( shadowCmp, float3( uv + kPre[p] * pcfStep, c ), depth );
+    if ( pre == 0.0 ) return 0.0;
+    if ( pre == 5.0 ) return 1.0;
 
     float sh = 0.0;
     [unroll] for ( int y = -2; y <= 2; ++y )

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -555,13 +555,22 @@ float3 AccumTiledPointLights( float3 svpos, float3 wpos, float3 N, float3 albedo
     uint2 tile = uint2( svpos.xy ) / TILE_SIZE;
     uint  tileIndex = tile.y * NumTilesX + tile.x;
     uint  slice = ComputeZSlice( svpos.z );
-    LightGrid g = LightGridBuf[tileIndex * NUM_Z_SLICES + slice];
+    // Index the fields directly rather than `LightGrid g = LightGridBuf[c]` — binding the whole struct loads all
+    // MASK_WORDS+1 words eagerly, which is exactly the cost WordOccupancy exists to avoid.
+    const uint cluster = tileIndex * NUM_Z_SLICES + slice;
     float3 V = normalize( CamPosWS - wpos );
     float3 total = 0;
     float3 maxLit = 0;
-    for ( uint w = 0; w < MASK_WORDS; ++w )
+    // Walk only the mask words WordOccupancy flags as non-empty (see ForwardPlusTypes.hlsl). An empty cluster —
+    // the common case — is now one load instead of 32, and since the light list is sorted nearest-first the set
+    // bits bunch into the low words, so even a lit cluster usually touches 1-2. The loop bound is still a
+    // popcount, so a corrupt entry bounds at MASK_WORDS iterations exactly as the old fixed loop did.
+    uint wm = LightGridBuf[cluster].WordOccupancy;
+    while ( wm != 0 )
     {
-        uint m = g.Mask[w];
+        uint w = firstbitlow( wm );
+        wm &= wm - 1;
+        uint m = LightGridBuf[cluster].Mask[w];
         while ( m != 0 )
         {
             uint bit = firstbitlow( m );

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -306,16 +306,12 @@ namespace {
         CreateShadowIndexBuffer( mesh );
     }
 
-    /** Some authored VOB meshes (eg. tree/foliage assets) contain wedges with a
- *  zero-length normal (degenerate source data). Unlike world-section geometry,
- *  VOB normals are copied verbatim from the original mesh data and never
- *  regenerated, so a zero vector survives untouched through the whole
- *  pipeline and shades as pure black. Recompute a geometric fallback from the
- *  surrounding triangles' face normals for just those vertices; anything with
- *  a valid authored normal is left untouched. */
-    // True for zero-length, NaN or infinite normals - anything unsafe to light with.
-    // Written as "not > threshold" (rather than "<= threshold") so NaN, which
-    // compares false against everything, is also caught as bad instead of slipping through.
+    /** Some authored VOB meshes (tree/foliage assets) ship wedges with a zero-length normal. Unlike
+     *  world-section geometry, VOB normals are copied verbatim and never regenerated, so the zero survives
+     *  the whole pipeline and shades pure black. Recompute a fallback from the surrounding face normals for
+     *  just those vertices. */
+    // Written as "not > threshold" rather than "<= threshold" so NaN, which compares false against
+    // everything, is caught as bad instead of slipping through.
     bool IsDegenerateNormal( FXMVECTOR n ) {
         float len2 = XMVectorGetX( XMVector3LengthSq( n ) );
         return !(len2 > 1e-12f) || !(len2 < 1e12f);


### PR DESCRIPTION
52398f2 - reduce light culling and light buffer usage
3bf59eb - reduce shadow sampling cost
79fcaa3 - staged graceful fallback for root signature serialization
70cb6ed - perf: merge consecutive world draws in depth prepass/shadow maps
9237ecf - Fix missing vegetation limitation in shadow maps. make shadow maps less expensive by excluding small vobs/indoor earlier
2913109 - reduce GPU idle time by submitting depth pass immediately instead of waiting for the cpu side submission of the lit pass.
26a0a2e - disable depth write for scene where we already drew all depth in the prepass
db85c11 - only use alpha test where needed
3e43b5a - optimize light culling by reduing the thread overhead
4a689f3 - only render last cascade once every 3 frames
8e76035 - Pipeline state cache by wrapping CmdList
ea62a28 - make use of `PFN_SERIALIZE_VERSIONED_ROOT_SIG` and tag resources with `D3D12RootLayout::RootDataStatic` etc. to allow more driver optimizations