### PR TITLE
(3/7) experimental features: horizon culling, shadow map skip. CPU friendly improvements to Vob collection/culling.

### DIFF
--- a/D3D11Engine/BaseGraphicsEngine.cpp
+++ b/D3D11Engine/BaseGraphicsEngine.cpp
@@ -1,23 +1,71 @@
 #include "BaseGraphicsEngine.h"
 #include "ImGuiShim.h"
 #include "GothicAPI.h"
+#include <algorithm>
 #include <iostream>
 #include <string>
+
+/** Resolves the limit for the frame about to start; see BaseGraphicsEngine.h. */
+int BaseGraphicsEngine::ResolveFrameLimit() const {
+    auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+
+    int limit = (!m_IsWindowActive && settings.EnableInactiveFpsLock) ? 20 : settings.FpsLimit;
+
+    // Nothing about a paused game is worth rendering at full speed, and ZENGIN's paused loop has
+    // no pacing of its own (see PausedFrameLimiterBeginFrame). Not optional - the runaway framerate
+    // it prevents crashes drivers. Videos and load screens still get to run unthrottled: they're
+    // paused too, but they're waiting on data, not on the player.
+    if ( Engine::GAPI->IsIngameMenuPaused()
+        && !settings.BinkVideoRunning && !Engine::GAPI->IsInSavingLoadingState() ) {
+        const int pausedLimit = std::clamp( settings.PausedFpsLimit,
+            GothicRendererSettings::PausedFpsLimitMin, GothicRendererSettings::PausedFpsLimitMax );
+        limit = limit != 0 ? std::min( limit, pausedLimit ) : pausedLimit;
+    }
+    return limit;
+}
 
 /** Arms the frame limiter for the frame about to start. Shared by every backend; see
     BaseGraphicsEngine.h for why this lives outside of OnBeginFrame. */
 void BaseGraphicsEngine::FrameLimiterBeginFrame() {
-    auto& rendererState = Engine::GAPI->GetRendererState();
-
-    if ( !m_IsWindowActive && rendererState.RendererSettings.EnableInactiveFpsLock ) {
-        m_FrameLimiter->SetLimit( 20 );
-        m_FrameLimiter->Start();
-    } else if ( rendererState.RendererSettings.FpsLimit != 0 ) {
-        m_FrameLimiter->SetLimit( rendererState.RendererSettings.FpsLimit );
+    if ( int limit = ResolveFrameLimit(); limit != 0 ) {
+        m_FrameLimiter->SetLimit( limit );
         m_FrameLimiter->Start();
     } else {
         m_FrameLimiter->Reset();
     }
+}
+
+/** Arms the nested paused/menu loop's own limiter, if this frame is one of its frames.
+    See BaseGraphicsEngine.h for the whole story. */
+void BaseGraphicsEngine::PausedFrameLimiterBeginFrame() {
+    const bool mainLoopTicked = (g_MainLoopFrameTick != m_LastSeenMainLoopTick);
+    m_LastSeenMainLoopTick = g_MainLoopFrameTick;
+    m_PacingPausedFrame = false;
+
+    // Without the main-loop patch every frame is already paced from OnBeginFrame/OnEndFrame,
+    // nested ones included - ResolveFrameLimit() applies the paused cap there too.
+    if ( !g_MainLoopFramePacingInstalled ) return;
+    if ( mainLoopTicked ) return; // the main-loop patch is pacing this frame itself
+
+    auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+    if ( settings.BinkVideoRunning || Engine::GAPI->IsInSavingLoadingState() ) return;
+    if ( !Engine::GAPI->IsIngameMenuPaused() ) return;
+
+    const int limit = ResolveFrameLimit();
+    if ( limit == 0 ) return;
+
+    m_PacingPausedFrame = true;
+    // The main loop normally does this once per iteration; nobody does it in the nested loop.
+    WaitForFrameLatencyWaitable();
+    m_PausedFrameLimiter->SetLimit( limit );
+    m_PausedFrameLimiter->Start();
+}
+
+/** Paces out a nested paused/menu frame armed by PausedFrameLimiterBeginFrame(). */
+void BaseGraphicsEngine::PausedFrameLimiterEndFrame() {
+    if ( !m_PacingPausedFrame ) return;
+    m_PacingPausedFrame = false;
+    m_PausedFrameLimiter->Wait();
 }
 
 /** Paces out the frame that just finished. Shared by every backend; see

--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -25,6 +25,12 @@ static void UpdateShouldBlockGameInput();
     OnEndFrame must NOT also drive the frame limiter, or every frame would get paced twice. */
 inline bool g_MainLoopFramePacingInstalled = false;
 
+/** Incremented once per CGameManager::Run() iteration by the same main-loop patch. Frames that
+    come and go without this changing were rendered from one of ZENGIN's *nested* frame loops
+    (see BaseGraphicsEngine::PausedFrameLimiterBeginFrame), which the main-loop patch cannot
+    reach. Wrap-around is harmless - only "did it change since the last frame" is ever asked. */
+inline unsigned int g_MainLoopFrameTick = 0;
+
 struct GraphicsEventName {
     const wchar_t* wide;
     const char* narrow;
@@ -141,6 +147,27 @@ public:
         Counterpart to FrameLimiterEndFrame(); see that method for why this lives outside
         of OnBeginFrame. */
     virtual void FrameLimiterBeginFrame();
+
+    /** Paces the frames ZENGIN renders from its *nested* frame loop while an in-game menu has
+        the game paused, which the main-loop patch above cannot see.
+
+        Every in-game menu (ESC main menu, inventory/status, log, map) calls oCGame::Pause() -
+        setting singleStep and freezing timeStep - and then blocks inside zCMenu::Run(), whose
+        HandleFrame -> Render() drives its own BeginFrame / screen->Render / EndFrame / Vid_Blit.
+        CGameManager::Run() never gets to iterate while that is happening, so neither the
+        main-loop pacing patch nor the frame-latency wait runs, and ZENGIN itself only throttles
+        that loop when *out* of game (zCMenu::Render: `if (!IsInGame()) Sleep(50);`). An in-game
+        menu therefore spins as fast as the GPU can blit an almost empty screen - thousands of
+        FPS, which has been observed to crash drivers.
+
+        Called from OnBeginFrame/OnEndFrame, which do fire for those frames since they come from
+        zrenderer->BeginFrame()/EndFrame(). Nested frames are told apart by g_MainLoopFrameTick
+        not having advanced, which also keeps this from double-waiting on frames the main-loop
+        patch already paces. */
+    void PausedFrameLimiterBeginFrame();
+
+    /** Counterpart to PausedFrameLimiterBeginFrame(); waits only if that call armed a frame. */
+    void PausedFrameLimiterEndFrame();
 
     /** Returns the DXGI frame-latency waitable handle for backends whose swapchain was created
         with DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT, or nullptr if the backend/current
@@ -391,4 +418,19 @@ protected:
 
     /** Shared by every backend via FrameLimiterBeginFrame/FrameLimiterEndFrame. */
     std::unique_ptr<FpsLimiter> m_FrameLimiter = std::make_unique<FpsLimiter>();
+
+    /** Resolves the limit for the frame about to start: the inactive-window lock, the user's
+        FpsLimit and the paused/menu cap, whichever is lowest. 0 means "no limit". */
+    int ResolveFrameLimit() const;
+
+    /** Separate limiter instance for the nested paused/menu loop, so arming or waiting there
+        can never disturb the main loop's own in-flight frame timing. Costs nothing until the
+        first paused frame actually arms it. */
+    std::unique_ptr<FpsLimiter> m_PausedFrameLimiter = std::make_unique<FpsLimiter>();
+
+    /** g_MainLoopFrameTick as of the previous PausedFrameLimiterBeginFrame(). */
+    unsigned int m_LastSeenMainLoopTick = 0;
+
+    /** Set when PausedFrameLimiterBeginFrame() armed m_PausedFrameLimiter for this frame. */
+    bool m_PacingPausedFrame = false;
 };

--- a/D3D11Engine/BspPortalCuller.cpp
+++ b/D3D11Engine/BspPortalCuller.cpp
@@ -558,6 +558,7 @@ void BspPortalCuller::Solve( FXMMATRIX worldToClip, const XMFLOAT3& cameraPositi
     LastStats.EnclosedInSector = cameraEnclosedIn;
     LastStats.OutdoorSeenFromSector = SECTOR_OUTDOOR;
     LastStats.EnclosureWalkSectors = 0;
+    LastStats.CameraRoomOpensOutdoor = false;
     OutdoorVisible = ambiguous || cameraEnclosedIn == SECTOR_OUTDOOR
         || ComputeOutdoorVisible( cameraEnclosedIn );
 
@@ -587,6 +588,7 @@ void BspPortalCuller::Solve( FXMMATRIX worldToClip, const XMFLOAT3& cameraPositi
 bool BspPortalCuller::ComputeOutdoorVisible( uint16_t fromSector ) {
     LastStats.OutdoorSeenFromSector = SECTOR_OUTDOOR;
     LastStats.EnclosureWalkSectors = 0;
+    LastStats.CameraRoomOpensOutdoor = false;
     if ( fromSector >= Sectors.size() )
         return true;
 
@@ -603,6 +605,21 @@ bool BspPortalCuller::ComputeOutdoorVisible( uint16_t fromSector ) {
         ScreenBox2D box = ProjectPolygon( SolveWorldToClip, portal.Verts.data(), portal.Verts.size() );
         return !box.IsEmpty() && !box.ClippedTo( aperture ).IsEmpty();
     };
+
+    // A room with any door outside is never enclosed - topology, deliberately not visibility. "On
+    // screen" derives from the camera pose, and the third-person camera orbits into walls, where a
+    // room's own doors go backfacing and the walk wrongly reports "sealed". Costs city interiors
+    // (one step from daylight anyway), keeps mine and cave chambers.
+    if ( !Sectors[fromSector].IncomingOutdoorPortals.empty() ) {
+        LastStats.CameraRoomOpensOutdoor = true;
+        return true;
+    }
+    for ( uint32_t portalIdx : Sectors[fromSector].OutgoingPortals ) {
+        if ( Portals[portalIdx].TargetSector == SECTOR_OUTDOOR ) {
+            LastStats.CameraRoomOpensOutdoor = true;
+            return true;
+        }
+    }
 
     visited[fromSector] = 1;
     apertures[fromSector] = ScreenBox2D::FullViewport();

--- a/D3D11Engine/BspPortalCuller.cpp
+++ b/D3D11Engine/BspPortalCuller.cpp
@@ -34,6 +34,7 @@ void BspPortalCuller::Clear() {
     Apertures.clear();
     CurrentStamp = 0;
     WarnedBudget = false;
+    OutdoorVisible = true;
     LastStats = Stats{};
 }
 
@@ -143,7 +144,11 @@ void BspPortalCuller::BuildFromWorld( zCBspTree* tree ) {
                 portal.TargetSector = idOf( back );
                 if ( portal.TargetSector == SECTOR_OUTDOOR ) continue;
 
-                OutdoorEntryPortals.push_back( static_cast<uint32_t>(Portals.size()) );
+                const uint32_t entryIdx = static_cast<uint32_t>(Portals.size());
+                OutdoorEntryPortals.push_back( entryIdx );
+                // Also file it under the room it opens into, so the enclosure walk can find the
+                // openings of a room whose doors are all stored from the outdoor side.
+                Sectors[portal.TargetSector].IncomingOutdoorPortals.push_back( entryIdx );
                 Portals.push_back( std::move( portal ) );
             } else {
                 // Traversable from inside `front` (which is this sector) towards `back`.
@@ -231,6 +236,93 @@ zCBspBase* BspPortalCuller::FindLeaf( const XMFLOAT3& position ) const {
         node = next;
     }
     return (node && node->IsLeaf()) ? node : nullptr;
+}
+
+/** Nearest sector-flagged polygon straight below `position`. Every node is tested, not just leafs -
+    zCBspBase::PolyList is on the base and inner nodes carry polys too. */
+void BspPortalCuller::TraceSectorPolyDown( zCBspBase* node, const XMFLOAT3& position,
+    float& bestY, zCPolygon*& bestPoly ) const {
+    if ( !node )
+        return;
+
+    // Vertical ray: a subtree matters only if it spans XZ, reaches below us, and beats the best hit.
+    const zTBBox3D& box = node->BBox3D;
+    if ( position.x < box.Min.x || position.x > box.Max.x ) return;
+    if ( position.z < box.Min.z || position.z > box.Max.z ) return;
+    if ( box.Min.y > position.y ) return;
+    if ( box.Max.y < bestY ) return;
+
+    for ( int i = 0; i < node->NumPolys; i++ ) {
+        zCPolygon* poly = node->PolyList[i];
+        if ( !poly ) continue;
+
+        // zCBspTree::Render's GetSectorFlag test. Portals stay in - a doorway underfoot must resolve.
+        if ( !poly->GetPolyFlags()->SectorPoly ) continue;
+
+        const uint8_t numVerts = poly->GetNumPolyVertices();
+        zCVertex** verts = poly->getVertices();
+        if ( numVerts < 3 || !verts ) continue;
+
+        // A near-vertical poly is a wall, never the floor under the camera - and would divide by ~0.
+        const zTPlane& plane = poly->GetPolyPlane();
+        if ( std::fabs( plane.Normal.y ) < 1e-4f ) continue;
+
+        // Point-in-polygon in XZ (crossing test), then the plane's height at that XZ.
+        bool inside = false;
+        for ( uint8_t a = 0, b = numVerts - 1; a < numVerts; b = a++ ) {
+            if ( !verts[a] || !verts[b] ) { inside = false; break; }
+            const float az = verts[a]->Position.z, bz = verts[b]->Position.z;
+            const float ax = verts[a]->Position.x, bx = verts[b]->Position.x;
+            if ( (az > position.z) != (bz > position.z)
+                && position.x < ax + (bx - ax) * (position.z - az) / (bz - az) ) {
+                inside = !inside;
+            }
+        }
+        if ( !inside ) continue;
+
+        const float y = (plane.Distance - plane.Normal.x * position.x - plane.Normal.z * position.z)
+            / plane.Normal.y;
+        if ( y <= position.y && y > bestY ) {
+            bestY = y;
+            bestPoly = poly;
+        }
+    }
+
+    if ( node->IsNode() ) {
+        zCBspNode* n = static_cast<zCBspNode*>(node);
+        TraceSectorPolyDown( n->Front, position, bestY, bestPoly );
+        TraceSectorPolyDown( n->Back, position, bestY, bestPoly );
+    }
+}
+
+/** Mirrors the start-sector block of zCBspTree::Render. The cheaper substitutes all fail: ZenGin
+    warns against GetGroundPoly() here (portals are filtered out of groundPolys, and it is stale on the
+    camera vob), while BspInfo::SectorIds names a room from open sand because outdoor leafs straddle
+    walls - as do sector bounds, being a union of those leafs' AABBs. */
+uint16_t BspPortalCuller::FindSectorBelow( const XMFLOAT3& position ) const {
+    float bestY = -FLT_MAX;
+    zCPolygon* hitPoly = nullptr;
+    TraceSectorPolyDown( BspRoot, position, bestY, hitPoly );
+
+    if ( !hitPoly )
+        return SECTOR_OUTDOOR;
+
+    zCMaterial* mat = hitPoly->GetMaterial();
+    if ( !mat )
+        return SECTOR_OUTDOOR;
+
+    zCBspSector* front = mat->GetBspSectorFront();
+
+    // An indoor=>outdoor portal underfoot means we are standing in a doorway from the outdoor side;
+    // ZenGin treats that as outdoor (its front is the outdoor).
+    if ( hitPoly->IsPortal() && !front )
+        return SECTOR_OUTDOOR;
+
+    if ( !front )
+        return SECTOR_OUTDOOR;
+
+    auto it = SectorIdByPtr.find( front );
+    return it != SectorIdByPtr.end() ? it->second : SECTOR_OUTDOOR;
 }
 
 ScreenBox2D BspPortalCuller::ProjectPolygon( FXMMATRIX worldToClip, const XMFLOAT3* verts, size_t numVerts ) {
@@ -353,6 +445,9 @@ void BspPortalCuller::Solve( FXMMATRIX worldToClip, const XMFLOAT3& cameraPositi
     uint16_t cameraSector = SECTOR_OUTDOOR;
     bool cameraOutdoor = true;
     bool ambiguous = false;
+    /** Strictly resolved room the camera stands in - see the block that fills it. Only the enclosure
+        test (ComputeOutdoorVisible) uses this; VOB culling keeps the looser camSectors. */
+    uint16_t cameraEnclosedIn = SECTOR_OUTDOOR;
 
     // Under-culling here is harmless, over-culling empties the room the player is standing in,
     // so the camera's sector is resolved from two independent sources and both are activated.
@@ -392,6 +487,10 @@ void BspPortalCuller::Solve( FXMMATRIX worldToClip, const XMFLOAT3& cameraPositi
             cameraOutdoor = false;
             cameraSector = camSectors[0];
         }
+
+        // The room the camera actually stands in - enclosure test only, camSectors above stays
+        // over-inclusive for VOB culling.
+        cameraEnclosedIn = FindSectorBelow( cameraPosition );
     }
 
     const ScreenBox2D fullScreen = ScreenBox2D::FullViewport();
@@ -454,6 +553,14 @@ void BspPortalCuller::Solve( FXMMATRIX worldToClip, const XMFLOAT3& cameraPositi
         }
     }
 
+    // Enclosure test for the sun cascades. Reset the walk's stats so short-circuited frames don't
+    // report stale ones.
+    LastStats.EnclosedInSector = cameraEnclosedIn;
+    LastStats.OutdoorSeenFromSector = SECTOR_OUTDOOR;
+    LastStats.EnclosureWalkSectors = 0;
+    OutdoorVisible = ambiguous || cameraEnclosedIn == SECTOR_OUTDOOR
+        || ComputeOutdoorVisible( cameraEnclosedIn );
+
     int active = 0;
     for ( uint32_t s : Stamps ) {
         if ( s == CurrentStamp ) active++;
@@ -461,9 +568,110 @@ void BspPortalCuller::Solve( FXMMATRIX worldToClip, const XMFLOAT3& cameraPositi
     LastStats.ActiveSectors = active;
     LastStats.CameraOutdoor = cameraOutdoor;
     LastStats.CameraSector = cameraSector;
+    LastStats.OutdoorVisible = OutdoorVisible;
 
     ZoneText( "activeSectors", std::size( "activeSectors" ) - 1 );
     ZoneValue( active );
+}
+
+/** Reproduces what zCBspSector::ActivateSectorRec computes for zCBspSector::IsOutdoorActive(): walks
+    out from the camera's room propagating apertures, and returns true once an opening to the outdoor
+    is reachable through the chain. ZenGin skips RenderOutdoor and the sky when this is false.
+
+    Needs its own walk, not a scan of the sectors Solve() activated: activation seeds every room
+    within NearSectorRadius with a full-screen aperture, and ProjectPolygon knows nothing about
+    occlusion, so a flat scan called every indoor spot in a dense complex open to the sky.
+
+    Stricter than ZenGin in one place: it also checks IncomingOutdoorPortals, which ActivateSectorRec
+    skips. That can only decline a skip, never cause a wrong one. */
+bool BspPortalCuller::ComputeOutdoorVisible( uint16_t fromSector ) {
+    LastStats.OutdoorSeenFromSector = SECTOR_OUTDOOR;
+    LastStats.EnclosureWalkSectors = 0;
+    if ( fromSector >= Sectors.size() )
+        return true;
+
+    // Own visited/aperture state - must not disturb the Stamps/Apertures the VOB cull reads.
+    static thread_local std::vector<uint8_t> visited;
+    static thread_local std::vector<ScreenBox2D> apertures;
+    static thread_local std::vector<std::pair<uint16_t, uint16_t>> stack;   // sector, cameFrom
+    visited.assign( Sectors.size(), 0 );
+    apertures.assign( Sectors.size(), ScreenBox2D{} );
+    stack.clear();
+
+    const auto reachesOutdoor = [this]( uint32_t portalIdx, const ScreenBox2D& aperture ) {
+        const Portal& portal = Portals[portalIdx];
+        ScreenBox2D box = ProjectPolygon( SolveWorldToClip, portal.Verts.data(), portal.Verts.size() );
+        return !box.IsEmpty() && !box.ClippedTo( aperture ).IsEmpty();
+    };
+
+    visited[fromSector] = 1;
+    apertures[fromSector] = ScreenBox2D::FullViewport();
+    stack.push_back( { fromSector, SECTOR_OUTDOOR } );
+
+    int budget = MAX_SECTOR_VISITS;
+    while ( !stack.empty() ) {
+        if ( --budget < 0 )
+            return true;   // pathological graph - assume the outdoor is reachable rather than guess
+
+        const auto [sector, cameFrom] = stack.back();
+        stack.pop_back();
+        const ScreenBox2D aperture = apertures[sector];
+        LastStats.EnclosureWalkSectors++;
+
+        // Doorways into this room that are stored from the outdoor side.
+        for ( uint32_t portalIdx : Sectors[sector].IncomingOutdoorPortals ) {
+            if ( reachesOutdoor( portalIdx, aperture ) ) {
+                LastStats.OutdoorSeenFromSector = sector;
+                return true;
+            }
+        }
+
+        for ( uint32_t portalIdx : Sectors[sector].OutgoingPortals ) {
+            const Portal& portal = Portals[portalIdx];
+
+            if ( portal.TargetSector == SECTOR_OUTDOOR ) {
+                if ( reachesOutdoor( portalIdx, aperture ) ) {
+                    LastStats.OutdoorSeenFromSector = sector;
+                    return true;
+                }
+                continue;
+            }
+
+            // --- traversal into the next room: identical rules to ActivateSector ---
+            const float side = portal.PlaneNormal.x * SolveCameraPos.x
+                             + portal.PlaneNormal.y * SolveCameraPos.y
+                             + portal.PlaneNormal.z * SolveCameraPos.z
+                             - portal.PlaneDistance;
+            if ( side < 0.0f )
+                continue;
+
+            ScreenBox2D box = ProjectPolygon( SolveWorldToClip, portal.Verts.data(), portal.Verts.size() );
+            if ( box.IsEmpty() )
+                continue;
+            box = box.ClippedTo( aperture );
+            if ( box.IsEmpty() )
+                continue;
+
+            if ( portal.TargetSector == cameFrom )
+                continue;
+
+            const uint16_t next = portal.TargetSector;
+            if ( next >= Sectors.size() )
+                continue;
+
+            if ( !visited[next] ) {
+                visited[next] = 1;
+                apertures[next] = box;
+                stack.push_back( { next, sector } );
+            } else if ( !apertures[next].Contains( box ) ) {
+                // Reached again through a wider chain - re-expand, like ActivateSector does.
+                apertures[next].Merge( box );
+                stack.push_back( { next, sector } );
+            }
+        }
+    }
+
+    return false;
 }
 
 bool BspPortalCuller::IsLeafVisible( const BspInfo& leaf ) const {

--- a/D3D11Engine/BspPortalCuller.h
+++ b/D3D11Engine/BspPortalCuller.h
@@ -104,6 +104,17 @@ public:
         visible sectors? Mirrors zCCamera::ScreenProjectionTouchesPortal. */
     bool IsBoxVisibleInLeafSectors( const BspInfo& leaf, const DirectX::XMFLOAT3& bbMin, const DirectX::XMFLOAT3& bbMax ) const;
 
+    /** Can any OUTDOOR geometry be on screen this frame? This is GD3D11's stand-in for
+     *  zCBspSector::IsOutdoorActive(), which the detoured traversal never gets to compute.
+     *
+     *  False only for a fully enclosed view: the camera stands in a room and no opening to the outdoor
+     *  is reachable through a chain of visible portals, so no surface the sun lights is on screen and
+     *  the cascades can be skipped. Note this is NOT Stats::CameraOutdoor, which merely says the
+     *  camera's BSP leaf touches a sector and is false on an open beach next to a hut.
+     *
+     *  Conservative: true when culling is inactive or the camera's room cannot be resolved. */
+    bool IsOutdoorVisible() const { return !IsActive() || OutdoorVisible; }
+
     /** Diagnostics for the ImGui overlay / Tracy. */
     struct Stats {
         int NumSectors = 0;
@@ -114,6 +125,16 @@ public:
         int UnreachableSectors = 0;
         bool CameraOutdoor = true;
         uint16_t CameraSector = SECTOR_OUTDOOR;
+        /** Mirrors IsOutdoorVisible() for this frame. False means the sun cascades were skippable. */
+        bool OutdoorVisible = true;
+
+        // --- Enclosure-test diagnostics: why the sun cascades were or were not skipped -------------
+        /** Room FindSectorBelow resolved, or SECTOR_OUTDOOR if none. */
+        uint16_t EnclosedInSector = SECTOR_OUTDOOR;
+        /** Room whose opening to the outdoor ended the walk. Set only when OutdoorVisible is true. */
+        uint16_t OutdoorSeenFromSector = SECTOR_OUTDOOR;
+        /** Rooms the enclosure walk reached before deciding. */
+        int EnclosureWalkSectors = 0;
     };
     const Stats& GetStats() const { return LastStats; }
 
@@ -130,6 +151,10 @@ private:
     struct Sector {
         /** Indices into Portals of the portals traversable when standing inside this sector. */
         std::vector<uint32_t> OutgoingPortals;
+        /** The subset of OutdoorEntryPortals targeting this sector. Their material has a null front,
+            so they appear in no sector's OutgoingPortals and a room whose doors are all stored that
+            way would look sealed from the inside. */
+        std::vector<uint32_t> IncomingOutdoorPortals;
         /** Union of this sector's leaf AABBs - used for the near-camera grace radius. */
         DirectX::XMFLOAT3 BoundsMin{ FLT_MAX, FLT_MAX, FLT_MAX };
         DirectX::XMFLOAT3 BoundsMax{ -FLT_MAX, -FLT_MAX, -FLT_MAX };
@@ -148,8 +173,20 @@ private:
     /** Descends the BSP by position, like zCBspBase::FindLeaf. */
     zCBspBase* FindLeaf( const DirectX::XMFLOAT3& position ) const;
 
+    /** The room the camera stands in, or SECTOR_OUTDOOR - reproducing what zCBspTree::Render does to
+        pick its start sector: cast a ray straight down (portals included) and look at the nearest poly
+        below that carries the sector flag. See FindSectorBelow for why nothing cheaper works. */
+    uint16_t FindSectorBelow( const DirectX::XMFLOAT3& position ) const;
+
+    /** Recursive half of FindSectorBelow: nearest sector-flagged poly under `position`. */
+    void TraceSectorPolyDown( zCBspBase* node, const DirectX::XMFLOAT3& position,
+        float& bestY, zCPolygon*& bestPoly ) const;
+
     /** Marks every sector no chain of portals can reach from the outdoor as AlwaysActive. */
     void BuildReachability();
+
+    /** Backs IsOutdoorVisible(); evaluated once per Solve(). */
+    bool ComputeOutdoorVisible( uint16_t fromSector );
 
     bool IsSectorActive( uint16_t s ) const {
         return s < Stamps.size() && (Stamps[s] == CurrentStamp || Sectors[s].AlwaysActive);
@@ -177,6 +214,9 @@ private:
     bool WarnedBudget = false;
 
     bool Enabled = true;
+    /** Result of the last Solve(). Starts true so a world that never solves is never treated as
+        enclosed. */
+    bool OutdoorVisible = true;
     float NearSectorRadius = 2500.0f; // ~25m
     Stats LastStats;
 };

--- a/D3D11Engine/BspPortalCuller.h
+++ b/D3D11Engine/BspPortalCuller.h
@@ -133,6 +133,10 @@ public:
         uint16_t EnclosedInSector = SECTOR_OUTDOOR;
         /** Room whose opening to the outdoor ended the walk. Set only when OutdoorVisible is true. */
         uint16_t OutdoorSeenFromSector = SECTOR_OUTDOOR;
+        /** The camera's own room has a doorway outside, so enclosure was rejected on topology without
+            looking at visibility at all. Distinguishes "one step from daylight" from "the walk found a
+            door on screen", which need different fixes if either verdict looks wrong. */
+        bool CameraRoomOpensOutdoor = false;
         /** Rooms the enclosure walk reached before deciding. */
         int EnclosureWalkSectors = 0;
     };

--- a/D3D11Engine/CGameManager.h
+++ b/D3D11Engine/CGameManager.h
@@ -24,6 +24,7 @@ static void __cdecl CGameManagerRunLoop_PaceFrame() {
         Engine::GraphicsEngine->FrameLimiterEndFrame();
         Engine::GraphicsEngine->WaitForFrameLatencyWaitable();
         Engine::GraphicsEngine->FrameLimiterBeginFrame();
+        FrameMark;
     }
 }
 

--- a/D3D11Engine/CGameManager.h
+++ b/D3D11Engine/CGameManager.h
@@ -20,6 +20,7 @@ DWORD g_CGameManagerRunLoop_ReturnAddr = 0;
     instead of being nested inside D3D11GraphicsEngine::OnEndFrame/OnBeginFrame (i.e.
     inside Render()). */
 static void __cdecl CGameManagerRunLoop_PaceFrame() {
+    ++g_MainLoopFrameTick;
     if ( Engine::GraphicsEngine ) {
         Engine::GraphicsEngine->FrameLimiterEndFrame();
         Engine::GraphicsEngine->WaitForFrameLatencyWaitable();

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -970,6 +970,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="EditorLinePrimitive.h" />
     <ClInclude Include="Engine.h" />
     <ClInclude Include="BspPortalCuller.h" />
+    <ClInclude Include="HorizonCuller.h" />
     <ClInclude Include="Frustum.h" />
     <ClInclude Include="GFSDK_SSAO.h" />
     <ClInclude Include="GInventory.h" />
@@ -1236,6 +1237,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="D3D12Engine\D3D12RenderQueue.cpp" />
     <ClCompile Include="D3D12Engine\InstancingUtils.cpp" />
     <ClCompile Include="BspPortalCuller.cpp" />
+    <ClCompile Include="HorizonCuller.cpp" />
     <ClCompile Include="ShaderRegistry.cpp" />
     <ClCompile Include="D3D12Engine\D3D12Device.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -929,6 +929,7 @@
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
     <ClInclude Include="BspPortalCuller.h" />
+    <ClInclude Include="HorizonCuller.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -1329,6 +1330,7 @@
     <ClCompile Include="D3D12Engine\D3D12SkyIbl.cpp" />
     <ClCompile Include="D3D12Engine\D3D12RootLayout.cpp" />
     <ClCompile Include="BspPortalCuller.cpp" />
+    <ClCompile Include="HorizonCuller.cpp" />
     <ClCompile Include="D3D12Engine\D3D12Sky.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -1515,8 +1515,6 @@ static const char* beginFrameEventName = "Frame";
 
 /** Called when the game wants to render a new frame */
 XRESULT D3D11GraphicsEngine::OnBeginFrame() {
-    FrameMarkStart( beginFrameEventName );
-
     auto& rendererState = Engine::GAPI->GetRendererState();
     static WindowModes lastWindowMode = ImGuiShim::InterpretWindowMode(rendererState.RendererSettings);
     WindowModes currentWindowMode = (WindowModes)rendererState.RendererSettings.ChangeWindowPreset;
@@ -1574,6 +1572,7 @@ XRESULT D3D11GraphicsEngine::OnBeginFrame() {
     if ( !g_MainLoopFramePacingInstalled ) {
         WaitForFrameLatencyWaitable();
         FrameLimiterBeginFrame();
+        FrameMarkStart( beginFrameEventName );
     }
 
     SteamOverlay::Update();
@@ -1656,9 +1655,9 @@ XRESULT D3D11GraphicsEngine::OnEndFrame() {
     EndFrameTransientBufferPools();
     PerObjectMaterialInfoPooledBuffer->EndFrame();
     DynamicConstantBufferPool->EndFrame();
-    FrameMarkEnd( beginFrameEventName );
 
     if ( !g_MainLoopFramePacingInstalled ) {
+        FrameMarkEnd( beginFrameEventName );
         FrameLimiterEndFrame();
     }
     return XR_SUCCESS;

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -5112,7 +5112,10 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
 
     static std::vector<WorldMeshSectionInfo*> renderList;
     if ( !m_FrameGeometryCache.worldMeshBuilt ) {
-        Engine::GAPI->CollectVisibleSections( m_FrameGeometryCache.visibleSections, nullptr, true );
+        // Player view: opt into the ghost-occluder horizon cull (shadow/rain collects must not).
+        const HorizonCuller& horizon = Engine::GAPI->GetHorizonCuller();
+        Engine::GAPI->CollectVisibleSections( m_FrameGeometryCache.visibleSections, nullptr, true,
+            horizon.IsActive() ? &horizon : nullptr );
         m_FrameGeometryCache.worldMeshBuilt = true;
     }
     renderList = m_FrameGeometryCache.visibleSections; // shallow copy of pointers — O(N_sections), not O(BSP)

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -1574,6 +1574,7 @@ XRESULT D3D11GraphicsEngine::OnBeginFrame() {
         FrameLimiterBeginFrame();
         FrameMarkStart( beginFrameEventName );
     }
+    PausedFrameLimiterBeginFrame();
 
     SteamOverlay::Update();
 #ifdef BUILD_1_12F
@@ -1660,6 +1661,7 @@ XRESULT D3D11GraphicsEngine::OnEndFrame() {
         FrameMarkEnd( beginFrameEventName );
         FrameLimiterEndFrame();
     }
+    PausedFrameLimiterEndFrame();
     return XR_SUCCESS;
 }
 

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1123,6 +1123,31 @@ XRESULT D3D11ShadowMap::DrawWorldShadow( )
     int numCascades = settings.NumShadowCascades;
     bool isOutdoor = Engine::GAPI->GetLoadedWorldInfo()->BspTree->GetBspTreeMode() == zBSP_MODE_OUTDOOR;
 
+    // Fully enclosed view (portal culling): nothing the sun lights is on screen, so clear every
+    // cascade to 0.0 = fully shadowed and cast nothing - the same result the room's own shell would
+    // have produced, for three clears. Only the DRAWS are skipped here; the culls were launched back
+    // in OnStartWorldRendering, before this frame's portal solve existed, and WaitShadowCullingComplete
+    // above already joined them. D3D12 evaluates this early enough to skip the culls too.
+    const bool sunFullyOccluded = isOutdoor && Engine::GAPI->AreSunShadowsFullyOccluded();
+    if ( sunFullyOccluded ) {
+        if ( m_useAtlas && m_shadowAtlas ) {
+            if ( auto dsv = m_shadowAtlas->GetDepthStencilView() ) {
+                m_context->ClearDepthStencilView( dsv, D3D11_CLEAR_DEPTH, 0.0f, 0 );
+            }
+        } else {
+            for ( int cascadeIdx = 0; cascadeIdx < numCascades; ++cascadeIdx ) {
+                if ( auto dsv = GetCascadeDSV( static_cast<UINT>( cascadeIdx ) ) ) {
+                    m_context->ClearDepthStencilView( dsv, D3D11_CLEAR_DEPTH, 0.0f, 0 );
+                }
+            }
+        }
+        for ( int cascadeIdx = 0; cascadeIdx < numCascades; ++cascadeIdx ) {
+            m_RenderQueues[cascadeIdx]->Reset();
+        }
+        Engine::GAPI->SetCameraReplacementPtr( nullptr );
+        return XR_SUCCESS;
+    }
+
     if ( isOutdoor ) {
         // For atlas path: clear entire atlas once before rendering all cascades
         if ( m_useAtlas && m_shadowAtlas ) {

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -1705,11 +1705,11 @@ XRESULT D3D12GraphicsEngine::OnBeginFrame() {
     if ( !m_SwapChainReady ) return XR_SUCCESS;
 
     if ( !g_MainLoopFramePacingInstalled ) {
+        FrameMark;
         WaitForFrameLatencyWaitable();
         FrameLimiterBeginFrame();
     }
 
-    FrameMark;
     TracyD3D12BeginFrame
 
     // Apply a pending TriggerResize() request here — the command list from the previous frame is already

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -1709,6 +1709,7 @@ XRESULT D3D12GraphicsEngine::OnBeginFrame() {
         WaitForFrameLatencyWaitable();
         FrameLimiterBeginFrame();
     }
+    PausedFrameLimiterBeginFrame();
 
     TracyD3D12BeginFrame
 
@@ -1848,6 +1849,7 @@ XRESULT D3D12GraphicsEngine::OnEndFrame() {
     if ( !g_MainLoopFramePacingInstalled ) {
         FrameLimiterEndFrame();
     }
+    PausedFrameLimiterEndFrame();
 
     return XR_SUCCESS;
 }

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2702,7 +2702,10 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
 
     static std::vector<WorldMeshSectionInfo*> sections;
     sections.clear();
-    Engine::GAPI->CollectVisibleSections( sections, nullptr, true );
+    // Player view: opt into the ghost-occluder horizon cull (the shadow/rain section collects must not).
+    const HorizonCuller& horizon = Engine::GAPI->GetHorizonCuller();
+    Engine::GAPI->CollectVisibleSections( sections, nullptr, true,
+        horizon.IsActive() ? &horizon : nullptr );
 
     WorldDrawCommand* cmds = reinterpret_cast<WorldDrawCommand*>( m_WorldDrawArgsPtr[m_FrameIndex] );
     UINT count = 0;

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -792,19 +792,17 @@ void D3D12ShadowMap::Prepare() {
 	// double-darkens the baked interior lighting.
 	const bool sunUp = !Engine::GAPI->IsIndoorWorld() && (lp.y > 0.0f);
 
-	// Fully enclosed view (portal culling): sun is up, but nothing it lights is on screen. Clear each
-	// slice to SHADOWED instead of far and cull/build/draw no casters. Safe to read here -
-	// OnStartWorldRendering ran this frame's CollectVisibleVobs (and BspPortalCuller::Solve) before
-	// Prepare(), which is also why D3D12 can skip the culls and D3D11 only the draws.
+	// Fully enclosed view (portal culling): sun is up, but nothing it lights is on screen. Clear each slice
+	// to SHADOWED instead of far and cull/build/draw no casters. Safe to read here - CollectVisibleVobs (and
+	// BspPortalCuller::Solve) ran before Prepare().
 	const bool sunFullyOccluded = sunUp && Engine::GAPI->AreSunShadowsFullyOccluded();
 	const bool castersNeeded = sunUp && !sunFullyOccluded;
 
 	m_SunUp = castersNeeded;            // RecordCascade runs on a pool thread; it can re-read neither
 	m_SunOccluded = sunFullyOccluded;   // the sky nor the portal culler
 
-	// The REAL sun state, not castersNeeded: an enclosed view is still daytime and must not take the
-	// sun-down branch, which halves ambient and would darken the interior. The shadowed cascade content
-	// is what removes the per-pixel sun term.
+	// The REAL sun state, not castersNeeded: an enclosed view is still daytime and must not take the sun-down
+	// branch, which halves ambient. The shadowed cascade content is what removes the per-pixel sun term.
 	UploadSamplingConstants( sunUp );
 
 	// --- Phase A (main thread): resolve everything that is shared by ALL cascades ------------------------
@@ -875,9 +873,8 @@ void D3D12ShadowMap::Prepare() {
 		// Nothing casts; each cascade still gets its slice cleared at record time - to far (= unshadowed) with the
 		// sun down, or to near (= fully shadowed) for an enclosed view, see m_SunOccluded / RecordCascade. No cull
 		// jobs are launched, so FinishPrepare has nothing to wait for and skips Phase C outright.
-		// The lazy gate is overridden here: a frozen cascade skips its RecordCascade entirely, so at dusk the
-		// last cascade would keep the daytime depth it was frozen with for up to two more frames and go on
-		// shadowing after the sun set. Clearing is cheap — always do it.
+		// The lazy gate is overridden here: a frozen cascade skips RecordCascade entirely, so at dusk it
+		// would go on shadowing with its daytime depth for two more frames. Clearing is cheap.
 		for ( UINT c = 0; c < kShadowCascades; ++c ) m_ShouldUpdateCascade[c] = true;
 		m_CascadeMatricesValid = false;   // the frozen matrices no longer describe any rendered slice
 		for ( UINT c = 0; c < kShadowCascades; ++c ) {

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -791,8 +791,20 @@ void D3D12ShadowMap::Prepare() {
 	// unshadowed and phases A/B/C are skipped entirely, so a mine pays no shadow cost and nothing
 	// double-darkens the baked interior lighting.
 	const bool sunUp = !Engine::GAPI->IsIndoorWorld() && (lp.y > 0.0f);
-	m_SunUp = sunUp;   // RecordCascade may run on a pool thread, so it can't re-read the sky itself
 
+	// Fully enclosed view (portal culling): sun is up, but nothing it lights is on screen. Clear each
+	// slice to SHADOWED instead of far and cull/build/draw no casters. Safe to read here -
+	// OnStartWorldRendering ran this frame's CollectVisibleVobs (and BspPortalCuller::Solve) before
+	// Prepare(), which is also why D3D12 can skip the culls and D3D11 only the draws.
+	const bool sunFullyOccluded = sunUp && Engine::GAPI->AreSunShadowsFullyOccluded();
+	const bool castersNeeded = sunUp && !sunFullyOccluded;
+
+	m_SunUp = castersNeeded;            // RecordCascade runs on a pool thread; it can re-read neither
+	m_SunOccluded = sunFullyOccluded;   // the sky nor the portal culler
+
+	// The REAL sun state, not castersNeeded: an enclosed view is still daytime and must not take the
+	// sun-down branch, which halves ambient and would darken the interior. The shadowed cascade content
+	// is what removes the per-pixel sun term.
 	UploadSamplingConstants( sunUp );
 
 	// --- Phase A (main thread): resolve everything that is shared by ALL cascades ------------------------
@@ -807,7 +819,7 @@ void D3D12ShadowMap::Prepare() {
 		&& (ib->GetSizeInBytes() / sizeof( uint32_t )) > 0;
 
 	g_WorldCasters.clear();
-	if ( haveWorld && sunUp ) {
+	if ( haveWorld && castersNeeded ) {
 		const Frustum& unionShadowFrustum = m_CascadeFrustum[kShadowCascades - 1];
 		static std::vector<WorldMeshSectionInfo*> shadowSections;
 		shadowSections.clear();
@@ -859,8 +871,9 @@ void D3D12ShadowMap::Prepare() {
 		g_GrassCB.HeroAffectStrength = 1.0f;
 	}
 
-	if ( !sunUp ) {
-		// Nothing casts; each cascade still gets its slice cleared to far (= unshadowed) at record time. No cull
+	if ( !castersNeeded ) {
+		// Nothing casts; each cascade still gets its slice cleared at record time - to far (= unshadowed) with the
+		// sun down, or to near (= fully shadowed) for an enclosed view, see m_SunOccluded / RecordCascade. No cull
 		// jobs are launched, so FinishPrepare has nothing to wait for and skips Phase C outright.
 		// The lazy gate is overridden here: a frozen cascade skips its RecordCascade entirely, so at dusk the
 		// last cascade would keep the daytime depth it was frozen with for up to two more frames and go on
@@ -1163,8 +1176,10 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 	TracyD3D12ZoneCGX( cmdList.Get(), "Sun Shadow Cascade" );
 
 	cmdList->OMSetRenderTargets( 0, nullptr, FALSE, &dsv );   // DSV stays bound across the PSO switches below
-	cmdList->ClearDepthStencilView( dsv, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr );   // normal-Z far
-	// Sun below the horizon → the slice stays cleared to far, i.e. fully unshadowed, and nothing casts.
+	// normal-Z under the LESS_EQUAL comparison sampler: far (1.0) reads as unshadowed, near (0.0) as
+	// fully shadowed - which is what an enclosed view wants, and what its shell would have cast.
+	cmdList->ClearDepthStencilView( dsv, D3D12_CLEAR_FLAG_DEPTH, m_SunOccluded ? 0.0f : 1.0f, 0, 0, nullptr );
+	// Sun below the horizon (or enclosed) → the slice keeps that clear and nothing casts.
 	if ( !sunUp ) return;
 
 	// Resolved once: GetSrvGpuHandle takes m_SrvHeapMutex and linear-scans the free-slot list, and all three

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
@@ -221,6 +221,11 @@ private:
 
     bool m_CullingPending = false;   // cascade jobs are in flight and must be joined before the results are read
     bool m_RecordedInJob = false;    // this frame's jobs also RECORDED (not just culled/built) — see RecordedInJob()
-    bool m_SunUp = false;            // resolved in Prepare(); RecordCascade may run on a pool thread and can't re-read the sky
+    /** "This frame casts sun shadows": sun up AND not fully enclosed by portals. Resolved in Prepare()
+        since RecordCascade (its only consumer, via IsSunUp) may run on a pool thread. */
+    bool m_SunUp = false;
+    /** Portal culling says the view is fully enclosed, so the slices are cleared to SHADOWED (0.0)
+        instead of far and nothing casts. Resolved in Prepare() next to m_SunUp, for the same reason. */
+    bool m_SunOccluded = false;
     bool m_PassReady = false;        // Prepare() ran to completion this frame — the cascades have something to record
 };

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4287,6 +4287,55 @@ void GothicAPI::DebugDrawTreeNode( zCBspBase* base, zTBBox3D boxCell, int clipFl
     }
 }
 
+/** Outlines the world's ghost occluders (WorldOccluders) so their placement can be eyeballed before
+    anything culls against them. Frustum- and distance-limited: a world ships up to ~2500 of them and
+    feeding every one to the line renderer every frame would swamp it. */
+void GothicAPI::DebugDrawOccluders( const Frustum& frustum ) {
+    if ( !LoadedWorldInfo || LoadedWorldInfo->Occluders.IsEmpty() )
+        return;
+
+    const WorldOccluders& occ = LoadedWorldInfo->Occluders;
+    BaseLineRenderer* lines = Engine::GraphicsEngine->GetLineRenderer();
+    if ( !lines )
+        return;
+
+    const XMVECTOR camPos = GetCameraPositionXM();
+    const float maxDist = 20000.0f;   // 200m - beyond that the outlines are unreadable anyway
+    const size_t maxDrawn = 400;      // line-renderer budget; overflow is logged once below
+
+    size_t drawn = 0;
+    size_t skippedForBudget = 0;
+    for ( const WorldOccluders::Entry& e : occ.Entries ) {
+        float distSq;
+        XMStoreFloat( &distSq, XMVector3LengthSq( XMLoadFloat3( &e.Center ) - camPos ) );
+        if ( distSq > (maxDist + e.Radius) * (maxDist + e.Radius) )
+            continue;
+        if ( !frustum.Intersects( zTBBox3D{
+                XMFLOAT3( e.Center.x - e.Radius, e.Center.y - e.Radius, e.Center.z - e.Radius ),
+                XMFLOAT3( e.Center.x + e.Radius, e.Center.y + e.Radius, e.Center.z + e.Radius ) } ) )
+            continue;
+
+        if ( drawn >= maxDrawn ) { skippedForBudget++; continue; }
+
+        // Green near, red far - makes it obvious which ones actually bound the current view.
+        const float t = std::min( 1.0f, std::sqrtf( distSq ) / maxDist );
+        const XMFLOAT4 color( t, 1.0f - t, 0.2f, 1.0f );
+
+        for ( uint32_t v = 0; v < e.NumVerts; v++ ) {
+            const XMFLOAT3& a = occ.Verts[e.VertexOffset + v];
+            const XMFLOAT3& b = occ.Verts[e.VertexOffset + ((v + 1) % e.NumVerts)];
+            lines->AddLine( LineVertex( a, color ), LineVertex( b, color ) );
+        }
+        drawn++;
+    }
+
+    if ( skippedForBudget && !OccluderDebugBudgetLogged ) {
+        LogInfo() << "DrawWorldOccluders: showing " << maxDrawn << " of " << (drawn + skippedForBudget)
+            << " in-view occluders (line budget)";
+        OccluderDebugBudgetLogged = true;
+    }
+}
+
 /** Draws the AABB for the BSP-Tree using the line renderer*/
 void GothicAPI::DebugDrawBSPTree() {
     zCBspTree* tree = LoadedWorldInfo->BspTree;
@@ -4311,6 +4360,8 @@ void GothicAPI::CollectVisibleVobs(
     Frustum frustum = Frustum::AlwaysContainingFrustum();
     bool haveCameraMatrices = false;
     XMMATRIX worldToClip = XMMatrixIdentity();
+    // Kept alongside worldToClip so the horizon cull can measure depth in the SAME camera's space.
+    XMMATRIX cameraView = XMMatrixIdentity();
     if ( auto cam = GetSceneCamera() ) {
         cam->Activate();
 
@@ -4322,6 +4373,7 @@ void GothicAPI::CollectVisibleVobs(
         frustum.BuildPerspective( viewM, projM );
 
         worldToClip = XMMatrixMultiply( viewM, projM );
+        cameraView = viewM;
         haveCameraMatrices = true;
     }
 
@@ -4368,6 +4420,27 @@ void GothicAPI::CollectVisibleVobs(
         oCGame* game = oCGame::GetGame();
         PortalCuller.Solve( worldToClip, ctx.cameraPosition, game ? game->_zCSession_camVob : nullptr );
         ctx.portalCuller = &PortalCuller;
+    }
+
+    // Rasterize the ghost-occluder horizon for THIS camera, then hand it to the collect. Main camera
+    // pass only - a shadow cascade has its own frustum and must not test against the player's skyline.
+    Horizon.SetEnabled( RendererState.RendererSettings.EnableHorizonCulling );
+    if ( haveCameraMatrices && LoadedWorldInfo && !LoadedWorldInfo->Occluders.IsEmpty() ) {
+        const INT2 res = Engine::GraphicsEngine->GetResolution();
+        // viewM, NOT GetViewMatrixXM(): worldToClip above is viewM*projM from this zCCamera, and the
+        // horizon compares occluder and box depths in that camera's space. GothicAPI's TransformView is
+        // a different, pass-dependent value - the shadow cascades overwrite it through
+        // SetCameraReplacementPtr - so mixing the two measured depth along two unrelated axes.
+        Horizon.Build( LoadedWorldInfo->Occluders, worldToClip, cameraView, ctx.cameraPosition,
+            frustum, res.x, res.y );
+        if ( Horizon.IsActive() )
+            ctx.horizon = &Horizon;
+    } else {
+        Horizon.Invalidate();
+    }
+
+    if ( RendererState.RendererSettings.DrawWorldOccluders ) {
+        DebugDrawOccluders( frustum );
     }
 
     CollectVisibleVobs( ctx );
@@ -4600,7 +4673,8 @@ bool GothicAPI::IsWorldMeshVisibleInFrustum( const WorldMeshInfo* mesh, const Fr
 
 void GothicAPI::QueryWorldSectionBVH( const Frustum& frustum,
     std::vector<WorldMeshSectionInfo*>& sections,
-    bool useSectionRadiusFilter ) const {
+    bool useSectionRadiusFilter,
+    const HorizonCuller* horizon ) const {
     if ( !WorldSectionBVHValid || WorldSectionBVHNodes.empty() ) {
         return;
     }
@@ -4623,6 +4697,19 @@ void GothicAPI::QueryWorldSectionBVH( const Frustum& frustum,
         const WorldSectionBVHNode& node = WorldSectionBVHNodes[nodeIndex];
         if ( !frustum.Intersects( node.Bounds ) ) {
             continue;
+        }
+        // Horizon on the BVH node itself: rejecting an interior node drops its whole subtree of
+        // sections in one test, which is where this pays best.
+        if ( horizon ) {
+            const XMFLOAT3 nodeMin( node.Bounds.Center.x - node.Bounds.Extents.x,
+                                    node.Bounds.Center.y - node.Bounds.Extents.y,
+                                    node.Bounds.Center.z - node.Bounds.Extents.z );
+            const XMFLOAT3 nodeMax( node.Bounds.Center.x + node.Bounds.Extents.x,
+                                    node.Bounds.Center.y + node.Bounds.Extents.y,
+                                    node.Bounds.Center.z + node.Bounds.Extents.z );
+            if ( !horizon->IsBoxVisible( nodeMin, nodeMax ) ) {
+                continue;
+            }
         }
 
         if ( node.IsLeaf() ) {
@@ -4670,7 +4757,8 @@ void GothicAPI::UpdateShouldBlockGameInput( ) {
 /** Collects visible sections from the current camera perspective */
 void GothicAPI::CollectVisibleSections( std::vector<WorldMeshSectionInfo*>& sections,
     const Frustum* queryFrustum,
-    bool useSectionRadiusFilter ) {
+    bool useSectionRadiusFilter,
+    const HorizonCuller* horizon ) {
     const XMFLOAT3 camPos = Engine::GAPI->GetCameraPosition();
     const INT2 camSection = WorldConverter::GetSectionOfPos( camPos );
     auto cullingEnabled = Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.Culling.CullBspSections;
@@ -4685,10 +4773,15 @@ void GothicAPI::CollectVisibleSections( std::vector<WorldMeshSectionInfo*>& sect
             if ( !queryFrustum->IsValid() ) {
                 return true;
             }
-            return queryFrustum->Intersects( section.BoundingBox );
+            if ( !queryFrustum->Intersects( section.BoundingBox ) ) return false;
+        } else if ( GetCameraBBox3DInFrustum( section.BoundingBox, EGothicCullFlags::CullSidesNear ) == ZTCAM_CLIPTYPE_OUT ) {
+            return false;
         }
 
-        return GetCameraBBox3DInFrustum( section.BoundingBox, EGothicCullFlags::CullSidesNear ) != ZTCAM_CLIPTYPE_OUT;
+        if ( horizon && !horizon->IsBoxVisible( section.BoundingBox.Min, section.BoundingBox.Max ) ) {
+            return false;
+        }
+        return true;
     };
 
     const bool queryFrustumValid = queryFrustum == nullptr || queryFrustum->IsValid();
@@ -4714,7 +4807,7 @@ void GothicAPI::CollectVisibleSections( std::vector<WorldMeshSectionInfo*>& sect
             activeFrustum = &generatedFrustum;
         }
 
-        QueryWorldSectionBVH( *activeFrustum, sections, useSectionRadiusFilter );
+        QueryWorldSectionBVH( *activeFrustum, sections, useSectionRadiusFilter, horizon );
         return;
     }
 
@@ -4914,6 +5007,13 @@ static void CVVH_AddNotDrawnVobToList(
             && !ctx.frustum.Intersects( it->LastRenderBBox ) ) {
             continue;
         }
+        // Horizon: hidden behind an occluder, so nothing below is built at all - no instance upload,
+        // no indirect command, no CacheIn. Kept after the frustum test, which is much cheaper.
+        if ( ctx.horizon ) {
+            const zTBBox3D& hb = it->LastRenderBBox;
+            if ( !ctx.horizon->IsBoxVisible( hb.Min, hb.Max ) )
+                continue;
+        }
         if ( portalLeaf ) {
             const zTBBox3D& bb = it->LastRenderBBox;
             if ( !ctx.portalCuller->IsBoxVisibleInLeafSectors( *portalLeaf, bb.Min, bb.Max ) )
@@ -4951,6 +5051,13 @@ static void CVVH_AddNotDrawnVobToList(
             && cullingEnabled
             && !ctx.frustum.Intersects( it->Vob->GetBBox() ) ) {
             continue;
+        }
+        // Horizon: static MOBs draw per-mesh rather than indirect, so a rejection here saves a whole
+        // draw plus its material binds - the cheapest win of the three lists.
+        if ( ctx.horizon ) {
+            const zTBBox3D bb = it->Vob->GetBBox();
+            if ( !ctx.horizon->IsBoxVisible( bb.Min, bb.Max ) )
+                continue;
         }
 
         ctx.queue->PushSkeletalVob( it );
@@ -5673,6 +5780,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "General", "CompressBackBuffer", to_string_locale_independent( s.CompressBackBuffer ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "AnimateStaticVobs", to_string_locale_independent( s.AnimateStaticVobs ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "DrawWorldSectionIntersections", to_string_locale_independent( s.DrawSectionIntersections ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "DrawWorldOccluders", to_string_locale_independent( s.DrawWorldOccluders ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "SunLightStrength", to_string_locale_independent( s.SunLightStrength ).c_str(), ini.c_str() );
 #ifdef BUILD_GOTHIC_1_08k
     WritePrivateProfileStringA( "General", "DrawG1ForestPortals", to_string_locale_independent( s.DrawG1ForestPortals ? TRUE : FALSE ).c_str(), ini.c_str() );
@@ -5688,6 +5796,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "General", "EnablePortalCulling", to_string_locale_independent( s.EnablePortalCulling ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "PortalCullingNearRadius", float_to_string( s.PortalCullingNearRadius, 1 ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "EnablePortalShadowSkip", to_string_locale_independent( s.EnablePortalShadowSkip ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "EnableHorizonCulling", to_string_locale_independent( s.EnableHorizonCulling ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "FpsLimit", to_string_locale_independent( s.FpsLimit ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "PausedFpsLimit", to_string_locale_independent( s.PausedFpsLimit ).c_str(), ini.c_str() );
     
@@ -5849,6 +5958,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.CompressBackBuffer = GetPrivateProfileBoolA( "General", "CompressBackBuffer", ds.CompressBackBuffer, ini );
         s.AnimateStaticVobs = GetPrivateProfileBoolA( "General", "AnimateStaticVobs", ds.AnimateStaticVobs, ini );
         s.DrawSectionIntersections = GetPrivateProfileBoolA( "General", "DrawWorldSectionIntersections", ds.DrawSectionIntersections, ini );
+        s.DrawWorldOccluders = GetPrivateProfileBoolA( "General", "DrawWorldOccluders", ds.DrawWorldOccluders, ini );
         s.SunLightStrength = GetPrivateProfileFloatA( "General", "SunLightStrength", ds.SunLightStrength, ini );
 #ifdef BUILD_GOTHIC_1_08k
         s.DrawG1ForestPortals = GetPrivateProfileBoolA( "General", "DrawG1ForestPortals", ds.DrawG1ForestPortals, ini );
@@ -5864,6 +5974,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.EnablePortalCulling = GetPrivateProfileBoolA( "General", "EnablePortalCulling", ds.EnablePortalCulling, ini );
         s.PortalCullingNearRadius = GetPrivateProfileFloatA( "General", "PortalCullingNearRadius", ds.PortalCullingNearRadius, ini );
         s.EnablePortalShadowSkip = GetPrivateProfileBoolA( "General", "EnablePortalShadowSkip", ds.EnablePortalShadowSkip, ini );
+        s.EnableHorizonCulling = GetPrivateProfileBoolA( "General", "EnableHorizonCulling", ds.EnableHorizonCulling, ini );
         s.FpsLimit = GetPrivateProfileIntA( "General", "FpsLimit", 0, ini.c_str() );
         s.PausedFpsLimit = GetPrivateProfileIntA( "General", "PausedFpsLimit", ds.PausedFpsLimit, ini.c_str() );
         // Not optional: an unthrottled paused loop crashes drivers, so the ini can only pick a value

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4059,6 +4059,16 @@ bool GothicAPI::IsGamePaused() {
     return game->GetSingleStep();
 }
 
+/** Returns true while an in-game menu holds the game paused */
+bool GothicAPI::IsIngameMenuPaused() {
+    // Deliberately stricter than IsGamePaused(): that one reports "paused" when there is no game
+    // session at all (out-game menu, startup, teardown), which is indistinguishable from loading.
+    // With a session present, singleStep can only have been set by oCGame::Pause(), which every
+    // in-game menu (ESC main menu, inventory/status, log, map) calls before entering zCMenu::Run().
+    oCGame* game = oCGame::GetGame();
+    return game && game->GetSingleStep();
+}
+
 /** Checks if a game is being saved now */
 bool GothicAPI::IsSavingGameNow() {
     oCGame* game = oCGame::GetGame();
@@ -5679,6 +5689,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "General", "PortalCullingNearRadius", float_to_string( s.PortalCullingNearRadius, 1 ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "EnablePortalShadowSkip", to_string_locale_independent( s.EnablePortalShadowSkip ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "FpsLimit", to_string_locale_independent( s.FpsLimit ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "PausedFpsLimit", to_string_locale_independent( s.PausedFpsLimit ).c_str(), ini.c_str() );
     
     auto res = Engine::GraphicsEngine->GetBackbufferResolution();
     WritePrivateProfileStringA( "Display", "TextureQuality", to_string_locale_independent( s.textureMaxSize ).c_str(), ini.c_str() );
@@ -5854,6 +5865,11 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.PortalCullingNearRadius = GetPrivateProfileFloatA( "General", "PortalCullingNearRadius", ds.PortalCullingNearRadius, ini );
         s.EnablePortalShadowSkip = GetPrivateProfileBoolA( "General", "EnablePortalShadowSkip", ds.EnablePortalShadowSkip, ini );
         s.FpsLimit = GetPrivateProfileIntA( "General", "FpsLimit", 0, ini.c_str() );
+        s.PausedFpsLimit = GetPrivateProfileIntA( "General", "PausedFpsLimit", ds.PausedFpsLimit, ini.c_str() );
+        // Not optional: an unthrottled paused loop crashes drivers, so the ini can only pick a value
+        // inside the allowed band (0/garbage included) - it can't switch the cap off.
+        s.PausedFpsLimit = std::clamp( s.PausedFpsLimit,
+            GothicRendererSettings::PausedFpsLimitMin, GothicRendererSettings::PausedFpsLimitMax );
 
         // override INI settings with GMP minimum values.
         if ( GMPModeActive ) {

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4420,10 +4420,9 @@ void GothicAPI::CollectVisibleVobs(
     Horizon.SetEnabled( RendererState.RendererSettings.EnableHorizonCulling );
     if ( haveCameraMatrices && LoadedWorldInfo && !LoadedWorldInfo->Occluders.IsEmpty() ) {
         const INT2 res = Engine::GraphicsEngine->GetResolution();
-        // viewM, NOT GetViewMatrixXM(): worldToClip above is viewM*projM from this zCCamera, and the
-        // horizon compares occluder and box depths in that camera's space. GothicAPI's TransformView is
-        // a different, pass-dependent value - the shadow cascades overwrite it through
-        // SetCameraReplacementPtr - so mixing the two measured depth along two unrelated axes.
+        // viewM, NOT GetViewMatrixXM(): worldToClip is viewM*projM from this zCCamera and the horizon
+        // compares depths in that camera's space, while TransformView is pass-dependent (the shadow
+        // cascades overwrite it through SetCameraReplacementPtr).
         Horizon.Build( LoadedWorldInfo->Occluders, worldToClip, cameraView, ctx.cameraPosition,
             frustum, res.x, res.y );
         if ( Horizon.IsActive() )
@@ -4984,8 +4983,8 @@ static void CVVH_AddNotDrawnVobToList(
         if ( needFrustumTest && !ctx.frustum.Intersects( it->LastRenderBBox ) ) {
             continue;
         }
-        // Horizon: hidden behind an occluder, so nothing below is built at all - no instance upload,
-        // no indirect command, no CacheIn. Kept after the frustum test, which is much cheaper.
+        // Horizon: hidden behind an occluder, so nothing below is built - no instance upload, no indirect
+        // command, no CacheIn. After the frustum test, which is much cheaper.
         if ( horizon ) {
             const zTBBox3D& hb = it->LastRenderBBox;
             if ( !horizon->IsBoxVisible( hb.Min, hb.Max ) )
@@ -5019,9 +5018,8 @@ static void CVVH_AddNotDrawnVobToList(
     const bool needFrustumTest = cullingEnabled && bspContainment != ContainmentType::CONTAINS;
 
     for ( auto const& it : source ) {
-        // Distance before Visit(): the test is leaf-independent, so a mob out of range fails it in
-        // every leaf it is registered in and marking it seen changes nothing. Ordering it first keeps
-        // the atomic off the reject path, exactly as in the static-vob overload above.
+        // Distance before Visit(): the test is leaf-independent, so an out-of-range mob fails it in every
+        // leaf and marking it seen changes nothing. Keeps the atomic off the reject path.
         if ( XMVector3Greater( XMVector3LengthSq( camPos - it->Vob->GetPositionWorldXM() ), vDistSq ) ) {
             continue;
         }
@@ -5034,8 +5032,8 @@ static void CVVH_AddNotDrawnVobToList(
         if ( needFrustumTest && !ctx.frustum.Intersects( it->Vob->GetBBox() ) ) {
             continue;
         }
-        // Horizon: static MOBs draw per-mesh rather than indirect, so a rejection here saves a whole
-        // draw plus its material binds - the cheapest win of the three lists.
+        // Horizon: static MOBs draw per-mesh rather than indirect, so a rejection saves a whole draw plus
+        // its material binds.
         if ( ctx.horizon ) {
             const zTBBox3D bb = it->Vob->GetBBox();
             if ( !ctx.horizon->IsBoxVisible( bb.Min, bb.Max ) )
@@ -7093,11 +7091,9 @@ static void CollectVisibleVobsWithLeafCache(
         // DirectX cached planes have OUTWARD-facing normals (positive dot = outside frustum),
         // matching FastIntersectAxisAlignedBoxPlane: Outside = (Dist > Radius).
         // blendv_ps(a, b, mask): MSB=0 -> a, MSB=1 (negative) -> b.
-        //   n-vertex (MINIMUM dot) = blendv(Min, Max, n): n>=0 -> Min, n<0 -> Max. dot > 0 => the
-        //     ENTIRE AABB is on the outer side of this plane, so the leaf is rejected.
-        //   p-vertex (MAXIMUM dot) = blendv(Max, Min, n), i.e. the operands swapped. dot <= 0 for
-        //     ALL six planes => every corner is inside every plane, so the leaf is fully CONTAINED
-        //     and no VOB, MOB or light inside it needs its own frustum test.
+        //   n-vertex (MINIMUM dot) = blendv(Min, Max, n); dot > 0 => whole AABB outside, leaf rejected.
+        //   p-vertex (MAXIMUM dot) = the same with the operands swapped; dot <= 0 for all six planes =>
+        //     the leaf is fully CONTAINED and nothing inside it needs its own frustum test.
         __m256 vOutside = vZero;
         __m256 vNotContained = vZero;
         if ( !skipVobFrustumCull ) {
@@ -7110,10 +7106,8 @@ static void CollectVisibleVobsWithLeafCache(
                                      _mm256_fmadd_ps( pNZ[p], vNZ, pD[p] ) ) );
                 vOutside = _mm256_or_ps( vOutside, _mm256_cmp_ps( vNDot, vZero, _CMP_GT_OQ ) );
 
-                // The p-vertex differs from the n-vertex only in which extent each axis picks, so it
-                // reuses the already-loaded Min/Max registers - 3 blends + 3 FMAs + a compare per
-                // plane per 8 leaves, against one full per-VOB box test saved for every VOB in every
-                // fully-contained leaf.
+                // The p-vertex differs only in which extent each axis picks, so it reuses the already-loaded
+                // Min/Max registers.
                 const __m256 vPX = _mm256_blendv_ps( vMaxX, vMinX, pNX[p] );
                 const __m256 vPY = _mm256_blendv_ps( vMaxY, vMinY, pNY[p] );
                 const __m256 vPZ = _mm256_blendv_ps( vMaxZ, vMinZ, pNZ[p] );
@@ -7164,10 +7158,8 @@ static void CollectVisibleVobsWithLeafCache(
             if ( enableOcclusionCulling && !leaf->OcclusionInfo.VisibleLastFrame )
                 continue;
 
-            // CONTAINS when the leaf box is fully inside all six planes: every VOB, MOB and light in
-            // it then skips its own frustum test in CollectLeafVobs. Conservative in the right
-            // direction - a VOB whose box pokes out of a contained leaf is kept rather than dropped,
-            // and it is registered in the neighbouring leaf it pokes into anyway.
+            // CONTAINS when the leaf box is fully inside all six planes: everything in it then skips its own
+            // frustum test in CollectLeafVobs. A VOB poking out of a contained leaf is kept, not dropped.
             const ContainmentType containment = ( partialMask & (1 << lane) )
                 ? ContainmentType::INTERSECTS
                 : ContainmentType::CONTAINS;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5677,6 +5677,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "General", "EnableOcclusionCulling", to_string_locale_independent( s.EnableOcclusionCulling ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "EnablePortalCulling", to_string_locale_independent( s.EnablePortalCulling ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "PortalCullingNearRadius", float_to_string( s.PortalCullingNearRadius, 1 ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "EnablePortalShadowSkip", to_string_locale_independent( s.EnablePortalShadowSkip ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "FpsLimit", to_string_locale_independent( s.FpsLimit ).c_str(), ini.c_str() );
     
     auto res = Engine::GraphicsEngine->GetBackbufferResolution();
@@ -5851,6 +5852,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.EnableOcclusionCulling = GetPrivateProfileBoolA( "General", "EnableOcclusionCulling", ds.EnableOcclusionCulling, ini );
         s.EnablePortalCulling = GetPrivateProfileBoolA( "General", "EnablePortalCulling", ds.EnablePortalCulling, ini );
         s.PortalCullingNearRadius = GetPrivateProfileFloatA( "General", "PortalCullingNearRadius", ds.PortalCullingNearRadius, ini );
+        s.EnablePortalShadowSkip = GetPrivateProfileBoolA( "General", "EnablePortalShadowSkip", ds.EnablePortalShadowSkip, ini );
         s.FpsLimit = GetPrivateProfileIntA( "General", "FpsLimit", 0, ini.c_str() );
 
         // override INI settings with GMP minimum values.

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -2052,6 +2052,19 @@ void GothicAPI::LeaveResourceCriticalSection() {
     LeaveCriticalSection( &ResourceCriticalSection );
 }
 
+/** Swap-and-pop removal of a vob from one BSP leaf list. Order in these lists is irrelevant -
+    collection walks them whole - so the swap keeps removal O(list size) instead of the shuffle
+    an erase() would do, and every list stays contiguous for the SIMD distance reject. */
+static void EraseVobFromLeafList( std::vector<LeafVobEntry>& list, const VobInfo* vob ) {
+    for ( auto it = list.begin(); it != list.end(); ++it ) {
+        if ( it->Info == vob ) {
+            *it = list.back();
+            list.pop_back();
+            return;
+        }
+    }
+}
+
 /** Called when a VOB got removed from the world */
 void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world ) {
     //LogInfo() << "Removing vob: " << vob;
@@ -2145,29 +2158,9 @@ void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world ) {
         for ( unsigned int i = 0; i < nodes->size(); i++ ) {
             BspInfo* node = (*nodes)[i];
             if ( vi ) {
-                for ( auto bit = node->IndoorVobs.begin(); bit != node->IndoorVobs.end(); ++bit ) {
-                    if ( (*bit) == vi ) {
-                        (*bit) = node->IndoorVobs.back();
-                        node->IndoorVobs.pop_back();
-                        break;
-                    }
-                }
-
-                for ( auto bit = node->Vobs.begin(); bit != node->Vobs.end(); ++bit ) {
-                    if ( (*bit) == vi ) {
-                        (*bit) = node->Vobs.back();
-                        node->Vobs.pop_back();
-                        break;
-                    }
-                }
-
-                for ( auto bit = node->SmallVobs.begin(); bit != node->SmallVobs.end(); ++bit ) {
-                    if ( (*bit) == vi ) {
-                        (*bit) = node->SmallVobs.back();
-                        node->SmallVobs.pop_back();
-                        break;
-                    }
-                }
+                EraseVobFromLeafList( node->IndoorVobs, vi );
+                EraseVobFromLeafList( node->Vobs, vi );
+                EraseVobFromLeafList( node->SmallVobs, vi );
             }
 
             if ( li && nodes ) {
@@ -4898,29 +4891,9 @@ void GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob ) {
         BspInfo* node = vob->ParentBSPNodes[i];
 
         // Remove from possible lists
-        for ( std::vector<VobInfo*>::iterator it = node->IndoorVobs.begin(); it != node->IndoorVobs.end(); ++it ) {
-            if ( (*it) == vob ) {
-                (*it) = node->IndoorVobs.back();
-                node->IndoorVobs.pop_back();
-                break;
-            }
-        }
-
-        for ( std::vector<VobInfo*>::iterator it = node->SmallVobs.begin(); it != node->SmallVobs.end(); ++it ) {
-            if ( (*it) == vob ) {
-                (*it) = node->SmallVobs.back();
-                node->SmallVobs.pop_back();
-                break;
-            }
-        }
-
-        for ( std::vector<VobInfo*>::iterator it = node->Vobs.begin(); it != node->Vobs.end(); ++it ) {
-            if ( (*it) == vob ) {
-                (*it) = node->Vobs.back();
-                node->Vobs.pop_back();
-                break;
-            }
-        }
+        EraseVobFromLeafList( node->IndoorVobs, vob );
+        EraseVobFromLeafList( node->SmallVobs, vob );
+        EraseVobFromLeafList( node->Vobs, vob );
     }
     vob->ParentBSPNodes.clear();
 
@@ -4928,9 +4901,9 @@ void GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob ) {
     DynamicallyAddedVobs.push_back( vob );
 }
 
-std::vector<VobInfo*>::iterator GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob, std::vector<VobInfo*>* source ) {
-    std::vector<VobInfo*>::iterator itn = source->end();
-    std::vector<VobInfo*>::iterator itc;
+std::vector<LeafVobEntry>::iterator GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob, std::vector<LeafVobEntry>* source ) {
+    std::vector<LeafVobEntry>::iterator itn = source->end();
+    std::vector<LeafVobEntry>::iterator itc;
 
     // Remove from all nodes
     for ( size_t i = 0; i < vob->ParentBSPNodes.size(); i++ ) {
@@ -4938,7 +4911,7 @@ std::vector<VobInfo*>::iterator GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob
 
         // Remove from possible lists
         for ( auto it = node->IndoorVobs.begin(); it != node->IndoorVobs.end(); ++it ) {
-            if ( (*it) == vob ) {
+            if ( it->Info == vob ) {
                 itc = node->IndoorVobs.erase( it );
                 break;
             }
@@ -4948,7 +4921,7 @@ std::vector<VobInfo*>::iterator GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob
             itn = itc;
 
         for ( auto it = node->SmallVobs.begin(); it != node->SmallVobs.end(); ++it ) {
-            if ( (*it) == vob ) {
+            if ( it->Info == vob ) {
                 itc = node->SmallVobs.erase( it );
                 break;
             }
@@ -4958,7 +4931,7 @@ std::vector<VobInfo*>::iterator GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob
             itn = itc;
 
         for ( auto it = node->Vobs.begin(); it != node->Vobs.end(); ++it ) {
-            if ( (*it) == vob ) {
+            if ( it->Info == vob ) {
                 itc = node->Vobs.erase( it );
                 break;
             }
@@ -4976,7 +4949,7 @@ std::vector<VobInfo*>::iterator GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob
 
 static void CVVH_AddNotDrawnVobToList(
         FXMVECTOR distSq,
-        std::vector<VobInfo*>& source,
+        std::vector<LeafVobEntry>& source,
         const RndCullContext& ctx,
         DirectX::ContainmentType bspContainment,
         BspTreeVobVisitor* visitor,
@@ -4987,31 +4960,35 @@ static void CVVH_AddNotDrawnVobToList(
     const auto camPos = XMLoadFloat3( &ctx.cameraPosition );
     // SkipVobFrustumCull: the backend culls these on the GPU (D3D12), so collect distance-only.
     const bool cullingEnabled = ctx.drawFlags.CullVobs && !ctx.drawFlags.SkipVobFrustumCull;
+    // Hoisted out of the loop: with a CONTAINS leaf the per-vob box test is provably redundant
+    // (see CollectVisibleVobsWithLeafCache), so the whole branch collapses to a constant here.
+    const bool needFrustumTest = cullingEnabled && bspContainment != ContainmentType::CONTAINS;
+    const HorizonCuller* horizon = ctx.horizon;
 
-    for ( auto const& it : source ) {
-        // Reject on distance FIRST: LastRenderPosition is already in the VobInfo cache line, while
-        // Visit() is an atomic RMW and GetShowVisual() dereferences into Gothic's own heap. Doing
-        // those first meant paying them for every candidate, including ones about to be dropped.
-        XMVECTOR vvdSq = XMVector3LengthSq( camPos - XMLoadFloat3( &it->LastRenderPosition ) );
+    for ( const LeafVobEntry& entry : source ) {
+        // Reject on distance FIRST, and out of the list element's OWN mirrored position: every
+        // later step - Visit()'s atomic word, GetFlags()' hop into Gothic's heap, LastRenderBBox -
+        // is a dereference of a scattered VobInfo, and the majority of candidates never survive to
+        // need one. This loop therefore walks nothing but the contiguous 16-byte entries.
+        XMVECTOR vvdSq = XMVector3LengthSq( camPos - XMLoadFloat3( &entry.Position ) );
         if ( XMVector3Greater( vvdSq, distSq )) continue;
 
+        VobInfo* it = entry.Info;
         if ( !visitor->Visit( it ) ) continue;
-        
-        const auto vobFlags = it->Vob->GetFlags();
-        if ( !zCVob::FlagGetShowVisual(vobFlags) ) continue;
+
+        const zTVobFlags vobFlags = it->Vob->GetFlags();
+        if ( !vobFlags.ShowVisual ) continue;
 
         // LastRenderBBox rather than Vob->GetBBox(): same value, but it lives in VobInfo instead of
         // Gothic's heap, so the reject path stays off a second allocation entirely.
-        if ( bspContainment != ContainmentType::CONTAINS // only do frustum check if previously "INTERSECTS"
-            && cullingEnabled
-            && !ctx.frustum.Intersects( it->LastRenderBBox ) ) {
+        if ( needFrustumTest && !ctx.frustum.Intersects( it->LastRenderBBox ) ) {
             continue;
         }
         // Horizon: hidden behind an occluder, so nothing below is built at all - no instance upload,
         // no indirect command, no CacheIn. Kept after the frustum test, which is much cheaper.
-        if ( ctx.horizon ) {
+        if ( horizon ) {
             const zTBBox3D& hb = it->LastRenderBBox;
-            if ( !ctx.horizon->IsBoxVisible( hb.Min, hb.Max ) )
+            if ( !horizon->IsBoxVisible( hb.Min, hb.Max ) )
                 continue;
         }
         if ( portalLeaf ) {
@@ -5019,7 +4996,7 @@ static void CVVH_AddNotDrawnVobToList(
             if ( !ctx.portalCuller->IsBoxVisibleInLeafSectors( *portalLeaf, bb.Min, bb.Max ) )
                 continue;
         }
-        if ( zCVob::FlagGetVisualAlpha(vobFlags) ) {
+        if ( vobFlags.VisualAlphaEnabled ) {
             ctx.queue->PushTransparencyVob( TransparencyVobInfo{ std::sqrtf( XMVectorGetX( vvdSq ) ), it->Vob->GetVobTransparency(), nullptr, it } );
             continue;
         }
@@ -5038,18 +5015,23 @@ static void CVVH_AddNotDrawnVobToList(
     const bool cullingEnabled = ctx.drawFlags.CullVobs;
     const auto vDistSq = XMVectorReplicate( distSq );
 
+    // Same hoist as the static-vob overload: a CONTAINS leaf makes the per-mob box test redundant.
+    const bool needFrustumTest = cullingEnabled && bspContainment != ContainmentType::CONTAINS;
+
     for ( auto const& it : source ) {
+        // Distance before Visit(): the test is leaf-independent, so a mob out of range fails it in
+        // every leaf it is registered in and marking it seen changes nothing. Ordering it first keeps
+        // the atomic off the reject path, exactly as in the static-vob overload above.
+        if ( XMVector3Greater( XMVector3LengthSq( camPos - it->Vob->GetPositionWorldXM() ), vDistSq ) ) {
+            continue;
+        }
+
         if ( !visitor->Visit( it ) ) continue;
 
         if ( !it->Vob->GetShowVisual() )
             continue;
 
-        if ( XMVector3Greater( XMVector3LengthSq( camPos - it->Vob->GetPositionWorldXM() ), vDistSq ) ) {
-            continue;
-        }
-        if ( bspContainment != ContainmentType::CONTAINS // only do frustum check if previously "INTERSECTS"
-            && cullingEnabled
-            && !ctx.frustum.Intersects( it->Vob->GetBBox() ) ) {
+        if ( needFrustumTest && !ctx.frustum.Intersects( it->Vob->GetBBox() ) ) {
             continue;
         }
         // Horizon: static MOBs draw per-mesh rather than indirect, so a rejection here saves a whole
@@ -5090,25 +5072,31 @@ void GothicAPI::BuildBspVobMapCacheHelper( zCBspBase* base ) {
                 if ( v ) {
                     float vobSmallSize = Engine::GAPI->GetRendererState().RendererSettings.SmallVobSize;
 
+                    // Position is read straight off the zCVob rather than from VobInfo::LastRenderPosition:
+                    // this runs at world load and a VobInfo registered moments ago may not have had
+                    // UpdateState() called on it yet. See LeafVobEntry for why the mirror stays valid.
+                    const LeafVobEntry entry{ vob->GetPositionWorld(), v };
+                    const auto sameVob = [v]( const LeafVobEntry& e ) { return e.Info == v; };
+
                     // Treat indoor vobs as indoor vobs only in outdoor locations
                     if ( outdoorLocation && vob->IsIndoorVob() ) {
                         // Only add once
-                        if (std::ranges::find(bvi.IndoorVobs, v ) == bvi.IndoorVobs.end() ) {
+                        if (std::ranges::find_if(bvi.IndoorVobs, sameVob ) == bvi.IndoorVobs.end() ) {
                             v->ParentBSPNodes.push_back( &bvi );
-                            bvi.IndoorVobs.push_back( v );
+                            bvi.IndoorVobs.push_back( entry );
                             v->IsIndoorVob = true;
                         }
                     } else if ( v->VisualInfo->MeshSize < vobSmallSize ) {
                         // Only add once
-                        if (std::ranges::find(bvi.SmallVobs, v ) == bvi.SmallVobs.end() ) {
+                        if (std::ranges::find_if(bvi.SmallVobs, sameVob ) == bvi.SmallVobs.end() ) {
                             v->ParentBSPNodes.push_back( &bvi );
-                            bvi.SmallVobs.push_back( v );
+                            bvi.SmallVobs.push_back( entry );
                         }
                     } else {
                         // Only add once
-                        if (std::ranges::find(bvi.Vobs, v ) == bvi.Vobs.end() ) {
+                        if (std::ranges::find_if(bvi.Vobs, sameVob ) == bvi.Vobs.end() ) {
                             v->ParentBSPNodes.push_back( &bvi );
-                            bvi.Vobs.push_back( v );
+                            bvi.Vobs.push_back( entry );
                         }
                     }
                 }
@@ -6810,9 +6798,9 @@ static void CollectLeafVobs(
     auto& VobLightMap = Engine::GAPI->VobLightMap;
 
     zCBspLeaf* leaf = static_cast<zCBspLeaf*>(base->OriginalNode);
-    std::vector<VobInfo*>& listA = base->IndoorVobs;
-    std::vector<VobInfo*>& listB = base->SmallVobs;
-    std::vector<VobInfo*>& listC = base->Vobs;
+    std::vector<LeafVobEntry>& listA = base->IndoorVobs;
+    std::vector<LeafVobEntry>& listB = base->SmallVobs;
+    std::vector<LeafVobEntry>& listC = base->Vobs;
     std::vector<SkeletalVobInfo*>& listD = base->Mobs;
 
     if ( ctx.drawFlags.DrawVOBs ) {
@@ -7100,24 +7088,44 @@ static void CollectVisibleVobsWithLeafCache(
         const __m256 vMaxY = _mm256_load_ps( pMaxY + i );
         const __m256 vMaxZ = _mm256_load_ps( pMaxZ + i );
 
-        // Frustum cull: n-vertex test across all 6 planes.
+        // Frustum cull: n-vertex test across all 6 planes, plus the p-vertex test that upgrades a
+        // surviving leaf from INTERSECTS to CONTAINS.
         // DirectX cached planes have OUTWARD-facing normals (positive dot = outside frustum),
         // matching FastIntersectAxisAlignedBoxPlane: Outside = (Dist > Radius).
-        // For each plane we pick the n-vertex (the AABB corner with the MINIMUM dot product).
-        // If that corner's dot > 0, the ENTIRE AABB is on the outside (positive/outer) side.
-        // blendv_ps(a, b, mask): MSB=0 -> a, MSB=1 (negative) -> b
-        // So blendv(MinX, MaxX, pNX): pNX>=0 (MSB=0) -> MinX (min along positive normal), pNX<0 (MSB=1) -> MaxX.
+        // blendv_ps(a, b, mask): MSB=0 -> a, MSB=1 (negative) -> b.
+        //   n-vertex (MINIMUM dot) = blendv(Min, Max, n): n>=0 -> Min, n<0 -> Max. dot > 0 => the
+        //     ENTIRE AABB is on the outer side of this plane, so the leaf is rejected.
+        //   p-vertex (MAXIMUM dot) = blendv(Max, Min, n), i.e. the operands swapped. dot <= 0 for
+        //     ALL six planes => every corner is inside every plane, so the leaf is fully CONTAINED
+        //     and no VOB, MOB or light inside it needs its own frustum test.
         __m256 vOutside = vZero;
-        for ( int p = 0; p < 6 && !skipVobFrustumCull; ++p ) {
-            const __m256 vPX = _mm256_blendv_ps( vMinX, vMaxX, pNX[p] );
-            const __m256 vPY = _mm256_blendv_ps( vMinY, vMaxY, pNY[p] );
-            const __m256 vPZ = _mm256_blendv_ps( vMinZ, vMaxZ, pNZ[p] );
-            // dot(n, n_vertex) + d: positive means the entire AABB is outside this plane
-            const __m256 vDot = _mm256_fmadd_ps( pNX[p], vPX,
-                                _mm256_fmadd_ps( pNY[p], vPY,
-                                _mm256_fmadd_ps( pNZ[p], vPZ, pD[p] ) ) );
-            // Accumulate "outside" flag: dot > 0 means AABB is fully on the outer side of this plane
-            vOutside = _mm256_or_ps( vOutside, _mm256_cmp_ps( vDot, vZero, _CMP_GT_OQ ) );
+        __m256 vNotContained = vZero;
+        if ( !skipVobFrustumCull ) {
+            for ( int p = 0; p < 6; ++p ) {
+                const __m256 vNX = _mm256_blendv_ps( vMinX, vMaxX, pNX[p] );
+                const __m256 vNY = _mm256_blendv_ps( vMinY, vMaxY, pNY[p] );
+                const __m256 vNZ = _mm256_blendv_ps( vMinZ, vMaxZ, pNZ[p] );
+                const __m256 vNDot = _mm256_fmadd_ps( pNX[p], vNX,
+                                     _mm256_fmadd_ps( pNY[p], vNY,
+                                     _mm256_fmadd_ps( pNZ[p], vNZ, pD[p] ) ) );
+                vOutside = _mm256_or_ps( vOutside, _mm256_cmp_ps( vNDot, vZero, _CMP_GT_OQ ) );
+
+                // The p-vertex differs from the n-vertex only in which extent each axis picks, so it
+                // reuses the already-loaded Min/Max registers - 3 blends + 3 FMAs + a compare per
+                // plane per 8 leaves, against one full per-VOB box test saved for every VOB in every
+                // fully-contained leaf.
+                const __m256 vPX = _mm256_blendv_ps( vMaxX, vMinX, pNX[p] );
+                const __m256 vPY = _mm256_blendv_ps( vMaxY, vMinY, pNY[p] );
+                const __m256 vPZ = _mm256_blendv_ps( vMaxZ, vMinZ, pNZ[p] );
+                const __m256 vPDot = _mm256_fmadd_ps( pNX[p], vPX,
+                                     _mm256_fmadd_ps( pNY[p], vPY,
+                                     _mm256_fmadd_ps( pNZ[p], vPZ, pD[p] ) ) );
+                vNotContained = _mm256_or_ps( vNotContained, _mm256_cmp_ps( vPDot, vZero, _CMP_GT_OQ ) );
+            }
+        } else {
+            // GPU culling: no frustum rejection at all, and deliberately never CONTAINS - CollectLeafVobs'
+            // per-light sphere test has to stay alive (see the note above).
+            vNotContained = _mm256_cmp_ps( vZero, vZero, _CMP_EQ_OQ );
         }
 
         // Distance cull: squared AABB-to-point distance
@@ -7135,25 +7143,12 @@ static void CollectVisibleVobsWithLeafCache(
         const int cullMask = _mm256_movemask_ps( vOutside );
         if ( cullMask == 0xFF ) continue; // All 8 culled — skip scalar work
 
-        if ( cullMask == 0 ) {
-            for ( uint32_t lane = 0; lane < 8; ++lane ) {
-                const uint32_t idx = i + lane;
-                if ( idx >= cache.Count ) break;
+        // Bit set => that lane's leaf is only partially inside, so its contents keep their own tests.
+        const int partialMask = _mm256_movemask_ps( vNotContained );
 
-                BspInfo* leaf = cache.Leaves[idx];
-                if ( !leaf ) continue;
-                if ( enableOcclusionCulling && !leaf->OcclusionInfo.VisibleLastFrame ) continue;
-
-                const float dx = std::max( 0.0f, std::max( pMinX[idx] - cpX, cpX - pMaxX[idx] ) );
-                const float dy = std::max( 0.0f, std::max( pMinY[idx] - cpY, cpY - pMaxY[idx] ) );
-                const float dz = std::max( 0.0f, std::max( pMinZ[idx] - cpZ, cpZ - pMaxZ[idx] ) );
-                const float leafDistSq = dx * dx + dy * dy + dz * dz;
-
-                // Use INTERSECTS so per-vob frustum checks still run inside CollectLeafVobs.
-                CollectLeafVobs( leaf, leafDistSq, ctx, ContainmentType::INTERSECTS, visitor );
-            }
-            continue;
-        }
+        // Store the already-computed distances instead of recomputing them per surviving lane.
+        alignas( 32 ) float laneDistSq[8];
+        _mm256_store_ps( laneDistSq, vDistSq );
 
         // Process surviving lanes with full scalar logic
         for ( int lane = 0; lane < 8; ++lane ) {
@@ -7169,14 +7164,15 @@ static void CollectVisibleVobsWithLeafCache(
             if ( enableOcclusionCulling && !leaf->OcclusionInfo.VisibleLastFrame )
                 continue;
 
-            // Recompute scalar distance^2 for per-category range checks inside CollectLeafVobs.
-            const float dx = std::max( 0.0f, std::max( pMinX[idx] - cpX, cpX - pMaxX[idx] ) );
-            const float dy = std::max( 0.0f, std::max( pMinY[idx] - cpY, cpY - pMaxY[idx] ) );
-            const float dz = std::max( 0.0f, std::max( pMinZ[idx] - cpZ, cpZ - pMaxZ[idx] ) );
-            const float leafDistSq = dx * dx + dy * dy + dz * dz;
+            // CONTAINS when the leaf box is fully inside all six planes: every VOB, MOB and light in
+            // it then skips its own frustum test in CollectLeafVobs. Conservative in the right
+            // direction - a VOB whose box pokes out of a contained leaf is kept rather than dropped,
+            // and it is registered in the neighbouring leaf it pokes into anyway.
+            const ContainmentType containment = ( partialMask & (1 << lane) )
+                ? ContainmentType::INTERSECTS
+                : ContainmentType::CONTAINS;
 
-            // Use INTERSECTS so per-vob frustum checks still run inside CollectLeafVobs
-            CollectLeafVobs( leaf, leafDistSq, ctx, ContainmentType::INTERSECTS, visitor );
+            CollectLeafVobs( leaf, laneDistSq[lane], ctx, containment, visitor );
         }
     }
 }

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -693,6 +693,15 @@ public:
     BspPortalCuller& GetPortalCuller() { return PortalCuller; }
     const BspPortalCuller& GetPortalCuller() const { return PortalCuller; }
 
+    /** True when the view is fully enclosed by sectors, so the sun cascades need not be rendered and
+        are cleared to "shadowed" instead. Reads the solve the main camera pass ran this frame, so call
+        it only after CollectVisibleVobs. */
+    bool AreSunShadowsFullyOccluded() const {
+        return RendererState.RendererSettings.EnablePortalShadowSkip
+            && PortalCuller.IsActive()
+            && !PortalCuller.IsOutdoorVisible();
+    }
+
     /** Returns the new node from tha base node */
     BspInfo* GetNewBspNode( zCBspBase* base );
 

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -619,6 +619,10 @@ public:
     /** Returns true, if the game was paused */
     bool IsGamePaused();
 
+    /** Returns true while an in-game menu holds the game paused. Stricter than IsGamePaused():
+        requires a live game session, so startup/teardown don't read as "paused". */
+    bool IsIngameMenuPaused();
+
     /** Checks if a game is being saved now */
     bool IsSavingGameNow();
 

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -4,6 +4,7 @@
 #include "AlignedAllocator.h"
 #include "Frustum.h"
 #include "BspPortalCuller.h"
+#include "HorizonCuller.h"
 #include "GothicGraphicsState.h"
 #include "WorldConverter.h"
 #include "zCTree.h"
@@ -45,6 +46,10 @@ struct RndCullContext {
         camera pass sets it: shadow passes must keep collecting casters in rooms the player cannot
         see into, and it is solved for the player camera anyway. */
     const class BspPortalCuller* portalCuller = nullptr;
+
+    /** Ghost-occluder horizon cull for this pass, or null to not use it. Main camera pass only: the
+        horizon is rasterized for the player's view, so a shadow cascade must not test against it. */
+    const class HorizonCuller* horizon = nullptr;
 
     struct
     {
@@ -651,6 +656,9 @@ public:
     /** Draws the AABB for the BSP-Tree using the line renderer*/
     void DebugDrawBSPTree();
 
+    /** Outlines the world's ghost occluders. Gated by RendererSettings::DrawWorldOccluders. */
+    void DebugDrawOccluders( const Frustum& frustum );
+
     /** Recursive helper function to draw the BSP-Tree */
     void DebugDrawTreeNode( zCBspBase* base, zTBBox3D boxCell, int clipFlags = 63 );
 
@@ -682,10 +690,14 @@ public:
 
     void CollectVisibleVobs( const RndCullContext& ctx );
 
-    /** Collects visible sections from the current camera perspective */
+    /** Collects visible sections from the current camera perspective.
+        `horizon` opts into the ghost-occluder cull and must stay null for every pass that is not the
+        player's view - it is an explicit parameter rather than a member read precisely so a shadow or
+        rain frustum cannot silently inherit the player's skyline. */
     void CollectVisibleSections( std::vector<WorldMeshSectionInfo*>& sections,
         const Frustum* queryFrustum = nullptr,
-        bool useSectionRadiusFilter = true );
+        bool useSectionRadiusFilter = true,
+        const HorizonCuller* horizon = nullptr );
 
     /** Returns whether a world mesh intersects the given frustum (true when no bounds are available). */
     bool IsWorldMeshVisibleInFrustum( const WorldMeshInfo* mesh, const Frustum& frustum ) const;
@@ -696,6 +708,10 @@ public:
     /** Sector/portal visibility, rebuilt on every world load. Inactive on worlds without portals. */
     BspPortalCuller& GetPortalCuller() { return PortalCuller; }
     const BspPortalCuller& GetPortalCuller() const { return PortalCuller; }
+
+    /** Ghost-occluder horizon, rebuilt once per frame for the player camera. */
+    HorizonCuller& GetHorizonCuller() { return Horizon; }
+    const HorizonCuller& GetHorizonCuller() const { return Horizon; }
 
     /** True when the view is fully enclosed by sectors, so the sun cascades need not be rendered and
         are cleared to "shadowed" instead. Reads the solve the main camera pass ran this frame, so call
@@ -962,7 +978,8 @@ private:
     void ClearWorldSectionBVH();
     void QueryWorldSectionBVH( const Frustum& frustum,
         std::vector<WorldMeshSectionInfo*>& sections,
-        bool useSectionRadiusFilter ) const;
+        bool useSectionRadiusFilter,
+        const HorizonCuller* horizon = nullptr ) const;
     bool UseWorldSectionBVH() const;
 
     /** Collects polygons in the given AABB */
@@ -1091,6 +1108,10 @@ public:
     BspLeafLinearCache LeafLinearCache;
 private:
     BspPortalCuller PortalCuller;
+    HorizonCuller Horizon;
+
+    /** One-shot guard for DebugDrawOccluders' line-budget message. */
+    bool OccluderDebugBudgetLogged = false;
 
     gtl::flat_hash_map<zCVob*, SkeletalVobInfo*> SkeletalVobMap;
 

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -99,6 +99,23 @@ enum EBspTreeCollectFlags : unsigned int {
     COLLECT_ALL_NO_MUTATE = COLLECT_ALL_MUTATE & ~COLLECT_MUTATE,
 };
 
+/** Entry of a BSP leaf's static-VOB list.
+ *
+ *  The world position is mirrored into the list element instead of being read back out of the
+ *  VobInfo. CollectLeafVobs' first act on every candidate is a distance reject, and with a bare
+ *  VobInfo* list that reject had to dereference a scattered heap object per candidate - a cache
+ *  miss for the majority that get rejected. Inline, the reject walks one contiguous 16-byte-stride
+ *  array and only survivors ever touch the VobInfo.
+ *
+ *  The mirror cannot go stale: a static vob that moves is pulled out of every leaf list by
+ *  MoveVobFromBspToDynamic (from OnVobMoved) *before* its transform is applied, so a VOB that is
+ *  in a leaf list is by construction a VOB that has not moved since it was put there. */
+struct LeafVobEntry {
+    DirectX::XMFLOAT3 Position;
+    VobInfo* Info;
+};
+static_assert( sizeof( LeafVobEntry ) == 16, "LeafVobEntry must stay 4-per-cache-line" );
+
 struct BspInfo {
     BspInfo() {
         NumStaticLights = 0;
@@ -143,9 +160,9 @@ struct BspInfo {
         return Vobs.empty() && IndoorVobs.empty() && SmallVobs.empty() && Lights.empty() && IndoorLights.empty();
     }
 
-    std::vector<VobInfo*> Vobs;
-    std::vector<VobInfo*> IndoorVobs;
-    std::vector<VobInfo*> SmallVobs;
+    std::vector<LeafVobEntry> Vobs;
+    std::vector<LeafVobEntry> IndoorVobs;
+    std::vector<LeafVobEntry> SmallVobs;
     std::vector<VobLightInfo*> Lights;
     std::vector<VobLightInfo*> IndoorLights;
     std::vector<SkeletalVobInfo*> Mobs;
@@ -675,7 +692,7 @@ public:
     void MoveVobFromBspToDynamic( VobInfo* vob );
     void MoveVobFromBspToDynamic( SkeletalVobInfo* vob );
 
-    std::vector<VobInfo*>::iterator MoveVobFromBspToDynamic( VobInfo* vob, std::vector<VobInfo*>* source );
+    std::vector<LeafVobEntry>::iterator MoveVobFromBspToDynamic( VobInfo* vob, std::vector<LeafVobEntry>* source );
 
     /** Collects vobs using gothics BSP-Tree */
     void CollectVisibleVobs(

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -800,6 +800,7 @@ struct GothicRendererSettings {
         EnableOcclusionCulling = false;
         EnablePortalCulling = true;
         PortalCullingNearRadius = 1500.0f;
+        EnablePortalShadowSkip = true;
         ShadowFilterMode = E_ShadowFilterMode::SHADOW_FILTER_SIMPLE;
 
         EnableShadows = true;
@@ -1051,6 +1052,9 @@ struct GothicRendererSettings {
     /** Rooms within this distance of the camera are never portal-culled (Gothic units, 100 = 1m).
         Raise it if interiors pop while standing near a doorway. */
     float PortalCullingNearRadius;
+    /** Skip the sun-shadow cascades while the view is fully enclosed by sectors, clearing the slices to
+        "shadowed" instead. Requires EnablePortalCulling; see BspPortalCuller::IsOutdoorVisible. */
+    bool EnablePortalShadowSkip;
     bool SortRenderQueue;
     bool DrawThreaded;
     EPointLightShadowMode EnablePointlightShadows;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -801,7 +801,8 @@ struct GothicRendererSettings {
         EnableOcclusionCulling = false;
         EnablePortalCulling = true;
         PortalCullingNearRadius = 1500.0f;
-        EnablePortalShadowSkip = true;
+        EnablePortalShadowSkip = false;
+        EnableHorizonCulling = false;
         ShadowFilterMode = E_ShadowFilterMode::SHADOW_FILTER_SIMPLE;
 
         EnableShadows = true;
@@ -823,6 +824,7 @@ struct GothicRendererSettings {
         GraphicsAPI = GRAPHICS_API_D3D11;
         MSAASamples = 1;
         DrawSectionIntersections = true;
+        DrawWorldOccluders = false;
 
         EnableGodRays = true;
 
@@ -1061,8 +1063,12 @@ struct GothicRendererSettings {
         Raise it if interiors pop while standing near a doorway. */
     float PortalCullingNearRadius;
     /** Skip the sun-shadow cascades while the view is fully enclosed by sectors, clearing the slices to
-        "shadowed" instead. Requires EnablePortalCulling; see BspPortalCuller::IsOutdoorVisible. */
+        "shadowed" instead. Requires EnablePortalCulling; see BspPortalCuller::IsOutdoorVisible.
+        Off by default: a false "enclosed" verdict drops every sun shadow, which is very visible. */
     bool EnablePortalShadowSkip;
+    /** Cull world sections, VOBs and MOBs against the ghost-occluder horizon - ZenGin's outdoor
+        "behind the mountain" test. Main camera pass only; see HorizonCuller. */
+    bool EnableHorizonCulling;
     bool SortRenderQueue;
     bool DrawThreaded;
     EPointLightShadowMode EnablePointlightShadows;
@@ -1075,6 +1081,8 @@ struct GothicRendererSettings {
     /** Hardware MSAA sample count (1/2/4/8). Only applied by the Forward+ renderer; Deferred always stays single-sample. */
     int MSAASamples;
     bool DrawSectionIntersections;
+    /** Debug: outline the world's ghost-occluder polys (see WorldOccluders) in the line renderer. */
+    bool DrawWorldOccluders;
 
     int MaxNumFaces;
 

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -686,6 +686,7 @@ struct GothicRendererSettings {
         SectionDrawRadius = 4;
 
         FpsLimit = 0;
+        PausedFpsLimit = 30;
         DrawVOBs = true;
         DrawWorldMesh = 3;
         DrawSkeletalMeshes = true;
@@ -999,6 +1000,13 @@ struct GothicRendererSettings {
 
     /** Rendering options */
     int FpsLimit;
+    /** Cap applied on top of FpsLimit while an in-game menu holds the game paused. ZENGIN renders
+        those frames from a nested loop it never throttles in-game, which lets an idle menu reach
+        thousands of FPS and has been seen to crash drivers - so this cap is mandatory and only
+        its value is configurable, clamped to [PausedFpsLimitMin, PausedFpsLimitMax]. */
+    int PausedFpsLimit;
+    static constexpr int PausedFpsLimitMin = 10;
+    static constexpr int PausedFpsLimitMax = 100;
     bool DrawVOBs;
     bool DrawDynamicVOBs;
     int DrawWorldMesh;

--- a/D3D11Engine/HorizonCuller.cpp
+++ b/D3D11Engine/HorizonCuller.cpp
@@ -1,0 +1,287 @@
+#include "pch.h"
+#include "HorizonCuller.h"
+
+#include "WorldObjects.h"
+#include "Logger.h"
+
+#include <algorithm>
+
+using namespace DirectX;
+
+namespace {
+    /** Clip-space w below this counts as behind the camera. */
+    constexpr float CLIP_W_EPSILON = 1e-4f;
+    /** Occluders farther than this contribute nothing worth the projection (200m). */
+    constexpr float MAX_OCCLUDER_DISTANCE = 20000.0f;
+    /** Per-frame projection budget. The surveyed worlds never approach it after frustum rejection;
+        it exists so a modded world with pathological occluder counts degrades instead of stalling. */
+    constexpr size_t MAX_CANDIDATES = 2048;
+
+    /** Minimum clip-space w (i.e. view depth) an occluder vertex may have. Below this the projection
+        divides by almost nothing and lands millions of pixels away. */
+    constexpr float MIN_OCCLUDER_DEPTH = 50.0f;   // 0.5m
+
+    /** Keeps a projected coordinate within a few screens of the viewport, so "covers everything and
+        then some" stays expressible but the float->int conversions downstream can never go out of
+        range. See the call site for what that cost us. */
+    float ClampToScreenRange( float value, float extent ) {
+        return std::clamp( value, -2.0f * extent, 3.0f * extent );
+    }
+}
+
+bool HorizonCuller::ProjectOccluder( const WorldOccluders& occluders, size_t entryIndex,
+    Candidate& out ) {
+    const WorldOccluders::Entry& entry = occluders.Entries[entryIndex];
+
+    // Clip to w>0 only (Sutherland-Hodgman). Side planes are left alone: the rasterizer clamps X, and a
+    // Y above the viewport means the occluder covers that column all the way up.
+    // World positions ride along, interpolated with the same t, so the depth below is view-space Z from
+    // the same matrix IsBoxVisible uses rather than clip-space w.
+    static thread_local std::vector<XMVECTOR> clipPos;
+    static thread_local std::vector<XMVECTOR> worldPos;
+    clipPos.clear();
+    worldPos.clear();
+
+    const XMMATRIX worldToClip = WorldToClip;
+    const uint32_t n = entry.NumVerts;
+    for ( uint32_t i = 0; i < n; i++ ) {
+        const XMVECTOR wCur = XMVectorSetW( XMLoadFloat3( &occluders.Verts[entry.VertexOffset + i] ), 1.0f );
+        const XMVECTOR wNxt = XMVectorSetW( XMLoadFloat3( &occluders.Verts[entry.VertexOffset + ((i + 1) % n)] ), 1.0f );
+
+        const XMVECTOR a = XMVector4Transform( wCur, worldToClip );
+        const XMVECTOR b = XMVector4Transform( wNxt, worldToClip );
+        const float wa = XMVectorGetW( a );
+        const float wb = XMVectorGetW( b );
+
+        if ( wa > CLIP_W_EPSILON ) {
+            clipPos.push_back( a );
+            worldPos.push_back( wCur );
+        }
+        if ( (wa > CLIP_W_EPSILON) != (wb > CLIP_W_EPSILON) ) {
+            const float t = (CLIP_W_EPSILON - wa) / (wb - wa);
+            clipPos.push_back( XMVectorLerp( a, b, t ) );
+            worldPos.push_back( XMVectorLerp( wCur, wNxt, t ) );
+        }
+    }
+
+    if ( clipPos.size() < 3 )
+        return false;
+
+    // Straddling the camera: the projection degenerates, and a blocker you stand on cannot usefully
+    // occlude anyway. Costs culling strength when hugging a wall - the safe direction.
+    for ( const XMVECTOR& clip : clipPos ) {
+        if ( XMVectorGetW( clip ) < MIN_OCCLUDER_DEPTH )
+            return false;
+    }
+
+    // --- Project to pixels, depth along the camera's at-vector ----------------------------------
+    const int firstVertex = static_cast<int>( ScratchVerts.size() );
+    float depthFar = -FLT_MAX;
+    float depthNear = FLT_MAX;
+
+    for ( size_t i = 0; i < clipPos.size(); i++ ) {
+        const float w = XMVectorGetW( clipPos[i] );
+
+        // NDC -> pixels, Y flipped. Clamped for correctness, not tidiness: a vertex on the clip plane
+        // lands millions of pixels out, which made the float->int conversions below out-of-range (UB;
+        // optimized builds gave INT_MIN) and poisoned HorizonYMin so the early-out stopped firing.
+        const float px = ClampToScreenRange( (XMVectorGetX( clipPos[i] ) / w * 0.5f + 0.5f) * ViewportWidth, ViewportWidth );
+        const float py = ClampToScreenRange( (0.5f - XMVectorGetY( clipPos[i] ) / w * 0.5f) * ViewportHeight, ViewportHeight );
+
+        // View-space Z, i.e. ZenGin's vertCamSpace[VZ]. IsBoxVisible measures the box the same way
+        // through the same matrix, so the two are directly comparable by construction.
+        const float depth = XMVectorGetZ( XMVector3TransformCoord( worldPos[i], View ) );
+        depthFar = std::max( depthFar, depth );
+        depthNear = std::min( depthNear, depth );
+
+        ScratchVerts.push_back( XMFLOAT3( px, py, depth ) );
+    }
+
+    out.FirstVertex = firstVertex;
+    out.NumVerts = static_cast<int>( clipPos.size() );
+    out.Depth = depthFar;
+    out.SortDepth = depthNear;
+    return true;
+}
+
+void HorizonCuller::ScanHorizon( const Candidate& candidate ) {
+    // ZenGin's ScanHorizon walks only leftmost->rightmost (its "obere Kanten"), assuming a winding we
+    // cannot verify. Every edge left-to-right with a per-column min Y gives the upper envelope for any
+    // winding, at the cost of the lower chain.
+    const XMFLOAT3* verts = &ScratchVerts[candidate.FirstVertex];
+    const int n = candidate.NumVerts;
+
+    for ( int i = 0; i < n; i++ ) {
+        const XMFLOAT3& a = verts[i];
+        const XMFLOAT3& b = verts[(i + 1) % n];
+
+        // Always rasterize left to right.
+        const XMFLOAT3& left = (a.x <= b.x) ? a : b;
+        const XMFLOAT3& right = (a.x <= b.x) ? b : a;
+
+        const float dx = right.x - left.x;
+        if ( dx <= 0.0f )
+            continue;   // vertical edge: the two endpoints are covered by the adjacent edges
+
+        const float slope = (right.y - left.y) / dx;
+        const auto yAt = [&]( float x ) { return left.y + slope * (x - left.x); };
+
+        const int firstColumn = std::max( 0, static_cast<int>( left.x ) >> COLUMN_SHIFT );
+        const int lastColumn = std::min( Columns - 1, static_cast<int>( right.x ) >> COLUMN_SHIFT );
+
+        for ( int column = firstColumn; column <= lastColumn; column++ ) {
+            // Both column boundaries, clamped to the edge's span: one sample would miss an edge
+            // dipping mid-column, i.e. under-occlude.
+            const float colLeft = std::max( left.x, static_cast<float>( column << COLUMN_SHIFT ) );
+            const float colRight = std::min( right.x, static_cast<float>( (column + 1) << COLUMN_SHIFT ) );
+            const float y = std::min( yAt( colLeft ), yAt( colRight ) );
+
+            if ( y < HorizonY[column] ) {
+                HorizonY[column] = y;
+                HorizonZ[column] = candidate.Depth;
+            }
+        }
+    }
+}
+
+void HorizonCuller::Build( const WorldOccluders& occluders, FXMMATRIX worldToClip,
+    FXMMATRIX view, const XMFLOAT3& cameraPosition, const Frustum& frustum,
+    int viewportWidth, int viewportHeight ) {
+    ZoneScopedN( "HorizonCuller::Build" );
+
+    Active = false;
+    LastStats.OccludersTotal = static_cast<int>( occluders.Entries.size() );
+    LastStats.OccludersRasterized = 0;
+    LastStats.OccludersTooNear = 0;
+    LastStats.HorizonTop = 0.0f;
+    LastStats.BoxesTested.store( 0, std::memory_order_relaxed );
+    LastStats.BoxesRejected.store( 0, std::memory_order_relaxed );
+
+    if ( !Enabled || occluders.IsEmpty() || viewportWidth < 8 || viewportHeight < 8 )
+        return;
+
+    ViewportWidth = static_cast<float>( viewportWidth );
+    ViewportHeight = static_cast<float>( viewportHeight );
+    CameraPosition = cameraPosition;
+    WorldToClip = worldToClip;
+    View = view;
+
+    Columns = std::min( MAX_COLUMNS, (viewportWidth + (1 << COLUMN_SHIFT) - 1) >> COLUMN_SHIFT );
+
+    // A column holding the viewport bottom occludes nothing, which is the empty state.
+    for ( int i = 0; i < Columns; i++ ) {
+        HorizonY[i] = ViewportHeight;
+        HorizonZ[i] = -FLT_MAX;
+    }
+    HorizonYMin = ViewportHeight;
+
+    // --- Gather the occluders worth projecting --------------------------------------------------
+    ScratchVerts.clear();
+    Candidates.clear();
+
+    const XMVECTOR camPos = XMLoadFloat3( &cameraPosition );
+    for ( size_t i = 0; i < occluders.Entries.size() && Candidates.size() < MAX_CANDIDATES; i++ ) {
+        const WorldOccluders::Entry& e = occluders.Entries[i];
+
+        float distSq;
+        XMStoreFloat( &distSq, XMVector3LengthSq( XMLoadFloat3( &e.Center ) - camPos ) );
+        const float cutoff = MAX_OCCLUDER_DISTANCE + e.Radius;
+        if ( distSq > cutoff * cutoff )
+            continue;
+
+        if ( !frustum.Intersects( zTBBox3D{
+                XMFLOAT3( e.Center.x - e.Radius, e.Center.y - e.Radius, e.Center.z - e.Radius ),
+                XMFLOAT3( e.Center.x + e.Radius, e.Center.y + e.Radius, e.Center.z + e.Radius ) } ) )
+            continue;
+
+        Candidate candidate = {};
+        if ( ProjectOccluder( occluders, i, candidate ) )
+            Candidates.push_back( candidate );
+        else
+            LastStats.OccludersTooNear++;
+    }
+
+    if ( Candidates.empty() )
+        return;
+
+    // Front to back, so a nearer occluder that wins a column also stores its nearer depth. Unsorted
+    // would still be safe (a farther stored depth only lets more objects through) but culls less.
+    std::sort( Candidates.begin(), Candidates.end(),
+        []( const Candidate& a, const Candidate& b ) { return a.SortDepth < b.SortDepth; } );
+
+    for ( const Candidate& candidate : Candidates )
+        ScanHorizon( candidate );
+
+    for ( int i = 0; i < Columns; i++ )
+        HorizonYMin = std::min( HorizonYMin, HorizonY[i] );
+
+    LastStats.OccludersRasterized = static_cast<int>( Candidates.size() );
+    LastStats.HorizonTop = HorizonYMin;
+    Active = true;
+}
+
+bool HorizonCuller::IsBoxVisible( const XMFLOAT3& bbMin, const XMFLOAT3& bbMax ) const {
+    if ( !Active )
+        return true;
+
+    LastStats.BoxesTested.fetch_add( 1, std::memory_order_relaxed );
+
+    const XMFLOAT3 corners[8] = {
+        { bbMin.x, bbMin.y, bbMin.z }, { bbMax.x, bbMin.y, bbMin.z },
+        { bbMin.x, bbMax.y, bbMin.z }, { bbMax.x, bbMax.y, bbMin.z },
+        { bbMin.x, bbMin.y, bbMax.z }, { bbMax.x, bbMin.y, bbMax.z },
+        { bbMin.x, bbMax.y, bbMax.z }, { bbMax.x, bbMax.y, bbMax.z },
+    };
+
+    float xMin = FLT_MAX, xMax = -FLT_MAX, yMin = FLT_MAX;
+    for ( const XMFLOAT3& c : corners ) {
+        XMVECTOR clip = XMVector4Transform( XMVectorSetW( XMLoadFloat3( &c ), 1.0f ), WorldToClip );
+        const float w = XMVectorGetW( clip );
+        if ( w <= CLIP_W_EPSILON )
+            return true;   // straddles the eye - cannot bound it on screen, keep it
+
+        const float px = ClampToScreenRange( (XMVectorGetX( clip ) / w * 0.5f + 0.5f) * ViewportWidth, ViewportWidth );
+        const float py = ClampToScreenRange( (0.5f - XMVectorGetY( clip ) / w * 0.5f) * ViewportHeight, ViewportHeight );
+        xMin = std::min( xMin, px );
+        xMax = std::max( xMax, px );
+        yMin = std::min( yMin, py );
+    }
+
+    // Above the entire skyline - nothing can hide it.
+    if ( yMin < 1.0f ) yMin = 1.0f;
+    if ( yMin < HorizonYMin )
+        return true;
+
+    int left = static_cast<int>( xMin ) >> COLUMN_SHIFT;
+    int right = static_cast<int>( xMax + 0.5f ) >> COLUMN_SHIFT;
+    left = std::max( 0, left );
+    right = std::min( Columns - 1, right );
+    if ( left > right )
+        return true;   // off-screen horizontally; that is the frustum test's business, not ours
+
+    // Depth: the bbox's top corner nearest the camera in XZ, as view-space Z through the SAME matrix
+    // the occluders were measured with. Mirrors ZenGin's "Variante B"; the near corner keeps the
+    // comparison conservative.
+    const float xCenter = (bbMin.x + bbMax.x) * 0.5f;
+    const float zCenter = (bbMin.z + bbMax.z) * 0.5f;
+    const XMFLOAT3 nearCorner(
+        CameraPosition.x < xCenter ? bbMin.x : bbMax.x,
+        bbMax.y,
+        CameraPosition.z < zCenter ? bbMin.z : bbMax.z );
+    const float boxDepth = XMVectorGetZ(
+        XMVector3TransformCoord( XMLoadFloat3( &nearCorner ), View ) );
+
+    // Nearer than the occluder that set this column -> visible. Three probes, as ZenGin does.
+    if ( HorizonZ[right] > boxDepth ) return true;
+    if ( HorizonZ[left] > boxDepth ) return true;
+    if ( HorizonZ[(left + right) >> 1] > boxDepth ) return true;
+
+    // Any column where the box reaches above the skyline -> visible.
+    for ( int i = left; i <= right; i++ ) {
+        if ( yMin <= HorizonY[i] )
+            return true;
+    }
+
+    LastStats.BoxesRejected.fetch_add( 1, std::memory_order_relaxed );
+    return false;
+}

--- a/D3D11Engine/HorizonCuller.h
+++ b/D3D11Engine/HorizonCuller.h
@@ -1,0 +1,105 @@
+#pragma once
+#include "pch.h"
+#include "Frustum.h"
+#include <DirectXMath.h>
+#include <vector>
+
+struct WorldOccluders;
+
+/** ZenGin's outdoor occlusion cull, reimplemented (zBsp.cpp: InitHorizon / ScanHorizon / IsVisible).
+ *
+ *  The world's ghost-occluder polys (see WorldOccluders) are rasterized each frame into a 1D horizon:
+ *  per screen column, the topmost occluded Y plus the view depth of whatever set it. A box entirely
+ *  below that skyline and farther than it is hidden - the original "behind the mountain" cull.
+ *
+ *  Being 1D is the limit: mountains and cliffs yes, a building behind a building with sky above it no.
+ *  The value of doing it on the CPU is that a rejection lands before the work exists - no instance
+ *  upload, no indirect command, no CacheIn, and for NPCs no animation update.
+ *
+ *  Build() runs once per frame on the main thread; the tests are const and safe to call concurrently
+ *  from the culling pool afterwards. */
+class HorizonCuller {
+public:
+    /** Screen columns are downsampled by 1<<COLUMN_SHIFT, as ZenGin's HORI_PREC_DIV does. 4 columns
+        per bucket keeps the buffer tiny and costs almost no culling accuracy at this scale. */
+    static constexpr int COLUMN_SHIFT = 2;
+    static constexpr int MAX_COLUMNS = 4096 >> COLUMN_SHIFT;
+
+    void SetEnabled( bool enabled ) { Enabled = enabled; }
+
+    /** True when this frame has a usable horizon. */
+    bool IsActive() const { return Active; }
+
+    /** Rasterizes the world's occluders for this camera. An empty occluder set just leaves IsActive()
+        false and every test passing.
+
+        `view` and `worldToClip` MUST come from the same camera: depth is view-space Z on both the
+        occluder and the box, so a mismatch compares along two different axes. Reading the direction
+        from GothicAPI's TransformView did that - the shadow cascades overwrite it, so it could hold a
+        cascade's light view. */
+    void Build( const WorldOccluders& occluders, DirectX::FXMMATRIX worldToClip,
+        DirectX::FXMMATRIX view, const DirectX::XMFLOAT3& cameraPosition,
+        const Frustum& frustum, int viewportWidth, int viewportHeight );
+
+    /** Marks the horizon unusable for the rest of the frame (menus, missing camera, disabled). */
+    void Invalidate() { Active = false; }
+
+    /** Mirrors ZenGin's IsVisible(zTBBox3D): false only when the box is provably hidden. */
+    bool IsBoxVisible( const DirectX::XMFLOAT3& bbMin, const DirectX::XMFLOAT3& bbMax ) const;
+
+    struct Stats {
+        int OccludersTotal = 0;
+        int OccludersRasterized = 0;
+        /** Dropped for straddling the camera. A non-zero count among occluders is expected. */
+        int OccludersTooNear = 0;
+        /** Topmost skyline point in pixels. Largely negative = something projected off to infinity. */
+        float HorizonTop = 0.0f;
+        /** Test counters, reset by Build. Incremented by the const tests, so atomic. */
+        mutable std::atomic<int> BoxesTested{ 0 };
+        mutable std::atomic<int> BoxesRejected{ 0 };
+    };
+    const Stats& GetStats() const { return LastStats; }
+
+private:
+    /** One occluder, projected and ready to rasterize. */
+    struct Candidate {
+        int FirstVertex;
+        int NumVerts;
+        /** Farthest camera-space depth of the poly - ZenGin's `zpos = max(vertCamSpace.z)`. Using the
+            FAR end is deliberate: it makes more objects count as "nearer than this occluder" and so
+            survive the depth test, which is the safe direction. */
+        float Depth;
+        /** Sort key: nearest depth, so the front-to-back order matches ActivateSectorRec's. */
+        float SortDepth;
+    };
+
+    /** Clips a poly to w>0, projects it to pixels, and appends it to ScratchVerts. */
+    bool ProjectOccluder( const WorldOccluders& occluders, size_t entryIndex, Candidate& out );
+
+    /** Rasterizes one projected poly's upper silhouette into the horizon. */
+    void ScanHorizon( const Candidate& candidate );
+
+    bool Enabled = true;
+    bool Active = false;
+
+    /** Topmost occluded Y per column, and the depth of the occluder that set it. Y grows downwards,
+        so "topmost" is the minimum, and a column reading the viewport bottom occludes nothing. */
+    float HorizonY[MAX_COLUMNS] = {};
+    float HorizonZ[MAX_COLUMNS] = {};
+    /** Global minimum of HorizonY - lets a box above the whole skyline skip the per-column loop. */
+    float HorizonYMin = 0.0f;
+    int Columns = 0;
+
+    float ViewportWidth = 0.0f;
+    float ViewportHeight = 0.0f;
+    DirectX::XMFLOAT3 CameraPosition{};
+    DirectX::XMMATRIX WorldToClip{};
+    /** Same camera as WorldToClip. Depth on both sides of the test is this matrix' Z. */
+    DirectX::XMMATRIX View{};
+
+    /** Projected-vertex scratch (x,y = pixels, z = camera depth), reused across frames. */
+    std::vector<DirectX::XMFLOAT3> ScratchVerts;
+    std::vector<Candidate> Candidates;
+
+    Stats LastStats;
+};

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1240,6 +1240,18 @@ void ImGuiShim::RenderSettingsWindow()
             ImGui::SliderInt( "##FPSLimit", &settings.FpsLimit, 10, 300 );
             ImGui::EndDisabled();
 
+            // Always on by design - Gothic renders paused frames from its own unthrottled loop, and
+            // letting that run free crashes some drivers. Only the value is up to the player.
+            ImText( "Paused FPS Limit", buttonWidth );
+            if ( ImGui::IsItemHovered() ) {
+                ImGui::SetTooltip( "Framerate while an in-game menu has the game paused.\n"
+                    "Gothic renders those frames from its own loop without any limit, which can\n"
+                    "reach thousands of FPS and crash some drivers, so this cap can't be turned off." );
+            }
+            ImGui::SameLine();
+            ImGui::SliderInt( "##PausedFPSLimit", &settings.PausedFpsLimit,
+                GothicRendererSettings::PausedFpsLimitMin, GothicRendererSettings::PausedFpsLimitMax );
+
             ImText( "Object Draw Distance", buttonWidth ); ImGui::SameLine();
             float objectDrawDistance = settings.OutdoorVobDrawRadius / 1000.0f;
             if ( ImGui::SliderFloat( "##OutdoorVobDrawRadius", &objectDrawDistance, 1.f, 100.0f, "%.0f" ) ) {

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1854,6 +1854,10 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 }
                 ImGui::SetItemTooltip( "Rooms closer than this are never culled (100 units = 1m).\n"
                                        "Raise it if interiors pop while standing near a doorway." );
+                ImGui::Checkbox( "Skip sun shadows when enclosed", &settings.EnablePortalShadowSkip );
+                ImGui::SetItemTooltip( "While no room you can see reaches the outdoors, skip the sun shadow\n"
+                                       "cascades entirely and clear them to fully shadowed - the same result\n"
+                                       "the room's own walls and roof would have cast." );
                 ImGui::EndDisabled();
 
                 const auto& ps = portalCuller.GetStats();
@@ -1863,6 +1867,18 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                     ImGui::Text( "sectors: %d active / %d  (portals: %d)",
                         ps.ActiveSectors, ps.NumSectors, ps.NumPortals );
                     ImGui::Text( "camera: %s", ps.CameraOutdoor ? "outdoor" : "in sector" );
+
+                    // Broken down so a wrong verdict says which step decided it.
+                    if ( ps.EnclosedInSector == BspPortalCuller::SECTOR_OUTDOOR ) {
+                        ImGui::TextDisabled( "enclosure: camera not strictly in a room" );
+                    } else if ( ps.OutdoorVisible ) {
+                        ImGui::Text( "enclosure: in room %u, outdoor seen from room %u (walked %d)",
+                            ps.EnclosedInSector, ps.OutdoorSeenFromSector, ps.EnclosureWalkSectors );
+                    } else {
+                        ImGui::TextColored( ImVec4( 0.4f, 1.0f, 0.5f, 1.0f ),
+                            "view fully enclosed in room %u (walked %d) - sun cascades skipped",
+                            ps.EnclosedInSector, ps.EnclosureWalkSectors );
+                    }
                     if ( ps.UnreachableSectors > 0 ) {
                         ImGui::TextColored( ImVec4( 1.0f, 0.7f, 0.2f, 1.0f ),
                             "%d sector(s) unreachable from outdoor - never culled", ps.UnreachableSectors );

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1853,6 +1853,35 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 ImGui::Checkbox("Vobs", &settings.DebugSettings.Culling.CullVobs );
 
                 ImGui::Separator();
+                if ( ImGui::Checkbox( "Horizon culling (occluders)", &settings.EnableHorizonCulling ) ) {
+                    Engine::GAPI->GetHorizonCuller().SetEnabled( settings.EnableHorizonCulling );
+                }
+                ImGui::SetItemTooltip( "Cull sections, VOBs and MOBs behind the world's ghost occluders." );
+                {
+                    const auto& hs = Engine::GAPI->GetHorizonCuller().GetStats();
+                    if ( hs.OccludersTotal == 0 ) {
+                        ImGui::TextDisabled( "world ships no occluders" );
+                    } else {
+                        const int tested = hs.BoxesTested.load( std::memory_order_relaxed );
+                        const int rejected = hs.BoxesRejected.load( std::memory_order_relaxed );
+                        ImGui::Text( "occluders: %d/%d in view (%d too near)", hs.OccludersRasterized,
+                            hs.OccludersTotal, hs.OccludersTooNear );
+                        ImGui::Text( "boxes: %d rejected / %d tested (%.0f%%)", rejected, tested,
+                            tested ? (100.0f * rejected / tested) : 0.0f );
+                        // A large negative skyline top means something projected off to infinity and
+                        // the horizon should not be trusted.
+                        if ( hs.HorizonTop < -1000.0f ) {
+                            ImGui::TextColored( ImVec4( 1.0f, 0.3f, 0.3f, 1.0f ),
+                                "skyline top %.0f px - degenerate projection!", hs.HorizonTop );
+                        } else {
+                            ImGui::Text( "skyline top: %.0f px", hs.HorizonTop );
+                        }
+                    }
+                }
+                ImGui::Checkbox( "Draw World Occluders", &settings.DrawWorldOccluders );
+                ImGui::SetItemTooltip( "Outline the world's ghost occluders. Green = near, red = far." );
+
+                ImGui::Separator();
                 auto& portalCuller = Engine::GAPI->GetPortalCuller();
                 if ( ImGui::Checkbox( "Portal culling", &settings.EnablePortalCulling ) ) {
                     portalCuller.SetEnabled( settings.EnablePortalCulling );
@@ -1867,9 +1896,8 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 ImGui::SetItemTooltip( "Rooms closer than this are never culled (100 units = 1m).\n"
                                        "Raise it if interiors pop while standing near a doorway." );
                 ImGui::Checkbox( "Skip sun shadows when enclosed", &settings.EnablePortalShadowSkip );
-                ImGui::SetItemTooltip( "While no room you can see reaches the outdoors, skip the sun shadow\n"
-                                       "cascades entirely and clear them to fully shadowed - the same result\n"
-                                       "the room's own walls and roof would have cast." );
+                ImGui::SetItemTooltip( "Skip the sun cascades in rooms with no way out to daylight.\n"
+                                       "EXPERIMENTAL: a wrong verdict drops ALL sun shadows." );
                 ImGui::EndDisabled();
 
                 const auto& ps = portalCuller.GetStats();
@@ -1883,6 +1911,8 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                     // Broken down so a wrong verdict says which step decided it.
                     if ( ps.EnclosedInSector == BspPortalCuller::SECTOR_OUTDOOR ) {
                         ImGui::TextDisabled( "enclosure: camera not strictly in a room" );
+                    } else if ( ps.CameraRoomOpensOutdoor ) {
+                        ImGui::TextDisabled( "enclosure: room %u has a door outside", ps.EnclosedInSector );
                     } else if ( ps.OutdoorVisible ) {
                         ImGui::Text( "enclosure: in room %u, outdoor seen from room %u (walked %d)",
                             ps.EnclosedInSector, ps.OutdoorSeenFromSector, ps.EnclosureWalkSectors );

--- a/D3D11Engine/RenderQueue.h
+++ b/D3D11Engine/RenderQueue.h
@@ -63,35 +63,35 @@ public:
     BspTreeVobVisitor(): seen_flag_id( 1 << g_nextSeenId.fetch_add(1, std::memory_order_relaxed ) ) {
     }
 
+    // A vob is registered in every BSP leaf its box touches, so Visit() is called several times per
+    // vob per pass while only the FIRST call does anything. The plain relaxed load short-circuits the
+    // repeats: a locked read-modify-write (which takes exclusive ownership of the cache line) is then
+    // paid once per vob per pass instead of once per (vob, leaf) pair. Correct because only this
+    // visitor's own thread ever sets seen_flag_id - other threads own other bits of the same word, so
+    // losing the race is impossible; the fetch_or is what keeps their bits intact.
     bool Visit( VobInfo* vobInfo ) {
-        const auto wasFlagged = vobInfo->VisibleInRenderPass.fetch_or( seen_flag_id, std::memory_order_relaxed );
+        if ( (vobInfo->VisibleInRenderPass.load( std::memory_order_relaxed ) & seen_flag_id) != 0 )
+            return false;
 
-        if ( (wasFlagged & seen_flag_id) == 0 ) {
-            vobs.emplace_back( vobInfo );
-            return true;
-        }
-
-        return false;
+        vobInfo->VisibleInRenderPass.fetch_or( seen_flag_id, std::memory_order_relaxed );
+        vobs.emplace_back( vobInfo );
+        return true;
     }
     bool Visit( SkeletalVobInfo* vobInfo ) {
-        const auto wasFlagged = vobInfo->VisibleInRenderPass.fetch_or( seen_flag_id, std::memory_order_relaxed );
+        if ( (vobInfo->VisibleInRenderPass.load( std::memory_order_relaxed ) & seen_flag_id) != 0 )
+            return false;
 
-        if ( (wasFlagged & seen_flag_id) == 0 ) {
-            skeltalVobs.emplace_back( vobInfo );
-            return true;
-        }
-
-        return false;
+        vobInfo->VisibleInRenderPass.fetch_or( seen_flag_id, std::memory_order_relaxed );
+        skeltalVobs.emplace_back( vobInfo );
+        return true;
     }
     bool Visit( VobLightInfo* vobInfo ) {
-        const auto wasFlagged = vobInfo->VisibleInRenderPass.fetch_or( seen_flag_id, std::memory_order_relaxed );
+        if ( (vobInfo->VisibleInRenderPass.load( std::memory_order_relaxed ) & seen_flag_id) != 0 )
+            return false;
 
-        if ( (wasFlagged & seen_flag_id) == 0 ) {
-            lights.emplace_back( vobInfo );
-            return true;
-        }
-
-        return false;
+        vobInfo->VisibleInRenderPass.fetch_or( seen_flag_id, std::memory_order_relaxed );
+        lights.emplace_back( vobInfo );
+        return true;
     }
 
     void ClearForReuse() {

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -781,6 +781,129 @@ static bool IsPortalMaterial( std::string_view matName )
         || matName.starts_with( "PI:" ));
 }
 
+/** One-shot census of the world's occluder polys, logged at the end of ConvertWorldMesh.
+ *
+ *  Answers the two questions that decide how (or whether) to revive ZenGin's horizon culling:
+ *  how many occluders exist at all, and how big they are - a horizon built from a handful of tiny
+ *  polys culls nothing, while a few hundred large ones can cull whole BSP subtrees. Size is measured
+ *  as the world-space AABB diagonal in metres (100 units = 1m). */
+struct OccluderSurvey {
+    int Total = 0;
+    int Occluder = 0;          // flags.occluder - what ScanHorizon actually gates on
+    int GhostOccluder = 0;     // ...of which are occluder-only, never drawn
+    int GhostNotOccluder = 0;  // ghost without the occluder flag: dropped AND useless for the horizon
+    int Portals = 0;           // ghost occluders are portal polys in ZenGin; verify that holds here
+
+    /** Occluder size histogram, bucketed by AABB diagonal: <1m, <5m, <15m, <50m, >=50m. */
+    int SizeBuckets[5] = {};
+    /** Same, restricted to ghost occluders - the set an up-front horizon build could use as-is. */
+    int GhostSizeBuckets[5] = {};
+    float LargestDiagonal = 0.0f;
+
+    static int BucketOf( float metres ) {
+        if ( metres < 1.0f ) return 0;
+        if ( metres < 5.0f ) return 1;
+        if ( metres < 15.0f ) return 2;
+        if ( metres < 50.0f ) return 3;
+        return 4;
+    }
+
+    void Account( zCPolygon* poly ) {
+        if ( !poly ) return;
+        Total++;
+
+        const PolyFlags* flags = poly->GetPolyFlags();
+        const bool isOccluder = flags->Occluder != 0;
+        const bool isGhost = flags->GhostOccluder != 0;
+
+        if ( isGhost && poly->IsPortal() ) Portals++;
+        if ( isGhost && !isOccluder ) GhostNotOccluder++;
+        if ( !isOccluder ) return;
+
+        Occluder++;
+
+        // World-space AABB of the poly -> diagonal, as a stand-in for "how much screen can this cover".
+        const uint8_t numVerts = poly->GetNumPolyVertices();
+        zCVertex** verts = poly->getVertices();
+        if ( numVerts < 3 || !verts ) return;
+
+        float3 bbMin( FLT_MAX, FLT_MAX, FLT_MAX );
+        float3 bbMax( -FLT_MAX, -FLT_MAX, -FLT_MAX );
+        for ( uint8_t v = 0; v < numVerts; v++ ) {
+            if ( !verts[v] ) return;
+            const float3& p = verts[v]->Position;
+            bbMin.x = std::min( bbMin.x, p.x ); bbMax.x = std::max( bbMax.x, p.x );
+            bbMin.y = std::min( bbMin.y, p.y ); bbMax.y = std::max( bbMax.y, p.y );
+            bbMin.z = std::min( bbMin.z, p.z ); bbMax.z = std::max( bbMax.z, p.z );
+        }
+        const float dx = bbMax.x - bbMin.x, dy = bbMax.y - bbMin.y, dz = bbMax.z - bbMin.z;
+        const float metres = std::sqrt( dx * dx + dy * dy + dz * dz ) / 100.0f;
+
+        const int bucket = BucketOf( metres );
+        SizeBuckets[bucket]++;
+        if ( isGhost ) {
+            GhostOccluder++;
+            GhostSizeBuckets[bucket]++;
+        }
+        LargestDiagonal = std::max( LargestDiagonal, metres );
+    }
+
+    // Not named Log(): LogInfo() is a macro expanding to Log(...), which would resolve to the member.
+    void LogSummary() const {
+        LogInfo() << "OccluderSurvey: " << Occluder << " occluder polys of " << Total
+            << " (" << GhostOccluder << " ghost/never-drawn, " << Portals << " of those portals"
+            << (GhostNotOccluder ? ", " + std::to_string( GhostNotOccluder ) + " ghost WITHOUT occluder flag" : "")
+            << "), largest " << LargestDiagonal << "m";
+        if ( Occluder == 0 ) {
+            LogInfo() << "OccluderSurvey: no occluders - horizon culling would do nothing in this world";
+            return;
+        }
+        LogInfo() << "OccluderSurvey: occluder sizes  <1m:" << SizeBuckets[0] << "  <5m:" << SizeBuckets[1]
+            << "  <15m:" << SizeBuckets[2] << "  <50m:" << SizeBuckets[3] << "  >=50m:" << SizeBuckets[4];
+        LogInfo() << "OccluderSurvey: ghost only      <1m:" << GhostSizeBuckets[0] << "  <5m:" << GhostSizeBuckets[1]
+            << "  <15m:" << GhostSizeBuckets[2] << "  <50m:" << GhostSizeBuckets[3] << "  >=50m:" << GhostSizeBuckets[4];
+    }
+};
+
+/** Appends one ghost-occluder poly to the world's occluder set. Degenerate polys are skipped: a
+    zero-area occluder cannot darken a horizon column and would only cost a projection. */
+static void CollectGhostOccluder( WorldOccluders& out, zCPolygon* poly ) {
+    const uint32_t numVerts = poly->GetNumPolyVertices();
+    zCVertex** verts = poly->getVertices();
+    if ( numVerts < 3 || !verts ) return;
+
+    const uint32_t firstVertex = static_cast<uint32_t>( out.Verts.size() );
+
+    float3 bbMin( FLT_MAX, FLT_MAX, FLT_MAX );
+    float3 bbMax( -FLT_MAX, -FLT_MAX, -FLT_MAX );
+    for ( uint32_t v = 0; v < numVerts; v++ ) {
+        if ( !verts[v] ) {
+            out.Verts.resize( firstVertex );   // partial poly - roll back
+            return;
+        }
+        const float3& p = verts[v]->Position;
+        out.Verts.push_back( XMFLOAT3( p.x, p.y, p.z ) );
+        bbMin.x = std::min( bbMin.x, p.x ); bbMax.x = std::max( bbMax.x, p.x );
+        bbMin.y = std::min( bbMin.y, p.y ); bbMax.y = std::max( bbMax.y, p.y );
+        bbMin.z = std::min( bbMin.z, p.z ); bbMax.z = std::max( bbMax.z, p.z );
+    }
+
+    WorldOccluders::Entry entry = {};
+    entry.VertexOffset = firstVertex;
+    entry.NumVerts = numVerts;
+    entry.Center = XMFLOAT3( ( bbMin.x + bbMax.x ) * 0.5f, ( bbMin.y + bbMax.y ) * 0.5f,
+                             ( bbMin.z + bbMax.z ) * 0.5f );
+    const float dx = bbMax.x - bbMin.x, dy = bbMax.y - bbMin.y, dz = bbMax.z - bbMin.z;
+    entry.Radius = std::sqrt( dx * dx + dy * dy + dz * dz ) * 0.5f;
+
+    if ( entry.Radius < 1.0f ) {   // < 2cm across
+        out.Verts.resize( firstVertex );
+        return;
+    }
+
+    out.Entries.push_back( entry );
+}
+
 /** Converts the worldmesh into a more usable format */
 HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPolygons, std::map<int, std::map<int, WorldMeshSectionInfo>>* outSections, WorldInfo* info, MeshInfo** outWrappedMesh, bool indoorLocation ) {
     ZoneScoped;
@@ -797,11 +920,23 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
         return it->second;
     };
 
+    // --- Occlusion-culling survey (see OccluderSurvey) -----------------------------------------
+    // ZenGin's outdoor renderer rasterizes every poly with the Occluder flag into a 1D horizon buffer
+    // (zBsp.cpp ScanHorizon) and rejects bboxes below it. GhostOccluders are the subset that is
+    // occluder-only, never drawn - which is why the loop below throws them away. This counts what the
+    // loaded world actually ships so we can tell whether reviving that is worth it, and whether the
+    // horizon can be built from ghost occluders alone or needs a largest-N cut of all occluders.
+    OccluderSurvey survey = {};
+
     for ( unsigned int i = 0; i < numPolygons; i++ ) {
         zCPolygon* poly = polys[i];
 
-        // Check if we even need this polygon
+        survey.Account( poly );
+
+        // Ghost occluders are never drawn - but they ARE the world's authored occlusion geometry, so
+        // keep a copy for the horizon cull before dropping them from the render mesh.
         if ( poly->GetPolyFlags()->GhostOccluder ) {
+            if ( info ) CollectGhostOccluder( info->Occluders, poly );
             continue;
         }
 
@@ -1023,6 +1158,14 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
     LogInfo() << "Worldmesh: " << allMeshes.size() << " meshes, " << totalWorldVertices
         << " vertices (" << (totalWorldVertices * sizeof( ExVertexStruct )) / (1024 * 1024)
         << " MB CPU-side), " << totalWorldIndices << " indices";
+
+    survey.LogSummary();
+    if ( info && !info->Occluders.IsEmpty() ) {
+        LogInfo() << "Occluders: kept " << info->Occluders.Entries.size() << " ghost occluders ("
+            << (info->Occluders.Verts.size() * sizeof( XMFLOAT3 )
+                + info->Occluders.Entries.size() * sizeof( WorldOccluders::Entry )) / 1024
+            << " KB)";
+    }
 
     std::vector<ExVertexStruct> wrappedVertices;
     std::vector<unsigned int> wrappedIndices;

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -781,12 +781,9 @@ static bool IsPortalMaterial( std::string_view matName )
         || matName.starts_with( "PI:" ));
 }
 
-/** One-shot census of the world's occluder polys, logged at the end of ConvertWorldMesh.
- *
- *  Answers the two questions that decide how (or whether) to revive ZenGin's horizon culling:
- *  how many occluders exist at all, and how big they are - a horizon built from a handful of tiny
- *  polys culls nothing, while a few hundred large ones can cull whole BSP subtrees. Size is measured
- *  as the world-space AABB diagonal in metres (100 units = 1m). */
+/** One-shot census of the world's occluder polys, logged at the end of ConvertWorldMesh: how many
+ *  occluders exist and how big they are, which is what decides whether horizon culling is worth
+ *  anything in a given world. Size is the world-space AABB diagonal in metres (100 units = 1m). */
 struct OccluderSurvey {
     int Total = 0;
     int Occluder = 0;          // flags.occluder - what ScanHorizon actually gates on
@@ -796,7 +793,7 @@ struct OccluderSurvey {
 
     /** Occluder size histogram, bucketed by AABB diagonal: <1m, <5m, <15m, <50m, >=50m. */
     int SizeBuckets[5] = {};
-    /** Same, restricted to ghost occluders - the set an up-front horizon build could use as-is. */
+    /** Same, restricted to ghost occluders. */
     int GhostSizeBuckets[5] = {};
     float LargestDiagonal = 0.0f;
 
@@ -920,12 +917,9 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
         return it->second;
     };
 
-    // --- Occlusion-culling survey (see OccluderSurvey) -----------------------------------------
-    // ZenGin's outdoor renderer rasterizes every poly with the Occluder flag into a 1D horizon buffer
-    // (zBsp.cpp ScanHorizon) and rejects bboxes below it. GhostOccluders are the subset that is
-    // occluder-only, never drawn - which is why the loop below throws them away. This counts what the
-    // loaded world actually ships so we can tell whether reviving that is worth it, and whether the
-    // horizon can be built from ghost occluders alone or needs a largest-N cut of all occluders.
+    // Occlusion-culling survey (see OccluderSurvey). ZenGin's outdoor renderer rasterizes every poly with
+    // the Occluder flag into a 1D horizon buffer (zBsp.cpp ScanHorizon) and rejects bboxes below it;
+    // GhostOccluders are the occluder-only subset the loop below throws away.
     OccluderSurvey survey = {};
 
     for ( unsigned int i = 0; i < numPolygons; i++ ) {
@@ -933,8 +927,8 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
 
         survey.Account( poly );
 
-        // Ghost occluders are never drawn - but they ARE the world's authored occlusion geometry, so
-        // keep a copy for the horizon cull before dropping them from the render mesh.
+        // Never drawn, but they are the world's authored occlusion geometry: keep a copy for the horizon
+        // cull before dropping them from the render mesh.
         if ( poly->GetPolyFlags()->GhostOccluder ) {
             if ( info ) CollectGhostOccluder( info->Occluders, poly );
             continue;

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -598,6 +598,34 @@ struct WorldMeshSectionInfo {
 
 class zCBspTree;
 class zCWorld;
+/** The world's ghost-occluder polys, kept for occlusion culling.
+ *
+ *  ZenGin rasterizes these into a 1D horizon buffer (zBsp.cpp ScanHorizon) and rejects bboxes that
+ *  fall below it - its outdoor "behind the mountain" cull. They are portal polys flagged
+ *  ghostOccluder: occluders only, never drawn, which is why ConvertWorldMesh drops them from the
+ *  render mesh and collects them here instead.
+ *
+ *  Surveyed across G2 NotR: 945-2544 per world, ~all of them over 15m across, and the count does not
+ *  grow with world size - so projecting them per frame is bounded work everywhere.
+ *
+ *  Flat vertex array rather than a vector per poly: one allocation instead of thousands, and the
+ *  per-frame projection walks it linearly. */
+struct WorldOccluders {
+    struct Entry {
+        uint32_t VertexOffset;
+        uint32_t NumVerts;
+        /** Bounding sphere, for frustum rejection and the front-to-back sort the horizon needs. */
+        XMFLOAT3 Center;
+        float Radius;
+    };
+
+    std::vector<XMFLOAT3> Verts;
+    std::vector<Entry> Entries;
+
+    void Clear() { Verts.clear(); Entries.clear(); }
+    bool IsEmpty() const { return Entries.empty(); }
+};
+
 struct WorldInfo {
     WorldInfo() :
         MidPoint{},
@@ -621,6 +649,8 @@ struct WorldInfo {
     zCWorld* MainWorld;
     std::string WorldName;
     bool CustomWorldLoaded;
+    /** Filled by ConvertWorldMesh; empty on worlds that ship none. */
+    WorldOccluders Occluders;
 };
 
 struct TransparencyVobInfo {

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -600,16 +600,14 @@ class zCBspTree;
 class zCWorld;
 /** The world's ghost-occluder polys, kept for occlusion culling.
  *
- *  ZenGin rasterizes these into a 1D horizon buffer (zBsp.cpp ScanHorizon) and rejects bboxes that
- *  fall below it - its outdoor "behind the mountain" cull. They are portal polys flagged
- *  ghostOccluder: occluders only, never drawn, which is why ConvertWorldMesh drops them from the
- *  render mesh and collects them here instead.
+ *  ZenGin rasterizes these into a 1D horizon buffer (zBsp.cpp ScanHorizon) and rejects bboxes that fall
+ *  below it - its outdoor "behind the mountain" cull. They are portal polys flagged ghostOccluder:
+ *  occluders only, never drawn, which is why ConvertWorldMesh drops them from the render mesh and collects
+ *  them here instead. G2 NotR ships 945-2544 per world, and the count does not grow with world size, so
+ *  projecting them per frame is bounded work.
  *
- *  Surveyed across G2 NotR: 945-2544 per world, ~all of them over 15m across, and the count does not
- *  grow with world size - so projecting them per frame is bounded work everywhere.
- *
- *  Flat vertex array rather than a vector per poly: one allocation instead of thousands, and the
- *  per-frame projection walks it linearly. */
+ *  Flat vertex array rather than a vector per poly: one allocation instead of thousands, and the per-frame
+ *  projection walks it linearly. */
 struct WorldOccluders {
     struct Entry {
         uint32_t VertexOffset;

--- a/D3D11Engine/zCVob.h
+++ b/D3D11Engine/zCVob.h
@@ -28,6 +28,33 @@ enum EVisualCamAlignType {
     zVISUAL_CAM_ALIGN_FULL = 2
 };
 
+/** ZENGIN's packed zCVob flag word, at zCVob + GothicMemoryLocations::zCVob::Offset_Flags
+ *  (G1 0xE4, G2 0x104). The engine declares these as `unsigned char` bitfields, so MSVC packs
+ *  the first eight into byte 0 and the next four into byte 1 - identical in every supported
+ *  build, which is why one struct serves both games. Everything past bit 11 lives in separate
+ *  allocation units (sleepingMode, visualCamAlign, ...) and is read through its own offset.
+ *
+ *  Read as one 16-bit load so a collection pass that needs several flags pays a single
+ *  dereference into Gothic's heap instead of one per flag. */
+union zTVobFlags {
+    struct {
+        unsigned short ShowVisual : 1;              // bit 0  - MASK_ShowVisual
+        unsigned short DrawBBox3D : 1;              // bit 1
+        unsigned short VisualAlphaEnabled : 1;      // bit 2  - MASK_VisualAlpha (ghost/fading vobs)
+        unsigned short PhysicsEnabled : 1;          // bit 3
+        unsigned short StaticVob : 1;               // bit 4
+        unsigned short IgnoredByTraceRay : 1;       // bit 5
+        unsigned short CollDetectionStatic : 1;     // bit 6
+        unsigned short CollDetectionDynamic : 1;    // bit 7  - MASK_DynColl
+        unsigned short CastDynShadow : 2;           // bits 8-9  (zTDynShadowType)
+        unsigned short LightColorStatDirty : 1;     // bit 10
+        unsigned short LightColorDynDirty : 1;      // bit 11
+        unsigned short _unused : 4;                 // padding of the second allocation unit
+    };
+    unsigned short Packed;
+};
+static_assert( sizeof( zTVobFlags ) == 2, "zTVobFlags must stay a 2-byte mirror of ZENGIN's bitfield" );
+
 class zCBspLeaf;
 class zCVisual;
 class zCWorld;
@@ -295,35 +322,26 @@ public:
     }
 #endif
 
-    unsigned int GetFlags() const {
-        unsigned int flags = *reinterpret_cast<unsigned int*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_Flags ));
-        return flags;
-    }
-
-    static bool FlagGetShowVisual( const unsigned int flags ) {
-        return (flags & GothicMemoryLocations::zCVob::MASK_ShowVisual) != 0;
-    }
-
-    static bool FlagGetVisualAlpha( const unsigned int flags ) {
-        return (flags & GothicMemoryLocations::zCVob::MASK_VisualAlpha) != 0;
+    /** Reads the whole packed flag word in one go. Prefer this over the single-flag accessors
+        below whenever more than one flag is needed - each of those is its own dereference into
+        Gothic's heap, which is a cache miss the collection loops used to pay repeatedly. */
+    zTVobFlags GetFlags() const {
+        return *reinterpret_cast<zTVobFlags*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_Flags ));
     }
 
     /** Returns whether to show the main visual or not. Only used for the spacer */
     bool GetShowMainVisual() const {
-        unsigned int flags = *reinterpret_cast<unsigned int*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_Flags ));
-        return (flags & GothicMemoryLocations::zCVob::MASK_ShowVisual);
+        return GetFlags().ShowVisual != 0;
     }
 
     /** Returns whether vob is transparent */
     bool GetVisualAlpha() const {
-        unsigned int flags = *reinterpret_cast<unsigned int*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_Flags ));
-        return (flags & GothicMemoryLocations::zCVob::MASK_VisualAlpha);
+        return GetFlags().VisualAlphaEnabled != 0;
     }
 
     /** Returns dynamic collision of the vob */
     bool GetDynColl() const {
-        unsigned int flags = *reinterpret_cast<unsigned int*>(THISPTR_OFFSET( GothicMemoryLocations::zCVob::Offset_Flags ));
-        return (flags & GothicMemoryLocations::zCVob::MASK_DynColl);
+        return GetFlags().CollDetectionDynamic != 0;
     }
 
     /** Vob transparency */


### PR DESCRIPTION
5e3bd1d - vob culling improvements, reorder for better CPU cache utilization.
8310151 - experimental horizon culling, as well shadow-cascade culling (i.e. stop drawing shadows completely when indoors)
6835883 - force inner-Paused loop in BeginFrame/EndFrame for Menu screens. Those currently explode FPS. Menu is not part of Game loop, but runs its own menu loop
bd81f1c - mark frame start on actual frame start if we're in hooked into the game loop