### PR TITLE
(4/7) increase batch-able VOBs by enabling morph mesh batching

### DIFF
--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1088,6 +1088,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="MemoryTracker.h" />
     <ClInclude Include="MeshManager.h" />
     <ClInclude Include="MorphBlend.h" />
+    <ClInclude Include="MorphGpu.h" />
     <ClInclude Include="SharedVisualRegistry.h" />
     <ClInclude Include="MeshModifier.h" />
     <ClInclude Include="oCGame.h" />
@@ -1481,6 +1482,21 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
     </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12MorphFold.cpp">
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_12f|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+    </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12Fog.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
@@ -1676,6 +1692,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="include\tracy\public\TracyClient.cpp" />
     <ClCompile Include="MeshManager.cpp" />
     <ClCompile Include="MorphBlend.cpp" />
+    <ClCompile Include="MorphGpu.cpp" />
     <ClCompile Include="SharedVisualRegistry.cpp" />
     <ClCompile Include="MeshModifier.cpp" />
     <ClCompile Include="pch.cpp">

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1087,6 +1087,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="Logger.h" />
     <ClInclude Include="MemoryTracker.h" />
     <ClInclude Include="MeshManager.h" />
+    <ClInclude Include="MorphBlend.h" />
     <ClInclude Include="SharedVisualRegistry.h" />
     <ClInclude Include="MeshModifier.h" />
     <ClInclude Include="oCGame.h" />
@@ -1674,6 +1675,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="vendor\mikktspace.c" />
     <ClCompile Include="include\tracy\public\TracyClient.cpp" />
     <ClCompile Include="MeshManager.cpp" />
+    <ClCompile Include="MorphBlend.cpp" />
     <ClCompile Include="SharedVisualRegistry.cpp" />
     <ClCompile Include="MeshModifier.cpp" />
     <ClCompile Include="pch.cpp">

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1087,6 +1087,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="Logger.h" />
     <ClInclude Include="MemoryTracker.h" />
     <ClInclude Include="MeshManager.h" />
+    <ClInclude Include="SharedVisualRegistry.h" />
     <ClInclude Include="MeshModifier.h" />
     <ClInclude Include="oCGame.h" />
     <ClInclude Include="oCMobInter.h" />
@@ -1673,6 +1674,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="vendor\mikktspace.c" />
     <ClCompile Include="include\tracy\public\TracyClient.cpp" />
     <ClCompile Include="MeshManager.cpp" />
+    <ClCompile Include="SharedVisualRegistry.cpp" />
     <ClCompile Include="MeshModifier.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -932,6 +932,7 @@
     <ClInclude Include="HorizonCuller.h" />
     <ClInclude Include="MorphBlend.h" />
     <ClInclude Include="SharedVisualRegistry.h" />
+    <ClInclude Include="MorphGpu.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -1336,6 +1337,8 @@
     <ClCompile Include="D3D12Engine\D3D12Sky.cpp" />
     <ClCompile Include="MorphBlend.cpp" />
     <ClCompile Include="SharedVisualRegistry.cpp" />
+    <ClCompile Include="D3D12Engine\D3D12MorphFold.cpp" />
+    <ClCompile Include="MorphGpu.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ddraw.def">

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -930,6 +930,8 @@
     </ClInclude>
     <ClInclude Include="BspPortalCuller.h" />
     <ClInclude Include="HorizonCuller.h" />
+    <ClInclude Include="MorphBlend.h" />
+    <ClInclude Include="SharedVisualRegistry.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -1332,6 +1334,8 @@
     <ClCompile Include="BspPortalCuller.cpp" />
     <ClCompile Include="HorizonCuller.cpp" />
     <ClCompile Include="D3D12Engine\D3D12Sky.cpp" />
+    <ClCompile Include="MorphBlend.cpp" />
+    <ClCompile Include="SharedVisualRegistry.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ddraw.def">

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3551,7 +3551,19 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                         instData.Color = modelColor;
                         instData.Color.w = getFocusColor( vi->Vob, playerFocusVob );
 
-                        for ( auto const& itm : mvi->Meshes ) {
+                        // Anything .MMS that gets here is out of morph range (the branch above consumed
+                        // every in-range one), so it must draw the SHARED undeformed rest mesh rather than
+                        // its own copy - that copy still holds the deformation from the last time it was in
+                        // range. This also makes the batching below correct: these records already share a
+                        // meshId, so a batch was binding one member's stale buffers for all of them. Falls
+                        // back to the morph copy while the rest mesh is still being built.
+                        MeshVisualInfo* drawVis = mvi;
+                        if ( isMMS && mvi->RestVisual
+                            && mvi->RestVisual->Ready.load( std::memory_order_acquire ) ) {
+                            drawVis = mvi->RestVisual;
+                        }
+
+                        for ( auto const& itm : drawVis->Meshes ) {
                             zCTexture* texture = nullptr;
                             FrameGeometryCache::SortKeyBuilder sortKeyBase = { 0 };
                             if ( itm.first ) {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3557,6 +3557,10 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                         if ( isMMS && mvi->RestVisual
                             && mvi->RestVisual->Ready.load( std::memory_order_acquire ) ) {
                             drawVis = mvi->RestVisual;
+                            // Drawing the shared rest mesh, so this instance's own DYNAMIC buffers are
+                            // dead weight. Hand them back once it has been out of morph range long
+                            // enough; the first draw that needs them again rebuilds them.
+                            mvi->ReleaseIdleMorphVertexBuffers( Engine::GAPI->GetFrameNumber() );
                         }
 
                         for ( auto const& itm : drawVis->Meshes ) {
@@ -3789,7 +3793,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
             if ( mi->GetMeshVertexBuffer() != lastVB ) {
                 UINT vbOffset = 0;
                 UINT vbStride = sizeof( ExVertexStruct );
-                Context->IASetVertexBuffers( 0, 1, D3D11VertexBuffer::From( mi->MeshVertexBuffer.get())->GetVertexBuffer().GetAddressOf(), &vbStride, &vbOffset );
+                Context->IASetVertexBuffers( 0, 1, D3D11VertexBuffer::From( mi->GetMeshVertexBuffer())->GetVertexBuffer().GetAddressOf(), &vbStride, &vbOffset );
                 lastVB = mi->GetMeshVertexBuffer();
             }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3582,10 +3582,11 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                             }
 
                             for ( unsigned int m = 0; m < itm.second.size(); m++ ) {
-                                FrameGeometryCache::SortKeyBuilder meshSortKey = sortKeyBase;
-                                meshSortKey.withMesh( itm.second[m]->meshId );
-
-                                instancedDrawItems.emplace_back( meshSortKey.sortKey, itm.second[m].get(), texture, itm.first, instData,
+                                // Deliberately no mesh component in the sort key: the sort below tie-breaks on
+                                // the MeshInfo pointer instead. Since the SharedVisualRegistry gives every
+                                // distinct converted mesh exactly one MeshInfo, that pointer IS the geometry
+                                // identity - and unlike meshId it cannot alias two different meshes together.
+                                instancedDrawItems.emplace_back( sortKeyBase.sortKey, itm.second[m].get(), texture, itm.first, instData,
                                     (texture && texture->HasAlphaChannel()) || (itm.first && itm.first->HasAlphaTest())
                                 );
                             }
@@ -3613,7 +3614,11 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
             std::sort( instancedDrawItems.begin(), instancedDrawItems.end(),
                 []( const NodeAttachmentDrawItem& a, const NodeAttachmentDrawItem& b ) {
-                        return a.sortKey < b.sortKey;
+                        // Tie-break on the MeshInfo pointer so identical geometry ends up contiguous and the
+                        // batch loop below can merge it. Ordering between distinct meshes is arbitrary and
+                        // irrelevant (all opaque, depth-tested); all that matters is that equal meshes group.
+                        if ( a.sortKey != b.sortKey ) return a.sortKey < b.sortKey;
+                        return a.mesh < b.mesh;
                 } );
 
             const unsigned int neededBytes = static_cast<unsigned int>(instancedDrawItems.size() * sizeof( NodeAttachmentInstanceData ));
@@ -3644,17 +3649,23 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
             unsigned int currentIdx = 0;
 
             for ( size_t i = 0; i < instancedDrawItems.size(); ) {
-                // Find the end of this batch (same mesh + texture)
+                // Find the end of this batch (same mesh + texture). Keyed on the MeshInfo POINTER, not on
+                // meshId: the draw below binds batchMesh's vertex/index buffers for every member, so the
+                // key has to mean "same buffers". meshId only meant "same source zCSubMesh", which is a
+                // weaker claim - a morph attachment and its undeformed rest mesh, or two .MDS/.ASC node
+                // visuals that baked different node transforms into their vertices, share a zCSubMesh while
+                // holding completely different geometry. The pointer is exact, and it is only usable as a
+                // batch key at all because the SharedVisualRegistry made one converted mesh serve every vob
+                // that references it. It also drops the old "meshId 0 means unbatchable" gate, which could
+                // leave 'i' unadvanced and spin this loop forever if an id ever came back 0.
                 size_t batchStart = i;
                 auto batchMesh = instancedDrawItems[i].mesh;
-                auto meshId = batchMesh->meshId;
                 zCTexture* batchTex = instancedDrawItems[i].texture;
                 zCMaterial* batchMat = instancedDrawItems[i].material;
 
                 bool needAlpha = false;
                 while ( i < instancedDrawItems.size()
-                        && meshId > 0 // assume meshId 0 means "not batch-able"
-                        && instancedDrawItems[i].mesh->meshId == meshId
+                        && instancedDrawItems[i].mesh == batchMesh
                         && instancedDrawItems[i].texture == batchTex ) {
                     // Some of them have needAlpha false, even though they share the same texture!
                     // thus we now just walk all batch items and assume if one needs alpha, all do.

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3432,8 +3432,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                 if ( nodeAttachments[i].size() && node->NodeVisual != nodeAttachments[i][0]->Visual ) {
                     // Check for deleted attachment
                     if ( !node->NodeVisual ) {
-                        // Remove attachment. Shared with every other vob carrying this visual, so it
-                        // goes back to the registry rather than being deleted here.
+                        // Remove attachment. Shared, so it goes back to the registry, not deleted here.
                         WorldConverter::ReleaseNodeAttachments( nodeAttachments, i );
 
                         LogInfo() << "Removed attachment from model " << vi->VisualInfo->VisualName;
@@ -3551,12 +3550,9 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                         instData.Color = modelColor;
                         instData.Color.w = getFocusColor( vi->Vob, playerFocusVob );
 
-                        // Anything .MMS that gets here is out of morph range (the branch above consumed
-                        // every in-range one), so it must draw the SHARED undeformed rest mesh rather than
-                        // its own copy - that copy still holds the deformation from the last time it was in
-                        // range. This also makes the batching below correct: these records already share a
-                        // meshId, so a batch was binding one member's stale buffers for all of them. Falls
-                        // back to the morph copy while the rest mesh is still being built.
+                        // Any .MMS reaching here is out of morph range (the branch above took the rest),
+                        // so it draws the shared rest mesh - its own copy still holds the deformation from
+                        // when it was last in range. Falls back to that copy until the rest mesh is built.
                         MeshVisualInfo* drawVis = mvi;
                         if ( isMMS && mvi->RestVisual
                             && mvi->RestVisual->Ready.load( std::memory_order_acquire ) ) {
@@ -3582,10 +3578,8 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                             }
 
                             for ( unsigned int m = 0; m < itm.second.size(); m++ ) {
-                                // Deliberately no mesh component in the sort key: the sort below tie-breaks on
-                                // the MeshInfo pointer instead. Since the SharedVisualRegistry gives every
-                                // distinct converted mesh exactly one MeshInfo, that pointer IS the geometry
-                                // identity - and unlike meshId it cannot alias two different meshes together.
+                                // No mesh component in the key - the sort below tie-breaks on the
+                                // MeshInfo pointer, the geometry identity now that the registry dedupes.
                                 instancedDrawItems.emplace_back( sortKeyBase.sortKey, itm.second[m].get(), texture, itm.first, instData,
                                     (texture && texture->HasAlphaChannel()) || (itm.first && itm.first->HasAlphaTest())
                                 );
@@ -3614,9 +3608,8 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
             std::sort( instancedDrawItems.begin(), instancedDrawItems.end(),
                 []( const NodeAttachmentDrawItem& a, const NodeAttachmentDrawItem& b ) {
-                        // Tie-break on the MeshInfo pointer so identical geometry ends up contiguous and the
-                        // batch loop below can merge it. Ordering between distinct meshes is arbitrary and
-                        // irrelevant (all opaque, depth-tested); all that matters is that equal meshes group.
+                        // Tie-break on the MeshInfo pointer so identical geometry is contiguous for the
+                        // batch loop. Order between distinct meshes is irrelevant (all opaque, depth-tested).
                         if ( a.sortKey != b.sortKey ) return a.sortKey < b.sortKey;
                         return a.mesh < b.mesh;
                 } );
@@ -3649,15 +3642,11 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
             unsigned int currentIdx = 0;
 
             for ( size_t i = 0; i < instancedDrawItems.size(); ) {
-                // Find the end of this batch (same mesh + texture). Keyed on the MeshInfo POINTER, not on
-                // meshId: the draw below binds batchMesh's vertex/index buffers for every member, so the
-                // key has to mean "same buffers". meshId only meant "same source zCSubMesh", which is a
-                // weaker claim - a morph attachment and its undeformed rest mesh, or two .MDS/.ASC node
-                // visuals that baked different node transforms into their vertices, share a zCSubMesh while
-                // holding completely different geometry. The pointer is exact, and it is only usable as a
-                // batch key at all because the SharedVisualRegistry made one converted mesh serve every vob
-                // that references it. It also drops the old "meshId 0 means unbatchable" gate, which could
-                // leave 'i' unadvanced and spin this loop forever if an id ever came back 0.
+                // Find the end of this batch (same mesh + texture). Keyed on the MeshInfo POINTER, not
+                // meshId: the draw binds batchMesh's buffers for every member, so the key must mean "same
+                // buffers", and meshId only means "same source zCSubMesh" (see MeshInfo::meshId). The
+                // pointer works as a key because the registry dedupes conversions. Dropping the old
+                // "meshId 0 is unbatchable" gate also removes a spin - it could leave 'i' unadvanced.
                 size_t batchStart = i;
                 auto batchMesh = instancedDrawItems[i].mesh;
                 zCTexture* batchTex = instancedDrawItems[i].texture;

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3557,10 +3557,6 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                         if ( isMMS && mvi->RestVisual
                             && mvi->RestVisual->Ready.load( std::memory_order_acquire ) ) {
                             drawVis = mvi->RestVisual;
-                            // Drawing the shared rest mesh, so this instance's own DYNAMIC buffers are
-                            // dead weight. Hand them back once it has been out of morph range long
-                            // enough; the first draw that needs them again rebuilds them.
-                            mvi->ReleaseIdleMorphVertexBuffers( Engine::GAPI->GetFrameNumber() );
                         }
 
                         for ( auto const& itm : drawVis->Meshes ) {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3432,9 +3432,9 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                 if ( nodeAttachments[i].size() && node->NodeVisual != nodeAttachments[i][0]->Visual ) {
                     // Check for deleted attachment
                     if ( !node->NodeVisual ) {
-                        // Remove attachment
-                        delete nodeAttachments[i][0];
-                        nodeAttachments[i].clear();
+                        // Remove attachment. Shared with every other vob carrying this visual, so it
+                        // goes back to the registry rather than being deleted here.
+                        WorldConverter::ReleaseNodeAttachments( nodeAttachments, i );
 
                         LogInfo() << "Removed attachment from model " << vi->VisualInfo->VisualName;
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3644,9 +3644,8 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
             for ( size_t i = 0; i < instancedDrawItems.size(); ) {
                 // Find the end of this batch (same mesh + texture). Keyed on the MeshInfo POINTER, not
                 // meshId: the draw binds batchMesh's buffers for every member, so the key must mean "same
-                // buffers", and meshId only means "same source zCSubMesh" (see MeshInfo::meshId). The
-                // pointer works as a key because the registry dedupes conversions. Dropping the old
-                // "meshId 0 is unbatchable" gate also removes a spin - it could leave 'i' unadvanced.
+                // buffers", while meshId only means "same source zCSubMesh" (see MeshInfo::meshId). The
+                // pointer works as a key because the registry dedupes conversions.
                 size_t batchStart = i;
                 auto batchMesh = instancedDrawItems[i].mesh;
                 zCTexture* batchTex = instancedDrawItems[i].texture;

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -62,10 +62,9 @@ struct FrameSkelDraw {
 // alphaTested = can the depth/caster PS' `clip(diffuse.a - 0.5)` ever discard for this attachment? Resolved on
 // the main thread with srvSlot (a pool-thread recorder must not read Gothic texture state), and used by every
 // depth-only consumer to route the attachment through a no-pixel-shader PSO when it can't.
-// inst = the per-instance data this attachment already uploaded at collection time (the same bytes instView
-// points at). Carried by value so the main-view batcher (BuildSkeletalDrawCommands) can re-emit runs of
-// instances CONTIGUOUSLY without reading back the write-combined UPLOAD ring — see the node-attachment
-// batching there. The per-draw consumers (CSM cascades, point shadows) ignore it and keep using instView.
+// inst = the per-instance data this attachment uploaded at collection time (the bytes instView points at),
+// by value so the main-view batcher can re-emit runs of instances CONTIGUOUSLY without reading back the
+// write-combined UPLOAD ring. The per-draw consumers (CSM cascades, point shadows) keep using instView.
 struct FrameAttachDraw {
     MeshInfo*                   mesh;
     zCTexture*                  tex;

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -74,11 +74,11 @@ struct FrameAttachDraw {
     UINT                        srvSlot;
     bool                        alphaTested;
     VobInstanceInfo             inst;
-    // May this attachment share an instanced draw with others of the same MeshInfo::meshId? False for .MMS
-    // morph meshes (facial morphs, bow/crossbow draw meshes): they share a meshId with every other instance
-    // of the same zCSubMesh, but zCMorphMesh deforms each one into its OWN dynamic vertex buffer, so a batch
-    // would give every instance the head-of-batch's morph. D3D11 excludes them from batching the same way
-    // (the "Non-MMS, non-cube" branch in D3D11GraphicsEngine.cpp's node-attachment collection).
+    // May this attachment share an instanced draw with others pointing at the same MeshInfo? False only for
+    // an ACTIVELY MORPHING .MMS (a facial morph or bow/crossbow draw mesh within kMorphMeshMaxDistance):
+    // zCMorphMesh re-deforms its vertex buffer every frame for whichever instance is being drawn, so a batch
+    // would give every member the head-of-batch's morph. Out of morph range the attachment switches to the
+    // shared undeformed rest mesh (MeshVisualInfo::RestVisual) and becomes batchable like anything else.
     bool                        batchable;
 };
 

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -75,10 +75,9 @@ struct FrameAttachDraw {
     bool                        alphaTested;
     VobInstanceInfo             inst;
     // May this attachment share an instanced draw with others pointing at the same MeshInfo? False only for
-    // an ACTIVELY MORPHING .MMS (a facial morph or bow/crossbow draw mesh within kMorphMeshMaxDistance):
-    // zCMorphMesh re-deforms its vertex buffer every frame for whichever instance is being drawn, so a batch
-    // would give every member the head-of-batch's morph. Out of morph range the attachment switches to the
-    // shared undeformed rest mesh (MeshVisualInfo::RestVisual) and becomes batchable like anything else.
+    // an actively morphing .MMS: its vertex buffer is re-deformed per frame for whichever instance is being
+    // drawn, so a batch would give every member the head-of-batch's morph. Out of range it switches to the
+    // shared rest mesh (MeshVisualInfo::RestVisual) and becomes batchable like anything else.
     bool                        batchable;
 };
 

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -12,6 +12,7 @@
 #include <DirectXMath.h>
 #include <wrl/client.h>
 #include "D3D12TracyDebug.h"
+#include "../ConstantBufferStructs.h"   // VobInstanceInfo — held by value in FrameAttachDraw
 
 class zCTexture;
 class zCVob;
@@ -61,6 +62,10 @@ struct FrameSkelDraw {
 // alphaTested = can the depth/caster PS' `clip(diffuse.a - 0.5)` ever discard for this attachment? Resolved on
 // the main thread with srvSlot (a pool-thread recorder must not read Gothic texture state), and used by every
 // depth-only consumer to route the attachment through a no-pixel-shader PSO when it can't.
+// inst = the per-instance data this attachment already uploaded at collection time (the same bytes instView
+// points at). Carried by value so the main-view batcher (BuildSkeletalDrawCommands) can re-emit runs of
+// instances CONTIGUOUSLY without reading back the write-combined UPLOAD ring — see the node-attachment
+// batching there. The per-draw consumers (CSM cascades, point shadows) ignore it and keep using instView.
 struct FrameAttachDraw {
     MeshInfo*                   mesh;
     zCTexture*                  tex;
@@ -68,6 +73,13 @@ struct FrameAttachDraw {
     const zCVob*                owner;
     UINT                        srvSlot;
     bool                        alphaTested;
+    VobInstanceInfo             inst;
+    // May this attachment share an instanced draw with others of the same MeshInfo::meshId? False for .MMS
+    // morph meshes (facial morphs, bow/crossbow draw meshes): they share a meshId with every other instance
+    // of the same zCSubMesh, but zCMorphMesh deforms each one into its OWN dynamic vertex buffer, so a batch
+    // would give every instance the head-of-batch's morph. D3D11 excludes them from batching the same way
+    // (the "Non-MMS, non-cube" branch in D3D11GraphicsEngine.cpp's node-attachment collection).
+    bool                        batchable;
 };
 
 // Per-frame GPU point light. Filled by BuildFrameLightBuffer (D3D12Scene.cpp); the point-shadow slot

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -152,6 +152,13 @@ XRESULT D3D12GraphicsEngine::Init() {
         // instance buffer from m_VobInstanceBufferCapacity) and after CreateVobIndirect.
         LogWarn() << "D3D12GraphicsEngine::Init: failed to create the GPU VOB-culling resources (falling back to CPU frustum culling).";
     }
+    if ( !m_Pipelines.CreateMorphFold() || !CreateMorphFoldResources() ) {
+        // Non-fatal, but it MUST be attempted here — before the first world/attachment conversion. Whether
+        // the fold is available is what decides how a morph submesh's vertex buffer is created (DEFAULT+UAV
+        // for the GPU fold vs DYNAMIC+CA_WRITE for ZENGIN's CPU deform), and MorphGpu::IsActive() freezes
+        // that answer for the session. Failing here simply leaves the CPU deform as the path.
+        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the GPU morph-fold resources (morph meshes will deform on the CPU).";
+    }
     if ( !CreateLightBuffer() ) {
         LogWarn() << "D3D12GraphicsEngine::Init: failed to create the point-light buffer.";
         return XR_FAILED;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -902,17 +902,16 @@ private:
 
     // ---- GPU morph fold (D3D12MorphFold.cpp + MorphGpu.h + Shaders/D3D12/MorphFold.hlsl) ----
     // Morph attachments (NPC heads, bow/crossbow draw meshes) fold their blend shapes in a compute pass that
-    // rewrites the Position of each vertex in the submesh's own (DEFAULT-heap, UAV) vertex buffer, instead of
-    // ZENGIN deforming on the CPU and re-uploading the whole vertex stream every animation frame. The
-    // prototype tables are per .MMS and immutable; the only per-frame upload is the channel records.
+    // rewrites the Position of each vertex in the submesh's own DEFAULT-heap UAV vertex buffer, instead of
+    // ZENGIN deforming on the CPU and re-uploading the stream every animation frame. The prototype tables are
+    // per .MMS and immutable; the only per-frame upload is the channel records.
     static constexpr UINT kMaxMorphChannelRecords = 4096;   // 24 B each -> 96 KB per frame-in-flight
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_MorphChannelBuffer[kBackBufferMax];   // persistently-mapped UPLOAD
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_MorphChannelBufferAlloc[kBackBufferMax];
     uint8_t* m_MorphChannelBufferPtr[kBackBufferMax] = {};
     bool m_MorphChannelOverflowLogged = false;
-    // One entry per MorphGpu::Prototype, uploaded to VRAM on the first frame that folds it and kept for the
-    // session (a handful of head types per world, ~1 MB in total — measured by MorphBlend::LogPrototypeBudget).
-    // Keyed by the opaque Prototype pointer so this header does not have to pull in MorphGpu.h.
+    // One entry per MorphGpu::Prototype, uploaded on the first frame that folds it and kept for the session
+    // (~1 MB in total). Keyed by the opaque Prototype pointer so this header need not include MorphGpu.h.
     struct MorphTableGpu {
         Microsoft::WRL::ComPtr<ID3D12Resource>      Positions;
         Microsoft::WRL::ComPtr<D3D12MA::Allocation> PositionsAlloc;
@@ -921,8 +920,8 @@ private:
     };
     std::unordered_map<const void*, MorphTableGpu> m_MorphTables;
     std::vector<D3D12_RESOURCE_BARRIER> m_MorphBarriers;   // scratch; keeps its capacity across frames
-    // This frame's queue, moved out of MorphGpu by DispatchMorphFold (see MorphGpu::TakeJobs for why it is a
-    // move rather than a borrow). Members rather than locals so they keep their capacity across frames.
+    // This frame's queue, moved out of MorphGpu by DispatchMorphFold (see MorphGpu::TakeJobs). Members rather
+    // than locals so they keep their capacity across frames.
     std::vector<MorphGpu::Job> m_MorphJobs;
     std::vector<MorphGpu::ChannelRecord> m_MorphChannels;
     UINT m_MorphFoldSubmeshCount = 0;   // submeshes folded last frame (diagnostic)

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -6,6 +6,7 @@
 
 #include "../BaseGraphicsEngine.h"
 #include "../Frustum.h"
+#include "../MorphGpu.h"         // MorphGpu::Job / ChannelRecord (the morph-fold queue members below)
 #include "../WorldConverter.h"   // SHADOW_LOD_FIRST_CASCADE
 #include "D3D12Device.h"
 #include <memory>
@@ -898,6 +899,36 @@ private:
     // The buffer both VOB passes ExecuteIndirect from: the GPU-patched DEFAULT copy when culling, else the
     // per-frame CPU-written UPLOAD ring.
     ID3D12Resource* GetVobDrawArgsBuffer() const;
+
+    // ---- GPU morph fold (D3D12MorphFold.cpp + MorphGpu.h + Shaders/D3D12/MorphFold.hlsl) ----
+    // Morph attachments (NPC heads, bow/crossbow draw meshes) fold their blend shapes in a compute pass that
+    // rewrites the Position of each vertex in the submesh's own (DEFAULT-heap, UAV) vertex buffer, instead of
+    // ZENGIN deforming on the CPU and re-uploading the whole vertex stream every animation frame. The
+    // prototype tables are per .MMS and immutable; the only per-frame upload is the channel records.
+    static constexpr UINT kMaxMorphChannelRecords = 4096;   // 24 B each -> 96 KB per frame-in-flight
+    Microsoft::WRL::ComPtr<ID3D12Resource>      m_MorphChannelBuffer[kBackBufferMax];   // persistently-mapped UPLOAD
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_MorphChannelBufferAlloc[kBackBufferMax];
+    uint8_t* m_MorphChannelBufferPtr[kBackBufferMax] = {};
+    bool m_MorphChannelOverflowLogged = false;
+    // One entry per MorphGpu::Prototype, uploaded to VRAM on the first frame that folds it and kept for the
+    // session (a handful of head types per world, ~1 MB in total — measured by MorphBlend::LogPrototypeBudget).
+    // Keyed by the opaque Prototype pointer so this header does not have to pull in MorphGpu.h.
+    struct MorphTableGpu {
+        Microsoft::WRL::ComPtr<ID3D12Resource>      Positions;
+        Microsoft::WRL::ComPtr<D3D12MA::Allocation> PositionsAlloc;
+        Microsoft::WRL::ComPtr<ID3D12Resource>      Indices;
+        Microsoft::WRL::ComPtr<D3D12MA::Allocation> IndicesAlloc;
+    };
+    std::unordered_map<const void*, MorphTableGpu> m_MorphTables;
+    std::vector<D3D12_RESOURCE_BARRIER> m_MorphBarriers;   // scratch; keeps its capacity across frames
+    // This frame's queue, moved out of MorphGpu by DispatchMorphFold (see MorphGpu::TakeJobs for why it is a
+    // move rather than a borrow). Members rather than locals so they keep their capacity across frames.
+    std::vector<MorphGpu::Job> m_MorphJobs;
+    std::vector<MorphGpu::ChannelRecord> m_MorphChannels;
+    UINT m_MorphFoldSubmeshCount = 0;   // submeshes folded last frame (diagnostic)
+    bool m_MorphFoldReady = false;
+    bool CreateMorphFoldResources();   // channel ring (once, at init); enables MorphGpu if the PSO is there too
+    void DispatchMorphFold();          // records this frame's folds; call before the first pass that draws them
 
     // Forward+ opaque depth-prepass PSOs/blobs (world + instanced VOB) live in m_Pipelines.World
     // (DepthPrepassPSO/VsBlob/PsBlob, DepthPrepassVobPSO/VobVsBlob/VobPsBlob). The skeletal depth-prepass PSO

--- a/D3D11Engine/D3D12Engine/D3D12MorphFold.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12MorphFold.cpp
@@ -1,21 +1,14 @@
 // D3D12GraphicsEngine — GPU morph fold.
 //
-// The D3D12 half of MorphGpu (see MorphGpu.h for the data model and why this exists). Morph attachments —
-// NPC heads and the bow/crossbow draw meshes — used to be deformed by ZENGIN on the CPU and re-uploaded
-// whole, once per animation frame per instance, into a per-instance DYNAMIC vertex buffer. Here the fold is
-// one Dispatch per submesh that rewrites only the 12-byte Position of the vertices already in that
-// submesh's own buffer, which is now a DEFAULT-heap UAV instead:
+// The D3D12 half of MorphGpu (see MorphGpu.h for the data model and why this exists). Instead of ZENGIN
+// deforming on the CPU and re-uploading a whole DYNAMIC vertex buffer per animation frame per instance, the
+// fold is one Dispatch per submesh that rewrites only the 12-byte Position of the vertices already in that
+// submesh's buffer, which is now a DEFAULT-heap UAV: no CPU mapping (so no 32-bit address space) and ONE
+// copy rather than kBackBufferCount, since the writer is the GPU on the same in-order direct queue.
 //
-//   * no CPU mapping at all, so it costs no 32-bit address space (the constraint that had forced the old
-//     release-after-120-idle-frames hysteresis on those buffers), and
-//   * ONE copy rather than kBackBufferCount — the CPU-write-vs-GPU-read race the dynamic ring exists for
-//     cannot happen when the writer is the GPU on the same in-order direct queue.
-//
-// Ordering. The dispatches go on the main command list right before the depth prepass, which is the first
-// pass of the frame (in SUBMISSION order, not recording order) that draws a morph attachment: the shadow
-// cascades and point-shadow cubes record into private lists but are executed later, in FinishShadowPasses.
-// Across frames the single direct queue orders frame N-1's draws before frame N's fold, which is what makes
-// the single copy safe.
+// Ordering. The dispatches go on the main command list right before the depth prepass, the first pass of the
+// frame in SUBMISSION order that draws a morph attachment (the shadow lists are recorded earlier but
+// executed later). Across frames the single direct queue orders frame N-1's draws before frame N's fold.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
 #include "../Engine.h"
@@ -150,11 +143,10 @@ void D3D12GraphicsEngine::DispatchMorphFold() {
 
     m_MorphBarriers.clear();
     bool uploadedTables = false;
-    // Walked BACKWARDS so the duplicate filter below keeps the NEWEST registration of a mesh. The queue can
-    // hold two for one submesh: a pass that collects after this dispatch (DrawGhostVobs' attachment loop is
-    // the one that does) leaves its job queued for the next frame, where that frame's own registration joins
-    // it. Reverse order costs nothing else - the dispatches are independent, and a whole instance's submeshes
-    // are still consecutive, so the per-prototype root-SRV rebind is still skipped.
+    // Walked BACKWARDS so the duplicate filter below keeps the NEWEST registration of a mesh: a pass that
+    // collects after this dispatch (DrawGhostVobs' attachment loop) leaves its job queued for the next frame,
+    // where that frame's own registration joins it. Costs nothing else — the dispatches are independent and
+    // an instance's submeshes are still consecutive, so the per-prototype root-SRV rebind is still skipped.
     for ( size_t ji = jobs.size(); ji-- > 0; ) {
         const MorphGpu::Job& job = jobs[ji];
         if ( !job.Mesh || !job.Proto || job.OutVertexCount == 0 ) continue;
@@ -272,9 +264,7 @@ void D3D12GraphicsEngine::DispatchMorphFold() {
     m_CmdList->ResourceBarrier( static_cast<UINT>( m_MorphBarriers.size() ), m_MorphBarriers.data() );
 
     m_MorphFoldSubmeshCount = static_cast<UINT>( resolved.size() );
-    // Replaces the old "Morph buffers: N resident" churn diagnostic - with the fold there is no churn left to
-    // report, so what is worth watching instead is how much work a crowded frame actually folds and how much
-    // table memory the world's head types add up to.
+    // How much a crowded frame actually folds, and how much table memory the world's head types add up to.
     {
         static size_t s_lastReportFrame = 0;
         const size_t now = Engine::GAPI->GetFrameNumber();

--- a/D3D11Engine/D3D12Engine/D3D12MorphFold.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12MorphFold.cpp
@@ -1,0 +1,288 @@
+// D3D12GraphicsEngine — GPU morph fold.
+//
+// The D3D12 half of MorphGpu (see MorphGpu.h for the data model and why this exists). Morph attachments —
+// NPC heads and the bow/crossbow draw meshes — used to be deformed by ZENGIN on the CPU and re-uploaded
+// whole, once per animation frame per instance, into a per-instance DYNAMIC vertex buffer. Here the fold is
+// one Dispatch per submesh that rewrites only the 12-byte Position of the vertices already in that
+// submesh's own buffer, which is now a DEFAULT-heap UAV instead:
+//
+//   * no CPU mapping at all, so it costs no 32-bit address space (the constraint that had forced the old
+//     release-after-120-idle-frames hysteresis on those buffers), and
+//   * ONE copy rather than kBackBufferCount — the CPU-write-vs-GPU-read race the dynamic ring exists for
+//     cannot happen when the writer is the GPU on the same in-order direct queue.
+//
+// Ordering. The dispatches go on the main command list right before the depth prepass, which is the first
+// pass of the frame (in SUBMISSION order, not recording order) that draws a morph attachment: the shadow
+// cascades and point-shadow cubes record into private lists but are executed later, in FinishShadowPasses.
+// Across frames the single direct queue orders frame N-1's draws before frame N's fold, which is what makes
+// the single copy safe.
+#include "../pch.h"
+#include "D3D12GraphicsEngine.h"
+#include "../Engine.h"
+#include "../GothicAPI.h"
+#include "../MorphGpu.h"
+#include "../WorldObjects.h"
+#include "D3D12VertexBuffer.h"
+
+using Microsoft::WRL::ComPtr;
+#include "D3D12EngineCommon.h"
+
+namespace {
+    /** Root-constant block. Mirrors MorphFold.hlsl's MorphFoldCB (8 DWORDs, matching CreateMorphFold). */
+    struct MorphFoldCB {
+        uint32_t OutVertexCount;
+        uint32_t VertexStride;
+        uint32_t RestBase;
+        uint32_t WedgeBase;
+        uint32_t ChannelFirst;
+        uint32_t ChannelCount;
+        uint32_t Pad0, Pad1;
+    };
+    static_assert( sizeof( MorphFoldCB ) == 8 * sizeof( uint32_t ), "MorphFoldCB must match the 8 root constants in CreateMorphFold()" );
+
+    constexpr UINT kFoldThreadGroupSize = 64;   // == MorphFold.hlsl's [numthreads(64,1,1)]
+}
+
+
+bool D3D12GraphicsEngine::CreateMorphFoldResources() {
+    m_MorphFoldReady = false;
+
+    // The compute pipeline is what actually decides whether folding is possible; without it there is nothing
+    // to feed and MorphGpu stays inactive (morph submeshes then get CPU-writable buffers at conversion time
+    // and ZENGIN's deform keeps running, exactly as before).
+    if ( !m_Pipelines.MorphFold.PSO || !m_Pipelines.MorphFold.RootSig ) {
+        MorphGpu::SetBackendAvailable( false );
+        return false;
+    }
+
+    ID3D12Device* device = m_Device.GetDevice();
+    if ( !device || !m_Allocator ) {
+        MorphGpu::SetBackendAvailable( false );
+        return false;
+    }
+
+    // Per-frame channel records. CPU-written once per frame (DispatchMorphFold, before the first dispatch is
+    // recorded) and read straight out of the UPLOAD heap as a root SRV — a DEFAULT-heap copy would buy
+    // nothing for 96 KB read once per fold.
+    D3D12MA::ALLOCATION_DESC upload = {};
+    upload.HeapType = DefaultUploadHeapType;
+
+    D3D12_RESOURCE_DESC bd = {};
+    bd.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+    bd.Width = static_cast<UINT64>( kMaxMorphChannelRecords ) * sizeof( MorphGpu::ChannelRecord );
+    bd.Height = 1;
+    bd.DepthOrArraySize = 1;
+    bd.MipLevels = 1;
+    bd.Format = DXGI_FORMAT_UNKNOWN;
+    bd.SampleDesc.Count = 1;
+    bd.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+    bd.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+    for ( UINT i = 0; i < kBackBufferCount; ++i ) {
+        if ( FAILED( m_Allocator->CreateResource( &upload, &bd, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+            m_MorphChannelBufferAlloc[i].ReleaseAndGetAddressOf(),
+            IID_PPV_ARGS( m_MorphChannelBuffer[i].ReleaseAndGetAddressOf() ) ) ) ) {
+            LogWarn() << "D3D12: failed to create the morph-fold channel ring.";
+            MorphGpu::SetBackendAvailable( false );
+            return false;
+        }
+        m_MorphChannelBuffer[i]->SetName( L"MorphChannelRing" );
+        D3D12_RANGE noRead = { 0, 0 };
+        void* mapped = nullptr;
+        if ( FAILED( m_MorphChannelBuffer[i]->Map( 0, &noRead, &mapped ) ) ) {
+            MorphGpu::SetBackendAvailable( false );
+            return false;
+        }
+        m_MorphChannelBufferPtr[i] = static_cast<uint8_t*>( mapped );
+    }
+
+    m_MorphBarriers.reserve( 64 );
+    m_MorphFoldReady = true;
+    MorphGpu::SetBackendAvailable( true );
+    return true;
+}
+
+
+void D3D12GraphicsEngine::DispatchMorphFold() {
+    if ( !m_MorphFoldReady || !m_FrameOpen ) return;
+    if ( !m_Pipelines.MorphFold.PSO || !m_Pipelines.MorphFold.RootSig ) return;
+
+    // Takes the queue rather than borrowing it: Register() runs on the worker pool too, so a live reference
+    // could be reallocated under this walk - and Job::ChannelFirst indexes the channel array, so the two may
+    // only be emptied together. Anything registered from here on folds next frame. See MorphGpu::TakeJobs.
+    MorphGpu::TakeJobs( m_MorphJobs, m_MorphChannels );
+    m_MorphFoldSubmeshCount = 0;   // so the diagnostic below never reports a stale count after a bail-out
+    if ( m_MorphJobs.empty() ) return;
+
+    const std::vector<MorphGpu::Job>& jobs = m_MorphJobs;
+    const std::vector<MorphGpu::ChannelRecord>& channels = m_MorphChannels;
+    if ( channels.size() > kMaxMorphChannelRecords ) {
+        // Not truncated: a partial channel list would fold every instance past the cut DIFFERENTLY rather
+        // than not at all (each channel attenuates the ones before it), so the whole frame's fold is skipped
+        // and every affected head keeps last frame's expression.
+        if ( !m_MorphChannelOverflowLogged ) {
+            LogWarn() << "D3D12: morph channel ring overflow (" << channels.size() << " > "
+                << kMaxMorphChannelRecords << " records). Morph fold skipped this frame.";
+            m_MorphChannelOverflowLogged = true;
+        }
+        return;
+    }
+
+    DX_ZONE( m_CmdList.Get(), "Morph fold (compute)" );
+    ZoneScopedN( "MorphFold" );
+
+    if ( !channels.empty() ) {
+        memcpy( m_MorphChannelBufferPtr[m_FrameIndex], channels.data(),
+            channels.size() * sizeof( MorphGpu::ChannelRecord ) );
+    }
+
+    // --- Resolve every job's resources, upload any prototype table this is the first fold of, and collect
+    //     the pre-barriers. A job whose table or output buffer cannot be resolved is dropped here; its head
+    //     keeps the pose already in its buffer (the rest pose, if it has never folded).
+    struct ResolvedJob {
+        const MorphGpu::Job* Job;
+        D3D12_GPU_VIRTUAL_ADDRESS Positions;
+        D3D12_GPU_VIRTUAL_ADDRESS Indices;
+        D3D12VertexBuffer* Out;
+    };
+    static std::vector<ResolvedJob> resolved;   // retains capacity; only ever touched on the main thread here
+    resolved.clear();
+
+    m_MorphBarriers.clear();
+    bool uploadedTables = false;
+    // Walked BACKWARDS so the duplicate filter below keeps the NEWEST registration of a mesh. The queue can
+    // hold two for one submesh: a pass that collects after this dispatch (DrawGhostVobs' attachment loop is
+    // the one that does) leaves its job queued for the next frame, where that frame's own registration joins
+    // it. Reverse order costs nothing else - the dispatches are independent, and a whole instance's submeshes
+    // are still consecutive, so the per-prototype root-SRV rebind is still skipped.
+    for ( size_t ji = jobs.size(); ji-- > 0; ) {
+        const MorphGpu::Job& job = jobs[ji];
+        if ( !job.Mesh || !job.Proto || job.OutVertexCount == 0 ) continue;
+
+        auto tableIt = m_MorphTables.find( job.Proto );
+        if ( tableIt == m_MorphTables.end() ) {
+            // First fold of this .MMS: push its immutable tables into VRAM. Both are small (measured ~1 MB
+            // of positions plus ~110 KB of index tables across ALL prototypes of a G2 world), so they go up
+            // eagerly and whole rather than being streamed per ani.
+            MorphTableGpu table;
+            const size_t posBytes = job.Proto->Positions.size() * sizeof( float3 );
+            const size_t idxBytes = job.Proto->Indices.size() * sizeof( uint32_t );
+            if ( posBytes == 0 || idxBytes == 0 ) continue;
+
+            D3D12MA::ALLOCATION_DESC heapDefault = {};
+            heapDefault.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+            D3D12_RESOURCE_DESC td = {};
+            td.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+            td.Height = 1; td.DepthOrArraySize = 1; td.MipLevels = 1;
+            td.Format = DXGI_FORMAT_UNKNOWN; td.SampleDesc.Count = 1;
+            td.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+            td.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+            td.Width = posBytes;
+            bool ok = SUCCEEDED( m_Allocator->CreateResource( &heapDefault, &td, D3D12_RESOURCE_STATE_COMMON, nullptr,
+                table.PositionsAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( table.Positions.ReleaseAndGetAddressOf() ) ) );
+            td.Width = idxBytes;
+            ok = ok && SUCCEEDED( m_Allocator->CreateResource( &heapDefault, &td, D3D12_RESOURCE_STATE_COMMON, nullptr,
+                table.IndicesAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( table.Indices.ReleaseAndGetAddressOf() ) ) );
+            ok = ok && UploadBufferData( table.Positions.Get(), job.Proto->Positions.data(), static_cast<UINT>( posBytes ) );
+            ok = ok && UploadBufferData( table.Indices.Get(), job.Proto->Indices.data(), static_cast<UINT>( idxBytes ) );
+            if ( !ok ) {
+                LogWarn() << "D3D12: failed to upload a morph prototype's fold tables (" << ( posBytes / 1024 )
+                    << " + " << ( idxBytes / 1024 ) << " KB). That head will not morph.";
+                continue;
+            }
+            table.Positions->SetName( L"MorphPositions" );
+            table.Indices->SetName( L"MorphIndices" );
+            uploadedTables = true;
+            tableIt = m_MorphTables.emplace( job.Proto, std::move( table ) ).first;
+        }
+
+        GfxVertexBuffer* vb = job.Mesh->GetMeshVertexBuffer();
+        if ( !vb ) continue;
+        D3D12VertexBuffer* out = D3D12VertexBuffer::From( vb );
+        if ( !out->IsUavCapable() || !out->GetResource() ) continue;   // CPU-deform buffer — not ours to write
+
+        // Already claimed by a newer job for the same submesh (see the reverse walk above), or a duplicate
+        // registration - either way folding it twice would double-transition the resource.
+        if ( out->GetUavState() == D3D12VertexBuffer::EUavState::Unordered ) continue;
+
+        // COMMON on the very first fold (a buffer promotes out of COMMON implicitly, so a draw before the
+        // first fold was legal too), VERTEX_AND_CONSTANT_BUFFER on every fold after it.
+        const D3D12_RESOURCE_STATES from = ( out->GetUavState() == D3D12VertexBuffer::EUavState::Vertex )
+            ? D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER : D3D12_RESOURCE_STATE_COMMON;
+        m_MorphBarriers.push_back( TransitionBarrier( out->GetResource(), from, D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) );
+        out->SetUavState( D3D12VertexBuffer::EUavState::Unordered );
+
+        resolved.push_back( { &job,
+            tableIt->second.Positions->GetGPUVirtualAddress(),
+            tableIt->second.Indices->GetGPUVirtualAddress(),
+            out } );
+    }
+
+    if ( resolved.empty() ) {
+        return;
+    }
+    if ( uploadedTables ) {
+        // UploadBufferData only RECORDS into the shared copy-queue batch; it is the flush that submits it and
+        // issues the direct queue's Wait on the copy fence. Without this the dispatches below (recorded now,
+        // submitted later on the direct queue) could read the tables before the copies land.
+        FlushTextureUploads();
+    }
+    m_CmdList->ResourceBarrier( static_cast<UINT>( m_MorphBarriers.size() ), m_MorphBarriers.data() );
+
+    // --- One dispatch per submesh ---
+    m_CmdList->SetPipelineState( m_Pipelines.MorphFold.PSO.Get() );
+    m_CmdList->SetComputeRootSignature( m_Pipelines.MorphFold.RootSig.Get() );
+    m_CmdList->SetComputeRootShaderResourceView( 3, m_MorphChannelBuffer[m_FrameIndex]->GetGPUVirtualAddress() );
+
+    D3D12_GPU_VIRTUAL_ADDRESS boundPositions = 0;
+    D3D12_GPU_VIRTUAL_ADDRESS boundIndices = 0;
+    for ( const ResolvedJob& r : resolved ) {
+        // Instances of one head type share their prototype's tables, so re-binding is skipped whenever
+        // consecutive jobs come from the same .MMS (which they do — Register queues a whole instance's
+        // submeshes together).
+        if ( r.Positions != boundPositions ) {
+            m_CmdList->SetComputeRootShaderResourceView( 1, r.Positions );
+            boundPositions = r.Positions;
+        }
+        if ( r.Indices != boundIndices ) {
+            m_CmdList->SetComputeRootShaderResourceView( 2, r.Indices );
+            boundIndices = r.Indices;
+        }
+
+        MorphFoldCB cb{};
+        cb.OutVertexCount = r.Job->OutVertexCount;
+        cb.VertexStride = static_cast<uint32_t>( sizeof( ExVertexStruct ) );
+        cb.RestBase = r.Job->RestBase;
+        cb.WedgeBase = r.Job->WedgeBase;
+        cb.ChannelFirst = r.Job->ChannelFirst;
+        cb.ChannelCount = r.Job->ChannelCount;
+        m_CmdList->SetComputeRoot32BitConstants( 0, 8, &cb, 0 );
+        m_CmdList->SetComputeRootUnorderedAccessView( 4, r.Out->GetGpuVirtualAddress() );
+        m_CmdList->Dispatch( ( r.Job->OutVertexCount + kFoldThreadGroupSize - 1 ) / kFoldThreadGroupSize, 1, 1 );
+    }
+
+    // --- Hand every folded buffer to the geometry passes ---
+    m_MorphBarriers.clear();
+    for ( const ResolvedJob& r : resolved ) {
+        m_MorphBarriers.push_back( TransitionBarrier( r.Out->GetResource(),
+            D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER ) );
+        r.Out->SetUavState( D3D12VertexBuffer::EUavState::Vertex );
+    }
+    m_CmdList->ResourceBarrier( static_cast<UINT>( m_MorphBarriers.size() ), m_MorphBarriers.data() );
+
+    m_MorphFoldSubmeshCount = static_cast<UINT>( resolved.size() );
+    // Replaces the old "Morph buffers: N resident" churn diagnostic - with the fold there is no churn left to
+    // report, so what is worth watching instead is how much work a crowded frame actually folds and how much
+    // table memory the world's head types add up to.
+    {
+        static size_t s_lastReportFrame = 0;
+        const size_t now = Engine::GAPI->GetFrameNumber();
+        if ( now - s_lastReportFrame > 1200 ) {
+            s_lastReportFrame = now;
+            LogInfo() << "Morph fold: " << m_MorphFoldSubmeshCount << " submeshes, " << channels.size()
+                << " channels this frame; " << m_MorphTables.size() << " prototype tables resident ("
+                << ( MorphGpu::ResidentTableBytes() / 1024 ) << " KB)";
+        }
+    }
+}

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -3552,14 +3552,11 @@ bool D3D12PipelineState::CreateCull() {
 
 bool D3D12PipelineState::CreateMorphFold() {
     // GPU morph fold (Shaders/D3D12/MorphFold.hlsl + D3D12MorphFold.cpp). Everything rides on root
-    // descriptors: the two per-prototype tables and the per-frame channel records are plain structured
-    // buffers, and the output is the submesh's own vertex buffer as a raw UAV — so no descriptor heap slots
-    // are involved and a dispatch is 4 Set calls.
+    // descriptors — no descriptor heap slots involved, so a dispatch is 4 Set calls.
     //
-    // On failure MorphGpu::IsActive() stays false and morph attachments keep ZENGIN's CPU deform (which is
-    // also what decides that their vertex buffers are created CPU-writable), so this is non-fatal — but it
-    // has to be attempted BEFORE the first world conversion, which is why Init() calls it with the other
-    // pre-load pipelines rather than lazily.
+    // On failure MorphGpu::IsActive() stays false and morph attachments keep ZENGIN's CPU deform, so this is
+    // non-fatal — but it must be attempted BEFORE the first world conversion (that is what decides whether
+    // the morph vertex buffers are created CPU-writable), hence Init() calling it with the pre-load pipelines.
     ID3D12Device* device = m_Device->GetDevice();
     if ( !device ) return false;
 
@@ -3569,7 +3566,7 @@ bool D3D12PipelineState::CreateMorphFold() {
     rs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 1: t0 Positions
     rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 2: t1 Indices
     // t2 is this frame's channel ring slice: fully written by DispatchMorphFold before the first dispatch is
-    // recorded, and not touched again until the frame's slot comes round again kBackBufferCount frames later.
+    // recorded, and not touched again until this slot comes round kBackBufferCount frames later.
     rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 3: t2 Channels
     rs.AddUAV( 0, D3D12_SHADER_VISIBILITY_ALL );                                       // 4: u0 OutVertices
     if ( !rs.Build( device ) )

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -3550,6 +3550,48 @@ bool D3D12PipelineState::CreateCull() {
 }
 
 
+bool D3D12PipelineState::CreateMorphFold() {
+    // GPU morph fold (Shaders/D3D12/MorphFold.hlsl + D3D12MorphFold.cpp). Everything rides on root
+    // descriptors: the two per-prototype tables and the per-frame channel records are plain structured
+    // buffers, and the output is the submesh's own vertex buffer as a raw UAV — so no descriptor heap slots
+    // are involved and a dispatch is 4 Set calls.
+    //
+    // On failure MorphGpu::IsActive() stays false and morph attachments keep ZENGIN's CPU deform (which is
+    // also what decides that their vertex buffers are created CPU-writable), so this is non-fatal — but it
+    // has to be attempted BEFORE the first world conversion, which is why Init() calls it with the other
+    // pre-load pipelines rather than lazily.
+    ID3D12Device* device = m_Device->GetDevice();
+    if ( !device ) return false;
+
+    D3D12RootLayout& rs = Layout( "MorphFold" );
+    rs.AddConstants( 0, 8, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 MorphFoldCB
+    // t0/t1 are the immutable per-prototype tables — uploaded once, never rewritten, so DATA_STATIC is safe.
+    rs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 1: t0 Positions
+    rs.AddSRV( 1, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 2: t1 Indices
+    // t2 is this frame's channel ring slice: fully written by DispatchMorphFold before the first dispatch is
+    // recorded, and not touched again until the frame's slot comes round again kBackBufferCount frames later.
+    rs.AddSRV( 2, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 3: t2 Channels
+    rs.AddUAV( 0, D3D12_SHADER_VISIBILITY_ALL );                                       // 4: u0 OutVertices
+    if ( !rs.Build( device ) )
+        return false;
+    MorphFold.RootSig = rs.RootSig();
+
+    if ( !m_Shaders->CompileFromFile( "MorphFold.hlsl", "CSFold", Shadermodel_CS,
+        MorphFold.CsBlob.ReleaseAndGetAddressOf() ) )
+        return false;
+    rs.ValidateShaders( { { MorphFold.CsBlob.Get(), "MorphFold.hlsl:CSFold", D3D12_SHADER_VISIBILITY_ALL } } );
+
+    D3D12_COMPUTE_PIPELINE_STATE_DESC desc = {};
+    desc.pRootSignature = MorphFold.RootSig.Get();
+    desc.CS = { MorphFold.CsBlob->GetBufferPointer(), MorphFold.CsBlob->GetBufferSize() };
+    if ( FAILED( device->CreateComputePipelineState( &desc, IID_PPV_ARGS( MorphFold.PSO.ReleaseAndGetAddressOf() ) ) ) ) {
+        LogWarn() << "D3D12: CreateComputePipelineState failed (CSFold).";
+        return false;
+    }
+    return true;
+}
+
+
 bool D3D12PipelineState::CreateLines() {
     // Debug/editor line lists (D3D12LineRenderer) — port of D3D11's PS_Lines + VS_Lines / VS_Lines_XYZRHW.
     // Drawn after the tonemap resolve, straight onto the swapchain backbuffer, so the vertex colors land
@@ -3661,6 +3703,9 @@ bool D3D12PipelineState::ReloadAll( bool hdrEncodeActive, std::vector<std::strin
     runFatal( "LightCull", &D3D12PipelineState::CreateLightCull );
     runFatal( "Vob", &D3D12PipelineState::CreateVob );
     runOptional( "Cull", &D3D12PipelineState::CreateCull );
+    // Reloadable, but a reload cannot flip MorphGpu::IsActive() (it is frozen for the session — the morph
+    // vertex buffers already exist in one usage or the other), so this only refreshes the shader.
+    runOptional( "MorphFold", &D3D12PipelineState::CreateMorphFold );
     runFatal( "Skeletal", &D3D12PipelineState::CreateSkeletal );
     runFatal( "PointShadow", &D3D12PipelineState::CreatePointShadow );
     runFatal( "Water", &D3D12PipelineState::CreateWater );

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.h
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.h
@@ -561,6 +561,7 @@ public:
     bool CreateAdvanceRain(); // rain/snow particle advance compute (b0 32-bit consts, t0 static SRV, u0 dynamic UAV)
     bool CreateRainDraw();    // rain/snow billboard draw (b0 ViewProj, b1 particle info, t0/t1 root SRVs, no IA)
     bool CreateCull();        // Hi-Z build + GPU VOB cull/compact + indirect-arg patch compute pipelines
+    bool CreateMorphFold();   // GPU morph-mesh fold compute (b0 8 consts, t0-t2 root SRVs, u0 root UAV)
     bool CreateLines();       // debug/editor line lists (world-space depth-tested + screen-space xyzrhw)
     bool CreateWorldTransparency(); // alpha-blended world-mesh surfaces (own root sig; warms the alpha + depth-fill PSOs)
 
@@ -619,6 +620,11 @@ public:
     ComputePipeline  AdvanceRain;   // rain/snow particle advance (Shaders/D3D12/AdvanceRain.hlsl)
     GraphicsPipeline RainDraw;      // rain/snow billboard draw (Shaders/D3D12/Rain.hlsl)
     CullPipeline     Cull;          // Hi-Z build + GPU VOB cull (Shaders/D3D12/HiZ.hlsl + VobCull.hlsl)
+    // GPU morph fold (Shaders/D3D12/MorphFold.hlsl). Its availability is what decides how morph submesh
+    // vertex buffers are CREATED (DEFAULT+UAV vs DYNAMIC+CA_WRITE — see MorphGpu::IsActive), so unlike the
+    // other optional pipelines it must be built before any world is converted, and a failure here has to
+    // leave the CPU deform as the path rather than silently drop the morphing.
+    ComputePipeline  MorphFold;
     LinePipeline     Lines;         // debug/editor line lists (Shaders/D3D12/Lines.hlsl)
     WorldTransparencyPipeline WorldTransparency;  // alpha-blended world surfaces (Shaders/D3D12/World.hlsl VSTransparent/PSTransparent)
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -3300,25 +3300,31 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
         // 50 benches / a crowd's worth of identical swords arrive here as 50 one-instance commands, each
         // rebinding two VBVs + an IBV — a full IA state change for ~200 vertices, which is what makes this
         // pass draw-bound rather than geometry-bound. Batch them the way D3D11 does (see the
-        // NodeAttachmentDrawItem loop in D3D11GraphicsEngine.cpp): MeshInfo::meshId is MeshManager's stable
-        // id for the underlying zCSubMesh, so equal meshId means byte-identical geometry even though every
-        // vob extracted its OWN MeshInfo/VB/IB — which is why binding any one member's buffers serves the
-        // whole batch. meshId 0 means "not batchable" and stays a singleton.
+        // NodeAttachmentDrawItem loop in D3D11GraphicsEngine.cpp): the batch head supplies the VB/IB for
+        // every member, so the key has to mean "same buffers" — and the MeshInfo POINTER says exactly that.
+        // It only works as a key because the SharedVisualRegistry gives every distinct converted mesh
+        // exactly one MeshInfo, shared by every vob referencing it; before that, identical geometry really
+        // did arrive as N distinct MeshInfos and meshId was the only thing that matched.
         //
-        // Grouped through a hash map rather than a sort: the key is (meshId, material, alphaTested) and
+        // meshId is NOT used here any more. It identifies the source zCSubMesh, which is a weaker claim
+        // than "same buffers": a morph attachment and its undeformed rest mesh are both extracted from the
+        // same zCProgMeshProto, and two .MDS/.ASC node visuals bake different node transforms into their
+        // vertices — in both cases equal meshId, different geometry. Keying on it aliased those together.
+        //
+        // Grouped through a hash map rather than a sort: the key is (mesh, material, alphaTested) and
         // nothing downstream depends on attachment draw ORDER (all opaque, depth-tested). The material is
         // still part of the key here — folding it into the per-instance data (VobInstanceInfo::GP_Slot) so
-        // the key collapses to meshId alone is the follow-up step.
+        // the key collapses to the mesh alone is the follow-up step.
         struct AttachBatchKey {
-            uint16_t meshId; UINT mats[3]; bool alphaTested;
+            const MeshInfo* mesh; UINT mats[3]; bool alphaTested;
             bool operator==( const AttachBatchKey& o ) const {
-                return meshId == o.meshId && alphaTested == o.alphaTested
+                return mesh == o.mesh && alphaTested == o.alphaTested
                     && mats[0] == o.mats[0] && mats[1] == o.mats[1] && mats[2] == o.mats[2];
             }
         };
         struct AttachBatchKeyHash {
             size_t operator()( const AttachBatchKey& k ) const {
-                size_t h = k.meshId;
+                size_t h = reinterpret_cast<size_t>( k.mesh );
                 h = h * 1000003u ^ k.mats[0];
                 h = h * 1000003u ^ k.mats[1];
                 h = h * 1000003u ^ k.mats[2];
@@ -3337,7 +3343,7 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
         batchIndex.clear();
         for ( AttachBatch& b : batches ) b.members.clear();   // keep the inner vectors' capacity
         size_t usedBatches = 0;
-        size_t unbatchable = 0;   // .MMS morph meshes + meshId 0 — forced singletons, see the plots below
+        size_t unbatchable = 0;   // actively morphing .MMS only — forced singletons, see the plots below
 
         for ( const FrameAttachDraw& a : g_FrameAttachDraws ) {
             if ( !a.mesh || a.mesh->Indices.empty() || !a.mesh->GetMeshVertexBuffer() || !a.mesh->GetMeshIndexBuffer() )
@@ -3355,11 +3361,12 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
             // other three builds also test is pure conservatism (a=1 everywhere never clips).
             const bool alphaTested = a.tex && a.tex->HasAlphaChannel();
 
-            // meshId 0 = MeshManager never recorded it; !batchable = .MMS morph mesh with per-instance
-            // deformed vertices (see FrameAttachDraw::batchable). Either way: its own singleton command,
-            // never entered into the index so nothing can join it either.
-            const bool batchable = a.batchable && a.mesh->meshId != 0;
-            const AttachBatchKey key{ a.mesh->meshId, { mats[0], mats[1], mats[2] }, alphaTested };
+            // !batchable = an actively morphing .MMS, whose vertex buffer is re-deformed per frame for this
+            // instance alone (see FrameAttachDraw::batchable). It gets its own singleton command and is
+            // never entered into the index, so nothing can join it either. The old "meshId 0" half of this
+            // gate is gone - a MeshInfo pointer is always a valid identity.
+            const bool batchable = a.batchable;
+            const AttachBatchKey key{ a.mesh, { mats[0], mats[1], mats[2] }, alphaTested };
             size_t bi;
             auto it = batchable ? batchIndex.find( key ) : batchIndex.end();
             if ( it != batchIndex.end() ) {

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -4358,6 +4358,10 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
                     if ( isMMS && !morphActive && mvi->RestVisual
                         && mvi->RestVisual->Ready.load( std::memory_order_acquire ) ) {
                         drawVis = mvi->RestVisual;
+                        // Its own DYNAMIC buffers are unused while the rest mesh is what draws — and on
+                        // D3D12 each one is kBackBufferCount persistently-mapped UPLOAD copies, so holding
+                        // them for every head ever walked past is the expensive case. Rebuilt on demand.
+                        mvi->ReleaseIdleMorphVertexBuffers( Engine::GAPI->GetFrameNumber() );
                     }
                     const bool attBatchable = !isMMS || drawVis != mvi;
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -3301,15 +3301,9 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
         // rebinding two VBVs + an IBV — a full IA state change for ~200 vertices, which is what makes this
         // pass draw-bound rather than geometry-bound. Batch them the way D3D11 does (see the
         // NodeAttachmentDrawItem loop in D3D11GraphicsEngine.cpp): the batch head supplies the VB/IB for
-        // every member, so the key has to mean "same buffers" — and the MeshInfo POINTER says exactly that.
-        // It only works as a key because the SharedVisualRegistry gives every distinct converted mesh
-        // exactly one MeshInfo, shared by every vob referencing it; before that, identical geometry really
-        // did arrive as N distinct MeshInfos and meshId was the only thing that matched.
-        //
-        // meshId is NOT used here any more. It identifies the source zCSubMesh, which is a weaker claim
-        // than "same buffers": a morph attachment and its undeformed rest mesh are both extracted from the
-        // same zCProgMeshProto, and two .MDS/.ASC node visuals bake different node transforms into their
-        // vertices — in both cases equal meshId, different geometry. Keying on it aliased those together.
+        // every member, so the key must mean "same buffers" — the MeshInfo POINTER says exactly that, and
+        // works as a key because the SharedVisualRegistry dedupes conversions. Not meshId: it identifies
+        // the source zCSubMesh, which is weaker and aliases distinct geometry (see MeshInfo::meshId).
         //
         // Grouped through a hash map rather than a sort: the key is (mesh, material, alphaTested) and
         // nothing downstream depends on attachment draw ORDER (all opaque, depth-tested). The material is
@@ -3361,10 +3355,8 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
             // other three builds also test is pure conservatism (a=1 everywhere never clips).
             const bool alphaTested = a.tex && a.tex->HasAlphaChannel();
 
-            // !batchable = an actively morphing .MMS, whose vertex buffer is re-deformed per frame for this
-            // instance alone (see FrameAttachDraw::batchable). It gets its own singleton command and is
-            // never entered into the index, so nothing can join it either. The old "meshId 0" half of this
-            // gate is gone - a MeshInfo pointer is always a valid identity.
+            // !batchable = an actively morphing .MMS (see FrameAttachDraw::batchable). Its own singleton
+            // command, never entered into the index, so nothing can join it either.
             const bool batchable = a.batchable;
             const AttachBatchKey key{ a.mesh, { mats[0], mats[1], mats[2] }, alphaTested };
             size_t bi;
@@ -4358,13 +4350,10 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
                         // own LastAniUpdateFrame guard already limits this to once per animation frame.
                         WorldConverter::UpdateMorphMeshVisual( mvi->Visual, mvi );
                     }
-                    // A non-morphing .MMS draws the SHARED undeformed rest mesh instead of its own copy.
-                    // That copy still holds whatever deformation was current the last time this head was
-                    // inside kMorphMeshMaxDistance, so drawing it out of range is both wrong and forces a
-                    // singleton command (every instance is stale differently). The rest mesh is one
-                    // MeshInfo for every head of this type, so they all collapse into one batch — this is
-                    // what turns the "Attach unbatchable" plot's NPC heads into batchable records. Falls
-                    // back to the morph copy while the rest mesh is still being built on a worker.
+                    // A non-morphing .MMS draws the shared rest mesh instead of its own copy, which still
+                    // holds the deformation from when it was last inside kMorphMeshMaxDistance. One MeshInfo
+                    // for every head of this type, so they batch — this is what drains "Attach unbatchable".
+                    // Falls back to the morph copy while the rest mesh is still being built on a worker.
                     MeshVisualInfo* drawVis = mvi;
                     if ( isMMS && !morphActive && mvi->RestVisual
                         && mvi->RestVisual->Ready.load( std::memory_order_acquire ) ) {

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2228,6 +2228,13 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// pre-resolved D3D12 handles and heap-slot ints snapshotted on this thread before it was launched. It is
 	// specifically NOT safe to move any Gothic read INTO a recorder for the same reason.
 	BuildSkeletalDrawCommands();
+	// Morph attachments (NPC heads, bow/crossbow draw meshes): fold this frame's blend shapes on the GPU into
+	// each submesh's own vertex buffer. Has to precede the depth prepass, which is the first pass of the frame
+	// IN SUBMISSION ORDER that draws one — the shadow cascades and point-shadow cubes record into private
+	// lists but are executed later (FinishShadowPasses). No-op when the fold is unavailable or inactive, in
+	// which case UpdateMorphMeshVisual already deformed them on the CPU during collection. See
+	// D3D12MorphFold.cpp / MorphGpu.h.
+	DispatchMorphFold();
     {
         DX_ZONE( m_CmdList.Get(), "Depth Prepass" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth Prepass" );
@@ -4358,10 +4365,6 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
                     if ( isMMS && !morphActive && mvi->RestVisual
                         && mvi->RestVisual->Ready.load( std::memory_order_acquire ) ) {
                         drawVis = mvi->RestVisual;
-                        // Its own DYNAMIC buffers are unused while the rest mesh is what draws — and on
-                        // D3D12 each one is kBackBufferCount persistently-mapped UPLOAD copies, so holding
-                        // them for every head ever walked past is the expensive case. Rebuilt on demand.
-                        mvi->ReleaseIdleMorphVertexBuffers( Engine::GAPI->GetFrameNumber() );
                     }
                     const bool attBatchable = !isMMS || drawVis != mvi;
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -3295,13 +3295,55 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
         VobDrawCommand* cmds = reinterpret_cast<VobDrawCommand*>( m_AttachDrawArgsPtr[frame] );
         UINT count = 0;
         alphaAttachCmds.clear();
+
+        // --- Instanced batching (main view only) -------------------------------------------------------
+        // 50 benches / a crowd's worth of identical swords arrive here as 50 one-instance commands, each
+        // rebinding two VBVs + an IBV — a full IA state change for ~200 vertices, which is what makes this
+        // pass draw-bound rather than geometry-bound. Batch them the way D3D11 does (see the
+        // NodeAttachmentDrawItem loop in D3D11GraphicsEngine.cpp): MeshInfo::meshId is MeshManager's stable
+        // id for the underlying zCSubMesh, so equal meshId means byte-identical geometry even though every
+        // vob extracted its OWN MeshInfo/VB/IB — which is why binding any one member's buffers serves the
+        // whole batch. meshId 0 means "not batchable" and stays a singleton.
+        //
+        // Grouped through a hash map rather than a sort: the key is (meshId, material, alphaTested) and
+        // nothing downstream depends on attachment draw ORDER (all opaque, depth-tested). The material is
+        // still part of the key here — folding it into the per-instance data (VobInstanceInfo::GP_Slot) so
+        // the key collapses to meshId alone is the follow-up step.
+        struct AttachBatchKey {
+            uint16_t meshId; UINT mats[3]; bool alphaTested;
+            bool operator==( const AttachBatchKey& o ) const {
+                return meshId == o.meshId && alphaTested == o.alphaTested
+                    && mats[0] == o.mats[0] && mats[1] == o.mats[1] && mats[2] == o.mats[2];
+            }
+        };
+        struct AttachBatchKeyHash {
+            size_t operator()( const AttachBatchKey& k ) const {
+                size_t h = k.meshId;
+                h = h * 1000003u ^ k.mats[0];
+                h = h * 1000003u ^ k.mats[1];
+                h = h * 1000003u ^ k.mats[2];
+                return h * 2u + (k.alphaTested ? 1u : 0u);
+            }
+        };
+        struct AttachBatch {
+            const FrameAttachDraw* head;   // supplies the VB/IB + index count for the whole batch
+            UINT mats[3];
+            bool alphaTested;
+            std::vector<const FrameAttachDraw*> members;
+        };
+        // static: retained capacity, no per-frame allocation (same idiom as alphaAttachCmds).
+        static std::unordered_map<AttachBatchKey, size_t, AttachBatchKeyHash> batchIndex;
+        static std::vector<AttachBatch> batches;
+        batchIndex.clear();
+        for ( AttachBatch& b : batches ) b.members.clear();   // keep the inner vectors' capacity
+        size_t usedBatches = 0;
+
         for ( const FrameAttachDraw& a : g_FrameAttachDraws ) {
             if ( !a.mesh || a.mesh->Indices.empty() || !a.mesh->GetMeshVertexBuffer() || !a.mesh->GetMeshIndexBuffer() )
                 continue;
             D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( a.mesh->GetMeshVertexBuffer() );
             D3D12VertexBuffer* mib = D3D12VertexBuffer::From( a.mesh->GetMeshIndexBuffer() );
             if ( !mvb->GetResource() || !mib->GetResource() ) continue;
-            if ( count + alphaAttachCmds.size() >= kMaxAttachDrawCommands ) { logOverflow( "attachment", kMaxAttachDrawCommands ); break; }
 
             UINT mats[3];
             ResolveMaterialMapSlots( a.tex, mats );
@@ -3312,25 +3354,75 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
             // other three builds also test is pure conservatism (a=1 everywhere never clips).
             const bool alphaTested = a.tex && a.tex->HasAlphaChannel();
 
+            // meshId 0 = MeshManager never recorded it; !batchable = .MMS morph mesh with per-instance
+            // deformed vertices (see FrameAttachDraw::batchable). Either way: its own singleton command,
+            // never entered into the index so nothing can join it either.
+            const bool batchable = a.batchable && a.mesh->meshId != 0;
+            const AttachBatchKey key{ a.mesh->meshId, { mats[0], mats[1], mats[2] }, alphaTested };
+            size_t bi;
+            auto it = batchable ? batchIndex.find( key ) : batchIndex.end();
+            if ( it != batchIndex.end() ) {
+                bi = it->second;
+            } else {
+                bi = usedBatches++;
+                if ( bi >= batches.size() ) batches.emplace_back();
+                AttachBatch& nb = batches[bi];
+                nb.head = &a;
+                nb.mats[0] = mats[0]; nb.mats[1] = mats[1]; nb.mats[2] = mats[2];
+                nb.alphaTested = alphaTested;
+                if ( batchable ) batchIndex.emplace( key, bi );
+            }
+            batches[bi].members.push_back( &a );
+            m_SkeletalDrawnTriangles += static_cast<unsigned int>( a.mesh->Indices.size() ) / 3;
+        }
+
+        // Emit one command per batch, re-uploading each batch's instances CONTIGUOUSLY so a single
+        // InstVBV spans them. This is a SECOND copy of the instance data (the collection-time write the
+        // per-draw cascade/point-shadow consumers still read through instView stays put) — a few KB per
+        // frame out of the VOB instance ring, which is the cheap half of the trade against the draws saved.
+        for ( size_t bi = 0; bi < usedBatches; ++bi ) {
+            const AttachBatch& b = batches[bi];
+            if ( b.members.empty() || !b.head ) continue;
+            if ( count + alphaAttachCmds.size() >= kMaxAttachDrawCommands ) { logOverflow( "attachment", kMaxAttachDrawCommands ); break; }
+
+            const UINT instBytes = static_cast<UINT>( sizeof( VobInstanceInfo ) );
+            const UINT need = instBytes * static_cast<UINT>( b.members.size() );
+            if ( m_VobInstanceBufferOffset + need > m_VobInstanceBufferCapacity ) {
+                if ( !m_VobInstanceOverflowLogged ) {
+                    LogWarn() << "D3D12: VOB instance ring overflow (attachment batches dropped this frame).";
+                    m_VobInstanceOverflowLogged = true;
+                }
+                break;
+            }
+            const UINT instOffset = m_VobInstanceBufferOffset;
+            uint8_t* dst = m_VobInstanceBufferPtr[frame] + instOffset;
+            for ( const FrameAttachDraw* m : b.members ) {
+                memcpy( dst, &m->inst, instBytes );
+                dst += instBytes;
+            }
+            m_VobInstanceBufferOffset += need;
+
+            D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( b.head->mesh->GetMeshVertexBuffer() );
+            D3D12VertexBuffer* mib = D3D12VertexBuffer::From( b.head->mesh->GetMeshIndexBuffer() );
+
             VobDrawCommand c{};
             c.MeshVBV = { mvb->GetGpuVirtualAddress(), mvb->GetSizeInBytes(), sizeof( ExVertexStruct ) };
-            c.InstVBV = a.instView;
+            c.InstVBV = { m_VobInstanceBuffer[frame]->GetGPUVirtualAddress() + instOffset, need, instBytes };
             c.IBV     = { mib->GetGpuVirtualAddress(), mib->GetSizeInBytes(), DXGI_FORMAT_R16_UINT };
-            c.MatNormalIndex  = mats[0];
-            c.MatOrmIndex     = mats[1];
-            c.MatDiffuseIndex = mats[2];
+            c.MatNormalIndex  = b.mats[0];
+            c.MatOrmIndex     = b.mats[1];
+            c.MatDiffuseIndex = b.mats[2];
             c.WindMinHeight   = 0.0f;
             c.WindMaxHeight   = 0.0f;
-            c.Draw.IndexCountPerInstance = static_cast<UINT>( a.mesh->Indices.size() );
-            c.Draw.InstanceCount         = 1;
+            c.Draw.IndexCountPerInstance = static_cast<UINT>( b.head->mesh->Indices.size() );
+            c.Draw.InstanceCount         = static_cast<UINT>( b.members.size() );
             c.Draw.StartIndexLocation    = 0;
             c.Draw.BaseVertexLocation    = 0;
             c.Draw.StartInstanceLocation = 0;
             c.VisualIndex = 0xFFFFFFFFu;   // never GPU-culled: "leave the CPU's instance count alone"
             c._cmdPad     = 0;
-            if ( alphaTested ) alphaAttachCmds.push_back( c );
-            else               cmds[count++] = c;
-            m_SkeletalDrawnTriangles += static_cast<unsigned int>( a.mesh->Indices.size() ) / 3;
+            if ( b.alphaTested ) alphaAttachCmds.push_back( c );
+            else                 cmds[count++] = c;
         }
         m_AttachOpaqueDrawCount = count;
         if ( !alphaAttachCmds.empty() ) {
@@ -4279,7 +4371,7 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
                             // must not do.
                             entry.attachments.push_back( { attMesh.get(), attTex, attInstView, vi->Vob,
                                 ResolveShadowDiffuseSlot( attTex ),
-                                attTex && attTex->HasAlphaChannel() } );
+                                attTex && attTex->HasAlphaChannel(), vii, !isMMS } );
                         }
                     }
                 }

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -3337,6 +3337,7 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
         batchIndex.clear();
         for ( AttachBatch& b : batches ) b.members.clear();   // keep the inner vectors' capacity
         size_t usedBatches = 0;
+        size_t unbatchable = 0;   // .MMS morph meshes + meshId 0 — forced singletons, see the plots below
 
         for ( const FrameAttachDraw& a : g_FrameAttachDraws ) {
             if ( !a.mesh || a.mesh->Indices.empty() || !a.mesh->GetMeshVertexBuffer() || !a.mesh->GetMeshIndexBuffer() )
@@ -3373,8 +3374,18 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
                 if ( batchable ) batchIndex.emplace( key, bi );
             }
             batches[bi].members.push_back( &a );
+            if ( !batchable ) ++unbatchable;
             m_SkeletalDrawnTriangles += static_cast<unsigned int>( a.mesh->Indices.size() ) / 3;
         }
+
+        // Live batching telemetry — readable in a real city, where a RenderDoc capture can't be taken at all
+        // (its overhead exhausts the 32-bit address space). "in" vs "batches" is the collapse ratio; "unbatch"
+        // is how much of the gap is structural rather than key-splitting: every NPC head is a .MMS morph mesh
+        // and can never batch (see FrameAttachDraw::batchable), so a high value here means no amount of
+        // refining the batch key will help.
+        TracyPlot( "Attach records in", static_cast<int64_t>( g_FrameAttachDraws.size() ) );
+        TracyPlot( "Attach batches out", static_cast<int64_t>( usedBatches ) );
+        TracyPlot( "Attach unbatchable", static_cast<int64_t>( unbatchable ) );
 
         // Emit one command per batch, re-uploading each batch's instances CONTIGUOUSLY so a single
         // InstVBV spans them. This is a SECOND copy of the instance data (the collection-time write the

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -4351,7 +4351,21 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
                         // own LastAniUpdateFrame guard already limits this to once per animation frame.
                         WorldConverter::UpdateMorphMeshVisual( mvi->Visual, mvi );
                     }
-                    for ( auto const& [attMat, attMeshes] : mvi->Meshes ) {
+                    // A non-morphing .MMS draws the SHARED undeformed rest mesh instead of its own copy.
+                    // That copy still holds whatever deformation was current the last time this head was
+                    // inside kMorphMeshMaxDistance, so drawing it out of range is both wrong and forces a
+                    // singleton command (every instance is stale differently). The rest mesh is one
+                    // MeshInfo for every head of this type, so they all collapse into one batch — this is
+                    // what turns the "Attach unbatchable" plot's NPC heads into batchable records. Falls
+                    // back to the morph copy while the rest mesh is still being built on a worker.
+                    MeshVisualInfo* drawVis = mvi;
+                    if ( isMMS && !morphActive && mvi->RestVisual
+                        && mvi->RestVisual->Ready.load( std::memory_order_acquire ) ) {
+                        drawVis = mvi->RestVisual;
+                    }
+                    const bool attBatchable = !isMMS || drawVis != mvi;
+
+                    for ( auto const& [attMat, attMeshes] : drawVis->Meshes ) {
                         zCTexture* attTex = attMat ? attMat->GetAniTexture() : nullptr;
                         for ( auto const& attMesh : attMeshes ) {
                             if ( !attMesh || attMesh->Indices.empty() ) continue;
@@ -4382,7 +4396,7 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
                             // must not do.
                             entry.attachments.push_back( { attMesh.get(), attTex, attInstView, vi->Vob,
                                 ResolveShadowDiffuseSlot( attTex ),
-                                attTex && attTex->HasAlphaChannel(), vii, !isMMS } );
+                                attTex && attTex->HasAlphaChannel(), vii, attBatchable } );
                         }
                     }
                 }

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -3304,18 +3304,12 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
         alphaAttachCmds.clear();
 
         // --- Instanced batching (main view only) -------------------------------------------------------
-        // 50 benches / a crowd's worth of identical swords arrive here as 50 one-instance commands, each
-        // rebinding two VBVs + an IBV — a full IA state change for ~200 vertices, which is what makes this
-        // pass draw-bound rather than geometry-bound. Batch them the way D3D11 does (see the
-        // NodeAttachmentDrawItem loop in D3D11GraphicsEngine.cpp): the batch head supplies the VB/IB for
-        // every member, so the key must mean "same buffers" — the MeshInfo POINTER says exactly that, and
-        // works as a key because the SharedVisualRegistry dedupes conversions. Not meshId: it identifies
-        // the source zCSubMesh, which is weaker and aliases distinct geometry (see MeshInfo::meshId).
-        //
-        // Grouped through a hash map rather than a sort: the key is (mesh, material, alphaTested) and
-        // nothing downstream depends on attachment draw ORDER (all opaque, depth-tested). The material is
-        // still part of the key here — folding it into the per-instance data (VobInstanceInfo::GP_Slot) so
-        // the key collapses to the mesh alone is the follow-up step.
+        // A crowd's worth of identical swords otherwise arrives as one one-instance command each, rebinding
+        // two VBVs + an IBV for ~200 vertices. The batch head supplies the VB/IB for every member, so the key
+        // must mean "same buffers": the MeshInfo POINTER, which works as a key because SharedVisualRegistry
+        // dedupes conversions. Not meshId — that identifies the source zCSubMesh and aliases distinct
+        // geometry (see MeshInfo::meshId). Grouped through a hash map, not a sort: nothing downstream depends
+        // on attachment draw order (all opaque, depth-tested).
         struct AttachBatchKey {
             const MeshInfo* mesh; UINT mats[3]; bool alphaTested;
             bool operator==( const AttachBatchKey& o ) const {
@@ -3356,10 +3350,9 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
             UINT mats[3];
             ResolveMaterialMapSlots( a.tex, mats );
             mats[2] = ResolveDiffuseSlotCacheIn( a.tex );
-            // Alpha-test partition. FrameAttachDraw carries only the texture, not the material — but that
-            // costs nothing here: the prepass cutout is `clip(diffuse.a - 0.5)`, which can only ever discard
-            // when the diffuse actually HAS an alpha channel. The material's HasAlphaTest() flag that the
-            // other three builds also test is pure conservatism (a=1 everywhere never clips).
+            // Alpha-test partition. FrameAttachDraw carries only the texture, not the material, which costs
+            // nothing: the prepass cutout is `clip(diffuse.a - 0.5)` and can only discard where the diffuse
+            // actually has an alpha channel.
             const bool alphaTested = a.tex && a.tex->HasAlphaChannel();
 
             // !batchable = an actively morphing .MMS (see FrameAttachDraw::batchable). Its own singleton
@@ -3384,19 +3377,15 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
             m_SkeletalDrawnTriangles += static_cast<unsigned int>( a.mesh->Indices.size() ) / 3;
         }
 
-        // Live batching telemetry — readable in a real city, where a RenderDoc capture can't be taken at all
-        // (its overhead exhausts the 32-bit address space). "in" vs "batches" is the collapse ratio; "unbatch"
-        // is how much of the gap is structural rather than key-splitting: every NPC head is a .MMS morph mesh
-        // and can never batch (see FrameAttachDraw::batchable), so a high value here means no amount of
-        // refining the batch key will help.
+        // "in" vs "batches" is the collapse ratio; "unbatch" is how much of the gap is structural rather than
+        // key-splitting (a morphing .MMS can never batch — see FrameAttachDraw::batchable).
         TracyPlot( "Attach records in", static_cast<int64_t>( g_FrameAttachDraws.size() ) );
         TracyPlot( "Attach batches out", static_cast<int64_t>( usedBatches ) );
         TracyPlot( "Attach unbatchable", static_cast<int64_t>( unbatchable ) );
 
-        // Emit one command per batch, re-uploading each batch's instances CONTIGUOUSLY so a single
-        // InstVBV spans them. This is a SECOND copy of the instance data (the collection-time write the
-        // per-draw cascade/point-shadow consumers still read through instView stays put) — a few KB per
-        // frame out of the VOB instance ring, which is the cheap half of the trade against the draws saved.
+        // Emit one command per batch, re-uploading each batch's instances CONTIGUOUSLY so a single InstVBV
+        // spans them. A second copy of the instance data (the collection-time write the cascade/point-shadow
+        // consumers read through instView stays put), a few KB per frame out of the VOB instance ring.
         for ( size_t bi = 0; bi < usedBatches; ++bi ) {
             const AttachBatch& b = batches[bi];
             if ( b.members.empty() || !b.head ) continue;
@@ -4357,10 +4346,9 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
                         // own LastAniUpdateFrame guard already limits this to once per animation frame.
                         WorldConverter::UpdateMorphMeshVisual( mvi->Visual, mvi );
                     }
-                    // A non-morphing .MMS draws the shared rest mesh instead of its own copy, which still
+                    // A non-morphing .MMS draws the shared rest mesh rather than its own copy, which still
                     // holds the deformation from when it was last inside kMorphMeshMaxDistance. One MeshInfo
-                    // for every head of this type, so they batch — this is what drains "Attach unbatchable".
-                    // Falls back to the morph copy while the rest mesh is still being built on a worker.
+                    // per head type, so they batch. Falls back while the rest mesh is still being built.
                     MeshVisualInfo* drawVis = mvi;
                     if ( isMMS && !morphActive && mvi->RestVisual
                         && mvi->RestVisual->Ready.load( std::memory_order_acquire ) ) {

--- a/D3D11Engine/D3D12Engine/D3D12VertexBuffer.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12VertexBuffer.cpp
@@ -163,7 +163,10 @@ XRESULT D3D12VertexBuffer::Init( void* initData, unsigned int sizeInBytes, EBind
     // ring-buffered (kBackBufferCount copies) so a per-frame UpdateBuffer() (morph meshes; also harmlessly
     // applied to the CPU-only D3D7 dynamic-buffer case) can never race an in-flight GPU read of the same
     // buffer from an earlier frame — see the class comment.
-    bool isDynamic = ( usage & U_DYNAMIC ) || ( cpuAccess & CA_WRITE );
+    // A UAV target is GPU-written (the morph fold), so it takes the static DEFAULT-heap path no matter what
+    // usage flags came in: one copy, no CPU mapping, no ring. See the class comment.
+    m_UavCapable = ( bindFlags & B_UNORDERED_ACCESS ) != 0;
+    bool isDynamic = !m_UavCapable && ( ( usage & U_DYNAMIC ) || ( cpuAccess & CA_WRITE ) );
     m_NumCopies = isDynamic ? Engine12()->kBackBufferCount : 1;
     if ( m_NumCopies > kMaxCopies ) m_NumCopies = kMaxCopies;   // defensive clamp; kBackBufferCount is at most kBackBufferMax
 
@@ -176,7 +179,7 @@ XRESULT D3D12VertexBuffer::Init( void* initData, unsigned int sizeInBytes, EBind
     bd.Format = DXGI_FORMAT_UNKNOWN;
     bd.SampleDesc.Count = 1;
     bd.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
-    bd.Flags = D3D12_RESOURCE_FLAG_NONE;
+    bd.Flags = m_UavCapable ? D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS : D3D12_RESOURCE_FLAG_NONE;
 
     const std::string debugName = "VB:" + ( fileName.empty() ? std::string( "unnamed" ) : fileName );
 

--- a/D3D11Engine/D3D12Engine/D3D12VertexBuffer.h
+++ b/D3D11Engine/D3D12Engine/D3D12VertexBuffer.h
@@ -88,6 +88,22 @@ public:
         return m_LastWriteSlot == kNoSlot ? nullptr : m_Copies[m_LastWriteSlot].MappedPtr;
     }
 
+    /** --- GPU-written vertex buffers (morph fold) ---
+
+        A buffer created with B_UNORDERED_ACCESS is a DEFAULT-heap (VRAM) resource with
+        ALLOW_UNORDERED_ACCESS and exactly ONE copy: its writer is the GPU, so the CPU-write-vs-GPU-read
+        race the dynamic ring exists for cannot happen, and a barrier orders the fold against the draws.
+        It is never CPU-mapped either, which is what takes it out of the 32-bit address space entirely.
+
+        The state has to be tracked here rather than in the pass, because the pass sees a MeshInfo and the
+        resource outlives any one frame: born in COMMON (a buffer promotes out of COMMON implicitly, so a
+        mesh that is drawn before it has ever been folded is still legal), then flipped UAV <-> VERTEX by
+        DispatchMorphFold. */
+    bool IsUavCapable() const { return m_UavCapable; }
+    enum class EUavState { Common, Unordered, Vertex };
+    EUavState GetUavState() const { return m_UavState; }
+    void SetUavState( EUavState state ) { m_UavState = state; }
+
     /** Called by DrawVertexBufferFF right after it bound the live copy straight off the IA: from here on
         a draw recorded THIS frame reads these bytes, so the next Lock() of the same copy must not write
         over them — Map() redirects it to the CPU shadow instead. See the comment in Map(). */
@@ -110,6 +126,8 @@ private:
     UINT m_NumCopies = 1;      // 1 for static/CPU-only-dynamic buffers, kBackBufferCount for GPU-bound dynamic ones
     UINT m_LastWriteSlot = kNoSlot;   // copy that last took a CPU write — see HasFreshCurrentCopy()
     unsigned int m_SizeInBytes = 0;
+    bool m_UavCapable = false;                        // created with B_UNORDERED_ACCESS (morph fold target)
+    EUavState m_UavState = EUavState::Common;         // only meaningful while m_UavCapable
 
     // Multi-Lock-per-frame protection for the direct-IA path (see Map()). m_DirectBoundSlot is the copy a
     // draw of the CURRENT frame reads off the IA; while Map() sees it as current it hands out m_Shadow.

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -900,9 +900,8 @@ void GothicAPI::ResetVobs() {
     SkeletalMeshVobs.clear();
     AnimatedSkeletalVobs.clear();
 
-    // Every skeletal vob is gone now, so every node-attachment reference is released and this should
-    // find nothing left to own. It drops whatever is still there anyway (and logs it) rather than
-    // carrying converted meshes - and the zCVisual keys they hang off - into the next world.
+    // Every skeletal vob is gone, so this should find nothing left to own. Drops (and logs) whatever
+    // is still there rather than carrying converted meshes into the next world.
     s_SharedVisualRegistry->Clear();
 }
 
@@ -1869,9 +1868,8 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
     // (WorldConverter::ExtractNodeVisualAsync) is still reading from it.
     WorldConverter::WaitForPendingNodeVisuals( visual );
 
-    // Retire it as a shared-attachment lookup key: the allocator can hand this exact address back out
-    // for an unrelated visual, and matching it would serve a sword's mesh for a lamp. Any attachment
-    // still holding the entry keeps it alive until its own "visual changed" check retires it.
+    // Retire it as a shared-attachment key - the address can be recycled for an unrelated visual.
+    // Attachments still holding the entry keep it alive until their "visual changed" check retires them.
     s_SharedVisualRegistry->Unregister( visual );
 
     std::vector<std::string> extv;
@@ -2915,8 +2913,7 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
         if ( nodeAttachments[i].size() && node->NodeVisual != nodeAttachments[i][0]->Visual ) {
             // Check for deleted attachment
             if ( !node->NodeVisual ) {
-                // Remove attachment. Shared with every other vob carrying this visual, so it goes
-                // back to the registry rather than being deleted here.
+                // Remove attachment. Shared, so it goes back to the registry, not deleted here.
                 WorldConverter::ReleaseNodeAttachments( nodeAttachments, i );
 
                 LogInfo() << "Removed attachment from model " << vi->VisualInfo->VisualName;
@@ -3166,8 +3163,7 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
         if ( nodeAttachments[i].size() && node->NodeVisual != nodeAttachments[i][0]->Visual ) {
             // Check for deleted attachment
             if ( !node->NodeVisual ) {
-                // Remove attachment. Shared with every other vob carrying this visual, so it goes
-                // back to the registry rather than being deleted here.
+                // Remove attachment. Shared, so it goes back to the registry, not deleted here.
                 WorldConverter::ReleaseNodeAttachments( nodeAttachments, i );
 
                 LogInfo() << "Removed attachment from model " << vi->VisualInfo->VisualName;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -50,6 +50,7 @@
 // TODO: REMOVE THIS!
 #include "D3D11GraphicsEngine.h"
 #include "MeshManager.h"
+#include "SharedVisualRegistry.h"
 #include "ThreadPool.h"
 #include "zFILE.h"
 #include "zFILE_VDFS.h"
@@ -898,6 +899,11 @@ void GothicAPI::ResetVobs() {
     }
     SkeletalMeshVobs.clear();
     AnimatedSkeletalVobs.clear();
+
+    // Every skeletal vob is gone now, so every node-attachment reference is released and this should
+    // find nothing left to own. It drops whatever is still there anyway (and logs it) rather than
+    // carrying converted meshes - and the zCVisual keys they hang off - into the next world.
+    s_SharedVisualRegistry->Clear();
 }
 
 /** Called when the game loaded a new level */
@@ -1862,6 +1868,11 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
     // Gothic frees this visual once we return - make sure no background node-attachment extraction
     // (WorldConverter::ExtractNodeVisualAsync) is still reading from it.
     WorldConverter::WaitForPendingNodeVisuals( visual );
+
+    // Retire it as a shared-attachment lookup key: the allocator can hand this exact address back out
+    // for an unrelated visual, and matching it would serve a sword's mesh for a lamp. Any attachment
+    // still holding the entry keeps it alive until its own "visual changed" check retires it.
+    s_SharedVisualRegistry->Unregister( visual );
 
     std::vector<std::string> extv;
 
@@ -2904,9 +2915,9 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
         if ( nodeAttachments[i].size() && node->NodeVisual != nodeAttachments[i][0]->Visual ) {
             // Check for deleted attachment
             if ( !node->NodeVisual ) {
-                // Remove attachment
-                delete nodeAttachments[i][0];
-                nodeAttachments[i].clear();
+                // Remove attachment. Shared with every other vob carrying this visual, so it goes
+                // back to the registry rather than being deleted here.
+                WorldConverter::ReleaseNodeAttachments( nodeAttachments, i );
 
                 LogInfo() << "Removed attachment from model " << vi->VisualInfo->VisualName;
 
@@ -3155,9 +3166,9 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
         if ( nodeAttachments[i].size() && node->NodeVisual != nodeAttachments[i][0]->Visual ) {
             // Check for deleted attachment
             if ( !node->NodeVisual ) {
-                // Remove attachment
-                delete nodeAttachments[i][0];
-                nodeAttachments[i].clear();
+                // Remove attachment. Shared with every other vob carrying this visual, so it goes
+                // back to the registry rather than being deleted here.
+                WorldConverter::ReleaseNodeAttachments( nodeAttachments, i );
 
                 LogInfo() << "Removed attachment from model " << vi->VisualInfo->VisualName;
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5890,6 +5890,9 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "Debug", "ThreadedShadowCulling", to_string_locale_independent( s.ThreadedShadowCulling ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Debug", "GpuVobCulling", to_string_locale_independent( s.GpuVobCulling ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Debug", "GpuVobOcclusionCulling", to_string_locale_independent( s.GpuVobOcclusionCulling ? TRUE : FALSE ).c_str(), ini.c_str() );
+    // Persisted because it is not a live toggle: MorphGpu::IsActive() freezes it at load (it decides how the
+    // morph vertex buffers get created), so the only way to turn it off is for the NEXT run.
+    WritePrivateProfileStringA( "Debug", "GpuMorphFold", to_string_locale_independent( s.UseGpuMorphFold ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Debug", "UseShadowAtlas", to_string_locale_independent( s.DebugSettings.FeatureSet.UseShadowAtlas ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Debug", "UseScreenSpaceShadowMask", to_string_locale_independent( s.DebugSettings.FeatureSet.UseScreenSpaceShadowMask ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Debug", "GenerateAONormalsFromDepth", to_string_locale_independent( s.DebugSettings.FeatureSet.GenerateAONormalsFromDepth ? TRUE : FALSE ).c_str(), ini.c_str() );
@@ -6112,6 +6115,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.ThreadedShadowCulling = GetPrivateProfileBoolA( "Debug", "ThreadedShadowCulling", ds.ThreadedShadowCulling, ini );
         s.GpuVobCulling = GetPrivateProfileBoolA( "Debug", "GpuVobCulling", ds.GpuVobCulling, ini );
         s.GpuVobOcclusionCulling = GetPrivateProfileBoolA( "Debug", "GpuVobOcclusionCulling", ds.GpuVobOcclusionCulling, ini );
+        s.UseGpuMorphFold = GetPrivateProfileBoolA( "Debug", "GpuMorphFold", ds.UseGpuMorphFold, ini );
         s.DebugSettings.FeatureSet.UseShadowAtlas = GetPrivateProfileBoolA( "Debug", "UseShadowAtlas", ds.DebugSettings.FeatureSet.UseShadowAtlas, ini );
         s.DebugSettings.FeatureSet.UseScreenSpaceShadowMask = GetPrivateProfileBoolA( "Debug", "UseScreenSpaceShadowMask", ds.DebugSettings.FeatureSet.UseScreenSpaceShadowMask, ini );
         s.DebugSettings.FeatureSet.GenerateAONormalsFromDepth = GetPrivateProfileBoolA( "Debug", "GenerateAONormalsFromDepth", ds.DebugSettings.FeatureSet.GenerateAONormalsFromDepth, ini );

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -694,6 +694,10 @@ struct GothicRendererSettings {
         // verified on real hardware. VerifyMorphBlend runs both and reports the difference.
         UseReimplementedMorphBlend = false;
         VerifyMorphBlend = false;
+        // On where the backend has a working fold pipeline (D3D12 today): it is what removed the per-frame
+        // CPU deform AND the per-instance CPU-writable vertex buffers those needed. Read exactly once, at
+        // the first MorphGpu::IsActive() - see the comment on the member.
+        UseGpuMorphFold = true;
         DrawMobs = true;
         DrawDynamicVOBs = true;
 
@@ -1025,6 +1029,13 @@ struct GothicRendererSettings {
     /** Every morph update also runs ZENGIN's deform and logs the worst per-component deviation from ours.
         Diagnostic only - it does BOTH deforms, so it is slower than either path. */
     bool VerifyMorphBlend;
+    /** Fold morph attachments in a compute shader (MorphGpu / Shaders/D3D12/MorphFold.hlsl) instead of
+        deforming them on the CPU and re-uploading the vertex stream every animation frame. Ignored by a
+        backend that has no fold pipeline, which keeps the CPU deform.
+        NOT a live toggle: MorphGpu::IsActive() reads it once and freezes the answer, because it also decides
+        how morph vertex buffers are CREATED (a GPU-written DEFAULT+UAV buffer vs a CPU-writable DYNAMIC one).
+        Changing it in the ImGui window therefore takes effect on the next restart. */
+    bool UseGpuMorphFold;
     bool DrawMobs;
     bool DrawParticleEffects;
     bool DrawSky;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -690,6 +690,10 @@ struct GothicRendererSettings {
         DrawVOBs = true;
         DrawWorldMesh = 3;
         DrawSkeletalMeshes = true;
+        // Off by default: ZENGIN's own deform stays the shipping path until the reimplementation has been
+        // verified on real hardware. VerifyMorphBlend runs both and reports the difference.
+        UseReimplementedMorphBlend = false;
+        VerifyMorphBlend = false;
         DrawMobs = true;
         DrawDynamicVOBs = true;
 
@@ -1013,6 +1017,14 @@ struct GothicRendererSettings {
     bool DrawDynamicVOBs;
     int DrawWorldMesh;
     bool DrawSkeletalMeshes;
+    /** Morph attachments (heads, bow/crossbow draw meshes) fold their blend shapes with our own
+        reimplementation (MorphBlend) instead of calling ZENGIN's CalcVertPositions. Same result, but the
+        state it captures is what a GPU deform would consume - this is the A/B switch for that port.
+        AdvanceAnis still runs either way; it is game state, not geometry. */
+    bool UseReimplementedMorphBlend;
+    /** Every morph update also runs ZENGIN's deform and logs the worst per-component deviation from ours.
+        Diagnostic only - it does BOTH deforms, so it is slower than either path. */
+    bool VerifyMorphBlend;
     bool DrawMobs;
     bool DrawParticleEffects;
     bool DrawSky;

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -636,11 +636,9 @@ struct GothicMemoryLocations {
     struct zCMorphMesh {
         static const unsigned int Offset_MorphMesh = 0x38;
         static const unsigned int Offset_TexAniState = 0x40;
-        // Shared morph prototype and the optional "reference shape" ani. Together these give the
-        // UNDEFORMED rest positions: zCMorphMesh::CalcVertPositions zeroes morphMesh->posList, sums the
-        // active ani deltas into it, then adds refShapeAni->vertPosMatrix if a refShape ani was started
-        // and morphProto->morphRefMeshVertPos otherwise. With no active channels that final add IS the
-        // rest pose, so reading those arrays directly reproduces it without touching engine state.
+        // Shared morph prototype + optional refShape ani. CalcVertPositions zeroes posList, sums the
+        // active ani deltas, then adds refShapeAni->vertPosMatrix (or morphRefMeshVertPos) as the base -
+        // with no active channels that base IS the rest pose, readable without touching engine state.
         static const unsigned int Offset_MorphProto = 0x34;
         static const unsigned int Offset_RefShapeAni = 0x3C;
         // zCMorphMeshProto members (the per-.MMS shared prototype).

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -636,6 +636,19 @@ struct GothicMemoryLocations {
     struct zCMorphMesh {
         static const unsigned int Offset_MorphMesh = 0x38;
         static const unsigned int Offset_TexAniState = 0x40;
+        // Shared morph prototype and the optional "reference shape" ani. Together these give the
+        // UNDEFORMED rest positions: zCMorphMesh::CalcVertPositions zeroes morphMesh->posList, sums the
+        // active ani deltas into it, then adds refShapeAni->vertPosMatrix if a refShape ani was started
+        // and morphProto->morphRefMeshVertPos otherwise. With no active channels that final add IS the
+        // rest pose, so reading those arrays directly reproduces it without touching engine state.
+        static const unsigned int Offset_MorphProto = 0x34;
+        static const unsigned int Offset_RefShapeAni = 0x3C;
+        // zCMorphMeshProto members (the per-.MMS shared prototype).
+        static const unsigned int Proto_Offset_MorphRefMesh = 0x20;
+        static const unsigned int Proto_Offset_MorphRefMeshVertPos = 0x24;
+        // zCMorphMeshAni members (entries of zCMorphMeshProto::aniList, also shared).
+        static const unsigned int Ani_Offset_NumVert = 0x40;
+        static const unsigned int Ani_Offset_VertPosMatrix = 0x4C;
         static const unsigned int AdvanceAnis = 0x00586E90;
         static const unsigned int CalcVertexPositions = 0x00586AE0;
 

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -647,6 +647,24 @@ struct GothicMemoryLocations {
         // zCMorphMeshAni members (entries of zCMorphMeshProto::aniList, also shared).
         static const unsigned int Ani_Offset_NumVert = 0x40;
         static const unsigned int Ani_Offset_VertPosMatrix = 0x4C;
+        static const unsigned int Ani_Offset_NumFrames = 0x48;
+        // zCMorphMeshAni::flags bitfield byte: bit0 discontinuity, bit1 looping, bit2 shape, bit3 refShape.
+        static const unsigned int Ani_Offset_Flags = 0x3C;
+        static const unsigned int Ani_Mask_Shape = 0x04;
+        static const unsigned int Ani_Offset_VertIndexList = 0x44;
+        // Active blend channels: zCArraySort<zTMorphAniEntry*>. NOTE the layout is
+        // { T* array; int numAlloc; int numInArray; } - the COUNT is the third dword, not the second.
+        // zCArrayAdapt reads the second, which is fine for file-loaded arrays (numAlloc == numInArray)
+        // but wrong here: this array grows and shrinks as anis start and finish.
+        static const unsigned int Offset_AniChannels = 0x6C;
+        static const unsigned int ArraySort_Offset_Array = 0x00;
+        static const unsigned int ArraySort_Offset_NumInArray = 0x08;
+        // zTMorphAniEntry (sizeof 0x2C)
+        static const unsigned int Entry_Offset_Ani = 0x00;
+        static const unsigned int Entry_Offset_Weight = 0x04;
+        static const unsigned int Entry_Offset_ActFrameInt = 0x10;
+        static const unsigned int Entry_Offset_NextFrameInt = 0x14;
+        static const unsigned int Entry_Offset_Frac = 0x18;
         static const unsigned int AdvanceAnis = 0x00586E90;
         static const unsigned int CalcVertexPositions = 0x00586AE0;
 

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -642,8 +642,12 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_MorphProto = 0x34;
         static const unsigned int Offset_RefShapeAni = 0x3C;
         // zCMorphMeshProto members (the per-.MMS shared prototype).
+        static const unsigned int Proto_Offset_Name = 0x0C;
         static const unsigned int Proto_Offset_MorphRefMesh = 0x20;
         static const unsigned int Proto_Offset_MorphRefMeshVertPos = 0x24;
+        // zCArraySort<zCMorphMeshAni*> - every ani this .MMS can play, written once at load. Same
+        // ArraySort_Offset_* layout as the channel array below.
+        static const unsigned int Proto_Offset_AniList = 0x28;
         // zCMorphMeshAni members (entries of zCMorphMeshProto::aniList, also shared).
         static const unsigned int Ani_Offset_NumVert = 0x40;
         static const unsigned int Ani_Offset_VertPosMatrix = 0x4C;

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -573,6 +573,24 @@ struct GothicMemoryLocations {
         // zCMorphMeshAni members (entries of zCMorphMeshProto::aniList, also shared).
         static const unsigned int Ani_Offset_NumVert = 0x40;
         static const unsigned int Ani_Offset_VertPosMatrix = 0x4C;
+        static const unsigned int Ani_Offset_NumFrames = 0x48;
+        // zCMorphMeshAni::flags bitfield byte: bit0 discontinuity, bit1 looping, bit2 shape, bit3 refShape.
+        static const unsigned int Ani_Offset_Flags = 0x3C;
+        static const unsigned int Ani_Mask_Shape = 0x04;
+        static const unsigned int Ani_Offset_VertIndexList = 0x44;
+        // Active blend channels: zCArraySort<zTMorphAniEntry*>. NOTE the layout is
+        // { T* array; int numAlloc; int numInArray; } - the COUNT is the third dword, not the second.
+        // zCArrayAdapt reads the second, which is fine for file-loaded arrays (numAlloc == numInArray)
+        // but wrong here: this array grows and shrinks as anis start and finish.
+        static const unsigned int Offset_AniChannels = 0x6C;
+        static const unsigned int ArraySort_Offset_Array = 0x00;
+        static const unsigned int ArraySort_Offset_NumInArray = 0x08;
+        // zTMorphAniEntry (sizeof 0x2C)
+        static const unsigned int Entry_Offset_Ani = 0x00;
+        static const unsigned int Entry_Offset_Weight = 0x04;
+        static const unsigned int Entry_Offset_ActFrameInt = 0x10;
+        static const unsigned int Entry_Offset_NextFrameInt = 0x14;
+        static const unsigned int Entry_Offset_Frac = 0x18;
         static const unsigned int AdvanceAnis = 0x005A1E90;
         static const unsigned int CalcVertexPositions = 0x005A19E0;
 

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -562,6 +562,19 @@ struct GothicMemoryLocations {
     struct zCMorphMesh {
         static const unsigned int Offset_MorphMesh = 0x38;
         static const unsigned int Offset_TexAniState = 0x40;
+        // Shared morph prototype and the optional "reference shape" ani. Together these give the
+        // UNDEFORMED rest positions: zCMorphMesh::CalcVertPositions zeroes morphMesh->posList, sums the
+        // active ani deltas into it, then adds refShapeAni->vertPosMatrix if a refShape ani was started
+        // and morphProto->morphRefMeshVertPos otherwise. With no active channels that final add IS the
+        // rest pose, so reading those arrays directly reproduces it without touching engine state.
+        static const unsigned int Offset_MorphProto = 0x34;
+        static const unsigned int Offset_RefShapeAni = 0x3C;
+        // zCMorphMeshProto members (the per-.MMS shared prototype).
+        static const unsigned int Proto_Offset_MorphRefMesh = 0x20;
+        static const unsigned int Proto_Offset_MorphRefMeshVertPos = 0x24;
+        // zCMorphMeshAni members (entries of zCMorphMeshProto::aniList, also shared).
+        static const unsigned int Ani_Offset_NumVert = 0x40;
+        static const unsigned int Ani_Offset_VertPosMatrix = 0x4C;
         static const unsigned int AdvanceAnis = 0x005A1E90;
         static const unsigned int CalcVertexPositions = 0x005A19E0;
 

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -568,8 +568,12 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_MorphProto = 0x34;
         static const unsigned int Offset_RefShapeAni = 0x3C;
         // zCMorphMeshProto members (the per-.MMS shared prototype).
+        static const unsigned int Proto_Offset_Name = 0x0C;
         static const unsigned int Proto_Offset_MorphRefMesh = 0x20;
         static const unsigned int Proto_Offset_MorphRefMeshVertPos = 0x24;
+        // zCArraySort<zCMorphMeshAni*> - every ani this .MMS can play, written once at load. Same
+        // ArraySort_Offset_* layout as the channel array below.
+        static const unsigned int Proto_Offset_AniList = 0x28;
         // zCMorphMeshAni members (entries of zCMorphMeshProto::aniList, also shared).
         static const unsigned int Ani_Offset_NumVert = 0x40;
         static const unsigned int Ani_Offset_VertPosMatrix = 0x4C;

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -562,11 +562,9 @@ struct GothicMemoryLocations {
     struct zCMorphMesh {
         static const unsigned int Offset_MorphMesh = 0x38;
         static const unsigned int Offset_TexAniState = 0x40;
-        // Shared morph prototype and the optional "reference shape" ani. Together these give the
-        // UNDEFORMED rest positions: zCMorphMesh::CalcVertPositions zeroes morphMesh->posList, sums the
-        // active ani deltas into it, then adds refShapeAni->vertPosMatrix if a refShape ani was started
-        // and morphProto->morphRefMeshVertPos otherwise. With no active channels that final add IS the
-        // rest pose, so reading those arrays directly reproduces it without touching engine state.
+        // Shared morph prototype + optional refShape ani. CalcVertPositions zeroes posList, sums the
+        // active ani deltas, then adds refShapeAni->vertPosMatrix (or morphRefMeshVertPos) as the base -
+        // with no active channels that base IS the rest pose, readable without touching engine state.
         static const unsigned int Offset_MorphProto = 0x34;
         static const unsigned int Offset_RefShapeAni = 0x3C;
         // zCMorphMeshProto members (the per-.MMS shared prototype).

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -380,8 +380,12 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_MorphProto = 0x34;
         static const unsigned int Offset_RefShapeAni = 0x3C;
         // zCMorphMeshProto members (the per-.MMS shared prototype).
+        static const unsigned int Proto_Offset_Name = 0x0C;
         static const unsigned int Proto_Offset_MorphRefMesh = 0x20;
         static const unsigned int Proto_Offset_MorphRefMeshVertPos = 0x24;
+        // zCArraySort<zCMorphMeshAni*> - every ani this .MMS can play, written once at load. Same
+        // ArraySort_Offset_* layout as the channel array below.
+        static const unsigned int Proto_Offset_AniList = 0x28;
         // zCMorphMeshAni members (entries of zCMorphMeshProto::aniList, also shared).
         static const unsigned int Ani_Offset_NumVert = 0x40;
         static const unsigned int Ani_Offset_VertPosMatrix = 0x4C;

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -385,6 +385,24 @@ struct GothicMemoryLocations {
         // zCMorphMeshAni members (entries of zCMorphMeshProto::aniList, also shared).
         static const unsigned int Ani_Offset_NumVert = 0x40;
         static const unsigned int Ani_Offset_VertPosMatrix = 0x4C;
+        static const unsigned int Ani_Offset_NumFrames = 0x48;
+        // zCMorphMeshAni::flags bitfield byte: bit0 discontinuity, bit1 looping, bit2 shape, bit3 refShape.
+        static const unsigned int Ani_Offset_Flags = 0x3C;
+        static const unsigned int Ani_Mask_Shape = 0x04;
+        static const unsigned int Ani_Offset_VertIndexList = 0x44;
+        // Active blend channels: zCArraySort<zTMorphAniEntry*>. NOTE the layout is
+        // { T* array; int numAlloc; int numInArray; } - the COUNT is the third dword, not the second.
+        // zCArrayAdapt reads the second, which is fine for file-loaded arrays (numAlloc == numInArray)
+        // but wrong here: this array grows and shrinks as anis start and finish.
+        static const unsigned int Offset_AniChannels = 0x6C;
+        static const unsigned int ArraySort_Offset_Array = 0x00;
+        static const unsigned int ArraySort_Offset_NumInArray = 0x08;
+        // zTMorphAniEntry (sizeof 0x2C)
+        static const unsigned int Entry_Offset_Ani = 0x00;
+        static const unsigned int Entry_Offset_Weight = 0x04;
+        static const unsigned int Entry_Offset_ActFrameInt = 0x10;
+        static const unsigned int Entry_Offset_NextFrameInt = 0x14;
+        static const unsigned int Entry_Offset_Frac = 0x18;
         static const unsigned int AdvanceAnis = 0x005A6830;
         static const unsigned int CalcVertexPositions = 0x005A6480;
     };

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -374,6 +374,19 @@ struct GothicMemoryLocations {
     struct zCMorphMesh {
         static const unsigned int Offset_MorphMesh = 0x38;
         static const unsigned int Offset_TexAniState = 0x40;
+        // Shared morph prototype and the optional "reference shape" ani. Together these give the
+        // UNDEFORMED rest positions: zCMorphMesh::CalcVertPositions zeroes morphMesh->posList, sums the
+        // active ani deltas into it, then adds refShapeAni->vertPosMatrix if a refShape ani was started
+        // and morphProto->morphRefMeshVertPos otherwise. With no active channels that final add IS the
+        // rest pose, so reading those arrays directly reproduces it without touching engine state.
+        static const unsigned int Offset_MorphProto = 0x34;
+        static const unsigned int Offset_RefShapeAni = 0x3C;
+        // zCMorphMeshProto members (the per-.MMS shared prototype).
+        static const unsigned int Proto_Offset_MorphRefMesh = 0x20;
+        static const unsigned int Proto_Offset_MorphRefMeshVertPos = 0x24;
+        // zCMorphMeshAni members (entries of zCMorphMeshProto::aniList, also shared).
+        static const unsigned int Ani_Offset_NumVert = 0x40;
+        static const unsigned int Ani_Offset_VertPosMatrix = 0x4C;
         static const unsigned int AdvanceAnis = 0x005A6830;
         static const unsigned int CalcVertexPositions = 0x005A6480;
     };

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -374,11 +374,9 @@ struct GothicMemoryLocations {
     struct zCMorphMesh {
         static const unsigned int Offset_MorphMesh = 0x38;
         static const unsigned int Offset_TexAniState = 0x40;
-        // Shared morph prototype and the optional "reference shape" ani. Together these give the
-        // UNDEFORMED rest positions: zCMorphMesh::CalcVertPositions zeroes morphMesh->posList, sums the
-        // active ani deltas into it, then adds refShapeAni->vertPosMatrix if a refShape ani was started
-        // and morphProto->morphRefMeshVertPos otherwise. With no active channels that final add IS the
-        // rest pose, so reading those arrays directly reproduces it without touching engine state.
+        // Shared morph prototype + optional refShape ani. CalcVertPositions zeroes posList, sums the
+        // active ani deltas, then adds refShapeAni->vertPosMatrix (or morphRefMeshVertPos) as the base -
+        // with no active channels that base IS the rest pose, readable without touching engine state.
         static const unsigned int Offset_MorphProto = 0x34;
         static const unsigned int Offset_RefShapeAni = 0x3C;
         // zCMorphMeshProto members (the per-.MMS shared prototype).

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -217,11 +217,9 @@ struct GothicMemoryLocations {
     struct zCMorphMesh {
         static const unsigned int Offset_MorphMesh = 0x38;
         static const unsigned int Offset_TexAniState = 0x40;
-        // Shared morph prototype and the optional "reference shape" ani. Together these give the
-        // UNDEFORMED rest positions: zCMorphMesh::CalcVertPositions zeroes morphMesh->posList, sums the
-        // active ani deltas into it, then adds refShapeAni->vertPosMatrix if a refShape ani was started
-        // and morphProto->morphRefMeshVertPos otherwise. With no active channels that final add IS the
-        // rest pose, so reading those arrays directly reproduces it without touching engine state.
+        // Shared morph prototype + optional refShape ani. CalcVertPositions zeroes posList, sums the
+        // active ani deltas, then adds refShapeAni->vertPosMatrix (or morphRefMeshVertPos) as the base -
+        // with no active channels that base IS the rest pose, readable without touching engine state.
         static const unsigned int Offset_MorphProto = 0x34;
         static const unsigned int Offset_RefShapeAni = 0x3C;
         // zCMorphMeshProto members (the per-.MMS shared prototype).

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -223,8 +223,12 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_MorphProto = 0x34;
         static const unsigned int Offset_RefShapeAni = 0x3C;
         // zCMorphMeshProto members (the per-.MMS shared prototype).
+        static const unsigned int Proto_Offset_Name = 0x0C;
         static const unsigned int Proto_Offset_MorphRefMesh = 0x20;
         static const unsigned int Proto_Offset_MorphRefMeshVertPos = 0x24;
+        // zCArraySort<zCMorphMeshAni*> - every ani this .MMS can play, written once at load. Same
+        // ArraySort_Offset_* layout as the channel array below.
+        static const unsigned int Proto_Offset_AniList = 0x28;
         // zCMorphMeshAni members (entries of zCMorphMeshProto::aniList, also shared).
         static const unsigned int Ani_Offset_NumVert = 0x40;
         static const unsigned int Ani_Offset_VertPosMatrix = 0x4C;

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -228,6 +228,24 @@ struct GothicMemoryLocations {
         // zCMorphMeshAni members (entries of zCMorphMeshProto::aniList, also shared).
         static const unsigned int Ani_Offset_NumVert = 0x40;
         static const unsigned int Ani_Offset_VertPosMatrix = 0x4C;
+        static const unsigned int Ani_Offset_NumFrames = 0x48;
+        // zCMorphMeshAni::flags bitfield byte: bit0 discontinuity, bit1 looping, bit2 shape, bit3 refShape.
+        static const unsigned int Ani_Offset_Flags = 0x3C;
+        static const unsigned int Ani_Mask_Shape = 0x04;
+        static const unsigned int Ani_Offset_VertIndexList = 0x44;
+        // Active blend channels: zCArraySort<zTMorphAniEntry*>. NOTE the layout is
+        // { T* array; int numAlloc; int numInArray; } - the COUNT is the third dword, not the second.
+        // zCArrayAdapt reads the second, which is fine for file-loaded arrays (numAlloc == numInArray)
+        // but wrong here: this array grows and shrinks as anis start and finish.
+        static const unsigned int Offset_AniChannels = 0x6C;
+        static const unsigned int ArraySort_Offset_Array = 0x00;
+        static const unsigned int ArraySort_Offset_NumInArray = 0x08;
+        // zTMorphAniEntry (sizeof 0x2C)
+        static const unsigned int Entry_Offset_Ani = 0x00;
+        static const unsigned int Entry_Offset_Weight = 0x04;
+        static const unsigned int Entry_Offset_ActFrameInt = 0x10;
+        static const unsigned int Entry_Offset_NextFrameInt = 0x14;
+        static const unsigned int Entry_Offset_Frac = 0x18;
         static const unsigned int AdvanceAnis = 0x00731920;
         static const unsigned int CalcVertexPositions = 0x00731570;
     };

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -217,6 +217,19 @@ struct GothicMemoryLocations {
     struct zCMorphMesh {
         static const unsigned int Offset_MorphMesh = 0x38;
         static const unsigned int Offset_TexAniState = 0x40;
+        // Shared morph prototype and the optional "reference shape" ani. Together these give the
+        // UNDEFORMED rest positions: zCMorphMesh::CalcVertPositions zeroes morphMesh->posList, sums the
+        // active ani deltas into it, then adds refShapeAni->vertPosMatrix if a refShape ani was started
+        // and morphProto->morphRefMeshVertPos otherwise. With no active channels that final add IS the
+        // rest pose, so reading those arrays directly reproduces it without touching engine state.
+        static const unsigned int Offset_MorphProto = 0x34;
+        static const unsigned int Offset_RefShapeAni = 0x3C;
+        // zCMorphMeshProto members (the per-.MMS shared prototype).
+        static const unsigned int Proto_Offset_MorphRefMesh = 0x20;
+        static const unsigned int Proto_Offset_MorphRefMeshVertPos = 0x24;
+        // zCMorphMeshAni members (entries of zCMorphMeshProto::aniList, also shared).
+        static const unsigned int Ani_Offset_NumVert = 0x40;
+        static const unsigned int Ani_Offset_VertPosMatrix = 0x4C;
         static const unsigned int AdvanceAnis = 0x00731920;
         static const unsigned int CalcVertexPositions = 0x00731570;
     };

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1449,6 +1449,13 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         ImGui::BeginDisabled( !settings.DrawSkeletalMeshes );
         ImGui::SliderFloat( "SkeletalMeshDrawRadius", &settings.SkeletalMeshDrawRadius, 0.0f, 18000.0f, "%.0f", ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput );
         ImGui::SetItemTooltip( "Draw distance for NPCs" );
+        ImGui::Checkbox( "Reimplemented morph blend", &settings.UseReimplementedMorphBlend );
+        ImGui::SetItemTooltip( "Fold morph attachments (heads, bow draw meshes) with our own blend instead of\n"
+            "ZENGIN's CalcVertPositions. Same result; this is the A/B for moving it to the GPU.\n"
+            "Ignored while 'Verify morph blend' is on." );
+        ImGui::Checkbox( "Verify morph blend", &settings.VerifyMorphBlend );
+        ImGui::SetItemTooltip( "Run BOTH deforms and log the worst deviation every 300 frames.\n"
+            "Slower than either path, and always draws the engine's result." );
         ImGui::EndDisabled();
 
         ImGui::Checkbox( "Draw Mobs", &settings.DrawMobs );

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -5,6 +5,7 @@
 #include <ShellScalingApi.h>
 
 #include "ImGuiEditorView.h"
+#include "MorphGpu.h"
 #include "zCParser.h"
 #include <sstream>
 #include <map>
@@ -1449,13 +1450,21 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         ImGui::BeginDisabled( !settings.DrawSkeletalMeshes );
         ImGui::SliderFloat( "SkeletalMeshDrawRadius", &settings.SkeletalMeshDrawRadius, 0.0f, 18000.0f, "%.0f", ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput );
         ImGui::SetItemTooltip( "Draw distance for NPCs" );
+        ImGui::Checkbox( "GPU morph fold", &settings.UseGpuMorphFold );
+        ImGui::SetItemTooltip( "Fold morph attachments (heads, bow draw meshes) in a compute shader instead of\n"
+            "deforming them on the CPU and re-uploading the vertex stream every animation frame.\n"
+            "Takes effect after a restart: it also decides how the morph vertex buffers are created.\n"
+            "Ignored on a backend with no fold pipeline (D3D11 today)." );
+        // Both of these only describe the CPU deform, which the fold replaces outright.
+        ImGui::BeginDisabled( MorphGpu::IsActive() );
         ImGui::Checkbox( "Reimplemented morph blend", &settings.UseReimplementedMorphBlend );
         ImGui::SetItemTooltip( "Fold morph attachments (heads, bow draw meshes) with our own blend instead of\n"
             "ZENGIN's CalcVertPositions. Same result; this is the A/B for moving it to the GPU.\n"
-            "Ignored while 'Verify morph blend' is on." );
+            "Ignored while 'Verify morph blend' is on, and while the GPU fold is active." );
         ImGui::Checkbox( "Verify morph blend", &settings.VerifyMorphBlend );
         ImGui::SetItemTooltip( "Run BOTH deforms and log the worst deviation every 300 frames.\n"
             "Slower than either path, and always draws the engine's result." );
+        ImGui::EndDisabled();
         ImGui::EndDisabled();
 
         ImGui::Checkbox( "Draw Mobs", &settings.DrawMobs );

--- a/D3D11Engine/MorphBlend.cpp
+++ b/D3D11Engine/MorphBlend.cpp
@@ -4,9 +4,21 @@
 
 namespace MorphBlend {
 
+    /** ZENGIN's zSinApprox is a 1-milliradian lookup table, NOT sin(): it quantises the argument to
+        1/1000 rad (zFloat2Int == fistp, round-to-nearest-even), wraps it into [-3.142, +3.142] and
+        reads a precomputed sine. Reproducing the quantisation matters - using a true sin() here leaves
+        a ~0.0025-unit disagreement with the engine on a head, which is invisible but would sit as a
+        noise floor under VerifyMorphBlend and hide small regressions. Index 3142 is a == 0, so the
+        table entry is sin((index - 3142) / 1000). */
+    static float SinApprox( float a ) {
+        const int lookup = static_cast<int>( lrintf( 1000.0f * a ) );
+        const int index = (lookup + 3142 + 6284 * 1000) % 6284;
+        return sinf( static_cast<float>( index - 3142 ) * 0.001f );
+    }
+
     float SinusEase( float t ) {
         constexpr float kPi = 3.14159265358979323846f;
-        return (sinf( t * kPi - kPi * 0.5f ) + 1.0f) * 0.5f;
+        return (SinApprox( t * kPi - kPi * 0.5f ) + 1.0f) * 0.5f;
     }
 
     void CaptureChannels( zCMorphMesh* mm, std::vector<ChannelState>& outChannels ) {

--- a/D3D11Engine/MorphBlend.cpp
+++ b/D3D11Engine/MorphBlend.cpp
@@ -115,6 +115,67 @@ namespace MorphBlend {
         }
     }
 
+    void LogPrototypeBudget( zCMorphMesh* mm ) {
+        if ( !mm ) {
+            return;
+        }
+        zCMorphMeshProto* proto = mm->GetMorphProto();
+        if ( !proto ) {
+            return;
+        }
+
+        // Once per .MMS, on the game thread (same context as the rest of UpdateMorphMeshVisual), so no
+        // lock. Bounded by the number of distinct morph prototypes the world loads - a handful of head
+        // meshes - which is why this does not need a settings switch.
+        static std::unordered_set<void*> s_seen;
+        if ( !s_seen.insert( proto ).second ) {
+            return;
+        }
+
+        zCProgMeshProto* ref = proto->GetMorphRefMesh();
+        zCArrayAdapt<float3>* refPos = ref ? ref->GetPositionList() : nullptr;
+        const int meshNumVert = refPos ? refPos->NumInArray : 0;
+
+        const int numAnis = proto->GetNumAnis();
+        size_t vertPosBytes = 0;    // what a GPU port would upload: all anis' vertPosMatrix concatenated
+        size_t indexBytes = 0;      // the sparse vertIndexList we would upload alongside it
+        size_t totalFrames = 0;
+        size_t widestAniBytes = 0;
+        for ( int i = 0; i < numAnis; i++ ) {
+            zCMorphMeshAni* ani = proto->GetAni( i );
+            if ( !ani ) {
+                continue;
+            }
+            const int aniNumVert = ani->GetNumVert();
+            const int numFrames = ani->GetNumFrames();
+            if ( aniNumVert <= 0 || numFrames <= 0 ) {
+                continue;
+            }
+            const size_t bytes = static_cast<size_t>(numFrames) * aniNumVert * sizeof( float3 );
+            vertPosBytes += bytes;
+            indexBytes += static_cast<size_t>(aniNumVert) * sizeof( int );
+            totalFrames += numFrames;
+            widestAniBytes = std::max( widestAniBytes, bytes );
+        }
+
+        // The gather-friendly inversion of vertIndexList the compute fold needs: one dense
+        // vertex -> slot table per ani, meshNumVert uints wide.
+        const size_t inverseTableBytes = static_cast<size_t>(numAnis) * meshNumVert * sizeof( uint32_t );
+
+        static size_t s_totalVertPosBytes = 0;
+        static size_t s_totalInverseBytes = 0;
+        s_totalVertPosBytes += vertPosBytes;
+        s_totalInverseBytes += inverseTableBytes;
+
+        LogInfo() << "MorphBlend budget: " << (proto->GetName() ? proto->GetName()->ToChar() : "?")
+            << " " << numAnis << " anis, " << totalFrames << " frames, " << meshNumVert << " mesh verts"
+            << " | vertPosMatrix " << (vertPosBytes / 1024) << " KB (widest ani "
+            << (widestAniBytes / 1024) << " KB), vertIndexList " << (indexBytes / 1024) << " KB"
+            << ", inverse tables " << (inverseTableBytes / 1024) << " KB"
+            << " | running total: vertPosMatrix " << (s_totalVertPosBytes / 1024) << " KB + inverse "
+            << (s_totalInverseBytes / 1024) << " KB over " << s_seen.size() << " prototypes";
+    }
+
     float CompareAgainstEngine( zCMorphMesh* mm ) {
         if ( !mm ) {
             return -1.0f;

--- a/D3D11Engine/MorphBlend.cpp
+++ b/D3D11Engine/MorphBlend.cpp
@@ -1,0 +1,145 @@
+#include "pch.h"
+#include "MorphBlend.h"
+#include "zCMorphMesh.h"
+
+namespace MorphBlend {
+
+    float SinusEase( float t ) {
+        constexpr float kPi = 3.14159265358979323846f;
+        return (sinf( t * kPi - kPi * 0.5f ) + 1.0f) * 0.5f;
+    }
+
+    void CaptureChannels( zCMorphMesh* mm, std::vector<ChannelState>& outChannels ) {
+        outChannels.clear();
+        if ( !mm ) {
+            return;
+        }
+
+        const int numChannels = mm->GetNumAniChannels();
+        if ( numChannels <= 0 ) {
+            return;
+        }
+
+        outChannels.reserve( numChannels );
+        for ( int i = 0; i < numChannels; i++ ) {
+            zTMorphAniEntry* entry = mm->GetAniChannel( i );
+            if ( !entry ) {
+                continue;
+            }
+            zCMorphMeshAni* ani = entry->GetAni();
+            if ( !ani ) {
+                continue;
+            }
+
+            const int aniNumVert = ani->GetNumVert();
+            const float3* vertPos = ani->GetVertPosMatrix();
+            const int* vertIndexList = ani->GetVertIndexList();
+            if ( aniNumVert <= 0 || !vertPos || !vertIndexList ) {
+                continue;
+            }
+
+            ChannelState& c = outChannels.emplace_back();
+            c.Ani = ani;
+            c.NumVert = aniNumVert;
+            c.VertIndexList = vertIndexList;
+
+            const float weight = SinusEase( SinusEase( entry->GetWeight() ) );
+            c.Weight = weight;
+            c.Weight1M = ani->IsShape() ? 1.0f : (1.0f - weight);
+
+            const int numFrames = ani->GetNumFrames();
+            if ( numFrames > 1 ) {
+                c.FrameA = vertPos + static_cast<ptrdiff_t>(entry->GetActFrameInt()) * aniNumVert;
+                c.FrameB = vertPos + static_cast<ptrdiff_t>(entry->GetNextFrameInt()) * aniNumVert;
+                c.Frac = entry->GetFrac();
+            } else {
+                // Single-frame anis take CalcVertPositions' non-lerping branch.
+                c.FrameA = vertPos;
+                c.FrameB = vertPos;
+                c.Frac = 0.0f;
+            }
+        }
+    }
+
+    void Apply( const std::vector<ChannelState>& channels, const float3* restPositions, int numVert,
+        float3* outPositions ) {
+        if ( !outPositions || numVert <= 0 ) {
+            return;
+        }
+
+        for ( int i = 0; i < numVert; i++ ) {
+            outPositions[i] = float3( 0.0f, 0.0f, 0.0f );
+        }
+
+        for ( const ChannelState& c : channels ) {
+            for ( int j = 0; j < c.NumVert; j++ ) {
+                const int v = c.VertIndexList[j];
+                if ( v < 0 || v >= numVert ) {
+                    continue;   // an ani wider than the mesh we are folding onto - skip rather than scribble
+                }
+
+                float3 sample = c.FrameA[j];
+                if ( c.Frac != 0.0f ) {
+                    const float3& next = c.FrameB[j];
+                    sample.x += c.Frac * (next.x - sample.x);
+                    sample.y += c.Frac * (next.y - sample.y);
+                    sample.z += c.Frac * (next.z - sample.z);
+                }
+
+                float3& acc = outPositions[v];
+                acc.x = c.Weight1M * acc.x + sample.x * c.Weight;
+                acc.y = c.Weight1M * acc.y + sample.y * c.Weight;
+                acc.z = c.Weight1M * acc.z + sample.z * c.Weight;
+            }
+        }
+
+        // CalcVertPositions' trailing add of the rest base.
+        if ( restPositions ) {
+            for ( int i = 0; i < numVert; i++ ) {
+                outPositions[i].x += restPositions[i].x;
+                outPositions[i].y += restPositions[i].y;
+                outPositions[i].z += restPositions[i].z;
+            }
+        }
+    }
+
+    float CompareAgainstEngine( zCMorphMesh* mm ) {
+        if ( !mm ) {
+            return -1.0f;
+        }
+
+        int restCount = 0;
+        const float3* rest = mm->GetRestPositions( restCount );
+        zCProgMeshProto* pm = mm->GetMorphMesh();
+        if ( !rest || restCount <= 0 || !pm ) {
+            return -1.0f;
+        }
+
+        zCArrayAdapt<float3>* posList = pm->GetPositionList();
+        if ( !posList || !posList->Array || posList->NumInArray <= 0 ) {
+            return -1.0f;
+        }
+        const int numVert = std::min( restCount, posList->NumInArray );
+
+        // Capture first, then let the engine deform into its own (shared) position list. Order matters:
+        // CalcVertexPositions does not touch channel state, but capturing after keeps the two reads of
+        // that state adjacent and makes the comparison independent of any future reordering here.
+        static std::vector<ChannelState> channels;
+        CaptureChannels( mm, channels );
+
+        mm->CalcVertexPositions();
+
+        static std::vector<float3> ours;
+        ours.resize( numVert );
+        Apply( channels, rest, numVert, ours.data() );
+
+        const float3* theirs = posList->Array;
+        float worst = 0.0f;
+        for ( int i = 0; i < numVert; i++ ) {
+            worst = std::max( worst, std::abs( ours[i].x - theirs[i].x ) );
+            worst = std::max( worst, std::abs( ours[i].y - theirs[i].y ) );
+            worst = std::max( worst, std::abs( ours[i].z - theirs[i].z ) );
+        }
+        return worst;
+    }
+}

--- a/D3D11Engine/MorphBlend.h
+++ b/D3D11Engine/MorphBlend.h
@@ -1,0 +1,54 @@
+#pragma once
+#include "pch.h"
+
+class zCMorphMesh;
+class zCMorphMeshAni;
+
+/** Reimplementation of zCMorphMesh::CalcVertPositions from captured channel state, so the morph blend
+    can be moved off the game thread (and, next, onto the GPU) instead of calling into ZENGIN's own
+    deform every animation frame.
+ *
+ *  What CANNOT move: zCMorphMesh::AdvanceAnis. It is game state, not geometry - it integrates channel
+ *  weights against frame time, runs the fade-in/const/fade-out machine, deletes finished channels,
+ *  advances frames and rolls zRandF() for discontinuity anis. It keeps being called; only the deform
+ *  is reproduced here.
+ *
+ *  The blend is a SEQUENTIAL FOLD, not a weighted sum:
+ *      acc = weight1M * acc + sample * weight     (per channel, in channel order)
+ *  Each channel attenuates everything accumulated before it, and a "shape" ani forces weight1M to 1.
+ *  So the channel order is load-bearing and the result cannot be precomputed as rest + sum(w*delta).
+ *  A channel that does not touch a given vertex is skipped entirely, leaving that vertex's accumulator
+ *  untouched - which is what makes the sparse vertIndexList indirection safe to invert. */
+namespace MorphBlend {
+
+    /** One channel, snapshotted on the game thread. Everything a consumer needs to fold it, with the
+        engine's easing already applied - the arrays it points at are written once at load. */
+    struct ChannelState {
+        zCMorphMeshAni* Ani = nullptr;
+        const float3* FrameA = nullptr;   // vertPosMatrix + actFrameInt * numVert
+        const float3* FrameB = nullptr;   // vertPosMatrix + nextFrameInt * numVert (== FrameA if 1 frame)
+        const int* VertIndexList = nullptr;
+        int NumVert = 0;
+        float Frac = 0.0f;                // FrameA -> FrameB lerp, 0 when the ani has a single frame
+        float Weight = 0.0f;              // zSinusEase applied twice, as CalcVertPositions does
+        float Weight1M = 0.0f;            // 1 - Weight, or exactly 1 for a shape ani
+    };
+
+    /** ZENGIN's zSinusEase (zTools.h): (sin(t*PI - PI/2) + 1) / 2. Applied twice by CalcVertPositions.
+        The engine uses a sin approximation; the difference is far below vertex precision. */
+    float SinusEase( float t );
+
+    /** Snapshots this morph mesh's active channels. Must run on the game thread, after AdvanceAnis:
+        the entries are owned by aniChannels and can be deleted by the next AdvanceAnis call. */
+    void CaptureChannels( zCMorphMesh* mm, std::vector<ChannelState>& outChannels );
+
+    /** Folds the captured channels over 'restPositions' and writes numVert positions to 'outPositions'.
+        Reproduces CalcVertPositions exactly, including the trailing add of the rest base. */
+    void Apply( const std::vector<ChannelState>& channels, const float3* restPositions, int numVert,
+        float3* outPositions );
+
+    /** Runs Apply against ZENGIN's own freshly-computed positions and returns the largest per-component
+        deviation, or -1.0f if the comparison could not be made. Diagnostic only - this is the check that
+        has to pass before the fold is worth porting to a shader. */
+    float CompareAgainstEngine( zCMorphMesh* mm );
+}

--- a/D3D11Engine/MorphBlend.h
+++ b/D3D11Engine/MorphBlend.h
@@ -34,8 +34,8 @@ namespace MorphBlend {
         float Weight1M = 0.0f;            // 1 - Weight, or exactly 1 for a shape ani
     };
 
-    /** ZENGIN's zSinusEase (zTools.h): (sin(t*PI - PI/2) + 1) / 2. Applied twice by CalcVertPositions.
-        The engine uses a sin approximation; the difference is far below vertex precision. */
+    /** ZENGIN's zSinusEase: (zSinApprox(t*PI - PI/2) + 1) / 2, applied twice by CalcVertPositions.
+        zSinApprox is a 1-milliradian quantised sine, not sin() - see the implementation. */
     float SinusEase( float t );
 
     /** Snapshots this morph mesh's active channels. Must run on the game thread, after AdvanceAnis:

--- a/D3D11Engine/MorphBlend.h
+++ b/D3D11Engine/MorphBlend.h
@@ -47,6 +47,11 @@ namespace MorphBlend {
     void Apply( const std::vector<ChannelState>& channels, const float3* restPositions, int numVert,
         float3* outPositions );
 
+    /** Logs, once per .MMS prototype, how many bytes a GPU fold would have to hold resident for it:
+        all anis' vertPosMatrix plus the per-ani vertex -> slot tables. This is the 32-bit address space
+        question the compute port hangs on, so it is measured before anything is uploaded. */
+    void LogPrototypeBudget( zCMorphMesh* mm );
+
     /** Runs Apply against ZENGIN's own freshly-computed positions and returns the largest per-component
         deviation, or -1.0f if the comparison could not be made. Diagnostic only - this is the check that
         has to pass before the fold is worth porting to a shader. */

--- a/D3D11Engine/MorphGpu.cpp
+++ b/D3D11Engine/MorphGpu.cpp
@@ -1,0 +1,302 @@
+#include "pch.h"
+#include "MorphGpu.h"
+#include "MorphBlend.h"
+#include "WorldObjects.h"
+#include "GothicAPI.h"
+#include "Engine.h"
+#include "zCMorphMesh.h"
+
+namespace MorphGpu {
+
+    namespace {
+        /** Guards the prototype cache and the frame queue. Register() is reachable from the shadow-cascade
+            and point-shadow collection, which run on the worker pool. Contention is negligible - a handful
+            of instances per frame, and the expensive half (building a prototype's tables) happens once per
+            .MMS for the whole session. */
+        std::mutex s_Mutex;
+
+        gtl::flat_hash_map<zCMorphMeshProto*, std::unique_ptr<Prototype>> s_Prototypes;
+        /** Prototypes displaced by a recycled zCMorphMeshProto address (see BuildPrototype). Kept alive
+            rather than freed so a Prototype* is stable for the session: the backends cache their uploaded
+            GPU tables under that pointer, and a reused address would silently alias them. Only ever grows on
+            a world change that recycles an address, i.e. essentially never. */
+        std::vector<std::unique_ptr<Prototype>> s_Retired;
+        size_t s_TableBytes = 0;
+
+        std::vector<Job> s_Jobs;
+        std::vector<ChannelRecord> s_Channels;
+        std::vector<MorphBlend::ChannelState> s_Capture;   // scratch, reused (holds its capacity)
+
+        std::atomic<bool> s_BackendAvailable{ false };
+
+        constexpr uint32_t kNoSlot = 0xFFFFFFFFu;
+
+        /** Builds the immutable tables for one .MMS. Reads only arrays ZENGIN writes once at load
+            (morphRefMeshVertPos, every ani's vertPosMatrix/vertIndexList, the progmesh wedge lists), so it
+            is safe from a worker thread - unlike the live position list, which CalcVertPositions deforms.
+            Caller holds s_Mutex. */
+        Prototype* BuildPrototype( zCMorphMesh* mm ) {
+            zCMorphMeshProto* protoObj = mm->GetMorphProto();
+            if ( !protoObj ) {
+                return nullptr;
+            }
+
+            zCProgMeshProto* ref = protoObj->GetMorphRefMesh();
+            zCArrayAdapt<float3>* posList = ref ? ref->GetPositionList() : nullptr;
+            const int meshNumVert = posList ? posList->NumInArray : 0;
+
+            auto it = s_Prototypes.find( protoObj );
+            if ( it != s_Prototypes.end() ) {
+                // Nothing frees these, but ZENGIN's resource manager can drop a .MMS prototype on a world
+                // change and hand the same ADDRESS back for a different one. Cheap identity re-check rather
+                // than trusting the pointer: a recycled entry would fold heads against another head's tables.
+                Prototype* cached = it->second.get();
+                if ( !cached->Valid || cached->MeshNumVert == meshNumVert ) {
+                    return cached;
+                }
+                s_TableBytes -= cached->Positions.size() * sizeof( float3 )
+                    + cached->Indices.size() * sizeof( uint32_t );
+                s_Retired.push_back( std::move( it->second ) );
+                s_Prototypes.erase( it );
+            }
+
+            auto owned = std::make_unique<Prototype>();
+            Prototype& p = *owned;
+            const char* name = protoObj->GetName() && protoObj->GetName()->ToChar()
+                ? protoObj->GetName()->ToChar() : "?";
+
+            const float3* refPos = protoObj->GetMorphRefMeshVertPos();
+            if ( !ref || !refPos || meshNumVert <= 0 ) {
+                LogWarn() << "MorphGpu: " << name << " has no usable rest mesh - folding it on the CPU.";
+                Prototype* raw = owned.get();
+                s_Prototypes.emplace( protoObj, std::move( owned ) );
+                return raw;   // Valid stays false
+            }
+            p.MeshNumVert = meshNumVert;
+
+            // --- Positions: the rest base first, then every ani's vertPosMatrix ---
+            // A refShape ani's own block doubles as a rest base (CalcVertPositions adds
+            // refShapeAni->vertPosMatrix[i] instead of morphRefMeshVertPos[i]), which is why Register can
+            // just point RestBase at it - see zCMorphMesh::GetRestPositions.
+            const int numAnis = protoObj->GetNumAnis();
+            size_t positionCount = static_cast<size_t>( meshNumVert );
+            size_t indexCount = 0;
+            for ( int i = 0; i < numAnis; i++ ) {
+                zCMorphMeshAni* ani = protoObj->GetAni( i );
+                if ( !ani ) continue;
+                const int aniNumVert = ani->GetNumVert();
+                const int numFrames = ani->GetNumFrames();
+                if ( aniNumVert <= 0 || numFrames <= 0 || !ani->GetVertPosMatrix() || !ani->GetVertIndexList() ) continue;
+                positionCount += static_cast<size_t>( numFrames ) * aniNumVert;
+                indexCount += static_cast<size_t>( meshNumVert );
+            }
+            p.Positions.reserve( positionCount );
+            p.Indices.reserve( indexCount );
+
+            p.RestBase = 0;
+            p.Positions.insert( p.Positions.end(), refPos, refPos + meshNumVert );
+
+            for ( int i = 0; i < numAnis; i++ ) {
+                zCMorphMeshAni* ani = protoObj->GetAni( i );
+                if ( !ani ) continue;
+                const int aniNumVert = ani->GetNumVert();
+                const int numFrames = ani->GetNumFrames();
+                const float3* vertPos = ani->GetVertPosMatrix();
+                const int* vertIndexList = ani->GetVertIndexList();
+                if ( aniNumVert <= 0 || numFrames <= 0 || !vertPos || !vertIndexList ) continue;
+
+                Prototype::AniInfo info{};
+                info.NumVert = aniNumVert;
+                info.NumFrames = numFrames;
+                info.FrameBase = static_cast<uint32_t>( p.Positions.size() );
+                p.Positions.insert( p.Positions.end(), vertPos,
+                    vertPos + static_cast<size_t>( numFrames ) * aniNumVert );
+
+                // Dense inversion of the sparse vertIndexList. The CPU fold walks slots and scatters; a
+                // thread-per-vertex shader has to gather, so it needs the mapping the other way round.
+                info.InverseBase = static_cast<uint32_t>( p.Indices.size() );
+                p.Indices.resize( p.Indices.size() + meshNumVert, kNoSlot );
+                uint32_t* inverse = p.Indices.data() + info.InverseBase;
+                bool duplicate = false;
+                for ( int j = 0; j < aniNumVert; j++ ) {
+                    const int v = vertIndexList[j];
+                    if ( v < 0 || v >= meshNumVert ) continue;   // an ani wider than the mesh, as MorphBlend::Apply skips
+                    if ( inverse[v] != kNoSlot ) {
+                        duplicate = true;
+                        break;
+                    }
+                    inverse[v] = static_cast<uint32_t>( j );
+                }
+                if ( duplicate ) {
+                    // Two slots of one ani touching the same vertex means the CPU fold applies that channel
+                    // TWICE to it, which a single-slot gather cannot reproduce. Not observed in shipped
+                    // content; refuse the whole prototype rather than render it subtly differently.
+                    LogWarn() << "MorphGpu: " << name << " ani #" << i
+                        << " has a duplicated vertIndexList entry - folding this prototype on the CPU.";
+                    Prototype* raw = owned.get();
+                    s_Prototypes.emplace( protoObj, std::move( owned ) );
+                    return raw;   // Valid stays false
+                }
+                p.Anis.emplace( ani, info );
+            }
+
+            // --- Per-submesh wedge -> mesh-vertex tables ---
+            // The fold writes one vertex per WEDGE, in wedge order, because that is exactly the order
+            // Extract3DSMeshFromVisual2 built the vertex buffer in (and morph submeshes deliberately skip
+            // the optimizers, so it still holds). Several wedges share a position; each just gathers it.
+            const int numSubmeshes = ref->GetNumSubmeshes();
+            p.WedgeBase.resize( numSubmeshes, 0 );
+            p.WedgeCount.resize( numSubmeshes, 0 );
+            for ( int i = 0; i < numSubmeshes; i++ ) {
+                zCSubMesh* s = ref->GetSubmesh( i );
+                const int numWedges = s ? s->WedgeList.NumInArray : 0;
+                p.WedgeBase[i] = static_cast<uint32_t>( p.Indices.size() );
+                p.WedgeCount[i] = static_cast<uint32_t>( numWedges );
+                for ( int v = 0; v < numWedges; v++ ) {
+                    p.Indices.push_back( static_cast<uint32_t>( s->WedgeList.Array[v].position ) );
+                }
+            }
+
+            p.Valid = !p.Positions.empty() && !p.Indices.empty();
+            const size_t bytes = p.Positions.size() * sizeof( float3 ) + p.Indices.size() * sizeof( uint32_t );
+            s_TableBytes += bytes;
+            LogInfo() << "MorphGpu: " << name << " tables built - " << meshNumVert << " verts, "
+                << p.Anis.size() << " anis, " << numSubmeshes << " submeshes, " << ( bytes / 1024 )
+                << " KB (" << ( s_TableBytes / 1024 ) << " KB over " << ( s_Prototypes.size() + 1 ) << " prototypes)";
+
+            Prototype* raw = owned.get();
+            s_Prototypes.emplace( protoObj, std::move( owned ) );
+            return raw;
+        }
+    }
+
+    void SetBackendAvailable( bool available ) {
+        s_BackendAvailable.store( available, std::memory_order_release );
+    }
+
+    bool IsActive() {
+        // Frozen on first query. WorldConverter picks a morph submesh's buffer USAGE from this (DEFAULT+UAV
+        // for the fold vs DYNAMIC+CA_WRITE for the CPU deform), so an answer that changed mid-session would
+        // leave already-converted heads with a buffer the active path cannot write.
+        // A function-local static, because Extract3DSMeshFromVisual2 (and therefore this) runs on the worker
+        // pool - ExtractNodeVisualAsync - so the freeze has to be race-free, not just once.
+        static const bool active = []() {
+            const bool a = s_BackendAvailable.load( std::memory_order_acquire )
+                && Engine::GAPI->GetRendererState().RendererSettings.UseGpuMorphFold;
+            LogInfo() << "MorphGpu: GPU morph fold " << ( a ? "ACTIVE" : "off" ) << " (backend "
+                << ( s_BackendAvailable.load( std::memory_order_relaxed ) ? "supports" : "does not support" ) << " it)";
+            return a;
+        }();
+        return active;
+    }
+
+    bool Register( zCMorphMesh* mm, MeshVisualInfo* mvi ) {
+        if ( !mm || !mvi ) {
+            return false;
+        }
+        zCProgMeshProto* morphMesh = mm->GetMorphMesh();
+        if ( !morphMesh ) {
+            return false;
+        }
+
+        std::scoped_lock lock( s_Mutex );
+
+        Prototype* proto = BuildPrototype( mm );
+        if ( !proto || !proto->Valid ) {
+            return false;
+        }
+
+        // This instance's rest base. A refShape ani replaces morphRefMeshVertPos as the base the deltas are
+        // added to, and it must therefore cover every mesh vertex - anything narrower cannot be indexed by
+        // mesh vertex and falls back to the CPU (which reads the same array through GetRestPositions).
+        uint32_t restBase = proto->RestBase;
+        if ( zCMorphMeshAni* shape = mm->GetRefShapeAni() ) {
+            auto it = proto->Anis.find( shape );
+            if ( it == proto->Anis.end() || it->second.NumVert < proto->MeshNumVert ) {
+                return false;
+            }
+            restBase = it->second.FrameBase;
+        }
+
+        // Resolve the captured channels to buffer offsets. An ani that is not in the prototype's table (it
+        // was rejected above, or the channel points at something the prototype does not own) makes the whole
+        // instance fall back: dropping a single channel would silently change the fold, since every later
+        // channel attenuates what the earlier ones left behind.
+        MorphBlend::CaptureChannels( mm, s_Capture );
+        const size_t channelFirst = s_Channels.size();
+        for ( const MorphBlend::ChannelState& c : s_Capture ) {
+            auto it = proto->Anis.find( c.Ani );
+            if ( it == proto->Anis.end() ) {
+                s_Channels.resize( channelFirst );
+                return false;
+            }
+            const Prototype::AniInfo& ani = it->second;
+
+            // CaptureChannels resolved the frames as POINTERS into the ani's own vertPosMatrix; recover the
+            // frame indices from them so the shader can index the concatenated pool. Deriving them here
+            // rather than re-reading the channel keeps this consistent with whatever CaptureChannels decided
+            // (notably its single-frame branch, which pins both frames to frame 0).
+            const float3* aniBase = c.Ani->GetVertPosMatrix();
+            if ( !aniBase || !c.FrameA || !c.FrameB ) {
+                s_Channels.resize( channelFirst );
+                return false;
+            }
+            const ptrdiff_t frameA = ( c.FrameA - aniBase ) / ( c.NumVert > 0 ? c.NumVert : 1 );
+            const ptrdiff_t frameB = ( c.FrameB - aniBase ) / ( c.NumVert > 0 ? c.NumVert : 1 );
+            if ( frameA < 0 || frameB < 0 || frameA >= ani.NumFrames || frameB >= ani.NumFrames
+                || c.NumVert != ani.NumVert ) {
+                s_Channels.resize( channelFirst );
+                return false;
+            }
+
+            ChannelRecord& rec = s_Channels.emplace_back();
+            rec.FrameA = ani.FrameBase + static_cast<uint32_t>( frameA ) * static_cast<uint32_t>( ani.NumVert );
+            rec.FrameB = ani.FrameBase + static_cast<uint32_t>( frameB ) * static_cast<uint32_t>( ani.NumVert );
+            rec.Inverse = ani.InverseBase;
+            rec.Frac = c.Frac;
+            rec.Weight = c.Weight;
+            rec.Weight1M = c.Weight1M;
+        }
+        const uint32_t channelCount = static_cast<uint32_t>( s_Channels.size() - channelFirst );
+
+        // One job per submesh. A submesh whose converted vertex count disagrees with its wedge count is not
+        // the mesh these tables describe (nothing in the current conversion path can produce that, but the
+        // fold would write the wrong vertices if it ever did) - fall back for the whole instance.
+        const size_t jobFirst = s_Jobs.size();
+        for ( auto& [material, meshes] : mvi->Meshes ) {
+            for ( auto& mi : meshes ) {
+                if ( !mi || mi->Vertices.empty() ) continue;
+                const unsigned int sub = mi->MeshIndex;
+                if ( sub >= proto->WedgeCount.size()
+                    || proto->WedgeCount[sub] != mi->Vertices.size() ) {
+                    s_Jobs.resize( jobFirst );
+                    s_Channels.resize( channelFirst );
+                    return false;
+                }
+                Job& job = s_Jobs.emplace_back();
+                job.Mesh = mi.get();
+                job.Proto = proto;
+                job.RestBase = restBase;
+                job.WedgeBase = proto->WedgeBase[sub];
+                job.OutVertexCount = proto->WedgeCount[sub];
+                job.ChannelFirst = static_cast<uint32_t>( channelFirst );
+                job.ChannelCount = channelCount;
+            }
+        }
+
+        if ( s_Jobs.size() == jobFirst ) {
+            s_Channels.resize( channelFirst );   // nothing to fold (all submeshes empty) - not a failure
+        }
+        return true;
+    }
+
+    void TakeJobs( std::vector<Job>& outJobs, std::vector<ChannelRecord>& outChannels ) {
+        std::scoped_lock lock( s_Mutex );
+        outJobs.clear();
+        outChannels.clear();
+        s_Jobs.swap( outJobs );
+        s_Channels.swap( outChannels );
+    }
+
+    size_t ResidentTableBytes() { return s_TableBytes; }
+}

--- a/D3D11Engine/MorphGpu.h
+++ b/D3D11Engine/MorphGpu.h
@@ -9,21 +9,15 @@ struct MeshVisualInfo;
 
 /** GPU morph fold: the compute-shader form of MorphBlend's sequential channel fold.
  *
- *  This is the module that took morph attachments off the per-frame CPU path. It replaces, per
- *  deforming instance and per animation frame:
- *      zCMorphMesh::CalcVertexPositions (or MorphBlend::Apply)   -- the fold itself
- *      the per-wedge ExVertexStruct expansion in UpdateMorphMeshVisual
- *      GfxVertexBuffer::UpdateBuffer                             -- a full vertex-buffer re-upload
- *  with one Dispatch per submesh that rewrites only the 12-byte Position of each vertex already in
- *  that submesh's vertex buffer. Everything else in the vertex (normal, tangent, UVs, color) is
- *  wedge data written once at conversion and never touched again, so there is nothing to copy.
+ *  Takes morph attachments off the per-frame CPU path. Per deforming instance and animation frame it
+ *  replaces zCMorphMesh::CalcVertexPositions (or MorphBlend::Apply), the per-wedge ExVertexStruct expansion
+ *  in UpdateMorphMeshVisual and a full GfxVertexBuffer::UpdateBuffer with one Dispatch per submesh that
+ *  rewrites only the 12-byte Position of each vertex already in that submesh's vertex buffer. Everything
+ *  else in the vertex is wedge data written once at conversion, so there is nothing to copy.
  *
- *  Why that also killed the buffer-lifetime machinery: a folded submesh's vertex buffer is a
- *  DEFAULT-heap (VRAM) UAV, created once with the mesh and destroyed with it. It is never CPU-mapped,
- *  so it costs no 32-bit address space, and on D3D12 it is ONE copy rather than kBackBufferCount
- *  persistently-mapped UPLOAD copies (the CPU-write-vs-GPU-read race that forced the ring is gone -
- *  the writer is the GPU, ordered by a barrier). That is what made the release/recreate hysteresis
- *  (MeshVisualInfo::ReleaseIdleMorphVertexBuffers and MeshInfo's self-healing accessor) unnecessary.
+ *  That buffer is then a DEFAULT-heap UAV created and destroyed with the mesh: never CPU-mapped (so no
+ *  32-bit address space), and ONE copy rather than kBackBufferCount, since the CPU-write-vs-GPU-read race
+ *  that forced the ring is gone. That is what made the old release/recreate hysteresis unnecessary.
  *
  *  Data model. Everything the fold reads that is not per-frame is per PROTOTYPE (per .MMS, so per head
  *  TYPE, not per NPC) and immutable, built once on first sight and never freed:
@@ -31,16 +25,14 @@ struct MeshVisualInfo;
  *      Indices    uint[]   : per ani a DENSE vertex -> slot table (the gather-friendly inversion of the
  *                            sparse vertIndexList; 0xFFFFFFFF = this ani does not touch that vertex),
  *                            then per submesh a wedge -> mesh-vertex table
- *  Measured at ~1 MB of Positions plus ~110 KB of Indices across all 26 prototypes of a G2 world
- *  (MorphBlend::LogPrototypeBudget), which is why they are uploaded eagerly rather than streamed.
+ *  ~1 MB total across a G2 world's prototypes (MorphBlend::LogPrototypeBudget), so they are uploaded
+ *  eagerly rather than streamed.
  *
- *  Per frame the only upload is one ChannelRecord per active blend channel per instance - the fold
- *  state MorphBlend::CaptureChannels already snapshots, with the engine's double zSinusEase baked in,
- *  so the shader never evaluates the easing (or ZENGIN's quantised zSinApprox) at all.
+ *  Per frame the only upload is one ChannelRecord per active blend channel per instance, with the engine's
+ *  double zSinusEase already baked in by MorphBlend::CaptureChannels.
  *
- *  Threading: Register() can be reached from the shadow-cascade / point-shadow collection running on
- *  the worker pool, so it takes a lock. It only READS Gothic state (the prototype arrays are written
- *  once at load; the channel list is the same read UpdateMorphMeshVisual already did on that thread). */
+ *  Threading: Register() can be reached from the shadow-cascade / point-shadow collection on the worker
+ *  pool, so it takes a lock. It only READS Gothic state. */
 namespace MorphGpu {
 
     /** One active blend channel, resolved to buffer offsets. MUST match MorphFold.hlsl's ChannelRecord. */
@@ -106,17 +98,15 @@ namespace MorphGpu {
 
     /** Hands the queued work to the backend's dispatch and empties the queue, in one locked step.
      *
-     *  A MOVE rather than a peek, for two reasons. Register() can run on the worker pool, so a borrowed
-     *  reference could be reallocated under the dispatch mid-walk; and Job::ChannelFirst indexes the channel
-     *  array, so the two containers may only ever be emptied together - clearing the channels while a Job
-     *  survived would repoint it at some other instance's channels.
+     *  A MOVE rather than a peek: Register() can run on the worker pool, so a borrowed reference could be
+     *  reallocated under the dispatch mid-walk, and Job::ChannelFirst indexes the channel array, so the two
+     *  containers may only ever be emptied together.
      *
-     *  A Job registered AFTER this returns is therefore not lost and not misindexed: it lands in the now-empty
-     *  queue and folds at the NEXT frame's dispatch. The ghost-VOB pass collects its attachments that late (and
-     *  a shadow-only instance can too), so those instances run one frame behind on facial animation.
+     *  A Job registered AFTER this returns lands in the now-empty queue and folds at the next frame's
+     *  dispatch — the ghost-VOB pass collects its attachments that late, so those instances run one frame
+     *  behind on facial animation.
      *
-     *  The caller should reuse the same two vectors every frame; they come back with their capacity intact, so
-     *  this settles into zero per-frame allocations. */
+     *  Reuse the same two vectors every frame; they come back with their capacity intact. */
     void TakeJobs( std::vector<Job>& outJobs, std::vector<ChannelRecord>& outChannels );
 
     /** Total bytes of prototype tables built so far, for the diagnostic log. */

--- a/D3D11Engine/MorphGpu.h
+++ b/D3D11Engine/MorphGpu.h
@@ -1,0 +1,124 @@
+#pragma once
+#include "pch.h"
+
+class zCMorphMesh;
+class zCMorphMeshAni;
+class zCMorphMeshProto;
+struct MeshInfo;
+struct MeshVisualInfo;
+
+/** GPU morph fold: the compute-shader form of MorphBlend's sequential channel fold.
+ *
+ *  This is the module that took morph attachments off the per-frame CPU path. It replaces, per
+ *  deforming instance and per animation frame:
+ *      zCMorphMesh::CalcVertexPositions (or MorphBlend::Apply)   -- the fold itself
+ *      the per-wedge ExVertexStruct expansion in UpdateMorphMeshVisual
+ *      GfxVertexBuffer::UpdateBuffer                             -- a full vertex-buffer re-upload
+ *  with one Dispatch per submesh that rewrites only the 12-byte Position of each vertex already in
+ *  that submesh's vertex buffer. Everything else in the vertex (normal, tangent, UVs, color) is
+ *  wedge data written once at conversion and never touched again, so there is nothing to copy.
+ *
+ *  Why that also killed the buffer-lifetime machinery: a folded submesh's vertex buffer is a
+ *  DEFAULT-heap (VRAM) UAV, created once with the mesh and destroyed with it. It is never CPU-mapped,
+ *  so it costs no 32-bit address space, and on D3D12 it is ONE copy rather than kBackBufferCount
+ *  persistently-mapped UPLOAD copies (the CPU-write-vs-GPU-read race that forced the ring is gone -
+ *  the writer is the GPU, ordered by a barrier). That is what made the release/recreate hysteresis
+ *  (MeshVisualInfo::ReleaseIdleMorphVertexBuffers and MeshInfo's self-healing accessor) unnecessary.
+ *
+ *  Data model. Everything the fold reads that is not per-frame is per PROTOTYPE (per .MMS, so per head
+ *  TYPE, not per NPC) and immutable, built once on first sight and never freed:
+ *      Positions  float3[] : the instance rest bases followed by every ani's vertPosMatrix, concatenated
+ *      Indices    uint[]   : per ani a DENSE vertex -> slot table (the gather-friendly inversion of the
+ *                            sparse vertIndexList; 0xFFFFFFFF = this ani does not touch that vertex),
+ *                            then per submesh a wedge -> mesh-vertex table
+ *  Measured at ~1 MB of Positions plus ~110 KB of Indices across all 26 prototypes of a G2 world
+ *  (MorphBlend::LogPrototypeBudget), which is why they are uploaded eagerly rather than streamed.
+ *
+ *  Per frame the only upload is one ChannelRecord per active blend channel per instance - the fold
+ *  state MorphBlend::CaptureChannels already snapshots, with the engine's double zSinusEase baked in,
+ *  so the shader never evaluates the easing (or ZENGIN's quantised zSinApprox) at all.
+ *
+ *  Threading: Register() can be reached from the shadow-cascade / point-shadow collection running on
+ *  the worker pool, so it takes a lock. It only READS Gothic state (the prototype arrays are written
+ *  once at load; the channel list is the same read UpdateMorphMeshVisual already did on that thread). */
+namespace MorphGpu {
+
+    /** One active blend channel, resolved to buffer offsets. MUST match MorphFold.hlsl's ChannelRecord. */
+    struct ChannelRecord {
+        uint32_t FrameA;     // float3 index into Positions of this channel's current frame, slot 0
+        uint32_t FrameB;     // ...and of the frame it lerps towards (== FrameA for a single-frame ani)
+        uint32_t Inverse;    // uint index into Indices of this ani's dense vertex -> slot table
+        float    Frac;       // FrameA -> FrameB lerp; exactly 0 for a single-frame ani
+        float    Weight;     // zSinusEase applied twice, as CalcVertPositions does
+        float    Weight1M;   // 1 - Weight, or exactly 1 for a shape ani (it replaces, it does not blend)
+    };
+    static_assert( sizeof( ChannelRecord ) == 24, "MorphFold.hlsl's ChannelRecord mirrors this" );
+
+    /** Immutable per-.MMS tables. Owned by the module for the process lifetime - there are a handful of
+        head prototypes per world and they are shared by every NPC wearing one. */
+    struct Prototype {
+        std::vector<float3>   Positions;
+        std::vector<uint32_t> Indices;
+
+        /** Where each ani of this prototype landed. Keyed by the ani pointer because that is what a
+            captured channel carries, and the pointers are owned by the shared prototype. */
+        struct AniInfo {
+            uint32_t FrameBase;    // float3 index of frame 0, slot 0
+            uint32_t InverseBase;  // uint index of the dense vertex -> slot table
+            int      NumVert;      // slots per frame
+            int      NumFrames;
+        };
+        gtl::flat_hash_map<zCMorphMeshAni*, AniInfo> Anis;
+
+        /** Per submesh: where its wedge -> mesh-vertex table starts, and how long it is. Indexed by
+            zCProgMeshProto submesh index, which is what MeshInfo::MeshIndex holds. */
+        std::vector<uint32_t> WedgeBase;
+        std::vector<uint32_t> WedgeCount;
+
+        uint32_t RestBase = 0;      // float3 index of morphRefMeshVertPos (the no-refShape rest base)
+        int      MeshNumVert = 0;
+        bool     Valid = false;     // false => this prototype can never be folded on the GPU
+    };
+
+    /** One submesh to fold this frame. The backend turns each of these into a single Dispatch. */
+    struct Job {
+        MeshInfo*        Mesh;            // fold target: its vertex buffer is the UAV
+        const Prototype* Proto;
+        uint32_t         RestBase;        // this INSTANCE's rest base (refShapeAni's shape, or Proto->RestBase)
+        uint32_t         WedgeBase;
+        uint32_t         OutVertexCount;
+        uint32_t         ChannelFirst;    // first ChannelRecord of this instance
+        uint32_t         ChannelCount;
+    };
+
+    /** Whether folding on the GPU is the active path. Frozen on first call (see the .cpp): the answer
+        decides how morph vertex buffers are CREATED, so it may not change while any exist. */
+    bool IsActive();
+
+    /** Called once by a backend that has a working fold pipeline, before any world is converted.
+        Without this IsActive() is false and the CPU deform stays the path. */
+    void SetBackendAvailable( bool available );
+
+    /** Snapshots this instance's channels and queues one Job per submesh. Returns false if this
+        prototype/instance cannot be folded on the GPU, in which case the caller must fall back to the
+        CPU deform for it (the reason is logged once per prototype). Thread-safe. */
+    bool Register( zCMorphMesh* mm, MeshVisualInfo* mvi );
+
+    /** Hands the queued work to the backend's dispatch and empties the queue, in one locked step.
+     *
+     *  A MOVE rather than a peek, for two reasons. Register() can run on the worker pool, so a borrowed
+     *  reference could be reallocated under the dispatch mid-walk; and Job::ChannelFirst indexes the channel
+     *  array, so the two containers may only ever be emptied together - clearing the channels while a Job
+     *  survived would repoint it at some other instance's channels.
+     *
+     *  A Job registered AFTER this returns is therefore not lost and not misindexed: it lands in the now-empty
+     *  queue and folds at the NEXT frame's dispatch. The ghost-VOB pass collects its attachments that late (and
+     *  a shadow-only instance can too), so those instances run one frame behind on facial animation.
+     *
+     *  The caller should reuse the same two vectors every frame; they come back with their capacity intact, so
+     *  this settles into zero per-frame allocations. */
+    void TakeJobs( std::vector<Job>& outJobs, std::vector<ChannelRecord>& outChannels );
+
+    /** Total bytes of prototype tables built so far, for the diagnostic log. */
+    size_t ResidentTableBytes();
+}

--- a/D3D11Engine/Shaders/D3D12/MorphFold.hlsl
+++ b/D3D11Engine/Shaders/D3D12/MorphFold.hlsl
@@ -1,11 +1,9 @@
 // GPU morph fold (D3D12MorphFold.cpp / MorphGpu.h) — the compute form of zCMorphMesh::CalcVertPositions.
 //
 // One thread per output VERTEX of one morph submesh. Each thread folds that vertex's blend channels and
-// rewrites ONLY the 12-byte Position of the vertex already sitting in the submesh's vertex buffer; the
-// normal/tangent/UV/color bytes beside it are per-wedge data written once at conversion, so nothing else
-// is read or copied. That is what lets this pass leave the vertex buffer bindable exactly as it was —
-// no new input layouts, no changes to the four attachment PSOs, and the CSM/point-shadow passes fold for
-// free because they draw the same buffer.
+// rewrites ONLY the 12-byte Position in place; the normal/tangent/UV/color bytes beside it are per-wedge data
+// written once at conversion. The buffer therefore stays bindable exactly as it was — no new input layouts,
+// no PSO changes, and the CSM/point-shadow passes fold for free because they draw the same buffer.
 //
 // The blend is a SEQUENTIAL FOLD, not a weighted sum:
 //     acc = Weight1M * acc + sample * Weight     (per channel, IN CHANNEL ORDER)

--- a/D3D11Engine/Shaders/D3D12/MorphFold.hlsl
+++ b/D3D11Engine/Shaders/D3D12/MorphFold.hlsl
@@ -1,0 +1,86 @@
+// GPU morph fold (D3D12MorphFold.cpp / MorphGpu.h) — the compute form of zCMorphMesh::CalcVertPositions.
+//
+// One thread per output VERTEX of one morph submesh. Each thread folds that vertex's blend channels and
+// rewrites ONLY the 12-byte Position of the vertex already sitting in the submesh's vertex buffer; the
+// normal/tangent/UV/color bytes beside it are per-wedge data written once at conversion, so nothing else
+// is read or copied. That is what lets this pass leave the vertex buffer bindable exactly as it was —
+// no new input layouts, no changes to the four attachment PSOs, and the CSM/point-shadow passes fold for
+// free because they draw the same buffer.
+//
+// The blend is a SEQUENTIAL FOLD, not a weighted sum:
+//     acc = Weight1M * acc + sample * Weight     (per channel, IN CHANNEL ORDER)
+// so ChannelFirst..ChannelFirst+ChannelCount must stay in the order ZENGIN folds them, and a channel that
+// does not touch this vertex has to be skipped ENTIRELY (leaving acc alone) rather than contributing zero.
+// See MorphBlend.h for the full derivation; the easing (ZENGIN's double zSinusEase over its quantised
+// zSinApprox table) is already baked into Weight/Weight1M on the CPU, so it never appears here.
+//
+// Everything rides on root descriptors / root constants — no descriptor tables, no heap slots.
+
+// Mirrors MorphGpu::ChannelRecord (24 B).
+struct ChannelRecord
+{
+    uint  FrameA;     // float3 index into Positions: this channel's current frame, slot 0
+    uint  FrameB;     // ...and the frame it lerps towards (== FrameA for a single-frame ani)
+    uint  Inverse;    // uint index into Indices: this ani's dense vertex -> slot table
+    float Frac;       // FrameA -> FrameB lerp; exactly 0 for a single-frame ani
+    float Weight;
+    float Weight1M;   // 1 - Weight, or exactly 1 for a shape ani (replaces instead of blending)
+};
+
+cbuffer MorphFoldCB : register( b0 )
+{
+    uint OutVertexCount;   // wedges in this submesh — the dispatch is padded up, so threads must range-check
+    uint VertexStride;     // bytes per vertex in the output buffer (sizeof(ExVertexStruct))
+    uint RestBase;         // float3 index of THIS INSTANCE's rest base (refShape shape, or morphRefMeshVertPos)
+    uint WedgeBase;        // uint index of this submesh's wedge -> mesh-vertex table
+    uint ChannelFirst;     // first ChannelRecord of this instance
+    uint ChannelCount;     // 0 is legal and normal: an instance with no active channel is the pure rest pose
+    uint _morphPad0;
+    uint _morphPad1;
+};
+
+// Both are per-PROTOTYPE (per .MMS) and immutable for the session — built once by MorphGpu and uploaded to
+// VRAM. Positions holds the rest bases plus every ani's vertPosMatrix concatenated; Indices holds the
+// per-ani inverse tables followed by the per-submesh wedge tables.
+StructuredBuffer<float3>        Positions : register( t0 );
+StructuredBuffer<uint>          Indices   : register( t1 );
+StructuredBuffer<ChannelRecord> Channels  : register( t2 );   // per-frame, all instances of the frame
+
+// The submesh's own vertex buffer, in place. Raw rather than structured because the vertex is 60 bytes of
+// mixed formats and only its first 12 are ours to touch.
+RWByteAddressBuffer OutVertices : register( u0 );
+
+#define MORPH_NO_SLOT 0xFFFFFFFFu
+
+[numthreads( 64, 1, 1 )]
+void CSFold( uint3 dtid : SV_DispatchThreadID )
+{
+    const uint wedge = dtid.x;
+    if ( wedge >= OutVertexCount )
+        return;
+
+    // Several wedges share one mesh vertex (a crease duplicates the wedge, not the position), so this is a
+    // gather: every wedge of a position folds the same channels and arrives at the same result.
+    const uint v = Indices[WedgeBase + wedge];
+
+    float3 acc = float3( 0.0f, 0.0f, 0.0f );
+    for ( uint i = 0; i < ChannelCount; ++i )
+    {
+        const ChannelRecord c = Channels[ChannelFirst + i];
+        const uint slot = Indices[c.Inverse + v];
+        if ( slot == MORPH_NO_SLOT )
+            continue;   // this ani does not touch this vertex — acc must survive untouched, not be scaled
+
+        const float3 a = Positions[c.FrameA + slot];
+        const float3 b = Positions[c.FrameB + slot];
+        // Written as a + frac*(b-a) to match MorphBlend::Apply's `sample += frac * (next - sample)` term
+        // for term; with Frac == 0 it degenerates to `a` exactly, which is the CPU's non-lerping branch.
+        const float3 sample = a + c.Frac * ( b - a );
+        acc = c.Weight1M * acc + sample * c.Weight;
+    }
+
+    // CalcVertPositions' trailing add of the rest base.
+    acc += Positions[RestBase + v];
+
+    OutVertices.Store3( wedge * VertexStride, asuint( acc ) );
+}

--- a/D3D11Engine/SharedVisualRegistry.cpp
+++ b/D3D11Engine/SharedVisualRegistry.cpp
@@ -1,0 +1,115 @@
+#include "pch.h"
+#include "SharedVisualRegistry.h"
+#include "WorldObjects.h"
+
+SharedVisualRegistry* s_SharedVisualRegistry = new SharedVisualRegistry();
+
+SharedVisualRegistry::~SharedVisualRegistry() {
+    Clear();
+}
+
+MeshVisualInfo* SharedVisualRegistry::Acquire( zCVisual* key, bool& outNeedsFill ) {
+    std::scoped_lock lock( m_mutex );
+    m_TotalAcquires++;
+
+    auto it = m_Visuals.find( key );
+    if ( it != m_Visuals.end() ) {
+        MeshVisualInfo* mvi = it->second;
+        mvi->SharedRefs++;
+
+        // A cancelled extraction (world change / shutdown flush) leaves a finished-but-empty entry
+        // behind. Without this it would stay empty forever and every vob sharing it would render an
+        // invisible weapon, because the "visual changed" check just re-enters here and gets the same
+        // dead object back. Hand it out for a refill instead.
+        outNeedsFill = mvi->Ready.load( std::memory_order_acquire ) && !mvi->Visual;
+        if ( outNeedsFill ) {
+            mvi->Ready.store( false, std::memory_order_release );
+        }
+        return mvi;
+    }
+
+    MeshVisualInfo* mvi = new MeshVisualInfo;
+    mvi->SharedKey = key;
+    mvi->SharedRefs = 1;
+    m_Visuals[key] = mvi;
+    m_TotalConversions++;
+    m_PeakSize = std::max( m_PeakSize, m_Visuals.size() );
+
+    outNeedsFill = true;
+    return mvi;
+}
+
+void SharedVisualRegistry::Release( MeshVisualInfo* mvi ) {
+    if ( !mvi ) {
+        return;
+    }
+
+    {
+        std::scoped_lock lock( m_mutex );
+        if ( mvi->SharedRefs > 1 ) {
+            mvi->SharedRefs--;
+            return;
+        }
+
+        mvi->SharedRefs = 0;
+        // Unregister() may already have dropped the mapping, in which case there is nothing to erase.
+        if ( mvi->SharedKey ) {
+            auto it = m_Visuals.find( mvi->SharedKey );
+            if ( it != m_Visuals.end() && it->second == mvi ) {
+                m_Visuals.erase( it );
+            }
+            mvi->SharedKey = nullptr;
+        }
+    }
+
+    // Outside the lock: ~MeshVisualInfo blocks on any in-flight extraction job for this visual, and
+    // that job has no business waiting on the registry mutex behind us.
+    delete mvi;
+}
+
+void SharedVisualRegistry::Unregister( zCVisual* key ) {
+    std::scoped_lock lock( m_mutex );
+
+    auto it = m_Visuals.find( key );
+    if ( it == m_Visuals.end() ) {
+        return;
+    }
+
+    it->second->SharedKey = nullptr;
+    m_Visuals.erase( it );
+}
+
+void SharedVisualRegistry::Clear() {
+    std::vector<MeshVisualInfo*> doomed;
+    {
+        std::scoped_lock lock( m_mutex );
+        doomed.reserve( m_Visuals.size() );
+        for ( auto const& it : m_Visuals ) {
+            if ( it.second->SharedRefs != 0 ) {
+                LogWarn() << "SharedVisualRegistry: dropping attachment visual '" << it.second->VisualName
+                    << "' that still has " << it.second->SharedRefs << " reference(s)";
+            }
+            it.second->SharedKey = nullptr;
+            it.second->SharedRefs = 0;
+            doomed.emplace_back( it.second );
+        }
+        m_Visuals.clear();
+
+        if ( m_TotalAcquires ) {
+            LogInfo() << "SharedVisualRegistry: " << m_TotalAcquires << " attachment(s) served by "
+                << m_TotalConversions << " converted mesh(es), peak " << m_PeakSize << " resident";
+        }
+        m_TotalAcquires = 0;
+        m_TotalConversions = 0;
+        m_PeakSize = 0;
+    }
+
+    for ( MeshVisualInfo* mvi : doomed ) {
+        delete mvi;
+    }
+}
+
+size_t SharedVisualRegistry::Size() const {
+    std::scoped_lock lock( m_mutex );
+    return m_Visuals.size();
+}

--- a/D3D11Engine/SharedVisualRegistry.cpp
+++ b/D3D11Engine/SharedVisualRegistry.cpp
@@ -17,10 +17,8 @@ MeshVisualInfo* SharedVisualRegistry::Acquire( const void* key, bool& outNeedsFi
         MeshVisualInfo* mvi = it->second;
         mvi->SharedRefs++;
 
-        // A cancelled extraction (world change / shutdown flush) leaves a finished-but-empty entry
-        // behind. Without this it would stay empty forever and every vob sharing it would render an
-        // invisible weapon, because the "visual changed" check just re-enters here and gets the same
-        // dead object back. Hand it out for a refill instead.
+        // A cancelled extraction leaves a finished-but-empty entry. Hand it out for a refill, or it
+        // stays empty forever - the "visual changed" check just lands back here on the same dead object.
         outNeedsFill = mvi->Ready.load( std::memory_order_acquire ) && !mvi->Visual;
         if ( outNeedsFill ) {
             mvi->Ready.store( false, std::memory_order_release );
@@ -31,8 +29,7 @@ MeshVisualInfo* SharedVisualRegistry::Acquire( const void* key, bool& outNeedsFi
     MeshVisualInfo* mvi = new MeshVisualInfo;
     mvi->SharedKey = key;
     mvi->SharedRefs = 1;
-    // Not ready until the caller has filled it. Handing out a fresh entry as "ready" would let a second
-    // acquirer draw it while it is still empty (or, worse, while a worker is writing it).
+    // Not ready until filled, or a second acquirer could draw it mid-write.
     mvi->Ready.store( false, std::memory_order_release );
     m_Visuals[key] = mvi;
     m_TotalConversions++;
@@ -55,8 +52,7 @@ void SharedVisualRegistry::Release( MeshVisualInfo* mvi ) {
         }
 
         mvi->SharedRefs = 0;
-        // Unregister() may already have dropped the mapping, in which case there is nothing to erase.
-        if ( mvi->SharedKey ) {
+        if ( mvi->SharedKey ) {   // null if Unregister() already dropped the mapping
             auto it = m_Visuals.find( mvi->SharedKey );
             if ( it != m_Visuals.end() && it->second == mvi ) {
                 m_Visuals.erase( it );
@@ -65,8 +61,7 @@ void SharedVisualRegistry::Release( MeshVisualInfo* mvi ) {
         }
     }
 
-    // Outside the lock: ~MeshVisualInfo blocks on any in-flight extraction job for this visual, and
-    // that job has no business waiting on the registry mutex behind us.
+    // Outside the lock: ~MeshVisualInfo waits on any in-flight extraction job for this visual.
     delete mvi;
 }
 

--- a/D3D11Engine/SharedVisualRegistry.cpp
+++ b/D3D11Engine/SharedVisualRegistry.cpp
@@ -8,7 +8,7 @@ SharedVisualRegistry::~SharedVisualRegistry() {
     Clear();
 }
 
-MeshVisualInfo* SharedVisualRegistry::Acquire( zCVisual* key, bool& outNeedsFill ) {
+MeshVisualInfo* SharedVisualRegistry::Acquire( const void* key, bool& outNeedsFill ) {
     std::scoped_lock lock( m_mutex );
     m_TotalAcquires++;
 
@@ -31,6 +31,9 @@ MeshVisualInfo* SharedVisualRegistry::Acquire( zCVisual* key, bool& outNeedsFill
     MeshVisualInfo* mvi = new MeshVisualInfo;
     mvi->SharedKey = key;
     mvi->SharedRefs = 1;
+    // Not ready until the caller has filled it. Handing out a fresh entry as "ready" would let a second
+    // acquirer draw it while it is still empty (or, worse, while a worker is writing it).
+    mvi->Ready.store( false, std::memory_order_release );
     m_Visuals[key] = mvi;
     m_TotalConversions++;
     m_PeakSize = std::max( m_PeakSize, m_Visuals.size() );
@@ -67,7 +70,7 @@ void SharedVisualRegistry::Release( MeshVisualInfo* mvi ) {
     delete mvi;
 }
 
-void SharedVisualRegistry::Unregister( zCVisual* key ) {
+void SharedVisualRegistry::Unregister( const void* key ) {
     std::scoped_lock lock( m_mutex );
 
     auto it = m_Visuals.find( key );

--- a/D3D11Engine/SharedVisualRegistry.h
+++ b/D3D11Engine/SharedVisualRegistry.h
@@ -5,29 +5,12 @@
 struct MeshVisualInfo;
 class zCVisual;
 
-/** Engine-wide cache of converted node-attachment visuals, keyed by the game's own zCVisual pointer.
+/** Refcounted cache of converted node-attachment visuals, so 40 orcs carrying the same axe share one
+ *  MeshVisualInfo instead of converting 40 identical copies into 40 buffer sets.
  *
- *  Every skeletal vob (i.e. every NPC) hangs weapons, shields, heads and held items off its model
- *  nodes. Those attachments used to be converted per *vob*: 40 orcs carrying the same axe meant 40
- *  MeshVisualInfos, 40 vertex/index/shadow-index buffer sets and 40 system-memory vertex copies of
- *  one axe. In a 32-bit address space that is exactly the allocation pattern the project bans (see
- *  CLAUDE.md, "Performance constraints") - and it also paid the wedge-unpack + meshoptimizer cost
- *  once per vob instead of once per mesh.
- *
- *  ZENGIN already caches visuals by filename, so all those orcs hand us the *same* zCVisual pointer.
- *  That pointer is therefore the natural identity key - and it is already what the draw loops compare
- *  against to notice "this node's attachment changed". Entries are refcounted: a vob acquires on
- *  extraction and releases when the attachment is swapped out or the vob dies.
- *
- *  Sharing is self-validating for morph meshes (.MMS): they only collapse when the game handed out
- *  the same zCMorphMesh, in which case they also share the morph animation state that
- *  UpdateMorphMeshVisual reads, so one shared deformed vertex buffer is what the game is describing
- *  anyway. Distinct per-NPC zCMorphMeshes keep distinct keys and simply never share.
- *
- *  All calls are main-thread today (extraction is kicked from the draw/update loops), but the mutex
- *  is kept because MeshVisualInfo filling itself runs on the worker pool and the cost here is nil -
- *  this is a per-attachment-change path, never a per-draw one.
- */
+ *  Keyed on the game's own visual pointer: ZENGIN caches visuals by filename, so identical attachments
+ *  really do arrive as one pointer. That also makes .MMS sharing self-validating - two morph meshes
+ *  only collapse when they share the zCMorphMesh whose animation state deforms them. */
 class SharedVisualRegistry {
 public:
     SharedVisualRegistry() = default;
@@ -36,28 +19,19 @@ public:
     SharedVisualRegistry( const SharedVisualRegistry& ) = delete;
     SharedVisualRegistry& operator=( const SharedVisualRegistry& ) = delete;
 
-    /** Returns the shared MeshVisualInfo for this visual, bumping its refcount.
-     *
-     *  'outNeedsFill' is true when the caller is responsible for actually converting the mesh into
-     *  the returned (empty) object - either because it was just created, or because a previous
-     *  extraction was cancelled and left it empty. When it comes back false the mesh is already
-     *  built (or is being built right now by a worker, in which case MeshVisualInfo::Ready is still
-     *  false and draw sites skip it as usual) and the caller must not touch it.
-     *
-     *  Never returns nullptr. */
+    /** Returns the shared visual, bumping its refcount. Never null. 'outNeedsFill' means the caller
+        must convert the mesh into the returned (empty) object; when false it is already built, or a
+        worker is still building it and Ready is false. */
     MeshVisualInfo* Acquire( const void* key, bool& outNeedsFill );
 
     /** Drops one reference. Destroys the visual (and unregisters it) when the last one goes. */
     void Release( MeshVisualInfo* mvi );
 
-    /** Removes the key -> visual mapping without touching refcounts. Called when Gothic frees a
-     *  visual: the pointer may be recycled for something completely different, so it must not stay
-     *  a valid lookup key. Attachments still holding the entry keep it alive until they release it,
-     *  and their own "visual changed" check retires them on the next frame. */
+    /** Drops the key -> visual mapping without touching refcounts, for when Gothic frees a visual and
+        the address can be recycled for something unrelated. Holders keep the entry alive. */
     void Unregister( const void* key );
 
-    /** Drops every entry regardless of refcount. Only for world teardown, after all vobs (and hence
-     *  all attachment references) are already gone. Logs anything still referenced. */
+    /** Drops every entry regardless of refcount. World teardown only, after all vobs are gone. */
     void Clear();
 
     size_t Size() const;
@@ -66,8 +40,7 @@ private:
     mutable std::mutex m_mutex;
     gtl::flat_hash_map<const void*, MeshVisualInfo*> m_Visuals;
 
-    /** Lifetime tallies for the summary Clear() logs - the ratio between them is the sharing factor
-        this whole class exists for (how many attachment slots one converted mesh ended up serving). */
+    /** Lifetime tallies for the Clear() summary; their ratio is the sharing factor. */
     size_t m_TotalAcquires = 0;
     size_t m_TotalConversions = 0;
     size_t m_PeakSize = 0;

--- a/D3D11Engine/SharedVisualRegistry.h
+++ b/D3D11Engine/SharedVisualRegistry.h
@@ -45,7 +45,7 @@ public:
      *  false and draw sites skip it as usual) and the caller must not touch it.
      *
      *  Never returns nullptr. */
-    MeshVisualInfo* Acquire( zCVisual* key, bool& outNeedsFill );
+    MeshVisualInfo* Acquire( const void* key, bool& outNeedsFill );
 
     /** Drops one reference. Destroys the visual (and unregisters it) when the last one goes. */
     void Release( MeshVisualInfo* mvi );
@@ -54,7 +54,7 @@ public:
      *  visual: the pointer may be recycled for something completely different, so it must not stay
      *  a valid lookup key. Attachments still holding the entry keep it alive until they release it,
      *  and their own "visual changed" check retires them on the next frame. */
-    void Unregister( zCVisual* key );
+    void Unregister( const void* key );
 
     /** Drops every entry regardless of refcount. Only for world teardown, after all vobs (and hence
      *  all attachment references) are already gone. Logs anything still referenced. */
@@ -64,7 +64,7 @@ public:
 
 private:
     mutable std::mutex m_mutex;
-    gtl::flat_hash_map<zCVisual*, MeshVisualInfo*> m_Visuals;
+    gtl::flat_hash_map<const void*, MeshVisualInfo*> m_Visuals;
 
     /** Lifetime tallies for the summary Clear() logs - the ratio between them is the sharing factor
         this whole class exists for (how many attachment slots one converted mesh ended up serving). */

--- a/D3D11Engine/SharedVisualRegistry.h
+++ b/D3D11Engine/SharedVisualRegistry.h
@@ -1,0 +1,76 @@
+#pragma once
+#include "pch.h"
+#include <mutex>
+
+struct MeshVisualInfo;
+class zCVisual;
+
+/** Engine-wide cache of converted node-attachment visuals, keyed by the game's own zCVisual pointer.
+ *
+ *  Every skeletal vob (i.e. every NPC) hangs weapons, shields, heads and held items off its model
+ *  nodes. Those attachments used to be converted per *vob*: 40 orcs carrying the same axe meant 40
+ *  MeshVisualInfos, 40 vertex/index/shadow-index buffer sets and 40 system-memory vertex copies of
+ *  one axe. In a 32-bit address space that is exactly the allocation pattern the project bans (see
+ *  CLAUDE.md, "Performance constraints") - and it also paid the wedge-unpack + meshoptimizer cost
+ *  once per vob instead of once per mesh.
+ *
+ *  ZENGIN already caches visuals by filename, so all those orcs hand us the *same* zCVisual pointer.
+ *  That pointer is therefore the natural identity key - and it is already what the draw loops compare
+ *  against to notice "this node's attachment changed". Entries are refcounted: a vob acquires on
+ *  extraction and releases when the attachment is swapped out or the vob dies.
+ *
+ *  Sharing is self-validating for morph meshes (.MMS): they only collapse when the game handed out
+ *  the same zCMorphMesh, in which case they also share the morph animation state that
+ *  UpdateMorphMeshVisual reads, so one shared deformed vertex buffer is what the game is describing
+ *  anyway. Distinct per-NPC zCMorphMeshes keep distinct keys and simply never share.
+ *
+ *  All calls are main-thread today (extraction is kicked from the draw/update loops), but the mutex
+ *  is kept because MeshVisualInfo filling itself runs on the worker pool and the cost here is nil -
+ *  this is a per-attachment-change path, never a per-draw one.
+ */
+class SharedVisualRegistry {
+public:
+    SharedVisualRegistry() = default;
+    ~SharedVisualRegistry();
+
+    SharedVisualRegistry( const SharedVisualRegistry& ) = delete;
+    SharedVisualRegistry& operator=( const SharedVisualRegistry& ) = delete;
+
+    /** Returns the shared MeshVisualInfo for this visual, bumping its refcount.
+     *
+     *  'outNeedsFill' is true when the caller is responsible for actually converting the mesh into
+     *  the returned (empty) object - either because it was just created, or because a previous
+     *  extraction was cancelled and left it empty. When it comes back false the mesh is already
+     *  built (or is being built right now by a worker, in which case MeshVisualInfo::Ready is still
+     *  false and draw sites skip it as usual) and the caller must not touch it.
+     *
+     *  Never returns nullptr. */
+    MeshVisualInfo* Acquire( zCVisual* key, bool& outNeedsFill );
+
+    /** Drops one reference. Destroys the visual (and unregisters it) when the last one goes. */
+    void Release( MeshVisualInfo* mvi );
+
+    /** Removes the key -> visual mapping without touching refcounts. Called when Gothic frees a
+     *  visual: the pointer may be recycled for something completely different, so it must not stay
+     *  a valid lookup key. Attachments still holding the entry keep it alive until they release it,
+     *  and their own "visual changed" check retires them on the next frame. */
+    void Unregister( zCVisual* key );
+
+    /** Drops every entry regardless of refcount. Only for world teardown, after all vobs (and hence
+     *  all attachment references) are already gone. Logs anything still referenced. */
+    void Clear();
+
+    size_t Size() const;
+
+private:
+    mutable std::mutex m_mutex;
+    gtl::flat_hash_map<zCVisual*, MeshVisualInfo*> m_Visuals;
+
+    /** Lifetime tallies for the summary Clear() logs - the ratio between them is the sharing factor
+        this whole class exists for (how many attachment slots one converted mesh ended up serving). */
+    size_t m_TotalAcquires = 0;
+    size_t m_TotalConversions = 0;
+    size_t m_PeakSize = 0;
+};
+
+extern SharedVisualRegistry* s_SharedVisualRegistry;

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -2101,15 +2101,13 @@ void WorldConverter::UpdateMorphMeshVisual( void* v, MeshVisualInfo* meshInfo ) 
 
     MorphBlend::LogPrototypeBudget( visual );
 
-    // GPU fold: everything below - the deform, the per-wedge ExVertexStruct expansion and the full
-    // vertex-buffer re-upload - becomes one Dispatch per submesh that the backend records later this frame.
-    // All that happens here is snapshotting the channel state, which is why AdvanceAnis above still runs (it
-    // is the animation STATE machine, not the deform) and the tex-ani update below is unaffected.
+    // GPU fold: everything below - the deform, the per-wedge ExVertexStruct expansion and the vertex-buffer
+    // re-upload - becomes one Dispatch per submesh the backend records later this frame. All that happens
+    // here is snapshotting the channel state.
     //
-    // There is deliberately NO CPU fallback inside this mode: the vertex buffers are GPU-written DEFAULT-heap
-    // UAVs, so nothing here could write them anyway. An instance Register() refuses (the cases are listed in
-    // MorphGpu.cpp - all of them content shapes not seen in shipped .MMS files) keeps the undeformed
-    // conversion pose, which is exactly what every out-of-range morph attachment already draws.
+    // No CPU fallback inside this mode: the vertex buffers are GPU-written DEFAULT-heap UAVs, so nothing here
+    // could write them. An instance Register() refuses (see MorphGpu.cpp) keeps the undeformed conversion
+    // pose, which is what every out-of-range morph attachment already draws.
     if ( MorphGpu::IsActive() ) {
         MorphGpu::Register( visual, meshInfo );
         return;
@@ -2263,15 +2261,12 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
         Engine::GraphicsEngine->CreateVertexBuffer( mi->MeshIndexBuffer );
 
         if ( meshInfo->MorphMeshVisual ) {
-            // A morph submesh deliberately skips OptimizeFaces/OptimizeVertices: the wedge numbering has to
-            // survive, because both deform paths address this buffer by WEDGE INDEX (the CPU one rebuilds the
-            // whole stream in wedge order, the GPU fold writes one vertex per wedge). It is also what keeps
-            // mi->Vertices an exact description of the buffer's non-position bytes.
+            // A morph submesh deliberately skips OptimizeFaces/OptimizeVertices: both deform paths address
+            // this buffer by WEDGE INDEX, so the wedge numbering has to survive.
             if ( MorphGpu::IsActive() ) {
-                // GPU fold: a DEFAULT-heap (VRAM) UAV written by MorphFold.hlsl, never by the CPU. The
-                // initial contents are this conversion's pose, so the mesh is already drawable before its
-                // first fold, and the normal/tangent/UV/color bytes written here are final - the fold only
-                // ever rewrites the leading 12-byte Position of each vertex.
+                // GPU fold: a DEFAULT-heap UAV written by MorphFold.hlsl, never by the CPU. Initialized with
+                // this conversion's pose, so it is drawable before its first fold; the fold only ever
+                // rewrites the leading 12-byte Position of each vertex.
                 mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ),
                     static_cast<GfxVertexBuffer::EBindFlags>( GfxVertexBuffer::B_VERTEXBUFFER | GfxVertexBuffer::B_UNORDERED_ACCESS ),
                     GfxVertexBuffer::U_DEFAULT );
@@ -2347,10 +2342,9 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
             i++;
         }
 
-        // No wrapped MeshInfo built from wrappedVertices/wrappedIndices any more: MeshVisualInfo::FullMesh
-        // was write-only - nothing ever bound it - so it was two IMMUTABLE buffers per converted visual
-        // (a full duplicate of every submesh vertex plus 32-bit indices) that only cost VRAM and 32-bit
-        // address space. WrapVertexBuffers still runs: BaseIndexLocation above is read by the draw paths.
+        // MeshVisualInfo::FullMesh is gone: it was write-only, two IMMUTABLE buffers per converted visual
+        // costing only VRAM and address space. WrapVertexBuffers still runs - the draw paths read
+        // BaseIndexLocation above.
     }
 
     // Every submesh was empty: don't let the ±FLT_MAX seeds turn MeshSize into an infinity.

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -24,6 +24,7 @@
 #include "zCQuadMark.h"
 #include <meshoptimizer/src/meshoptimizer.h>
 #include "MeshManager.h"
+#include "SharedVisualRegistry.h"
 #include "ThreadPool.h"
 #include "vendor/mikktspace.h"
 #include "VertexPacking.h"
@@ -1841,15 +1842,23 @@ void WorldConverter::ExtractProgMeshProtoFromMesh( zCMesh* mesh, MeshVisualInfo*
     meshInfo->Visual = reinterpret_cast<zCVisual*>(mesh);
 }
 
+/** Drops this node's attachment(s) back to the shared registry and empties the slot. Leaves the slot
+    itself present in the map: callers use find() != end() to mean "extraction was already attempted
+    for this node", and re-creating it every frame would re-kick extraction forever. */
+void WorldConverter::ReleaseNodeAttachments( gtl::flat_hash_map<int, std::vector<MeshVisualInfo*>>& attachments, int index ) {
+    auto& slot = attachments[index];
+    for ( MeshVisualInfo* mvi : slot ) {
+        s_SharedVisualRegistry->Release( mvi );
+    }
+    slot.clear();
+}
+
 /** Extracts a node-visual */
 void WorldConverter::ExtractNodeVisual( int index, zCModelNodeInst* node, gtl::flat_hash_map<int, std::vector<MeshVisualInfo*>>& attachments ) {
     ZoneScoped;
 
     // Only allow 1 attachment
-    if ( !attachments[index].empty() ) {
-        delete attachments[index][0];
-        attachments[index].clear();
-    }
+    ReleaseNodeAttachments( attachments, index );
 
     // Extract node visuals
     if ( node->NodeVisual ) {
@@ -1866,21 +1875,31 @@ void WorldConverter::ExtractNodeVisual( int index, zCModelNodeInst* node, gtl::f
                 return;
             }
 
-            MeshVisualInfo* mi = new MeshVisualInfo;
-            if ( isMMS ) {
-                mi->MorphMeshVisual = reinterpret_cast<void*>(node->NodeVisual);
-                zCObject_AddRef( mi->MorphMeshVisual );
-            }
+            // Every other vob carrying this exact visual gets the same object back - the conversion
+            // and its buffers only happen for the first one. See SharedVisualRegistry.h.
+            bool needsFill = false;
+            MeshVisualInfo* mi = s_SharedVisualRegistry->Acquire( node->NodeVisual, needsFill );
+            if ( needsFill ) {
+                if ( isMMS && !mi->MorphMeshVisual ) {
+                    mi->MorphMeshVisual = reinterpret_cast<void*>(node->NodeVisual);
+                    zCObject_AddRef( mi->MorphMeshVisual );
+                }
 
-            Extract3DSMeshFromVisual2( pm, mi );
-            if ( isMMS ) {
-                mi->Visual = node->NodeVisual;
+                Extract3DSMeshFromVisual2( pm, mi );
+                if ( isMMS ) {
+                    mi->Visual = node->NodeVisual;
+                }
+                mi->Ready.store( true, std::memory_order_release );
             }
 
             attachments[index].emplace_back( mi );
         } else if ( strcmp( ext, ".MDS" ) == 0 || strcmp( ext, ".ASC" ) == 0 ) {
-            MeshVisualInfo* mi = new MeshVisualInfo;
-            ExtractProgMeshProtoFromModel( static_cast<zCModel*>(node->NodeVisual), mi );
+            bool needsFill = false;
+            MeshVisualInfo* mi = s_SharedVisualRegistry->Acquire( node->NodeVisual, needsFill );
+            if ( needsFill ) {
+                ExtractProgMeshProtoFromModel( static_cast<zCModel*>(node->NodeVisual), mi );
+                mi->Ready.store( true, std::memory_order_release );
+            }
             attachments[index].emplace_back( mi );
         }
     }
@@ -1966,21 +1985,26 @@ void WorldConverter::ExtractNodeVisualAsync( int index, zCModelNodeInst* node, g
 
     // Only allow 1 attachment (same rule as the synchronous path). The MeshVisualInfo destructor blocks
     // on this visual's own job, so replacing an attachment that is still being extracted is safe.
-    if ( !attachments[index].empty() ) {
-        delete attachments[index][0];
-        attachments[index].clear();
+    ReleaseNodeAttachments( attachments, index );
+
+    // Shared across every vob carrying this visual. If somebody already built (or is building) it, we
+    // are done here - no second conversion, no second set of buffers, no second worker job. This is
+    // where a crowd of identically-armed NPCs stops costing anything past the first one.
+    bool needsFill = false;
+    MeshVisualInfo* mi = s_SharedVisualRegistry->Acquire( node->NodeVisual, needsFill );
+    attachments[index].emplace_back( mi );
+    if ( !needsFill ) {
+        return;
     }
 
     // Build the shell on this thread so the caller can already identify the attachment (Visual is what
     // the "did the visual change?" check compares against), then let a worker fill in the meshes.
-    MeshVisualInfo* mi = new MeshVisualInfo;
     mi->Visual = node->NodeVisual;
-    if ( isMMS ) {
+    if ( isMMS && !mi->MorphMeshVisual ) {
         mi->MorphMeshVisual = reinterpret_cast<void*>(node->NodeVisual);
         zCObject_AddRef( mi->MorphMeshVisual );
     }
     mi->Ready.store( false, std::memory_order_relaxed );
-    attachments[index].emplace_back( mi );
 
     zCVisual* nodeVisual = node->NodeVisual;
     auto task = Engine::WorkerThreadPool->enqueue( [pm, mi, isMMS]( const std::stop_token& token ) {

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -1843,10 +1843,10 @@ void WorldConverter::ExtractProgMeshProtoFromMesh( zCMesh* mesh, MeshVisualInfo*
 }
 
 namespace {
-    /** Everything needed to build a morph attachment's undeformed rest mesh, resolved on the game thread
-        (these fields can change under us - StartAni can install a refShapeAni at any time). */
+    /** Rest-mesh source for a morph attachment. Resolved on the game thread - StartAni can install a
+        refShapeAni at any time, which changes the rest pose. */
     struct MorphRestSource {
-        const void* Key = nullptr;          // shared identity; null means "no rest mesh for this one"
+        const void* Key = nullptr;          // null means "no rest mesh for this one"
         const float3* Positions = nullptr;  // pristine, never written by the engine after load
         int NumVert = 0;
     };
@@ -1857,12 +1857,8 @@ namespace {
             return src;
         }
 
-        // Instances carrying a refShape ani are handled too, and GetRestPoseKey separates them: their rest
-        // pose comes from the shape ani rather than from morphRefMeshVertPos, so they get their own shared
-        // rest mesh and batch among themselves. That is only safe because both backends now key attachment
-        // batches on the MeshInfo POINTER. They used to key on meshId, which a rest mesh inherits from the
-        // zCSubMesh it was extracted from - so two different rest poses of one head would have collided on
-        // the batch key and rendered each other's geometry.
+        // refShape instances get their own key, hence their own rest mesh. Only safe because attachment
+        // batching keys on the MeshInfo pointer - on meshId, two rest poses of one head would collide.
         const void* key = mm->GetRestPoseKey();
         if ( !key ) {
             return src;
@@ -1878,9 +1874,7 @@ namespace {
         return src;
     }
 
-    /** Acquires (and fills, if we are the first) the shared rest mesh and hangs it off the morph visual.
-        Safe to call from a worker thread - the registry is locked and 'src' was resolved on the game
-        thread. */
+    /** Acquires (and fills, if we are the first) the shared rest mesh. Worker-thread safe. */
     void AttachMorphRestVisual( MeshVisualInfo* morphVisual, zCProgMeshProto* pm, const MorphRestSource& src ) {
         if ( !src.Key || !pm || morphVisual->RestVisual ) {
             return;
@@ -1896,9 +1890,8 @@ namespace {
     }
 }
 
-/** Drops this node's attachment(s) back to the shared registry and empties the slot. Leaves the slot
-    itself present in the map: callers use find() != end() to mean "extraction was already attempted
-    for this node", and re-creating it every frame would re-kick extraction forever. */
+/** Drops this node's attachment(s) back to the shared registry and empties the slot. The slot itself
+    stays in the map - callers read find() != end() as "extraction already attempted for this node". */
 void WorldConverter::ReleaseNodeAttachments( gtl::flat_hash_map<int, std::vector<MeshVisualInfo*>>& attachments, int index ) {
     auto& slot = attachments[index];
     for ( MeshVisualInfo* mvi : slot ) {
@@ -1929,8 +1922,7 @@ void WorldConverter::ExtractNodeVisual( int index, zCModelNodeInst* node, gtl::f
                 return;
             }
 
-            // Every other vob carrying this exact visual gets the same object back - the conversion
-            // and its buffers only happen for the first one. See SharedVisualRegistry.h.
+            // Every other vob with this visual gets the same object back; only the first converts.
             bool needsFill = false;
             MeshVisualInfo* mi = s_SharedVisualRegistry->Acquire( node->NodeVisual, needsFill );
             if ( needsFill ) {
@@ -2042,9 +2034,7 @@ void WorldConverter::ExtractNodeVisualAsync( int index, zCModelNodeInst* node, g
     // on this visual's own job, so replacing an attachment that is still being extracted is safe.
     ReleaseNodeAttachments( attachments, index );
 
-    // Shared across every vob carrying this visual. If somebody already built (or is building) it, we
-    // are done here - no second conversion, no second set of buffers, no second worker job. This is
-    // where a crowd of identically-armed NPCs stops costing anything past the first one.
+    // If somebody already built (or is building) this visual we are done - no second worker job.
     bool needsFill = false;
     MeshVisualInfo* mi = s_SharedVisualRegistry->Acquire( node->NodeVisual, needsFill );
     attachments[index].emplace_back( mi );
@@ -2061,9 +2051,8 @@ void WorldConverter::ExtractNodeVisualAsync( int index, zCModelNodeInst* node, g
     }
     mi->Ready.store( false, std::memory_order_relaxed );
 
-    // Resolved here rather than in the job: refShapeAni can be installed by StartAni at any time, and the
-    // rest pose has to be the one this attachment was identified with. The arrays it points at are
-    // written once at load and never again, so the worker can read them freely.
+    // Resolved here, not in the job: StartAni can install a refShapeAni at any time. The arrays it
+    // points at are written once at load, so the worker can read them freely.
     const MorphRestSource restSource = isMMS
         ? ResolveMorphRestSource( reinterpret_cast<zCMorphMesh*>(node->NodeVisual) )
         : MorphRestSource{};
@@ -2083,8 +2072,7 @@ void WorldConverter::ExtractNodeVisualAsync( int index, zCModelNodeInst* node, g
             // Extract3DSMeshFromVisual2 sets Visual to the morph mesh's inner progmesh; the attachment
             // identity is the outer zCMorphMesh (mirrors ExtractNodeVisual).
             mi->Visual = reinterpret_cast<zCVisual*>(mi->MorphMeshVisual);
-            // Built on the worker too - it is a second full conversion, but only for the FIRST morph mesh
-            // resolving to this rest pose; every other head of the same type just takes a reference.
+            // A second conversion, but only for the first morph mesh resolving to this rest pose.
             AttachMorphRestVisual( mi, pm, restSource );
         }
         mi->Ready.store( true, std::memory_order_release );
@@ -2151,8 +2139,7 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
     XMFLOAT3 bbmin = XMFLOAT3( FLT_MAX, FLT_MAX, FLT_MAX );
     XMFLOAT3 bbmax = XMFLOAT3( -FLT_MAX, -FLT_MAX, -FLT_MAX );
 
-    // Wedges index into the visual's position list, so an override has to cover all of it or the
-    // wedge indices would run off the end - fall back to the live list rather than read out of bounds.
+    // Wedges index the full position list, so a short override would read out of bounds - ignore it.
     zCArrayAdapt<float3>* livePositions = visual->GetPositionList();
     const float3* posList = ( positionOverride && positionOverrideCount >= livePositions->NumInArray )
         ? positionOverride

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -26,6 +26,7 @@
 #include "MeshManager.h"
 #include "SharedVisualRegistry.h"
 #include "MorphBlend.h"
+#include "MorphGpu.h"
 #include "ThreadPool.h"
 #include "vendor/mikktspace.h"
 #include "VertexPacking.h"
@@ -2100,6 +2101,20 @@ void WorldConverter::UpdateMorphMeshVisual( void* v, MeshVisualInfo* meshInfo ) 
 
     MorphBlend::LogPrototypeBudget( visual );
 
+    // GPU fold: everything below - the deform, the per-wedge ExVertexStruct expansion and the full
+    // vertex-buffer re-upload - becomes one Dispatch per submesh that the backend records later this frame.
+    // All that happens here is snapshotting the channel state, which is why AdvanceAnis above still runs (it
+    // is the animation STATE machine, not the deform) and the tex-ani update below is unaffected.
+    //
+    // There is deliberately NO CPU fallback inside this mode: the vertex buffers are GPU-written DEFAULT-heap
+    // UAVs, so nothing here could write them anyway. An instance Register() refuses (the cases are listed in
+    // MorphGpu.cpp - all of them content shapes not seen in shipped .MMS files) keeps the undeformed
+    // conversion pose, which is exactly what every out-of-range morph attachment already draws.
+    if ( MorphGpu::IsActive() ) {
+        MorphGpu::Register( visual, meshInfo );
+        return;
+    }
+
     auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
     if ( settings.VerifyMorphBlend ) {
         // Runs both deforms and reports the worst disagreement. Deliberately rate-limited rather than
@@ -2248,16 +2263,23 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
         Engine::GraphicsEngine->CreateVertexBuffer( mi->MeshIndexBuffer );
 
         if ( meshInfo->MorphMeshVisual ) {
-            // We need to keep original indices so that we can reuse them(we can't optimize them)
-            // Use dynamic buffer since we'll reupload it every frame we see this visual
-
-            // Handed back again once this instance stops deforming, and rebuilt from mi->Vertices on the
-            // next draw that needs it - see MeshVisualInfo::ReleaseIdleMorphVertexBuffers. Skipping the
-            // optimizers above is what keeps Vertices a valid description of this buffer.
-            mi->DynamicMorphVertices = true;
-
-            // Init and fill it
-            mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_DYNAMIC, D3D11VertexBuffer::CA_WRITE );
+            // A morph submesh deliberately skips OptimizeFaces/OptimizeVertices: the wedge numbering has to
+            // survive, because both deform paths address this buffer by WEDGE INDEX (the CPU one rebuilds the
+            // whole stream in wedge order, the GPU fold writes one vertex per wedge). It is also what keeps
+            // mi->Vertices an exact description of the buffer's non-position bytes.
+            if ( MorphGpu::IsActive() ) {
+                // GPU fold: a DEFAULT-heap (VRAM) UAV written by MorphFold.hlsl, never by the CPU. The
+                // initial contents are this conversion's pose, so the mesh is already drawable before its
+                // first fold, and the normal/tangent/UV/color bytes written here are final - the fold only
+                // ever rewrites the leading 12-byte Position of each vertex.
+                mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ),
+                    static_cast<GfxVertexBuffer::EBindFlags>( GfxVertexBuffer::B_VERTEXBUFFER | GfxVertexBuffer::B_UNORDERED_ACCESS ),
+                    GfxVertexBuffer::U_DEFAULT );
+            } else {
+                // CPU deform: re-uploaded whole by UpdateMorphMeshVisual every animation frame this instance
+                // is inside kMorphMeshMaxDistance, so it has to stay CPU-writable.
+                mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_DYNAMIC, D3D11VertexBuffer::CA_WRITE );
+            }
         } else {
             // Reduced caster geometry for the distant shadow cascades, rebuilt from this sub-mesh's own
             // progressive-mesh data. Built here because it is expressed in the pre-optimization wedge

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -1733,15 +1733,8 @@ void WorldConverter::ExtractProgMeshProtoFromModel( zCModel* model, MeshVisualIn
             it->BaseIndexLocation = offsets[i++];
         }
 
-        MeshInfo* wmi = new MeshInfo;
-        Engine::GraphicsEngine->CreateVertexBuffer( wmi->MeshVertexBuffer );
-        Engine::GraphicsEngine->CreateVertexBuffer( wmi->MeshIndexBuffer );
-
-        // Init and fill them
-        wmi->MeshVertexBuffer->Init( &wrappedVertices[0], wrappedVertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
-        wmi->MeshIndexBuffer->Init( &wrappedIndices[0], wrappedIndices.size() * sizeof( unsigned int ), D3D11VertexBuffer::B_INDEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
-
-        meshInfo->FullMesh = wmi;
+        // FullMesh's buffers are gone - see the note in Extract3DSMeshFromVisual2. Nothing ever bound
+        // them; only BaseIndexLocation above is actually consumed.
     }
 
     // No usable node visual at all: leave a degenerate-but-finite box. The ±FLT_MAX
@@ -2105,6 +2098,8 @@ void WorldConverter::UpdateMorphMeshVisual( void* v, MeshVisualInfo* meshInfo ) 
     if ( !morphMesh )
         return;
 
+    MorphBlend::LogPrototypeBudget( visual );
+
     auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
     if ( settings.VerifyMorphBlend ) {
         // Runs both deforms and reports the worst disagreement. Deliberately rate-limited rather than
@@ -2162,7 +2157,11 @@ void WorldConverter::UpdateMorphMeshVisual( void* v, MeshVisualInfo* meshInfo ) 
         for ( auto const& it : meshInfo->Meshes ) {
             for ( auto& mi : it.second ) {
                 if ( mi->MeshIndex == i ) {
-                    mi->MeshVertexBuffer->UpdateBuffer( &vertices[0], vertices.size() * sizeof( ExVertexStruct ) );
+                    // Accessor, not the member: an instance that has been out of morph range for a while
+                    // has had its dynamic buffer handed back, and this is the draw that needs it again.
+                    if ( GfxVertexBuffer* vb = mi->GetMeshVertexBuffer() ) {
+                        vb->UpdateBuffer( &vertices[0], vertices.size() * sizeof( ExVertexStruct ) );
+                    }
                     goto Out_Of_Nested_Loop;
                 }
             }
@@ -2252,6 +2251,11 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
             // We need to keep original indices so that we can reuse them(we can't optimize them)
             // Use dynamic buffer since we'll reupload it every frame we see this visual
 
+            // Handed back again once this instance stops deforming, and rebuilt from mi->Vertices on the
+            // next draw that needs it - see MeshVisualInfo::ReleaseIdleMorphVertexBuffers. Skipping the
+            // optimizers above is what keeps Vertices a valid description of this buffer.
+            mi->DynamicMorphVertices = true;
+
             // Init and fill it
             mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_DYNAMIC, D3D11VertexBuffer::CA_WRITE );
         } else {
@@ -2321,15 +2325,10 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
             i++;
         }
 
-        MeshInfo* wmi = new MeshInfo;
-        Engine::GraphicsEngine->CreateVertexBuffer( wmi->MeshVertexBuffer );
-        Engine::GraphicsEngine->CreateVertexBuffer( wmi->MeshIndexBuffer );
-
-        // Init and fill them
-        wmi->MeshVertexBuffer->Init( &wrappedVertices[0], wrappedVertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
-        wmi->MeshIndexBuffer->Init( &wrappedIndices[0], wrappedIndices.size() * sizeof( unsigned int ), D3D11VertexBuffer::B_INDEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
-
-        meshInfo->FullMesh = wmi;
+        // No wrapped MeshInfo built from wrappedVertices/wrappedIndices any more: MeshVisualInfo::FullMesh
+        // was write-only - nothing ever bound it - so it was two IMMUTABLE buffers per converted visual
+        // (a full duplicate of every submesh vertex plus 32-bit indices) that only cost VRAM and 32-bit
+        // address space. WrapVertexBuffers still runs: BaseIndexLocation above is read by the draw paths.
     }
 
     // Every submesh was empty: don't let the ±FLT_MAX seeds turn MeshSize into an infinity.

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -25,6 +25,7 @@
 #include <meshoptimizer/src/meshoptimizer.h>
 #include "MeshManager.h"
 #include "SharedVisualRegistry.h"
+#include "MorphBlend.h"
 #include "ThreadPool.h"
 #include "vendor/mikktspace.h"
 #include "VertexPacking.h"
@@ -2096,14 +2097,52 @@ void WorldConverter::UpdateMorphMeshVisual( void* v, MeshVisualInfo* meshInfo ) 
     }
     meshInfo->LastAniUpdateFrame = now;
 
+    // Always the engine's: AdvanceAnis is the animation STATE machine (weights, frames, channel
+    // lifetime, random anis), not the deform. Only the deform below has an alternative.
     visual->AdvanceAnis();
-    visual->CalcVertexPositions();
 
     zCProgMeshProto* morphMesh = visual->GetMorphMesh();
     if ( !morphMesh )
         return;
 
-    float3* posList = morphMesh->GetPositionList()->Array;
+    auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+    if ( settings.VerifyMorphBlend ) {
+        // Runs both deforms and reports the worst disagreement. Deliberately rate-limited rather than
+        // per-mesh-per-frame; one bad visual will still show up within a second or two.
+        const float deviation = MorphBlend::CompareAgainstEngine( visual );
+        static size_t s_lastReportFrame = 0;
+        static float s_worstSeen = 0.0f;
+        if ( deviation >= 0.0f ) {
+            s_worstSeen = std::max( s_worstSeen, deviation );
+        }
+        if ( now - s_lastReportFrame > 300 ) {
+            s_lastReportFrame = now;
+            LogInfo() << "MorphBlend verify: worst deviation " << s_worstSeen << " units over the last 300 frames";
+            s_worstSeen = 0.0f;
+        }
+    }
+
+    // The deform. 'posList' ends up pointing at whichever one produced this frame's positions.
+    const float3* posList = nullptr;
+    static std::vector<float3> reimplementedPositions;
+    if ( settings.UseReimplementedMorphBlend && !settings.VerifyMorphBlend ) {
+        int restCount = 0;
+        const float3* rest = visual->GetRestPositions( restCount );
+        zCArrayAdapt<float3>* livePositions = morphMesh->GetPositionList();
+        if ( rest && restCount >= livePositions->NumInArray && livePositions->NumInArray > 0 ) {
+            static std::vector<MorphBlend::ChannelState> channels;
+            MorphBlend::CaptureChannels( visual, channels );
+            reimplementedPositions.resize( livePositions->NumInArray );
+            MorphBlend::Apply( channels, rest, livePositions->NumInArray, reimplementedPositions.data() );
+            posList = reimplementedPositions.data();
+        }
+    }
+    if ( !posList ) {
+        // Engine deform (also the fallback when the rest positions aren't available). VerifyMorphBlend
+        // already called this inside CompareAgainstEngine, but it is idempotent for a given state.
+        visual->CalcVertexPositions();
+        posList = morphMesh->GetPositionList()->Array;
+    }
     static std::vector<ExVertexStruct> vertices;
     for ( int i = 0; i < morphMesh->GetNumSubmeshes(); i++ ) {
         vertices.clear();

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -1857,24 +1857,12 @@ namespace {
             return src;
         }
 
-        // Deliberately no rest mesh for instances carrying a refShape ani, even though GetRestPositions
-        // handles them correctly. A rest mesh is extracted from the same zCProgMeshProto as the morph
-        // copy, so its MeshInfos inherit the SAME zCSubMesh-derived meshIds - and both backends batch on
-        // meshId and then bind the head-of-batch's buffers (D3D11GraphicsEngine's batchMesh loop,
-        // D3D12's AttachBatchKey). Two different rest poses of one head would therefore collide on the
-        // batch key and render each other's geometry. One rest pose per inner progmesh keeps that
-        // impossible; shape-ani heads simply stay on the (unbatchable) morph path exactly as before.
-        if ( mm->GetRefShapeAni() ) {
-            static bool s_loggedRefShapeSkip = false;
-            if ( !s_loggedRefShapeSkip ) {
-                s_loggedRefShapeSkip = true;
-                LogInfo() << "Morph attachment with a refShape ani seen - those keep using their deformed "
-                    "copy and stay unbatchable. If this shows up a lot, the rest-mesh key needs to include "
-                    "the shape ani and the batch keys need to stop aliasing on meshId.";
-            }
-            return src;
-        }
-
+        // Instances carrying a refShape ani are handled too, and GetRestPoseKey separates them: their rest
+        // pose comes from the shape ani rather than from morphRefMeshVertPos, so they get their own shared
+        // rest mesh and batch among themselves. That is only safe because both backends now key attachment
+        // batches on the MeshInfo POINTER. They used to key on meshId, which a rest mesh inherits from the
+        // zCSubMesh it was extracted from - so two different rest poses of one head would have collided on
+        // the batch key and rendered each other's geometry.
         const void* key = mm->GetRestPoseKey();
         if ( !key ) {
             return src;

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -1842,6 +1842,72 @@ void WorldConverter::ExtractProgMeshProtoFromMesh( zCMesh* mesh, MeshVisualInfo*
     meshInfo->Visual = reinterpret_cast<zCVisual*>(mesh);
 }
 
+namespace {
+    /** Everything needed to build a morph attachment's undeformed rest mesh, resolved on the game thread
+        (these fields can change under us - StartAni can install a refShapeAni at any time). */
+    struct MorphRestSource {
+        const void* Key = nullptr;          // shared identity; null means "no rest mesh for this one"
+        const float3* Positions = nullptr;  // pristine, never written by the engine after load
+        int NumVert = 0;
+    };
+
+    MorphRestSource ResolveMorphRestSource( zCMorphMesh* mm ) {
+        MorphRestSource src;
+        if ( !mm ) {
+            return src;
+        }
+
+        // Deliberately no rest mesh for instances carrying a refShape ani, even though GetRestPositions
+        // handles them correctly. A rest mesh is extracted from the same zCProgMeshProto as the morph
+        // copy, so its MeshInfos inherit the SAME zCSubMesh-derived meshIds - and both backends batch on
+        // meshId and then bind the head-of-batch's buffers (D3D11GraphicsEngine's batchMesh loop,
+        // D3D12's AttachBatchKey). Two different rest poses of one head would therefore collide on the
+        // batch key and render each other's geometry. One rest pose per inner progmesh keeps that
+        // impossible; shape-ani heads simply stay on the (unbatchable) morph path exactly as before.
+        if ( mm->GetRefShapeAni() ) {
+            static bool s_loggedRefShapeSkip = false;
+            if ( !s_loggedRefShapeSkip ) {
+                s_loggedRefShapeSkip = true;
+                LogInfo() << "Morph attachment with a refShape ani seen - those keep using their deformed "
+                    "copy and stay unbatchable. If this shows up a lot, the rest-mesh key needs to include "
+                    "the shape ani and the batch keys need to stop aliasing on meshId.";
+            }
+            return src;
+        }
+
+        const void* key = mm->GetRestPoseKey();
+        if ( !key ) {
+            return src;
+        }
+        int numVert = 0;
+        const float3* positions = mm->GetRestPositions( numVert );
+        if ( !positions || numVert <= 0 ) {
+            return src;
+        }
+        src.Key = key;
+        src.Positions = positions;
+        src.NumVert = numVert;
+        return src;
+    }
+
+    /** Acquires (and fills, if we are the first) the shared rest mesh and hangs it off the morph visual.
+        Safe to call from a worker thread - the registry is locked and 'src' was resolved on the game
+        thread. */
+    void AttachMorphRestVisual( MeshVisualInfo* morphVisual, zCProgMeshProto* pm, const MorphRestSource& src ) {
+        if ( !src.Key || !pm || morphVisual->RestVisual ) {
+            return;
+        }
+
+        bool needsFill = false;
+        MeshVisualInfo* rest = s_SharedVisualRegistry->Acquire( src.Key, needsFill );
+        if ( needsFill ) {
+            WorldConverter::Extract3DSMeshFromVisual2( pm, rest, src.Positions, src.NumVert );
+            rest->Ready.store( true, std::memory_order_release );
+        }
+        morphVisual->RestVisual = rest;
+    }
+}
+
 /** Drops this node's attachment(s) back to the shared registry and empties the slot. Leaves the slot
     itself present in the map: callers use find() != end() to mean "extraction was already attempted
     for this node", and re-creating it every frame would re-kick extraction forever. */
@@ -1888,6 +1954,7 @@ void WorldConverter::ExtractNodeVisual( int index, zCModelNodeInst* node, gtl::f
                 Extract3DSMeshFromVisual2( pm, mi );
                 if ( isMMS ) {
                     mi->Visual = node->NodeVisual;
+                    AttachMorphRestVisual( mi, pm, ResolveMorphRestSource( reinterpret_cast<zCMorphMesh*>(node->NodeVisual) ) );
                 }
                 mi->Ready.store( true, std::memory_order_release );
             }
@@ -2006,8 +2073,15 @@ void WorldConverter::ExtractNodeVisualAsync( int index, zCModelNodeInst* node, g
     }
     mi->Ready.store( false, std::memory_order_relaxed );
 
+    // Resolved here rather than in the job: refShapeAni can be installed by StartAni at any time, and the
+    // rest pose has to be the one this attachment was identified with. The arrays it points at are
+    // written once at load and never again, so the worker can read them freely.
+    const MorphRestSource restSource = isMMS
+        ? ResolveMorphRestSource( reinterpret_cast<zCMorphMesh*>(node->NodeVisual) )
+        : MorphRestSource{};
+
     zCVisual* nodeVisual = node->NodeVisual;
-    auto task = Engine::WorkerThreadPool->enqueue( [pm, mi, isMMS]( const std::stop_token& token ) {
+    auto task = Engine::WorkerThreadPool->enqueue( [pm, mi, isMMS, restSource]( const std::stop_token& token ) {
         if ( token.stop_requested() ) {
             // Cancelled before a worker picked it up (world change / shutdown flush) - the visual we
             // would read from may already be gone. Clear Visual so the next frame notices the mismatch
@@ -2021,6 +2095,9 @@ void WorldConverter::ExtractNodeVisualAsync( int index, zCModelNodeInst* node, g
             // Extract3DSMeshFromVisual2 sets Visual to the morph mesh's inner progmesh; the attachment
             // identity is the outer zCMorphMesh (mirrors ExtractNodeVisual).
             mi->Visual = reinterpret_cast<zCVisual*>(mi->MorphMeshVisual);
+            // Built on the worker too - it is a second full conversion, but only for the FIRST morph mesh
+            // resolving to this rest pose; every other head of the same type just takes a reference.
+            AttachMorphRestVisual( mi, pm, restSource );
         }
         mi->Ready.store( true, std::memory_order_release );
     } );
@@ -2080,13 +2157,18 @@ void WorldConverter::UpdateMorphMeshVisual( void* v, MeshVisualInfo* meshInfo ) 
 }
 
 /** Extracts a 3DS-Mesh from a zCVisual */
-void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVisualInfo* meshInfo ) {
+void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVisualInfo* meshInfo, const float3* positionOverride, int positionOverrideCount ) {
     ZoneScoped;
 
     XMFLOAT3 bbmin = XMFLOAT3( FLT_MAX, FLT_MAX, FLT_MAX );
     XMFLOAT3 bbmax = XMFLOAT3( -FLT_MAX, -FLT_MAX, -FLT_MAX );
 
-    float3* posList = visual->GetPositionList()->Array;
+    // Wedges index into the visual's position list, so an override has to cover all of it or the
+    // wedge indices would run off the end - fall back to the live list rather than read out of bounds.
+    zCArrayAdapt<float3>* livePositions = visual->GetPositionList();
+    const float3* posList = ( positionOverride && positionOverrideCount >= livePositions->NumInArray )
+        ? positionOverride
+        : livePositions->Array;
 
     std::list<std::vector<ExVertexStruct>*> vertexBuffers;
     std::list<std::vector<VERTEX_INDEX>*> indexBuffers;

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -72,12 +72,10 @@ public:
     /** Extracts a 3DS-Mesh from a zCVisual */
     static void Extract3DSMeshFromVisual( zCProgMeshProto* visual, MeshVisualInfo* meshInfo );
 
-    /** Extracts a 3DS-Mesh from a zCVisual */
-    /** 'positionOverride' replaces the visual's live position list for the duration of the extraction,
-        which is how the undeformed rest mesh of a .MMS is built: zCMorphMesh deforms one SHARED position
-        list in place right before each instance draws, so the only way to capture the rest pose is to
-        read zCMorphMeshProto's pristine arrays instead. Ignored (with a fallback to the live list) unless
-        it covers every vertex the wedges can index. */
+    /** Extracts a 3DS-Mesh from a zCVisual. 'positionOverride' substitutes for the visual's live position
+        list, which is how a .MMS rest mesh is built: zCMorphMesh deforms one shared position list in place
+        per draw, so the rest pose can only come from zCMorphMeshProto's pristine arrays. Ignored unless it
+        covers every vertex. */
     static void Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVisualInfo* meshInfo, const float3* positionOverride = nullptr, int positionOverrideCount = 0 );
 
     /** Updates a Morph-Mesh visual */
@@ -92,9 +90,8 @@ public:
     /** Extracts a zCProgMeshProto from a zCMesh */
     static void ExtractProgMeshProtoFromMesh( zCMesh* mesh, MeshVisualInfo* meshInfo );
 
-    /** Releases this node's attachment(s) back to the SharedVisualRegistry and empties the slot without
-        erasing it. Use this instead of deleting a MeshVisualInfo out of a NodeAttachments map - the
-        object is shared with every other vob carrying the same visual. */
+    /** Releases this node's attachment(s) and empties the slot without erasing it. Use instead of
+        deleting a MeshVisualInfo out of a NodeAttachments map - the object is shared. */
     static void ReleaseNodeAttachments( gtl::flat_hash_map<int, std::vector<MeshVisualInfo*>>& attachments, int index );
 
     /** Extracts a node-visual */

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -73,7 +73,12 @@ public:
     static void Extract3DSMeshFromVisual( zCProgMeshProto* visual, MeshVisualInfo* meshInfo );
 
     /** Extracts a 3DS-Mesh from a zCVisual */
-    static void Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVisualInfo* meshInfo );
+    /** 'positionOverride' replaces the visual's live position list for the duration of the extraction,
+        which is how the undeformed rest mesh of a .MMS is built: zCMorphMesh deforms one SHARED position
+        list in place right before each instance draws, so the only way to capture the rest pose is to
+        read zCMorphMeshProto's pristine arrays instead. Ignored (with a fallback to the live list) unless
+        it covers every vertex the wedges can index. */
+    static void Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVisualInfo* meshInfo, const float3* positionOverride = nullptr, int positionOverrideCount = 0 );
 
     /** Updates a Morph-Mesh visual */
     static void UpdateMorphMeshVisual( void* visual, MeshVisualInfo* meshInfo );

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -87,6 +87,11 @@ public:
     /** Extracts a zCProgMeshProto from a zCMesh */
     static void ExtractProgMeshProtoFromMesh( zCMesh* mesh, MeshVisualInfo* meshInfo );
 
+    /** Releases this node's attachment(s) back to the SharedVisualRegistry and empties the slot without
+        erasing it. Use this instead of deleting a MeshVisualInfo out of a NodeAttachments map - the
+        object is shared with every other vob carrying the same visual. */
+    static void ReleaseNodeAttachments( gtl::flat_hash_map<int, std::vector<MeshVisualInfo*>>& attachments, int index );
+
     /** Extracts a node-visual */
     static void ExtractNodeVisual( int index, zCModelNodeInst* node, gtl::flat_hash_map<int, std::vector<MeshVisualInfo*>>& attachments );
 

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -15,8 +15,7 @@ MeshVisualInfo::~MeshVisualInfo() {
     if ( !Ready.load( std::memory_order_acquire ) ) {
         WaitForPendingNodeVisualExtraction( this );
     }
-    // One reference, taken when this morph visual was first built. The rest mesh is shared with every
-    // other zCMorphMesh resolving to the same rest pose, so it only dies with the last of them.
+    // The rest mesh is shared with every other zCMorphMesh resolving to the same rest pose.
     if ( RestVisual ) {
         s_SharedVisualRegistry->Release( RestVisual );
         RestVisual = nullptr;

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -7,6 +7,15 @@
 #include "zCMaterial.h"
 #include "zCTexture.h"
 #include "D3D11_Helpers.h"
+#include "SharedVisualRegistry.h"
+
+SkeletalVobInfo::~SkeletalVobInfo() {
+    for ( auto& [k, meshes] : NodeAttachments ) {
+        for ( MeshVisualInfo* mvi : meshes ) {
+            s_SharedVisualRegistry->Release( mvi );
+        }
+    }
+}
 
 /** Updates the vobs constantbuffer */
 void VobInfo::UpdateVobConstantBuffer(VS_ExConstantBuffer_PerInstance& cb) {

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -9,6 +9,102 @@
 #include "D3D11_Helpers.h"
 #include "SharedVisualRegistry.h"
 
+namespace {
+    /** Serialises RecreateDynamicVertexBuffer. Cold path (only after an idle release), and the D3D12
+        deferred shadow/point-shadow recording can reach a MeshInfo off the main thread, so two threads
+        must not race to fill the same unique_ptr. One global lock is enough - contention is impossible
+        in practice and the work behind it is a single small buffer creation. */
+    std::mutex s_MorphBufferRecreateMutex;
+
+    /** Diagnostics for the release/recreate cycle: how many morph submesh buffers are resident right now
+        and how much churn the hysteresis is absorbing. Logged from ReleaseIdleMorphVertexBuffers. */
+    std::atomic<int> s_MorphBuffersResident{ 0 };
+    std::atomic<int> s_MorphBuffersReleased{ 0 };
+    std::atomic<int> s_MorphBuffersRecreated{ 0 };
+}
+
+GfxVertexBuffer* MeshInfo::RecreateDynamicVertexBuffer() const {
+    if ( !DynamicMorphVertices || Vertices.empty() || !Engine::GraphicsEngine ) {
+        return nullptr;
+    }
+
+    std::scoped_lock lock( s_MorphBufferRecreateMutex );
+    if ( MeshVertexBuffer ) {
+        return MeshVertexBuffer.get();   // another thread got here first
+    }
+
+    // Vertices still holds the conversion-time pose: morph submeshes deliberately skip OptimizeFaces/
+    // OptimizeVertices (the wedge numbering has to survive for UpdateMorphMeshVisual), so this is the
+    // exact content Init() was originally given. The next UpdateMorphMeshVisual overwrites it with the
+    // current deform; until then the mesh draws its undeformed-ish pose rather than vanishing.
+    std::unique_ptr<GfxVertexBuffer> vb;
+    Engine::GraphicsEngine->CreateVertexBuffer( vb );
+    if ( !vb ) {
+        return nullptr;
+    }
+    if ( XR_SUCCESS != vb->Init( const_cast<ExVertexStruct*>( Vertices.data() ),
+        static_cast<unsigned int>( Vertices.size() * sizeof( ExVertexStruct ) ),
+        GfxVertexBuffer::B_VERTEXBUFFER, GfxVertexBuffer::U_DYNAMIC, GfxVertexBuffer::CA_WRITE ) ) {
+        return nullptr;
+    }
+
+    MeshVertexBuffer = std::move( vb );
+    s_MorphBuffersResident.fetch_add( 1, std::memory_order_relaxed );
+    s_MorphBuffersRecreated.fetch_add( 1, std::memory_order_relaxed );
+    return MeshVertexBuffer.get();
+}
+
+void MeshInfo::ReleaseDynamicVertexBuffer() {
+    if ( !DynamicMorphVertices || !MeshVertexBuffer ) {
+        return;
+    }
+    std::scoped_lock lock( s_MorphBufferRecreateMutex );
+    if ( !MeshVertexBuffer ) {
+        return;
+    }
+    // D3D11 defers the real destruction until the GPU is done with the buffer; D3D12VertexBuffer's
+    // destructor queues resource + allocation on the engine's frame-fenced release list. Both are safe
+    // to do mid-frame, with command lists still open, which is exactly where this runs from.
+    MeshVertexBuffer.reset();
+    s_MorphBuffersResident.fetch_sub( 1, std::memory_order_relaxed );
+    s_MorphBuffersReleased.fetch_add( 1, std::memory_order_relaxed );
+}
+
+bool MeshVisualInfo::ReleaseIdleMorphVertexBuffers( size_t currentFrame ) {
+    // Only a morph visual has anything to release, and only one that can be drawn without its own copy.
+    if ( !MorphMeshVisual || !RestVisual ) {
+        return false;
+    }
+    // LastAniUpdateFrame is stamped by every path that deforms this instance, so it is the activity
+    // signal. Zero (never deformed) deliberately falls through: those buffers were built by the
+    // conversion and have never been used.
+    if ( currentFrame - LastAniUpdateFrame < kMorphBufferIdleFrames ) {
+        return false;
+    }
+
+    bool released = false;
+    for ( auto& [material, meshes] : Meshes ) {
+        for ( auto& mi : meshes ) {
+            if ( mi && mi->MeshVertexBuffer ) {
+                mi->ReleaseDynamicVertexBuffer();
+                released = true;
+            }
+        }
+    }
+
+    if ( released ) {
+        static size_t s_lastReportFrame = 0;
+        if ( currentFrame - s_lastReportFrame > 1200 ) {
+            s_lastReportFrame = currentFrame;
+            LogInfo() << "Morph buffers: " << s_MorphBuffersResident.load( std::memory_order_relaxed )
+                << " resident (" << s_MorphBuffersReleased.load( std::memory_order_relaxed )
+                << " released, " << s_MorphBuffersRecreated.load( std::memory_order_relaxed )
+                << " recreated since start)";
+        }
+    }
+    return released;
+}
+
 MeshVisualInfo::~MeshVisualInfo() {
     // Node attachments may be extracted on a worker thread (WorldConverter::ExtractNodeVisualAsync).
     // Never free the target out from under a running job.
@@ -74,6 +170,9 @@ SectionInstanceCache::~SectionInstanceCache() {
 MeshInfo::~MeshInfo() {
     //Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize -= Indices.size() * sizeof(VERTEX_INDEX);
     //Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize -= Vertices.size() * sizeof(ExVertexStruct);
+
+    // Keeps the resident counter honest when a morph visual is evicted with its buffer still up.
+    ReleaseDynamicVertexBuffer();
 
     MeshVertexBuffer.reset();
     MeshPositionBuffer.reset();

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -9,6 +9,24 @@
 #include "D3D11_Helpers.h"
 #include "SharedVisualRegistry.h"
 
+MeshVisualInfo::~MeshVisualInfo() {
+    // Node attachments may be extracted on a worker thread (WorldConverter::ExtractNodeVisualAsync).
+    // Never free the target out from under a running job.
+    if ( !Ready.load( std::memory_order_acquire ) ) {
+        WaitForPendingNodeVisualExtraction( this );
+    }
+    // One reference, taken when this morph visual was first built. The rest mesh is shared with every
+    // other zCMorphMesh resolving to the same rest pose, so it only dies with the last of them.
+    if ( RestVisual ) {
+        s_SharedVisualRegistry->Release( RestVisual );
+        RestVisual = nullptr;
+    }
+    if ( MorphMeshVisual ) {
+        zCObject_Release( MorphMeshVisual );
+    }
+    delete FullMesh;
+}
+
 SkeletalVobInfo::~SkeletalVobInfo() {
     for ( auto& [k, meshes] : NodeAttachments ) {
         for ( MeshVisualInfo* mvi : meshes ) {

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -9,102 +9,6 @@
 #include "D3D11_Helpers.h"
 #include "SharedVisualRegistry.h"
 
-namespace {
-    /** Serialises RecreateDynamicVertexBuffer. Cold path (only after an idle release), and the D3D12
-        deferred shadow/point-shadow recording can reach a MeshInfo off the main thread, so two threads
-        must not race to fill the same unique_ptr. One global lock is enough - contention is impossible
-        in practice and the work behind it is a single small buffer creation. */
-    std::mutex s_MorphBufferRecreateMutex;
-
-    /** Diagnostics for the release/recreate cycle: how many morph submesh buffers are resident right now
-        and how much churn the hysteresis is absorbing. Logged from ReleaseIdleMorphVertexBuffers. */
-    std::atomic<int> s_MorphBuffersResident{ 0 };
-    std::atomic<int> s_MorphBuffersReleased{ 0 };
-    std::atomic<int> s_MorphBuffersRecreated{ 0 };
-}
-
-GfxVertexBuffer* MeshInfo::RecreateDynamicVertexBuffer() const {
-    if ( !DynamicMorphVertices || Vertices.empty() || !Engine::GraphicsEngine ) {
-        return nullptr;
-    }
-
-    std::scoped_lock lock( s_MorphBufferRecreateMutex );
-    if ( MeshVertexBuffer ) {
-        return MeshVertexBuffer.get();   // another thread got here first
-    }
-
-    // Vertices still holds the conversion-time pose: morph submeshes deliberately skip OptimizeFaces/
-    // OptimizeVertices (the wedge numbering has to survive for UpdateMorphMeshVisual), so this is the
-    // exact content Init() was originally given. The next UpdateMorphMeshVisual overwrites it with the
-    // current deform; until then the mesh draws its undeformed-ish pose rather than vanishing.
-    std::unique_ptr<GfxVertexBuffer> vb;
-    Engine::GraphicsEngine->CreateVertexBuffer( vb );
-    if ( !vb ) {
-        return nullptr;
-    }
-    if ( XR_SUCCESS != vb->Init( const_cast<ExVertexStruct*>( Vertices.data() ),
-        static_cast<unsigned int>( Vertices.size() * sizeof( ExVertexStruct ) ),
-        GfxVertexBuffer::B_VERTEXBUFFER, GfxVertexBuffer::U_DYNAMIC, GfxVertexBuffer::CA_WRITE ) ) {
-        return nullptr;
-    }
-
-    MeshVertexBuffer = std::move( vb );
-    s_MorphBuffersResident.fetch_add( 1, std::memory_order_relaxed );
-    s_MorphBuffersRecreated.fetch_add( 1, std::memory_order_relaxed );
-    return MeshVertexBuffer.get();
-}
-
-void MeshInfo::ReleaseDynamicVertexBuffer() {
-    if ( !DynamicMorphVertices || !MeshVertexBuffer ) {
-        return;
-    }
-    std::scoped_lock lock( s_MorphBufferRecreateMutex );
-    if ( !MeshVertexBuffer ) {
-        return;
-    }
-    // D3D11 defers the real destruction until the GPU is done with the buffer; D3D12VertexBuffer's
-    // destructor queues resource + allocation on the engine's frame-fenced release list. Both are safe
-    // to do mid-frame, with command lists still open, which is exactly where this runs from.
-    MeshVertexBuffer.reset();
-    s_MorphBuffersResident.fetch_sub( 1, std::memory_order_relaxed );
-    s_MorphBuffersReleased.fetch_add( 1, std::memory_order_relaxed );
-}
-
-bool MeshVisualInfo::ReleaseIdleMorphVertexBuffers( size_t currentFrame ) {
-    // Only a morph visual has anything to release, and only one that can be drawn without its own copy.
-    if ( !MorphMeshVisual || !RestVisual ) {
-        return false;
-    }
-    // LastAniUpdateFrame is stamped by every path that deforms this instance, so it is the activity
-    // signal. Zero (never deformed) deliberately falls through: those buffers were built by the
-    // conversion and have never been used.
-    if ( currentFrame - LastAniUpdateFrame < kMorphBufferIdleFrames ) {
-        return false;
-    }
-
-    bool released = false;
-    for ( auto& [material, meshes] : Meshes ) {
-        for ( auto& mi : meshes ) {
-            if ( mi && mi->MeshVertexBuffer ) {
-                mi->ReleaseDynamicVertexBuffer();
-                released = true;
-            }
-        }
-    }
-
-    if ( released ) {
-        static size_t s_lastReportFrame = 0;
-        if ( currentFrame - s_lastReportFrame > 1200 ) {
-            s_lastReportFrame = currentFrame;
-            LogInfo() << "Morph buffers: " << s_MorphBuffersResident.load( std::memory_order_relaxed )
-                << " resident (" << s_MorphBuffersReleased.load( std::memory_order_relaxed )
-                << " released, " << s_MorphBuffersRecreated.load( std::memory_order_relaxed )
-                << " recreated since start)";
-        }
-    }
-    return released;
-}
-
 MeshVisualInfo::~MeshVisualInfo() {
     // Node attachments may be extracted on a worker thread (WorldConverter::ExtractNodeVisualAsync).
     // Never free the target out from under a running job.
@@ -170,9 +74,6 @@ SectionInstanceCache::~SectionInstanceCache() {
 MeshInfo::~MeshInfo() {
     //Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize -= Indices.size() * sizeof(VERTEX_INDEX);
     //Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize -= Vertices.size() * sizeof(ExVertexStruct);
-
-    // Keeps the resident counter honest when a morph visual is evicted with its buffer still up.
-    ReleaseDynamicVertexBuffer();
 
     MeshVertexBuffer.reset();
     MeshPositionBuffer.reset();

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -283,6 +283,15 @@ struct MeshVisualInfo : public BaseVisualInfo {
         it flips to true - reading the containers before that races the extraction. Synchronously
         extracted visuals (every other path) leave it at true. */
     std::atomic<bool> Ready{ true };
+
+    /** Set only on node-attachment visuals owned by the SharedVisualRegistry, which hands the same
+        object to every vob attaching the same zCVisual. SharedKey is the registry's lookup key and,
+        unlike Visual, is never rewritten by a background extraction - it is cleared when the entry
+        is unregistered. SharedRefs is the number of NodeAttachments slots pointing here; the visual
+        is destroyed when it hits zero. Both stay 0/null for the non-shared visuals (static meshes,
+        particle effect meshes) that continue to be owned outright by their holder. */
+    zCVisual* SharedKey = nullptr;
+    uint32_t SharedRefs = 0;
 };
 
 /** Holds the converted mesh of a VOB */
@@ -478,14 +487,10 @@ struct SkeletalVobInfo : public BaseVobInfo {
     SkeletalVobInfo(const SkeletalVobInfo& other) = delete;
     SkeletalVobInfo& operator=(const SkeletalVobInfo& other) = delete;
 
-    ~SkeletalVobInfo() override
-    {
-        for ( auto& [k, meshes] : NodeAttachments ) {
-            for ( MeshVisualInfo* mvi : meshes ) {
-                delete mvi;
-            }
-        }
-    }
+    /** Releases this vob's attachments back to the SharedVisualRegistry - they are shared with every
+        other vob carrying the same visuals, so they are not ours to delete. Out of line because it
+        needs the registry. */
+    ~SkeletalVobInfo() override;
 
     /** Updates the vobs constantbuffer */
     void UpdateVobConstantBuffer(VS_ExConstantBuffer_PerInstance& cb);

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -102,24 +102,13 @@ struct MeshInfo {
     /** Creates buffers for this mesh info */
     XRESULT Create( ExVertexStruct* vertices, unsigned int numVertices, VERTEX_INDEX* indices, unsigned int numIndices );
 
-    /** Self-healing: a morph attachment's DYNAMIC vertex buffer is dropped again whenever the instance
-        stops deforming (MeshVisualInfo::ReleaseIdleMorphVertexBuffers), so this recreates it from the
-        retained CPU vertices on the first draw that needs it again. Every draw site must go through
-        this accessor rather than touching MeshVertexBuffer - reading the member directly would see the
-        released null and silently skip the draw. Returns nullptr for a mesh that never had a buffer. */
-    GfxVertexBuffer* GetMeshVertexBuffer() const {
-        return MeshVertexBuffer ? MeshVertexBuffer.get()
-            : ( DynamicMorphVertices ? RecreateDynamicVertexBuffer() : nullptr );
-    }
+    GfxVertexBuffer* GetMeshVertexBuffer() const { return MeshVertexBuffer.get(); }
     GfxVertexBuffer* GetMeshPositionBuffer() const { return MeshPositionBuffer.get(); }
     GfxVertexBuffer* GetMeshIndexBuffer() const { return MeshIndexBuffer.get(); }
     GfxVertexBuffer* GetMeshShadowIndexBuffer() const { return MeshShadowIndexBuffer.get(); }
     GfxVertexBuffer* GetMeshLodIndexBuffer() const { return MeshLodIndexBuffer.get(); }
 
-    /** Mutable so GetMeshVertexBuffer() can recreate a released morph buffer from a const accessor;
-        RecreateDynamicVertexBuffer serialises that on a mutex, since the D3D12 deferred shadow paths can
-        reach it off the main thread. */
-    mutable std::unique_ptr<GfxVertexBuffer> MeshVertexBuffer;
+    std::unique_ptr<GfxVertexBuffer> MeshVertexBuffer;
     // Optional position-only (float3, 12 bytes) copy of MeshVertexBuffer, in the same vertex
     // ordering. Bound for opaque depth/shadow passes to cut vertex-fetch bandwidth (~3.6x vs the
     // full 44-byte stream). Currently only populated for the wrapped world mesh. May be nullptr.
@@ -140,20 +129,6 @@ struct MeshInfo {
     // Offset in wrapped world mesh
     unsigned int BaseIndexLocation;
     unsigned int MeshIndex;
-
-    /** Set for the per-instance submeshes of a morph (.MMS) visual, whose vertex buffer is DYNAMIC and
-        re-uploaded from the CPU every frame the instance deforms. Those are the only buffers that may be
-        dropped and rebuilt on demand, and the only ones whose CPU-side Vertices must stay around for it. */
-    bool DynamicMorphVertices = false;
-
-    /** Rebuilds MeshVertexBuffer from Vertices. Out of line and cold - only reached after an idle
-        release. */
-    GfxVertexBuffer* RecreateDynamicVertexBuffer() const;
-
-    /** Drops the DYNAMIC vertex buffer of a morph submesh. No-op for anything else: every other buffer
-        here is IMMUTABLE and shared, and its CPU copy is not guaranteed to still describe it (the
-        optimizer reorders Vertices in place). */
-    void ReleaseDynamicVertexBuffer();
 
     /** MeshManager's id for the SOURCE zCSubMesh. NOT a "same buffers" key - a morph attachment and its
         RestVisual, or two .MDS/.ASC node visuals with different baked node transforms, share a meshId
@@ -309,19 +284,6 @@ struct MeshVisualInfo : public BaseVisualInfo {
         SharedRefs (the number of NodeAttachments slots pointing here) hits zero. */
     const void* SharedKey = nullptr;
     uint32_t SharedRefs = 0;
-
-    /** Frames a morph attachment may go without deforming before its per-instance DYNAMIC vertex buffers
-        are handed back. Every .MMS attachment converts one set of them, so without this a walk through a
-        city leaves one set resident per NPC head ever seen - hundreds of small CPU-writable buffers, and
-        on D3D12 kBackBufferCount UPLOAD copies of each. Two seconds of hysteresis is long enough that
-        turning away from an NPC and back does not thrash the allocator. */
-    static constexpr size_t kMorphBufferIdleFrames = 120;
-
-    /** Releases the per-instance morph vertex buffers if this instance has not deformed for
-        kMorphBufferIdleFrames. Call it only where the mesh is drawable WITHOUT them - i.e. where RestVisual
-        is being drawn instead - since the very next draw of our own copy recreates them (see
-        MeshInfo::GetMeshVertexBuffer). Returns true if it released anything. */
-    bool ReleaseIdleMorphVertexBuffers( size_t currentFrame );
 
     /** Shared undeformed conversion of a .MMS, drawn instead of this one whenever the instance isn't
         actively morphing - our copy would still hold the deformation from the last time it was in range.

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -130,14 +130,10 @@ struct MeshInfo {
     unsigned int BaseIndexLocation;
     unsigned int MeshIndex;
 
-    /** MeshManager's id for the SOURCE zCSubMesh this was built from. Do NOT use it as an
-        "these are the same buffers" key - it is a weaker claim than that, and two MeshInfos sharing a
-        meshId can hold completely different geometry: a morph attachment and its undeformed RestVisual are
-        both extracted from one zCProgMeshProto, and .MDS/.ASC node visuals bake their own node transform
-        into their vertices. Node-attachment batching used to key on this and aliased both cases together;
-        it now keys on the MeshInfo pointer, which the SharedVisualRegistry made a stable shared identity.
-        Still used by the static-vob instancing sort, where StaticMeshVisuals guarantees exactly one
-        MeshInfo per progmesh submesh and the ambiguity cannot arise. */
+    /** MeshManager's id for the SOURCE zCSubMesh. NOT a "same buffers" key - a morph attachment and its
+        RestVisual, or two .MDS/.ASC node visuals with different baked node transforms, share a meshId
+        while holding different geometry. Attachment batching keys on the MeshInfo pointer for that
+        reason; only the static-vob sort still uses this, where StaticMeshVisuals rules out the case. */
     uint16_t meshId;
 };
 
@@ -283,23 +279,16 @@ struct MeshVisualInfo : public BaseVisualInfo {
         extracted visuals (every other path) leave it at true. */
     std::atomic<bool> Ready{ true };
 
-    /** Set only on node-attachment visuals owned by the SharedVisualRegistry, which hands the same
-        object to every vob attaching the same zCVisual. SharedKey is the registry's lookup key and,
-        unlike Visual, is never rewritten by a background extraction - it is cleared when the entry
-        is unregistered. SharedRefs is the number of NodeAttachments slots pointing here; the visual
-        is destroyed when it hits zero. Both stay 0/null for the non-shared visuals (static meshes,
-        particle effect meshes) that continue to be owned outright by their holder. */
+    /** SharedVisualRegistry bookkeeping; 0/null on visuals owned outright by their holder. SharedKey is
+        the lookup key - unlike Visual it is never rewritten by a background extraction. Destroyed when
+        SharedRefs (the number of NodeAttachments slots pointing here) hits zero. */
     const void* SharedKey = nullptr;
     uint32_t SharedRefs = 0;
 
-    /** For a .MMS morph attachment: the shared UNDEFORMED conversion of the same visual, used whenever
-        this instance isn't actively morphing (out of kMorphMeshMaxDistance range). ZENGIN deforms one
-        shared position list in place per draw, so our morph copy holds whatever deformation was current
-        the last time it was in range - drawing that when the morph is switched off is both wrong and
-        unbatchable, because every instance's copy is stale in a different way. The rest mesh is keyed on
-        zCMorphMesh::GetRestPoseKey(), so all instances that aren't morphing land on ONE MeshInfo and
-        collapse into a single instanced batch. Null for non-morph attachments. This object holds one
-        registry reference to it, released in the destructor. */
+    /** Shared undeformed conversion of a .MMS, drawn instead of this one whenever the instance isn't
+        actively morphing - our copy would still hold the deformation from the last time it was in range.
+        Keyed on GetRestPoseKey(), so every non-morphing instance lands on one MeshInfo and batches. Null
+        for non-morph attachments. Holds one registry reference, released in the destructor. */
     MeshVisualInfo* RestVisual = nullptr;
 };
 
@@ -496,9 +485,7 @@ struct SkeletalVobInfo : public BaseVobInfo {
     SkeletalVobInfo(const SkeletalVobInfo& other) = delete;
     SkeletalVobInfo& operator=(const SkeletalVobInfo& other) = delete;
 
-    /** Releases this vob's attachments back to the SharedVisualRegistry - they are shared with every
-        other vob carrying the same visuals, so they are not ours to delete. Out of line because it
-        needs the registry. */
+    /** Releases this vob's attachments back to the SharedVisualRegistry - shared, so not ours to delete. */
     ~SkeletalVobInfo() override;
 
     /** Updates the vobs constantbuffer */

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -102,13 +102,24 @@ struct MeshInfo {
     /** Creates buffers for this mesh info */
     XRESULT Create( ExVertexStruct* vertices, unsigned int numVertices, VERTEX_INDEX* indices, unsigned int numIndices );
 
-    GfxVertexBuffer* GetMeshVertexBuffer() const { return MeshVertexBuffer.get(); }
+    /** Self-healing: a morph attachment's DYNAMIC vertex buffer is dropped again whenever the instance
+        stops deforming (MeshVisualInfo::ReleaseIdleMorphVertexBuffers), so this recreates it from the
+        retained CPU vertices on the first draw that needs it again. Every draw site must go through
+        this accessor rather than touching MeshVertexBuffer - reading the member directly would see the
+        released null and silently skip the draw. Returns nullptr for a mesh that never had a buffer. */
+    GfxVertexBuffer* GetMeshVertexBuffer() const {
+        return MeshVertexBuffer ? MeshVertexBuffer.get()
+            : ( DynamicMorphVertices ? RecreateDynamicVertexBuffer() : nullptr );
+    }
     GfxVertexBuffer* GetMeshPositionBuffer() const { return MeshPositionBuffer.get(); }
     GfxVertexBuffer* GetMeshIndexBuffer() const { return MeshIndexBuffer.get(); }
     GfxVertexBuffer* GetMeshShadowIndexBuffer() const { return MeshShadowIndexBuffer.get(); }
     GfxVertexBuffer* GetMeshLodIndexBuffer() const { return MeshLodIndexBuffer.get(); }
 
-    std::unique_ptr<GfxVertexBuffer> MeshVertexBuffer;
+    /** Mutable so GetMeshVertexBuffer() can recreate a released morph buffer from a const accessor;
+        RecreateDynamicVertexBuffer serialises that on a mutex, since the D3D12 deferred shadow paths can
+        reach it off the main thread. */
+    mutable std::unique_ptr<GfxVertexBuffer> MeshVertexBuffer;
     // Optional position-only (float3, 12 bytes) copy of MeshVertexBuffer, in the same vertex
     // ordering. Bound for opaque depth/shadow passes to cut vertex-fetch bandwidth (~3.6x vs the
     // full 44-byte stream). Currently only populated for the wrapped world mesh. May be nullptr.
@@ -129,6 +140,20 @@ struct MeshInfo {
     // Offset in wrapped world mesh
     unsigned int BaseIndexLocation;
     unsigned int MeshIndex;
+
+    /** Set for the per-instance submeshes of a morph (.MMS) visual, whose vertex buffer is DYNAMIC and
+        re-uploaded from the CPU every frame the instance deforms. Those are the only buffers that may be
+        dropped and rebuilt on demand, and the only ones whose CPU-side Vertices must stay around for it. */
+    bool DynamicMorphVertices = false;
+
+    /** Rebuilds MeshVertexBuffer from Vertices. Out of line and cold - only reached after an idle
+        release. */
+    GfxVertexBuffer* RecreateDynamicVertexBuffer() const;
+
+    /** Drops the DYNAMIC vertex buffer of a morph submesh. No-op for anything else: every other buffer
+        here is IMMUTABLE and shared, and its CPU copy is not guaranteed to still describe it (the
+        optimizer reorders Vertices in place). */
+    void ReleaseDynamicVertexBuffer();
 
     /** MeshManager's id for the SOURCE zCSubMesh. NOT a "same buffers" key - a morph attachment and its
         RestVisual, or two .MDS/.ASC node visuals with different baked node transforms, share a meshId
@@ -284,6 +309,19 @@ struct MeshVisualInfo : public BaseVisualInfo {
         SharedRefs (the number of NodeAttachments slots pointing here) hits zero. */
     const void* SharedKey = nullptr;
     uint32_t SharedRefs = 0;
+
+    /** Frames a morph attachment may go without deforming before its per-instance DYNAMIC vertex buffers
+        are handed back. Every .MMS attachment converts one set of them, so without this a walk through a
+        city leaves one set resident per NPC head ever seen - hundreds of small CPU-writable buffers, and
+        on D3D12 kBackBufferCount UPLOAD copies of each. Two seconds of hysteresis is long enough that
+        turning away from an NPC and back does not thrash the allocator. */
+    static constexpr size_t kMorphBufferIdleFrames = 120;
+
+    /** Releases the per-instance morph vertex buffers if this instance has not deformed for
+        kMorphBufferIdleFrames. Call it only where the mesh is drawable WITHOUT them - i.e. where RestVisual
+        is being drawn instead - since the very next draw of our own copy recreates them (see
+        MeshInfo::GetMeshVertexBuffer). Returns true if it released anything. */
+    bool ReleaseIdleMorphVertexBuffers( size_t currentFrame );
 
     /** Shared undeformed conversion of a .MMS, drawn instead of this one whenever the instance isn't
         actively morphing - our copy would still hold the deformation from the last time it was in range.

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -129,6 +129,15 @@ struct MeshInfo {
     // Offset in wrapped world mesh
     unsigned int BaseIndexLocation;
     unsigned int MeshIndex;
+
+    /** MeshManager's id for the SOURCE zCSubMesh this was built from. Do NOT use it as an
+        "these are the same buffers" key - it is a weaker claim than that, and two MeshInfos sharing a
+        meshId can hold completely different geometry: a morph attachment and its undeformed RestVisual are
+        both extracted from one zCProgMeshProto, and .MDS/.ASC node visuals bake their own node transform
+        into their vertices. Node-attachment batching used to key on this and aliased both cases together;
+        it now keys on the MeshInfo pointer, which the SharedVisualRegistry made a stable shared identity.
+        Still used by the static-vob instancing sort, where StaticMeshVisuals guarantees exactly one
+        MeshInfo per progmesh submesh and the ambiguity cannot arise. */
     uint16_t meshId;
 };
 

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -240,18 +240,8 @@ struct MeshVisualInfo : public BaseVisualInfo {
     MeshVisualInfo(const MeshVisualInfo& other) = delete;
     MeshVisualInfo& operator=(const MeshVisualInfo& other) = delete;
 
-    ~MeshVisualInfo() override
-    {
-        // Node attachments may be extracted on a worker thread (WorldConverter::ExtractNodeVisualAsync).
-        // Never free the target out from under a running job.
-        if ( !Ready.load( std::memory_order_acquire ) ) {
-            WaitForPendingNodeVisualExtraction( this );
-        }
-        if ( MorphMeshVisual ) {
-            zCObject_Release( MorphMeshVisual );
-        }
-        delete FullMesh;
-    }
+    /** Out of line because it releases RestVisual back to the SharedVisualRegistry. */
+    ~MeshVisualInfo() override;
 
     /** Starts a new frame for this mesh */
     void StartNewFrame() {
@@ -290,8 +280,18 @@ struct MeshVisualInfo : public BaseVisualInfo {
         is unregistered. SharedRefs is the number of NodeAttachments slots pointing here; the visual
         is destroyed when it hits zero. Both stay 0/null for the non-shared visuals (static meshes,
         particle effect meshes) that continue to be owned outright by their holder. */
-    zCVisual* SharedKey = nullptr;
+    const void* SharedKey = nullptr;
     uint32_t SharedRefs = 0;
+
+    /** For a .MMS morph attachment: the shared UNDEFORMED conversion of the same visual, used whenever
+        this instance isn't actively morphing (out of kMorphMeshMaxDistance range). ZENGIN deforms one
+        shared position list in place per draw, so our morph copy holds whatever deformation was current
+        the last time it was in range - drawing that when the morph is switched off is both wrong and
+        unbatchable, because every instance's copy is stale in a different way. The rest mesh is keyed on
+        zCMorphMesh::GetRestPoseKey(), so all instances that aren't morphing land on ONE MeshInfo and
+        collapse into a single instanced batch. Null for non-morph attachments. This object holds one
+        registry reference to it, released in the destructor. */
+    MeshVisualInfo* RestVisual = nullptr;
 };
 
 /** Holds the converted mesh of a VOB */

--- a/D3D11Engine/zCMorphMesh.h
+++ b/D3D11Engine/zCMorphMesh.h
@@ -8,30 +8,28 @@
 #include "zCProgMeshProto.h"
 
 
-/** One entry of zCMorphMeshProto::aniList. Owned by the (shared) prototype, so two zCMorphMeshes
-    built from the same .MMS hand out the same zCMorphMeshAni pointers. */
+/** One entry of zCMorphMeshProto::aniList. Owned by the shared prototype, so morph meshes built from
+    the same .MMS hand out the same ani pointers. */
 class zCMorphMeshAni {
 public:
     int GetNumVert() {
         return *reinterpret_cast<int*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Ani_Offset_NumVert ));
     }
 
-    /** numFrames * numVert positions. For a refShape ani only the first numVert are the shape itself. */
+    /** numFrames * numVert positions; for a refShape ani the first numVert are the shape. */
     float3* GetVertPosMatrix() {
         return *reinterpret_cast<float3**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Ani_Offset_VertPosMatrix ));
     }
 };
 
-/** The per-.MMS prototype. Refcounted and cached by name in ZENGIN (zCMorphMeshProto::SearchName), so
-    every NPC wearing the same head shares one of these - which is exactly what makes a single rest
-    mesh serve all of them. */
+/** The per-.MMS prototype. Cached by name in ZENGIN, so every NPC wearing the same head shares one. */
 class zCMorphMeshProto {
 public:
     zCProgMeshProto* GetMorphRefMesh() {
         return *reinterpret_cast<zCProgMeshProto**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Proto_Offset_MorphRefMesh ));
     }
 
-    /** The pristine, never-written base vertex positions, one per morphRefMesh vertex. Read only. */
+    /** Pristine base vertex positions, one per morphRefMesh vertex. Never written after load. */
     float3* GetMorphRefMeshVertPos() {
         return *reinterpret_cast<float3**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Proto_Offset_MorphRefMeshVertPos ));
     }
@@ -39,11 +37,10 @@ public:
 
 class zCMorphMesh {
 public:
-    /** NOTE: this is NOT a per-instance mesh - zCMorphMesh's constructor does
-        morphMesh = morphProto->morphRefMesh->AddRef(), so every zCMorphMesh built from the same .MMS
-        returns the SAME zCProgMeshProto, and CalcVertexPositions deforms that one shared position list
-        immediately before each instance is drawn. That is why our converted copies have to be snapshots,
-        and why the undeformed geometry has to come from the arrays below rather than from here. */
+    /** NOT per-instance: the constructor does morphMesh = morphProto->morphRefMesh->AddRef(), so every
+        zCMorphMesh from the same .MMS returns the SAME progmesh and CalcVertexPositions deforms that one
+        shared position list right before each instance draws. Hence our copies are snapshots, and the
+        undeformed geometry has to come from the arrays above. */
     zCProgMeshProto* GetMorphMesh() {
         return *reinterpret_cast<zCProgMeshProto**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Offset_MorphMesh ));
     }
@@ -52,9 +49,8 @@ public:
         return *reinterpret_cast<zCMorphMeshProto**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Offset_MorphProto ));
     }
 
-    /** Non-null only once a refShape ani has been started on this instance (zCMorphMesh::StartAni
-        routes anis flagged refShape here instead of onto a blend channel). When set it replaces
-        morphRefMeshVertPos as the base the morph deltas are added to. */
+    /** Non-null once a refShape-flagged ani has been started here; it then replaces morphRefMeshVertPos
+        as the base the morph deltas are added to. */
     zCMorphMeshAni* GetRefShapeAni() {
         return *reinterpret_cast<zCMorphMeshAni**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Offset_RefShapeAni ));
     }
@@ -71,11 +67,9 @@ public:
         reinterpret_cast<void( __fastcall* )( zCMorphMesh* )>( GothicMemoryLocations::zCMorphMesh::AdvanceAnis )( this );
     }
 
-    /** Identity of this instance's rest pose. Two zCMorphMeshes with the same key have byte-identical
-        undeformed geometry, so they can share one converted rest mesh (and therefore batch together).
-        Both candidates live on shared objects - morphRefMesh is the prototype's own mesh and a
-        refShapeAni is an entry of the prototype's aniList - so heads that were given the same shape ani
-        still collapse onto one key. Returns nullptr when the rest pose can't be determined. */
+    /** Identity of this instance's rest pose: equal keys mean byte-identical undeformed geometry. Both
+        candidates live on the shared prototype, so heads given the same shape ani still collapse onto one
+        key. Null when the rest pose can't be determined. */
     void* GetRestPoseKey() {
         if ( zCMorphMeshAni* shape = GetRefShapeAni() ) {
             return reinterpret_cast<void*>(shape);
@@ -84,9 +78,8 @@ public:
         return proto ? reinterpret_cast<void*>(proto->GetMorphRefMesh()) : nullptr;
     }
 
-    /** The undeformed positions matching GetRestPoseKey(), indexed exactly like morphMesh's position
-        list. 'outNumVert' is how many of them are valid. Returns nullptr if unavailable, in which case
-        the caller must fall back to the deformed path. */
+    /** The undeformed positions matching GetRestPoseKey(), indexed like morphMesh's position list. Null
+        if unavailable, in which case the caller must fall back to the deformed path. */
     float3* GetRestPositions( int& outNumVert ) {
         outNumVert = 0;
         if ( zCMorphMeshAni* shape = GetRefShapeAni() ) {

--- a/D3D11Engine/zCMorphMesh.h
+++ b/D3D11Engine/zCMorphMesh.h
@@ -5,12 +5,58 @@
 #include "Engine.h"
 #include "GothicAPI.h"
 #include "zCModelTexAniState.h"
+#include "zCProgMeshProto.h"
 
+
+/** One entry of zCMorphMeshProto::aniList. Owned by the (shared) prototype, so two zCMorphMeshes
+    built from the same .MMS hand out the same zCMorphMeshAni pointers. */
+class zCMorphMeshAni {
+public:
+    int GetNumVert() {
+        return *reinterpret_cast<int*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Ani_Offset_NumVert ));
+    }
+
+    /** numFrames * numVert positions. For a refShape ani only the first numVert are the shape itself. */
+    float3* GetVertPosMatrix() {
+        return *reinterpret_cast<float3**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Ani_Offset_VertPosMatrix ));
+    }
+};
+
+/** The per-.MMS prototype. Refcounted and cached by name in ZENGIN (zCMorphMeshProto::SearchName), so
+    every NPC wearing the same head shares one of these - which is exactly what makes a single rest
+    mesh serve all of them. */
+class zCMorphMeshProto {
+public:
+    zCProgMeshProto* GetMorphRefMesh() {
+        return *reinterpret_cast<zCProgMeshProto**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Proto_Offset_MorphRefMesh ));
+    }
+
+    /** The pristine, never-written base vertex positions, one per morphRefMesh vertex. Read only. */
+    float3* GetMorphRefMeshVertPos() {
+        return *reinterpret_cast<float3**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Proto_Offset_MorphRefMeshVertPos ));
+    }
+};
 
 class zCMorphMesh {
 public:
+    /** NOTE: this is NOT a per-instance mesh - zCMorphMesh's constructor does
+        morphMesh = morphProto->morphRefMesh->AddRef(), so every zCMorphMesh built from the same .MMS
+        returns the SAME zCProgMeshProto, and CalcVertexPositions deforms that one shared position list
+        immediately before each instance is drawn. That is why our converted copies have to be snapshots,
+        and why the undeformed geometry has to come from the arrays below rather than from here. */
     zCProgMeshProto* GetMorphMesh() {
         return *reinterpret_cast<zCProgMeshProto**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Offset_MorphMesh ));
+    }
+
+    zCMorphMeshProto* GetMorphProto() {
+        return *reinterpret_cast<zCMorphMeshProto**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Offset_MorphProto ));
+    }
+
+    /** Non-null only once a refShape ani has been started on this instance (zCMorphMesh::StartAni
+        routes anis flagged refShape here instead of onto a blend channel). When set it replaces
+        morphRefMeshVertPos as the base the morph deltas are added to. */
+    zCMorphMeshAni* GetRefShapeAni() {
+        return *reinterpret_cast<zCMorphMeshAni**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Offset_RefShapeAni ));
     }
 
     zCModelTexAniState* GetTexAniState() {
@@ -23,5 +69,36 @@ public:
 
     void AdvanceAnis() {
         reinterpret_cast<void( __fastcall* )( zCMorphMesh* )>( GothicMemoryLocations::zCMorphMesh::AdvanceAnis )( this );
+    }
+
+    /** Identity of this instance's rest pose. Two zCMorphMeshes with the same key have byte-identical
+        undeformed geometry, so they can share one converted rest mesh (and therefore batch together).
+        Both candidates live on shared objects - morphRefMesh is the prototype's own mesh and a
+        refShapeAni is an entry of the prototype's aniList - so heads that were given the same shape ani
+        still collapse onto one key. Returns nullptr when the rest pose can't be determined. */
+    void* GetRestPoseKey() {
+        if ( zCMorphMeshAni* shape = GetRefShapeAni() ) {
+            return reinterpret_cast<void*>(shape);
+        }
+        zCMorphMeshProto* proto = GetMorphProto();
+        return proto ? reinterpret_cast<void*>(proto->GetMorphRefMesh()) : nullptr;
+    }
+
+    /** The undeformed positions matching GetRestPoseKey(), indexed exactly like morphMesh's position
+        list. 'outNumVert' is how many of them are valid. Returns nullptr if unavailable, in which case
+        the caller must fall back to the deformed path. */
+    float3* GetRestPositions( int& outNumVert ) {
+        outNumVert = 0;
+        if ( zCMorphMeshAni* shape = GetRefShapeAni() ) {
+            outNumVert = shape->GetNumVert();
+            return outNumVert > 0 ? shape->GetVertPosMatrix() : nullptr;
+        }
+        zCMorphMeshProto* proto = GetMorphProto();
+        zCProgMeshProto* ref = proto ? proto->GetMorphRefMesh() : nullptr;
+        if ( !ref ) {
+            return nullptr;
+        }
+        outNumVert = ref->GetPositionList()->NumInArray;
+        return outNumVert > 0 ? proto->GetMorphRefMeshVertPos() : nullptr;
     }
 };

--- a/D3D11Engine/zCMorphMesh.h
+++ b/D3D11Engine/zCMorphMesh.h
@@ -16,9 +16,47 @@ public:
         return *reinterpret_cast<int*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Ani_Offset_NumVert ));
     }
 
+    int GetNumFrames() {
+        return *reinterpret_cast<int*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Ani_Offset_NumFrames ));
+    }
+
     /** numFrames * numVert positions; for a refShape ani the first numVert are the shape. */
     float3* GetVertPosMatrix() {
         return *reinterpret_cast<float3**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Ani_Offset_VertPosMatrix ));
+    }
+
+    /** Maps this ani's slot j to a vertex index in the morph mesh's position list - the ani only
+        touches numVert of the mesh's vertices, and does so by indirection. */
+    int* GetVertIndexList() {
+        return *reinterpret_cast<int**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Ani_Offset_VertIndexList ));
+    }
+
+    /** A "shape" ani replaces what earlier channels accumulated instead of blending against it
+        (CalcVertPositions forces weight1M to 1 for these). */
+    bool IsShape() {
+        return (*reinterpret_cast<uint8_t*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Ani_Offset_Flags ))
+            & GothicMemoryLocations::zCMorphMesh::Ani_Mask_Shape) != 0;
+    }
+};
+
+/** One active blend channel of a zCMorphMesh. AdvanceAnis owns these - it integrates the weight,
+    advances the frame and deletes the entry when it has faded out. We only ever read them. */
+class zTMorphAniEntry {
+public:
+    zCMorphMeshAni* GetAni() {
+        return *reinterpret_cast<zCMorphMeshAni**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Entry_Offset_Ani ));
+    }
+    float GetWeight() {
+        return *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Entry_Offset_Weight ));
+    }
+    int GetActFrameInt() {
+        return *reinterpret_cast<int*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Entry_Offset_ActFrameInt ));
+    }
+    int GetNextFrameInt() {
+        return *reinterpret_cast<int*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Entry_Offset_NextFrameInt ));
+    }
+    float GetFrac() {
+        return *reinterpret_cast<float*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Entry_Offset_Frac ));
     }
 };
 
@@ -53,6 +91,21 @@ public:
         as the base the morph deltas are added to. */
     zCMorphMeshAni* GetRefShapeAni() {
         return *reinterpret_cast<zCMorphMeshAni**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Offset_RefShapeAni ));
+    }
+
+    /** Active blend channels, in the order CalcVertPositions folds them - the order is load-bearing,
+        see MorphBlend.h. Read the count off the THIRD dword: zCArraySort is
+        { T* array; int numAlloc; int numInArray; }, and this array shrinks as anis fade out, so
+        numAlloc (what zCArrayAdapt would report) is not the live count. */
+    int GetNumAniChannels() {
+        uint8_t* arr = reinterpret_cast<uint8_t*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Offset_AniChannels ));
+        return *reinterpret_cast<int*>(arr + GothicMemoryLocations::zCMorphMesh::ArraySort_Offset_NumInArray);
+    }
+
+    zTMorphAniEntry* GetAniChannel( int i ) {
+        uint8_t* arr = reinterpret_cast<uint8_t*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Offset_AniChannels ));
+        zTMorphAniEntry** entries = *reinterpret_cast<zTMorphAniEntry***>(arr + GothicMemoryLocations::zCMorphMesh::ArraySort_Offset_Array);
+        return entries ? entries[i] : nullptr;
     }
 
     zCModelTexAniState* GetTexAniState() {

--- a/D3D11Engine/zCMorphMesh.h
+++ b/D3D11Engine/zCMorphMesh.h
@@ -71,6 +71,26 @@ public:
     float3* GetMorphRefMeshVertPos() {
         return *reinterpret_cast<float3**>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Proto_Offset_MorphRefMeshVertPos ));
     }
+
+    /** The .MMS name this prototype was loaded from, e.g. "HUM_HEAD_PONY.MMS". */
+    const zSTRING* GetName() {
+        return reinterpret_cast<zSTRING*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Proto_Offset_Name ));
+    }
+
+    /** Every ani this .MMS can play - the superset of what a zCMorphMesh instance ever has as an active
+        channel, which is what a GPU port has to upload per prototype. Unlike zCMorphMesh::aniChannels
+        this array is filled at load and never shrinks, but read the count off the third dword anyway:
+        LoadMMB grows it entry by entry, so numAlloc can exceed numInArray. */
+    int GetNumAnis() {
+        uint8_t* arr = reinterpret_cast<uint8_t*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Proto_Offset_AniList ));
+        return *reinterpret_cast<int*>(arr + GothicMemoryLocations::zCMorphMesh::ArraySort_Offset_NumInArray);
+    }
+
+    zCMorphMeshAni* GetAni( int i ) {
+        uint8_t* arr = reinterpret_cast<uint8_t*>(THISPTR_OFFSET( GothicMemoryLocations::zCMorphMesh::Proto_Offset_AniList ));
+        zCMorphMeshAni** anis = *reinterpret_cast<zCMorphMeshAni***>(arr + GothicMemoryLocations::zCMorphMesh::ArraySort_Offset_Array);
+        return anis ? anis[i] : nullptr;
+    }
 };
 
 class zCMorphMesh {


### PR DESCRIPTION
- SharedVisualRegistry for collecting NodeVisual/Vob visuals that use the same idle pose.
- optional GPU compute-shader based Morphing of Morph mesh visuals
- reduce Morph Mesh visual memory usage by removing VertexBuffers and instead pool it.