### PR TITLE
(5/7) dx12: (optional) LOD for Shadows and main Geometry, reduce cpu side vertex buffer size-cost

### DIFF
--- a/D3D11Engine/AsyncVisualExtractor.cpp
+++ b/D3D11Engine/AsyncVisualExtractor.cpp
@@ -1,0 +1,148 @@
+#include "pch.h"
+#include "AsyncVisualExtractor.h"
+#include "Engine.h"
+#include "WorldConverter.h"
+#include "WorldObjects.h"
+#include "zCModel.h"
+#include "zCMeshSoftSkin.h"
+
+AsyncVisualExtractor* s_AsyncVisualExtractor = new AsyncVisualExtractor();
+
+namespace {
+    /** Copies the model's softskin list and takes a reference on every entry, so the worker can walk it
+        without racing the game thread refilling it. A torn zCMeshSoftSkin is not a theoretical concern:
+        one being torn down still reports its old submesh count while its submesh array is already null,
+        and zCProgMeshProto::GetSubmesh is plain arithmetic off that base, so it hands back a null (or
+        near-null) pointer that reads as a valid submesh. */
+    std::vector<zCMeshSoftSkin*> SnapshotSoftSkins( zCModel* model ) {
+        std::vector<zCMeshSoftSkin*> snapshot;
+
+        zCArray<zCMeshSoftSkin*>* list = model->GetMeshSoftSkinList();
+        if ( !list )
+            return snapshot;
+
+        snapshot.reserve( list->NumInArray );
+        for ( int i = 0; i < list->NumInArray; i++ ) {
+            if ( zCMeshSoftSkin* s = list->Array[i] ) {
+                zCObject_AddRef( s );
+                snapshot.push_back( s );
+            }
+        }
+        return snapshot;
+    }
+}
+
+void AsyncVisualExtractor::ExtractSkeletal( zCModel* model, SkeletalMeshVisualInfo* info ) {
+    ZoneScoped;
+
+    // Whatever was attached to this info may be extracting from an older model - the armor-change case,
+    // where oCNPC::SetVisual has already released the model only our reference is still holding up.
+    WaitForSkeletal( info );
+
+    // Ready gates every draw/update site, so nobody touches Meshes/SkeletalMeshes while we fill them.
+    info->Ready = false;
+
+    PendingExtraction pending;
+    pending.Model = model;
+    pending.SoftSkins = SnapshotSoftSkins( model );
+    zCObject_AddRef( model );
+
+    // Points into pending.SoftSkins, which survives the move into m_Pending: moving a vector - and
+    // rehashing the map - relocates the vector object, never its heap buffer.
+    const std::span<zCMeshSoftSkin* const> softSkins = pending.SoftSkins;
+
+    // CPU vertex/weight unpacking plus GPU buffer creation is the expensive part of a vob popping into
+    // range, which is why this is worth taking off the game thread at all.
+    pending.Task = Engine::WorkerThreadPool->enqueue( [model, softSkins, info]( const std::stop_token& token ) {
+        if ( token.stop_requested() ) {
+            // Cancelled before a worker picked it up. Everything we would read is still alive - we hold
+            // references - but the caller has moved on and no longer wants this extraction.
+            info->Ready.store( true );
+            return;
+        }
+        info->ClearMeshes();
+        WorldConverter::ExtractSkeletalMeshFromVob( model, softSkins, info );
+        info->Visual = model;
+        info->Ready.store( true );
+    } );
+
+    m_Pending[info] = std::move( pending );
+}
+
+void AsyncVisualExtractor::WaitForSkeletal( SkeletalMeshVisualInfo* info ) {
+    if ( !info )
+        return;
+
+    auto it = m_Pending.find( info );
+    if ( it == m_Pending.end() )
+        return;
+
+    PendingExtraction pending = std::move( it->second );
+    m_Pending.erase( it );
+
+    pending.Task.cancel(); // Lets the job bail out immediately if a worker hasn't picked it up yet
+    if ( pending.Task.future.valid() )
+        pending.Task.future.wait();
+
+    QueueRelease( pending.Model );
+    for ( zCMeshSoftSkin* s : pending.SoftSkins )
+        QueueRelease( s );
+}
+
+void AsyncVisualExtractor::DrainFinished() {
+    if ( m_Pending.empty() )
+        return;
+
+    static std::vector<SkeletalMeshVisualInfo*> finished; // Main thread only, keeps its capacity
+    finished.clear();
+
+    for ( auto& it : m_Pending ) {
+        if ( !it.second.Task.future.valid() ||
+            it.second.Task.future.wait_for( std::chrono::seconds( 0 ) ) == std::future_status::ready ) {
+            finished.push_back( it.first );
+        }
+    }
+
+    // Collected first: WaitForSkeletal erases from the map we would otherwise still be iterating.
+    for ( SkeletalMeshVisualInfo* info : finished )
+        WaitForSkeletal( info ); // Already finished, so this doesn't block
+}
+
+void AsyncVisualExtractor::CancelAll() {
+    // No waiting here - the world teardown that calls this has already flushed the thread pool, and the
+    // infos these jobs write into are gone. All that is left is handing the references back.
+    for ( auto& it : m_Pending ) {
+        QueueRelease( it.second.Model );
+        for ( zCMeshSoftSkin* s : it.second.SoftSkins )
+            QueueRelease( s );
+    }
+    m_Pending.clear();
+
+    FlushReleases();
+}
+
+void AsyncVisualExtractor::QueueRelease( void* object ) {
+    if ( !object )
+        return;
+
+    std::scoped_lock lock( m_ReleaseMutex );
+    m_PendingReleases.push_back( object );
+}
+
+void AsyncVisualExtractor::FlushReleases() {
+    for ( ;; ) {
+        void* object;
+        {
+            // The lock is dropped before the release: the destructor's OnVisualDeleted re-entry can queue
+            // further releases, and this mutex is not recursive. That re-entry is also why the vector is
+            // re-checked every round rather than iterated.
+            std::scoped_lock lock( m_ReleaseMutex );
+            if ( m_PendingReleases.empty() )
+                return;
+
+            object = m_PendingReleases.back();
+            m_PendingReleases.pop_back();
+        }
+        zCObject_Release( object );
+    }
+}

--- a/D3D11Engine/AsyncVisualExtractor.h
+++ b/D3D11Engine/AsyncVisualExtractor.h
@@ -10,13 +10,11 @@ struct SkeletalMeshVisualInfo;
 /** Converts ZENGIN visuals into our own mesh/buffer objects on worker threads, and owns the ZENGIN
  *  references that makes safe.
  *
- *  The references are the whole point, because the obvious alternative does not work: a job cannot be
- *  waited on before the data it reads is freed. Our only notification that a visual is dying -
- *  GothicAPI::OnVisualDeleted - hangs off zCVisual's destructor, the *base* destructor, which runs
- *  last, so by the time it fires ~zCModel and ~zCProgMeshProto have already released everything the
- *  worker is reading. Holding a zCObject_AddRef for the life of the job stops refCtr reaching 0 at all,
- *  and with it stops a vob unloading and reloading within one frame from handing the recycled address
- *  back out as a different object.
+ *  The references are the whole point: a job cannot be waited on before the data it reads is freed. Our
+ *  only notification that a visual is dying - GothicAPI::OnVisualDeleted - hangs off zCVisual's *base*
+ *  destructor, which runs last, so by then ~zCModel and ~zCProgMeshProto have already released everything
+ *  the worker is reading. Holding a zCObject_AddRef for the life of the job stops refCtr reaching 0 at all,
+ *  and stops a vob that unloads and reloads within one frame from handing the recycled address back out.
  *
  *  Releasing them is always deferred, never done where a job is retired - see QueueRelease(). */
 class AsyncVisualExtractor {

--- a/D3D11Engine/AsyncVisualExtractor.h
+++ b/D3D11Engine/AsyncVisualExtractor.h
@@ -1,0 +1,71 @@
+#pragma once
+#include "pch.h"
+#include "ThreadPool.h"
+#include <mutex>
+
+class zCModel;
+class zCMeshSoftSkin;
+struct SkeletalMeshVisualInfo;
+
+/** Converts ZENGIN visuals into our own mesh/buffer objects on worker threads, and owns the ZENGIN
+ *  references that makes safe.
+ *
+ *  The references are the whole point, because the obvious alternative does not work: a job cannot be
+ *  waited on before the data it reads is freed. Our only notification that a visual is dying -
+ *  GothicAPI::OnVisualDeleted - hangs off zCVisual's destructor, the *base* destructor, which runs
+ *  last, so by the time it fires ~zCModel and ~zCProgMeshProto have already released everything the
+ *  worker is reading. Holding a zCObject_AddRef for the life of the job stops refCtr reaching 0 at all,
+ *  and with it stops a vob unloading and reloading within one frame from handing the recycled address
+ *  back out as a different object.
+ *
+ *  Releasing them is always deferred, never done where a job is retired - see QueueRelease(). */
+class AsyncVisualExtractor {
+public:
+    /** Starts the background extraction that fills 'info' from 'model'. Retires any job already
+     *  attached to 'info' first. Main thread only. */
+    void ExtractSkeletal( zCModel* model, SkeletalMeshVisualInfo* info );
+
+    /** Blocks until the job attached to 'info' has finished, then retires it. Must be called before
+     *  deleting 'info' - the job writes straight into it. No-op when there is no such job. */
+    void WaitForSkeletal( SkeletalMeshVisualInfo* info );
+
+    /** Retires the jobs that have already finished, so their references don't outlive them - nobody
+     *  else would ever come back for a job whose result was never awaited. Never blocks. Once per
+     *  frame, from the main thread. */
+    void DrainFinished();
+
+    /** Retires every job, finished or not, and flushes the release queue. World teardown only: the
+     *  caller must already have dropped the SkeletalMeshVisualInfos these jobs write into. */
+    void CancelAll();
+
+    /** Queues one reference to be handed back at the next FlushReleases(). Callable from anywhere -
+     *  all it does is append - which matters because releasing inline is a trap:
+     *   - the destructor it may run re-enters OnVisualDeleted, which walks (and deletes out of) the
+     *     very containers every caller here is in the middle of;
+     *   - from WorldConverter's node-visual pruner that re-entry ends up back at the mutex the pruner
+     *     is holding, which is a deadlock rather than a race. */
+    void QueueRelease( void* object );
+
+    /** Hands the queued references back to ZENGIN. Main thread, and only from a top-level point: each
+     *  release can run a visual's destructor and come back around into OnVisualDeleted. */
+    void FlushReleases();
+
+private:
+    /** One in-flight extraction, plus every reference it depends on.
+     *
+     *  SoftSkins is a snapshot and not just the model, because a live zCModel is no guarantee that the
+     *  meshes it pointed at a moment ago still exist: ZENGIN refills zCModel::SoftSkinList *in place*
+     *  on armor changes and mesh-lib swaps, releasing the old zCMeshSoftSkins as it goes. */
+    struct PendingExtraction {
+        TaskHandle<void> Task;
+        zCModel* Model = nullptr;
+        std::vector<zCMeshSoftSkin*> SoftSkins;
+    };
+
+    gtl::flat_hash_map<SkeletalMeshVisualInfo*, PendingExtraction> m_Pending;
+
+    std::mutex m_ReleaseMutex;
+    std::vector<void*> m_PendingReleases;
+};
+
+extern AsyncVisualExtractor* s_AsyncVisualExtractor;

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1684,6 +1684,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="include\meshoptimizer\src\indexgenerator.cpp" />
     <ClCompile Include="include\meshoptimizer\src\overdrawoptimizer.cpp" />
     <ClCompile Include="include\meshoptimizer\src\quantization.cpp" />
+    <ClCompile Include="include\meshoptimizer\src\simplifier.cpp" />
     <ClCompile Include="include\meshoptimizer\src\vcacheoptimizer.cpp" />
     <ClCompile Include="include\meshoptimizer\src\vfetchoptimizer.cpp" />
     <ClCompile Include="vendor\D3D12MemoryAllocator\src\Common.cpp" />

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1090,6 +1090,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="MeshManager.h" />
     <ClInclude Include="MorphBlend.h" />
     <ClInclude Include="MorphGpu.h" />
+    <ClInclude Include="AsyncVisualExtractor.h" />
     <ClInclude Include="SharedVisualRegistry.h" />
     <ClInclude Include="MeshModifier.h" />
     <ClInclude Include="oCGame.h" />
@@ -1710,6 +1711,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="MeshManager.cpp" />
     <ClCompile Include="MorphBlend.cpp" />
     <ClCompile Include="MorphGpu.cpp" />
+    <ClCompile Include="AsyncVisualExtractor.cpp" />
     <ClCompile Include="SharedVisualRegistry.cpp" />
     <ClCompile Include="MeshModifier.cpp" />
     <ClCompile Include="pch.cpp">

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -502,7 +502,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>TRACY_ENABLE;TRACY_ON_DEMAND;PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TRACY_ENABLE1;TRACY_ON_DEMAND1;PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ExceptionHandling>Sync</ExceptionHandling>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -502,7 +502,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>TRACY_ENABLE1;TRACY_ON_DEMAND1;PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TRACY_ENABLE;TRACY_ON_DEMAND;PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ExceptionHandling>Sync</ExceptionHandling>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -945,6 +945,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="D3D12Engine\D3D12StateCache.h" />
     <ClInclude Include="D3D12Engine\D3D12RenderQueue.h" />
     <ClInclude Include="D3D12Engine\D3D12ShadowMap.h" />
+<ClInclude Include="D3D12Engine\D3D12VobArena.h" />
     <ClInclude Include="D3D12Engine\D3D12PointShadows.h" />
     <ClInclude Include="D3D12Engine\InstancingUtils.h" />
     <ClInclude Include="D3D12Engine\D3D12TracyDebug.h" />
@@ -1483,6 +1484,21 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12MorphFold.cpp">
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_12f|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+<ClCompile Include="D3D12Engine\D3D12VobArena.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -934,6 +934,7 @@
     <ClInclude Include="BspPortalCuller.h" />
     <ClInclude Include="HorizonCuller.h" />
     <ClInclude Include="MorphBlend.h" />
+    <ClInclude Include="AsyncVisualExtractor.h" />
     <ClInclude Include="SharedVisualRegistry.h" />
     <ClInclude Include="MorphGpu.h" />
   </ItemGroup>
@@ -1339,6 +1340,7 @@
     <ClCompile Include="HorizonCuller.cpp" />
     <ClCompile Include="D3D12Engine\D3D12Sky.cpp" />
     <ClCompile Include="MorphBlend.cpp" />
+    <ClCompile Include="AsyncVisualExtractor.cpp" />
     <ClCompile Include="SharedVisualRegistry.cpp" />
     <ClCompile Include="D3D12Engine\D3D12MorphFold.cpp" />
     <ClCompile Include="D3D12Engine\D3D12VobArena.cpp" />

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -777,6 +777,9 @@
     <ClInclude Include="D3D12Engine\D3D12ShadowMap.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
+<ClInclude Include="D3D12Engine\D3D12VobArena.h">
+      <Filter>Engine\D3D12</Filter>
+    </ClInclude>
     <ClInclude Include="D3D12Engine\D3D12PointShadows.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
@@ -1338,6 +1341,8 @@
     <ClCompile Include="MorphBlend.cpp" />
     <ClCompile Include="SharedVisualRegistry.cpp" />
     <ClCompile Include="D3D12Engine\D3D12MorphFold.cpp" />
+    <ClCompile Include="D3D12Engine\D3D12VobArena.cpp" />
+    <ClCompile Include="include\meshoptimizer\src\simplifier.cpp" />
     <ClCompile Include="MorphGpu.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3957,7 +3957,7 @@ namespace {
     // the shadow is small enough on screen that the baked progressive-mesh LOD is free silhouette. Both
     // reduced buffers are position-welded, so neither may be used where the pixel shader alpha-tests:
     // welding merges wedges that share a position but not a UV. cascadeIndex -1 = not a cascade render.
-    constexpr int FIRST_LOD_SHADOW_CASCADE = 2;
+    constexpr int FIRST_LOD_SHADOW_CASCADE = 1;
 
     GfxVertexBuffer* GetShadowAwareIndexBuffer( MeshInfo* mesh, bool isAlpha, int cascadeIndex = -1, int lodCascadeIndex = FIRST_LOD_SHADOW_CASCADE ) {
         if ( !mesh ) {
@@ -6972,7 +6972,13 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
 
         // use LOD shadows only for last cascade for now, as it looks uuuugly in gothic 1 due to mesh trees becoming large blobs.
         // TODO: Maybe we need more LOD levels for large geometry?
-        const int lodCascadeStart = std::max(renderState.RendererSettings.NumShadowCascades - 1, 2);
+        // DebugSettings.ShadowCascades.FirstLodCascade overrides that: -1 keeps the automatic rule, any other
+        // value is the first cascade allowed to take the LOD buffer (>= NumShadowCascades disables it).
+        const int lastCascade = std::max( renderState.RendererSettings.NumShadowCascades - 1, 0 );
+        const int firstLodCascadeSetting = renderState.RendererSettings.DebugSettings.ShadowCascades.FirstLodCascade;
+        const int lodCascadeStart = firstLodCascadeSetting < 0
+            ? std::max( lastCascade, FIRST_LOD_SHADOW_CASCADE )
+            : firstLodCascadeSetting;
 
         for ( auto const& [staticMeshVisual, meshKey, meshInfo, _] : instancedMeshesToDraw ) {
             if ( !useWindMetadata && windBuffer != INVALID_SHADER_CB_SLOT && lastWindVisual != staticMeshVisual ) {
@@ -6991,7 +6997,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
 
             // also ignore the fact that something is alpha-tested if its the last cascade
             // will cause some pop-in, but allows us to render much less expensive verticies
-            const bool isAlpha = bindTexture && (params.CascadeIndex != lodCascadeStart);
+            const bool isAlpha = bindTexture && (params.CascadeIndex < lodCascadeStart);
 
             // Bind texture
             if ( bindTexture ) {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3953,24 +3953,24 @@ namespace {
         }
     }
 
-    // Cascade 0 covers everything close to the camera and keeps full-detail casters; from cascade 1 out
-    // the shadow is small enough on screen that the baked progressive-mesh LOD is free silhouette. Both
-    // reduced buffers are position-welded, so neither may be used where the pixel shader alpha-tests:
+    // The position-welded shadow index buffer may not be used where the pixel shader alpha-tests:
     // welding merges wedges that share a position but not a UV. cascadeIndex -1 = not a cascade render.
+    //
+    // The cascade parameters are vestigial here: they used to pick MeshInfo::LodIndices for the distant
+    // cascades, but that reduced level is now built for the D3D12 backend only (see WorldObjects.h) - it
+    // would cost D3D11 one extra index buffer per sub-mesh, and D3D11 is the address-space-starved path.
+    // Kept so the call sites, which do know their cascade, need not change if it ever comes back.
     constexpr int FIRST_LOD_SHADOW_CASCADE = 1;
 
     GfxVertexBuffer* GetShadowAwareIndexBuffer( MeshInfo* mesh, bool isAlpha, int cascadeIndex = -1, int lodCascadeIndex = FIRST_LOD_SHADOW_CASCADE ) {
+        UNREFERENCED_PARAMETER( cascadeIndex );
+        UNREFERENCED_PARAMETER( lodCascadeIndex );
         if ( !mesh ) {
             return nullptr;
         }
 
         if ( isAlpha ) {
             return mesh->GetMeshIndexBuffer();
-        }
-
-        if ( cascadeIndex >= lodCascadeIndex
-            && mesh->MeshLodIndexBuffer && !mesh->LodIndices.empty() ) {
-            return mesh->GetMeshLodIndexBuffer();
         }
 
         if ( mesh->MeshShadowIndexBuffer && !mesh->ShadowIndices.empty() ) {
@@ -3980,15 +3980,14 @@ namespace {
     }
 
     unsigned int GetShadowAwareIndexCount( const MeshInfo* mesh, bool isAlpha, int cascadeIndex = -1, int lodCascadeIndex = FIRST_LOD_SHADOW_CASCADE ) {
+        UNREFERENCED_PARAMETER( cascadeIndex );
+        UNREFERENCED_PARAMETER( lodCascadeIndex );
         if ( !mesh ) {
             return 0;
         }
 
         if ( isAlpha ) {
-        return mesh->Indices.size();
-    }
-        if ( cascadeIndex >= lodCascadeIndex && !mesh->LodIndices.empty() ) {
-            return static_cast<unsigned int>( mesh->LodIndices.size() );
+            return mesh->Indices.size();
         }
         return static_cast<unsigned int>(mesh->ShadowIndices.empty() ? mesh->Indices.size() : mesh->ShadowIndices.size() );
     }

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3956,10 +3956,9 @@ namespace {
     // The position-welded shadow index buffer may not be used where the pixel shader alpha-tests:
     // welding merges wedges that share a position but not a UV. cascadeIndex -1 = not a cascade render.
     //
-    // The cascade parameters are vestigial here: they used to pick MeshInfo::LodIndices for the distant
-    // cascades, but that reduced level is now built for the D3D12 backend only (see WorldObjects.h) - it
-    // would cost D3D11 one extra index buffer per sub-mesh, and D3D11 is the address-space-starved path.
-    // Kept so the call sites, which do know their cascade, need not change if it ever comes back.
+    // The cascade parameters are vestigial: they used to pick MeshInfo::LodIndices for the distant cascades,
+    // but that reduced level is built for D3D12 only (see WorldObjects.h). Kept so the call sites need not
+    // change if it comes back.
     constexpr int FIRST_LOD_SHADOW_CASCADE = 1;
 
     GfxVertexBuffer* GetShadowAwareIndexBuffer( MeshInfo* mesh, bool isAlpha, int cascadeIndex = -1, int lodCascadeIndex = FIRST_LOD_SHADOW_CASCADE ) {

--- a/D3D11Engine/D3D11VertexBuffer.cpp
+++ b/D3D11Engine/D3D11VertexBuffer.cpp
@@ -4,6 +4,7 @@
 #include "D3D11GraphicsEngineBase.h"
 #include "Engine.h"
 #include <meshoptimizer/src/meshoptimizer.h>
+#include "MeshLodBuilder.h"
 #include <limits>
 #include <vector>
 #include "D3D11_Helpers.h"
@@ -34,43 +35,6 @@ namespace {
         }
 
         return true;
-    }
-
-    /** Carries a baked progressive-mesh LOD index list through the vertex-fetch remap OptimizeVertices
-        just applied to the mesh, then position-welds it exactly like the shadow index list. On anything
-        unexpected the list is cleared instead of left half-remapped - callers treat an empty LOD list as
-        "this mesh has no reduced level" and fall back to full detail, which is always correct. */
-    void OptimizeLodIndices( std::vector<VERTEX_INDEX>& lodIndices,
-        const std::vector<unsigned int>& remap,
-        const std::vector<byte>& remappedVertices,
-        size_t fetchedVertexCount,
-        unsigned int stride ) {
-        if ( lodIndices.size() % 3 != 0 ) {
-            lodIndices.clear();
-            return;
-        }
-
-        std::vector<unsigned int> lod;
-        ConvertIndicesToUInt32( lodIndices.data(), lodIndices.size(), lod );
-
-        for ( unsigned int& idx : lod ) {
-            // A collapsed triangle can only reference wedges that survive, and every surviving wedge is
-            // referenced by the full-detail index buffer too - so remap never hands back the ~0u it
-            // reserves for unreferenced vertices. Verified rather than trusted: mod content is content.
-            if ( idx >= remap.size() || remap[idx] >= fetchedVertexCount ) {
-                lodIndices.clear();
-                return;
-            }
-            idx = remap[idx];
-        }
-
-        std::vector<unsigned int> welded( lod.size() );
-        meshopt_generateShadowIndexBuffer( welded.data(), lod.data(), lod.size(),
-            remappedVertices.data(), fetchedVertexCount, sizeof( float ) * 3, stride );
-
-        if ( !ConvertIndicesToVertexIndex( welded, lodIndices.data(), lodIndices.size() ) ) {
-            lodIndices.clear();
-        }
     }
 
     float DequantizeSnorm( int v, int bits ) {
@@ -353,8 +317,10 @@ XRESULT D3D11VertexBuffer::OptimizeVertices( VERTEX_INDEX* indices, byte* vertic
         }
     }
 
-    if ( inOutLodIndices && !inOutLodIndices->empty() ) {
-        OptimizeLodIndices( *inOutLodIndices, remap, remappedVertices, fetchedVertexCount, stride );
+    // Pure OUTPUT now: the simplifier builds the level itself, so a visual no longer needs .MRM LOD data.
+    if ( inOutLodIndices ) {
+        MeshLod::BuildSimplifiedIndices( *inOutLodIndices, remappedIndices, remappedVertices,
+            fetchedVertexCount, stride, ConvertIndicesToVertexIndex );
     }
 
     if ( !ConvertIndicesToVertexIndex( remappedIndices, indices, numIndices ) ) {

--- a/D3D11Engine/D3D11VertexBuffer.cpp
+++ b/D3D11Engine/D3D11VertexBuffer.cpp
@@ -5,6 +5,7 @@
 #include "Engine.h"
 #include <meshoptimizer/src/meshoptimizer.h>
 #include "MeshLodBuilder.h"
+#include "MeshShadowIndexBuilder.h"
 #include <limits>
 #include <vector>
 #include "D3D11_Helpers.h"
@@ -299,20 +300,11 @@ XRESULT D3D11VertexBuffer::OptimizeVertices( VERTEX_INDEX* indices, byte* vertic
     memcpy( remappedVertices.data(), vertices, remappedVertices.size() );
     meshopt_remapVertexBuffer( remappedVertices.data(), vertices, numVertices, stride, remap.data() );
 
+    // Left empty when welding changed nothing - see MeshShadowIndexBuilder.h. Shared with D3D12 rather
+    // than duplicated here, so the drop rule cannot apply to only one backend.
     if ( outShadowIndices ) {
-        std::vector<unsigned int> shadowIndices( numIndices );
-        meshopt_generateShadowIndexBuffer( shadowIndices.data(),
-            remappedIndices.data(),
-            numIndices,
-            remappedVertices.data(),
-            fetchedVertexCount,
-            sizeof( float ) * 3,
-            stride );
-
-        outShadowIndices->resize( numIndices );
-        if ( !ConvertIndicesToVertexIndex( shadowIndices, outShadowIndices->data(), outShadowIndices->size() ) ) {
-            LogError() << "OptimizeVertices: shadow index exceeds VERTEX_INDEX range";
-            outShadowIndices->clear();
+        if ( !MeshShadow::BuildShadowIndices( *outShadowIndices, remappedIndices, remappedVertices,
+            fetchedVertexCount, stride, ConvertIndicesToVertexIndex ) ) {
             return XR_FAILED;
         }
     }

--- a/D3D11Engine/D3D11VertexBuffer.cpp
+++ b/D3D11Engine/D3D11VertexBuffer.cpp
@@ -14,6 +14,20 @@ namespace {
     constexpr float kOverdrawThreshold = 1.05f;
     constexpr int kNormalQuantizationBits = 10;
 
+    /** meshoptimizer indexes its per-vertex scratch arrays (buildTriangleAdjacency's counts[], the vertex
+        cache timestamps, the remap table) by the raw index, and its bounds asserts are compiled out here
+        because NDEBUG is defined in every config. An out-of-range index therefore corrupts the heap deep
+        inside the library instead of failing. One linear pass at the entry point turns that into a log
+        line and an unoptimized - but correct - buffer. */
+    bool IndicesWithinRange( const VERTEX_INDEX* indices, size_t count, unsigned int numVertices ) {
+        for ( size_t i = 0; i < count; ++i ) {
+            if ( static_cast<unsigned int>(indices[i]) >= numVertices ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     void ConvertIndicesToUInt32( const VERTEX_INDEX* src, size_t count, std::vector<unsigned int>& dst ) {
         dst.resize( count );
         for ( size_t i = 0; i < count; ++i ) {
@@ -285,6 +299,17 @@ XRESULT D3D11VertexBuffer::OptimizeVertices( VERTEX_INDEX* indices, byte* vertic
         return XR_FAILED;
     }
 
+    if ( !IndicesWithinRange( indices, numIndices, numVertices ) ) {
+        LogError() << "OptimizeVertices: index out of range (numVertices=" << numVertices << ") - skipping";
+        if ( outShadowIndices ) {
+            outShadowIndices->clear();
+        }
+        if ( inOutLodIndices ) {
+            inOutLodIndices->clear();
+        }
+        return XR_FAILED;
+    }
+
     ZoneScoped;
 
     std::vector<unsigned int> indexData;
@@ -344,6 +369,11 @@ XRESULT D3D11VertexBuffer::OptimizeFaces( VERTEX_INDEX* indices, byte* vertices,
     const unsigned int maxVertexIndex = static_cast<unsigned int>(std::numeric_limits<VERTEX_INDEX>::max());
     if ( numVertices > maxVertexIndex + 1 ) {
         LogError() << "OptimizeFaces: numVertices exceeds VERTEX_INDEX range";
+        return XR_FAILED;
+    }
+
+    if ( !IndicesWithinRange( indices, numIndices, numVertices ) ) {
+        LogError() << "OptimizeFaces: index out of range (numVertices=" << numVertices << ") - skipping";
         return XR_FAILED;
     }
 

--- a/D3D11Engine/D3D12Engine/D3D12Cull.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Cull.cpp
@@ -204,6 +204,16 @@ ID3D12Resource* D3D12GraphicsEngine::GetVobDrawArgsBuffer() const {
 }
 
 
+ID3D12Resource* D3D12GraphicsEngine::GetVobInstanceBufferForDraws() const {
+    // Which per-instance stream the two main-view VOB passes bind on slot 1. Since the VOB arena removed the
+    // per-command instance VBV, this is a single per-pass choice instead: the compacted buffer CSCull wrote
+    // when culling is on, the raw upload ring otherwise. It has to agree with what BuildVobDrawCommands
+    // assumed, which is the same m_GpuVobCullActive snapshot taken once at the top of the frame.
+    if ( m_GpuVobCullActive && m_VobCulledInstances ) return m_VobCulledInstances.Get();
+    return m_VobInstanceBuffer[m_FrameIndex].Get();
+}
+
+
 void D3D12GraphicsEngine::BuildHiZ() {
     // Called right after DrawDepthPrepass (world mesh only) and before the VOB depth prepass, so the pyramid
     // contains world geometry exclusively — exactly what the VOBs must be tested against.
@@ -278,8 +288,18 @@ void D3D12GraphicsEngine::CullVobsGPU() {
             pre[n++] = TransitionBarrier( m_VobDrawArgsGpu.Get(), D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT, D3D12_RESOURCE_STATE_COPY_DEST );
             m_VobDrawArgsGpuInIndirectState = false;
         }
+        // Cull-record overflow safety net: a visual that didn't fit kMaxCullVisuals keeps VisualIndex
+        // 0xFFFFFFFF, so CSPatchArgs leaves its command alone and it draws its CPU instance count from its
+        // absolute InstanceBase. That used to be fine because the command carried its own InstVBV pointing
+        // back at the uncompacted ring — but with the VOB arena the pass binds ONE instance buffer, and with
+        // culling on that is the compacted one, which CSCull only writes for visuals that DID get a record.
+        // Seed it with the raw ring so the overflowed visuals still find their instances where their
+        // (unpatched) StartInstanceLocation says. Costs a copy of exactly what was uploaded, and only in a
+        // frame that actually overflowed — i.e. essentially never, since the cap is 16384 visuals.
+        const bool seedCulled = m_VobCullVisualOverflowed && m_VobInstanceBufferOffset > 0;
         if ( m_VobCulledInstancesInVertexState ) {
-            pre[n++] = TransitionBarrier( m_VobCulledInstances.Get(), D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+            pre[n++] = TransitionBarrier( m_VobCulledInstances.Get(), D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER,
+                seedCulled ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
             m_VobCulledInstancesInVertexState = false;
         }
         if ( m_VobVisibleCountsInSrvState ) {
@@ -287,6 +307,15 @@ void D3D12GraphicsEngine::CullVobsGPU() {
             m_VobVisibleCountsInSrvState = false;
         }
         if ( n ) m_CmdList->ResourceBarrier( n, pre );
+
+        if ( seedCulled ) {
+            m_CmdList->CopyBufferRegion( m_VobCulledInstances.Get(), 0, m_VobInstanceBuffer[m_FrameIndex].Get(), 0,
+                m_VobInstanceBufferOffset );
+            // Back to UNORDERED_ACCESS for CSCull, which is about to overwrite the compacted prefixes.
+            D3D12_RESOURCE_BARRIER toUav = TransitionBarrier( m_VobCulledInstances.Get(),
+                D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+            m_CmdList->ResourceBarrier( 1, &toUav );
+        }
     }
 
     if ( m_VobDrawCount == 0 || m_VobCullVisualCount == 0 ) return;
@@ -315,7 +344,7 @@ void D3D12GraphicsEngine::CullVobsGPU() {
         float    LodDistance;
         uint32_t Pad0;        // mirrors VobCull.hlsl's explicit float3 alignment pad
         XMFLOAT3 CamPosWS;
-        uint32_t Pad1;
+        float    AlphaPrepassDistance;
     } cb{};
     static_assert( sizeof( VobCullCB ) == 28 * sizeof( uint32_t ), "VobCullCB must match the 28 root constants in CreateCull()" );
     cb.ViewProj = viewProj;
@@ -328,6 +357,9 @@ void D3D12GraphicsEngine::CullVobsGPU() {
     // Must be the SAME value BuildVobDrawCommands used, or a far run ends up with no command to draw it.
     cb.LodDistance = m_VobLodDistance;
     cb.CamPosWS = Engine::GAPI->GetCameraPosition();
+    // Same rule as LodDistance: must be the value BuildVobDrawCommands used, or an alpha-split visual's far
+    // run ends up bucketed by one threshold and drawn by commands built for another.
+    cb.AlphaPrepassDistance = m_VobAlphaPrepassDistance;
 
     m_CmdList->SetPipelineState( m_Pipelines.Cull.VobCullPSO.Get() );
     m_CmdList->SetComputeRootSignature( m_Pipelines.Cull.VobCullRootSig.Get() );

--- a/D3D11Engine/D3D12Engine/D3D12Cull.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Cull.cpp
@@ -344,9 +344,8 @@ void D3D12GraphicsEngine::CullVobsGPU() {
         float    LodDistance;
         uint32_t Pad0;        // mirrors VobCull.hlsl's explicit float3 alignment pad
         XMFLOAT3 CamPosWS;
-        float    AlphaPrepassDistance;
     } cb{};
-    static_assert( sizeof( VobCullCB ) == 28 * sizeof( uint32_t ), "VobCullCB must match the 28 root constants in CreateCull()" );
+    static_assert( sizeof( VobCullCB ) == 27 * sizeof( uint32_t ), "VobCullCB must match the 27 root constants in CreateCull()" );
     cb.ViewProj = viewProj;
     cb.VisualCount = m_VobCullVisualCount;
     cb.HiZIndex = occlusion ? m_HiZSrvSlot : 0u;
@@ -357,13 +356,10 @@ void D3D12GraphicsEngine::CullVobsGPU() {
     // Must be the SAME value BuildVobDrawCommands used, or a far run ends up with no command to draw it.
     cb.LodDistance = m_VobLodDistance;
     cb.CamPosWS = Engine::GAPI->GetCameraPosition();
-    // Same rule as LodDistance: must be the value BuildVobDrawCommands used, or an alpha-split visual's far
-    // run ends up bucketed by one threshold and drawn by commands built for another.
-    cb.AlphaPrepassDistance = m_VobAlphaPrepassDistance;
 
     m_CmdList->SetPipelineState( m_Pipelines.Cull.VobCullPSO.Get() );
     m_CmdList->SetComputeRootSignature( m_Pipelines.Cull.VobCullRootSig.Get() );
-    m_CmdList->SetComputeRoot32BitConstants( 0, 28, &cb, 0 );
+    m_CmdList->SetComputeRoot32BitConstants( 0, 27, &cb, 0 );
     m_CmdList->SetComputeRootShaderResourceView( 1, m_VobCullVisuals[m_FrameIndex]->GetGPUVirtualAddress() );
     m_CmdList->SetComputeRootShaderResourceView( 2, m_VobInstanceBuffer[m_FrameIndex]->GetGPUVirtualAddress() );
     m_CmdList->SetComputeRootUnorderedAccessView( 3, m_VobCulledInstances->GetGPUVirtualAddress() );

--- a/D3D11Engine/D3D12Engine/D3D12Cull.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Cull.cpp
@@ -99,7 +99,7 @@ bool D3D12GraphicsEngine::CreateVobCullResources() {
     // VobCull.hlsl mirrors both of these as structured-buffer element types; a size change on either side
     // would silently mis-index every instance. Verified against `dxc -Fc` reflection (144 B / 32 B).
     static_assert( sizeof( VobInstanceInfo ) == 144, "VobCull.hlsl's VobInstanceGpu mirrors VobInstanceInfo" );
-    static_assert( sizeof( VobCullVisual ) == 32, "VobCull.hlsl's VobCullVisual must match this layout" );
+    static_assert( sizeof( VobCullVisual ) == 36, "VobCull.hlsl's VobCullVisual must match this layout" );
 
     m_VobCullReady = false;
     ID3D12Device* device = m_Device.GetDevice();
@@ -153,7 +153,8 @@ bool D3D12GraphicsEngine::CreateVobCullResources() {
         m_VobCulledInstances->SetName( L"VobCulledInstances" );
     }
     {
-        D3D12_RESOURCE_DESC bd = makeBufferDesc( static_cast<UINT64>( kMaxCullVisuals ) * sizeof( uint32_t ), true );
+        // TWO counts per visual (near, far); CSPatchArgs indexes (visualIndex * 2 + LodBucket).
+        D3D12_RESOURCE_DESC bd = makeBufferDesc( static_cast<UINT64>( kMaxCullVisuals ) * 2ull * sizeof( uint32_t ), true );
         if ( FAILED( m_Allocator->CreateResource( &heapDefault, &bd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr,
             m_VobVisibleCountsAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( m_VobVisibleCounts.ReleaseAndGetAddressOf() ) ) ) ) {
             LogWarn() << "D3D12: failed to create the VOB visible-count buffer.";
@@ -311,9 +312,12 @@ void D3D12GraphicsEngine::CullVobsGPU() {
         uint32_t HiZHeight;
         uint32_t HiZMipCount;
         uint32_t EnableOcclusion;
-        uint32_t Pad0, Pad1;
+        float    LodDistance;
+        uint32_t Pad0;        // mirrors VobCull.hlsl's explicit float3 alignment pad
+        XMFLOAT3 CamPosWS;
+        uint32_t Pad1;
     } cb{};
-    static_assert( sizeof( VobCullCB ) == 24 * sizeof( uint32_t ), "VobCullCB must match the 24 root constants in CreateCull()" );
+    static_assert( sizeof( VobCullCB ) == 28 * sizeof( uint32_t ), "VobCullCB must match the 28 root constants in CreateCull()" );
     cb.ViewProj = viewProj;
     cb.VisualCount = m_VobCullVisualCount;
     cb.HiZIndex = occlusion ? m_HiZSrvSlot : 0u;
@@ -321,10 +325,13 @@ void D3D12GraphicsEngine::CullVobsGPU() {
     cb.HiZHeight = m_HiZHeight;
     cb.HiZMipCount = occlusion ? m_HiZMipCount : 0u;
     cb.EnableOcclusion = occlusion ? 1u : 0u;
+    // Must be the SAME value BuildVobDrawCommands used, or a far run ends up with no command to draw it.
+    cb.LodDistance = m_VobLodDistance;
+    cb.CamPosWS = Engine::GAPI->GetCameraPosition();
 
     m_CmdList->SetPipelineState( m_Pipelines.Cull.VobCullPSO.Get() );
     m_CmdList->SetComputeRootSignature( m_Pipelines.Cull.VobCullRootSig.Get() );
-    m_CmdList->SetComputeRoot32BitConstants( 0, 24, &cb, 0 );
+    m_CmdList->SetComputeRoot32BitConstants( 0, 28, &cb, 0 );
     m_CmdList->SetComputeRootShaderResourceView( 1, m_VobCullVisuals[m_FrameIndex]->GetGPUVirtualAddress() );
     m_CmdList->SetComputeRootShaderResourceView( 2, m_VobInstanceBuffer[m_FrameIndex]->GetGPUVirtualAddress() );
     m_CmdList->SetComputeRootUnorderedAccessView( 3, m_VobCulledInstances->GetGPUVirtualAddress() );
@@ -343,17 +350,24 @@ void D3D12GraphicsEngine::CullVobsGPU() {
         m_VobVisibleCountsInSrvState = true;
     }
 
-    struct VobPatchCB { uint32_t CmdCount, CmdStride, InstCountOffset, VisualIdxOffset; } patch{};
+    struct VobPatchCB {
+        uint32_t CmdCount, CmdStride, InstCountOffset, VisualIdxOffset;
+        uint32_t StartInstOffset, LodBucketOffset, Pad0;
+    } patch{};
+    static_assert( sizeof( VobPatchCB ) == 7 * sizeof( uint32_t ), "VobPatchCB must match the 7 root constants in CreateCull()" );
     patch.CmdCount = m_VobDrawCount;
     patch.CmdStride = sizeof( VobDrawCommand );
     patch.InstCountOffset = static_cast<uint32_t>( offsetof( VobDrawCommand, Draw ) + offsetof( D3D12_DRAW_INDEXED_ARGUMENTS, InstanceCount ) );
     patch.VisualIdxOffset = static_cast<uint32_t>( offsetof( VobDrawCommand, VisualIndex ) );
+    patch.StartInstOffset = static_cast<uint32_t>( offsetof( VobDrawCommand, Draw ) + offsetof( D3D12_DRAW_INDEXED_ARGUMENTS, StartInstanceLocation ) );
+    patch.LodBucketOffset = static_cast<uint32_t>( offsetof( VobDrawCommand, LodBucket ) );
 
     m_CmdList->SetPipelineState( m_Pipelines.Cull.PatchPSO.Get() );
     m_CmdList->SetComputeRootSignature( m_Pipelines.Cull.PatchRootSig.Get() );
-    m_CmdList->SetComputeRoot32BitConstants( 0, 4, &patch, 0 );
+    m_CmdList->SetComputeRoot32BitConstants( 0, 7, &patch, 0 );
     m_CmdList->SetComputeRootShaderResourceView( 1, m_VobVisibleCounts->GetGPUVirtualAddress() );
-    m_CmdList->SetComputeRootUnorderedAccessView( 2, m_VobDrawArgsGpu->GetGPUVirtualAddress() );
+    m_CmdList->SetComputeRootShaderResourceView( 2, m_VobCullVisuals[m_FrameIndex]->GetGPUVirtualAddress() );
+    m_CmdList->SetComputeRootUnorderedAccessView( 3, m_VobDrawArgsGpu->GetGPUVirtualAddress() );
     m_CmdList->Dispatch( ( m_VobDrawCount + 63 ) / 64, 1, 1 );
 
     // --- Hand both buffers to the two VOB passes ---

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -42,6 +42,12 @@ struct FrameVobUpload {
     D3D12_VERTEX_BUFFER_VIEW culledInstView;
     UINT numInstances;
     UINT instanceBase;
+    // Length of the leading NEAR run inside this visual's instance block, for the CPU-side geometry-LOD
+    // split (UploadFrameVobInstances partitions the block by distance while it copies). The far run is the
+    // remainder and is contiguous with it, so it starts at instanceBase + nearInstances. Equal to
+    // numInstances whenever no CPU split applies — including every shadow/rain upload and every GPU-culled
+    // frame, where CSCull does the bucketing instead and CSPatchArgs writes the counts.
+    UINT nearInstances;
     uint32_t cullVisualIndex;
 };
 

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -32,11 +32,16 @@ struct SkeletalMeshVisualInfo;
 // but based at m_VobCulledInstances (where CSCull compacts the survivors), plus this visual's index into the
 // per-frame VobCullVisual record buffer. cullVisualIndex == 0xFFFFFFFF means "not culled" (the visual didn't
 // fit the record cap, or GPU culling is off) and the command keeps instView + the CPU's instance count.
+// instView/culledInstView survive for the CPU draw loops that still bind per-draw (the blended-VOB replay in
+// D3D12Transparency.cpp). The ExecuteIndirect path no longer uses them: with the VOB arena there is one
+// instance buffer bound per pass, so a command addresses its visual's block through instanceBase — the
+// ELEMENT index of the visual's first instance, which is also what CSPatchArgs adds its run offset to.
 struct FrameVobUpload {
     MeshVisualInfo* visual;
     D3D12_VERTEX_BUFFER_VIEW instView;
     D3D12_VERTEX_BUFFER_VIEW culledInstView;
     UINT numInstances;
+    UINT instanceBase;
     uint32_t cullVisualIndex;
 };
 

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -637,7 +637,7 @@ bool D3D12GraphicsEngine::AcquireStagingSpaceLocked( UINT64 size, UINT64 alignme
 }
 
 
-bool D3D12GraphicsEngine::UploadBufferData( ID3D12Resource* dst, const void* srcData, UINT64 sizeInBytes ) {
+bool D3D12GraphicsEngine::UploadBufferData( ID3D12Resource* dst, UINT64 dstOffset, const void* srcData, UINT64 sizeInBytes ) {
 	if ( !dst || !srcData || sizeInBytes == 0 ) return false;
 
 	// Record into the shared batched copy list (submitted once at flush) — same rationale as
@@ -657,7 +657,7 @@ bool D3D12GraphicsEngine::UploadBufferData( ID3D12Resource* dst, const void* src
 		// 16-byte alignment: CopyBufferRegion imposes none, this is purely so the memcpy lands aligned.
 		if ( AcquireStagingSpaceLocked( sizeInBytes, 16, &stagingResource, &stagingOffset, &stagingCpu ) ) {
 			memcpy( stagingCpu, srcData, sizeInBytes );
-			m_CopyBatchList->CopyBufferRegion( dst, 0, stagingResource, stagingOffset, sizeInBytes );
+			m_CopyBatchList->CopyBufferRegion( dst, dstOffset, stagingResource, stagingOffset, sizeInBytes );
 
 			m_CopyBatchDestResources.emplace_back( dst );   // see PendingCopyRelease::DestResources
 			m_CopyBatchBytes += sizeInBytes;
@@ -709,7 +709,7 @@ bool D3D12GraphicsEngine::UploadBufferData( ID3D12Resource* dst, const void* src
 	if ( !BeginCopyBatch() )   // may be a different batch than the one probed above; harmless
 		return false;
 
-	m_CopyBatchList->CopyBufferRegion( dst, 0, upload.Get(), 0, sizeInBytes );
+	m_CopyBatchList->CopyBufferRegion( dst, dstOffset, upload.Get(), 0, sizeInBytes );
 
 	m_CopyBatchUploadAllocs.push_back( std::move( uploadAllocation ) );
 	m_CopyBatchUploadResources.push_back( std::move( upload ) );

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -789,8 +789,11 @@ private:
     // The LOD gate is shared with D3D11 (WorldConverter.h) rather than picked per backend: an edge
     // collapse MOVES the caster surface, so a cascade whose bias is smaller than that deviation
     // self-shadows the full-detail surface black. See the constant's comment for the failure mode.
+    // DebugSettings.ShadowCascades.FirstLodCascade overrides the constant at runtime (-1 = keep it);
+    // GetFirstLodShadowCascade() resolves the two.
     static constexpr int kVobIndicesMainView = -1;
     static constexpr int kFirstLodShadowCascade = SHADOW_LOD_FIRST_CASCADE;
+    static int GetFirstLodShadowCascade();
     // outOpaqueCount (optional): how many of the returned commands form the leading no-alpha-cutout run. The
     // build always partitions — opaque materials first, alpha-tested ones after — so the depth prepass can
     // submit the prefix through a PS-less PSO. Callers that don't split (the color pass, the shadow cascades)

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -18,6 +18,7 @@
 #include "D3D12StateCache.h"
 #include "D3D12PipelineState.h"
 #include "D3D12ShadowMap.h"
+#include "D3D12VobArena.h"
 #include "D3D12PointShadows.h"
 
 struct RenderBucket;
@@ -46,6 +47,9 @@ class D3D12GraphicsEngine : public BaseGraphicsEngine {
     // rather than widening the engine's public surface for them.
     friend class D3D12ShadowMap;
     friend class D3D12PointShadows;
+    // Same deal: the VOB mega-buffer arena needs the allocator + the fence-deferred cleanup to swap its
+    // buffers out from under frames that may still be reading them.
+    friend class D3D12VobArena;
 
 public:
     /** Compile-time array-sizing bound for every per-frame resource ring (1 current + up to 2 queued).
@@ -154,7 +158,11 @@ public:
         submitted value. The caller can then issue a direct-queue transition barrier once the copy has
         completed. */
     bool UploadTextureSubresources( ID3D12Resource* dst, const D3D12_SUBRESOURCE_DATA* subresources, UINT numSubresources );
-    bool UploadBufferData( ID3D12Resource* dst, const void* srcData, UINT64 sizeInBytes );
+    bool UploadBufferData( ID3D12Resource* dst, const void* srcData, UINT64 sizeInBytes ) {
+        return UploadBufferData( dst, 0, srcData, sizeInBytes );
+    }
+    /** dstOffset variant, for filling one slice of a larger DEFAULT-heap buffer (the VOB arena). */
+    bool UploadBufferData( ID3D12Resource* dst, UINT64 dstOffset, const void* srcData, UINT64 sizeInBytes );
     bool InitCopyQueue();
     UINT64 GetCopyFenceValue() const { return m_CopyFenceValue; }
     void WaitForCopyFence( UINT64 fenceValue );
@@ -733,33 +741,58 @@ private:
     // depth-tested but never depth-writing. Also in D3D12Transparency.cpp.
     void DrawVobAlphaMeshes();
 
-    // ---- GPU-driven instanced VOBs (P2.12): ExecuteIndirect + bindless diffuse. Unlike the world mesh (one
-    // shared VB/IB, so a command only carries material indices + DrawIndexed), every VOB visual/mesh has its OWN
-    // vertex/index buffer and its own per-instance stream — so each command ALSO sets the two vertex-buffer views
-    // (packed mesh @slot0, per-instance @slot1) + the index-buffer view before drawing. Diffuse goes bindless
-    // (b6.MatDiffuseIndex root const) so no per-draw descriptor table is needed. Wind min/max height (per-visual)
-    // rides as a 2-const partial write into b4 @ offset 4; the frame-global wind fields (dir/time/playerPos) are
-    // set once before the ExecuteIndirect. Built ONCE per frame (BuildVobDrawCommands) and consumed by BOTH the
-    // depth prepass and the color pass; the CSM cascades build their own per-cascade command set. Arg-member order
-    // MUST match the command signature's pArgumentDescs order below (VBV0, VBV1, IBV, b6 consts, b4 consts, draw).
-    struct VobDrawCommand {                          // 96 bytes; UINT64 members force 8-byte align, 96 % 8 == 0
-        D3D12_VERTEX_BUFFER_VIEW MeshVBV;            // @0  packed ExVertexStruct stream (slot 0)
-        D3D12_VERTEX_BUFFER_VIEW InstVBV;            // @16 per-instance VobInstanceInfo stream (slot 1)
-        D3D12_INDEX_BUFFER_VIEW  IBV;                // @32 R16_UINT sub-mesh indices
-        uint32_t MatNormalIndex;                     // @48 b6.x  (0xFFFFFFFF = no normal map)
-        uint32_t MatOrmIndex;                        // @52 b6.y  (default ORM slot when no _FX)
-        uint32_t MatDiffuseIndex;                    // @56 b6.z  bindless diffuse (alpha clip + albedo)
-        float    WindMinHeight;                      // @60 b4[4] per-visual bbox.min.y
-        float    WindMaxHeight;                      // @64 b4[5] per-visual bbox.max.y
-        D3D12_DRAW_INDEXED_ARGUMENTS Draw;           // @68 (20 bytes)
+    // ---- GPU-driven instanced VOBs (P2.12): ExecuteIndirect + bindless diffuse + the VOB mega-buffer arena.
+    //
+    // Every static VOB sub-mesh in the world lives in ONE DEFAULT-heap vertex buffer + ONE index buffer
+    // (D3D12VobArena), so a command no longer carries any buffer views at all: the mesh reduces to
+    // BaseVertexLocation/StartIndexLocation inside the shared pair, and the per-instance stream is a single
+    // buffer every visual already offsets into, so StartInstanceLocation covers it. Each pass therefore binds
+    // the IA exactly once and every command is pure state-free payload — which is the point: it is the
+    // presence of VBV/IBV arguments in a command signature that costs, not how many there are, and 560
+    // per-command IA rebinds were the dominant cost of the four VOB passes. See D3D12VobArena.h.
+    //
+    // Diffuse goes bindless (b6.MatDiffuseIndex root const) so no per-draw descriptor table is needed. Wind
+    // min/max height (per-visual) rides as a 2-const partial write into b4 @ offset 4; the frame-global wind
+    // fields (dir/time/playerPos) are set once before the ExecuteIndirect. Built ONCE per frame
+    // (BuildVobDrawCommands) and consumed by BOTH the depth prepass and the color pass; the CSM cascades and
+    // the rain shadowmap build their own command sets over the same arena. Arg-member order MUST match the
+    // command signature's pArgumentDescs order (b6 consts, b4 consts, draw).
+    struct VobDrawCommand {                          // 48 bytes; all members 4-byte, no GPUVA alignment to keep
+        uint32_t MatNormalIndex;                     // @0  b6.x  (0xFFFFFFFF = no normal map)
+        uint32_t MatOrmIndex;                        // @4  b6.y  (default ORM slot when no _FX)
+        uint32_t MatDiffuseIndex;                    // @8  b6.z  bindless diffuse (alpha clip + albedo)
+        float    WindMinHeight;                      // @12 b4[4] per-visual bbox.min.y
+        float    WindMaxHeight;                      // @16 b4[5] per-visual bbox.max.y
+        D3D12_DRAW_INDEXED_ARGUMENTS Draw;           // @20 (20 bytes) — ends the indirect arguments at @40
         // --- Past the end of the command signature's arguments. ExecuteIndirect reads the args packed from
         // offset 0 and only requires ByteStride to COVER them, so trailing fields are free per-command payload
         // for our own compute passes. VisualIndex tells CSPatchArgs which per-visual surviving-instance count
         // to write into Draw.InstanceCount; 0xFFFFFFFF = "leave the CPU's count alone" (not GPU-culled).
-        uint32_t VisualIndex;                        // @88
+        uint32_t VisualIndex;                        // @40
         // Which of the visual's two compacted instance runs this command draws; CSPatchArgs picks the
-        // matching count + StartInstanceLocation from it. Doubles as the stride's 8-byte alignment pad.
-        uint32_t LodBucket;                          // @92
+        // matching count + StartInstanceLocation from it.
+        uint32_t LodBucket;                          // @44
+    };
+
+    // The pre-arena command shape, kept for the ONE consumer that cannot use the arena: node attachments
+    // (weapons/heads/held items). Their geometry comes from the SharedVisualRegistry rather than the world's
+    // static VOB set, arrives and leaves with NPCs, and amounts to a few dozen commands a frame — nothing the
+    // arena would pay for. They keep their own signature (m_VobBoundIndirectCmdSig) with the two VBVs + IBV
+    // inline, and go through World.RootSig exactly as before. VSMainAttach/VSDepthAttach never read the b4
+    // wind min/max the signature also writes (the instance stream's wind fields carry Fatness/Scaling here),
+    // so those two floats go out as 0.
+    struct VobBoundDrawCommand {                     // 96 bytes; UINT64 members force 8-byte align, 96 % 8 == 0
+        D3D12_VERTEX_BUFFER_VIEW MeshVBV;            // @0  packed ExVertexStruct stream (slot 0)
+        D3D12_VERTEX_BUFFER_VIEW InstVBV;            // @16 per-instance VobInstanceInfo stream (slot 1)
+        D3D12_INDEX_BUFFER_VIEW  IBV;                // @32 R16_UINT sub-mesh indices
+        uint32_t MatNormalIndex;                     // @48 b6.x
+        uint32_t MatOrmIndex;                        // @52 b6.y
+        uint32_t MatDiffuseIndex;                    // @56 b6.z
+        float    WindMinHeight;                      // @60 b4[4]
+        float    WindMaxHeight;                      // @64 b4[5]
+        D3D12_DRAW_INDEXED_ARGUMENTS Draw;           // @68 (20 bytes)
+        uint32_t VisualIndex;                        // @88 always 0xFFFFFFFF here — attachments are never GPU-culled
+        uint32_t LodBucket;                          // @92 pad / always kLodBucketNear
     };
     static constexpr uint32_t kLodBucketNear = 0;
     static constexpr uint32_t kLodBucketFar  = 1;
@@ -768,12 +801,51 @@ private:
     // bump would multiply across 3 cascades x kBackBufferCount rings and cost real 32-bit address space.
     static constexpr UINT kMaxVobDrawCommands       = 16384;  // main view: visuals x materials x sub-meshes
     static constexpr UINT kMaxShadowVobDrawCommands = 8192;   // per shadow cascade; overflow logs + drops
-    Microsoft::WRL::ComPtr<ID3D12CommandSignature> m_VobIndirectCmdSig;   // VBVx2 + IBV + b6(3) + b4[4..5](2) + DrawIndexed
+    Microsoft::WRL::ComPtr<ID3D12CommandSignature> m_VobIndirectCmdSig;        // b6(3) + b4[4..5](2) + DrawIndexed
+    Microsoft::WRL::ComPtr<ID3D12CommandSignature> m_VobBoundIndirectCmdSig;   // + VBVx2 + IBV (node attachments)
+    // Every static VOB sub-mesh in one DEFAULT-heap VB/IB pair — see D3D12VobArena.h. Filled from OnAddVob
+    // (which fires per vob during world load, so the world is resident before the first frame) and flushed
+    // once per frame at the top of UploadFrameVobInstances.
+    D3D12VobArena m_VobArena;
+    // Re-uploads the arena ranges of animated static VOBs (.MMS morph meshes) from their own vertex buffers.
+    // Runs right after DispatchMorphFold, which is what produces this frame's deformed vertices.
+    void RefreshDynamicVobArena();
+    /** The one IA bind every instanced-VOB ExecuteIndirect needs: the mega-buffers on slot 0 / the index
+        stream, and `instances` (the per-instance VobInstanceInfo stream this pass draws from — the raw
+        upload ring for the shadow/rain passes, the GPU-compacted buffer for a culled main view) on slot 1.
+        Returns false when the arena holds nothing, in which case the caller must not submit: its commands
+        would index a buffer that doesn't exist. */
+    bool BindVobArenaIA( D3D12CmdList& cmdList, ID3D12Resource* instances, UINT instanceBytes );
     Microsoft::WRL::ComPtr<ID3D12Resource> m_VobDrawArgs[kBackBufferMax];   // main-view (prepass+color share it)
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_VobDrawArgsAlloc[kBackBufferMax];
     uint8_t* m_VobDrawArgsPtr[kBackBufferMax] = {};
     UINT m_VobDrawCount = 0;                          // commands built this frame (shared by both main-view VOB passes)
     UINT m_VobOpaqueDrawCount = 0;                    // alpha-test partition of the above — see m_WorldOpaqueDrawCount
+    // How many of the alpha-tested commands (the run starting at m_VobOpaqueDrawCount) the DEPTH PREPASS
+    // should submit. Equal to the whole alpha run unless the kSplitModeAlpha split is on, in which case the
+    // alpha run is ordered [near][far] and this is the length of the near part. The COLOR pass always draws
+    // all of them.
+    UINT m_VobAlphaNearDrawCount = 0;
+
+public:
+    /** Last frame's VOB submission shape, for the ImGui stats panel. The VOB passes are the frame's
+        dominant GPU cost and the three plausible causes - too many COMMANDS, too many INSTANCES, too many
+        TRIANGLES - are indistinguishable from a Tracy GPU zone alone, so publish all three plus whether the
+        features that would reduce each are actually engaged. */
+    struct VobFrameStats {
+        UINT Commands;        // total ExecuteIndirect commands in the main-view set
+        UINT OpaqueCommands;  // leading no-cutout run
+        UINT AlphaNearCommands;   // of the alpha-tested tail, how many the depth prepass submits
+        UINT CullVisuals;     // VobCullVisual records written (== visuals with instances this frame)
+        UINT Instances;       // total instances uploaded across all visuals (pre-GPU-cull)
+        UINT SplitNone;       // visuals per SplitMode - if these are all in SplitNone, neither the LOD
+        UINT SplitLod;        // nor the alpha slider can possibly be doing anything
+        UINT SplitAlpha;
+        bool GpuCullActive;   // both split features are inert when this is false
+    };
+    const VobFrameStats& GetVobFrameStats() const { return m_VobStats; }
+private:
+    VobFrameStats m_VobStats = {};
     unsigned int m_VobDrawnTriangles = 0;            // triangles in this frame's main-view VOB command set (stats)
     bool m_VobDrawArgsOverflowLogged = false;
     // The shadow-caster variant of this pipeline (VSDepth + PSShadowClipBindless) and the per-cascade arg rings
@@ -806,9 +878,12 @@ private:
     // build always partitions — opaque materials first, alpha-tested ones after — so the depth prepass can
     // submit the prefix through a PS-less PSO. Callers that don't split (the color pass, the shadow cascades)
     // just pass nullptr and draw the whole range. See m_WorldOpaqueDrawCount.
+    // outAlphaNearCount (optional, main-view build only): length of the NEAR part of the alpha-tested run,
+    // for the depth prepass' kSplitModeAlpha trim. Always the whole alpha run when the split is inactive.
     UINT BuildVobDrawCommands( const std::vector<FrameVobUpload>& uploads, uint8_t* argPtr, bool resolveMaps,
         UINT maxCommands, bool culled = false, bool cacheIn = true,
-        int shadowCascade = kVobIndicesMainView, UINT* outOpaqueCount = nullptr );
+        int shadowCascade = kVobIndicesMainView, UINT* outOpaqueCount = nullptr,
+        UINT* outAlphaNearCount = nullptr );
 
     // ---- GPU-driven skeletal meshes + node attachments (T9): ExecuteIndirect + bindless materials ----------
     // Possible because neither Skeletal.RootSig nor the attachment PSOs bind a t0 descriptor table any more,
@@ -883,19 +958,37 @@ private:
         UINT              InstanceBase;
         DirectX::XMFLOAT3 BBoxMax;
         UINT              InstanceCount;
-        // 1 = every drawn sub-mesh emitted a far command, so CSCull may split by distance. Written by
-        // BuildVobDrawCommands, not here - only the command build knows. See VobCull.hlsl for the failure.
-        UINT              LodSplit;
+        // Which distance CSCull buckets this visual's instances by - see kSplitMode* below. Written by
+        // BuildVobDrawCommands, not here: only the command build knows whether the far bucket actually has
+        // commands to draw it, and splitting without them strands those instances (see VobCull.hlsl).
+        UINT              SplitMode;
     };
+    // No split: every surviving instance lands in the near run.
+    static constexpr UINT kSplitModeNone  = 0;
+    // Split at m_VobLodDistance: the far run draws the simplified LOD index buffer. Requires EVERY drawn
+    // sub-mesh of the visual to have emitted a far command.
+    static constexpr UINT kSplitModeLod   = 1;
+    // Split at m_VobAlphaPrepassDistance: both runs draw the SAME (full) indices, but the depth prepass
+    // submits only the near one. For visuals carrying alpha-tested materials, whose cutout pixel shader is
+    // what makes the prepass expensive. Mutually exclusive with kSplitModeLod by construction - a visual
+    // with any alpha-tested sub-mesh can never satisfy the "all sub-meshes have a far command" LOD rule,
+    // because alpha-tested materials are excluded from the LOD buffer.
+    static constexpr UINT kSplitModeAlpha = 2;
     static constexpr UINT kMaxCullVisuals = 16384;
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_VobCullVisuals[kBackBufferMax];   // persistently-mapped UPLOAD
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_VobCullVisualsAlloc[kBackBufferMax];
     uint8_t* m_VobCullVisualsPtr[kBackBufferMax] = {};
     UINT m_VobCullVisualCount = 0;                  // records written this frame
     bool m_VobCullVisualOverflowLogged = false;
+    // THIS frame's overflow (the ...Logged flag above is sticky for the session). CullVobsGPU seeds the
+    // compacted instance buffer from the raw ring when it is set — see the note there.
+    bool m_VobCullVisualOverflowed = false;
     // Resolved ONCE per frame: BuildVobDrawCommands and CSCull must see the same value or a bucket is
     // left with no command to draw it. 0 = off.
     float m_VobLodDistance = 0.0f;
+    // Ditto, for the alpha-tested prepass split (kSplitModeAlpha). 0 = off, which is the default: the
+    // useful threshold has to come from a capture, not a guess.
+    float m_VobAlphaPrepassDistance = 0.0f;
     // Single-instance GPU-side buffers: the direct queue is in-order, so frame N's draws are consumed before
     // frame N+1's cull writes — no per-frame-in-flight copies needed (and none of the 32-bit VA cost).
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_VobCulledInstances;   // DEFAULT UAV, mirrors the instance ring layout
@@ -920,6 +1013,7 @@ private:
     // The buffer both VOB passes ExecuteIndirect from: the GPU-patched DEFAULT copy when culling, else the
     // per-frame CPU-written UPLOAD ring.
     ID3D12Resource* GetVobDrawArgsBuffer() const;
+    ID3D12Resource* GetVobInstanceBufferForDraws() const;
 
     // ---- GPU morph fold (D3D12MorphFold.cpp + MorphGpu.h + Shaders/D3D12/MorphFold.hlsl) ----
     // Morph attachments (NPC heads, bow/crossbow draw meshes) fold their blend shapes in a compute pass that

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -821,11 +821,6 @@ private:
     uint8_t* m_VobDrawArgsPtr[kBackBufferMax] = {};
     UINT m_VobDrawCount = 0;                          // commands built this frame (shared by both main-view VOB passes)
     UINT m_VobOpaqueDrawCount = 0;                    // alpha-test partition of the above — see m_WorldOpaqueDrawCount
-    // How many of the alpha-tested commands (the run starting at m_VobOpaqueDrawCount) the DEPTH PREPASS
-    // should submit. Equal to the whole alpha run unless the kSplitModeAlpha split is on, in which case the
-    // alpha run is ordered [near][far] and this is the length of the near part. The COLOR pass always draws
-    // all of them.
-    UINT m_VobAlphaNearDrawCount = 0;
 
 public:
     /** Last frame's VOB submission shape, for the ImGui stats panel. The VOB passes are the frame's
@@ -835,13 +830,11 @@ public:
     struct VobFrameStats {
         UINT Commands;        // total ExecuteIndirect commands in the main-view set
         UINT OpaqueCommands;  // leading no-cutout run
-        UINT AlphaNearCommands;   // of the alpha-tested tail, how many the depth prepass submits
         UINT CullVisuals;     // VobCullVisual records written (== visuals with instances this frame)
         UINT Instances;       // total instances uploaded across all visuals (pre-GPU-cull)
-        UINT SplitNone;       // visuals per SplitMode - if these are all in SplitNone, neither the LOD
-        UINT SplitLod;        // nor the alpha slider can possibly be doing anything
-        UINT SplitAlpha;
-        bool GpuCullActive;   // both split features are inert when this is false
+        UINT SplitNone;       // visuals per SplitMode - if these are all in SplitNone, the LOD slider
+        UINT SplitLod;        // cannot be doing anything, whatever it is set to
+        bool GpuCullActive;   // which of the two paths produced the split (compute vs the CPU upload)
     };
     const VobFrameStats& GetVobFrameStats() const { return m_VobStats; }
 private:
@@ -878,12 +871,9 @@ private:
     // build always partitions — opaque materials first, alpha-tested ones after — so the depth prepass can
     // submit the prefix through a PS-less PSO. Callers that don't split (the color pass, the shadow cascades)
     // just pass nullptr and draw the whole range. See m_WorldOpaqueDrawCount.
-    // outAlphaNearCount (optional, main-view build only): length of the NEAR part of the alpha-tested run,
-    // for the depth prepass' kSplitModeAlpha trim. Always the whole alpha run when the split is inactive.
     UINT BuildVobDrawCommands( const std::vector<FrameVobUpload>& uploads, uint8_t* argPtr, bool resolveMaps,
         UINT maxCommands, bool culled = false, bool cacheIn = true,
-        int shadowCascade = kVobIndicesMainView, UINT* outOpaqueCount = nullptr,
-        UINT* outAlphaNearCount = nullptr );
+        int shadowCascade = kVobIndicesMainView, UINT* outOpaqueCount = nullptr );
 
     // ---- GPU-driven skeletal meshes + node attachments (T9): ExecuteIndirect + bindless materials ----------
     // Possible because neither Skeletal.RootSig nor the attachment PSOs bind a t0 descriptor table any more,
@@ -968,12 +958,6 @@ private:
     // Split at m_VobLodDistance: the far run draws the simplified LOD index buffer. Requires EVERY drawn
     // sub-mesh of the visual to have emitted a far command.
     static constexpr UINT kSplitModeLod   = 1;
-    // Split at m_VobAlphaPrepassDistance: both runs draw the SAME (full) indices, but the depth prepass
-    // submits only the near one. For visuals carrying alpha-tested materials, whose cutout pixel shader is
-    // what makes the prepass expensive. Mutually exclusive with kSplitModeLod by construction - a visual
-    // with any alpha-tested sub-mesh can never satisfy the "all sub-meshes have a far command" LOD rule,
-    // because alpha-tested materials are excluded from the LOD buffer.
-    static constexpr UINT kSplitModeAlpha = 2;
     static constexpr UINT kMaxCullVisuals = 16384;
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_VobCullVisuals[kBackBufferMax];   // persistently-mapped UPLOAD
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_VobCullVisualsAlloc[kBackBufferMax];
@@ -986,9 +970,6 @@ private:
     // Resolved ONCE per frame: BuildVobDrawCommands and CSCull must see the same value or a bucket is
     // left with no command to draw it. 0 = off.
     float m_VobLodDistance = 0.0f;
-    // Ditto, for the alpha-tested prepass split (kSplitModeAlpha). 0 = off, which is the default: the
-    // useful threshold has to come from a capture, not a guess.
-    float m_VobAlphaPrepassDistance = 0.0f;
     // Single-instance GPU-side buffers: the direct queue is in-order, so frame N's draws are consumed before
     // frame N+1's cull writes — no per-frame-in-flight copies needed (and none of the 32-bit VA cost).
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_VobCulledInstances;   // DEFAULT UAV, mirrors the instance ring layout

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -110,10 +110,18 @@ public:
         `noTextures` is accepted for interface parity but currently always effectively true. */
     XRESULT DrawWorldMesh( bool noTextures = false ) override;
 
-    /** Fills the sky/background with Gothic's atmosphere (fog) color. Forward-renderer MVP: a color
-        clear at the start of the world pass; distance fog in the geometry shaders fades into the same
-        color so the horizon dissolves seamlessly. No sky dome/scattering yet. */
+    /** Fog-color fill + Gothic's atmosphere solve (RenderSky). Runs at the top of the world pass, before
+        the shadow prepare and the depth prepass, because RenderSkyIBL and the wetness/fog constants read
+        what it computes. Sets m_SkyGeometryPending for DrawSky. */
+    XRESULT PrepareSky();
+
+    /** The sky's actual geometry (atmosphere dome or Gothic's fixed-function RenderSkyPre), submitted AFTER
+        the opaque depth prepass so the far-plane-pinned sky is depth-rejected behind geometry instead of
+        shading 2.6 screens' worth of fragments that get painted over. See the body for the ordering rules. */
     XRESULT DrawSky() override;
+
+    /** Set by PrepareSky: false indoors (zCSkyControler_Indoor draws nothing) or on a closed frame. */
+    bool m_SkyGeometryPending = false;
 
     BaseLineRenderer* GetLineRenderer() override;
 

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -749,8 +749,12 @@ private:
         // for our own compute passes. VisualIndex tells CSPatchArgs which per-visual surviving-instance count
         // to write into Draw.InstanceCount; 0xFFFFFFFF = "leave the CPU's count alone" (not GPU-culled).
         uint32_t VisualIndex;                        // @88
-        uint32_t _cmdPad;                            // @92 keeps the stride 8-aligned for the next command's VBVs
+        // Which of the visual's two compacted instance runs this command draws; CSPatchArgs picks the
+        // matching count + StartInstanceLocation from it. Doubles as the stride's 8-byte alignment pad.
+        uint32_t LodBucket;                          // @92
     };
+    static constexpr uint32_t kLodBucketNear = 0;
+    static constexpr uint32_t kLodBucketFar  = 1;
     // Separate caps: the main view now collects distance-only (360 degrees, GPU-culled) so it needs headroom,
     // while the CSM cascades still CPU-cull against their own frustum and keep the original budget — a shared
     // bump would multiply across 3 cascades x kBackBufferCount rings and cost real 32-bit address space.
@@ -868,6 +872,9 @@ private:
         UINT              InstanceBase;
         DirectX::XMFLOAT3 BBoxMax;
         UINT              InstanceCount;
+        // 1 = every drawn sub-mesh emitted a far command, so CSCull may split by distance. Written by
+        // BuildVobDrawCommands, not here - only the command build knows. See VobCull.hlsl for the failure.
+        UINT              LodSplit;
     };
     static constexpr UINT kMaxCullVisuals = 16384;
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_VobCullVisuals[kBackBufferMax];   // persistently-mapped UPLOAD
@@ -875,6 +882,9 @@ private:
     uint8_t* m_VobCullVisualsPtr[kBackBufferMax] = {};
     UINT m_VobCullVisualCount = 0;                  // records written this frame
     bool m_VobCullVisualOverflowLogged = false;
+    // Resolved ONCE per frame: BuildVobDrawCommands and CSCull must see the same value or a bucket is
+    // left with no command to draw it. 0 = off.
+    float m_VobLodDistance = 0.0f;
     // Single-instance GPU-side buffers: the direct queue is in-order, so frame N's draws are consumed before
     // frame N+1's cull writes — no per-frame-in-flight copies needed (and none of the 32-bit VA cost).
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_VobCulledInstances;   // DEFAULT UAV, mirrors the instance ring layout

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -743,20 +743,17 @@ private:
 
     // ---- GPU-driven instanced VOBs (P2.12): ExecuteIndirect + bindless diffuse + the VOB mega-buffer arena.
     //
-    // Every static VOB sub-mesh in the world lives in ONE DEFAULT-heap vertex buffer + ONE index buffer
-    // (D3D12VobArena), so a command no longer carries any buffer views at all: the mesh reduces to
-    // BaseVertexLocation/StartIndexLocation inside the shared pair, and the per-instance stream is a single
-    // buffer every visual already offsets into, so StartInstanceLocation covers it. Each pass therefore binds
-    // the IA exactly once and every command is pure state-free payload — which is the point: it is the
-    // presence of VBV/IBV arguments in a command signature that costs, not how many there are, and 560
-    // per-command IA rebinds were the dominant cost of the four VOB passes. See D3D12VobArena.h.
+    // Every static VOB sub-mesh lives in ONE DEFAULT-heap vertex buffer + ONE index buffer (D3D12VobArena),
+    // so a command carries no buffer views at all: the mesh is BaseVertexLocation/StartIndexLocation inside
+    // the shared pair and StartInstanceLocation covers the single instance buffer. Each pass therefore binds
+    // the IA once — the presence of VBV/IBV arguments is what makes a command an IA state change, and 560 of
+    // those per pass was the dominant VOB cost. See D3D12VobArena.h.
     //
-    // Diffuse goes bindless (b6.MatDiffuseIndex root const) so no per-draw descriptor table is needed. Wind
-    // min/max height (per-visual) rides as a 2-const partial write into b4 @ offset 4; the frame-global wind
-    // fields (dir/time/playerPos) are set once before the ExecuteIndirect. Built ONCE per frame
-    // (BuildVobDrawCommands) and consumed by BOTH the depth prepass and the color pass; the CSM cascades and
-    // the rain shadowmap build their own command sets over the same arena. Arg-member order MUST match the
-    // command signature's pArgumentDescs order (b6 consts, b4 consts, draw).
+    // Diffuse goes bindless (b6.MatDiffuseIndex root const). Wind min/max height (per-visual) rides as a
+    // 2-const partial write into b4 @ offset 4; the frame-global wind fields are set once before the
+    // ExecuteIndirect. Built ONCE per frame and consumed by both the depth prepass and the color pass; the
+    // CSM cascades and rain shadowmap build their own sets over the same arena. Arg-member order MUST match
+    // the command signature's pArgumentDescs order (b6 consts, b4 consts, draw).
     struct VobDrawCommand {                          // 48 bytes; all members 4-byte, no GPUVA alignment to keep
         uint32_t MatNormalIndex;                     // @0  b6.x  (0xFFFFFFFF = no normal map)
         uint32_t MatOrmIndex;                        // @4  b6.y  (default ORM slot when no _FX)
@@ -774,13 +771,11 @@ private:
         uint32_t LodBucket;                          // @44
     };
 
-    // The pre-arena command shape, kept for the ONE consumer that cannot use the arena: node attachments
-    // (weapons/heads/held items). Their geometry comes from the SharedVisualRegistry rather than the world's
-    // static VOB set, arrives and leaves with NPCs, and amounts to a few dozen commands a frame — nothing the
-    // arena would pay for. They keep their own signature (m_VobBoundIndirectCmdSig) with the two VBVs + IBV
-    // inline, and go through World.RootSig exactly as before. VSMainAttach/VSDepthAttach never read the b4
-    // wind min/max the signature also writes (the instance stream's wind fields carry Fatness/Scaling here),
-    // so those two floats go out as 0.
+    // The pre-arena command shape, kept for the one consumer that cannot use the arena: node attachments
+    // (weapons/heads/held items), whose geometry comes from the SharedVisualRegistry and arrives and leaves
+    // with NPCs. They keep their own signature (m_VobBoundIndirectCmdSig) with the two VBVs + IBV inline.
+    // VSMainAttach/VSDepthAttach never read the b4 wind min/max (the instance stream's wind fields carry
+    // Fatness/Scaling here), so those two floats go out as 0.
     struct VobBoundDrawCommand {                     // 96 bytes; UINT64 members force 8-byte align, 96 % 8 == 0
         D3D12_VERTEX_BUFFER_VIEW MeshVBV;            // @0  packed ExVertexStruct stream (slot 0)
         D3D12_VERTEX_BUFFER_VIEW InstVBV;            // @16 per-instance VobInstanceInfo stream (slot 1)
@@ -844,26 +839,22 @@ private:
     // The shadow-caster variant of this pipeline (VSDepth + PSShadowClipBindless) and the per-cascade arg rings
     // it submits from live in D3D12ShadowMap; this signature is shared by both.
     bool CreateVobIndirect();                         // command signature + per-frame arg rings + shadow-caster PSO (once, at init)
-    // Fill an arg buffer from the given VOB uploads; returns command count. resolveMaps=false leaves normal/orm at
-    // defaults (depth/shadow passes only alpha-clip on diffuse), true resolves the full PBR material set (color pass).
-    // culled=true points each command's instance stream at the GPU-compacted output buffer and stamps
-    // VisualIndex so CSPatchArgs can overwrite the instance count (main view only — the cascades CPU-cull).
-    // cacheIn=false resolves each material's diffuse with zCTexture::GetCacheState instead of CacheIn, making
-    // the build a pure read so it can run on a cascade's worker thread (CacheIn mutates Gothic's resource
-    // manager). A texture that has not been pulled in yet simply alpha-clips against black for that frame —
-    // a caster silhouette, not a visible surface, so the inaccuracy never reaches the screen as a wrong pixel.
-    // shadowCascade picks which of a sub-mesh's index buffers each command draws, mirroring D3D11's
-    // GetShadowAwareIndexBuffer: kVobIndicesMainView keeps the full render indices (the lit and prepass
-    // draws need per-wedge normals/UVs), a cascade index >= 0 takes the position-welded shadow indices,
-    // and >= kFirstLodShadowCascade takes the baked progressive-mesh LOD on top of that. Both reduced
-    // buffers merge wedges that share a position but not a UV, so a material the caster alpha-clips
-    // always keeps its render indices regardless of pass.
+    // Fill an arg buffer from the given VOB uploads; returns command count.
+    //   resolveMaps  false leaves normal/orm at defaults (depth/shadow passes only alpha-clip on diffuse).
+    //   culled       points each command's instance stream at the GPU-compacted buffer and stamps
+    //                VisualIndex so CSPatchArgs can overwrite the instance count (main view only).
+    //   cacheIn      false resolves diffuse with GetCacheState instead of CacheIn, making the build a pure
+    //                read so it can run on a cascade's worker thread. A texture not yet pulled in alpha-clips
+    //                against black for one frame, which on a caster silhouette never reaches the screen.
+    //   shadowCascade  which of a sub-mesh's index buffers to draw, mirroring D3D11's
+    //                GetShadowAwareIndexBuffer: main view = full render indices, cascade >= 0 = position-
+    //                welded shadow indices, >= kFirstLodShadowCascade = the baked progressive-mesh LOD.
+    //                Both reduced buffers merge wedges sharing a position but not a UV, so an alpha-clipped
+    //                material always keeps its render indices.
     //
-    // The LOD gate is shared with D3D11 (WorldConverter.h) rather than picked per backend: an edge
-    // collapse MOVES the caster surface, so a cascade whose bias is smaller than that deviation
-    // self-shadows the full-detail surface black. See the constant's comment for the failure mode.
-    // DebugSettings.ShadowCascades.FirstLodCascade overrides the constant at runtime (-1 = keep it);
-    // GetFirstLodShadowCascade() resolves the two.
+    // The LOD gate is shared with D3D11 (WorldConverter.h): an edge collapse MOVES the caster surface, so a
+    // cascade biased tighter than that deviation self-shadows the full-detail surface black.
+    // DebugSettings.ShadowCascades.FirstLodCascade overrides it at runtime; GetFirstLodShadowCascade() wins.
     static constexpr int kVobIndicesMainView = -1;
     static constexpr int kFirstLodShadowCascade = SHADOW_LOD_FIRST_CASCADE;
     static int GetFirstLodShadowCascade();

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -3514,11 +3514,11 @@ bool D3D12PipelineState::CreateCull() {
     if ( !makeComputePSO( "HiZ.hlsl", "CSReduce", hiZRs,
         Cull.HiZReduceCsBlob.ReleaseAndGetAddressOf(), Cull.HiZReducePSO.ReleaseAndGetAddressOf() ) ) return false;
 
-    // --- VOB cull root sig: b0 28 consts (ViewProj + Hi-Z params + LOD bucketing), t0/t1 root SRVs, u0/u1 root UAVs ---
+    // --- VOB cull root sig: b0 27 consts (ViewProj + Hi-Z params + LOD bucketing), t0/t1 root SRVs, u0/u1 root UAVs ---
     // The visual records + instance streams are plain structured buffers, so they ride as root descriptors
     // (no heap slots). Only the Hi-Z pyramid is a texture and it comes in bindlessly by heap index.
     D3D12RootLayout& vobCullRs = Layout( "CullVob" );
-    vobCullRs.AddConstants( 0, 28, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 VobCullCB — float4x4 ViewProj + 12
+    vobCullRs.AddConstants( 0, 27, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 VobCullCB — float4x4 ViewProj + 11
     // Both inputs are CPU-written once per frame by UploadFrameVobInstances / BuildVobDrawCommands,
     // which complete before this dispatch is recorded and are not touched again this frame.
     vobCullRs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 1: t0 Visuals

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -3514,11 +3514,11 @@ bool D3D12PipelineState::CreateCull() {
     if ( !makeComputePSO( "HiZ.hlsl", "CSReduce", hiZRs,
         Cull.HiZReduceCsBlob.ReleaseAndGetAddressOf(), Cull.HiZReducePSO.ReleaseAndGetAddressOf() ) ) return false;
 
-    // --- VOB cull root sig: b0 24 consts (ViewProj + Hi-Z params), t0/t1 root SRVs, u0/u1 root UAVs ---
+    // --- VOB cull root sig: b0 28 consts (ViewProj + Hi-Z params + LOD bucketing), t0/t1 root SRVs, u0/u1 root UAVs ---
     // The visual records + instance streams are plain structured buffers, so they ride as root descriptors
     // (no heap slots). Only the Hi-Z pyramid is a texture and it comes in bindlessly by heap index.
     D3D12RootLayout& vobCullRs = Layout( "CullVob" );
-    vobCullRs.AddConstants( 0, 24, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 VobCullCB — float4x4 ViewProj + 8 uints
+    vobCullRs.AddConstants( 0, 28, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 VobCullCB — float4x4 ViewProj + 12
     // Both inputs are CPU-written once per frame by UploadFrameVobInstances / BuildVobDrawCommands,
     // which complete before this dispatch is recorded and are not touched again this frame.
     vobCullRs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 1: t0 Visuals
@@ -3532,13 +3532,16 @@ bool D3D12PipelineState::CreateCull() {
     if ( !makeComputePSO( "VobCull.hlsl", "CSCull", vobCullRs,
         Cull.VobCullCsBlob.ReleaseAndGetAddressOf(), Cull.VobCullPSO.ReleaseAndGetAddressOf() ) ) return false;
 
-    // --- Indirect-arg patch root sig: b0 4 consts (count/stride/offsets), t0 counts SRV, u0 raw arg UAV ---
+    // --- Indirect-arg patch root sig: b0 7 consts (count/stride/offsets), t0 counts + t1 visuals SRVs, u0 raw arg UAV ---
     D3D12RootLayout& patchRs = Layout( "CullPatch" );
-    patchRs.AddConstants( 0, 4, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 VobPatchCB
+    patchRs.AddConstants( 0, 7, D3D12_SHADER_VISIBILITY_ALL );   // 0: b0 VobPatchCB
     // t0 is the VisibleCounts UAV the cull dispatch just finished writing, read back here behind a
     // barrier: final from this bind onwards (the next write is next frame's cull, a later list).
     patchRs.AddSRV( 0, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 1: t0 PatchCounts
-    patchRs.AddUAV( 0, D3D12_SHADER_VISIBILITY_ALL );            // 2: u0 PatchArgs (RWByteAddressBuffer)
+    // t1: the same per-visual records CSCull read — the far run's StartInstanceLocation is
+    // (InstanceCount - farCount), so the patch pass needs each visual's capacity.
+    patchRs.AddSRV( 1, D3D12_SHADER_VISIBILITY_ALL, 0, D3D12RootLayout::RootDataStatic );   // 2: t1 PatchVisuals
+    patchRs.AddUAV( 0, D3D12_SHADER_VISIBILITY_ALL );            // 3: u0 PatchArgs (RWByteAddressBuffer)
     if ( !patchRs.Build( device ) )
         return false;
     Cull.PatchRootSig = patchRs.RootSig();

--- a/D3D11Engine/D3D12Engine/D3D12Rain.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Rain.cpp
@@ -826,7 +826,7 @@ void D3D12GraphicsEngine::RecordRainShadowmap( D3D12CmdList& cmdList ) {
     // Same viewport/scissor/topology the world block set (both are unconditional there... except when the
     // world had no casters), so re-establish them here rather than depending on that branch having run.
     if ( m_RainVobDrawCount > 0 && m_ShadowMap.GetVobIndirectCasterPSO() && m_VobIndirectCmdSig
-        && m_RainVobDrawArgs[m_FrameIndex] ) {
+        && m_RainVobDrawArgs[m_FrameIndex] && m_VobArena.Ready() ) {
         DX_ZONE( cmdList.Get(), "Vobs" );
         TracyD3D12ZoneCGX( cmdList.Get(), "Vobs" );
 
@@ -843,6 +843,10 @@ void D3D12GraphicsEngine::RecordRainShadowmap( D3D12CmdList& cmdList ) {
         cmdList->SetGraphicsRootSignature( m_Pipelines.World.RootSig.Get() );
         cmdList->SetGraphicsRoot32BitConstants( 0, 16, &m_RainShadowViewProj, 0 );
         cmdList->SetGraphicsRoot32BitConstants( 11, 12, &m_WindBuffer, 0 );   // b4 frame-global wind baseline
+        // One IA bind for the pass: the VOB mega-buffers + the shadow instance ring this pass' UploadVobs
+        // slot wrote into (CPU-culled, never compacted — StartInstanceLocation is absolute).
+        BindVobArenaIA( cmdList, m_ShadowVobInstanceBuffer[m_FrameIndex].Get(),
+            m_ShadowInstanceSliceCapacity * kShadowInstanceRingSlots );
         if ( !vobNoAlphaPso ) {
             cmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_RainVobDrawCount,
                 m_RainVobDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2131,10 +2131,14 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// mid-frame would mix culled and unculled state. See D3D12Cull.cpp.
 	m_GpuVobCullActive = EvaluateGpuVobCulling();
 
-	// Snapshotted ONCE: BuildVobDrawCommands and CSCull must agree on it, and the ImGui slider moving
-	// between them would strand a bucket with no command. Needs GPU culling - CSCull produces the split.
-	m_VobLodDistance = ( m_GpuVobCullActive
-		&& Engine::GAPI->GetRendererState().RendererSettings.VobLodDrawRadius > 0.0f )
+	// Snapshotted ONCE: the instance partition and the command build must agree on it, and the ImGui slider
+	// moving between them would strand a bucket with no command to draw it.
+	//
+	// NOT gated on GPU culling. The near/far bucketing is produced by CSCull when the GPU cull is on and by
+	// UploadFrameVobInstances' own distance partition when it is off — so the geometry LOD is available on
+	// either path. That matters for the machine this feature is actually for: a weak GPU behind a strong CPU,
+	// which is exactly the configuration that also wants the CPU frustum cull rather than the compute one.
+	m_VobLodDistance = Engine::GAPI->GetRendererState().RendererSettings.VobLodDrawRadius > 0.0f
 		? Engine::GAPI->GetRendererState().RendererSettings.VobLodDrawRadius : 0.0f;
 	// Same one-shot snapshot, same reason, for the alpha-tested prepass split (kSplitModeAlpha).
 	m_VobAlphaPrepassDistance = ( m_GpuVobCullActive
@@ -3215,6 +3219,12 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
     const bool alphaSplitEnabled = ( shadowCascade == kVobIndicesMainView ) && culled && resolveMaps
         && cullRecords != nullptr && m_VobAlphaPrepassDistance > 0.0f;
 
+    // CPU-side geometry LOD: the uploads already carry a near/far partition of each visual's instance block
+    // (UploadFrameVobInstances), so the far command's instance count and start are known HERE and get baked
+    // straight into the argument buffer — no cull records, no CSPatchArgs, no compute at all. Mutually
+    // exclusive with the GPU path by construction: `culled` picks which of the two produced the buckets.
+    const bool cpuLodSplit = ( shadowCascade == kVobIndicesMainView ) && !culled && m_VobLodDistance > 0.0f;
+
     // Per-visual command staging. The alpha split is a per-VISUAL decision (CSCull buckets a visual's whole
     // instance range one way) but `alphaTested` is only known per sub-mesh, and only AFTER that sub-mesh's
     // material has been through CacheIn - zCTexture::HasAlphaChannel() reads a flag byte that is not
@@ -3323,7 +3333,7 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 // Whether this sub-mesh can offer a reduced far level to the main view. No longer gated on
                 // the visual's split mode - that is decided at flush time below, and suppressing LOD there
                 // keeps the two modes from ever both applying.
-                const bool lodEligible = ( shadowCascade == kVobIndicesMainView ) && culled
+                const bool lodEligible = ( shadowCascade == kVobIndicesMainView ) && ( culled || cpuLodSplit )
                     && m_VobLodDistance > 0.0f && !alphaTested && range->LodCount > 0;
 
                 // Pick this command's index range. A missing level just falls through to the next-best one,
@@ -3409,11 +3419,22 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
             return finish();
         }
 
+        // CPU LOD split, resolved here for the same reason the GPU one is: only now is it known that EVERY
+        // drawn sub-mesh has a far counterpart. If one doesn't, the whole visual falls back to a single
+        // command per sub-mesh covering the WHOLE instance block — which still draws every instance
+        // correctly, because the near and far runs the upload produced are adjacent and contiguous.
+        const bool cpuSplit = cpuLodSplit && visualAllHaveLod && !staged.empty()
+            && up.nearInstances < up.numInstances;
+        const UINT cpuNearCount = cpuSplit ? up.nearInstances : up.numInstances;
+        const UINT cpuFarCount  = cpuSplit ? ( up.numInstances - up.nearInstances ) : 0;
+
         for ( const StagedSubMesh& s : staged ) {
             // Partition by alpha cutout (see m_WorldOpaqueDrawCount): opaque first, alpha-tested appended
             // by finish().
-            if ( s.AlphaTested ) alphaCmds.push_back( s.Cmd );
-            else                 cmds[count++] = s.Cmd;
+            VobDrawCommand n = s.Cmd;
+            if ( cpuLodSplit ) n.Draw.InstanceCount = cpuNearCount;
+            if ( s.AlphaTested ) alphaCmds.push_back( n );
+            else                 cmds[count++] = n;
             if ( resolveMaps )
                 m_VobDrawnTriangles += ( s.Cmd.Draw.IndexCountPerInstance / 3 ) * up.numInstances;
 
@@ -3436,15 +3457,24 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 f.Draw.InstanceCount = 0;
                 if ( s.AlphaTested ) alphaFarCmds.push_back( f );
                 else                 cmds[count++] = f;
-            } else if ( s.LodEligible ) {
-                // LOD split: same sub-mesh, reduced indices, over the run CSCull packed backward from the
-                // end of this visual's range. LOD-eligible implies !AlphaTested, so this always belongs in
-                // the opaque partition.
+            } else if ( s.LodEligible && ( !cpuLodSplit || cpuSplit ) ) {
+                // LOD split: same sub-mesh, reduced indices, over the far run — packed backward from the
+                // end of this visual's range by CSCull on the GPU path, forward-adjacent to the near run by
+                // UploadFrameVobInstances on the CPU one. LOD-eligible implies !AlphaTested, so this always
+                // belongs in the opaque partition.
                 VobDrawCommand f = s.Cmd;
                 f.LodBucket = kLodBucketFar;
                 f.Draw.StartIndexLocation = s.LodStart;
                 f.Draw.IndexCountPerInstance = s.LodIndexCount;
-                f.Draw.InstanceCount = 0;
+                if ( cpuSplit ) {
+                    // Final: nothing patches this command, so both halves of the run are named outright.
+                    f.Draw.InstanceCount = cpuFarCount;
+                    f.Draw.StartInstanceLocation = up.instanceBase + cpuNearCount;
+                } else {
+                    // GPU path: CSPatchArgs fills in both. 0 so an unpatched command draws nothing rather
+                    // than every instance a second time.
+                    f.Draw.InstanceCount = 0;
+                }
                 cmds[count++] = f;   // not counted in m_VobDrawnTriangles: the near command already
             }                        // counted every instance, keeping that stat a pre-cull upper bound
         }
@@ -3463,6 +3493,12 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 else if ( mode == kSplitModeAlpha ) m_VobStats.SplitAlpha++;
                 else                                m_VobStats.SplitNone++;
             }
+        } else if ( resolveMaps && cpuLodSplit ) {
+            // Same histogram for the CPU path, so the panel does not read as "no split is happening" just
+            // because there are no cull records to hang it off. Only kSplitModeLod is reachable here — the
+            // alpha-prepass split still needs CSCull.
+            if ( cpuSplit ) m_VobStats.SplitLod++;
+            else            m_VobStats.SplitNone++;
         }
     }
     return finish();
@@ -4110,6 +4146,7 @@ bool D3D12GraphicsEngine::UploadVobs(
         up.culledInstView = up.instView;
         up.numInstances = numInstances;
         up.instanceBase = instOffset / kInstStride;   // exact: sliceBase and every block are stride multiples
+        up.nearInstances = numInstances;              // shadow casters are never LOD-split by distance-to-camera
         up.cullVisualIndex = 0xFFFFFFFFu;
         uploads.push_back( up );
     }
@@ -4166,6 +4203,16 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
     if ( m_GpuVobCullActive && ( !m_VobCullVisualsPtr[m_FrameIndex] || !m_VobCulledInstances ) )
         m_GpuVobCullActive = false;
 
+    // CPU-side geometry-LOD split. With the GPU cull on, CSCull does the near/far bucketing; with it off
+    // nothing else would, so partition each visual's instance block by distance right here, as we copy it
+    // into the ring. Same decision CSCull makes, same math (see IsInstanceVisible / the note there on why
+    // the bbox CENTRE and not the vob origin), just done on the thread that is already touching every
+    // instance. The cost is one distance per instance on a list the CPU frustum cull has already thinned.
+    const bool cpuLodSplit = !m_GpuVobCullActive && m_VobLodDistance > 0.0f;
+    const float lodDistSq = m_VobLodDistance * m_VobLodDistance;
+    XMFLOAT3 camPos;
+    XMStoreFloat3( &camPos, Engine::GAPI->GetCameraPositionXM() );
+
     m_VobCullVisualCount = 0;
     m_VobCullVisualOverflowed = false;
     VobCullVisual* cullRecords = m_GpuVobCullActive
@@ -4194,7 +4241,36 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
         }
 
         const UINT instOffset = m_VobInstanceBufferOffset;
-        memcpy( m_VobInstanceBufferPtr[frame] + instOffset, visual->Instances.data(), instBytes );
+        UINT nearInstances = numInstances;
+        if ( !cpuLodSplit ) {
+            memcpy( m_VobInstanceBufferPtr[frame] + instOffset, visual->Instances.data(), instBytes );
+        } else {
+            // Partition in one pass: near packs forward from the start of the block, far backward from its
+            // end. Every instance lands in exactly one run and none are dropped here (the CPU frustum cull
+            // already ran), so the two runs are adjacent and the far one begins at exactly nearInstances —
+            // which is what lets a single StartInstanceLocation address it. Packing far backward reverses
+            // its order; nothing downstream cares (opaque, depth-tested, one draw).
+            VobInstanceInfo* dst = reinterpret_cast<VobInstanceInfo*>( m_VobInstanceBufferPtr[frame] + instOffset );
+            const float cx = ( visual->BBox.Min.x + visual->BBox.Max.x ) * 0.5f;
+            const float cy = ( visual->BBox.Min.y + visual->BBox.Max.y ) * 0.5f;
+            const float cz = ( visual->BBox.Min.z + visual->BBox.Max.z ) * 0.5f;
+            UINT nearCursor = 0;
+            UINT farCursor = numInstances;
+            for ( const VobInstanceInfo& inst : visual->Instances ) {
+                // The instance matrix is uploaded row-major and read COLUMN-major by the shaders, so the
+                // stored XMFLOAT4X4 is the transpose of the matrix HLSL multiplies with. Written out
+                // component-wise rather than through XMMatrixTranspose so it is visibly the same
+                // expression VobCull.hlsl evaluates: mul( float4(centre,1), world ).
+                const XMFLOAT4X4& w = inst.world;
+                const float wx = cx * w.m[0][0] + cy * w.m[0][1] + cz * w.m[0][2] + w.m[0][3] - camPos.x;
+                const float wy = cx * w.m[1][0] + cy * w.m[1][1] + cz * w.m[1][2] + w.m[1][3] - camPos.y;
+                const float wz = cx * w.m[2][0] + cy * w.m[2][1] + cz * w.m[2][2] + w.m[2][3] - camPos.z;
+                // Squared compare — the threshold is a plain distance, so no sqrt is needed.
+                if ( wx * wx + wy * wy + wz * wz > lodDistSq ) dst[--farCursor] = inst;
+                else                                          dst[nearCursor++] = inst;
+            }
+            nearInstances = nearCursor;
+        }
         m_VobInstanceBufferOffset += instBytes;
 
         FrameVobUpload up;
@@ -4203,6 +4279,7 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
         up.culledInstView = up.instView;
         up.numInstances = numInstances;
         up.instanceBase = instOffset / kInstStride;   // exact — the ring offset was just stride-aligned above
+        up.nearInstances = nearInstances;
         up.cullVisualIndex = 0xFFFFFFFFu;
 
         if ( cullRecords ) {

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2182,7 +2182,9 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// matching StoreVobPreviousTransforms at the bottom of this function rolls it into history. See D3D12Motion.cpp.
 	UploadMotionConstants();
 
-	DrawSky();
+	// Sky: fog fill + Gothic's atmosphere solve now, geometry later (after the depth prepass, right before the
+	// lit passes) so opaque depth rejects the sky fragments behind geometry. See PrepareSky/DrawSky.
+	PrepareSky();
 	// The other two shadow passes resolve their Gothic-side state here, on the main thread, WITHOUT recording any
 	// draws: the point-light shadow cubes (P2.10 — each selected light's 6 faces into the shared cube array) and
 	// the rain shadowmap (world-mesh + instanced-VOB depth along the rain-velocity direction, so DrawRainParticles'
@@ -2307,6 +2309,10 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// everything recorded from here on — the lit passes below are the first thing this frame that samples the
 	// cascade map / point-shadow cubes. Also re-establishes the scene-color RT + depth for them.
 	FinishShadowPasses();
+	// Sky geometry, now that the depth prepass has something for it to be rejected against. Placed after
+	// FinishShadowPasses because that is what re-establishes the scene-color RT + depth on the reopened list -
+	// the fixed-function path draws through MyDirect3DDevice7 and inherits whatever OM state is bound.
+	DrawSky();
     {
         DX_ZONE( m_CmdList.Get(), "Lit Geometry Pass" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Lit Geometry Pass" );
@@ -2473,10 +2479,15 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 }
 
 
-XRESULT D3D12GraphicsEngine::DrawSky() {
+XRESULT D3D12GraphicsEngine::PrepareSky() {
+	// The half of the sky that is NOT geometry: the fog-color fill and Gothic's atmosphere solve. Kept at the
+	// original DrawSky slot (before the shadow prepare / depth prepass) because several later passes read what
+	// RenderSky() computes — RenderSkyIBL takes its sun direction from it, and the wetness/fog constants are
+	// derived from the same state. Only the sky's DRAWS moved; see DrawSky.
+	m_SkyGeometryPending = false;
 	if ( !m_FrameOpen ) return XR_SUCCESS;
-	DX_ZONE( m_CmdList.Get(), "Draw sky" );
-	TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw sky" );
+	DX_ZONE( m_CmdList.Get(), "Prepare sky" );
+	TracyD3D12ZoneCGX( m_CmdList.Get(), "Prepare sky" );
 
 	// Base fallback fill: Gothic's current sky/fog color (see GetSceneFogColorXM — tracks time of day when
 	// AtmosphericScattering is off, matching D3D11's own background-clear formula). Runs first so a gap in
@@ -2498,7 +2509,26 @@ XRESULT D3D12GraphicsEngine::DrawSky() {
 	// The clear above already turned black via GetSceneFogColorXM; drawing the atmosphere dome or handing
 	// off to the outdoor controller's RenderSkyPre would paint daylight over it. RenderSky() still ran, so
 	// the atmosphere constants other passes read stay current.
-	if ( Engine::GAPI->IsIndoorWorld() ) return XR_SUCCESS;
+	m_SkyGeometryPending = !Engine::GAPI->IsIndoorWorld();
+	return XR_SUCCESS;
+}
+
+XRESULT D3D12GraphicsEngine::DrawSky() {
+	// The sky's GEOMETRY, deliberately submitted AFTER the opaque depth prepass rather than before it.
+	//
+	// The sky is pinned to the reversed-Z far plane (FORCE_MAX_Z / the dome's own depth) and tests
+	// GREATER_EQUAL with depth writes off, so once the prepass has laid down opaque depth every sky fragment
+	// behind geometry fails the test at the depth unit and never reaches the pixel shader. Drawn first — as it
+	// was — the depth buffer still held nothing but the frame's 0.0 clear, so every one of those fragments
+	// shaded and was then painted over: a measured 5.4 M PS invocations at 2.6x overdraw with nothing to
+	// reject against.
+	//
+	// Nothing between the two positions reads scene color (the prepass has its color write mask off, the light
+	// cull / SSAO / IBL read depth-normals and their own targets), so the fill in PrepareSky still lands before
+	// the first real color write, which is the lit geometry pass right after this.
+	if ( !m_FrameOpen || !m_SkyGeometryPending ) return XR_SUCCESS;
+	DX_ZONE( m_CmdList.Get(), "Draw sky" );
+	TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw sky" );
 
 	GothicRendererState& rs = Engine::GAPI->GetRendererState();
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2955,6 +2955,14 @@ bool D3D12GraphicsEngine::CreateVobIndirect() {
 }
 
 
+/** First cascade allowed to take the baked progressive-mesh LOD index buffer. The debug setting wins,
+    -1 (its default) keeps the compile-time gate the LOD buffers were validated against. A value at or
+    above NumShadowCascades simply means no cascade ever qualifies, i.e. shadow LOD off. */
+int D3D12GraphicsEngine::GetFirstLodShadowCascade() {
+    const int setting = Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.ShadowCascades.FirstLodCascade;
+    return setting < 0 ? kFirstLodShadowCascade : setting;
+}
+
 UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload>& uploads, uint8_t* argPtr, bool resolveMaps,
     UINT maxCommands, bool culled, bool cacheIn, int shadowCascade, UINT* outOpaqueCount ) {
     // Fill an arg buffer with one command per (visual x material x sub-mesh): resolve the material's bindless
@@ -2982,6 +2990,8 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
         };
     const uint32_t whiteSlot   = m_BlackTexture->GetSrvSlot();
     const uint32_t defaultOrm  = GetDefaultOrmSrvSlot();
+    // Resolved once per built buffer: the cascades run this on worker threads, so keep it a single read.
+    const int firstLodCascade = GetFirstLodShadowCascade();
     // Attribute the triangle stat to the main-view build only (resolveMaps): the shadow cascades build the same
     // geometry and would double-count. Reset here; the color pass adds it to FrameDrawnTriangles once.
     // NOTE: with GPU culling (culled=true) this is a pre-cull UPPER BOUND — the real instance counts only exist
@@ -3102,7 +3112,7 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 D3D12VertexBuffer* cmdIb = mib;
                 UINT cmdIndexCount = static_cast<UINT>( mi->Indices.size() );
                 if ( shadowCascade != kVobIndicesMainView && !alphaTested ) {
-                    if ( shadowCascade >= kFirstLodShadowCascade && !mi->LodIndices.empty()
+                    if ( shadowCascade >= firstLodCascade && !mi->LodIndices.empty()
                         && mi->GetMeshLodIndexBuffer() ) {
                         if ( D3D12VertexBuffer* lodIb = D3D12VertexBuffer::From( mi->GetMeshLodIndexBuffer() );
                             lodIb->GetResource() ) {

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -296,12 +296,9 @@ void D3D12GraphicsEngine::OnAddVob(VobInfo* vi) {
     }
     vi->VisualIndex = it->second;
 
-    // Register this visual's sub-meshes with the VOB mega-buffers. This hook fires per vob during world
-    // load, so by the first rendered frame the whole world's static geometry is queued — which is exactly
-    // the "build it once at load, with no culling" property the arena needs to be able to serve every pass
-    // (including the shadow cascades, which see casters the main view never does). Everything added later
-    // (a dropped weapon, an item thrown out of the inventory) arrives through the same call and lands in the
-    // arena's headroom. Queueing is cheap and idempotent; the upload happens at the next frame's flush.
+    // Register this visual's sub-meshes with the VOB mega-buffers. Fires per vob during world load, so the
+    // whole world's static geometry is queued before the first frame; vobs added later land in the arena's
+    // headroom. Queueing is cheap and idempotent, the upload happens at the next frame's flush.
     m_VobArena.QueueVisual( static_cast<MeshVisualInfo*>( vi->VisualInfo ) );
 
     // A VOB added after a nearby point light already cached its static-aside shadow cube would otherwise cast no
@@ -337,9 +334,8 @@ void D3D12GraphicsEngine::OnLoadWorld()
         v.Reset();
     }
     m_RainShadowVobs.Reset();
-    // The VOB mega-buffers describe the world being left: every MeshInfo they index is about to be freed,
-    // so the ranges have to go before the new world's OnAddVob calls start refilling them. The buffers
-    // themselves are kept and refilled from offset 0 — see D3D12VobArena::Reset.
+    // Every MeshInfo the arena indexes is about to be freed, so the ranges have to go before the new world's
+    // OnAddVob calls refill them. The buffers themselves are kept — see D3D12VobArena::Reset.
     m_VobArena.Reset();
     // AO needs no reset here — it runs entirely off THIS frame's depth prepass, so the first frame of the new
     // world already produces a correct mask.
@@ -2124,20 +2120,14 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	m_HeightFogActive = EvaluateHeightFogActive();
 	g_HeightFogActive = m_HeightFogActive;
 
-	// Decide ONCE, before anything collects, whether this frame's static VOBs are culled on the GPU. Every stage
-	// downstream has to agree: the CollectVisibleVobs call below switches to distance-only, UploadFrameVobInstances
-	// emits the per-visual cull records, BuildVobDrawCommands points each command's instance stream at the
-	// compacted buffer, and both VOB passes ExecuteIndirect from the patched arg buffer. Re-evaluating any of that
-	// mid-frame would mix culled and unculled state. See D3D12Cull.cpp.
+	// Decide ONCE, before anything collects, whether this frame's static VOBs are culled on the GPU: every
+	// stage downstream has to agree, and re-evaluating mid-frame would mix culled and unculled state.
+	// See D3D12Cull.cpp.
 	m_GpuVobCullActive = EvaluateGpuVobCulling();
 
-	// Snapshotted ONCE: the instance partition and the command build must agree on it, and the ImGui slider
-	// moving between them would strand a bucket with no command to draw it.
-	//
-	// NOT gated on GPU culling. The near/far bucketing is produced by CSCull when the GPU cull is on and by
-	// UploadFrameVobInstances' own distance partition when it is off — so the geometry LOD is available on
-	// either path. That matters for the machine this feature is actually for: a weak GPU behind a strong CPU,
-	// which is exactly the configuration that also wants the CPU frustum cull rather than the compute one.
+	// Snapshotted ONCE: the instance partition and the command build must agree on it, or a bucket ends up with
+	// no command to draw it. Not gated on GPU culling — the near/far bucketing comes from CSCull when it is on
+	// and from UploadFrameVobInstances' own distance partition when it is off.
 	m_VobLodDistance = Engine::GAPI->GetRendererState().RendererSettings.VobLodDrawRadius > 0.0f
 		? Engine::GAPI->GetRendererState().RendererSettings.VobLodDrawRadius : 0.0f;
 
@@ -2198,8 +2188,8 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// matching StoreVobPreviousTransforms at the bottom of this function rolls it into history. See D3D12Motion.cpp.
 	UploadMotionConstants();
 
-	// Sky: fog fill + Gothic's atmosphere solve now, geometry later (after the depth prepass, right before the
-	// lit passes) so opaque depth rejects the sky fragments behind geometry. See PrepareSky/DrawSky.
+	// Sky: fog fill + Gothic's atmosphere solve now, geometry later (after the depth prepass) so opaque depth
+	// rejects the sky fragments behind geometry. See PrepareSky/DrawSky.
 	PrepareSky();
 	// The other two shadow passes resolve their Gothic-side state here, on the main thread, WITHOUT recording any
 	// draws: the point-light shadow cubes (P2.10 — each selected light's 6 faces into the shared cube array) and
@@ -2243,7 +2233,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 		m_VobDrawCount = 0;
 		m_VobOpaqueDrawCount = 0;
 	}
-	// Publish this frame's VOB submission shape for the ImGui stats panel — see VobFrameStats.
+	// VOB submission shape for the ImGui stats panel.
 	m_VobStats.Commands = m_VobDrawCount;
 	m_VobStats.OpaqueCommands = m_VobOpaqueDrawCount;
 	m_VobStats.CullVisuals = m_VobCullVisualCount;
@@ -2253,25 +2243,19 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 		for ( const FrameVobUpload& u : g_FrameVobUploads ) inst += u.numInstances;
 		m_VobStats.Instances = inst;
 	}
-	// Build the skeletal + node-attachment ExecuteIndirect command sets ONCE (T9) from g_FrameSkelDraws/
-	// g_FrameAttachDraws, resolving each material's full bindless index set — the depth prepass ignores the
-	// extra two, so both skeletal passes submit over these same two buffers.
-	// This is the last Gothic-touching skeletal work of the frame (UpdateMeshLibTexAniState mutates the model's
-	// SHARED texani slots, zCTexture::CacheIn touches the resource manager), and it now runs WHILE the shadow
-	// recorders are already going. That is safe because none of them touch Gothic: every recorder replays
-	// pre-resolved D3D12 handles and heap-slot ints snapshotted on this thread before it was launched. It is
-	// specifically NOT safe to move any Gothic read INTO a recorder for the same reason.
+	// Build the skeletal + node-attachment command sets ONCE, resolving each material's full bindless index
+	// set; the depth prepass ignores the extra two, so both skeletal passes submit over the same buffers.
+	// This is the frame's last Gothic-touching skeletal work and runs WHILE the shadow recorders are going,
+	// which is safe only because no recorder touches Gothic — they replay handles snapshotted on this thread.
+	// Moving a Gothic read INTO a recorder would break that.
 	BuildSkeletalDrawCommands();
 	// Morph attachments (NPC heads, bow/crossbow draw meshes): fold this frame's blend shapes on the GPU into
-	// each submesh's own vertex buffer. Has to precede the depth prepass, which is the first pass of the frame
-	// IN SUBMISSION ORDER that draws one — the shadow cascades and point-shadow cubes record into private
-	// lists but are executed later (FinishShadowPasses). No-op when the fold is unavailable or inactive, in
-	// which case UpdateMorphMeshVisual already deformed them on the CPU during collection. See
-	// D3D12MorphFold.cpp / MorphGpu.h.
+	// each submesh's vertex buffer. Must precede the depth prepass, the first pass in SUBMISSION order that
+	// draws one. No-op when the fold is inactive; UpdateMorphMeshVisual then deformed them on the CPU.
+	// See D3D12MorphFold.cpp / MorphGpu.h.
 	DispatchMorphFold();
-	// ...and mirror the deformed vertices of any ANIMATED STATIC vob into its VOB-arena range. Must follow
-	// the fold (that is what produced them) and precede the depth prepass (the first pass on this list that
-	// draws out of the arena). No-op unless the world actually has .MMS static vobs in it.
+	// ...and mirror the deformed vertices of any animated static vob into its VOB-arena range. Between the fold
+	// (which produced them) and the depth prepass (the first pass here that draws out of the arena).
 	RefreshDynamicVobArena();
     {
         DX_ZONE( m_CmdList.Get(), "Depth Prepass" );
@@ -2317,31 +2301,22 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// sky; the shaders fall back to the old flat ambient whenever the indices are the 0xFFFFFFFF sentinel.
 	RenderSkyIBL();
 
-	// Submit part B1 (prepass -> G-buffer -> HiZ/VOB cull -> light cull -> SSAO -> sky IBL) NOW instead of letting
-	// it ride along to Present. Without this the GPU sat idle from the shadow lists all the way to the end of the
-	// frame: everything above was recorded long ago but stayed in an open, unsubmitted list while the main thread
-	// went on recording the lit passes, transparency, particles and post-FX. Costs one extra ExecuteCommandLists
-	// (plus the RT/heap rebind Reset drops) and buys the GPU that whole span.
-	//
-	// The reorder this introduces is [A][B1][shadows][B2] rather than [A][shadows][B1+B2]: none of the passes in
-	// B1 read anything a shadow pass writes (the tile cull and SSAO consume only the prepass depth/normals, and
-	// the IBL compute is self-contained on its own cubes), so their new position ahead of the shadow lists is
-	// safe. What still must NOT move is FinishShadowPasses' TransitionToReadState and the lit passes below —
-	// both are recorded into the reopened list and therefore stay behind the shadow lists.
+	// Submit part B1 (prepass -> G-buffer -> HiZ/VOB cull -> light cull -> SSAO -> sky IBL) now instead of
+	// letting it ride along to Present, which left the GPU idle from the shadow lists to the end of the frame.
+	// Ordering is [A][B1][shadows][B2]: nothing in B1 reads what a shadow pass writes, while FinishShadowPasses'
+	// TransitionToReadState and the lit passes are recorded into the reopened list and stay behind the shadows.
 	if ( m_FrameOpen ) {
 		SubmitRecordedCommandsAndReopen();
-		// The reopen Resets m_CmdList, dropping its render targets/viewport (FinishShadowPasses re-establishes
-		// them again at its tail, but a cascade re-issued inline records before that point).
+		// The reopen Resets m_CmdList, dropping its render targets/viewport, and a cascade re-issued inline
+		// records before FinishShadowPasses re-establishes them.
 		BindSceneColorTarget();
 	}
 
-	// Join the shadow recorders and slot their lists into the queue between the block submitted just above and
-	// everything recorded from here on — the lit passes below are the first thing this frame that samples the
-	// cascade map / point-shadow cubes. Also re-establishes the scene-color RT + depth for them.
+	// Join the shadow recorders and slot their lists in between — the lit passes below are the first thing this
+	// frame that samples the cascade map / point-shadow cubes. Also re-establishes the scene-color RT + depth.
 	FinishShadowPasses();
-	// Sky geometry, now that the depth prepass has something for it to be rejected against. Placed after
-	// FinishShadowPasses because that is what re-establishes the scene-color RT + depth on the reopened list -
-	// the fixed-function path draws through MyDirect3DDevice7 and inherits whatever OM state is bound.
+	// Sky geometry, now that the depth prepass has something for it to be rejected against. After
+	// FinishShadowPasses because the fixed-function path inherits whatever OM state that re-established.
 	DrawSky();
     {
         DX_ZONE( m_CmdList.Get(), "Lit Geometry Pass" );
@@ -2510,10 +2485,9 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 
 
 XRESULT D3D12GraphicsEngine::PrepareSky() {
-	// The half of the sky that is NOT geometry: the fog-color fill and Gothic's atmosphere solve. Kept at the
-	// original DrawSky slot (before the shadow prepare / depth prepass) because several later passes read what
-	// RenderSky() computes — RenderSkyIBL takes its sun direction from it, and the wetness/fog constants are
-	// derived from the same state. Only the sky's DRAWS moved; see DrawSky.
+	// The half of the sky that is NOT geometry: the fog-color fill and Gothic's atmosphere solve. Stays at the
+	// original DrawSky slot because later passes read what RenderSky() computes (RenderSkyIBL's sun direction,
+	// the wetness/fog constants). Only the sky's draws moved; see DrawSky.
 	m_SkyGeometryPending = false;
 	if ( !m_FrameOpen ) return XR_SUCCESS;
 	DX_ZONE( m_CmdList.Get(), "Prepare sky" );
@@ -2544,36 +2518,23 @@ XRESULT D3D12GraphicsEngine::PrepareSky() {
 }
 
 XRESULT D3D12GraphicsEngine::DrawSky() {
-	// The sky's GEOMETRY, deliberately submitted AFTER the opaque depth prepass rather than before it.
-	//
-	// The sky is pinned to the reversed-Z far plane (FORCE_MAX_Z / the dome's own depth) and tests
-	// GREATER_EQUAL with depth writes off, so once the prepass has laid down opaque depth every sky fragment
-	// behind geometry fails the test at the depth unit and never reaches the pixel shader. Drawn first — as it
-	// was — the depth buffer still held nothing but the frame's 0.0 clear, so every one of those fragments
-	// shaded and was then painted over: a measured 5.4 M PS invocations at 2.6x overdraw with nothing to
-	// reject against.
-	//
-	// Nothing between the two positions reads scene color (the prepass has its color write mask off, the light
-	// cull / SSAO / IBL read depth-normals and their own targets), so the fill in PrepareSky still lands before
-	// the first real color write, which is the lit geometry pass right after this.
+	// The sky's GEOMETRY, submitted AFTER the opaque depth prepass. The sky is pinned to the reversed-Z far
+	// plane and tests GREATER_EQUAL with depth writes off, so with opaque depth already down every sky fragment
+	// behind geometry is rejected before shading (drawn first it cost 5.4M PS invocations at 2.6x overdraw).
+	// Nothing between the two positions reads scene color, so PrepareSky's fill still lands first.
 	if ( !m_FrameOpen || !m_SkyGeometryPending ) return XR_SUCCESS;
 	DX_ZONE( m_CmdList.Get(), "Draw sky" );
 	TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw sky" );
 
 	GothicRendererState& rs = Engine::GAPI->GetRendererState();
 
-	// Procedural atmospheric-scattering sky dome (D3D12Sky.cpp) — ONE indexed draw instead of the ~5-15
-	// fixed-function draws RenderSkyPre() issues below, each of which pays a full state resolve + FF constant
-	// buffer update + vertex-buffer refill on its way back through MyDirect3DDevice7::DrawPrimitive. Gated on
-	// the SAME user setting D3D11's DrawSky uses, so both backends respond identically to it, and on the pass
-	// having actually drawn — if the PSO failed to compile or the dome mesh isn't loaded yet, it returns false
-	// having submitted nothing and we fall through to the fixed-function sky rather than show an empty sky.
+	// Procedural atmospheric-scattering sky dome (D3D12Sky.cpp) — one indexed draw instead of the ~5-15
+	// fixed-function draws RenderSkyPre() issues below, each paying a full state resolve on its way back
+	// through MyDirect3DDevice7. Returns false having submitted nothing if the PSO or the dome mesh isn't
+	// there, so we fall through to the fixed-function sky rather than show an empty one.
 	//
-	// (History, so this isn't "fixed" back: an earlier attempt just `return`ed here when AtmosphericScattering
-	// was true, leaving only the flat FogColorMod fill above as the entire sky. That fill has no time-of-day
-	// term, which is what produced the "sky is shining light-blue at night" bug. The dome below does vary with
-	// time of day — it is driven by the same AC_* constants D3D11's sky is — so that failure mode is gone, but
-	// the fallback is kept for exactly the case where the dome cannot draw.)
+	// Do NOT replace the fallback with a plain `return`: the fill above has no time-of-day term, so the sky
+	// would shine light-blue at night whenever the dome cannot draw.
 	if ( rs.RendererSettings.AtmosphericScattering && DrawAtmosphereSkyDome() ) {
 		// The magic barrier (dome + lightning) is drawn by a derived sky controller's RenderSkyPre override -
 		// vanilla oCWorld installs an oCSkyControler_Barrier in every world of both games. Called through the
@@ -2941,22 +2902,19 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
 bool D3D12GraphicsEngine::CreateVobIndirect() {
     // Command signatures + per-frame UPLOAD arg rings for the GPU-driven instanced VOBs (P2.12).
     //
-    // TWO signatures now. The instanced-VOB one carries NO buffer views at all: every static VOB sub-mesh
-    // lives in the shared vertex/index mega-buffers (D3D12VobArena) and every instance in the one instance
-    // buffer the pass binds, so a command is just material consts + wind consts + DrawIndexed, exactly like
-    // the world mesh's. That is the whole point of the arena — it is the PRESENCE of VBV/IBV arguments that
-    // makes a command an IA state change, and 560 of those per pass was the dominant VOB cost.
+    // Two signatures. The instanced-VOB one carries NO buffer views: every static VOB sub-mesh lives in the
+    // shared mega-buffers (D3D12VobArena) and every instance in the one instance buffer the pass binds, so a
+    // command is just material consts + wind consts + DrawIndexed. That is the point of the arena — VBV/IBV
+    // arguments are what make a command an IA state change, and 560 of those per pass dominated the VOB cost.
     //
-    // The second ("bound") signature is the old six-argument shape, kept for node attachments, whose
-    // geometry comes and goes with NPCs and is a few dozen commands a frame. Arg order MUST match each
-    // struct's member layout. Both rings stay UPLOAD/GENERIC_READ (which includes INDIRECT_ARGUMENT),
-    // rebuilt each frame — no DEFAULT-heap copy.
+    // The second ("bound") signature is the old six-argument shape, kept for node attachments, whose geometry
+    // comes and goes with NPCs. Arg order MUST match each struct's member layout. Both rings stay
+    // UPLOAD/GENERIC_READ (which includes INDIRECT_ARGUMENT) and are rebuilt each frame.
     ID3D12Device* device = m_Device.GetDevice();
     if ( !device || !m_Pipelines.World.RootSig ) return false;
 
-    // The GPU reads each command as tightly-packed native argument structs in pArgumentDescs order. The
-    // trailing 8 bytes (VisualIndex + LodBucket) sit PAST the arguments: ByteStride only has to cover them,
-    // so those bytes are ours (VobCull.hlsl's CSPatchArgs reads both out of the buffer it patches).
+    // The trailing 8 bytes (VisualIndex + LodBucket) sit PAST the arguments the GPU reads; ByteStride only has
+    // to cover them, so they are ours (VobCull.hlsl's CSPatchArgs reads both out of the buffer it patches).
     static_assert( sizeof( VobDrawCommand ) == 48, "VobDrawCommand must match the command signature arg layout (48 B stride)" );
     static_assert( offsetof( VobDrawCommand, MatNormalIndex ) == 0, "b6 consts lead the VOB command" );
     static_assert( offsetof( VobDrawCommand, Draw ) == 20, "VobDrawCommand draw args must be last of the indirect arguments" );
@@ -3045,14 +3003,9 @@ bool D3D12GraphicsEngine::CreateVobIndirect() {
 
 void D3D12GraphicsEngine::RefreshDynamicVobArena() {
     // Animated static VOBs (.MMS) are the one kind of VOB geometry that is not immutable: their vertices are
-    // rewritten every frame, either by ZENGIN's CPU deform into the MeshInfo's own DYNAMIC upload buffer
-    // (UpdateMorphMeshVisual, during UploadFrameVobInstances) or by the GPU morph fold into its DEFAULT UAV
-    // (DispatchMorphFold, immediately before this). The arena copy uploaded at registration is only the
-    // conversion pose, so mirror the live buffer into the arena range here — a handful of small
-    // CopyBufferRegions, and only for morph visuals that exist at all.
-    //
-    // Placed right after DispatchMorphFold on purpose: that is what produces THIS frame's folded vertices,
-    // and everything that draws VOBs out of the arena (the depth prepass onwards on this list) comes after.
+    // rewritten every frame, by ZENGIN's CPU deform into the MeshInfo's DYNAMIC upload buffer
+    // (UpdateMorphMeshVisual) or by the GPU morph fold into its DEFAULT UAV (DispatchMorphFold). The arena
+    // copy uploaded at registration is only the conversion pose, so mirror the live buffer into it here.
     const std::vector<MeshInfo*>& dynamic = m_VobArena.DynamicMeshes();
     if ( dynamic.empty() || !m_FrameOpen || !m_VobArena.Ready() ) return;
 
@@ -3068,9 +3021,8 @@ void D3D12GraphicsEngine::RefreshDynamicVobArena() {
         if ( !range || !mi->GetMeshVertexBuffer() ) continue;
         D3D12VertexBuffer* src = D3D12VertexBuffer::From( mi->GetMeshVertexBuffer() );
         if ( !src->GetResource() ) continue;
-        // The fold's output is a DEFAULT UAV it left in VERTEX_AND_CONSTANT_BUFFER (or COMMON before its
-        // first fold); as a copy source it has to be COPY_SOURCE. The CPU-deform buffer is an UPLOAD
-        // resource permanently in GENERIC_READ, which already includes COPY_SOURCE — nothing to do.
+        // The fold's DEFAULT UAV output needs a transition to COPY_SOURCE. The CPU-deform buffer is UPLOAD,
+        // permanently in GENERIC_READ, which already includes COPY_SOURCE.
         if ( src->IsUavCapable() ) {
             const D3D12_RESOURCE_STATES from = ( src->GetUavState() == D3D12VertexBuffer::EUavState::Vertex )
                 ? D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER : D3D12_RESOURCE_STATE_COMMON;
@@ -3085,9 +3037,8 @@ void D3D12GraphicsEngine::RefreshDynamicVobArena() {
 
     for ( auto const& [mi, src] : copies ) {
         const D3D12VobArena::Range* range = m_VobArena.Find( mi );
-        // The source buffer holds exactly this sub-mesh's vertices in the same wedge order the arena copy
-        // was uploaded in (a morph sub-mesh deliberately skips OptimizeVertices for precisely that reason),
-        // so this is a straight range overwrite. min() guards a buffer that is somehow shorter.
+        // Same wedge order the arena copy was uploaded in (a morph sub-mesh deliberately skips
+        // OptimizeVertices), so this is a straight range overwrite. min() guards a shorter buffer.
         const UINT64 bytes = std::min<UINT64>( src->GetSizeInBytes(),
             static_cast<UINT64>( mi->Vertices.size() ) * D3D12VobArena::VertexStride() );
         m_CmdList->CopyBufferRegion( m_VobArena.GetVertexBuffer(),
@@ -3095,9 +3046,8 @@ void D3D12GraphicsEngine::RefreshDynamicVobArena() {
             src->GetResource(), 0, bytes );
     }
 
-    // Hand the fold buffers back to the state DispatchMorphFold expects to find them in next frame, and the
-    // arena back to the IA. The arena is a BUFFER, so it promoted out of COMMON into COPY_DEST implicitly
-    // and needs an explicit barrier out again before the prepass reads it as a vertex/index stream.
+    // Hand the fold buffers back to the state DispatchMorphFold expects next frame, and the arena back to the
+    // IA — it promoted into COPY_DEST implicitly and needs an explicit barrier out before the prepass reads it.
     barriers.clear();
     for ( auto const& [mi, src] : copies ) {
         if ( !src->IsUavCapable() ) continue;
@@ -3114,9 +3064,9 @@ void D3D12GraphicsEngine::RefreshDynamicVobArena() {
 bool D3D12GraphicsEngine::BindVobArenaIA( D3D12CmdList& cmdList, ID3D12Resource* instances, UINT instanceBytes ) {
     if ( !m_VobArena.Ready() || !instances || instanceBytes == 0 ) return false;
 
-    // The whole buffer is bound, every time — a VOB command addresses its sub-mesh through
-    // BaseVertexLocation/StartIndexLocation and its instances through StartInstanceLocation, so there is
-    // nothing per-draw left in the IA state. That is exactly what makes this one bind instead of ~560.
+    // The whole buffer is bound once: a VOB command addresses its sub-mesh through
+    // BaseVertexLocation/StartIndexLocation and its instances through StartInstanceLocation, so nothing
+    // per-draw is left in the IA state. That is what replaces ~560 binds with this one.
     const D3D12_VERTEX_BUFFER_VIEW views[2] = {
         { m_VobArena.GetVertexBuffer()->GetGPUVirtualAddress(), m_VobArena.GetVertexBytes(),
           D3D12VobArena::VertexStride() },
@@ -3187,24 +3137,21 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
         m_VobStats.SplitLod = 0;
     }
 
-    // Records are still CPU-writable here and CullVobsGPU has not run, and this is the only place that
-    // knows which sub-meshes actually emitted a far command. Main-view build only.
+    // Records are still CPU-writable (CullVobsGPU has not run) and this is the only place that knows which
+    // sub-meshes actually emitted a far command. Main-view build only.
     VobCullVisual* cullRecords = ( culled && resolveMaps && m_VobCullVisualsPtr[m_FrameIndex] )
         ? reinterpret_cast<VobCullVisual*>( m_VobCullVisualsPtr[m_FrameIndex] ) : nullptr;
 
     // CPU-side geometry LOD: the uploads already carry a near/far partition of each visual's instance block
-    // (UploadFrameVobInstances), so the far command's instance count and start are known HERE and get baked
-    // straight into the argument buffer — no cull records, no CSPatchArgs, no compute at all. Mutually
-    // exclusive with the GPU path by construction: `culled` picks which of the two produced the buckets.
+    // (UploadFrameVobInstances), so the far command's instance count and start get baked straight into the
+    // argument buffer — no cull records, no CSPatchArgs. `culled` picks which path produced the buckets.
     const bool cpuLodSplit = ( shadowCascade == kVobIndicesMainView ) && !culled && m_VobLodDistance > 0.0f;
 
-    // Per-visual command staging. The alpha split is a per-VISUAL decision (CSCull buckets a visual's whole
-    // instance range one way) but `alphaTested` is only known per sub-mesh, and only AFTER that sub-mesh's
-    // material has been through CacheIn - zCTexture::HasAlphaChannel() reads a flag byte that is not
-    // populated until the texture is actually resident, so asking ahead of the material loop would answer
-    // "no alpha" for every visual the frame it first comes into view. So: build each visual's near commands
-    // into this scratch list, then decide and flush once every sub-mesh has been resolved. One pass, one
-    // authoritative answer, and no second copy of the alpha-tested test to drift out of sync.
+    // Per-visual command staging. The split is a per-VISUAL decision (CSCull buckets a visual's whole instance
+    // range one way) but `alphaTested` is only known per sub-mesh, and only AFTER its material has been
+    // through CacheIn — zCTexture::HasAlphaChannel() reads a flag byte that is unpopulated until the texture
+    // is resident, so asking earlier answers "no alpha" the frame a visual first comes into view. So stage
+    // each visual's near commands and flush once every sub-mesh is resolved.
     // thread_local for the same reason alphaCmds is: the cascades build concurrently on the pool.
     struct StagedSubMesh {
         VobDrawCommand Cmd;
@@ -3259,10 +3206,9 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
             // the wrong UV would clip away the wrong texels, so alpha-relevant materials keep full indices
             // in every pass. Same condition D3D11's shadow VOB loop gates on.
             //
-            // The LOD buffer is no longer welded (see OptimizeLodIndices) and so carries correct UVs, but
-            // alpha-tested materials stay excluded from it too: an edge collapse deletes triangles outright,
-            // and on a cutout that means chunks of the silhouette — leaves, grates, ladders — simply
-            // disappearing rather than getting coarser.
+            // The LOD buffer is no longer welded (see OptimizeLodIndices) so its UVs are correct, but
+            // alpha-tested materials stay excluded from it too: an edge collapse deletes triangles, and on a
+            // cutout that means chunks of the silhouette disappearing rather than getting coarser.
             const bool alphaTested = ( tex && tex->HasAlphaChannel() )
                 || ( meshKey.Material && meshKey.Material->HasAlphaTest() );
 
@@ -3293,24 +3239,19 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                     continue;
                 }
 
-                // Where this sub-mesh lives in the VOB mega-buffers. Missing means it was never registered
-                // (a visual that appeared this frame is queued but not yet flushed) or its upload failed;
-                // either way it simply isn't drawn this frame and reappears on the next one. Everything
-                // below indexes the SAME vertex range - the shadow and LOD index levels are alternative
-                // index lists over the identical vertices, which is what lets one BaseVertexLocation serve
-                // all three.
+                // Where this sub-mesh lives in the VOB mega-buffers. Missing (not yet flushed, or a failed
+                // upload) simply means it isn't drawn this frame. The shadow and LOD index levels are
+                // alternative index lists over the SAME vertices, so one BaseVertexLocation serves all three.
                 const D3D12VobArena::Range* range = m_VobArena.Find( mi );
                 if ( !range || range->IndexCount == 0 ) continue;
 
-                // Whether this sub-mesh can offer a reduced far level to the main view. No longer gated on
-                // the visual's split mode - that is decided at flush time below, and suppressing LOD there
-                // keeps the two modes from ever both applying.
+                // Whether this sub-mesh can offer a reduced far level to the main view. The visual's split
+                // mode is decided at flush time below, which is also what keeps both modes from applying.
                 const bool lodEligible = ( shadowCascade == kVobIndicesMainView ) && ( culled || cpuLodSplit )
                     && m_VobLodDistance > 0.0f && !alphaTested && range->LodCount > 0;
 
-                // Pick this command's index range. A missing level just falls through to the next-best one,
-                // so a mesh that ships no LOD data still gets the welded shadow indices, and one that has
-                // neither still draws — the only cost of an absent level is that nothing is saved.
+                // Pick this command's index range. A missing level falls through to the next-best one, so a
+                // mesh with no LOD data still gets the welded shadow indices, and one with neither still draws.
                 UINT cmdIndexStart = range->IndexStart;
                 UINT cmdIndexCount = range->IndexCount;
                 if ( shadowCascade != kVobIndicesMainView && !alphaTested ) {
@@ -3324,9 +3265,8 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 }
 
                 VobDrawCommand c{};
-                // GPU-culled: draw from the compacted buffer CSCull writes (same layout, different
-                // resource - the pass binds one or the other) and let CSPatchArgs replace InstanceCount and
-                // StartInstanceLocation below with the surviving run for this visual.
+                // GPU-culled: draw from the compacted buffer CSCull writes, and let CSPatchArgs replace
+                // InstanceCount and StartInstanceLocation with the surviving run for this visual.
                 c.VisualIndex = culled ? up.cullVisualIndex : 0xFFFFFFFFu;
                 c.LodBucket = kLodBucketNear;
                 c.MatNormalIndex  = normalIdx;
@@ -3338,14 +3278,11 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 c.Draw.InstanceCount         = up.numInstances;
                 c.Draw.StartIndexLocation    = cmdIndexStart;
                 c.Draw.BaseVertexLocation    = static_cast<INT>( range->BaseVertex );
-                // Absolute, not range-relative: there is no per-command instance VBV any more, so the
-                // command has to name its visual's block inside the one buffer the pass binds. For culled
-                // commands CSPatchArgs overwrites this with InstanceBase + the run's offset; the value here
-                // is what an UNpatched command (cull off, or cull-record overflow) draws.
+                // Absolute, not range-relative: there is no per-command instance VBV any more, so the command
+                // names its visual's block inside the one buffer the pass binds. CSPatchArgs overwrites this
+                // for culled commands; the value here is what an unpatched one draws.
                 c.Draw.StartInstanceLocation = up.instanceBase;
-                // Staged, not emitted: the visual's split mode is not known until every sub-mesh has been
-                // resolved (see the `staged` declaration for why the alpha-tested answer cannot be had any
-                // earlier than this).
+                // Staged, not emitted: the visual's split mode isn't known until every sub-mesh is resolved.
                 StagedSubMesh s{};
                 s.Cmd = c;
                 s.AlphaTested = alphaTested;
@@ -3358,8 +3295,7 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
             }
         }
 
-        // ---- Flush this visual ----------------------------------------------------------------------
-        // Everything below needs the WHOLE visual resolved, which is why it could not happen inline.
+        // ---- Flush this visual (needs the WHOLE visual resolved) -------------------------------------
 
         // Split only if EVERY drawn sub-mesh has a far counterpart; a visual that drew nothing is not
         // splittable at all.
@@ -3370,9 +3306,8 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
             cmdsNeeded += s.LodEligible ? 2u : 1u;
         }
 
-        // Checked per VISUAL now rather than per sub-mesh: a split pair cut in half would drop every far
-        // instance of the visual, since CSCull still buckets them away from the near run. Dropping the
-        // whole visual instead of part of one is also the tidier failure.
+        // Checked per VISUAL, not per sub-mesh: a split pair cut in half would drop every far instance of the
+        // visual, since CSCull still buckets them away from the near run.
         if ( !staged.empty()
             && count + alphaCmds.size() + cmdsNeeded > maxCommands ) {
             if ( !m_VobDrawArgsOverflowLogged ) {
@@ -3383,10 +3318,9 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
             return finish();
         }
 
-        // CPU LOD split, resolved here for the same reason the GPU one is: only now is it known that EVERY
-        // drawn sub-mesh has a far counterpart. If one doesn't, the whole visual falls back to a single
-        // command per sub-mesh covering the WHOLE instance block — which still draws every instance
-        // correctly, because the near and far runs the upload produced are adjacent and contiguous.
+        // CPU LOD split. If a sub-mesh has no far counterpart the whole visual falls back to one command per
+        // sub-mesh over the WHOLE instance block, which still draws correctly because the near and far runs
+        // the upload produced are adjacent and contiguous.
         const bool cpuSplit = cpuLodSplit && visualAllHaveLod && !staged.empty()
             && up.nearInstances < up.numInstances;
         const UINT cpuNearCount = cpuSplit ? up.nearInstances : up.numInstances;
@@ -3404,10 +3338,9 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
 
             // Far bucket.
             if ( s.LodEligible && ( !cpuLodSplit || cpuSplit ) ) {
-                // LOD split: same sub-mesh, reduced indices, over the far run — packed backward from the
-                // end of this visual's range by CSCull on the GPU path, forward-adjacent to the near run by
-                // UploadFrameVobInstances on the CPU one. LOD-eligible implies !AlphaTested, so this always
-                // belongs in the opaque partition.
+                // Same sub-mesh, reduced indices, over the far run — packed backward from the end of this
+                // visual's range by CSCull on the GPU path, forward-adjacent to the near run on the CPU one.
+                // LOD-eligible implies !AlphaTested, so this always belongs in the opaque partition.
                 VobDrawCommand f = s.Cmd;
                 f.LodBucket = kLodBucketFar;
                 f.Draw.StartIndexLocation = s.LodStart;
@@ -3430,14 +3363,11 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
             const UINT mode = ( !staged.empty() && visualAllHaveLod ) ? kSplitModeLod : kSplitModeNone;
             cullRecords[up.cullVisualIndex].SplitMode = mode;
             if ( resolveMaps ) {
-                // Stats only: if these come back as "everything in SplitNone", the LOD slider cannot be
-                // having any effect, whatever it is set to.
                 if ( mode == kSplitModeLod ) m_VobStats.SplitLod++;
                 else                         m_VobStats.SplitNone++;
             }
         } else if ( resolveMaps && cpuLodSplit ) {
-            // Same histogram for the CPU path, so the panel does not read as "no split is happening" just
-            // because there are no cull records to hang it off.
+            // Same histogram for the CPU path, which has no cull records to hang it off.
             if ( cpuSplit ) m_VobStats.SplitLod++;
             else            m_VobStats.SplitNone++;
         }
@@ -3524,16 +3454,13 @@ bool D3D12GraphicsEngine::CreateSkeletalIndirect() {
 
 
 void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
-    // T9: fold the whole per-mesh CPU draw path of BOTH skeletal passes into one build. Per base-mesh record:
-    // run the instance's texani update ONCE (it mutates the model's SHARED texture slots, so it has to happen
-    // while we read that instance's materials — see [[skeletal-texani-shared-slots]]), resolve the material's
-    // bindless normal/ORM/diffuse indices, and emit one command per sub-mesh carrying the two root CBVs, the
-    // skinned VB, the IB and DrawIndexed. Node attachments do the same into a VobBoundDrawCommand buffer.
+    // Folds the per-mesh CPU draw path of BOTH skeletal passes into one build. Per base-mesh record: run the
+    // instance's texani update ONCE (it mutates the model's SHARED texture slots, so it must happen while we
+    // read that instance's materials), resolve the bindless normal/ORM/diffuse indices, and emit one command
+    // per sub-mesh. Node attachments do the same into a VobBoundDrawCommand buffer.
     //
-    // Runs on the main thread from OnStartWorldRendering BEFORE BeginShadowRecording — every Gothic-touching
-    // call here (UpdateMeshLibTexAniState, zCTexture::CacheIn) must be finished before the cascade recorders
-    // start reading Gothic state on pool threads. That is also why the passes themselves are now pure GPU
-    // submits: they used to do this work after the fan-out.
+    // Main thread, before BeginShadowRecording: every Gothic-touching call here must finish before the
+    // cascade recorders start reading Gothic state on pool threads.
     m_SkeletalDrawCount = 0;
     m_AttachDrawCount = 0;
     m_SkeletalOpaqueDrawCount = 0;
@@ -4047,8 +3974,8 @@ bool D3D12GraphicsEngine::UploadVobs(
     // partitioning — a cascade's upload runs on its own worker thread and must not touch a shared cursor.
     //
     // Rounded up to a whole instance: with the VOB arena a command addresses its instances by ELEMENT index
-    // (StartInstanceLocation) into the one buffer the pass binds, not by a per-command VBV, so every block
-    // must start at an exact multiple of the stride. The slice size is a round byte count and is not one.
+    // (StartInstanceLocation), so every block must start at an exact multiple of the stride — and the slice
+    // size is a round byte count, not a round instance count.
     constexpr UINT kInstStride = static_cast<UINT>( sizeof( VobInstanceInfo ) );
     const UINT sliceBase = ( ( ringSlot * m_ShadowInstanceSliceCapacity + kInstStride - 1 ) / kInstStride ) * kInstStride;
     const UINT sliceCapacity = m_ShadowInstanceSliceCapacity - ( sliceBase - ringSlot * m_ShadowInstanceSliceCapacity );
@@ -4122,33 +4049,27 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
     // Only visible visuals are touched, since the loop below already skips visuals with no instances.
     const bool animateStaticVobs = rs.RendererSettings.AnimateStaticVobs;
 
-    // Upload whatever OnAddVob queued into the VOB mega-buffers (D3D12VobArena). This is the one point per
-    // frame that touches the arena's GPU resources, and it deliberately sits here: the main thread, an open
-    // frame, before BuildVobDrawCommands reads any range and before m_ShadowMap.Prepare() fans the cascade
-    // command builds out to the worker pool. That ordering is what makes D3D12VobArena::Find() lock-free.
-    // A failed flush leaves ranges missing and those sub-meshes simply don't draw (it logs once).
+    // Upload whatever OnAddVob queued into the VOB mega-buffers (D3D12VobArena). The one point per frame that
+    // touches the arena's GPU resources, and it must stay here — main thread, open frame, before
+    // BuildVobDrawCommands reads any range and before m_ShadowMap.Prepare() fans the cascade builds out to the
+    // pool. That is what makes D3D12VobArena::Find() lock-free. A failed flush just leaves ranges missing.
     m_VobArena.Flush( this );
 
     const UINT frame = m_FrameIndex;
 
     // GPU culling (D3D12Cull.cpp): emit one VobCullVisual per visual alongside the instance memcpy — the local
-    // bbox all its instances share plus where they landed in the ring. CSCull reads both the input and the
-    // compacted output as StructuredBuffer<VobInstanceInfo>, so the record carries an ELEMENT index; the loop
-    // below keeps the ring offset a whole multiple of the stride so byte offset / stride is exact. (Today it
-    // trivially is — this is the first thing to allocate after OnBeginFrame reset the ring, and every block is
-    // numInstances * sizeof(VobInstanceInfo) — but the ring is shared with the skeletal node-attachment
-    // uploads, so aligning explicitly keeps a future reordering from silently mis-indexing every instance.)
+    // bbox its instances share plus where they landed in the ring. CSCull reads input and output as
+    // StructuredBuffer<VobInstanceInfo>, so the record carries an ELEMENT index; the loop below keeps the ring
+    // offset a whole multiple of the stride, since the ring is shared with the node-attachment uploads.
     //
-    // This is also the LAST point at which GPU culling can still be switched off: BuildVobDrawCommands (next)
-    // stamps commands that reference the compacted buffer, and from then on the cull MUST run.
+    // Also the LAST point at which GPU culling can be switched off: BuildVobDrawCommands stamps commands that
+    // reference the compacted buffer, and from then on the cull MUST run.
     if ( m_GpuVobCullActive && ( !m_VobCullVisualsPtr[m_FrameIndex] || !m_VobCulledInstances ) )
         m_GpuVobCullActive = false;
 
-    // CPU-side geometry-LOD split. With the GPU cull on, CSCull does the near/far bucketing; with it off
-    // nothing else would, so partition each visual's instance block by distance right here, as we copy it
-    // into the ring. Same decision CSCull makes, same math (see IsInstanceVisible / the note there on why
-    // the bbox CENTRE and not the vob origin), just done on the thread that is already touching every
-    // instance. The cost is one distance per instance on a list the CPU frustum cull has already thinned.
+    // CPU-side geometry-LOD split, for when the GPU cull (which would otherwise do the near/far bucketing in
+    // CSCull) is off: partition each visual's instance block by distance as we copy it into the ring. Same
+    // decision and math CSCull makes (see IsInstanceVisible, including why it uses the bbox CENTRE).
     const bool cpuLodSplit = !m_GpuVobCullActive && m_VobLodDistance > 0.0f;
     const float lodDistSq = m_VobLodDistance * m_VobLodDistance;
     XMFLOAT3 camPos;
@@ -4186,11 +4107,10 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
         if ( !cpuLodSplit ) {
             memcpy( m_VobInstanceBufferPtr[frame] + instOffset, visual->Instances.data(), instBytes );
         } else {
-            // Partition in one pass: near packs forward from the start of the block, far backward from its
-            // end. Every instance lands in exactly one run and none are dropped here (the CPU frustum cull
-            // already ran), so the two runs are adjacent and the far one begins at exactly nearInstances —
-            // which is what lets a single StartInstanceLocation address it. Packing far backward reverses
-            // its order; nothing downstream cares (opaque, depth-tested, one draw).
+            // One pass: near packs forward from the start of the block, far backward from its end. Nothing is
+            // dropped here (the CPU frustum cull already ran), so the two runs are adjacent and the far one
+            // begins at exactly nearInstances — which is what lets a single StartInstanceLocation address it.
+            // Packing far backward reverses its order; nothing downstream cares.
             VobInstanceInfo* dst = reinterpret_cast<VobInstanceInfo*>( m_VobInstanceBufferPtr[frame] + instOffset );
             const float cx = ( visual->BBox.Min.x + visual->BBox.Max.x ) * 0.5f;
             const float cy = ( visual->BBox.Min.y + visual->BBox.Max.y ) * 0.5f;
@@ -4199,14 +4119,12 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
             UINT farCursor = numInstances;
             for ( const VobInstanceInfo& inst : visual->Instances ) {
                 // The instance matrix is uploaded row-major and read COLUMN-major by the shaders, so the
-                // stored XMFLOAT4X4 is the transpose of the matrix HLSL multiplies with. Written out
-                // component-wise rather than through XMMatrixTranspose so it is visibly the same
-                // expression VobCull.hlsl evaluates: mul( float4(centre,1), world ).
+                // stored XMFLOAT4X4 is the transpose of what HLSL multiplies with. Written component-wise so
+                // this is visibly the same expression VobCull.hlsl evaluates: mul( float4(centre,1), world ).
                 const XMFLOAT4X4& w = inst.world;
                 const float wx = cx * w.m[0][0] + cy * w.m[0][1] + cz * w.m[0][2] + w.m[0][3] - camPos.x;
                 const float wy = cx * w.m[1][0] + cy * w.m[1][1] + cz * w.m[1][2] + w.m[1][3] - camPos.y;
                 const float wz = cx * w.m[2][0] + cy * w.m[2][1] + cz * w.m[2][2] + w.m[2][3] - camPos.z;
-                // Squared compare — the threshold is a plain distance, so no sqrt is needed.
                 if ( wx * wx + wy * wy + wz * wz > lodDistSq ) dst[--farCursor] = inst;
                 else                                          dst[nearCursor++] = inst;
             }
@@ -4230,16 +4148,15 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
                 rec.BBoxMax = visual->BBox.Max;
                 rec.InstanceBase = instOffset / kInstStride;
                 rec.InstanceCount = numInstances;
-                // Conservative default: no split until BuildVobDrawCommands confirms the far bucket actually
-                // has commands to draw it. Defaulting to either split mode here would strand instances
-                // behind a bucket nothing draws.
+                // No split until BuildVobDrawCommands confirms the far bucket has commands to draw it;
+                // anything else would strand instances behind a bucket nothing draws.
                 rec.SplitMode = kSplitModeNone;
                 up.cullVisualIndex = m_VobCullVisualCount++;
                 up.culledInstView.BufferLocation = m_VobCulledInstances->GetGPUVirtualAddress() + instOffset;
             } else {
-                // Graceful: the remaining visuals keep the CPU's instance count and their absolute
-                // instanceBase, so they render uncompacted (i.e. unculled) instead of vanishing — which is
-                // why CullVobsGPU has to seed the compacted buffer from the raw ring when this happens.
+                // The remaining visuals keep the CPU's instance count and absolute instanceBase, so they
+                // render unculled instead of vanishing — which is why CullVobsGPU seeds the compacted buffer
+                // from the raw ring when this happens.
                 m_VobCullVisualOverflowed = true;
                 if ( !m_VobCullVisualOverflowLogged ) {
                     LogWarn() << "D3D12: VOB cull-record overflow (" << kMaxCullVisuals
@@ -4312,23 +4229,18 @@ void D3D12GraphicsEngine::DrawVobDepthPrepass() {
     // drawArgs (GetVobDrawArgsBuffer): the GPU-culled DEFAULT copy (instance counts patched by CullVobsGPU) when
     // culling is active, else the CPU-written UPLOAD ring.
     if ( !splitAlpha ) {
-        // Motion-G-buffer prepass: everything draws, including the far alpha-tested run. Omitting it here
-        // would leave distant cutout pixels with no motion vector and no normal, which TAA reads as ghosting
-        // and XeGTAO as a wrong normal — a visual regression, not just a coverage loss. The trim below is
-        // therefore deliberately confined to the plain depth-only path.
+        // Motion-G-buffer prepass: everything draws, including the far alpha-tested run — omitting it leaves
+        // distant cutout pixels with no motion vector and no normal (TAA ghosting, wrong XeGTAO normals).
         m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_VobDrawCount, drawArgs, 0, nullptr, 0 );
         return;
     }
-    // drawArgs may be the GPU-culled DEFAULT copy — but CSPatchArgs only rewrites each command's
-    // InstanceCount in place (keyed on the VisualIndex embedded in the command itself), so the opaque/
-    // alpha-tested partition the CPU build laid out survives the cull byte-for-byte. See D3D12Cull.cpp.
+    // drawArgs may be the GPU-culled DEFAULT copy, but CSPatchArgs only rewrites InstanceCount in place, so
+    // the opaque/alpha-tested partition the CPU build laid out survives the cull. See D3D12Cull.cpp.
     if ( m_VobOpaqueDrawCount > 0 ) {
         m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_VobOpaqueDrawCount, drawArgs, 0, nullptr, 0 );
     }
-    // The alpha-tested run, whole. A distance trim used to live here (only the near part of the run went
-    // into the prepass, on the theory that a distant cutout re-shades in the lit pass anyway). It is gone:
-    // leaving alpha-tested surfaces out of the prepass lets grass and other later geometry draw ON TOP of
-    // them, which is a plainly visible artifact, and it never paid for itself.
+    // The alpha-tested run, whole — no distance trim. Leaving alpha-tested surfaces out of the prepass lets
+    // grass and other later geometry draw on top of them.
     const UINT alphaCount = m_VobDrawCount - m_VobOpaqueDrawCount;
     if ( alphaCount > 0 ) {
         m_CmdList->SetPipelineState( m_Pipelines.World.DepthPrepassVobIndirectPSO.Get() );

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2119,6 +2119,12 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// mid-frame would mix culled and unculled state. See D3D12Cull.cpp.
 	m_GpuVobCullActive = EvaluateGpuVobCulling();
 
+	// Snapshotted ONCE: BuildVobDrawCommands and CSCull must agree on it, and the ImGui slider moving
+	// between them would strand a bucket with no command. Needs GPU culling - CSCull produces the split.
+	m_VobLodDistance = ( m_GpuVobCullActive
+		&& Engine::GAPI->GetRendererState().RendererSettings.VobLodDrawRadius > 0.0f )
+		? Engine::GAPI->GetRendererState().RendererSettings.VobLodDrawRadius : 0.0f;
+
 	// zCBspNodeRender hook — Gothic's BSP traversal is replaced; we draw the world ourselves.
 	// Order mirrors D3D11's DrawWorldMeshNaive: sky background, world mesh, skeletal (NPCs/monsters),
 	// then instanced static VOBs. The sky is a fog-colored fill so the horizon dissolves into the
@@ -2987,11 +2993,20 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
     const bool peelBlended = resolveMaps && m_Pipelines.World.VobAlphaBlendPSO != nullptr;
     if ( resolveMaps ) g_FrameVobAlpha.clear();
 
+    // Records are still CPU-writable here and CullVobsGPU has not run, and this is the only place that
+    // knows which sub-meshes actually emitted a far command. Main-view build only.
+    VobCullVisual* cullRecords = ( culled && resolveMaps && m_VobCullVisualsPtr[m_FrameIndex] )
+        ? reinterpret_cast<VobCullVisual*>( m_VobCullVisualsPtr[m_FrameIndex] ) : nullptr;
+
     for ( const FrameVobUpload& up : uploads ) {
         MeshVisualInfo* visual = up.visual;
         if ( !visual ) continue;
         const float minH = visual->BBox.Min.y;
         const float maxH = visual->BBox.Max.y;
+        // Split only if EVERY drawn sub-mesh has a far counterpart; anyDrawn keeps a visual that drew
+        // nothing from being marked splittable.
+        bool visualAllHaveLod = true;
+        bool visualAnyDrawn = false;
 
         for ( auto const& [meshKey, meshList] : visual->MeshesByTexture ) {
             zCTexture* tex = meshKey.Material->GetAniTexture();
@@ -3025,10 +3040,15 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
             const bool blended = peelBlended
                 && ( alphaFunc == zMAT_ALPHA_FUNC_BLEND || alphaFunc == zMAT_ALPHA_FUNC_ADD );
 
-            // The caster PS alpha-clips against this material's diffuse, and both reduced index buffers are
+            // The caster PS alpha-clips against this material's diffuse, and the SHADOW index buffer is
             // position-welded — which merges wedges that share a position but not a UV. Feeding a leaf card
             // the wrong UV would clip away the wrong texels, so alpha-relevant materials keep full indices
             // in every pass. Same condition D3D11's shadow VOB loop gates on.
+            //
+            // The LOD buffer is no longer welded (see OptimizeLodIndices) and so carries correct UVs, but
+            // alpha-tested materials stay excluded from it too: an edge collapse deletes triangles outright,
+            // and on a cutout that means chunks of the silhouette — leaves, grates, ladders — simply
+            // disappearing rather than getting coarser.
             const bool alphaTested = ( tex && tex->HasAlphaChannel() )
                 || ( meshKey.Material && meshKey.Material->HasAlphaTest() );
 
@@ -3059,7 +3079,15 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                     continue;
                 }
 
-                if ( count + alphaCmds.size() >= maxCommands ) {
+                // Reserve room for BOTH commands: cutting a split pair in half would drop every far
+                // instance of this visual, since CSCull still buckets them away from the near run.
+                const bool mainViewLod = ( shadowCascade == kVobIndicesMainView ) && culled
+                    && m_VobLodDistance > 0.0f && !alphaTested
+                    && !mi->LodIndices.empty() && mi->GetMeshLodIndexBuffer()
+                    && D3D12VertexBuffer::From( mi->GetMeshLodIndexBuffer() )->GetResource() != nullptr;
+                const size_t cmdsNeeded = mainViewLod ? 2u : 1u;
+
+                if ( count + alphaCmds.size() + cmdsNeeded > maxCommands ) {
                     if ( !m_VobDrawArgsOverflowLogged ) {
                         LogWarn() << "D3D12: VOB draw-command ring overflow (" << maxCommands
                             << " draws/frame); some VOBs dropped this frame.";
@@ -3097,7 +3125,7 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 // and let CSPatchArgs replace InstanceCount below with the surviving count for this visual.
                 c.InstVBV = culled ? up.culledInstView : up.instView;
                 c.VisualIndex = culled ? up.cullVisualIndex : 0xFFFFFFFFu;
-                c._cmdPad = 0;
+                c.LodBucket = kLodBucketNear;
                 c.IBV     = { cmdIb->GetGpuVirtualAddress(), cmdIb->GetSizeInBytes(), DXGI_FORMAT_R16_UINT };
                 c.MatNormalIndex  = normalIdx;
                 c.MatOrmIndex     = ormIdx;
@@ -3116,7 +3144,29 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 else               cmds[count++] = c;
                 if ( resolveMaps )
                     m_VobDrawnTriangles += (cmdIndexCount / 3) * up.numInstances;
+                visualAnyDrawn = true;
+                if ( !mainViewLod ) visualAllHaveLod = false;   // this sub-mesh has no far bucket to draw
+
+                // Far bucket: same sub-mesh, reduced indices, over the run CSCull packed backward from the
+                // end of this visual's range. Counts and StartInstanceLocation are patched by CSPatchArgs -
+                // the split happens on the GPU, so the CPU cannot know either. InstanceCount starts at 0 so
+                // an unpatched command draws nothing rather than every instance a second time.
+                if ( mainViewLod ) {
+                    D3D12VertexBuffer* lodIb = D3D12VertexBuffer::From( mi->GetMeshLodIndexBuffer() );
+                    VobDrawCommand f = c;
+                    f.LodBucket = kLodBucketFar;
+                    f.IBV = { lodIb->GetGpuVirtualAddress(), lodIb->GetSizeInBytes(), DXGI_FORMAT_R16_UINT };
+                    f.Draw.IndexCountPerInstance = static_cast<UINT>( mi->LodIndices.size() );
+                    f.Draw.InstanceCount = 0;
+                    cmds[count++] = f;   // not counted in m_VobDrawnTriangles: the near command already
+                }                        // counted every instance, keeping that stat a pre-cull upper bound
             }
+        }
+
+        // Publish for CSCull. Visuals with no record (cull-record overflow) render uncompacted anyway.
+        if ( cullRecords && up.cullVisualIndex != 0xFFFFFFFFu && up.cullVisualIndex < kMaxCullVisuals ) {
+            cullRecords[up.cullVisualIndex].LodSplit =
+                ( visualAnyDrawn && visualAllHaveLod ) ? 1u : 0u;
         }
     }
     return finish();
@@ -3426,7 +3476,7 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
             c.Draw.BaseVertexLocation    = 0;
             c.Draw.StartInstanceLocation = 0;
             c.VisualIndex = 0xFFFFFFFFu;   // never GPU-culled: "leave the CPU's instance count alone"
-            c._cmdPad     = 0;
+            c.LodBucket   = kLodBucketNear;   // attachments never split; VisualIndex already skips them
             if ( b.alphaTested ) alphaAttachCmds.push_back( c );
             else                 cmds[count++] = c;
         }
@@ -3848,6 +3898,12 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
                 rec.BBoxMax = visual->BBox.Max;
                 rec.InstanceBase = instOffset / kInstStride;
                 rec.InstanceCount = numInstances;
+                rec.LodSplit = 0;   // BuildVobDrawCommands raises this once it knows every sub-mesh has a
+                                    // far command; defaulting on would strand instances nothing draws.
+                // Conservative default: no split until BuildVobDrawCommands confirms every drawn sub-mesh
+                // of this visual emitted a far command. Leaving it 1 here would strand instances behind a
+                // bucket nothing draws.
+                rec.LodSplit = 0;
                 up.cullVisualIndex = m_VobCullVisualCount++;
                 up.culledInstView.BufferLocation = m_VobCulledInstances->GetGPUVirtualAddress() + instOffset;
             } else if ( !m_VobCullVisualOverflowLogged ) {

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -296,6 +296,14 @@ void D3D12GraphicsEngine::OnAddVob(VobInfo* vi) {
     }
     vi->VisualIndex = it->second;
 
+    // Register this visual's sub-meshes with the VOB mega-buffers. This hook fires per vob during world
+    // load, so by the first rendered frame the whole world's static geometry is queued — which is exactly
+    // the "build it once at load, with no culling" property the arena needs to be able to serve every pass
+    // (including the shadow cascades, which see casters the main view never does). Everything added later
+    // (a dropped weapon, an item thrown out of the inventory) arrives through the same call and lands in the
+    // arena's headroom. Queueing is cheap and idempotent; the upload happens at the next frame's flush.
+    m_VobArena.QueueVisual( static_cast<MeshVisualInfo*>( vi->VisualInfo ) );
+
     // A VOB added after a nearby point light already cached its static-aside shadow cube would otherwise cast no
     // point-light shadow: the static cube is only re-rendered when the light is fresh / moved / resized (the
     // renderStatic gate in BuildFramePointShadows), not when world geometry around it changes. Walk the active
@@ -329,6 +337,10 @@ void D3D12GraphicsEngine::OnLoadWorld()
         v.Reset();
     }
     m_RainShadowVobs.Reset();
+    // The VOB mega-buffers describe the world being left: every MeshInfo they index is about to be freed,
+    // so the ranges have to go before the new world's OnAddVob calls start refilling them. The buffers
+    // themselves are kept and refilled from offset 0 — see D3D12VobArena::Reset.
+    m_VobArena.Reset();
     // AO needs no reset here — it runs entirely off THIS frame's depth prepass, so the first frame of the new
     // world already produces a correct mask.
     // TAA does: the accumulated history and its depth snapshot belong to the world being left.
@@ -2124,6 +2136,10 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	m_VobLodDistance = ( m_GpuVobCullActive
 		&& Engine::GAPI->GetRendererState().RendererSettings.VobLodDrawRadius > 0.0f )
 		? Engine::GAPI->GetRendererState().RendererSettings.VobLodDrawRadius : 0.0f;
+	// Same one-shot snapshot, same reason, for the alpha-tested prepass split (kSplitModeAlpha).
+	m_VobAlphaPrepassDistance = ( m_GpuVobCullActive
+		&& Engine::GAPI->GetRendererState().RendererSettings.VobAlphaPrepassRadius > 0.0f )
+		? Engine::GAPI->GetRendererState().RendererSettings.VobAlphaPrepassRadius : 0.0f;
 
 	// zCBspNodeRender hook — Gothic's BSP traversal is replaced; we draw the world ourselves.
 	// Order mirrors D3D11's DrawWorldMeshNaive: sky background, world mesh, skeletal (NPCs/monsters),
@@ -2222,10 +2238,23 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// vertex/index binds happen once/frame instead of per-pass, and neither pass issues per-mesh CPU draw calls).
 	if ( Engine::GAPI->GetRendererState().RendererSettings.DrawVOBs && m_VobDrawArgsPtr[m_FrameIndex] ) {
 		m_VobDrawCount = BuildVobDrawCommands( g_FrameVobUploads, m_VobDrawArgsPtr[m_FrameIndex], true,
-			kMaxVobDrawCommands, m_GpuVobCullActive, true, kVobIndicesMainView, &m_VobOpaqueDrawCount );
+			kMaxVobDrawCommands, m_GpuVobCullActive, true, kVobIndicesMainView, &m_VobOpaqueDrawCount,
+			&m_VobAlphaNearDrawCount );
 	} else {
 		m_VobDrawCount = 0;
 		m_VobOpaqueDrawCount = 0;
+		m_VobAlphaNearDrawCount = 0;
+	}
+	// Publish this frame's VOB submission shape for the ImGui stats panel — see VobFrameStats.
+	m_VobStats.Commands = m_VobDrawCount;
+	m_VobStats.OpaqueCommands = m_VobOpaqueDrawCount;
+	m_VobStats.AlphaNearCommands = m_VobAlphaNearDrawCount;
+	m_VobStats.CullVisuals = m_VobCullVisualCount;
+	m_VobStats.GpuCullActive = m_GpuVobCullActive;
+	{
+		UINT inst = 0;
+		for ( const FrameVobUpload& u : g_FrameVobUploads ) inst += u.numInstances;
+		m_VobStats.Instances = inst;
 	}
 	// Build the skeletal + node-attachment ExecuteIndirect command sets ONCE (T9) from g_FrameSkelDraws/
 	// g_FrameAttachDraws, resolving each material's full bindless index set — the depth prepass ignores the
@@ -2243,6 +2272,10 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// which case UpdateMorphMeshVisual already deformed them on the CPU during collection. See
 	// D3D12MorphFold.cpp / MorphGpu.h.
 	DispatchMorphFold();
+	// ...and mirror the deformed vertices of any ANIMATED STATIC vob into its VOB-arena range. Must follow
+	// the fold (that is what produced them) and precede the depth prepass (the first pass on this list that
+	// draws out of the arena). No-op unless the world actually has .MMS static vobs in it.
+	RefreshDynamicVobArena();
     {
         DX_ZONE( m_CmdList.Get(), "Depth Prepass" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth Prepass" );
@@ -2909,47 +2942,75 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
 
 
 bool D3D12GraphicsEngine::CreateVobIndirect() {
-    // Command signature + per-frame UPLOAD arg rings for the GPU-driven instanced VOBs (P2.12). Unlike the world
-    // mesh's signature (material consts + DrawIndexed over one shared VB/IB), each VOB command ALSO sets its own
-    // two vertex-buffer views (packed mesh @slot0, per-instance @slot1) + index-buffer view — VOB visuals don't
-    // share a buffer. Arg order MUST match VobDrawCommand's member layout. The rings stay UPLOAD/GENERIC_READ
-    // (which includes INDIRECT_ARGUMENT), rebuilt each frame by BuildVobDrawCommands — no DEFAULT-heap copy.
+    // Command signatures + per-frame UPLOAD arg rings for the GPU-driven instanced VOBs (P2.12).
+    //
+    // TWO signatures now. The instanced-VOB one carries NO buffer views at all: every static VOB sub-mesh
+    // lives in the shared vertex/index mega-buffers (D3D12VobArena) and every instance in the one instance
+    // buffer the pass binds, so a command is just material consts + wind consts + DrawIndexed, exactly like
+    // the world mesh's. That is the whole point of the arena — it is the PRESENCE of VBV/IBV arguments that
+    // makes a command an IA state change, and 560 of those per pass was the dominant VOB cost.
+    //
+    // The second ("bound") signature is the old six-argument shape, kept for node attachments, whose
+    // geometry comes and goes with NPCs and is a few dozen commands a frame. Arg order MUST match each
+    // struct's member layout. Both rings stay UPLOAD/GENERIC_READ (which includes INDIRECT_ARGUMENT),
+    // rebuilt each frame — no DEFAULT-heap copy.
     ID3D12Device* device = m_Device.GetDevice();
     if ( !device || !m_Pipelines.World.RootSig ) return false;
 
-    // The GPU reads each command as tightly-packed native argument structs in pArgumentDescs order; the two VBVs +
-    // IBV lead so their UINT64 GPUVAs stay 8-aligned. 96 is a multiple of 8 → the next command's VBV is aligned too.
-    // The final 8 bytes (VisualIndex + pad) sit PAST the arguments: ByteStride only has to cover them, so those
-    // bytes are ours (VobCull.hlsl's CSPatchArgs reads VisualIndex out of the same buffer it patches).
-    static_assert( sizeof( VobDrawCommand ) == 96, "VobDrawCommand must match the command signature arg layout (96 B stride)" );
-    static_assert( offsetof( VobDrawCommand, MatNormalIndex ) == 48, "VobDrawCommand b6 consts must follow the 3 buffer views" );
-    static_assert( offsetof( VobDrawCommand, Draw ) == 68, "VobDrawCommand draw args must be last of the indirect arguments" );
-    static_assert( offsetof( VobDrawCommand, VisualIndex ) == 88, "VisualIndex must follow the indirect arguments" );
+    // The GPU reads each command as tightly-packed native argument structs in pArgumentDescs order. The
+    // trailing 8 bytes (VisualIndex + LodBucket) sit PAST the arguments: ByteStride only has to cover them,
+    // so those bytes are ours (VobCull.hlsl's CSPatchArgs reads both out of the buffer it patches).
+    static_assert( sizeof( VobDrawCommand ) == 48, "VobDrawCommand must match the command signature arg layout (48 B stride)" );
+    static_assert( offsetof( VobDrawCommand, MatNormalIndex ) == 0, "b6 consts lead the VOB command" );
+    static_assert( offsetof( VobDrawCommand, Draw ) == 20, "VobDrawCommand draw args must be last of the indirect arguments" );
+    static_assert( offsetof( VobDrawCommand, VisualIndex ) == 40, "VisualIndex must follow the indirect arguments" );
 
-    D3D12_INDIRECT_ARGUMENT_DESC args[6] = {};
-    args[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_VERTEX_BUFFER_VIEW;
-    args[0].VertexBuffer.Slot = 0;                            // packed ExVertexStruct
-    args[1].Type = D3D12_INDIRECT_ARGUMENT_TYPE_VERTEX_BUFFER_VIEW;
-    args[1].VertexBuffer.Slot = 1;                            // per-instance VobInstanceInfo
-    args[2].Type = D3D12_INDIRECT_ARGUMENT_TYPE_INDEX_BUFFER_VIEW;
-    args[3].Type = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT;
-    args[3].Constant.RootParameterIndex = 10;                 // b6 MaterialCB { normal, orm, diffuse }
-    args[3].Constant.DestOffsetIn32BitValues = 0;
-    args[3].Constant.Num32BitValuesToSet = 3;
-    args[4].Type = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT;
-    args[4].Constant.RootParameterIndex = 11;                 // b4 WindCB: overwrite only minHeight/maxHeight (@4,5)
-    args[4].Constant.DestOffsetIn32BitValues = 4;
-    args[4].Constant.Num32BitValuesToSet = 2;
-    args[5].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED;
+    D3D12_INDIRECT_ARGUMENT_DESC args[3] = {};
+    args[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT;
+    args[0].Constant.RootParameterIndex = 10;                 // b6 MaterialCB { normal, orm, diffuse }
+    args[0].Constant.DestOffsetIn32BitValues = 0;
+    args[0].Constant.Num32BitValuesToSet = 3;
+    args[1].Type = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT;
+    args[1].Constant.RootParameterIndex = 11;                 // b4 WindCB: overwrite only minHeight/maxHeight (@4,5)
+    args[1].Constant.DestOffsetIn32BitValues = 4;
+    args[1].Constant.Num32BitValuesToSet = 2;
+    args[2].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED;
 
     D3D12_COMMAND_SIGNATURE_DESC sigDesc = {};
-    sigDesc.ByteStride = sizeof( VobDrawCommand );            // 96 B; MUST match the struct + arg layout
+    sigDesc.ByteStride = sizeof( VobDrawCommand );            // 48 B; MUST match the struct + arg layout
     sigDesc.NumArgumentDescs = _countof( args );
     sigDesc.pArgumentDescs = args;
     // Commands set root constants (b6/b4), so the signature must carry the root signature those param indices refer to.
     if ( FAILED( device->CreateCommandSignature( &sigDesc, m_Pipelines.World.RootSig.Get(),
         IID_PPV_ARGS( m_VobIndirectCmdSig.ReleaseAndGetAddressOf() ) ) ) ) {
         LogWarn() << "D3D12: failed to create the VOB indirect command signature.";
+        return false;
+    }
+
+    // ---- Bound variant (node attachments) -------------------------------------------------------------
+    // The two VBVs + IBV lead so their UINT64 GPUVAs stay 8-aligned; 96 is a multiple of 8, so the next
+    // command's VBV is aligned too.
+    static_assert( sizeof( VobBoundDrawCommand ) == 96, "VobBoundDrawCommand must match its arg layout (96 B stride)" );
+    static_assert( offsetof( VobBoundDrawCommand, MatNormalIndex ) == 48, "b6 consts must follow the 3 buffer views" );
+    static_assert( offsetof( VobBoundDrawCommand, Draw ) == 68, "draw args must be last of the indirect arguments" );
+
+    D3D12_INDIRECT_ARGUMENT_DESC boundArgs[6] = {};
+    boundArgs[0].Type = D3D12_INDIRECT_ARGUMENT_TYPE_VERTEX_BUFFER_VIEW;
+    boundArgs[0].VertexBuffer.Slot = 0;                       // packed ExVertexStruct
+    boundArgs[1].Type = D3D12_INDIRECT_ARGUMENT_TYPE_VERTEX_BUFFER_VIEW;
+    boundArgs[1].VertexBuffer.Slot = 1;                       // per-instance VobInstanceInfo
+    boundArgs[2].Type = D3D12_INDIRECT_ARGUMENT_TYPE_INDEX_BUFFER_VIEW;
+    boundArgs[3] = args[0];
+    boundArgs[4] = args[1];
+    boundArgs[5].Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED;
+
+    D3D12_COMMAND_SIGNATURE_DESC boundDesc = {};
+    boundDesc.ByteStride = sizeof( VobBoundDrawCommand );
+    boundDesc.NumArgumentDescs = _countof( boundArgs );
+    boundDesc.pArgumentDescs = boundArgs;
+    if ( FAILED( device->CreateCommandSignature( &boundDesc, m_Pipelines.World.RootSig.Get(),
+        IID_PPV_ARGS( m_VobBoundIndirectCmdSig.ReleaseAndGetAddressOf() ) ) ) ) {
+        LogWarn() << "D3D12: failed to create the bound VOB indirect command signature.";
         return false;
     }
 
@@ -2985,6 +3046,93 @@ bool D3D12GraphicsEngine::CreateVobIndirect() {
 }
 
 
+void D3D12GraphicsEngine::RefreshDynamicVobArena() {
+    // Animated static VOBs (.MMS) are the one kind of VOB geometry that is not immutable: their vertices are
+    // rewritten every frame, either by ZENGIN's CPU deform into the MeshInfo's own DYNAMIC upload buffer
+    // (UpdateMorphMeshVisual, during UploadFrameVobInstances) or by the GPU morph fold into its DEFAULT UAV
+    // (DispatchMorphFold, immediately before this). The arena copy uploaded at registration is only the
+    // conversion pose, so mirror the live buffer into the arena range here — a handful of small
+    // CopyBufferRegions, and only for morph visuals that exist at all.
+    //
+    // Placed right after DispatchMorphFold on purpose: that is what produces THIS frame's folded vertices,
+    // and everything that draws VOBs out of the arena (the depth prepass onwards on this list) comes after.
+    const std::vector<MeshInfo*>& dynamic = m_VobArena.DynamicMeshes();
+    if ( dynamic.empty() || !m_FrameOpen || !m_VobArena.Ready() ) return;
+
+    DX_ZONE( m_CmdList.Get(), "Morph arena refresh" );
+
+    static std::vector<D3D12_RESOURCE_BARRIER> barriers;
+    static std::vector<std::pair<MeshInfo*, D3D12VertexBuffer*>> copies;
+    barriers.clear();
+    copies.clear();
+
+    for ( MeshInfo* mi : dynamic ) {
+        const D3D12VobArena::Range* range = m_VobArena.Find( mi );
+        if ( !range || !mi->GetMeshVertexBuffer() ) continue;
+        D3D12VertexBuffer* src = D3D12VertexBuffer::From( mi->GetMeshVertexBuffer() );
+        if ( !src->GetResource() ) continue;
+        // The fold's output is a DEFAULT UAV it left in VERTEX_AND_CONSTANT_BUFFER (or COMMON before its
+        // first fold); as a copy source it has to be COPY_SOURCE. The CPU-deform buffer is an UPLOAD
+        // resource permanently in GENERIC_READ, which already includes COPY_SOURCE — nothing to do.
+        if ( src->IsUavCapable() ) {
+            const D3D12_RESOURCE_STATES from = ( src->GetUavState() == D3D12VertexBuffer::EUavState::Vertex )
+                ? D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER : D3D12_RESOURCE_STATE_COMMON;
+            barriers.push_back( TransitionBarrier( src->GetResource(), from, D3D12_RESOURCE_STATE_COPY_SOURCE ) );
+        }
+        copies.emplace_back( mi, src );
+    }
+    if ( copies.empty() ) return;
+
+    if ( !barriers.empty() )
+        m_CmdList->ResourceBarrier( static_cast<UINT>( barriers.size() ), barriers.data() );
+
+    for ( auto const& [mi, src] : copies ) {
+        const D3D12VobArena::Range* range = m_VobArena.Find( mi );
+        // The source buffer holds exactly this sub-mesh's vertices in the same wedge order the arena copy
+        // was uploaded in (a morph sub-mesh deliberately skips OptimizeVertices for precisely that reason),
+        // so this is a straight range overwrite. min() guards a buffer that is somehow shorter.
+        const UINT64 bytes = std::min<UINT64>( src->GetSizeInBytes(),
+            static_cast<UINT64>( mi->Vertices.size() ) * D3D12VobArena::VertexStride() );
+        m_CmdList->CopyBufferRegion( m_VobArena.GetVertexBuffer(),
+            static_cast<UINT64>( range->BaseVertex ) * D3D12VobArena::VertexStride(),
+            src->GetResource(), 0, bytes );
+    }
+
+    // Hand the fold buffers back to the state DispatchMorphFold expects to find them in next frame, and the
+    // arena back to the IA. The arena is a BUFFER, so it promoted out of COMMON into COPY_DEST implicitly
+    // and needs an explicit barrier out again before the prepass reads it as a vertex/index stream.
+    barriers.clear();
+    for ( auto const& [mi, src] : copies ) {
+        if ( !src->IsUavCapable() ) continue;
+        barriers.push_back( TransitionBarrier( src->GetResource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
+            D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER ) );
+        src->SetUavState( D3D12VertexBuffer::EUavState::Vertex );
+    }
+    barriers.push_back( TransitionBarrier( m_VobArena.GetVertexBuffer(), D3D12_RESOURCE_STATE_COPY_DEST,
+        D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER ) );
+    m_CmdList->ResourceBarrier( static_cast<UINT>( barriers.size() ), barriers.data() );
+}
+
+
+bool D3D12GraphicsEngine::BindVobArenaIA( D3D12CmdList& cmdList, ID3D12Resource* instances, UINT instanceBytes ) {
+    if ( !m_VobArena.Ready() || !instances || instanceBytes == 0 ) return false;
+
+    // The whole buffer is bound, every time — a VOB command addresses its sub-mesh through
+    // BaseVertexLocation/StartIndexLocation and its instances through StartInstanceLocation, so there is
+    // nothing per-draw left in the IA state. That is exactly what makes this one bind instead of ~560.
+    const D3D12_VERTEX_BUFFER_VIEW views[2] = {
+        { m_VobArena.GetVertexBuffer()->GetGPUVirtualAddress(), m_VobArena.GetVertexBytes(),
+          D3D12VobArena::VertexStride() },
+        { instances->GetGPUVirtualAddress(), instanceBytes, static_cast<UINT>( sizeof( VobInstanceInfo ) ) },
+    };
+    const D3D12_INDEX_BUFFER_VIEW ibv = {
+        m_VobArena.GetIndexBuffer()->GetGPUVirtualAddress(), m_VobArena.GetIndexBytes(), DXGI_FORMAT_R16_UINT };
+    cmdList->IASetVertexBuffers( 0, 2, views );
+    cmdList->IASetIndexBuffer( &ibv );
+    return true;
+}
+
+
 /** First cascade allowed to take the baked progressive-mesh LOD index buffer. The debug setting wins,
     -1 (its default) keeps the compile-time gate the LOD buffers were validated against. A value at or
     above NumShadowCascades simply means no cascade ever qualifies, i.e. shadow LOD off. */
@@ -2994,27 +3142,42 @@ int D3D12GraphicsEngine::GetFirstLodShadowCascade() {
 }
 
 UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload>& uploads, uint8_t* argPtr, bool resolveMaps,
-    UINT maxCommands, bool culled, bool cacheIn, int shadowCascade, UINT* outOpaqueCount ) {
+    UINT maxCommands, bool culled, bool cacheIn, int shadowCascade, UINT* outOpaqueCount, UINT* outAlphaNearCount ) {
     // Fill an arg buffer with one command per (visual x material x sub-mesh): resolve the material's bindless
     // indices (diffuse always; normal/ORM only when resolveMaps — the depth/shadow passes just alpha-clip on
     // diffuse), pack the mesh + instance VB views + IB view, the per-visual wind min/max, and DrawIndexedInstanced.
     // Same CacheIn/From resolution the per-draw path did — but done ONCE per built buffer instead of per pass.
-    if ( !argPtr ) { if ( outOpaqueCount ) *outOpaqueCount = 0; return 0; }
+    if ( !argPtr ) {
+        if ( outOpaqueCount ) *outOpaqueCount = 0;
+        if ( outAlphaNearCount ) *outAlphaNearCount = 0;
+        return 0;
+    }
     VobDrawCommand* cmds = reinterpret_cast<VobDrawCommand*>( argPtr );
     UINT count = 0;
     // Alpha-test partition staging — see the identical block in BuildWorldDrawCommands for why the tail is
     // staged in normal RAM instead of compacted inside the write-combined UPLOAD ring. thread_local, not
     // static: the shadow cascades call this concurrently on the worker pool (cacheIn=false).
-    thread_local std::vector<VobDrawCommand> alphaCmds;
+    //
+    // Two staged runs, not one: the alpha-tested partition is itself ordered [near][far] so the depth prepass
+    // can submit just the near prefix (kSplitModeAlpha). With the split off, alphaFarCmds stays empty and the
+    // layout is byte-identical to what a single list produced.
+    thread_local std::vector<VobDrawCommand> alphaCmds;      // near run (or the whole run when not split)
+    thread_local std::vector<VobDrawCommand> alphaFarCmds;   // far run, drawn by the color pass only
     alphaCmds.clear();
-    // Appends the staged alpha-tested run behind the opaque one and reports the partition point. Both exits
+    alphaFarCmds.clear();
+    // Appends the staged alpha-tested runs behind the opaque one and reports the partition points. Both exits
     // below (ring overflow and normal completion) go through this, or an overflowing frame would silently
     // drop every alpha-tested draw instead of just the ones past the cap.
     auto finish = [&]() -> UINT {
         if ( outOpaqueCount ) *outOpaqueCount = count;
+        if ( outAlphaNearCount ) *outAlphaNearCount = static_cast<UINT>( alphaCmds.size() );
         if ( !alphaCmds.empty() ) {
             std::memcpy( cmds + count, alphaCmds.data(), alphaCmds.size() * sizeof( VobDrawCommand ) );
             count += static_cast<UINT>( alphaCmds.size() );
+        }
+        if ( !alphaFarCmds.empty() ) {
+            std::memcpy( cmds + count, alphaFarCmds.data(), alphaFarCmds.size() * sizeof( VobDrawCommand ) );
+            count += static_cast<UINT>( alphaFarCmds.size() );
         }
         return count;
         };
@@ -3033,20 +3196,49 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
     const bool peelBlended = resolveMaps && m_Pipelines.World.VobAlphaBlendPSO != nullptr;
     if ( resolveMaps ) g_FrameVobAlpha.clear();
 
+    // Stats: the split-mode histogram is accumulated in the visual loop below (main-view build only).
+    if ( resolveMaps ) {
+        m_VobStats.SplitNone = 0;
+        m_VobStats.SplitLod = 0;
+        m_VobStats.SplitAlpha = 0;
+    }
+
     // Records are still CPU-writable here and CullVobsGPU has not run, and this is the only place that
     // knows which sub-meshes actually emitted a far command. Main-view build only.
     VobCullVisual* cullRecords = ( culled && resolveMaps && m_VobCullVisualsPtr[m_FrameIndex] )
         ? reinterpret_cast<VobCullVisual*>( m_VobCullVisualsPtr[m_FrameIndex] ) : nullptr;
+
+    // Alpha-tested prepass split (kSplitModeAlpha): main-view, GPU-culled builds only, exactly like the LOD
+    // split it shares the bucket machinery with. Gated on cullRecords as well - without a record to raise
+    // SplitMode on, CSCull would leave every instance in the near run while the far commands sat emitted
+    // and unpatched.
+    const bool alphaSplitEnabled = ( shadowCascade == kVobIndicesMainView ) && culled && resolveMaps
+        && cullRecords != nullptr && m_VobAlphaPrepassDistance > 0.0f;
+
+    // Per-visual command staging. The alpha split is a per-VISUAL decision (CSCull buckets a visual's whole
+    // instance range one way) but `alphaTested` is only known per sub-mesh, and only AFTER that sub-mesh's
+    // material has been through CacheIn - zCTexture::HasAlphaChannel() reads a flag byte that is not
+    // populated until the texture is actually resident, so asking ahead of the material loop would answer
+    // "no alpha" for every visual the frame it first comes into view. So: build each visual's near commands
+    // into this scratch list, then decide and flush once every sub-mesh has been resolved. One pass, one
+    // authoritative answer, and no second copy of the alpha-tested test to drift out of sync.
+    // thread_local for the same reason alphaCmds is: the cascades build concurrently on the pool.
+    struct StagedSubMesh {
+        VobDrawCommand Cmd;
+        UINT LodStart;                    // arena index offsets; valid only when LodEligible
+        UINT LodIndexCount;
+        bool AlphaTested;
+        bool LodEligible;
+    };
+    thread_local std::vector<StagedSubMesh> staged;
 
     for ( const FrameVobUpload& up : uploads ) {
         MeshVisualInfo* visual = up.visual;
         if ( !visual ) continue;
         const float minH = visual->BBox.Min.y;
         const float maxH = visual->BBox.Max.y;
-        // Split only if EVERY drawn sub-mesh has a far counterpart; anyDrawn keeps a visual that drew
-        // nothing from being marked splittable.
-        bool visualAllHaveLod = true;
-        bool visualAnyDrawn = false;
+        staged.clear();
+        bool visualHasAlphaTested = false;
 
         for ( auto const& [meshKey, meshList] : visual->MeshesByTexture ) {
             zCTexture* tex = meshKey.Material->GetAniTexture();
@@ -3093,13 +3285,13 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 || ( meshKey.Material && meshKey.Material->HasAlphaTest() );
 
             for ( MeshInfo* mi : meshList ) {
-                if ( !mi || mi->Indices.empty() || !mi->GetMeshVertexBuffer() || !mi->GetMeshIndexBuffer() )
-                    continue;
-                D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( mi->GetMeshVertexBuffer() );
-                D3D12VertexBuffer* mib = D3D12VertexBuffer::From( mi->GetMeshIndexBuffer() );
-                if ( !mvb->GetResource() || !mib->GetResource() ) continue;
+                if ( !mi || mi->Indices.empty() ) continue;
 
                 if ( blended ) {
+                    if ( !mi->GetMeshVertexBuffer() || !mi->GetMeshIndexBuffer() ) continue;
+                    D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( mi->GetMeshVertexBuffer() );
+                    D3D12VertexBuffer* mib = D3D12VertexBuffer::From( mi->GetMeshIndexBuffer() );
+                    if ( !mvb->GetResource() || !mib->GetResource() ) continue;
                     // Draws from the UNcompacted instance stream: the GPU cull only patches instance counts
                     // inside the indirect arg buffer, and this pass is a plain CPU draw loop that never sees
                     // that patch. A handful of cobweb draws is not worth a second GPU-culled command set.
@@ -3119,54 +3311,42 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                     continue;
                 }
 
-                // Reserve room for BOTH commands: cutting a split pair in half would drop every far
-                // instance of this visual, since CSCull still buckets them away from the near run.
-                const bool mainViewLod = ( shadowCascade == kVobIndicesMainView ) && culled
-                    && m_VobLodDistance > 0.0f && !alphaTested
-                    && !mi->LodIndices.empty() && mi->GetMeshLodIndexBuffer()
-                    && D3D12VertexBuffer::From( mi->GetMeshLodIndexBuffer() )->GetResource() != nullptr;
-                const size_t cmdsNeeded = mainViewLod ? 2u : 1u;
+                // Where this sub-mesh lives in the VOB mega-buffers. Missing means it was never registered
+                // (a visual that appeared this frame is queued but not yet flushed) or its upload failed;
+                // either way it simply isn't drawn this frame and reappears on the next one. Everything
+                // below indexes the SAME vertex range - the shadow and LOD index levels are alternative
+                // index lists over the identical vertices, which is what lets one BaseVertexLocation serve
+                // all three.
+                const D3D12VobArena::Range* range = m_VobArena.Find( mi );
+                if ( !range || range->IndexCount == 0 ) continue;
 
-                if ( count + alphaCmds.size() + cmdsNeeded > maxCommands ) {
-                    if ( !m_VobDrawArgsOverflowLogged ) {
-                        LogWarn() << "D3D12: VOB draw-command ring overflow (" << maxCommands
-                            << " draws/frame); some VOBs dropped this frame.";
-                        m_VobDrawArgsOverflowLogged = true;
-                    }
-                    return finish();
-                }
+                // Whether this sub-mesh can offer a reduced far level to the main view. No longer gated on
+                // the visual's split mode - that is decided at flush time below, and suppressing LOD there
+                // keeps the two modes from ever both applying.
+                const bool lodEligible = ( shadowCascade == kVobIndicesMainView ) && culled
+                    && m_VobLodDistance > 0.0f && !alphaTested && range->LodCount > 0;
 
-                // Pick this command's index buffer. A missing level just falls through to the next-best one,
+                // Pick this command's index range. A missing level just falls through to the next-best one,
                 // so a mesh that ships no LOD data still gets the welded shadow indices, and one that has
                 // neither still draws — the only cost of an absent level is that nothing is saved.
-                D3D12VertexBuffer* cmdIb = mib;
-                UINT cmdIndexCount = static_cast<UINT>( mi->Indices.size() );
+                UINT cmdIndexStart = range->IndexStart;
+                UINT cmdIndexCount = range->IndexCount;
                 if ( shadowCascade != kVobIndicesMainView && !alphaTested ) {
-                    if ( shadowCascade >= firstLodCascade && !mi->LodIndices.empty()
-                        && mi->GetMeshLodIndexBuffer() ) {
-                        if ( D3D12VertexBuffer* lodIb = D3D12VertexBuffer::From( mi->GetMeshLodIndexBuffer() );
-                            lodIb->GetResource() ) {
-                            cmdIb = lodIb;
-                            cmdIndexCount = static_cast<UINT>( mi->LodIndices.size() );
-                        }
-                    }
-                    if ( cmdIb == mib && !mi->ShadowIndices.empty() && mi->GetMeshShadowIndexBuffer() ) {
-                        if ( D3D12VertexBuffer* shadowIb = D3D12VertexBuffer::From( mi->GetMeshShadowIndexBuffer() );
-                            shadowIb->GetResource() ) {
-                            cmdIb = shadowIb;
-                            cmdIndexCount = static_cast<UINT>( mi->ShadowIndices.size() );
-                        }
+                    if ( shadowCascade >= firstLodCascade && range->LodCount > 0 ) {
+                        cmdIndexStart = range->LodStart;
+                        cmdIndexCount = range->LodCount;
+                    } else if ( range->ShadowCount > 0 ) {
+                        cmdIndexStart = range->ShadowStart;
+                        cmdIndexCount = range->ShadowCount;
                     }
                 }
 
                 VobDrawCommand c{};
-                c.MeshVBV = { mvb->GetGpuVirtualAddress(), mvb->GetSizeInBytes(), sizeof( ExVertexStruct ) };
-                // GPU-culled: draw from the compacted buffer CSCull writes (same byte range, different base)
-                // and let CSPatchArgs replace InstanceCount below with the surviving count for this visual.
-                c.InstVBV = culled ? up.culledInstView : up.instView;
+                // GPU-culled: draw from the compacted buffer CSCull writes (same layout, different
+                // resource - the pass binds one or the other) and let CSPatchArgs replace InstanceCount and
+                // StartInstanceLocation below with the surviving run for this visual.
                 c.VisualIndex = culled ? up.cullVisualIndex : 0xFFFFFFFFu;
                 c.LodBucket = kLodBucketNear;
-                c.IBV     = { cmdIb->GetGpuVirtualAddress(), cmdIb->GetSizeInBytes(), DXGI_FORMAT_R16_UINT };
                 c.MatNormalIndex  = normalIdx;
                 c.MatOrmIndex     = ormIdx;
                 c.MatDiffuseIndex = diffuseIdx;
@@ -3174,39 +3354,115 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 c.WindMaxHeight   = maxH;
                 c.Draw.IndexCountPerInstance = cmdIndexCount;
                 c.Draw.InstanceCount         = up.numInstances;
-                c.Draw.StartIndexLocation    = 0;
-                c.Draw.BaseVertexLocation    = 0;
-                c.Draw.StartInstanceLocation = 0;
-                // Partition by alpha cutout (see m_WorldOpaqueDrawCount): opaque first, alpha-tested appended
-                // by finish(). `alphaTested` is the same flag that already gates the reduced shadow index
-                // buffers above, so there is nothing new to compute here.
-                if ( alphaTested ) alphaCmds.push_back( c );
-                else               cmds[count++] = c;
-                if ( resolveMaps )
-                    m_VobDrawnTriangles += (cmdIndexCount / 3) * up.numInstances;
-                visualAnyDrawn = true;
-                if ( !mainViewLod ) visualAllHaveLod = false;   // this sub-mesh has no far bucket to draw
-
-                // Far bucket: same sub-mesh, reduced indices, over the run CSCull packed backward from the
-                // end of this visual's range. Counts and StartInstanceLocation are patched by CSPatchArgs -
-                // the split happens on the GPU, so the CPU cannot know either. InstanceCount starts at 0 so
-                // an unpatched command draws nothing rather than every instance a second time.
-                if ( mainViewLod ) {
-                    D3D12VertexBuffer* lodIb = D3D12VertexBuffer::From( mi->GetMeshLodIndexBuffer() );
-                    VobDrawCommand f = c;
-                    f.LodBucket = kLodBucketFar;
-                    f.IBV = { lodIb->GetGpuVirtualAddress(), lodIb->GetSizeInBytes(), DXGI_FORMAT_R16_UINT };
-                    f.Draw.IndexCountPerInstance = static_cast<UINT>( mi->LodIndices.size() );
-                    f.Draw.InstanceCount = 0;
-                    cmds[count++] = f;   // not counted in m_VobDrawnTriangles: the near command already
-                }                        // counted every instance, keeping that stat a pre-cull upper bound
+                c.Draw.StartIndexLocation    = cmdIndexStart;
+                c.Draw.BaseVertexLocation    = static_cast<INT>( range->BaseVertex );
+                // Absolute, not range-relative: there is no per-command instance VBV any more, so the
+                // command has to name its visual's block inside the one buffer the pass binds. For culled
+                // commands CSPatchArgs overwrites this with InstanceBase + the run's offset; the value here
+                // is what an UNpatched command (cull off, or cull-record overflow) draws.
+                c.Draw.StartInstanceLocation = up.instanceBase;
+                // Staged, not emitted: the visual's split mode is not known until every sub-mesh has been
+                // resolved (see the `staged` declaration for why the alpha-tested answer cannot be had any
+                // earlier than this).
+                StagedSubMesh s{};
+                s.Cmd = c;
+                s.AlphaTested = alphaTested;
+                s.LodEligible = lodEligible;
+                if ( lodEligible ) {
+                    s.LodStart = range->LodStart;
+                    s.LodIndexCount = range->LodCount;
+                }
+                staged.push_back( s );
+                visualHasAlphaTested |= alphaTested;
             }
+        }
+
+        // ---- Flush this visual ----------------------------------------------------------------------
+        // Everything below needs the WHOLE visual resolved, which is why it could not happen inline.
+        //
+        // The two split modes are mutually exclusive, and this is where that is enforced rather than
+        // hoped for: an alpha-split visual has its LOD suppressed on every sub-mesh, so a mixed visual's
+        // opaque sub-mesh can never leave a stale far *LOD* command for CSPatchArgs to then populate from
+        // the ALPHA distance.
+        const bool alphaSplit = alphaSplitEnabled && visualHasAlphaTested;
+
+        // Split only if EVERY drawn sub-mesh has a far counterpart; a visual that drew nothing is not
+        // splittable at all.
+        bool visualAllHaveLod = true;
+        size_t cmdsNeeded = 0;
+        for ( const StagedSubMesh& s : staged ) {
+            const bool lod = s.LodEligible && !alphaSplit;
+            if ( !lod ) visualAllHaveLod = false;
+            cmdsNeeded += ( lod || alphaSplit ) ? 2u : 1u;
+        }
+
+        // Checked per VISUAL now rather than per sub-mesh: a split pair cut in half would drop every far
+        // instance of the visual, since CSCull still buckets them away from the near run. Dropping the
+        // whole visual instead of part of one is also the tidier failure.
+        if ( !staged.empty()
+            && count + alphaCmds.size() + alphaFarCmds.size() + cmdsNeeded > maxCommands ) {
+            if ( !m_VobDrawArgsOverflowLogged ) {
+                LogWarn() << "D3D12: VOB draw-command ring overflow (" << maxCommands
+                    << " draws/frame); some VOBs dropped this frame.";
+                m_VobDrawArgsOverflowLogged = true;
+            }
+            return finish();
+        }
+
+        for ( const StagedSubMesh& s : staged ) {
+            // Partition by alpha cutout (see m_WorldOpaqueDrawCount): opaque first, alpha-tested appended
+            // by finish().
+            if ( s.AlphaTested ) alphaCmds.push_back( s.Cmd );
+            else                 cmds[count++] = s.Cmd;
+            if ( resolveMaps )
+                m_VobDrawnTriangles += ( s.Cmd.Draw.IndexCountPerInstance / 3 ) * up.numInstances;
+
+            // Far bucket. Counts and StartInstanceLocation are patched by CSPatchArgs - the split happens
+            // on the GPU, so the CPU cannot know either. InstanceCount starts at 0 so an unpatched command
+            // draws nothing rather than every instance a second time.
+            if ( alphaSplit ) {
+                // Alpha-prepass split: the far bucket draws the SAME indices as the near one - nothing
+                // about the geometry changes, only WHICH PASS submits it. The near command is drawn by both
+                // the depth prepass and the color pass; this one only by the color pass, which is the whole
+                // point (a distant cutout re-shades in the lit pass anyway, so paying for it a second time
+                // in the prepass buys nothing but the tile near-plane bound).
+                // Emitted for opaque sub-meshes too: CSCull buckets the visual's WHOLE instance range, so
+                // an opaque sub-mesh with only a near command would lose every far instance from BOTH
+                // passes - a tree trunk vanishing past the threshold while its leaves stayed. Opaque far
+                // commands stay in the opaque partition (the prepass draws that run whole); alpha-tested
+                // ones go to the tail the prepass trims.
+                VobDrawCommand f = s.Cmd;
+                f.LodBucket = kLodBucketFar;
+                f.Draw.InstanceCount = 0;
+                if ( s.AlphaTested ) alphaFarCmds.push_back( f );
+                else                 cmds[count++] = f;
+            } else if ( s.LodEligible ) {
+                // LOD split: same sub-mesh, reduced indices, over the run CSCull packed backward from the
+                // end of this visual's range. LOD-eligible implies !AlphaTested, so this always belongs in
+                // the opaque partition.
+                VobDrawCommand f = s.Cmd;
+                f.LodBucket = kLodBucketFar;
+                f.Draw.StartIndexLocation = s.LodStart;
+                f.Draw.IndexCountPerInstance = s.LodIndexCount;
+                f.Draw.InstanceCount = 0;
+                cmds[count++] = f;   // not counted in m_VobDrawnTriangles: the near command already
+            }                        // counted every instance, keeping that stat a pre-cull upper bound
         }
 
         // Publish for CSCull. Visuals with no record (cull-record overflow) render uncompacted anyway.
         if ( cullRecords && up.cullVisualIndex != 0xFFFFFFFFu && up.cullVisualIndex < kMaxCullVisuals ) {
-            cullRecords[up.cullVisualIndex].LodSplit =
-                ( visualAnyDrawn && visualAllHaveLod ) ? 1u : 0u;
+            const UINT mode = staged.empty()      ? kSplitModeNone
+                            : visualAllHaveLod    ? kSplitModeLod
+                            : alphaSplit          ? kSplitModeAlpha
+                                                  : kSplitModeNone;
+            cullRecords[up.cullVisualIndex].SplitMode = mode;
+            if ( resolveMaps ) {
+                // Stats only: if these come back as "everything in SplitNone", neither the LOD slider nor
+                // the alpha slider can be having any effect, whatever they are set to.
+                if ( mode == kSplitModeLod )        m_VobStats.SplitLod++;
+                else if ( mode == kSplitModeAlpha ) m_VobStats.SplitAlpha++;
+                else                                m_VobStats.SplitNone++;
+            }
         }
     }
     return finish();
@@ -3216,14 +3472,14 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
 bool D3D12GraphicsEngine::CreateSkeletalIndirect() {
     // T9: command signature + per-frame UPLOAD arg rings for the GPU-driven skeletal base meshes, plus the
     // (signature-less) arg rings for the node attachments, which submit through the existing VOB signature.
-    // Must run AFTER CreateVobIndirect — the attachment rings are sized on VobDrawCommand and the attachment
-    // passes reuse m_VobIndirectCmdSig itself.
+    // Must run AFTER CreateVobIndirect — the attachment rings are sized on VobBoundDrawCommand and the
+    // attachment passes reuse m_VobBoundIndirectCmdSig itself.
     ID3D12Device* device = m_Device.GetDevice();
     if ( !device || !m_Pipelines.Skeletal.RootSig || !m_Pipelines.World.RootSig ) return false;
 
     // The GPU reads each command as tightly-packed native argument structs in pArgumentDescs order. The two root
     // CBVs are bare 8-byte GPU VAs and lead, so everything after them (both buffer views) stays 8-aligned; 80 is a
-    // multiple of 8 so the next command's InstCB is aligned too. Unlike VobDrawCommand there is no trailing
+    // multiple of 8 so the next command's InstCB is aligned too. Unlike VobBoundDrawCommand there is no trailing
     // payload here — nothing GPU-side patches skeletal commands (no GPU cull for NPCs yet).
     static_assert( sizeof( SkeletalDrawCommand ) == 80, "SkeletalDrawCommand must match the command signature arg layout (80 B stride)" );
     static_assert( offsetof( SkeletalDrawCommand, MeshVBV ) == 16, "SkeletalDrawCommand VBV must follow the two root CBVs" );
@@ -3282,7 +3538,7 @@ bool D3D12GraphicsEngine::CreateSkeletalIndirect() {
         if ( !makeRing( static_cast<UINT64>( kMaxSkeletalDrawCommands ) * sizeof( SkeletalDrawCommand ),
             m_SkeletalDrawArgs[i], m_SkeletalDrawArgsAlloc[i], m_SkeletalDrawArgsPtr[i], L"SkeletalDrawArgsRing" ) )
             return false;
-        if ( !makeRing( static_cast<UINT64>( kMaxAttachDrawCommands ) * sizeof( VobDrawCommand ),
+        if ( !makeRing( static_cast<UINT64>( kMaxAttachDrawCommands ) * sizeof( VobBoundDrawCommand ),
             m_AttachDrawArgs[i], m_AttachDrawArgsAlloc[i], m_AttachDrawArgsPtr[i], L"AttachDrawArgsRing" ) )
             return false;
     }
@@ -3295,7 +3551,7 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
     // run the instance's texani update ONCE (it mutates the model's SHARED texture slots, so it has to happen
     // while we read that instance's materials — see [[skeletal-texani-shared-slots]]), resolve the material's
     // bindless normal/ORM/diffuse indices, and emit one command per sub-mesh carrying the two root CBVs, the
-    // skinned VB, the IB and DrawIndexed. Node attachments do the same into a VobDrawCommand buffer.
+    // skinned VB, the IB and DrawIndexed. Node attachments do the same into a VobBoundDrawCommand buffer.
     //
     // Runs on the main thread from OnStartWorldRendering BEFORE BeginShadowRecording — every Gothic-touching
     // call here (UpdateMeshLibTexAniState, zCTexture::CacheIn) must be finished before the cascade recorders
@@ -3312,7 +3568,7 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
     // Alpha-test partition staging for both command sets below — see BuildWorldDrawCommands for the rationale.
     // Main thread only (this runs before BeginShadowRecording fans anything out), so plain statics.
     static std::vector<SkeletalDrawCommand> alphaSkelCmds;
-    static std::vector<VobDrawCommand>      alphaAttachCmds;
+    static std::vector<VobBoundDrawCommand> alphaAttachCmds;
 
     auto logOverflow = [this]( const char* what, UINT cap ) {
         if ( !m_SkeletalDrawArgsOverflowLogged ) {
@@ -3385,11 +3641,13 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
     }
 
     // --- Node attachments (weapons/heads/held items) ----------------------------------------------------
-    // Same VobDrawCommand/m_VobIndirectCmdSig the instanced VOBs use — an attachment IS a one-instance VOB
-    // draw, down to the packed ExVertexStruct + VobInstanceInfo stream. WindMinHeight/MaxHeight go out as 0:
+    // The BOUND command shape (VobBoundDrawCommand/m_VobBoundIndirectCmdSig): unlike the instanced VOBs,
+    // attachment geometry is not in the world arena — it comes and goes with NPCs — so each command still
+    // carries its own VBVs + IBV. An attachment is otherwise a one-instance VOB draw, down to the packed
+    // ExVertexStruct + VobInstanceInfo stream. WindMinHeight/MaxHeight go out as 0:
     // VSMainAttach/VSDepthAttach never read b4 (the instance stream's wind fields carry Fatness/Scaling here).
     if ( !g_FrameAttachDraws.empty() && m_AttachDrawArgsPtr[frame] ) {
-        VobDrawCommand* cmds = reinterpret_cast<VobDrawCommand*>( m_AttachDrawArgsPtr[frame] );
+        VobBoundDrawCommand* cmds = reinterpret_cast<VobBoundDrawCommand*>( m_AttachDrawArgsPtr[frame] );
         UINT count = 0;
         alphaAttachCmds.clear();
 
@@ -3501,7 +3759,7 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
             D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( b.head->mesh->GetMeshVertexBuffer() );
             D3D12VertexBuffer* mib = D3D12VertexBuffer::From( b.head->mesh->GetMeshIndexBuffer() );
 
-            VobDrawCommand c{};
+            VobBoundDrawCommand c{};
             c.MeshVBV = { mvb->GetGpuVirtualAddress(), mvb->GetSizeInBytes(), sizeof( ExVertexStruct ) };
             c.InstVBV = { m_VobInstanceBuffer[frame]->GetGPUVirtualAddress() + instOffset, need, instBytes };
             c.IBV     = { mib->GetGpuVirtualAddress(), mib->GetSizeInBytes(), DXGI_FORMAT_R16_UINT };
@@ -3522,7 +3780,7 @@ void D3D12GraphicsEngine::BuildSkeletalDrawCommands() {
         }
         m_AttachOpaqueDrawCount = count;
         if ( !alphaAttachCmds.empty() ) {
-            std::memcpy( cmds + count, alphaAttachCmds.data(), alphaAttachCmds.size() * sizeof( VobDrawCommand ) );
+            std::memcpy( cmds + count, alphaAttachCmds.data(), alphaAttachCmds.size() * sizeof( VobBoundDrawCommand ) );
             count += static_cast<UINT>( alphaAttachCmds.size() );
         }
         m_AttachDrawCount = count;
@@ -3810,7 +4068,13 @@ bool D3D12GraphicsEngine::UploadVobs(
 
     // This slot's private slice. sliceCursor is a LOCAL, not a member: that is the whole point of the
     // partitioning — a cascade's upload runs on its own worker thread and must not touch a shared cursor.
-    const UINT sliceBase = ringSlot * m_ShadowInstanceSliceCapacity;
+    //
+    // Rounded up to a whole instance: with the VOB arena a command addresses its instances by ELEMENT index
+    // (StartInstanceLocation) into the one buffer the pass binds, not by a per-command VBV, so every block
+    // must start at an exact multiple of the stride. The slice size is a round byte count and is not one.
+    constexpr UINT kInstStride = static_cast<UINT>( sizeof( VobInstanceInfo ) );
+    const UINT sliceBase = ( ( ringSlot * m_ShadowInstanceSliceCapacity + kInstStride - 1 ) / kInstStride ) * kInstStride;
+    const UINT sliceCapacity = m_ShadowInstanceSliceCapacity - ( sliceBase - ringSlot * m_ShadowInstanceSliceCapacity );
     UINT sliceCursor = 0;
 
     bool hasInstances = false;
@@ -3822,9 +4086,9 @@ bool D3D12GraphicsEngine::UploadVobs(
         }
 
         const UINT numInstances = instances.size();
-        const UINT instBytes = numInstances * sizeof( VobInstanceInfo );
+        const UINT instBytes = numInstances * kInstStride;
 
-        if ( sliceCursor + instBytes > m_ShadowInstanceSliceCapacity ) {
+        if ( sliceCursor + instBytes > sliceCapacity ) {
             if ( !m_ShadowInstanceOverflowLogged[ringSlot] ) {
                 LogWarn() << "D3D12: shadow VOB instance ring slot " << ringSlot << " overflow ("
                     << m_ShadowInstanceSliceCapacity << " bytes/slot/frame). Some shadow casters dropped.";
@@ -3840,11 +4104,12 @@ bool D3D12GraphicsEngine::UploadVobs(
 
         FrameVobUpload up;
         up.visual = reinterpret_cast<MeshVisualInfo*>(g_vobInfoVisualIndexToVisualInfo[i]);
-        up.instView = { m_ShadowVobInstanceBuffer[frame]->GetGPUVirtualAddress() + instOffset, instBytes, sizeof( VobInstanceInfo ) };
+        up.instView = { m_ShadowVobInstanceBuffer[frame]->GetGPUVirtualAddress() + instOffset, instBytes, kInstStride };
         // Shadow cascades are CPU-culled and never GPU-compacted (BuildVobDrawCommands culled=false), so these
         // two only exist to keep the struct fully initialised.
         up.culledInstView = up.instView;
         up.numInstances = numInstances;
+        up.instanceBase = instOffset / kInstStride;   // exact: sliceBase and every block are stride multiples
         up.cullVisualIndex = 0xFFFFFFFFu;
         uploads.push_back( up );
     }
@@ -3879,6 +4144,13 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
     // Only visible visuals are touched, since the loop below already skips visuals with no instances.
     const bool animateStaticVobs = rs.RendererSettings.AnimateStaticVobs;
 
+    // Upload whatever OnAddVob queued into the VOB mega-buffers (D3D12VobArena). This is the one point per
+    // frame that touches the arena's GPU resources, and it deliberately sits here: the main thread, an open
+    // frame, before BuildVobDrawCommands reads any range and before m_ShadowMap.Prepare() fans the cascade
+    // command builds out to the worker pool. That ordering is what makes D3D12VobArena::Find() lock-free.
+    // A failed flush leaves ranges missing and those sub-meshes simply don't draw (it logs once).
+    m_VobArena.Flush( this );
+
     const UINT frame = m_FrameIndex;
 
     // GPU culling (D3D12Cull.cpp): emit one VobCullVisual per visual alongside the instance memcpy — the local
@@ -3895,6 +4167,7 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
         m_GpuVobCullActive = false;
 
     m_VobCullVisualCount = 0;
+    m_VobCullVisualOverflowed = false;
     VobCullVisual* cullRecords = m_GpuVobCullActive
         ? reinterpret_cast<VobCullVisual*>( m_VobCullVisualsPtr[frame] ) : nullptr;
 
@@ -3929,6 +4202,7 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
         up.instView = { m_VobInstanceBuffer[frame]->GetGPUVirtualAddress() + instOffset, instBytes, sizeof( VobInstanceInfo ) };
         up.culledInstView = up.instView;
         up.numInstances = numInstances;
+        up.instanceBase = instOffset / kInstStride;   // exact — the ring offset was just stride-aligned above
         up.cullVisualIndex = 0xFFFFFFFFu;
 
         if ( cullRecords ) {
@@ -3938,20 +4212,22 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
                 rec.BBoxMax = visual->BBox.Max;
                 rec.InstanceBase = instOffset / kInstStride;
                 rec.InstanceCount = numInstances;
-                rec.LodSplit = 0;   // BuildVobDrawCommands raises this once it knows every sub-mesh has a
-                                    // far command; defaulting on would strand instances nothing draws.
-                // Conservative default: no split until BuildVobDrawCommands confirms every drawn sub-mesh
-                // of this visual emitted a far command. Leaving it 1 here would strand instances behind a
-                // bucket nothing draws.
-                rec.LodSplit = 0;
+                // Conservative default: no split until BuildVobDrawCommands confirms the far bucket actually
+                // has commands to draw it. Defaulting to either split mode here would strand instances
+                // behind a bucket nothing draws.
+                rec.SplitMode = kSplitModeNone;
                 up.cullVisualIndex = m_VobCullVisualCount++;
                 up.culledInstView.BufferLocation = m_VobCulledInstances->GetGPUVirtualAddress() + instOffset;
-            } else if ( !m_VobCullVisualOverflowLogged ) {
-                // Graceful: the remaining visuals keep instView + the CPU's instance count, so they render
-                // uncompacted (i.e. unculled) instead of vanishing.
-                LogWarn() << "D3D12: VOB cull-record overflow (" << kMaxCullVisuals
-                    << " visuals/frame); the rest render without GPU culling this frame.";
-                m_VobCullVisualOverflowLogged = true;
+            } else {
+                // Graceful: the remaining visuals keep the CPU's instance count and their absolute
+                // instanceBase, so they render uncompacted (i.e. unculled) instead of vanishing — which is
+                // why CullVobsGPU has to seed the compacted buffer from the raw ring when this happens.
+                m_VobCullVisualOverflowed = true;
+                if ( !m_VobCullVisualOverflowLogged ) {
+                    LogWarn() << "D3D12: VOB cull-record overflow (" << kMaxCullVisuals
+                        << " visuals/frame); the rest render without GPU culling this frame.";
+                    m_VobCullVisualOverflowLogged = true;
+                }
             }
         }
 
@@ -4009,6 +4285,8 @@ void D3D12GraphicsEngine::DrawVobDepthPrepass() {
     m_CmdList->RSSetViewports( 1, &vp );
     m_CmdList->RSSetScissorRects( 1, &sc );
     m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
+    if ( !BindVobArenaIA( m_CmdList, GetVobInstanceBufferForDraws(), m_VobInstanceBufferCapacity ) )
+        return;
 
     // One GPU-driven submit over the shared command set BuildVobDrawCommands filled (same set the color pass draws).
     // Each command sets its mesh/instance VBVs + IBV + b6 diffuse (PSDepthClipBindless alpha-clips) + b4 min/max
@@ -4016,6 +4294,10 @@ void D3D12GraphicsEngine::DrawVobDepthPrepass() {
     // drawArgs (GetVobDrawArgsBuffer): the GPU-culled DEFAULT copy (instance counts patched by CullVobsGPU) when
     // culling is active, else the CPU-written UPLOAD ring.
     if ( !splitAlpha ) {
+        // Motion-G-buffer prepass: everything draws, including the far alpha-tested run. Omitting it here
+        // would leave distant cutout pixels with no motion vector and no normal, which TAA reads as ghosting
+        // and XeGTAO as a wrong normal — a visual regression, not just a coverage loss. The trim below is
+        // therefore deliberately confined to the plain depth-only path.
         m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_VobDrawCount, drawArgs, 0, nullptr, 0 );
         return;
     }
@@ -4025,9 +4307,16 @@ void D3D12GraphicsEngine::DrawVobDepthPrepass() {
     if ( m_VobOpaqueDrawCount > 0 ) {
         m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_VobOpaqueDrawCount, drawArgs, 0, nullptr, 0 );
     }
-    if ( m_VobDrawCount > m_VobOpaqueDrawCount ) {
+    // Alpha-tested run: only its NEAR part (kSplitModeAlpha). Equal to the whole run when the split is off,
+    // so this is the original submit unless the feature is switched on. Safe to draw less: the lit passes are
+    // GREATER_EQUAL with DEPTH_WRITE_MASK_ALL — never EQUAL — so geometry missing from the prepass still
+    // renders correctly, it just writes its own depth and forfeits the overdraw + tile-near-plane benefit.
+    // That trade is exactly the point: a distant cutout re-shades in the lit pass regardless, and its cutout
+    // pixel shader is what makes this pass expensive.
+    const UINT alphaCount = std::min( m_VobAlphaNearDrawCount, m_VobDrawCount - m_VobOpaqueDrawCount );
+    if ( alphaCount > 0 ) {
         m_CmdList->SetPipelineState( m_Pipelines.World.DepthPrepassVobIndirectPSO.Get() );
-        m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_VobDrawCount - m_VobOpaqueDrawCount, drawArgs,
+        m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), alphaCount, drawArgs,
             static_cast<UINT64>( m_VobOpaqueDrawCount ) * sizeof( VobDrawCommand ), nullptr, 0 );
     }
 }
@@ -4079,6 +4368,8 @@ XRESULT D3D12GraphicsEngine::DrawVobsInstanced() {
     m_CmdList->RSSetViewports( 1, &vp );
     m_CmdList->RSSetScissorRects( 1, &sc );
     m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
+    if ( !BindVobArenaIA( m_CmdList, GetVobInstanceBufferForDraws(), m_VobInstanceBufferCapacity ) )
+        return XR_SUCCESS;
 
     static_assert( sizeof( VS_ExConstantBuffer_Wind ) == 48, "WindCB (b4) layout must match Vob.hlsl's WindCB" );
 
@@ -4578,7 +4869,7 @@ void D3D12GraphicsEngine::DrawSkeletalDepthPrepass() {
     // Node attachments (depth only) through the VOB attachment depth PSO (Fatness/Scaling variant — see
     // Vob.hlsl's VSDepthAttach; must match DrawSkeletalColor's attachment PSO choice or the prepass depth
     // won't reflect the same inflate/scale as the color pass, the same class of bug the wind fix addressed).
-    if ( m_AttachDrawCount > 0 && m_VobIndirectCmdSig && m_AttachDrawArgs[m_FrameIndex]
+    if ( m_AttachDrawCount > 0 && m_VobBoundIndirectCmdSig && m_AttachDrawArgs[m_FrameIndex]
         && m_Pipelines.World.DepthPrepassVobAttachPSO && m_Pipelines.World.RootSig ) {
         DX_ZONE( m_CmdList.Get(), "Depth Prepass (attachments)" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth Prepass (attachments)" );
@@ -4598,18 +4889,18 @@ void D3D12GraphicsEngine::DrawSkeletalDepthPrepass() {
         m_CmdList->RSSetScissorRects( 1, &sc );
         m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
         if ( !attachSplit ) {
-            m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_AttachDrawCount,
+            m_CmdList->ExecuteIndirect( m_VobBoundIndirectCmdSig.Get(), m_AttachDrawCount,
                 m_AttachDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
         } else {
             if ( m_AttachOpaqueDrawCount > 0 ) {
-                m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_AttachOpaqueDrawCount,
+                m_CmdList->ExecuteIndirect( m_VobBoundIndirectCmdSig.Get(), m_AttachOpaqueDrawCount,
                     m_AttachDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
             }
             if ( m_AttachDrawCount > m_AttachOpaqueDrawCount ) {
                 m_CmdList->SetPipelineState( m_Pipelines.World.DepthPrepassVobAttachPSO.Get() );
-                m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(),
+                m_CmdList->ExecuteIndirect( m_VobBoundIndirectCmdSig.Get(),
                     m_AttachDrawCount - m_AttachOpaqueDrawCount, m_AttachDrawArgs[m_FrameIndex].Get(),
-                    static_cast<UINT64>( m_AttachOpaqueDrawCount ) * sizeof( VobDrawCommand ), nullptr, 0 );
+                    static_cast<UINT64>( m_AttachOpaqueDrawCount ) * sizeof( VobBoundDrawCommand ), nullptr, 0 );
             }
         }
     }
@@ -4662,7 +4953,7 @@ void D3D12GraphicsEngine::DrawSkeletalColor() {
     // VSMainAttach; non-morph attachments get Fatness=0/Scaling=1, a no-op, so this is a drop-in replacement
     // for the plain VobPSO). BindFrameLights() is REQUIRED — the VOB PS reads the light count/grid, so an
     // unbound count would run the loop on garbage → GPU TDR hang.
-    if ( m_AttachDrawCount > 0 && m_VobIndirectCmdSig && m_AttachDrawArgs[m_FrameIndex]
+    if ( m_AttachDrawCount > 0 && m_VobBoundIndirectCmdSig && m_AttachDrawArgs[m_FrameIndex]
         && m_Pipelines.World.VobAttachPSO && m_Pipelines.World.RootSig ) {
         DX_ZONE( m_CmdList.Get(), "Draw attachments" );
         TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw attachments" );
@@ -4682,7 +4973,7 @@ void D3D12GraphicsEngine::DrawSkeletalColor() {
         m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
         // Each command sets its own mesh/instance VBVs + IBV + b6 { normal, ORM, diffuse } bindless material
         // constants, then DrawIndexed — PSMainBindless reads the identical MaterialCB layout the base meshes use.
-        m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_AttachDrawCount,
+        m_CmdList->ExecuteIndirect( m_VobBoundIndirectCmdSig.Get(), m_AttachDrawCount,
             m_AttachDrawArgs[m_FrameIndex].Get(), 0, nullptr, 0 );
     }
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2140,10 +2140,6 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// which is exactly the configuration that also wants the CPU frustum cull rather than the compute one.
 	m_VobLodDistance = Engine::GAPI->GetRendererState().RendererSettings.VobLodDrawRadius > 0.0f
 		? Engine::GAPI->GetRendererState().RendererSettings.VobLodDrawRadius : 0.0f;
-	// Same one-shot snapshot, same reason, for the alpha-tested prepass split (kSplitModeAlpha).
-	m_VobAlphaPrepassDistance = ( m_GpuVobCullActive
-		&& Engine::GAPI->GetRendererState().RendererSettings.VobAlphaPrepassRadius > 0.0f )
-		? Engine::GAPI->GetRendererState().RendererSettings.VobAlphaPrepassRadius : 0.0f;
 
 	// zCBspNodeRender hook — Gothic's BSP traversal is replaced; we draw the world ourselves.
 	// Order mirrors D3D11's DrawWorldMeshNaive: sky background, world mesh, skeletal (NPCs/monsters),
@@ -2242,17 +2238,14 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// vertex/index binds happen once/frame instead of per-pass, and neither pass issues per-mesh CPU draw calls).
 	if ( Engine::GAPI->GetRendererState().RendererSettings.DrawVOBs && m_VobDrawArgsPtr[m_FrameIndex] ) {
 		m_VobDrawCount = BuildVobDrawCommands( g_FrameVobUploads, m_VobDrawArgsPtr[m_FrameIndex], true,
-			kMaxVobDrawCommands, m_GpuVobCullActive, true, kVobIndicesMainView, &m_VobOpaqueDrawCount,
-			&m_VobAlphaNearDrawCount );
+			kMaxVobDrawCommands, m_GpuVobCullActive, true, kVobIndicesMainView, &m_VobOpaqueDrawCount );
 	} else {
 		m_VobDrawCount = 0;
 		m_VobOpaqueDrawCount = 0;
-		m_VobAlphaNearDrawCount = 0;
 	}
 	// Publish this frame's VOB submission shape for the ImGui stats panel — see VobFrameStats.
 	m_VobStats.Commands = m_VobDrawCount;
 	m_VobStats.OpaqueCommands = m_VobOpaqueDrawCount;
-	m_VobStats.AlphaNearCommands = m_VobAlphaNearDrawCount;
 	m_VobStats.CullVisuals = m_VobCullVisualCount;
 	m_VobStats.GpuCullActive = m_GpuVobCullActive;
 	{
@@ -3146,14 +3139,13 @@ int D3D12GraphicsEngine::GetFirstLodShadowCascade() {
 }
 
 UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload>& uploads, uint8_t* argPtr, bool resolveMaps,
-    UINT maxCommands, bool culled, bool cacheIn, int shadowCascade, UINT* outOpaqueCount, UINT* outAlphaNearCount ) {
+    UINT maxCommands, bool culled, bool cacheIn, int shadowCascade, UINT* outOpaqueCount ) {
     // Fill an arg buffer with one command per (visual x material x sub-mesh): resolve the material's bindless
     // indices (diffuse always; normal/ORM only when resolveMaps — the depth/shadow passes just alpha-clip on
     // diffuse), pack the mesh + instance VB views + IB view, the per-visual wind min/max, and DrawIndexedInstanced.
     // Same CacheIn/From resolution the per-draw path did — but done ONCE per built buffer instead of per pass.
     if ( !argPtr ) {
         if ( outOpaqueCount ) *outOpaqueCount = 0;
-        if ( outAlphaNearCount ) *outAlphaNearCount = 0;
         return 0;
     }
     VobDrawCommand* cmds = reinterpret_cast<VobDrawCommand*>( argPtr );
@@ -3161,27 +3153,16 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
     // Alpha-test partition staging — see the identical block in BuildWorldDrawCommands for why the tail is
     // staged in normal RAM instead of compacted inside the write-combined UPLOAD ring. thread_local, not
     // static: the shadow cascades call this concurrently on the worker pool (cacheIn=false).
-    //
-    // Two staged runs, not one: the alpha-tested partition is itself ordered [near][far] so the depth prepass
-    // can submit just the near prefix (kSplitModeAlpha). With the split off, alphaFarCmds stays empty and the
-    // layout is byte-identical to what a single list produced.
-    thread_local std::vector<VobDrawCommand> alphaCmds;      // near run (or the whole run when not split)
-    thread_local std::vector<VobDrawCommand> alphaFarCmds;   // far run, drawn by the color pass only
+    thread_local std::vector<VobDrawCommand> alphaCmds;
     alphaCmds.clear();
-    alphaFarCmds.clear();
-    // Appends the staged alpha-tested runs behind the opaque one and reports the partition points. Both exits
+    // Appends the staged alpha-tested run behind the opaque one and reports the partition point. Both exits
     // below (ring overflow and normal completion) go through this, or an overflowing frame would silently
     // drop every alpha-tested draw instead of just the ones past the cap.
     auto finish = [&]() -> UINT {
         if ( outOpaqueCount ) *outOpaqueCount = count;
-        if ( outAlphaNearCount ) *outAlphaNearCount = static_cast<UINT>( alphaCmds.size() );
         if ( !alphaCmds.empty() ) {
             std::memcpy( cmds + count, alphaCmds.data(), alphaCmds.size() * sizeof( VobDrawCommand ) );
             count += static_cast<UINT>( alphaCmds.size() );
-        }
-        if ( !alphaFarCmds.empty() ) {
-            std::memcpy( cmds + count, alphaFarCmds.data(), alphaFarCmds.size() * sizeof( VobDrawCommand ) );
-            count += static_cast<UINT>( alphaFarCmds.size() );
         }
         return count;
         };
@@ -3204,20 +3185,12 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
     if ( resolveMaps ) {
         m_VobStats.SplitNone = 0;
         m_VobStats.SplitLod = 0;
-        m_VobStats.SplitAlpha = 0;
     }
 
     // Records are still CPU-writable here and CullVobsGPU has not run, and this is the only place that
     // knows which sub-meshes actually emitted a far command. Main-view build only.
     VobCullVisual* cullRecords = ( culled && resolveMaps && m_VobCullVisualsPtr[m_FrameIndex] )
         ? reinterpret_cast<VobCullVisual*>( m_VobCullVisualsPtr[m_FrameIndex] ) : nullptr;
-
-    // Alpha-tested prepass split (kSplitModeAlpha): main-view, GPU-culled builds only, exactly like the LOD
-    // split it shares the bucket machinery with. Gated on cullRecords as well - without a record to raise
-    // SplitMode on, CSCull would leave every instance in the near run while the far commands sat emitted
-    // and unpatched.
-    const bool alphaSplitEnabled = ( shadowCascade == kVobIndicesMainView ) && culled && resolveMaps
-        && cullRecords != nullptr && m_VobAlphaPrepassDistance > 0.0f;
 
     // CPU-side geometry LOD: the uploads already carry a near/far partition of each visual's instance block
     // (UploadFrameVobInstances), so the far command's instance count and start are known HERE and get baked
@@ -3248,7 +3221,6 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
         const float minH = visual->BBox.Min.y;
         const float maxH = visual->BBox.Max.y;
         staged.clear();
-        bool visualHasAlphaTested = false;
 
         for ( auto const& [meshKey, meshList] : visual->MeshesByTexture ) {
             zCTexture* tex = meshKey.Material->GetAniTexture();
@@ -3383,34 +3355,26 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                     s.LodIndexCount = range->LodCount;
                 }
                 staged.push_back( s );
-                visualHasAlphaTested |= alphaTested;
             }
         }
 
         // ---- Flush this visual ----------------------------------------------------------------------
         // Everything below needs the WHOLE visual resolved, which is why it could not happen inline.
-        //
-        // The two split modes are mutually exclusive, and this is where that is enforced rather than
-        // hoped for: an alpha-split visual has its LOD suppressed on every sub-mesh, so a mixed visual's
-        // opaque sub-mesh can never leave a stale far *LOD* command for CSPatchArgs to then populate from
-        // the ALPHA distance.
-        const bool alphaSplit = alphaSplitEnabled && visualHasAlphaTested;
 
         // Split only if EVERY drawn sub-mesh has a far counterpart; a visual that drew nothing is not
         // splittable at all.
         bool visualAllHaveLod = true;
         size_t cmdsNeeded = 0;
         for ( const StagedSubMesh& s : staged ) {
-            const bool lod = s.LodEligible && !alphaSplit;
-            if ( !lod ) visualAllHaveLod = false;
-            cmdsNeeded += ( lod || alphaSplit ) ? 2u : 1u;
+            if ( !s.LodEligible ) visualAllHaveLod = false;
+            cmdsNeeded += s.LodEligible ? 2u : 1u;
         }
 
         // Checked per VISUAL now rather than per sub-mesh: a split pair cut in half would drop every far
         // instance of the visual, since CSCull still buckets them away from the near run. Dropping the
         // whole visual instead of part of one is also the tidier failure.
         if ( !staged.empty()
-            && count + alphaCmds.size() + alphaFarCmds.size() + cmdsNeeded > maxCommands ) {
+            && count + alphaCmds.size() + cmdsNeeded > maxCommands ) {
             if ( !m_VobDrawArgsOverflowLogged ) {
                 LogWarn() << "D3D12: VOB draw-command ring overflow (" << maxCommands
                     << " draws/frame); some VOBs dropped this frame.";
@@ -3438,26 +3402,8 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
             if ( resolveMaps )
                 m_VobDrawnTriangles += ( s.Cmd.Draw.IndexCountPerInstance / 3 ) * up.numInstances;
 
-            // Far bucket. Counts and StartInstanceLocation are patched by CSPatchArgs - the split happens
-            // on the GPU, so the CPU cannot know either. InstanceCount starts at 0 so an unpatched command
-            // draws nothing rather than every instance a second time.
-            if ( alphaSplit ) {
-                // Alpha-prepass split: the far bucket draws the SAME indices as the near one - nothing
-                // about the geometry changes, only WHICH PASS submits it. The near command is drawn by both
-                // the depth prepass and the color pass; this one only by the color pass, which is the whole
-                // point (a distant cutout re-shades in the lit pass anyway, so paying for it a second time
-                // in the prepass buys nothing but the tile near-plane bound).
-                // Emitted for opaque sub-meshes too: CSCull buckets the visual's WHOLE instance range, so
-                // an opaque sub-mesh with only a near command would lose every far instance from BOTH
-                // passes - a tree trunk vanishing past the threshold while its leaves stayed. Opaque far
-                // commands stay in the opaque partition (the prepass draws that run whole); alpha-tested
-                // ones go to the tail the prepass trims.
-                VobDrawCommand f = s.Cmd;
-                f.LodBucket = kLodBucketFar;
-                f.Draw.InstanceCount = 0;
-                if ( s.AlphaTested ) alphaFarCmds.push_back( f );
-                else                 cmds[count++] = f;
-            } else if ( s.LodEligible && ( !cpuLodSplit || cpuSplit ) ) {
+            // Far bucket.
+            if ( s.LodEligible && ( !cpuLodSplit || cpuSplit ) ) {
                 // LOD split: same sub-mesh, reduced indices, over the far run — packed backward from the
                 // end of this visual's range by CSCull on the GPU path, forward-adjacent to the near run by
                 // UploadFrameVobInstances on the CPU one. LOD-eligible implies !AlphaTested, so this always
@@ -3481,22 +3427,17 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
 
         // Publish for CSCull. Visuals with no record (cull-record overflow) render uncompacted anyway.
         if ( cullRecords && up.cullVisualIndex != 0xFFFFFFFFu && up.cullVisualIndex < kMaxCullVisuals ) {
-            const UINT mode = staged.empty()      ? kSplitModeNone
-                            : visualAllHaveLod    ? kSplitModeLod
-                            : alphaSplit          ? kSplitModeAlpha
-                                                  : kSplitModeNone;
+            const UINT mode = ( !staged.empty() && visualAllHaveLod ) ? kSplitModeLod : kSplitModeNone;
             cullRecords[up.cullVisualIndex].SplitMode = mode;
             if ( resolveMaps ) {
-                // Stats only: if these come back as "everything in SplitNone", neither the LOD slider nor
-                // the alpha slider can be having any effect, whatever they are set to.
-                if ( mode == kSplitModeLod )        m_VobStats.SplitLod++;
-                else if ( mode == kSplitModeAlpha ) m_VobStats.SplitAlpha++;
-                else                                m_VobStats.SplitNone++;
+                // Stats only: if these come back as "everything in SplitNone", the LOD slider cannot be
+                // having any effect, whatever it is set to.
+                if ( mode == kSplitModeLod ) m_VobStats.SplitLod++;
+                else                         m_VobStats.SplitNone++;
             }
         } else if ( resolveMaps && cpuLodSplit ) {
             // Same histogram for the CPU path, so the panel does not read as "no split is happening" just
-            // because there are no cull records to hang it off. Only kSplitModeLod is reachable here — the
-            // alpha-prepass split still needs CSCull.
+            // because there are no cull records to hang it off.
             if ( cpuSplit ) m_VobStats.SplitLod++;
             else            m_VobStats.SplitNone++;
         }
@@ -4384,13 +4325,11 @@ void D3D12GraphicsEngine::DrawVobDepthPrepass() {
     if ( m_VobOpaqueDrawCount > 0 ) {
         m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), m_VobOpaqueDrawCount, drawArgs, 0, nullptr, 0 );
     }
-    // Alpha-tested run: only its NEAR part (kSplitModeAlpha). Equal to the whole run when the split is off,
-    // so this is the original submit unless the feature is switched on. Safe to draw less: the lit passes are
-    // GREATER_EQUAL with DEPTH_WRITE_MASK_ALL — never EQUAL — so geometry missing from the prepass still
-    // renders correctly, it just writes its own depth and forfeits the overdraw + tile-near-plane benefit.
-    // That trade is exactly the point: a distant cutout re-shades in the lit pass regardless, and its cutout
-    // pixel shader is what makes this pass expensive.
-    const UINT alphaCount = std::min( m_VobAlphaNearDrawCount, m_VobDrawCount - m_VobOpaqueDrawCount );
+    // The alpha-tested run, whole. A distance trim used to live here (only the near part of the run went
+    // into the prepass, on the theory that a distant cutout re-shades in the lit pass anyway). It is gone:
+    // leaving alpha-tested surfaces out of the prepass lets grass and other later geometry draw ON TOP of
+    // them, which is a plainly visible artifact, and it never paid for itself.
+    const UINT alphaCount = m_VobDrawCount - m_VobOpaqueDrawCount;
     if ( alphaCount > 0 ) {
         m_CmdList->SetPipelineState( m_Pipelines.World.DepthPrepassVobIndirectPSO.Get() );
         m_CmdList->ExecuteIndirect( m_VobIndirectCmdSig.Get(), alphaCount, drawArgs,

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -1116,6 +1116,18 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
     ctx.drawDistancesSq.IndoorVobs = ctx.drawDistances.IndoorVobs * ctx.drawDistances.IndoorVobs;
 	ctx.drawDistancesSq.VisualFX = 0.0f;
 
+	// Caster size gate, in world units, derived from THIS cascade's texel footprint (m_CascadeTexelWorld[c],
+	// filled by Prepare above — cascadeSize / m_MapSize). A prop whose bbox diagonal spans fewer than
+	// CasterMinTexels texels can only ever produce a smudge in this slice, but it costs a full instance
+	// upload, an indirect command and its whole vertex + raster load. Scaling by the cascade's own texel size
+	// is what makes one setting safe across all three: the near cascade has fine texels so almost nothing
+	// trips the gate there, while the far one — which sweeps up the entire VOB population — prunes hard.
+	// MeshSize is the bbox DIAGONAL, so this over-estimates the on-screen footprint and keeps more than
+	// strictly necessary.
+	ctx.minVobSize = ( rs.DebugSettings.ShadowCascades.CasterMinTexels > 0.0f && c < kShadowCascades )
+		? m_CascadeTexelWorld[c] * rs.DebugSettings.ShadowCascades.CasterMinTexels
+		: 0.0f;
+
 	ctx.drawFlags.DrawVOBs = rs.DrawVOBs;
 	ctx.drawFlags.DrawMobs = rs.DrawMobs;
 	ctx.drawFlags.EnableDynamicLighting = rs.EnableDynamicLighting;

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -1116,14 +1116,11 @@ void D3D12ShadowMap::CullCascade( UINT cascade ) {
     ctx.drawDistancesSq.IndoorVobs = ctx.drawDistances.IndoorVobs * ctx.drawDistances.IndoorVobs;
 	ctx.drawDistancesSq.VisualFX = 0.0f;
 
-	// Caster size gate, in world units, derived from THIS cascade's texel footprint (m_CascadeTexelWorld[c],
-	// filled by Prepare above — cascadeSize / m_MapSize). A prop whose bbox diagonal spans fewer than
-	// CasterMinTexels texels can only ever produce a smudge in this slice, but it costs a full instance
-	// upload, an indirect command and its whole vertex + raster load. Scaling by the cascade's own texel size
-	// is what makes one setting safe across all three: the near cascade has fine texels so almost nothing
-	// trips the gate there, while the far one — which sweeps up the entire VOB population — prunes hard.
-	// MeshSize is the bbox DIAGONAL, so this over-estimates the on-screen footprint and keeps more than
-	// strictly necessary.
+	// Caster size gate, in world units, derived from THIS cascade's texel footprint (m_CascadeTexelWorld[c]).
+	// A prop spanning fewer than CasterMinTexels texels can only produce a smudge in this slice but costs a
+	// full instance upload, an indirect command and its raster load. Scaling by the cascade's own texel size
+	// is what makes one setting safe across all three. MeshSize is the bbox DIAGONAL, so this over-estimates
+	// the footprint and keeps more than strictly necessary.
 	ctx.minVobSize = ( rs.DebugSettings.ShadowCascades.CasterMinTexels > 0.0f && c < kShadowCascades )
 		? m_CascadeTexelWorld[c] * rs.DebugSettings.ShadowCascades.CasterMinTexels
 		: 0.0f;

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -1252,7 +1252,7 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 
 	// --- Instanced VOBs: one ExecuteIndirect over the command set Phase C built for this cascade ---
 	if ( m_VobDrawCount[c] > 0 && m_CasterVobIndirectPSO && m_E->m_VobIndirectCmdSig
-		&& m_VobDrawArgs[c][frame] ) {
+		&& m_VobDrawArgs[c][frame] && m_E->m_VobArena.Ready() ) {
 		DX_ZONE( cmdList.Get(), "Vobs" );
 		TracyD3D12ZoneCGX( cmdList.Get(), "Vobs" );
 		// Same alpha-test split as the world casters above — BuildVobDrawCommands partitioned this cascade's
@@ -1262,6 +1262,11 @@ void D3D12ShadowMap::RecordCascade( UINT cascade, D3D12CmdList& cmdList, bool su
 		cmdList->SetGraphicsRootSignature( m_E->m_Pipelines.World.RootSig.Get() );
 		cmdList->SetGraphicsRoot32BitConstants( 0, 16, &m_CascadeViewProj[c], 0 );
 		cmdList->SetGraphicsRoot32BitConstants( 11, 12, &m_E->m_WindBuffer, 0 );   // b4 frame-global wind baseline
+		// One IA bind for the cascade: the VOB mega-buffers plus the SHADOW instance ring (cascades are
+		// CPU-culled and never GPU-compacted, so this is the raw upload ring, and each command's
+		// StartInstanceLocation is the absolute element index UploadVobs handed it).
+		m_E->BindVobArenaIA( cmdList, m_E->m_ShadowVobInstanceBuffer[frame].Get(),
+			m_E->m_ShadowInstanceSliceCapacity * D3D12GraphicsEngine::kShadowInstanceRingSlots );
 		if ( !splitAlpha ) {
 			cmdList->ExecuteIndirect( m_E->m_VobIndirectCmdSig.Get(), m_VobDrawCount[c],
 				m_VobDrawArgs[c][frame].Get(), 0, nullptr, 0 );

--- a/D3D11Engine/D3D12Engine/D3D12VertexBuffer.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12VertexBuffer.cpp
@@ -5,6 +5,7 @@
 
 #include <meshoptimizer/src/meshoptimizer.h>
 #include "../MeshLodBuilder.h"
+#include "../MeshShadowIndexBuilder.h"
 #include <limits>
 
 using Microsoft::WRL::ComPtr;
@@ -298,20 +299,11 @@ XRESULT D3D12VertexBuffer::OptimizeVertices( VERTEX_INDEX* indices, uint8_t* ver
     memcpy( remappedVertices.data(), vertices, remappedVertices.size() );
     meshopt_remapVertexBuffer( remappedVertices.data(), vertices, numVertices, stride, remap.data() );
 
+    // Left empty when welding changed nothing (MeshShadowIndexBuilder.h); Reserve() then leaves
+    // Range::ShadowCount at 0 and BuildVobDrawCommands already falls back to the render range.
     if ( outShadowIndices ) {
-        std::vector<unsigned int> shadowIndices( numIndices );
-        meshopt_generateShadowIndexBuffer( shadowIndices.data(),
-            remappedIndices.data(),
-            numIndices,
-            remappedVertices.data(),
-            fetchedVertexCount,
-            sizeof( float ) * 3,
-            stride );
-
-        outShadowIndices->resize( numIndices );
-        if ( !ConvertIndicesToVertexIndex( shadowIndices, outShadowIndices->data(), outShadowIndices->size() ) ) {
-            LogError() << "OptimizeVertices: shadow index exceeds VERTEX_INDEX range";
-            outShadowIndices->clear();
+        if ( !MeshShadow::BuildShadowIndices( *outShadowIndices, remappedIndices, remappedVertices,
+            fetchedVertexCount, stride, ConvertIndicesToVertexIndex ) ) {
             return XR_FAILED;
         }
     }

--- a/D3D11Engine/D3D12Engine/D3D12VertexBuffer.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12VertexBuffer.cpp
@@ -4,6 +4,7 @@
 #include "../Engine.h"
 
 #include <meshoptimizer/src/meshoptimizer.h>
+#include "../MeshLodBuilder.h"
 #include <limits>
 
 using Microsoft::WRL::ComPtr;
@@ -37,43 +38,6 @@ namespace {
             dst[i] = static_cast<VERTEX_INDEX>(src[i]);
         }
         return true;
-    }
-
-    /** Carries a baked progressive-mesh LOD index list through the vertex-fetch remap OptimizeVertices
-        just applied to the mesh, then position-welds it exactly like the shadow index list. On anything
-        unexpected the list is cleared instead of left half-remapped - callers treat an empty LOD list as
-        "this mesh has no reduced level" and fall back to full detail, which is always correct. */
-    void OptimizeLodIndices( std::vector<VERTEX_INDEX>& lodIndices,
-        const std::vector<unsigned int>& remap,
-        const std::vector<uint8_t>& remappedVertices,
-        size_t fetchedVertexCount,
-        unsigned int stride ) {
-        if ( lodIndices.size() % 3 != 0 ) {
-            lodIndices.clear();
-            return;
-        }
-
-        std::vector<unsigned int> lod;
-        ConvertIndicesToUInt32( lodIndices.data(), lodIndices.size(), lod );
-
-        for ( unsigned int& idx : lod ) {
-            // A collapsed triangle can only reference wedges that survive, and every surviving wedge is
-            // referenced by the full-detail index buffer too - so remap never hands back the ~0u it
-            // reserves for unreferenced vertices. Verified rather than trusted: mod content is content.
-            if ( idx >= remap.size() || remap[idx] >= fetchedVertexCount ) {
-                lodIndices.clear();
-                return;
-            }
-            idx = remap[idx];
-        }
-
-        std::vector<unsigned int> welded( lod.size() );
-        meshopt_generateShadowIndexBuffer( welded.data(), lod.data(), lod.size(),
-            remappedVertices.data(), fetchedVertexCount, sizeof( float ) * 3, stride );
-
-        if ( !ConvertIndicesToVertexIndex( welded, lodIndices.data(), lodIndices.size() ) ) {
-            lodIndices.clear();
-        }
     }
 
     float DequantizeSnorm( int v, int bits ) {
@@ -352,8 +316,10 @@ XRESULT D3D12VertexBuffer::OptimizeVertices( VERTEX_INDEX* indices, uint8_t* ver
         }
     }
 
-    if ( inOutLodIndices && !inOutLodIndices->empty() ) {
-        OptimizeLodIndices( *inOutLodIndices, remap, remappedVertices, fetchedVertexCount, stride );
+    // Pure OUTPUT, and shared with the D3D11 backend (MeshLodBuilder.h) rather than duplicated here.
+    if ( inOutLodIndices ) {
+        MeshLod::BuildSimplifiedIndices( *inOutLodIndices, remappedIndices, remappedVertices,
+            fetchedVertexCount, stride, ConvertIndicesToVertexIndex );
     }
 
     if ( !ConvertIndicesToVertexIndex( remappedIndices, indices, numIndices ) ) {

--- a/D3D11Engine/D3D12Engine/D3D12VertexBuffer.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12VertexBuffer.cpp
@@ -19,6 +19,17 @@ namespace {
     constexpr float kOverdrawThreshold = 1.05f;
     constexpr int kNormalQuantizationBits = 10;
 
+    /** See D3D11VertexBuffer.cpp: meshoptimizer's bounds asserts are compiled out (NDEBUG), so an
+        out-of-range index corrupts the heap inside the library instead of failing. */
+    bool IndicesWithinRange( const VERTEX_INDEX* indices, size_t count, unsigned int numVertices ) {
+        for ( size_t i = 0; i < count; ++i ) {
+            if ( static_cast<unsigned int>(indices[i]) >= numVertices ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     void ConvertIndicesToUInt32( const VERTEX_INDEX* src, size_t count, std::vector<unsigned int>& dst ) {
         dst.resize( count );
         for ( size_t i = 0; i < count; ++i ) {
@@ -284,6 +295,13 @@ XRESULT D3D12VertexBuffer::OptimizeVertices( VERTEX_INDEX* indices, uint8_t* ver
         return XR_FAILED;
     }
 
+    if ( !IndicesWithinRange( indices, numIndices, numVertices ) ) {
+        LogError() << "OptimizeVertices: index out of range (numVertices=" << numVertices << ") - skipping";
+        if ( outShadowIndices ) outShadowIndices->clear();
+        if ( inOutLodIndices ) inOutLodIndices->clear();
+        return XR_FAILED;
+    }
+
     ZoneScoped;
 
     std::vector<unsigned int> indexData;
@@ -339,6 +357,11 @@ XRESULT D3D12VertexBuffer::OptimizeFaces( VERTEX_INDEX* indices, uint8_t* vertic
     const unsigned int maxVertexIndex = static_cast<unsigned int>(std::numeric_limits<VERTEX_INDEX>::max());
     if ( numVertices > maxVertexIndex + 1 ) {
         LogError() << "OptimizeFaces: numVertices exceeds VERTEX_INDEX range";
+        return XR_FAILED;
+    }
+
+    if ( !IndicesWithinRange( indices, numIndices, numVertices ) ) {
+        LogError() << "OptimizeFaces: index out of range (numVertices=" << numVertices << ") - skipping";
         return XR_FAILED;
     }
 

--- a/D3D11Engine/D3D12Engine/D3D12VobArena.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12VobArena.cpp
@@ -9,9 +9,8 @@ const UINT D3D12VobArena::kVertexStride = static_cast<UINT>( sizeof( ExVertexStr
 
 namespace {
     // Headroom on every (re)allocation. A world's static VOB geometry is fully registered before the first
-    // frame (OnAddVob fires per vob during load), so the initial size is already exact — the slack is for
-    // what gets added afterwards: dropped weapons, items thrown out of the inventory, spawned mobs. Growth
-    // is correct but costs a full re-upload, so buy enough headroom to make it rare rather than cheap.
+    // frame, so the initial size is exact and the slack is only for what gets added afterwards (dropped
+    // weapons, spawned mobs). Growth is correct but costs a full re-upload, so make it rare.
     constexpr float kGrowthHeadroom = 1.25f;
     // ...but never below this, so a world that starts nearly empty doesn't reallocate on every single item.
     constexpr UINT kMinSpareVertices = 64 * 1024;
@@ -52,10 +51,9 @@ void D3D12VobArena::QueueVisual( MeshVisualInfo* visual ) {
     // added, and until then it simply isn't drawn by the arena path.
     if ( !visual || !visual->Ready.load( std::memory_order_acquire ) ) return;
 
-    // Animated static VOBs (.MMS): their vertices are rewritten every frame, either by ZENGIN's CPU deform
-    // into a DYNAMIC upload buffer or by the GPU morph fold into a DEFAULT UAV. The arena copy is then only
-    // the conversion pose and has to be refreshed per frame — see DynamicMeshes(). Only the VISUAL knows
-    // this; the MeshInfo looks static from here.
+    // Animated static VOBs (.MMS): their vertices are rewritten every frame, so the arena copy is only the
+    // conversion pose and has to be refreshed per frame — see DynamicMeshes(). Only the VISUAL knows this;
+    // the MeshInfo looks static from here.
     const bool dynamic = visual->MorphMeshVisual != nullptr;
 
     std::lock_guard<std::mutex> lock( m_PendingMutex );
@@ -63,9 +61,8 @@ void D3D12VobArena::QueueVisual( MeshVisualInfo* visual ) {
         for ( MeshInfo* mi : meshList ) {
             if ( !mi || mi->Vertices.empty() || mi->Indices.empty() ) continue;
             if ( m_Ranges.find( mi ) != m_Ranges.end() ) continue;
-            // O(n) over the pending list, but it only ever holds what one frame's worth of newly added
-            // vobs contributed (a handful) — during world load it holds the whole world exactly once,
-            // and the Ranges check above is what keeps THAT from being quadratic across repeat vobs.
+            // O(n) over the pending list, which only holds one frame's newly added vobs — the Ranges check
+            // above is what keeps world load (where it holds everything once) from going quadratic.
             const auto same = [mi]( const PendingMesh& p ) { return p.Mesh == mi; };
             if ( std::find_if( m_Pending.begin(), m_Pending.end(), same ) != m_Pending.end() ) continue;
             m_Pending.push_back( { mi, dynamic } );
@@ -211,9 +208,8 @@ bool D3D12VobArena::Flush( D3D12GraphicsEngine* engine ) {
         m_IndexCapacity = std::max( static_cast<UINT>( m_IndexCursor * kGrowthHeadroom ),
             m_IndexCursor + kMinSpareIndices );
         if ( !Reallocate( engine ) ) {
-            // Roll the whole batch back rather than leave half-registered ranges pointing into a buffer
-            // that doesn't exist: every reserved sub-mesh loses its range and the VOB path draws nothing
-            // this frame (Ready() is false), which is a blank pass, not corruption.
+            // Roll the whole batch back rather than leave half-registered ranges pointing into a buffer that
+            // doesn't exist: Ready() goes false and the VOB path draws nothing this frame.
             LogWarn() << "D3D12: VOB arena allocation failed ("
                 << ( static_cast<UINT64>( m_VertexCapacity ) * kVertexStride / ( 1024 * 1024 ) ) << " MB verts + "
                 << ( static_cast<UINT64>( m_IndexCapacity ) * kIndexStride / ( 1024 * 1024 ) ) << " MB indices). "
@@ -234,10 +230,9 @@ bool D3D12VobArena::Flush( D3D12GraphicsEngine* engine ) {
         auto it = m_Ranges.find( mi );
         if ( it != m_Ranges.end() ) UploadMesh( engine, mi, it->second );
     }
-    // UploadBufferData only RECORDS into the shared copy-queue batch; it is the flush that submits it and
-    // issues the direct queue's Wait on the copy fence. Without this, THIS frame's VOB passes (recorded a
-    // few calls from now, submitted at the end of the frame) could read vertices that have not landed yet.
-    // Same reason DispatchMorphFold flushes after uploading its prototype tables.
+    // UploadBufferData only RECORDS into the shared copy-queue batch; the flush is what submits it and issues
+    // the direct queue's Wait on the copy fence. Without it this frame's VOB passes could read vertices that
+    // have not landed yet. Same reason DispatchMorphFold flushes after uploading its prototype tables.
     if ( !reserved.empty() ) engine->FlushTextureUploads();
     return true;
 }

--- a/D3D11Engine/D3D12Engine/D3D12VobArena.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12VobArena.cpp
@@ -1,0 +1,243 @@
+#include "../pch.h"
+#include "D3D12VobArena.h"
+
+#include "D3D12GraphicsEngine.h"
+#include "../WorldObjects.h"
+#include "../Logger.h"
+
+const UINT D3D12VobArena::kVertexStride = static_cast<UINT>( sizeof( ExVertexStruct ) );
+
+namespace {
+    // Headroom on every (re)allocation. A world's static VOB geometry is fully registered before the first
+    // frame (OnAddVob fires per vob during load), so the initial size is already exact — the slack is for
+    // what gets added afterwards: dropped weapons, items thrown out of the inventory, spawned mobs. Growth
+    // is correct but costs a full re-upload, so buy enough headroom to make it rare rather than cheap.
+    constexpr float kGrowthHeadroom = 1.25f;
+    // ...but never below this, so a world that starts nearly empty doesn't reallocate on every single item.
+    constexpr UINT kMinSpareVertices = 64 * 1024;
+    constexpr UINT kMinSpareIndices = 128 * 1024;
+
+    D3D12_RESOURCE_DESC MakeBufferDesc( UINT64 bytes ) {
+        D3D12_RESOURCE_DESC bd = {};
+        bd.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+        bd.Width = bytes;
+        bd.Height = 1;
+        bd.DepthOrArraySize = 1;
+        bd.MipLevels = 1;
+        bd.Format = DXGI_FORMAT_UNKNOWN;
+        bd.SampleDesc.Count = 1;
+        bd.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+        return bd;
+    }
+}
+
+
+void D3D12VobArena::Reset() {
+    std::lock_guard<std::mutex> lock( m_PendingMutex );
+    m_Pending.clear();
+    m_Ranges.clear();
+    m_Resident.clear();
+    m_Dynamic.clear();
+    m_VertexCursor = 0;
+    m_IndexCursor = 0;
+    m_AllocFailed = false;
+    // The buffers themselves are kept: the next world refills them from offset 0 and they are very likely
+    // to be about the right size already. Reallocate() replaces them if it isn't.
+}
+
+
+void D3D12VobArena::QueueVisual( MeshVisualInfo* visual ) {
+    // Ready() false means a worker thread is still filling MeshesByTexture in (async node-visual
+    // extraction). Skipping is safe: the visual gets queued again the next time a vob referencing it is
+    // added, and until then it simply isn't drawn by the arena path.
+    if ( !visual || !visual->Ready.load( std::memory_order_acquire ) ) return;
+
+    // Animated static VOBs (.MMS): their vertices are rewritten every frame, either by ZENGIN's CPU deform
+    // into a DYNAMIC upload buffer or by the GPU morph fold into a DEFAULT UAV. The arena copy is then only
+    // the conversion pose and has to be refreshed per frame — see DynamicMeshes(). Only the VISUAL knows
+    // this; the MeshInfo looks static from here.
+    const bool dynamic = visual->MorphMeshVisual != nullptr;
+
+    std::lock_guard<std::mutex> lock( m_PendingMutex );
+    for ( auto const& [meshKey, meshList] : visual->MeshesByTexture ) {
+        for ( MeshInfo* mi : meshList ) {
+            if ( !mi || mi->Vertices.empty() || mi->Indices.empty() ) continue;
+            if ( m_Ranges.find( mi ) != m_Ranges.end() ) continue;
+            // O(n) over the pending list, but it only ever holds what one frame's worth of newly added
+            // vobs contributed (a handful) — during world load it holds the whole world exactly once,
+            // and the Ranges check above is what keeps THAT from being quadratic across repeat vobs.
+            const auto same = [mi]( const PendingMesh& p ) { return p.Mesh == mi; };
+            if ( std::find_if( m_Pending.begin(), m_Pending.end(), same ) != m_Pending.end() ) continue;
+            m_Pending.push_back( { mi, dynamic } );
+        }
+    }
+}
+
+
+bool D3D12VobArena::Reserve( MeshInfo* mesh, bool dynamic ) {
+    // 16-bit indices are kept verbatim, so a sub-mesh must still fit the 0..65535 vertex window its own
+    // indices address. Every VOB sub-mesh already satisfies this (its own IB was R16_UINT), but an
+    // oversized one would silently wrap, so refuse it rather than draw garbage.
+    if ( mesh->Vertices.size() > 65536 ) return false;
+
+    Range r;
+    r.BaseVertex = m_VertexCursor;
+    r.IndexStart = m_IndexCursor;
+    r.IndexCount = static_cast<UINT>( mesh->Indices.size() );
+    m_IndexCursor += r.IndexCount;
+
+    if ( !mesh->ShadowIndices.empty() ) {
+        r.ShadowStart = m_IndexCursor;
+        r.ShadowCount = static_cast<UINT>( mesh->ShadowIndices.size() );
+        m_IndexCursor += r.ShadowCount;
+    }
+    if ( !mesh->LodIndices.empty() ) {
+        r.LodStart = m_IndexCursor;
+        r.LodCount = static_cast<UINT>( mesh->LodIndices.size() );
+        m_IndexCursor += r.LodCount;
+    }
+    m_VertexCursor += static_cast<UINT>( mesh->Vertices.size() );
+
+    m_Ranges.emplace( mesh, r );
+    m_Resident.push_back( mesh );
+    if ( dynamic && mesh->GetMeshVertexBuffer() ) m_Dynamic.push_back( mesh );
+    return true;
+}
+
+
+bool D3D12VobArena::UploadMesh( D3D12GraphicsEngine* engine, MeshInfo* mesh, const Range& range ) {
+    bool ok = engine->UploadBufferData( m_VertexBuffer.Get(),
+        static_cast<UINT64>( range.BaseVertex ) * kVertexStride,
+        mesh->Vertices.data(), static_cast<UINT64>( mesh->Vertices.size() ) * kVertexStride );
+    ok = engine->UploadBufferData( m_IndexBuffer.Get(),
+        static_cast<UINT64>( range.IndexStart ) * kIndexStride,
+        mesh->Indices.data(), static_cast<UINT64>( range.IndexCount ) * kIndexStride ) && ok;
+    if ( range.ShadowCount ) {
+        ok = engine->UploadBufferData( m_IndexBuffer.Get(),
+            static_cast<UINT64>( range.ShadowStart ) * kIndexStride,
+            mesh->ShadowIndices.data(), static_cast<UINT64>( range.ShadowCount ) * kIndexStride ) && ok;
+    }
+    if ( range.LodCount ) {
+        ok = engine->UploadBufferData( m_IndexBuffer.Get(),
+            static_cast<UINT64>( range.LodStart ) * kIndexStride,
+            mesh->LodIndices.data(), static_cast<UINT64>( range.LodCount ) * kIndexStride ) && ok;
+    }
+    return ok;
+}
+
+
+bool D3D12VobArena::Reallocate( D3D12GraphicsEngine* engine ) {
+    D3D12MA::Allocator* allocator = engine->GetAllocator();
+    if ( !allocator ) return false;
+
+    D3D12MA::ALLOCATION_DESC heapDefault = {};
+    heapDefault.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
+    Microsoft::WRL::ComPtr<ID3D12Resource>      vb, ib;
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation> vbAlloc, ibAlloc;
+
+    // COMMON, with no barriers anywhere: a BUFFER always promotes implicitly out of COMMON (to COPY_DEST
+    // for the uploads on the copy queue, to VERTEX_AND_CONSTANT_BUFFER / INDEX_BUFFER for the draws on the
+    // direct queue) and decays back to COMMON at the end of each ExecuteCommandLists. The copy queue's
+    // completion is ordered against the direct queue by the Wait FlushTextureUploads issues.
+    D3D12_RESOURCE_DESC vbDesc = MakeBufferDesc( static_cast<UINT64>( m_VertexCapacity ) * kVertexStride );
+    D3D12_RESOURCE_DESC ibDesc = MakeBufferDesc( static_cast<UINT64>( m_IndexCapacity ) * kIndexStride );
+    if ( FAILED( allocator->CreateResource( &heapDefault, &vbDesc, D3D12_RESOURCE_STATE_COMMON, nullptr,
+        vbAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( vb.ReleaseAndGetAddressOf() ) ) ) )
+        return false;
+    if ( FAILED( allocator->CreateResource( &heapDefault, &ibDesc, D3D12_RESOURCE_STATE_COMMON, nullptr,
+        ibAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( ib.ReleaseAndGetAddressOf() ) ) ) )
+        return false;
+
+    vb->SetName( L"VobVertexArena" );
+    ib->SetName( L"VobIndexArena" );
+
+    // Frames already in flight may still be reading the old pair off the IA, so it cannot be dropped here —
+    // hand it to the fence-deferred cleanup and let the ComPtrs die when the GPU has passed this frame.
+    if ( m_VertexBuffer || m_IndexBuffer ) {
+        engine->QueueCleanupJob( [oldVb = m_VertexBuffer, oldVbAlloc = m_VertexAlloc,
+            oldIb = m_IndexBuffer, oldIbAlloc = m_IndexAlloc]() mutable {
+                // Keeps the old arena alive until the calling frame's fence completes.
+            } );
+    }
+
+    m_VertexBuffer = std::move( vb );
+    m_VertexAlloc = std::move( vbAlloc );
+    m_IndexBuffer = std::move( ib );
+    m_IndexAlloc = std::move( ibAlloc );
+
+    // Re-upload every resident sub-mesh at its EXISTING offsets, straight out of the CPU-side vectors
+    // MeshInfo keeps — which is what makes previously handed-out ranges survive a reallocation untouched.
+    bool ok = true;
+    for ( MeshInfo* mi : m_Resident ) {
+        auto it = m_Ranges.find( mi );
+        if ( it == m_Ranges.end() ) continue;
+        ok = UploadMesh( engine, mi, it->second ) && ok;
+    }
+    return ok;
+}
+
+
+bool D3D12VobArena::Flush( D3D12GraphicsEngine* engine ) {
+    if ( !engine ) return false;
+
+    std::vector<PendingMesh> pending;
+    {
+        std::lock_guard<std::mutex> lock( m_PendingMutex );
+        pending.swap( m_Pending );
+    }
+
+    if ( pending.empty() )
+        return m_VertexBuffer != nullptr && !m_AllocFailed;
+    if ( m_AllocFailed )
+        return false;
+
+    // Reserve first (pure bookkeeping), so the growth decision below sees the exact final cursors instead
+    // of a per-mesh estimate.
+    std::vector<MeshInfo*> reserved;
+    reserved.reserve( pending.size() );
+    for ( const PendingMesh& p : pending ) {
+        if ( m_Ranges.find( p.Mesh ) != m_Ranges.end() ) continue;   // queued twice before the first flush
+        if ( !Reserve( p.Mesh, p.Dynamic ) ) continue;
+        reserved.push_back( p.Mesh );
+    }
+
+    const bool grow = !m_VertexBuffer || !m_IndexBuffer
+        || m_VertexCursor > m_VertexCapacity || m_IndexCursor > m_IndexCapacity;
+
+    if ( grow ) {
+        m_VertexCapacity = std::max( static_cast<UINT>( m_VertexCursor * kGrowthHeadroom ),
+            m_VertexCursor + kMinSpareVertices );
+        m_IndexCapacity = std::max( static_cast<UINT>( m_IndexCursor * kGrowthHeadroom ),
+            m_IndexCursor + kMinSpareIndices );
+        if ( !Reallocate( engine ) ) {
+            // Roll the whole batch back rather than leave half-registered ranges pointing into a buffer
+            // that doesn't exist: every reserved sub-mesh loses its range and the VOB path draws nothing
+            // this frame (Ready() is false), which is a blank pass, not corruption.
+            LogWarn() << "D3D12: VOB arena allocation failed ("
+                << ( static_cast<UINT64>( m_VertexCapacity ) * kVertexStride / ( 1024 * 1024 ) ) << " MB verts + "
+                << ( static_cast<UINT64>( m_IndexCapacity ) * kIndexStride / ( 1024 * 1024 ) ) << " MB indices). "
+                << "Instanced VOBs will not render.";
+            m_AllocFailed = true;
+            return false;
+        }
+        LogInfo() << "D3D12: VOB arena now " << m_Ranges.size() << " sub-meshes, "
+            << ( GetBytes() / ( 1024 * 1024 ) ) << " MB ("
+            << ( GetVertexBytes() / ( 1024 * 1024 ) ) << " MB verts + "
+            << ( GetIndexBytes() / ( 1024 * 1024 ) ) << " MB indices)";
+        // Reallocate() already re-uploaded everything, including what was just reserved.
+        engine->FlushTextureUploads();
+        return true;
+    }
+
+    for ( MeshInfo* mi : reserved ) {
+        auto it = m_Ranges.find( mi );
+        if ( it != m_Ranges.end() ) UploadMesh( engine, mi, it->second );
+    }
+    // UploadBufferData only RECORDS into the shared copy-queue batch; it is the flush that submits it and
+    // issues the direct queue's Wait on the copy fence. Without this, THIS frame's VOB passes (recorded a
+    // few calls from now, submitted at the end of the frame) could read vertices that have not landed yet.
+    // Same reason DispatchMorphFold flushes after uploading its prototype tables.
+    if ( !reserved.empty() ) engine->FlushTextureUploads();
+    return true;
+}

--- a/D3D11Engine/D3D12Engine/D3D12VobArena.h
+++ b/D3D11Engine/D3D12Engine/D3D12VobArena.h
@@ -1,0 +1,134 @@
+#pragma once
+#include <d3d12.h>
+#include <mutex>
+#include <vector>
+#include <wrl/client.h>
+
+#include "D3D12MemAlloc.h"
+
+struct MeshInfo;
+struct MeshVisualInfo;
+class D3D12GraphicsEngine;
+
+/** One DEFAULT-heap vertex buffer + one DEFAULT-heap index buffer holding EVERY static VOB sub-mesh in the
+    world ("mega buffers").
+
+    Why this exists: the instanced-VOB ExecuteIndirect command signature used to carry two
+    VERTEX_BUFFER_VIEWs and an INDEX_BUFFER_VIEW per command, because every VOB visual owned its own
+    buffers. That makes each of the frame's ~560 commands a full IA state change, and it was measurably the
+    dominant cost of the four VOB passes (depth prepass, three shadow cascades, lit pass) — the same failure
+    the world mesh had before its sections were consolidated into one wrapped buffer, and the same fix.
+
+    With every sub-mesh living in one pair of buffers, a sub-mesh is just
+    `{ BaseVertexLocation, StartIndexLocation, IndexCount }`, the signature collapses to
+    `{ b6 material consts, b4 wind consts, DrawIndexed }`, and each pass binds the IA exactly once.
+
+    16-bit indices survive consolidation untouched. `BaseVertexLocation` is a 32-bit value added AFTER the
+    index fetch, so each sub-mesh's `R16_UINT` indices stay sub-mesh-relative (0..numVertices-1) exactly as
+    they were authored — the index data is concatenated verbatim, with no reindexing and no widening to
+    32 bit. The same holds for the position-welded SHADOW indices and the baked progressive-mesh LOD
+    indices, which index the very same vertices and therefore the very same base.
+
+    Ownership/threading contract:
+    - `Reset()` on world load, `QueueVisual()` from OnAddVob (which fires per vob during world load, so the
+      whole world's geometry is registered before the first frame renders).
+    - Queueing only records a pointer. All GPU work — allocation, growth, uploads — happens in `Flush()`,
+      which the engine calls ONCE per frame on the main thread from UploadFrameVobInstances, i.e. before
+      anything reads the arena that frame and before the shadow cascades' concurrent command builds start.
+      That is what lets `Find()` be a lock-free read from those worker threads.
+    - Growth reallocates and re-uploads every resident sub-mesh from its (retained) CPU-side
+      `MeshInfo::Vertices/Indices`, at the SAME offsets — so ranges handed out earlier stay valid and no
+      caller has to be invalidated. The old resources are handed to the engine's fence-deferred cleanup.
+
+    A second full CPU copy of the world's VOB geometry is deliberately never materialised (32-bit address
+    space): uploads are fed sub-mesh by sub-mesh straight out of `MeshInfo`'s own vectors through the
+    engine's pooled/batched copy-queue staging. */
+class D3D12VobArena {
+public:
+    /** Where one sub-mesh lives in the arena. Counts of 0 mean "this level does not exist for this
+        sub-mesh" — the caller falls through to the next-best index range, exactly as it did when these
+        were separate buffers. */
+    struct Range {
+        UINT BaseVertex   = 0;   // first vertex, in vertices (goes into DrawIndexed::BaseVertexLocation)
+        UINT IndexStart   = 0;   // full render indices, in indices (-> StartIndexLocation)
+        UINT IndexCount   = 0;
+        UINT ShadowStart  = 0;   // position-welded shadow indices
+        UINT ShadowCount  = 0;
+        UINT LodStart     = 0;   // baked progressive-mesh LOD indices
+        UINT LodCount     = 0;
+    };
+
+    /** Drops every range and both buffers. Called from OnLoadWorld, before the new world's vobs arrive. */
+    void Reset();
+
+    /** Register every drawable sub-mesh of a static VOB visual. Cheap and idempotent: already-resident and
+        already-pending sub-meshes are skipped, so calling it once per vob (i.e. many times per visual) is
+        fine. Safe to call from any thread. */
+    void QueueVisual( MeshVisualInfo* visual );
+
+    /** Upload everything queued since the last call, growing the buffers if needed. Main thread, inside an
+        open frame. Returns false if the arena is unusable this frame (allocation failure) — the caller
+        should then simply not build VOB commands, since nothing would draw. */
+    bool Flush( D3D12GraphicsEngine* engine );
+
+    /** Look up a sub-mesh's range. nullptr = not resident (never queued, or its upload failed); the
+        command build skips such a sub-mesh for the frame. Lock-free: only Flush() mutates the map, and it
+        runs before any reader. */
+    const Range* Find( const MeshInfo* mesh ) const {
+        auto it = m_Ranges.find( mesh );
+        return it == m_Ranges.end() ? nullptr : &it->second;
+    }
+
+    /** Sub-meshes whose vertices are rewritten every frame (animated static VOBs built from an .MMS —
+        either ZENGIN's CPU deform or the GPU morph fold). Their arena range holds the CONVERSION pose
+        after upload and has to be refreshed from the mesh's own vertex buffer once per frame; the engine
+        does that right after DispatchMorphFold. Empty in the overwhelmingly common case. */
+    const std::vector<MeshInfo*>& DynamicMeshes() const { return m_Dynamic; }
+
+    bool Ready() const { return m_VertexBuffer != nullptr && m_IndexBuffer != nullptr && m_VertexCursor > 0; }
+    ID3D12Resource* GetVertexBuffer() const { return m_VertexBuffer.Get(); }
+    ID3D12Resource* GetIndexBuffer() const { return m_IndexBuffer.Get(); }
+    UINT GetVertexBytes() const { return m_VertexCapacity * kVertexStride; }
+    UINT GetIndexBytes() const { return m_IndexCapacity * kIndexStride; }
+    static constexpr UINT VertexStride() { return kVertexStride; }
+
+    /** Stats for the ImGui panel — resident sub-meshes and how much VRAM the two buffers cost. */
+    UINT GetMeshCount() const { return static_cast<UINT>( m_Ranges.size() ); }
+    UINT64 GetBytes() const { return static_cast<UINT64>( GetVertexBytes() ) + GetIndexBytes(); }
+
+private:
+    static const UINT kVertexStride;      // sizeof(ExVertexStruct) — out of line, WorldObjects.h isn't pulled in here
+    static constexpr UINT kIndexStride = 2;   // R16_UINT
+
+    /** Assigns `mesh` a range at the current cursors and records it. Does no GPU work. */
+    bool Reserve( MeshInfo* mesh, bool dynamic );
+    /** (Re)creates both buffers at m_VertexCapacity/m_IndexCapacity and re-uploads every resident
+        sub-mesh. Old resources go to the engine's fence-deferred cleanup. */
+    bool Reallocate( D3D12GraphicsEngine* engine );
+    bool UploadMesh( D3D12GraphicsEngine* engine, MeshInfo* mesh, const Range& range );
+
+    Microsoft::WRL::ComPtr<ID3D12Resource>      m_VertexBuffer;
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_VertexAlloc;
+    Microsoft::WRL::ComPtr<ID3D12Resource>      m_IndexBuffer;
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_IndexAlloc;
+
+    UINT m_VertexCapacity = 0;   // vertices the buffer can hold
+    UINT m_IndexCapacity = 0;    // indices the buffer can hold
+    UINT m_VertexCursor = 0;     // vertices handed out
+    UINT m_IndexCursor = 0;      // indices handed out
+
+    gtl::flat_hash_map<const MeshInfo*, Range> m_Ranges;
+    std::vector<MeshInfo*> m_Resident;     // insertion order — re-upload order on growth
+    std::vector<MeshInfo*> m_Dynamic;      // subset of m_Resident, see DynamicMeshes()
+
+    // Queued-but-not-yet-uploaded. `Dynamic` rides along from QueueVisual because only the VISUAL knows it
+    // (MeshVisualInfo::MorphMeshVisual); the MeshInfo itself looks static.
+    struct PendingMesh {
+        MeshInfo* Mesh;
+        bool Dynamic;
+    };
+    std::mutex m_PendingMutex;             // guards m_Pending only; the rest is main-thread/Flush-only
+    std::vector<PendingMesh> m_Pending;
+
+    bool m_AllocFailed = false;            // logged once; stops us retrying a doomed allocation every frame
+};

--- a/D3D11Engine/Engine.cpp
+++ b/D3D11Engine/Engine.cpp
@@ -54,12 +54,14 @@ namespace Engine {
         // (Phase 1: first-light — device + swapchain + per-frame clear/present, rest stubbed),
         // otherwise we log + show a one-time notice and fall back to D3D11.
         GraphicsEngine = nullptr;
+        IsD3D12Backend = false;
         bool initialized = false;   // set when the chosen backend's Init() has already run below
         if ( ReadRequestedGraphicsAPI() == GothicRendererSettings::GRAPHICS_API_D3D12 ) {
             GAPI->GetRendererState().RendererSettings.GraphicsAPI = GothicRendererSettings::GRAPHICS_API_D3D12;
             GraphicsEngine = new D3D12GraphicsEngine;
             if ( GraphicsEngine->Init() == XRESULT::XR_SUCCESS ) {
                 initialized = true;
+                IsD3D12Backend = true;
             } else {
                 SAFE_DELETE( GraphicsEngine );
                 

--- a/D3D11Engine/Engine.h
+++ b/D3D11Engine/Engine.h
@@ -19,6 +19,15 @@ namespace Engine {
     /** Global engine object */
     __declspec(selectany) BaseGraphicsEngine* GraphicsEngine;
 
+    /** True only when the D3D12 backend was actually created AND initialized. Deliberately NOT
+        RendererSettings.GraphicsAPI: that one mirrors what the ini/CLI *requested* and is rewritten
+        again by LoadMenuSettings, so it still says D3D12 after a failed probe fell back to D3D11.
+        Set once by CreateGraphicsEngine, before any world is converted.
+
+        Used to keep D3D12-only scene data (the VOB LOD index lists) out of the D3D11 build entirely -
+        D3D11 is the address-space-starved path and must not pay for buffers it never binds. */
+    __declspec(selectany) bool IsD3D12Backend;
+
     /** Global GothicAPI object */
     __declspec(selectany) GothicAPI* GAPI;
 

--- a/D3D11Engine/GVegetationBox.cpp
+++ b/D3D11Engine/GVegetationBox.cpp
@@ -157,23 +157,32 @@ XRESULT GVegetationBox::InitVegetationBox( MeshInfo* mesh,
     BoxMax = XMFLOAT3( -FLT_MAX, -FLT_MAX, -FLT_MAX );
     BoxMin = XMFLOAT3( FLT_MAX, FLT_MAX, FLT_MAX );
 
-    for ( unsigned int i = 0; i < mesh->Vertices.size(); i++ ) {
-        BoxMin.x = BoxMin.x > mesh->Vertices[i].Position.x ? mesh->Vertices[i].Position.x : BoxMin.x;
-        BoxMin.y = BoxMin.y > mesh->Vertices[i].Position.y ? mesh->Vertices[i].Position.y : BoxMin.y;
-        BoxMin.z = BoxMin.z > mesh->Vertices[i].Position.z ? mesh->Vertices[i].Position.z : BoxMin.z;
+    // Editor entry point, and what it gets handed is a world mesh - which keeps only the slim CPU copy.
+    // The Vertices branch stays for any other MeshInfo that ends up selected.
+    const std::vector<WorldVertexCPU>* slim = mesh->GetCpuVertices();
+    const size_t vertexCount = slim ? slim->size() : mesh->Vertices.size();
+    auto position = [&]( size_t idx ) -> const float3& {
+        return slim ? (*slim)[idx].Position : mesh->Vertices[idx].Position;
+    };
 
-        BoxMax.x = BoxMax.x < mesh->Vertices[i].Position.x ? mesh->Vertices[i].Position.x : BoxMax.x;
-        BoxMax.y = BoxMax.y < mesh->Vertices[i].Position.y ? mesh->Vertices[i].Position.y : BoxMax.y;
-        BoxMax.z = BoxMax.z < mesh->Vertices[i].Position.z ? mesh->Vertices[i].Position.z : BoxMax.z;
+    for ( unsigned int i = 0; i < vertexCount; i++ ) {
+        const float3& p = position( i );
+        BoxMin.x = BoxMin.x > p.x ? p.x : BoxMin.x;
+        BoxMin.y = BoxMin.y > p.y ? p.y : BoxMin.y;
+        BoxMin.z = BoxMin.z > p.z ? p.z : BoxMin.z;
+
+        BoxMax.x = BoxMax.x < p.x ? p.x : BoxMax.x;
+        BoxMax.y = BoxMax.y < p.y ? p.y : BoxMax.y;
+        BoxMax.z = BoxMax.z < p.z ? p.z : BoxMax.z;
     }
 
     std::vector<XMFLOAT3> trisInside;
     for ( unsigned int i = 0; i < mesh->Indices.size(); i += 3 ) {
         XMFLOAT3 tri[3];
 
-        tri[0] = mesh->Vertices[mesh->Indices[i]].Position;
-        tri[1] = mesh->Vertices[mesh->Indices[i + 1]].Position;
-        tri[2] = mesh->Vertices[mesh->Indices[i + 2]].Position;
+        tri[0] = position( mesh->Indices[i] );
+        tri[1] = position( mesh->Indices[i + 1] );
+        tri[2] = position( mesh->Indices[i + 2] );
 
         trisInside.push_back( tri[0] );
         trisInside.push_back( tri[1] );

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -51,6 +51,7 @@
 #include "D3D11GraphicsEngine.h"
 #include "MeshManager.h"
 #include "SharedVisualRegistry.h"
+#include "AsyncVisualExtractor.h"
 #include "ThreadPool.h"
 #include "zFILE.h"
 #include "zFILE_VDFS.h"
@@ -569,12 +570,12 @@ void GothicAPI::OnWorldUpdate() {
     }
 #endif
 
-    // Retire background extractions that finished on their own and hand the zCVisual references
-    // they held back to ZENGIN. Has to happen at a top-level main-thread point like this one: a
-    // release can run a visual's destructor, which re-enters us via OnVisualDeleted.
-    DrainFinishedSkeletalLoads();
+    // Retire background extractions that finished on their own and hand the references they held back
+    // to ZENGIN. Has to happen at a top-level point like this one: a release can run a visual's
+    // destructor, which re-enters us via OnVisualDeleted.
+    s_AsyncVisualExtractor->DrainFinished();
     WorldConverter::PruneFinishedNodeVisuals();
-    FlushDeferredVisualReleases();
+    s_AsyncVisualExtractor->FlushReleases();
 
     RendererState.RendererInfo.Reset();
     RendererState.RendererInfo.FPS = GetFramesPerSecond();
@@ -911,18 +912,11 @@ void GothicAPI::ResetVobs() {
     SkeletalMeshVisuals.clear();
     SkeletalMeshNpcs.clear();
 
-    // clearAndFlush() above already waited for every background LoadzCModelData(...) job to
-    // finish, so it's safe to drop the (now stale) handles without waiting on them again. Their
-    // zCModel references still have to go back, though. Safe to do right here: SkeletalMeshVisuals
-    // and SkeletalMeshNpcs are already empty, so the OnVisualDeleted a release may trigger finds
-    // nothing left to tear down.
-    for ( auto& it : PendingSkeletalLoads ) {
-        QueueDeferredVisualRelease( it.second.Model );
-        for ( zCMeshSoftSkin* s : it.second.SoftSkins )
-            QueueDeferredVisualRelease( s );
-    }
-    PendingSkeletalLoads.clear();
-    FlushDeferredVisualReleases();
+    // clearAndFlush() above already waited for every background extraction to finish, and the infos
+    // they wrote into are gone with the two clears right above, so all that is left is handing their
+    // references back. Safe to release here rather than deferring: the maps are empty, so the
+    // OnVisualDeleted each release may trigger finds nothing left to tear down.
+    s_AsyncVisualExtractor->CancelAll();
 
     // Delete static mesh vobs
     for ( auto const& it : VobMap ) {
@@ -1983,11 +1977,10 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
                 }
 
                 auto it = SkeletalMeshVisuals.find( str );
-                // Only tear the cache entry down if it actually belongs to *this* model. Holding an
-                // extraction reference (LoadzCModelData) can push a model's destructor past the
-                // point where a reload has already re-bound this name to a newer model - tearing
-                // down here would then delete the live entry out from under it. A null Visual means
-                // the extraction never completed, i.e. the entry is nobody else's either.
+                // Only tear the entry down if it belongs to *this* model. An extraction reference can
+                // hold a model's destructor past the point where a reload has re-bound this name to a
+                // newer one, and tearing down then would delete the live entry out from under it. A
+                // null Visual means the extraction never completed, so the entry is nobody else's.
                 if ( it != SkeletalMeshVisuals.end() && (!it->second->Visual || it->second->Visual == zmodel) ) {
                     // Find vobs using this visual
                     for ( SkeletalVobInfo* vobInfo : SkeletalMeshVobs ) {
@@ -1996,9 +1989,8 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
                         }
                     }
 
-                    // Make sure no background extraction job (GothicAPI::LoadzCModelData) is still
-                    // writing into the info we are about to delete.
-                    WaitForPendingSkeletalLoad( it->second );
+                    // Make sure no background extraction is still writing into the info we delete.
+                    s_AsyncVisualExtractor->WaitForSkeletal( it->second );
 
                     delete SkeletalMeshVisuals[str];
                     SkeletalMeshVisuals.erase( str );
@@ -2009,9 +2001,9 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
             if ( homeVob && homeVob->GetVobType() == zVOB_TYPE_NSC ) {
                 oCNPC* npc = static_cast<oCNPC*>(homeVob);
                 auto it = SkeletalMeshNpcs.find( npc );
-                // Same identity check as above, and the armor-change case is exactly what it is
-                // for: the NPC's entry may already have been rebuilt from its new zCModel by the
-                // time this (deferred) destructor gets to run.
+                // Same identity check as above; the armor change is exactly what it is for, since the
+                // NPC's entry may already have been rebuilt from its new zCModel by the time this
+                // (deferred) destructor gets to run.
                 if ( it != SkeletalMeshNpcs.end() && (!it->second->Visual || it->second->Visual == zmodel) ) {
                     // Find vobs using this visual
                     for ( SkeletalVobInfo* vobInfo : SkeletalMeshVobs ) {
@@ -2020,9 +2012,8 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
                         }
                     }
 
-                    // Make sure no background extraction job (GothicAPI::LoadzCModelData) is still
-                    // writing into the info we are about to delete.
-                    WaitForPendingSkeletalLoad( it->second );
+                    // Make sure no background extraction is still writing into the info we delete.
+                    s_AsyncVisualExtractor->WaitForSkeletal( it->second );
 
                     delete SkeletalMeshNpcs[npc];
                     SkeletalMeshNpcs.erase( npc );
@@ -2466,106 +2457,6 @@ void GothicAPI::OnAddVob( zCVob* vob, zCWorld* world ) {
     }
 }
 
-/** Copies the model's softskin list and takes a reference on every entry, so a background extraction
- *  can walk it without racing the game thread. Holding the zCModel alive is not enough: ZENGIN refills
- *  zCModel::SoftSkinList *in place* (armor changes, mesh-lib swaps) and releases the old meshes as it
- *  goes, and a zCMeshSoftSkin that is being torn down reports its old submesh count with an already
- *  nulled submesh array - which zCProgMeshProto::GetSubmesh turns into a null (or near-null) pointer,
- *  since it is plain arithmetic off that base. */
-static std::vector<zCMeshSoftSkin*> SnapshotSoftSkins( zCModel* model ) {
-    std::vector<zCMeshSoftSkin*> snapshot;
-
-    zCArray<zCMeshSoftSkin*>* list = model->GetMeshSoftSkinList();
-    if ( !list )
-        return snapshot;
-
-    snapshot.reserve( list->NumInArray );
-    for ( int i = 0; i < list->NumInArray; i++ ) {
-        if ( zCMeshSoftSkin* s = list->Array[i] ) {
-            zCObject_AddRef( s );
-            snapshot.push_back( s );
-        }
-    }
-    return snapshot;
-}
-
-/** Blocks until a background LoadzCModelData(...) extraction job for this visual (if any) has
- *  finished, then forgets about it and queues the references it held for release.
- *  Must be called before deleting a SkeletalMeshVisualInfo - the job writes directly into it. */
-void GothicAPI::WaitForPendingSkeletalLoad( SkeletalMeshVisualInfo* mi ) {
-    if ( !mi )
-        return;
-
-    auto it = PendingSkeletalLoads.find( mi );
-    if ( it == PendingSkeletalLoads.end() )
-        return;
-
-    PendingSkeletalLoad load = std::move( it->second );
-    PendingSkeletalLoads.erase( it );
-
-    load.Task.cancel(); // Lets the job bail out immediately if it hasn't started running yet (see below)
-    if ( load.Task.future.valid() )
-        load.Task.future.wait();
-
-    // Deliberately not released here: this is the last reference in the common case, and dropping
-    // it runs ZENGIN's zCModel destructor, which re-enters us through zCVisual::Hooked_Destructor
-    // -> OnVisualDeleted. Every caller is either inside OnVisualDeleted already or is holding 'mi'
-    // - which that re-entry would happily delete. FlushDeferredVisualReleases() does it later.
-    QueueDeferredVisualRelease( load.Model );
-    for ( zCMeshSoftSkin* s : load.SoftSkins )
-        QueueDeferredVisualRelease( s );
-}
-
-/** Extraction jobs that nobody comes back for would keep their zCModel reference (and with it the
- *  model itself) alive forever. Retire the ones that have run to completion. */
-void GothicAPI::DrainFinishedSkeletalLoads() {
-    if ( PendingSkeletalLoads.empty() )
-        return;
-
-    static std::vector<SkeletalMeshVisualInfo*> finished; // Main thread only, keeps its capacity
-    finished.clear();
-
-    for ( auto& it : PendingSkeletalLoads ) {
-        if ( !it.second.Task.future.valid() ||
-            it.second.Task.future.wait_for( std::chrono::seconds( 0 ) ) == std::future_status::ready ) {
-            finished.push_back( it.first );
-        }
-    }
-
-    for ( SkeletalMeshVisualInfo* mi : finished )
-        WaitForPendingSkeletalLoad( mi ); // Already finished, so this doesn't block
-}
-
-/** Queues one extraction reference for release. Callable from anywhere, including from under
- *  WorldConverter's node-visual mutex - all it does is append. */
-void GothicAPI::QueueDeferredVisualRelease( void* object ) {
-    if ( !object )
-        return;
-
-    std::scoped_lock lock( DeferredVisualReleaseMutex );
-    DeferredVisualReleases.push_back( object );
-}
-
-/** Hands the extraction references back to ZENGIN. Must only be called from a top-level main-thread
- *  point: a release can run a visual's destructor, which comes back around into OnVisualDeleted. */
-void GothicAPI::FlushDeferredVisualReleases() {
-    for ( ;; ) {
-        void* object;
-        {
-            // The lock is dropped before the release: the destructor's OnVisualDeleted re-entry can
-            // queue further releases, and this mutex is not recursive. That re-entry is also why the
-            // vector is re-checked every round instead of being iterated.
-            std::scoped_lock lock( DeferredVisualReleaseMutex );
-            if ( DeferredVisualReleases.empty() )
-                return;
-
-            object = DeferredVisualReleases.back();
-            DeferredVisualReleases.pop_back();
-        }
-        zCObject_Release( object );
-    }
-}
-
 /** Loads the data out of a zCModel */
 SkeletalMeshVisualInfo* GothicAPI::LoadzCModelData( zCModel* model ) {
     auto visName = model->GetVisualName();
@@ -2580,43 +2471,14 @@ SkeletalMeshVisualInfo* GothicAPI::LoadzCModelData( zCModel* model ) {
         SkeletalMeshVisuals[str] = mi;
     }
 
-    // Retire whatever job was still attached to this info. It may be extracting from an older
-    // zCModel than the one we were just handed, and its reference has to come back either way.
-    WaitForPendingSkeletalLoad( mi );
+    // Retire whatever job was still attached to this info before reading Meshes below: it may be
+    // extracting from an older zCModel, and it writes straight into mi.
+    s_AsyncVisualExtractor->WaitForSkeletal( mi );
 
     if ( !mi->Meshes.empty() )
         return mi; // Already loaded
 
-    // Extraction (CPU vertex/weight unpacking + GPU buffer creation) is the expensive part of a
-    // vob popping into range, so run it on a worker thread instead of stalling the main thread.
-    // Ready gates every draw/update site so nobody touches Meshes/SkeletalMeshes early.
-    mi->Ready = false;
-
-    // ZENGIN can free the model while the job is queued or running: a vob that unloads and reloads
-    // inside one frame drops refCtr to 0, the destructor runs, and the allocator happily hands the
-    // same address back out for the reload. Own a reference for the duration of the job instead of
-    // relying on nobody deleting the model in the meantime - it is handed back once the job is
-    // retired (WaitForPendingSkeletalLoad / DrainFinishedSkeletalLoads).
-    zCObject_AddRef( model );
-
-    PendingSkeletalLoad load;
-    load.Model = model;
-    load.SoftSkins = SnapshotSoftSkins( model );
-
-    const std::span<zCMeshSoftSkin* const> softSkins = load.SoftSkins;
-    load.Task = Engine::WorkerThreadPool->enqueue( [model, softSkins, mi]( const std::stop_token& token ) {
-        if ( token.stop_requested() ) {
-            // Cancelled before a worker picked it up (WaitForPendingSkeletalLoad). The model is
-            // still alive - we hold a reference - but the caller no longer wants this extraction.
-            mi->Ready.store( true );
-            return;
-        }
-        WorldConverter::ExtractSkeletalMeshFromVob( model, softSkins, mi );
-        mi->Visual = model;
-        mi->Ready.store( true );
-    } );
-
-    PendingSkeletalLoads[mi] = std::move( load );
+    s_AsyncVisualExtractor->ExtractSkeletal( model, mi );
     return mi;
 }
 
@@ -2629,39 +2491,9 @@ SkeletalMeshVisualInfo* GothicAPI::LoadzCModelData( oCNPC* npc ) {
         SkeletalMeshNpcs[npc] = mi;
     }
 
-    // Retire the previous job first. For NPCs this is the armor-change case: the old job is very
-    // likely still extracting from the *previous* zCModel, which oCNPC::SetVisual has already
-    // released - only our own reference is keeping it alive.
-    WaitForPendingSkeletalLoad( mi );
-
     // can't cache the meshes and VisualName as it otherwise
     // won't properly fire for changing armors. for whatever reason...
-
-    // See LoadzCModelData(zCModel*) above for why this runs on a worker thread and why we hold
-    // references on the model and its softskins while it does. The softskin snapshot matters most
-    // here: an armor change refills SoftSkinList in place on the game thread.
-    mi->Ready = false;
-    zCObject_AddRef( model );
-
-    PendingSkeletalLoad load;
-    load.Model = model;
-    load.SoftSkins = SnapshotSoftSkins( model );
-
-    const std::span<zCMeshSoftSkin* const> softSkins = load.SoftSkins;
-    load.Task = Engine::WorkerThreadPool->enqueue( [model, softSkins, mi]( const std::stop_token& token ) {
-        if ( token.stop_requested() ) {
-            // Cancelled before a worker picked it up (WaitForPendingSkeletalLoad). The model is
-            // still alive - we hold a reference - but the caller no longer wants this extraction.
-            mi->Ready.store( true );
-        } );
-    } else {
-        mi->ClearMeshes();
-        WorldConverter::ExtractSkeletalMeshFromVob( model, softSkins, mi );
-        mi->Visual = model;
-        mi->Ready.store( true );
-    } );
-
-    PendingSkeletalLoads[mi] = std::move( load );
+    s_AsyncVisualExtractor->ExtractSkeletal( model, mi );
     return mi;
 }
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -912,10 +912,9 @@ void GothicAPI::ResetVobs() {
     SkeletalMeshVisuals.clear();
     SkeletalMeshNpcs.clear();
 
-    // clearAndFlush() above already waited for every background extraction to finish, and the infos
-    // they wrote into are gone with the two clears right above, so all that is left is handing their
-    // references back. Safe to release here rather than deferring: the maps are empty, so the
-    // OnVisualDeleted each release may trigger finds nothing left to tear down.
+    // Only the held references are left to hand back — clearAndFlush() above waited for every background
+    // extraction and the infos they wrote into are gone. Safe inline rather than deferred: the maps are
+    // empty, so the OnVisualDeleted a release may trigger finds nothing to tear down.
     s_AsyncVisualExtractor->CancelAll();
 
     // Delete static mesh vobs
@@ -1977,10 +1976,9 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
                 }
 
                 auto it = SkeletalMeshVisuals.find( str );
-                // Only tear the entry down if it belongs to *this* model. An extraction reference can
-                // hold a model's destructor past the point where a reload has re-bound this name to a
-                // newer one, and tearing down then would delete the live entry out from under it. A
-                // null Visual means the extraction never completed, so the entry is nobody else's.
+                // Only tear the entry down if it belongs to *this* model: an extraction reference can hold a
+                // model's destructor past a reload that re-bound this name to a newer one. A null Visual
+                // means the extraction never completed, so the entry is nobody else's.
                 if ( it != SkeletalMeshVisuals.end() && (!it->second->Visual || it->second->Visual == zmodel) ) {
                     // Find vobs using this visual
                     for ( SkeletalVobInfo* vobInfo : SkeletalMeshVobs ) {
@@ -4948,19 +4946,18 @@ static void CVVH_AddNotDrawnVobToList(
     const float minVobSize = ctx.minVobSize;
 
     for ( const LeafVobEntry& entry : source ) {
-        // Reject on distance FIRST, and out of the list element's OWN mirrored position: every
-        // later step - Visit()'s atomic word, GetFlags()' hop into Gothic's heap, LastRenderBBox -
-        // is a dereference of a scattered VobInfo, and the majority of candidates never survive to
-        // need one. This loop therefore walks nothing but the contiguous 16-byte entries.
+        // Reject on distance FIRST, out of the list element's OWN mirrored position: every later step
+        // dereferences a scattered VobInfo, and most candidates never survive to need one. The reject path
+        // therefore touches nothing but the contiguous 16-byte entries.
         XMVECTOR vvdSq = XMVector3LengthSq( camPos - XMLoadFloat3( &entry.Position ) );
         if ( XMVector3Greater( vvdSq, distSq )) continue;
 
         VobInfo* it = entry.Info;
         if ( !visitor->Visit( it ) ) continue;
 
-        // Caster size gate (shadow cascades only; minVobSize is 0 for every main-view pass). Placed right
-        // after Visit rather than before it: MeshSize is leaf-independent like the distance, but reading it
-        // costs two pointer hops, so it is worth paying once per vob per pass instead of once per leaf.
+        // Caster size gate (shadow cascades only; minVobSize is 0 for every main-view pass). After Visit,
+        // not before: MeshSize is leaf-independent but costs two pointer hops, so pay it once per vob per
+        // pass rather than once per leaf.
         if ( minVobSize > 0.0f && it->VisualInfo && it->VisualInfo->MeshSize < minVobSize ) continue;
 
         const zTVobFlags vobFlags = it->Vob->GetFlags();
@@ -6584,10 +6581,8 @@ void GothicAPI::CreatezCPolygonsForSections() {
                 it->first.Material->SetAlphaFunc( zMAT_ALPHA_FUNC_NONE );
 
                 // The world mesh only keeps WorldVertexCPU now, so rebuild the full vertices this wants.
-                // Per-vertex normals come out zero; zCPolygon::CalcNormal() (which the conversion calls)
-                // still derives the polygon plane from the positions, and that is what the BSP/collision
-                // side of this path uses. G1-classic + custom-world only, and dead in practice - not worth
-                // carrying 12 bytes per world vertex to preserve.
+                // Per-vertex normals come out zero; zCPolygon::CalcNormal() still derives the polygon plane
+                // from the positions, which is what the BSP/collision side of this path uses.
                 std::vector<ExVertexStruct> rebuilt( it->second->CpuVertices.size() );
                 for ( size_t v = 0; v < it->second->CpuVertices.size(); ++v ) {
                     rebuilt[v].Position = it->second->CpuVertices[v].Position;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -3802,18 +3802,24 @@ bool GothicAPI::TraceWorldMesh( const XMFLOAT3& origin, const XMFLOAT3& dir, XMF
         for ( auto it = bit.first->WorldMeshes.begin(); it != bit.first->WorldMeshes.end(); ++it ) {
             float u, v, t;
 
+            // Positions come from the slim CPU copy the world mesh keeps instead of the full vertices.
+            const std::vector<WorldVertexCPU>& verts = it->second->CpuVertices;
+            if ( verts.empty() ) {
+                continue;
+            }
+
             for ( unsigned int i = 0; i < it->second->Indices.size(); i += 3 ) {
-                if ( Toolbox::IntersectTri( it->second->Vertices[it->second->Indices[i]].Position,
-                    it->second->Vertices[it->second->Indices[i + 1]].Position,
-                    it->second->Vertices[it->second->Indices[i + 2]].Position,
+                if ( Toolbox::IntersectTri( verts[it->second->Indices[i]].Position,
+                    verts[it->second->Indices[i + 1]].Position,
+                    verts[it->second->Indices[i + 2]].Position,
                     origin, dir, u, v, t ) ) {
                     if ( t > 0 && t < closest ) {
                         closest = t;
 
                         if ( hitTriangle ) {
-                            hitTriangle[0] = it->second->Vertices[it->second->Indices[i]].Position;
-                            hitTriangle[1] = it->second->Vertices[it->second->Indices[i + 1]].Position;
-                            hitTriangle[2] = it->second->Vertices[it->second->Indices[i + 2]].Position;
+                            hitTriangle[0] = verts[it->second->Indices[i]].Position;
+                            hitTriangle[1] = verts[it->second->Indices[i + 1]].Position;
+                            hitTriangle[2] = verts[it->second->Indices[i + 2]].Position;
                         }
 
                         if ( hitMesh ) {
@@ -6577,7 +6583,19 @@ void GothicAPI::CreatezCPolygonsForSections() {
 
                 it->first.Material->SetAlphaFunc( zMAT_ALPHA_FUNC_NONE );
 
-                WorldConverter::ConvertExVerticesTozCPolygons( it->second->Vertices, it->second->Indices, it->first.Material, section.SectionPolygons );
+                // The world mesh only keeps WorldVertexCPU now, so rebuild the full vertices this wants.
+                // Per-vertex normals come out zero; zCPolygon::CalcNormal() (which the conversion calls)
+                // still derives the polygon plane from the positions, and that is what the BSP/collision
+                // side of this path uses. G1-classic + custom-world only, and dead in practice - not worth
+                // carrying 12 bytes per world vertex to preserve.
+                std::vector<ExVertexStruct> rebuilt( it->second->CpuVertices.size() );
+                for ( size_t v = 0; v < it->second->CpuVertices.size(); ++v ) {
+                    rebuilt[v].Position = it->second->CpuVertices[v].Position;
+                    rebuilt[v].TexCoord = it->second->CpuVertices[v].TexCoord;
+                    rebuilt[v].TexCoord2 = it->second->CpuVertices[v].TexCoord2;
+                }
+
+                WorldConverter::ConvertExVerticesTozCPolygons( rebuilt, it->second->Indices, it->first.Material, section.SectionPolygons );
             }
         }
     }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1123,6 +1123,7 @@ void GothicAPI::LoadRendererWorldSettings( GothicRendererSettings& s, const char
     if ( true ) {
 	    s.VisualFXDrawRadius = GetPrivateProfileFloatA( "General", "VisualFXDrawRadius", s.VisualFXDrawRadius, ini );
 	    s.VobLodDrawRadius = GetPrivateProfileFloatA( "General", "VobLodDrawRadius", s.VobLodDrawRadius, ini );
+	    s.VobAlphaPrepassRadius = GetPrivateProfileFloatA( "General", "VobAlphaPrepassRadius", s.VobAlphaPrepassRadius, ini );
 	    s.OutdoorVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorVobDrawRadius", s.OutdoorVobDrawRadius, ini );
         s.OutdoorSmallVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorSmallVobDrawRadius", s.OutdoorSmallVobDrawRadius, ini );
         s.IndoorVobDrawRadius = GetPrivateProfileFloatA( "General", "IndoorVobDrawRadius", s.IndoorVobDrawRadius, ini );
@@ -1192,6 +1193,7 @@ void GothicAPI::SaveRendererWorldSettings( const GothicRendererSettings& s, cons
     WritePrivateProfileStringA( "General", "GraphicsPreset", to_string_locale_independent( (int)s.GraphicsPreset ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "VisualFXDrawRadius", to_string_locale_independent( s.VisualFXDrawRadius ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "VobLodDrawRadius", to_string_locale_independent( s.VobLodDrawRadius ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "VobAlphaPrepassRadius", to_string_locale_independent( s.VobAlphaPrepassRadius ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "OutdoorVobDrawRadius", to_string_locale_independent( s.OutdoorVobDrawRadius ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "OutdoorSmallVobDrawRadius", to_string_locale_independent( s.OutdoorSmallVobDrawRadius ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "IndoorVobDrawRadius", to_string_locale_independent( s.IndoorVobDrawRadius ).c_str(), ini.c_str() );

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4993,6 +4993,7 @@ static void CVVH_AddNotDrawnVobToList(
     // (see CollectVisibleVobsWithLeafCache), so the whole branch collapses to a constant here.
     const bool needFrustumTest = cullingEnabled && bspContainment != ContainmentType::CONTAINS;
     const HorizonCuller* horizon = ctx.horizon;
+    const float minVobSize = ctx.minVobSize;
 
     for ( const LeafVobEntry& entry : source ) {
         // Reject on distance FIRST, and out of the list element's OWN mirrored position: every
@@ -5004,6 +5005,11 @@ static void CVVH_AddNotDrawnVobToList(
 
         VobInfo* it = entry.Info;
         if ( !visitor->Visit( it ) ) continue;
+
+        // Caster size gate (shadow cascades only; minVobSize is 0 for every main-view pass). Placed right
+        // after Visit rather than before it: MeshSize is leaf-independent like the distance, but reading it
+        // costs two pointer hops, so it is worth paying once per vob per pass instead of once per leaf.
+        if ( minVobSize > 0.0f && it->VisualInfo && it->VisualInfo->MeshSize < minVobSize ) continue;
 
         const zTVobFlags vobFlags = it->Vob->GetFlags();
         if ( !vobFlags.ShowVisual ) continue;
@@ -5871,6 +5877,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "Shadows", "SkyIblNightFloor", to_string_locale_independent( s.SkyIblNightFloor ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "ShadowDepthSlopeBias", to_string_locale_independent( s.DebugSettings.ShadowCascades.ShadowDepthSlopeBias ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "FirstLodCascade", to_string_locale_independent( s.DebugSettings.ShadowCascades.FirstLodCascade ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "CasterMinTexels", to_string_locale_independent( s.DebugSettings.ShadowCascades.CasterMinTexels ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "AllowSelfShadowingPointlights", to_string_locale_independent( s.AllowSelfShadowingPointlights ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "DisableStaticPointlights", to_string_locale_independent( s.DisableStaticPointlights ? TRUE : FALSE ).c_str(), ini.c_str() );
 
@@ -6031,6 +6038,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.SkyIblNightFloor = GetPrivateProfileFloatA( "Shadows", "SkyIblNightFloor", ds.SkyIblNightFloor, ini );
         s.DebugSettings.ShadowCascades.ShadowDepthSlopeBias = GetPrivateProfileFloatA( "Shadows", "ShadowDepthSlopeBias", ds.DebugSettings.ShadowCascades.ShadowDepthSlopeBias, ini );
         s.DebugSettings.ShadowCascades.FirstLodCascade = std::clamp( GetPrivateProfileSignedIntA( "Shadows", "FirstLodCascade", ds.DebugSettings.ShadowCascades.FirstLodCascade, ini ), -1, MAX_CSM_CASCADES );
+        s.DebugSettings.ShadowCascades.CasterMinTexels = std::clamp( GetPrivateProfileFloatA( "Shadows", "CasterMinTexels", ds.DebugSettings.ShadowCascades.CasterMinTexels, ini ), 0.0f, 32.0f );
         s.AllowSelfShadowingPointlights = GetPrivateProfileBoolA( "Shadows", "AllowSelfShadowingPointlights", ds.AllowSelfShadowingPointlights, ini );
         s.DisableStaticPointlights = GetPrivateProfileBoolA( "Shadows", "DisableStaticPointlights", ds.DisableStaticPointlights, ini );
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1123,7 +1123,6 @@ void GothicAPI::LoadRendererWorldSettings( GothicRendererSettings& s, const char
     if ( true ) {
 	    s.VisualFXDrawRadius = GetPrivateProfileFloatA( "General", "VisualFXDrawRadius", s.VisualFXDrawRadius, ini );
 	    s.VobLodDrawRadius = GetPrivateProfileFloatA( "General", "VobLodDrawRadius", s.VobLodDrawRadius, ini );
-	    s.VobAlphaPrepassRadius = GetPrivateProfileFloatA( "General", "VobAlphaPrepassRadius", s.VobAlphaPrepassRadius, ini );
 	    s.OutdoorVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorVobDrawRadius", s.OutdoorVobDrawRadius, ini );
         s.OutdoorSmallVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorSmallVobDrawRadius", s.OutdoorSmallVobDrawRadius, ini );
         s.IndoorVobDrawRadius = GetPrivateProfileFloatA( "General", "IndoorVobDrawRadius", s.IndoorVobDrawRadius, ini );
@@ -1193,7 +1192,6 @@ void GothicAPI::SaveRendererWorldSettings( const GothicRendererSettings& s, cons
     WritePrivateProfileStringA( "General", "GraphicsPreset", to_string_locale_independent( (int)s.GraphicsPreset ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "VisualFXDrawRadius", to_string_locale_independent( s.VisualFXDrawRadius ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "VobLodDrawRadius", to_string_locale_independent( s.VobLodDrawRadius ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "General", "VobAlphaPrepassRadius", to_string_locale_independent( s.VobAlphaPrepassRadius ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "OutdoorVobDrawRadius", to_string_locale_independent( s.OutdoorVobDrawRadius ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "OutdoorSmallVobDrawRadius", to_string_locale_independent( s.OutdoorSmallVobDrawRadius ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "IndoorVobDrawRadius", to_string_locale_independent( s.IndoorVobDrawRadius ).c_str(), ini.c_str() );

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1101,6 +1101,7 @@ void GothicAPI::LoadRendererWorldSettings( GothicRendererSettings& s, const char
 	s.GraphicsPreset = (GothicRendererSettings::E_GraphicsPreset)GetPrivateProfileIntA( "General", "GraphicsPreset", s.GraphicsPreset, ini.c_str() );
     if ( true ) {
 	    s.VisualFXDrawRadius = GetPrivateProfileFloatA( "General", "VisualFXDrawRadius", s.VisualFXDrawRadius, ini );
+	    s.VobLodDrawRadius = GetPrivateProfileFloatA( "General", "VobLodDrawRadius", s.VobLodDrawRadius, ini );
 	    s.OutdoorVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorVobDrawRadius", s.OutdoorVobDrawRadius, ini );
         s.OutdoorSmallVobDrawRadius = GetPrivateProfileFloatA( "General", "OutdoorSmallVobDrawRadius", s.OutdoorSmallVobDrawRadius, ini );
         s.IndoorVobDrawRadius = GetPrivateProfileFloatA( "General", "IndoorVobDrawRadius", s.IndoorVobDrawRadius, ini );
@@ -1169,6 +1170,7 @@ void GothicAPI::SaveRendererWorldSettings( const GothicRendererSettings& s, cons
 
     WritePrivateProfileStringA( "General", "GraphicsPreset", to_string_locale_independent( (int)s.GraphicsPreset ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "VisualFXDrawRadius", to_string_locale_independent( s.VisualFXDrawRadius ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "VobLodDrawRadius", to_string_locale_independent( s.VobLodDrawRadius ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "OutdoorVobDrawRadius", to_string_locale_independent( s.OutdoorVobDrawRadius ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "OutdoorSmallVobDrawRadius", to_string_locale_independent( s.OutdoorSmallVobDrawRadius ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "IndoorVobDrawRadius", to_string_locale_independent( s.IndoorVobDrawRadius ).c_str(), ini.c_str() );

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -569,6 +569,13 @@ void GothicAPI::OnWorldUpdate() {
     }
 #endif
 
+    // Retire background extractions that finished on their own and hand the zCVisual references
+    // they held back to ZENGIN. Has to happen at a top-level main-thread point like this one: a
+    // release can run a visual's destructor, which re-enters us via OnVisualDeleted.
+    DrainFinishedSkeletalLoads();
+    WorldConverter::PruneFinishedNodeVisuals();
+    FlushDeferredVisualReleases();
+
     RendererState.RendererInfo.Reset();
     RendererState.RendererInfo.FPS = GetFramesPerSecond();
     RendererState.GraphicsState.FF_Time = GetTimeSeconds();
@@ -905,8 +912,17 @@ void GothicAPI::ResetVobs() {
     SkeletalMeshNpcs.clear();
 
     // clearAndFlush() above already waited for every background LoadzCModelData(...) job to
-    // finish, so it's safe to drop the (now stale) handles without waiting on them again.
+    // finish, so it's safe to drop the (now stale) handles without waiting on them again. Their
+    // zCModel references still have to go back, though. Safe to do right here: SkeletalMeshVisuals
+    // and SkeletalMeshNpcs are already empty, so the OnVisualDeleted a release may trigger finds
+    // nothing left to tear down.
+    for ( auto& it : PendingSkeletalLoads ) {
+        QueueDeferredVisualRelease( it.second.Model );
+        for ( zCMeshSoftSkin* s : it.second.SoftSkins )
+            QueueDeferredVisualRelease( s );
+    }
     PendingSkeletalLoads.clear();
+    FlushDeferredVisualReleases();
 
     // Delete static mesh vobs
     for ( auto const& it : VobMap ) {
@@ -1967,7 +1983,12 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
                 }
 
                 auto it = SkeletalMeshVisuals.find( str );
-                if ( it != SkeletalMeshVisuals.end() ) {
+                // Only tear the cache entry down if it actually belongs to *this* model. Holding an
+                // extraction reference (LoadzCModelData) can push a model's destructor past the
+                // point where a reload has already re-bound this name to a newer model - tearing
+                // down here would then delete the live entry out from under it. A null Visual means
+                // the extraction never completed, i.e. the entry is nobody else's either.
+                if ( it != SkeletalMeshVisuals.end() && (!it->second->Visual || it->second->Visual == zmodel) ) {
                     // Find vobs using this visual
                     for ( SkeletalVobInfo* vobInfo : SkeletalMeshVobs ) {
                         if ( vobInfo->VisualInfo == it->second ) {
@@ -1975,8 +1996,8 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
                         }
                     }
 
-                    // The model is about to be freed by Gothic once this function returns - make sure no
-                    // background extraction job (GothicAPI::LoadzCModelData) is still reading from it.
+                    // Make sure no background extraction job (GothicAPI::LoadzCModelData) is still
+                    // writing into the info we are about to delete.
                     WaitForPendingSkeletalLoad( it->second );
 
                     delete SkeletalMeshVisuals[str];
@@ -1988,7 +2009,10 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
             if ( homeVob && homeVob->GetVobType() == zVOB_TYPE_NSC ) {
                 oCNPC* npc = static_cast<oCNPC*>(homeVob);
                 auto it = SkeletalMeshNpcs.find( npc );
-                if ( it != SkeletalMeshNpcs.end() ) {
+                // Same identity check as above, and the armor-change case is exactly what it is
+                // for: the NPC's entry may already have been rebuilt from its new zCModel by the
+                // time this (deferred) destructor gets to run.
+                if ( it != SkeletalMeshNpcs.end() && (!it->second->Visual || it->second->Visual == zmodel) ) {
                     // Find vobs using this visual
                     for ( SkeletalVobInfo* vobInfo : SkeletalMeshVobs ) {
                         if ( vobInfo->VisualInfo == it->second ) {
@@ -1996,8 +2020,8 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
                         }
                     }
 
-                    // The model is about to be freed by Gothic once this function returns - make sure no
-                    // background extraction job (GothicAPI::LoadzCModelData) is still reading from it.
+                    // Make sure no background extraction job (GothicAPI::LoadzCModelData) is still
+                    // writing into the info we are about to delete.
                     WaitForPendingSkeletalLoad( it->second );
 
                     delete SkeletalMeshNpcs[npc];
@@ -2442,9 +2466,32 @@ void GothicAPI::OnAddVob( zCVob* vob, zCWorld* world ) {
     }
 }
 
+/** Copies the model's softskin list and takes a reference on every entry, so a background extraction
+ *  can walk it without racing the game thread. Holding the zCModel alive is not enough: ZENGIN refills
+ *  zCModel::SoftSkinList *in place* (armor changes, mesh-lib swaps) and releases the old meshes as it
+ *  goes, and a zCMeshSoftSkin that is being torn down reports its old submesh count with an already
+ *  nulled submesh array - which zCProgMeshProto::GetSubmesh turns into a null (or near-null) pointer,
+ *  since it is plain arithmetic off that base. */
+static std::vector<zCMeshSoftSkin*> SnapshotSoftSkins( zCModel* model ) {
+    std::vector<zCMeshSoftSkin*> snapshot;
+
+    zCArray<zCMeshSoftSkin*>* list = model->GetMeshSoftSkinList();
+    if ( !list )
+        return snapshot;
+
+    snapshot.reserve( list->NumInArray );
+    for ( int i = 0; i < list->NumInArray; i++ ) {
+        if ( zCMeshSoftSkin* s = list->Array[i] ) {
+            zCObject_AddRef( s );
+            snapshot.push_back( s );
+        }
+    }
+    return snapshot;
+}
+
 /** Blocks until a background LoadzCModelData(...) extraction job for this visual (if any) has
- *  finished, then forgets about it. Must be called before deleting a SkeletalMeshVisualInfo or
- *  destroying the zCModel/oCNPC it was built from - the job reads directly from that model. */
+ *  finished, then forgets about it and queues the references it held for release.
+ *  Must be called before deleting a SkeletalMeshVisualInfo - the job writes directly into it. */
 void GothicAPI::WaitForPendingSkeletalLoad( SkeletalMeshVisualInfo* mi ) {
     if ( !mi )
         return;
@@ -2453,12 +2500,70 @@ void GothicAPI::WaitForPendingSkeletalLoad( SkeletalMeshVisualInfo* mi ) {
     if ( it == PendingSkeletalLoads.end() )
         return;
 
-    TaskHandle<void> handle = std::move( it->second );
+    PendingSkeletalLoad load = std::move( it->second );
     PendingSkeletalLoads.erase( it );
 
-    handle.cancel(); // Lets the job bail out immediately if it hasn't started running yet (see below)
-    if ( handle.future.valid() )
-        handle.future.wait();
+    load.Task.cancel(); // Lets the job bail out immediately if it hasn't started running yet (see below)
+    if ( load.Task.future.valid() )
+        load.Task.future.wait();
+
+    // Deliberately not released here: this is the last reference in the common case, and dropping
+    // it runs ZENGIN's zCModel destructor, which re-enters us through zCVisual::Hooked_Destructor
+    // -> OnVisualDeleted. Every caller is either inside OnVisualDeleted already or is holding 'mi'
+    // - which that re-entry would happily delete. FlushDeferredVisualReleases() does it later.
+    QueueDeferredVisualRelease( load.Model );
+    for ( zCMeshSoftSkin* s : load.SoftSkins )
+        QueueDeferredVisualRelease( s );
+}
+
+/** Extraction jobs that nobody comes back for would keep their zCModel reference (and with it the
+ *  model itself) alive forever. Retire the ones that have run to completion. */
+void GothicAPI::DrainFinishedSkeletalLoads() {
+    if ( PendingSkeletalLoads.empty() )
+        return;
+
+    static std::vector<SkeletalMeshVisualInfo*> finished; // Main thread only, keeps its capacity
+    finished.clear();
+
+    for ( auto& it : PendingSkeletalLoads ) {
+        if ( !it.second.Task.future.valid() ||
+            it.second.Task.future.wait_for( std::chrono::seconds( 0 ) ) == std::future_status::ready ) {
+            finished.push_back( it.first );
+        }
+    }
+
+    for ( SkeletalMeshVisualInfo* mi : finished )
+        WaitForPendingSkeletalLoad( mi ); // Already finished, so this doesn't block
+}
+
+/** Queues one extraction reference for release. Callable from anywhere, including from under
+ *  WorldConverter's node-visual mutex - all it does is append. */
+void GothicAPI::QueueDeferredVisualRelease( void* object ) {
+    if ( !object )
+        return;
+
+    std::scoped_lock lock( DeferredVisualReleaseMutex );
+    DeferredVisualReleases.push_back( object );
+}
+
+/** Hands the extraction references back to ZENGIN. Must only be called from a top-level main-thread
+ *  point: a release can run a visual's destructor, which comes back around into OnVisualDeleted. */
+void GothicAPI::FlushDeferredVisualReleases() {
+    for ( ;; ) {
+        void* object;
+        {
+            // The lock is dropped before the release: the destructor's OnVisualDeleted re-entry can
+            // queue further releases, and this mutex is not recursive. That re-entry is also why the
+            // vector is re-checked every round instead of being iterated.
+            std::scoped_lock lock( DeferredVisualReleaseMutex );
+            if ( DeferredVisualReleases.empty() )
+                return;
+
+            object = DeferredVisualReleases.back();
+            DeferredVisualReleases.pop_back();
+        }
+        zCObject_Release( object );
+    }
 }
 
 /** Loads the data out of a zCModel */
@@ -2475,34 +2580,43 @@ SkeletalMeshVisualInfo* GothicAPI::LoadzCModelData( zCModel* model ) {
         SkeletalMeshVisuals[str] = mi;
     }
 
-    if ( !mi->Ready.load() ) {
-        auto pendingLoad = PendingSkeletalLoads.find( mi );
-        if ( pendingLoad != PendingSkeletalLoads.end() ) {
-            if ( pendingLoad->second.future.valid() ) {
-                pendingLoad->second.future.wait();
-            }
-        }
-    }
+    // Retire whatever job was still attached to this info. It may be extracting from an older
+    // zCModel than the one we were just handed, and its reference has to come back either way.
+    WaitForPendingSkeletalLoad( mi );
 
     if ( !mi->Meshes.empty() )
         return mi; // Already loaded
 
     // Extraction (CPU vertex/weight unpacking + GPU buffer creation) is the expensive part of a
     // vob popping into range, so run it on a worker thread instead of stalling the main thread.
-    // GothicAPI::OnVisualDeleted() blocks on PendingSkeletalLoads before freeing this model/mi,
-    // and Ready gates every draw/update site so nobody touches Meshes/SkeletalMeshes early.
+    // Ready gates every draw/update site so nobody touches Meshes/SkeletalMeshes early.
     mi->Ready = false;
-    PendingSkeletalLoads[mi] = Engine::WorkerThreadPool->enqueue( [model, mi]( const std::stop_token& token ) {
+
+    // ZENGIN can free the model while the job is queued or running: a vob that unloads and reloads
+    // inside one frame drops refCtr to 0, the destructor runs, and the allocator happily hands the
+    // same address back out for the reload. Own a reference for the duration of the job instead of
+    // relying on nobody deleting the model in the meantime - it is handed back once the job is
+    // retired (WaitForPendingSkeletalLoad / DrainFinishedSkeletalLoads).
+    zCObject_AddRef( model );
+
+    PendingSkeletalLoad load;
+    load.Model = model;
+    load.SoftSkins = SnapshotSoftSkins( model );
+
+    const std::span<zCMeshSoftSkin* const> softSkins = load.SoftSkins;
+    load.Task = Engine::WorkerThreadPool->enqueue( [model, softSkins, mi]( const std::stop_token& token ) {
         if ( token.stop_requested() ) {
-            // Cancelled before a worker picked it up (WaitForPendingSkeletalLoad) - the model
-            // it would read from may already be gone, so don't touch it.
+            // Cancelled before a worker picked it up (WaitForPendingSkeletalLoad). The model is
+            // still alive - we hold a reference - but the caller no longer wants this extraction.
             mi->Ready.store( true );
             return;
         }
-        WorldConverter::ExtractSkeletalMeshFromVob( model, mi );
+        WorldConverter::ExtractSkeletalMeshFromVob( model, softSkins, mi );
         mi->Visual = model;
         mi->Ready.store( true );
     } );
+
+    PendingSkeletalLoads[mi] = std::move( load );
     return mi;
 }
 
@@ -2515,39 +2629,39 @@ SkeletalMeshVisualInfo* GothicAPI::LoadzCModelData( oCNPC* npc ) {
         SkeletalMeshNpcs[npc] = mi;
     }
 
-    if ( !mi->Ready.load() ) {
-        auto pendingLoad = PendingSkeletalLoads.find( mi );
-        if ( pendingLoad != PendingSkeletalLoads.end() ) {
-            if ( pendingLoad->second.future.valid() ) {
-                pendingLoad->second.future.wait();
-            }
-        }
-    }
+    // Retire the previous job first. For NPCs this is the armor-change case: the old job is very
+    // likely still extracting from the *previous* zCModel, which oCNPC::SetVisual has already
+    // released - only our own reference is keeping it alive.
+    WaitForPendingSkeletalLoad( mi );
 
     // can't cache the meshes and VisualName as it otherwise
     // won't properly fire for changing armors. for whatever reason...
 
-    // See LoadzCModelData(zCModel*) above for why this runs on a worker thread.
+    // See LoadzCModelData(zCModel*) above for why this runs on a worker thread and why we hold
+    // references on the model and its softskins while it does. The softskin snapshot matters most
+    // here: an armor change refills SoftSkinList in place on the game thread.
     mi->Ready = false;
-    if ( false /* TODO: the zCMesh can become corrupted on the worker thread when same frame load/unload/load */ ) {
-        PendingSkeletalLoads[mi] = Engine::WorkerThreadPool->enqueue( [model, mi]( const std::stop_token& token ) {
-            if ( token.stop_requested() ) {
-                // Cancelled before a worker picked it up (WaitForPendingSkeletalLoad) - the model
-                // it would read from may already be gone, so don't touch it.
-                mi->Ready.store( true );
-                return;
-            }
-            mi->ClearMeshes();
-            WorldConverter::ExtractSkeletalMeshFromVob( model, mi );
-            mi->Visual = model;
+    zCObject_AddRef( model );
+
+    PendingSkeletalLoad load;
+    load.Model = model;
+    load.SoftSkins = SnapshotSoftSkins( model );
+
+    const std::span<zCMeshSoftSkin* const> softSkins = load.SoftSkins;
+    load.Task = Engine::WorkerThreadPool->enqueue( [model, softSkins, mi]( const std::stop_token& token ) {
+        if ( token.stop_requested() ) {
+            // Cancelled before a worker picked it up (WaitForPendingSkeletalLoad). The model is
+            // still alive - we hold a reference - but the caller no longer wants this extraction.
             mi->Ready.store( true );
         } );
     } else {
         mi->ClearMeshes();
-        WorldConverter::ExtractSkeletalMeshFromVob( model, mi );
+        WorldConverter::ExtractSkeletalMeshFromVob( model, softSkins, mi );
         mi->Visual = model;
         mi->Ready.store( true );
-    }
+    } );
+
+    PendingSkeletalLoads[mi] = std::move( load );
     return mi;
 }
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -221,6 +221,27 @@ namespace
         return nDefault;
     }
     
+    // Win32's GetPrivateProfileInt clamps negative values to 0, which kills any "-1 = auto" sentinel.
+    // Parse the raw string ourselves instead.
+    OPT_DBG_NOINLINE int GetPrivateProfileSignedIntA(
+        const LPCSTR lpAppName,
+        const LPCSTR lpKeyName,
+        const int nDefault,
+        const std::string& lpFileName
+    ) {
+        constexpr int int_str_max = 30;
+        TCHAR nInt[int_str_max];
+        if ( auto count = ::GetPrivateProfileStringA( lpAppName, lpKeyName, nullptr, nInt, int_str_max, lpFileName.c_str() ) ) {
+            int value;
+            auto dataPtr = &nInt[0];
+            auto [_, ec] = std::from_chars( dataPtr, dataPtr + count, value );
+            if ( ec == std::errc{} ) {
+                return value;
+            }
+        }
+        return nDefault;
+    }
+
     template<typename T>
     std::string to_string_locale_independent(const T value) {
         std::array<char, 255> buffer;
@@ -5849,6 +5870,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "Shadows", "SkyOcclusionStrength", to_string_locale_independent( s.SkyOcclusionStrength ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "SkyIblNightFloor", to_string_locale_independent( s.SkyIblNightFloor ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "ShadowDepthSlopeBias", to_string_locale_independent( s.DebugSettings.ShadowCascades.ShadowDepthSlopeBias ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "FirstLodCascade", to_string_locale_independent( s.DebugSettings.ShadowCascades.FirstLodCascade ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "AllowSelfShadowingPointlights", to_string_locale_independent( s.AllowSelfShadowingPointlights ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "DisableStaticPointlights", to_string_locale_independent( s.DisableStaticPointlights ? TRUE : FALSE ).c_str(), ini.c_str() );
 
@@ -6008,6 +6030,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.SkyOcclusionStrength = GetPrivateProfileFloatA( "Shadows", "SkyOcclusionStrength", ds.SkyOcclusionStrength, ini );
         s.SkyIblNightFloor = GetPrivateProfileFloatA( "Shadows", "SkyIblNightFloor", ds.SkyIblNightFloor, ini );
         s.DebugSettings.ShadowCascades.ShadowDepthSlopeBias = GetPrivateProfileFloatA( "Shadows", "ShadowDepthSlopeBias", ds.DebugSettings.ShadowCascades.ShadowDepthSlopeBias, ini );
+        s.DebugSettings.ShadowCascades.FirstLodCascade = std::clamp( GetPrivateProfileSignedIntA( "Shadows", "FirstLodCascade", ds.DebugSettings.ShadowCascades.FirstLodCascade, ini ), -1, MAX_CSM_CASCADES );
         s.AllowSelfShadowingPointlights = GetPrivateProfileBoolA( "Shadows", "AllowSelfShadowingPointlights", ds.AllowSelfShadowingPointlights, ini );
         s.DisableStaticPointlights = GetPrivateProfileBoolA( "Shadows", "DisableStaticPointlights", ds.DisableStaticPointlights, ini );
 

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -1107,15 +1107,39 @@ private:
      *  missed it (origin had no visual yet). Cheap no-op once the shape is set. */
     void RepairShapeMeshEmitter( zCVob* source, zCParticleFX* fx );
 
+    /** A background LoadzCModelData(...) extraction job together with the zCObject references we
+     *  hold on everything it reads. The model reference is what keeps a vob that unloads and reloads
+     *  within the same frame from pulling the model out from under the worker; the softskin snapshot
+     *  is separate because zCModel::SoftSkinList is *refilled in place* on armor changes and mesh-lib
+     *  swaps - a live model is no guarantee that the meshes it pointed at a moment ago still exist. */
+    struct PendingSkeletalLoad {
+        TaskHandle<void> Task;
+        zCModel* Model = nullptr;
+        std::vector<zCMeshSoftSkin*> SoftSkins;
+    };
+
     /** In-flight background extraction jobs, keyed by the SkeletalMeshVisualInfo they populate.
-     *  Must be cancelled+waited-on before that SkeletalMeshVisualInfo (or the zCModel/oCNPC it
-     *  reads from) is destroyed - see WaitForPendingSkeletalLoad(). */
-    gtl::flat_hash_map<SkeletalMeshVisualInfo*, TaskHandle<void>> PendingSkeletalLoads;
+     *  Must be cancelled+waited-on before that SkeletalMeshVisualInfo is destroyed - see
+     *  WaitForPendingSkeletalLoad(). */
+    gtl::flat_hash_map<SkeletalMeshVisualInfo*, PendingSkeletalLoad> PendingSkeletalLoads;
+
+    /** zCObjects whose extraction reference we still owe ZENGIN. Dropping the last reference runs
+     *  the object's destructor, which re-enters us through zCVisual::Hooked_Destructor, so the
+     *  release can only happen at a top-level main-thread point - FlushDeferredVisualReleases(). */
+    std::vector<void*> DeferredVisualReleases;
+    std::mutex DeferredVisualReleaseMutex;
 
     /** Blocks until a background LoadzCModelData(...) extraction job for this visual (if any)
-     *  has finished, then removes it from PendingSkeletalLoads. Must be called before deleting
-     *  a SkeletalMeshVisualInfo or destroying the zCModel/oCNPC it was built from. */
+     *  has finished, then removes it from PendingSkeletalLoads and queues its zCModel reference
+     *  for release. Must be called before deleting a SkeletalMeshVisualInfo. */
     void WaitForPendingSkeletalLoad( SkeletalMeshVisualInfo* mi );
+
+    /** Retires every extraction job that has already finished, so the zCModel references they
+     *  hold don't outlive the job. Main thread, once per frame. */
+    void DrainFinishedSkeletalLoads();
+
+    /** Hands back the references queued by QueueDeferredVisualRelease(). */
+    void FlushDeferredVisualReleases();
 
     /** Set of all vobs we registered by now */
     gtl::flat_hash_set<zCVob*> RegisteredVobs;
@@ -1126,6 +1150,12 @@ private:
     /** Map of vobs and VobIndfos */
     gtl::flat_hash_map<zCVob*, VobInfo*> VobMap;
 public:
+    /** Queues one zCObject reference to be handed back at the next top-level main-thread point.
+     *  Never release an extraction reference directly: the destructor it may run re-enters
+     *  OnVisualDeleted, which walks (and can delete out of) the very structures the caller is in
+     *  the middle of - and, from WorldConverter's node-visual list, would deadlock on its mutex. */
+    void QueueDeferredVisualRelease( void* object );
+
     // temporarily, to allow CollectVisibleVobsHelper to be templated for inlining optimizations
     gtl::flat_hash_map<zCVobLight*, VobLightInfo*> VobLightMap;
     // Exposed for CollectLeafVobs/CollectVisibleVobsWithLeafCache (file-static helpers)

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -51,6 +51,13 @@ struct RndCullContext {
         horizon is rasterized for the player's view, so a shadow cascade must not test against it. */
     const class HorizonCuller* horizon = nullptr;
 
+    /** Drop static VOBs whose BaseVisualInfo::MeshSize (bounding-box diagonal) is below this, in world
+        units. 0 = keep everything, which is what every main-view pass wants. Set only by the shadow
+        cascades, which derive it from their own world-units-per-texel: a prop that resolves to under a
+        couple of texels in a coarse cascade costs its full vertex + raster work for a smudge. Rejecting
+        it here rather than at draw time also skips its instance upload and indirect command. */
+    float minVobSize = 0.0f;
+
     struct
     {
         float OutdoorVobs;

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -1107,40 +1107,6 @@ private:
      *  missed it (origin had no visual yet). Cheap no-op once the shape is set. */
     void RepairShapeMeshEmitter( zCVob* source, zCParticleFX* fx );
 
-    /** A background LoadzCModelData(...) extraction job together with the zCObject references we
-     *  hold on everything it reads. The model reference is what keeps a vob that unloads and reloads
-     *  within the same frame from pulling the model out from under the worker; the softskin snapshot
-     *  is separate because zCModel::SoftSkinList is *refilled in place* on armor changes and mesh-lib
-     *  swaps - a live model is no guarantee that the meshes it pointed at a moment ago still exist. */
-    struct PendingSkeletalLoad {
-        TaskHandle<void> Task;
-        zCModel* Model = nullptr;
-        std::vector<zCMeshSoftSkin*> SoftSkins;
-    };
-
-    /** In-flight background extraction jobs, keyed by the SkeletalMeshVisualInfo they populate.
-     *  Must be cancelled+waited-on before that SkeletalMeshVisualInfo is destroyed - see
-     *  WaitForPendingSkeletalLoad(). */
-    gtl::flat_hash_map<SkeletalMeshVisualInfo*, PendingSkeletalLoad> PendingSkeletalLoads;
-
-    /** zCObjects whose extraction reference we still owe ZENGIN. Dropping the last reference runs
-     *  the object's destructor, which re-enters us through zCVisual::Hooked_Destructor, so the
-     *  release can only happen at a top-level main-thread point - FlushDeferredVisualReleases(). */
-    std::vector<void*> DeferredVisualReleases;
-    std::mutex DeferredVisualReleaseMutex;
-
-    /** Blocks until a background LoadzCModelData(...) extraction job for this visual (if any)
-     *  has finished, then removes it from PendingSkeletalLoads and queues its zCModel reference
-     *  for release. Must be called before deleting a SkeletalMeshVisualInfo. */
-    void WaitForPendingSkeletalLoad( SkeletalMeshVisualInfo* mi );
-
-    /** Retires every extraction job that has already finished, so the zCModel references they
-     *  hold don't outlive the job. Main thread, once per frame. */
-    void DrainFinishedSkeletalLoads();
-
-    /** Hands back the references queued by QueueDeferredVisualRelease(). */
-    void FlushDeferredVisualReleases();
-
     /** Set of all vobs we registered by now */
     gtl::flat_hash_set<zCVob*> RegisteredVobs;
 
@@ -1150,12 +1116,6 @@ private:
     /** Map of vobs and VobIndfos */
     gtl::flat_hash_map<zCVob*, VobInfo*> VobMap;
 public:
-    /** Queues one zCObject reference to be handed back at the next top-level main-thread point.
-     *  Never release an extraction reference directly: the destructor it may run re-enters
-     *  OnVisualDeleted, which walks (and can delete out of) the very structures the caller is in
-     *  the middle of - and, from WorldConverter's node-visual list, would deadlock on its mutex. */
-    void QueueDeferredVisualRelease( void* object );
-
     // temporarily, to allow CollectVisibleVobsHelper to be templated for inlining optimizations
     gtl::flat_hash_map<zCVobLight*, VobLightInfo*> VobLightMap;
     // Exposed for CollectLeafVobs/CollectVisibleVobsWithLeafCache (file-static helpers)

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -727,6 +727,8 @@ struct GothicRendererSettings {
         // Past readable-silhouette range, but well inside OutdoorVobDrawRadius so it covers most of the
         // visible VOB population.
         VobLodDrawRadius = 8000.0f;
+        // Off until a capture says otherwise — see the field comment.
+        VobAlphaPrepassRadius = 0.0f;
 
 #if BUILD_SPACER_NET
         VisualFXDrawRadius = 16000.0f;
@@ -1127,6 +1129,13 @@ struct GothicRendererSettings {
     // Distance past which an instanced VOB draws its reduced index buffer (D3D12 main view; cascades pick
     // LOD by cascade index). 0 = off. Bucketed per INSTANCE in CSCull - Gothic reuses visuals map-wide.
     float VobLodDrawRadius;
+    // D3D12 + GPU VOB culling only. Alpha-tested VOB instances further than this from the camera are left
+    // OUT of the depth prepass (they still draw, lit, in the color pass). Cutout materials are what make the
+    // VOB prepass expensive - their clip pixel shader runs over the full silhouette - and a distant one
+    // re-shades in the lit pass anyway, so paying for it twice buys only the tiled light cull's near-plane
+    // bound. Safe because the lit passes use GREATER_EQUAL + full depth write, never EQUAL.
+    // 0 = off, and that is the default deliberately: the useful threshold has to come from a capture.
+    float VobAlphaPrepassRadius;
     float SmallVobSize;
     float WorldShadowRangeScale;
     int NumShadowCascades;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -1315,11 +1315,10 @@ struct GothicRendererSettings {
             // collapse introduces, so they self-shadow the full-detail surface black - see WorldConverter.h.
             int FirstLodCascade;
             // Drop a VOB caster from a cascade when its bounding-box diagonal covers fewer than this many
-            // texels OF THAT CASCADE. The far cascades stretch one texel over a lot of world, so props that
-            // resolve to a pixel or two of shadow there still cost their full vertex + raster work; this is
-            // the lever on VOB casters dominating the shadow pass. Scaled per cascade by
-            // D3D12ShadowMap::m_CascadeTexelWorld, so the near cascade (fine texels) drops almost nothing and
-            // only the coarse far ones prune hard. 0 disables it entirely.
+            // texels OF THAT CASCADE. Scaled per cascade by D3D12ShadowMap::m_CascadeTexelWorld, so the near
+            // cascade (fine texels) drops almost nothing and only the coarse far ones prune hard, where a
+            // prop resolves to a pixel or two of shadow but still costs its full vertex + raster work.
+            // 0 disables it entirely.
             float CasterMinTexels;
         } ShadowCascades;
         struct {

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -980,6 +980,7 @@ struct GothicRendererSettings {
         DebugSettings.Culling.CullVobs = true;
         DebugSettings.ShadowCascades.LazyCascadeUpdate = true;
         DebugSettings.ShadowCascades.ShadowDepthSlopeBias = 0.0f;
+        DebugSettings.ShadowCascades.FirstLodCascade = -1; // auto
         DebugSettings.FeatureSet.EnableDriverExtensions = true;
         DebugSettings.FeatureSet.UseWorldSectionBVH = true;
         DebugSettings.FeatureSet.UseScreenSpaceShadowMask = false;
@@ -1304,6 +1305,12 @@ struct GothicRendererSettings {
             float Lambda;
             float Bias;
             float ShadowDepthSlopeBias;
+            // First shadow cascade allowed to draw the baked progressive-mesh LOD index buffer.
+            // -1 = auto (D3D11: last cascade, but never below SHADOW_LOD_FIRST_CASCADE; D3D12:
+            // SHADOW_LOD_FIRST_CASCADE). A value >= NumShadowCascades disables the LOD entirely.
+            // Cascades below SHADOW_LOD_FIRST_CASCADE are biased tighter than the deviation an edge
+            // collapse introduces, so they self-shadow the full-detail surface black - see WorldConverter.h.
+            int FirstLodCascade;
         } ShadowCascades;
         struct {
             bool CullVobs;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -724,6 +724,9 @@ struct GothicRendererSettings {
         OutdoorVobDrawRadius = 30000.0f;
         SkeletalMeshDrawRadius = 6000.0f;
         VisualFXDrawRadius = 10000.0f;
+        // Past readable-silhouette range, but well inside OutdoorVobDrawRadius so it covers most of the
+        // visible VOB population.
+        VobLodDrawRadius = 8000.0f;
 
 #if BUILD_SPACER_NET
         VisualFXDrawRadius = 16000.0f;
@@ -1117,6 +1120,9 @@ struct GothicRendererSettings {
     float SkeletalMeshDrawRadius;
     float OutdoorSmallVobDrawRadius;
     float VisualFXDrawRadius;
+    // Distance past which an instanced VOB draws its reduced index buffer (D3D12 main view; cascades pick
+    // LOD by cascade index). 0 = off. Bucketed per INSTANCE in CSCull - Gothic reuses visuals map-wide.
+    float VobLodDrawRadius;
     float SmallVobSize;
     float WorldShadowRangeScale;
     int NumShadowCascades;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -727,8 +727,6 @@ struct GothicRendererSettings {
         // Past readable-silhouette range, but well inside OutdoorVobDrawRadius so it covers most of the
         // visible VOB population.
         VobLodDrawRadius = 8000.0f;
-        // Off until a capture says otherwise — see the field comment.
-        VobAlphaPrepassRadius = 0.0f;
 
 #if BUILD_SPACER_NET
         VisualFXDrawRadius = 16000.0f;
@@ -1129,13 +1127,6 @@ struct GothicRendererSettings {
     // Distance past which an instanced VOB draws its reduced index buffer (D3D12 main view; cascades pick
     // LOD by cascade index). 0 = off. Bucketed per INSTANCE in CSCull - Gothic reuses visuals map-wide.
     float VobLodDrawRadius;
-    // D3D12 + GPU VOB culling only. Alpha-tested VOB instances further than this from the camera are left
-    // OUT of the depth prepass (they still draw, lit, in the color pass). Cutout materials are what make the
-    // VOB prepass expensive - their clip pixel shader runs over the full silhouette - and a distant one
-    // re-shades in the lit pass anyway, so paying for it twice buys only the tiled light cull's near-plane
-    // bound. Safe because the lit passes use GREATER_EQUAL + full depth write, never EQUAL.
-    // 0 = off, and that is the default deliberately: the useful threshold has to come from a capture.
-    float VobAlphaPrepassRadius;
     float SmallVobSize;
     float WorldShadowRangeScale;
     int NumShadowCascades;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -981,6 +981,9 @@ struct GothicRendererSettings {
         DebugSettings.ShadowCascades.LazyCascadeUpdate = true;
         DebugSettings.ShadowCascades.ShadowDepthSlopeBias = 0.0f;
         DebugSettings.ShadowCascades.FirstLodCascade = -1; // auto
+        // Deliberately conservative: at 2 texels only props that resolve to a smudge get dropped. Raise it
+        // against a capture - this is the one lever left on VOB casters dominating the shadow pass.
+        DebugSettings.ShadowCascades.CasterMinTexels = 2.0f;
         DebugSettings.FeatureSet.EnableDriverExtensions = true;
         DebugSettings.FeatureSet.UseWorldSectionBVH = true;
         DebugSettings.FeatureSet.UseScreenSpaceShadowMask = false;
@@ -1311,6 +1314,13 @@ struct GothicRendererSettings {
             // Cascades below SHADOW_LOD_FIRST_CASCADE are biased tighter than the deviation an edge
             // collapse introduces, so they self-shadow the full-detail surface black - see WorldConverter.h.
             int FirstLodCascade;
+            // Drop a VOB caster from a cascade when its bounding-box diagonal covers fewer than this many
+            // texels OF THAT CASCADE. The far cascades stretch one texel over a lot of world, so props that
+            // resolve to a pixel or two of shadow there still cost their full vertex + raster work; this is
+            // the lever on VOB casters dominating the shadow pass. Scaled per cascade by
+            // D3D12ShadowMap::m_CascadeTexelWorld, so the near cascade (fine texels) drops almost nothing and
+            // only the coarse far ones prune hard. 0 disables it entirely.
+            float CasterMinTexels;
         } ShadowCascades;
         struct {
             bool CullVobs;

--- a/D3D11Engine/ImGuiEditorView.cpp
+++ b/D3D11Engine/ImGuiEditorView.cpp
@@ -700,17 +700,31 @@ void ImGuiEditorView::DoSelection() {
 }
 
 void ImGuiEditorView::VisualizeMeshInfo(MeshInfo* m, const XMFLOAT4& color, bool showBounds, const XMFLOAT4X4* world) {
+    // World meshes dropped their full vertices after upload and serve the slim copy instead; everything
+    // else (VOB sub-meshes, BSP node boxes) still has Vertices. Resolved once, not per triangle.
+    const std::vector<WorldVertexCPU>* slim = m->GetCpuVertices();
+    if ((slim ? slim->empty() : m->Vertices.empty())) {
+        return;
+    }
+
+    auto position = [&](VERTEX_INDEX idx) -> const float3& {
+        return slim ? (*slim)[idx].Position : m->Vertices[idx].Position;
+    };
+    auto edgeMark = [&](VERTEX_INDEX idx) -> float {
+        return slim ? (*slim)[idx].TexCoord2.x : m->Vertices[idx].TexCoord2.x;
+    };
+
     for (unsigned int i = 0; i < m->Indices.size(); i += 3) {
         XMFLOAT3 tri[3];
         float edge[3];
 
-        tri[0] = m->Vertices[m->Indices[i]].Position;
-        tri[1] = m->Vertices[m->Indices[i + 1]].Position;
-        tri[2] = m->Vertices[m->Indices[i + 2]].Position;
+        tri[0] = position(m->Indices[i]);
+        tri[1] = position(m->Indices[i + 1]);
+        tri[2] = position(m->Indices[i + 2]);
 
-        edge[0] = m->Vertices[m->Indices[i]].TexCoord2.x;
-        edge[1] = m->Vertices[m->Indices[i + 1]].TexCoord2.x;
-        edge[2] = m->Vertices[m->Indices[i + 2]].TexCoord2.x;
+        edge[0] = edgeMark(m->Indices[i]);
+        edge[1] = edgeMark(m->Indices[i + 1]);
+        edge[2] = edgeMark(m->Indices[i + 2]);
 
         if (world) {
             XMMATRIX XMV_world = XMLoadFloat4x4(world);
@@ -1195,10 +1209,19 @@ void ImGuiEditorView::OnDelete() {
     }
 
     if (Selection.SelectedMesh && Selection.SelectedMaterial && Selection.SelectedMaterial->GetTextureSingle()) {
-        // Find the section of this mesh
-        FXMVECTOR Position0 = XMVectorSet(Selection.SelectedMesh->Vertices[0].Position.x, Selection.SelectedMesh->Vertices[0].Position.y, Selection.SelectedMesh->Vertices[0].Position.z, 0);
-        FXMVECTOR Position1 = XMVectorSet(Selection.SelectedMesh->Vertices[1].Position.x, Selection.SelectedMesh->Vertices[1].Position.y, Selection.SelectedMesh->Vertices[1].Position.z, 0);
-        FXMVECTOR Position2 = XMVectorSet(Selection.SelectedMesh->Vertices[2].Position.x, Selection.SelectedMesh->Vertices[2].Position.y, Selection.SelectedMesh->Vertices[2].Position.z, 0);
+        // Find the section of this mesh. Selected meshes come from TraceWorldMesh, so they are world
+        // meshes serving the slim copy; the Vertices branch covers anything else that gets selected.
+        const std::vector<WorldVertexCPU>* slim = Selection.SelectedMesh->GetCpuVertices();
+        const size_t vertexCount = slim ? slim->size() : Selection.SelectedMesh->Vertices.size();
+        if (vertexCount < 3) {
+            return;
+        }
+        auto vpos = [&](size_t idx) -> const float3& {
+            return slim ? (*slim)[idx].Position : Selection.SelectedMesh->Vertices[idx].Position;
+        };
+        FXMVECTOR Position0 = XMVectorSet(vpos(0).x, vpos(0).y, vpos(0).z, 0);
+        FXMVECTOR Position1 = XMVectorSet(vpos(1).x, vpos(1).y, vpos(1).z, 0);
+        FXMVECTOR Position2 = XMVectorSet(vpos(2).x, vpos(2).y, vpos(2).z, 0);
         XMFLOAT3 avgPos;
         XMStoreFloat3(&avgPos, (Position0 + Position1 + Position2) / 3.0f);
 

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1477,8 +1477,9 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
 
         ImGui::SliderFloat( "VobLodDrawRadius", &settings.VobLodDrawRadius, 0.0f, 50000.0f, "%.0f", ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput );
         ImGui::SetItemTooltip( "D3D12 only. Distance past which static VOBs switch to their reduced\n"
-            "progressive-mesh LOD. 0 disables it. Requires GPU VOB culling, which\n"
-            "produces the per-instance near/far split this draws from." );
+            "progressive-mesh LOD. 0 disables it. Works with GPU VOB culling either way:\n"
+            "the per-instance near/far split comes from the cull compute shader when that\n"
+            "is on, and from the CPU instance upload when it is off." );
 
         ImGui::SliderFloat( "VobAlphaPrepassRadius", &settings.VobAlphaPrepassRadius, 0.0f, 50000.0f, "%.0f", ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput );
         ImGui::SetItemTooltip( "D3D12 only. Alpha-tested (cutout) VOB instances further away than this are\n"

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1481,15 +1481,6 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
             "the per-instance near/far split comes from the cull compute shader when that\n"
             "is on, and from the CPU instance upload when it is off." );
 
-        ImGui::SliderFloat( "VobAlphaPrepassRadius", &settings.VobAlphaPrepassRadius, 0.0f, 50000.0f, "%.0f", ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput );
-        ImGui::SetItemTooltip( "D3D12 only. Alpha-tested (cutout) VOB instances further away than this are\n"
-            "left OUT of the depth prepass - they still draw, lit, in the color pass.\n"
-            "Their clip pixel shader over the full silhouette is what makes the VOB\n"
-            "prepass expensive, and a distant one re-shades in the lit pass anyway.\n"
-            "Cost of lowering it: slightly looser tiled-light-cull near planes and more\n"
-            "lit-pass overdraw behind foliage. No effect while TAA/motion vectors are on\n"
-            "(the G-buffer prepass needs every pixel). 0 disables it. Requires GPU VOB culling." );
-
         // ImGui::Checkbox( "Draw Sky", &settings.DrawSky );
         if ( ImGui::Checkbox( "Draw Fog", &settings.DrawFog ) ) {
             if ( Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D11 ) {
@@ -2119,11 +2110,10 @@ void RenderAdvancedColumn3( GothicRendererSettings& settings, GothicAPI* gapi ) 
                 ImGui::Text( vs.GpuCullActive ? "on" : "OFF (splits inert)" );
                 addRowUInt( "VOB Commands", vs.Commands );
                 addRowUInt( "VOB Cmd opaque", vs.OpaqueCommands );
-                addRowUInt( "VOB Cmd alphaNear", vs.AlphaNearCommands );
                 addRowUInt( "VOB Instances", vs.Instances );
                 addRowUInt( "VOB Visuals", vs.CullVisuals );
-                addRowLabel( "VOB Splits n/lod/alpha" );
-                ImGui::Text( "%u / %u / %u", vs.SplitNone, vs.SplitLod, vs.SplitAlpha );
+                addRowLabel( "VOB Splits none/lod" );
+                ImGui::Text( "%u / %u", vs.SplitNone, vs.SplitLod );
             }
             addRowFloat( "FarPlane", rendererInfo.FarPlane, "%.0f" );
             addRowFloat( "NearPlane", rendererInfo.NearPlane, "%.0f" );

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1480,6 +1480,15 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
             "progressive-mesh LOD. 0 disables it. Requires GPU VOB culling, which\n"
             "produces the per-instance near/far split this draws from." );
 
+        ImGui::SliderFloat( "VobAlphaPrepassRadius", &settings.VobAlphaPrepassRadius, 0.0f, 50000.0f, "%.0f", ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput );
+        ImGui::SetItemTooltip( "D3D12 only. Alpha-tested (cutout) VOB instances further away than this are\n"
+            "left OUT of the depth prepass - they still draw, lit, in the color pass.\n"
+            "Their clip pixel shader over the full silhouette is what makes the VOB\n"
+            "prepass expensive, and a distant one re-shades in the lit pass anyway.\n"
+            "Cost of lowering it: slightly looser tiled-light-cull near planes and more\n"
+            "lit-pass overdraw behind foliage. No effect while TAA/motion vectors are on\n"
+            "(the G-buffer prepass needs every pixel). 0 disables it. Requires GPU VOB culling." );
+
         // ImGui::Checkbox( "Draw Sky", &settings.DrawSky );
         if ( ImGui::Checkbox( "Draw Fog", &settings.DrawFog ) ) {
             if ( Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D11 ) {
@@ -2098,6 +2107,23 @@ void RenderAdvancedColumn3( GothicRendererSettings& settings, GothicAPI* gapi ) 
             addRowInt( "DrawnLights", rendererInfo.FrameDrawnLights );
             addRowInt( "SectionsDrawn", rendererInfo.FrameNumSectionsDrawn );
             addRowInt( "WorldMeshDrawCalls", rendererInfo.WorldMeshDrawCalls );
+
+            // D3D12 VOB submission shape. The VOB passes dominate the frame and the three candidate causes
+            // — command count, instance count, triangle count — look identical in a Tracy GPU zone, so they
+            // are all listed here. SplitNone/Lod/Alpha say whether the LOD and alpha-prepass sliders are
+            // engaged at all: if everything sits in SplitNone, neither can be doing anything.
+            if ( auto* d12 = dynamic_cast<D3D12GraphicsEngine*>( Engine::GraphicsEngine ) ) {
+                const auto& vs = d12->GetVobFrameStats();
+                addRowLabel( "VOB GpuCull" );
+                ImGui::Text( vs.GpuCullActive ? "on" : "OFF (splits inert)" );
+                addRowUInt( "VOB Commands", vs.Commands );
+                addRowUInt( "VOB Cmd opaque", vs.OpaqueCommands );
+                addRowUInt( "VOB Cmd alphaNear", vs.AlphaNearCommands );
+                addRowUInt( "VOB Instances", vs.Instances );
+                addRowUInt( "VOB Visuals", vs.CullVisuals );
+                addRowLabel( "VOB Splits n/lod/alpha" );
+                ImGui::Text( "%u / %u / %u", vs.SplitNone, vs.SplitLod, vs.SplitAlpha );
+            }
             addRowFloat( "FarPlane", rendererInfo.FarPlane, "%.0f" );
             addRowFloat( "NearPlane", rendererInfo.NearPlane, "%.0f" );
 

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1475,6 +1475,11 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         ImGui::SetItemTooltip( "Draw distance for Special effects, like torches, spells, campfires..." );
         ImGui::EndDisabled();
 
+        ImGui::SliderFloat( "VobLodDrawRadius", &settings.VobLodDrawRadius, 0.0f, 50000.0f, "%.0f", ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput );
+        ImGui::SetItemTooltip( "D3D12 only. Distance past which static VOBs switch to their reduced\n"
+            "progressive-mesh LOD. 0 disables it. Requires GPU VOB culling, which\n"
+            "produces the per-instance near/far split this draws from." );
+
         // ImGui::Checkbox( "Draw Sky", &settings.DrawSky );
         if ( ImGui::Checkbox( "Draw Fog", &settings.DrawFog ) ) {
             if ( Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D11 ) {

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1857,6 +1857,20 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 ImGui::SliderFloat("Split Bias", &settings.DebugSettings.ShadowCascades.Bias, 0.0f, 10.0f, "%.1f");
                 ImGui::SliderFloat("Depth Slope Bias", &settings.DebugSettings.ShadowCascades.ShadowDepthSlopeBias, 0.0f, 8.0f, "%.6f");
                 ImGui::SetItemTooltip("Slope-scaled depth bias for the shadow caster pass. Higher removes shadow acne/stepping on thin geometry; too high detaches contact shadows (peter-panning)");
+
+                int& firstLodCascade = settings.DebugSettings.ShadowCascades.FirstLodCascade;
+                firstLodCascade = std::clamp( firstLodCascade, -1, MAX_CSM_CASCADES );
+                const char* lodFormat = firstLodCascade < 0 ? "Auto"
+                    : (firstLodCascade >= settings.NumShadowCascades ? "%d (off)" : "%d");
+                if ( ImGui::SliderInt( "First LOD cascade", &firstLodCascade, -1, MAX_CSM_CASCADES, lodFormat, ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput ) ) {
+                    firstLodCascade = std::clamp( firstLodCascade, -1, MAX_CSM_CASCADES );
+                }
+                ImGui::SetItemTooltip("First shadow cascade that draws the baked progressive-mesh LOD instead of the\n"
+                                      "full-detail caster geometry. Auto = last cascade on D3D11, cascade %d on D3D12.\n"
+                                      "Lower is cheaper but an edge collapse moves the surface: tight cascades then\n"
+                                      "self-shadow black (facades darkening as the camera tilts up).\n"
+                                      "A value >= the cascade count (%d) disables shadow LOD.",
+                                      SHADOW_LOD_FIRST_CASCADE, settings.NumShadowCascades);
                 ImGui::EndTabItem();
             }
 

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1871,6 +1871,15 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                                       "self-shadow black (facades darkening as the camera tilts up).\n"
                                       "A value >= the cascade count (%d) disables shadow LOD.",
                                       SHADOW_LOD_FIRST_CASCADE, settings.NumShadowCascades);
+
+                ImGui::SliderFloat( "Caster min texels", &settings.DebugSettings.ShadowCascades.CasterMinTexels,
+                    0.0f, 16.0f, "%.1f", ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput );
+                ImGui::SetItemTooltip("Drop a VOB caster from a cascade when its bounding-box diagonal covers\n"
+                                      "fewer than this many texels OF THAT CASCADE (D3D12 only). Scaled per\n"
+                                      "cascade by its own world-units-per-texel, so the near cascade drops\n"
+                                      "almost nothing and only the coarse far ones prune hard. Raising this is\n"
+                                      "the main lever on VOB casters dominating the shadow pass; too high and\n"
+                                      "small props visibly stop casting. 0 = off.");
                 ImGui::EndTabItem();
             }
 

--- a/D3D11Engine/MeshLodBuilder.h
+++ b/D3D11Engine/MeshLodBuilder.h
@@ -42,9 +42,9 @@ namespace MeshLod {
 
     inline void ReportStats() {
         const uint32_t total = g_Built + g_SkipSmall + g_SkipStride + g_SkipNoReduction;
-        // First sub-mesh, then every 500. A plain "every N" gate prints nothing at all when a world has
-        // fewer than N sub-meshes, which makes silence ambiguous between "nothing ran" and "nothing to
-        // report" - the exact thing this counter exists to distinguish. EVERY exit path must call this.
+        // First sub-mesh, then every 500: a plain "every N" gate prints nothing at all in a world with
+        // fewer than N sub-meshes, which is the ambiguity this counter exists to remove. EVERY exit path
+        // must call this.
         if ( total != 1 && ( total == 0 || total % 500 != 0 ) ) return;
         const uint64_t in = g_TrisIn, out = g_TrisOut;
         LogInfo() << "VOB LOD: " << g_Built.load() << " built / " << total << " submeshes"

--- a/D3D11Engine/MeshLodBuilder.h
+++ b/D3D11Engine/MeshLodBuilder.h
@@ -1,0 +1,124 @@
+#pragma once
+
+/** Backend-neutral construction of a mesh's reduced (LOD) index list.
+
+    Shared on purpose: both backends implement GfxVertexBuffer::OptimizeVertices independently and each used
+    to carry its own copy, so reworking one silently changed nothing in the other. Do not re-fork. */
+
+#include "VertexTypes.h"
+#include "Logger.h"
+
+#include <meshoptimizer/src/meshoptimizer.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace MeshLod {
+
+    /** Compile-time: the buffer is baked at visual-extraction time, so the runtime knob is the DISTANCE it
+        is used at (VobLodDrawRadius), not this. One buffer serves both the far shadow cascades and the main
+        view, and 0.35 matches what the cascades got before - laxer would regress shadows (~45% of frame). */
+    constexpr float kTriangleRatio = 0.35f;
+    /** Max deviation, relative to mesh extents. MEASURED: at 0.02 this - not kTriangleRatio - was the
+        binding constraint (500 submeshes reduced to 72% while asking for 35%). Lower it if silhouettes
+        wobble; do not raise the ratio instead. */
+    constexpr float kTargetError = 0.10f;
+    /** Modest on purpose: Gothic's UVs tile hard, and an over-weighted UV term refuses almost every useful
+        collapse. */
+    constexpr float kNormalWeight = 0.5f;
+    constexpr float kUvWeight     = 0.5f;
+    /** Floor protecting 32-bit address space from trivial extra buffers. Applied PER MATERIAL sub-mesh, so
+        it lands on a fraction of a prop - at the inherited 96 it rejected 300 of 500. The principled fix is
+        to gate on the visual's total, which needs that count plumbed into the per-sub-mesh OptimizeVertices. */
+    constexpr size_t kMinTriangles = 32;
+
+    /** Build tally: "no LODs at all" has several causes that look identical in-game, so log the breakdown
+        rather than guess. Atomic - visual extraction runs on the worker pool. */
+    inline std::atomic<uint32_t> g_Built{ 0 }, g_SkipSmall{ 0 }, g_SkipStride{ 0 }, g_SkipNoReduction{ 0 };
+    inline std::atomic<uint64_t> g_TrisIn{ 0 }, g_TrisOut{ 0 };
+
+    inline void ReportStats() {
+        const uint32_t total = g_Built + g_SkipSmall + g_SkipStride + g_SkipNoReduction;
+        // First sub-mesh, then every 500. A plain "every N" gate prints nothing at all when a world has
+        // fewer than N sub-meshes, which makes silence ambiguous between "nothing ran" and "nothing to
+        // report" - the exact thing this counter exists to distinguish. EVERY exit path must call this.
+        if ( total != 1 && ( total == 0 || total % 500 != 0 ) ) return;
+        const uint64_t in = g_TrisIn, out = g_TrisOut;
+        LogInfo() << "VOB LOD: " << g_Built.load() << " built / " << total << " submeshes"
+            << " (skipped: " << g_SkipSmall.load() << " too-small, " << g_SkipStride.load() << " stride, "
+            << g_SkipNoReduction.load() << " no-reduction)"
+            << "; tris " << in << " -> " << out
+            << ( in ? " (" + std::to_string( out * 100 / in ) + "%)" : "" );
+    }
+
+    /** Builds the reduced index list over the fetch-remapped vertex buffer. Clears it on anything
+        unexpected - callers read an empty list as "no reduced level" and fall back to full detail.
+
+        Replaces ZENGIN's progressive-mesh collapse, which needed a position weld to be geometrically sound
+        but was therefore depth-only (the weld merges wedges differing only in UV/normal). Those two
+        requirements conflict; an attribute-aware simplifier has none, and its output indexes the SAME
+        vertex buffer, so this stays one index buffer valid for both the lit view and the cascades.
+
+        `convertToVertexIndex` is the caller's uint32 -> VERTEX_INDEX narrowing helper; false on overflow. */
+    template <typename ConvertFn>
+    void BuildSimplifiedIndices( std::vector<VERTEX_INDEX>& lodIndices,
+        const std::vector<unsigned int>& remappedIndices,
+        const std::vector<byte>& remappedVertices,
+        size_t fetchedVertexCount,
+        unsigned int stride,
+        ConvertFn convertToVertexIndex ) {
+        lodIndices.clear();
+
+        // The attribute offsets below are ExVertexStruct's; any other stream shape gets no LOD rather than
+        // a mis-read attribute run.
+        if ( stride != sizeof( ExVertexStruct ) ) { ++g_SkipStride; ReportStats(); return; }
+        if ( remappedIndices.size() < kMinTriangles * 3 || remappedIndices.size() % 3 != 0 ) { ++g_SkipSmall; ReportStats(); return; }
+        if ( fetchedVertexCount == 0 ) { ++g_SkipSmall; ReportStats(); return; }
+
+        // Normal (+12) and TexCoord (+24) are adjacent, so they feed the simplifier as one contiguous
+        // 5-float run rather than needing a repacked scratch buffer.
+        static_assert( offsetof( ExVertexStruct, TexCoord ) == offsetof( ExVertexStruct, Normal ) + 3 * sizeof( float ),
+            "BuildSimplifiedIndices feeds Normal+TexCoord as a single 5-float attribute run" );
+        const float* positions = reinterpret_cast<const float*>( remappedVertices.data() );
+        const float* attributes = reinterpret_cast<const float*>(
+            remappedVertices.data() + offsetof( ExVertexStruct, Normal ) );
+        const float weights[5] = { kNormalWeight, kNormalWeight, kNormalWeight, kUvWeight, kUvWeight };
+
+        const size_t targetIndices = static_cast<size_t>( remappedIndices.size() * kTriangleRatio ) / 3 * 3;
+        if ( targetIndices == 0 || targetIndices >= remappedIndices.size() ) { ++g_SkipSmall; ReportStats(); return; }
+
+        std::vector<unsigned int> simplified( remappedIndices.size() );
+        // LockBorder is not optional: per-material sub-meshes share border edges, and simplifying them
+        // independently without pinning those borders cracks every reduced VOB between its material patches.
+        const size_t resultCount = meshopt_simplifyWithAttributes( simplified.data(),
+            remappedIndices.data(), remappedIndices.size(),
+            positions, fetchedVertexCount, stride,
+            attributes, stride, weights, 5,
+            nullptr,   // no per-vertex lock mask beyond the border rule
+            targetIndices, kTargetError, meshopt_SimplifyLockBorder, nullptr );
+
+        // A mesh the simplifier could not usefully reduce (dense silhouette, or all-border after the lock)
+        // gets no LOD buffer rather than a same-size one that costs memory and saves nothing.
+        if ( resultCount == 0 || resultCount % 3 != 0 || resultCount >= remappedIndices.size() ) {
+            ++g_SkipNoReduction;
+            ReportStats();
+            return;
+        }
+
+        lodIndices.resize( resultCount );
+        simplified.resize( resultCount );
+        if ( !convertToVertexIndex( simplified, lodIndices.data(), lodIndices.size() ) ) {
+            lodIndices.clear();
+            ++g_SkipNoReduction;
+        } else {
+            ++g_Built;
+            g_TrisIn += remappedIndices.size() / 3;
+            g_TrisOut += resultCount / 3;
+        }
+        ReportStats();
+    }
+
+}   // namespace MeshLod

--- a/D3D11Engine/MeshShadowIndexBuilder.h
+++ b/D3D11Engine/MeshShadowIndexBuilder.h
@@ -1,0 +1,97 @@
+#pragma once
+
+/** Backend-neutral construction of a mesh's position-welded (shadow) index list.
+
+    Shared for the same reason as MeshLodBuilder.h: both backends implement GfxVertexBuffer::OptimizeVertices
+    independently, and a rule that lives in only one of them silently does nothing in the other. */
+
+#include "VertexTypes.h"
+#include "Logger.h"
+
+#include <meshoptimizer/src/meshoptimizer.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace MeshShadow {
+
+    /** Build tally. Atomic - visual extraction runs on the worker pool. */
+    inline std::atomic<uint32_t> g_Built{ 0 }, g_SkipIdentical{ 0 }, g_SkipOverflow{ 0 };
+    inline std::atomic<uint64_t> g_BytesSaved{ 0 };
+
+    inline void ReportStats() {
+        const uint32_t total = g_Built + g_SkipIdentical + g_SkipOverflow;
+        // Same cadence rule as MeshLod::ReportStats: first sub-mesh, then every 500, so that silence is
+        // never ambiguous between "nothing ran" and "fewer than N sub-meshes exist".
+        if ( total != 1 && ( total == 0 || total % 500 != 0 ) ) return;
+        LogInfo() << "Shadow IB: " << g_Built.load() << " built / " << total << " submeshes"
+            << " (" << g_SkipIdentical.load() << " identical to render IB, "
+            << g_SkipOverflow.load() << " overflow)"
+            << "; skipped " << ( g_BytesSaved.load() / 1024 ) << " KiB of index data";
+    }
+
+    /** Builds the position-welded index list over the fetch-remapped vertex buffer, and DROPS it when it
+        came out byte-identical to the render index list.
+
+        Welding buys two things - fewer unique vertices for the vertex cache, and a smaller post-transform
+        working set - and it buys neither on a mesh whose vertices all sit at distinct positions, which is
+        the common shape for small single-material props. There the generated list is an exact copy of the
+        render list, and keeping it costs a whole extra index buffer (a large VA reservation in a 32-bit
+        process, per sub-mesh) plus its CPU vector, for nothing.
+
+        Callers already read an empty list as "use the render index buffer": CreateShadowIndexBuffer()
+        skips the allocation, D3D11's GetShadowAwareIndexBuffer/Count fall through to MeshIndexBuffer/
+        Indices, D3D12VobArena::Reserve leaves ShadowCount 0 and BuildVobDrawCommands falls back on it, and
+        the world-mesh wrapper substitutes &Indices. So dropping it here needs no change at any consumer.
+
+        `remappedIndices` is the RENDER index list this is compared against - it must already be the
+        post-remap one that gets written back to the caller, or the comparison is against the wrong list.
+
+        `convertToVertexIndex` is the caller's uint32 -> VERTEX_INDEX narrowing helper; false on overflow.
+        Returns false only for that overflow, which the callers escalate to XR_FAILED exactly as they did
+        when this lived inline - a dropped-because-identical list is a success, not a failure. */
+    template <typename ConvertFn>
+    bool BuildShadowIndices( std::vector<VERTEX_INDEX>& shadowIndices,
+        const std::vector<unsigned int>& remappedIndices,
+        const std::vector<byte>& remappedVertices,
+        size_t fetchedVertexCount,
+        unsigned int stride,
+        ConvertFn convertToVertexIndex ) {
+        shadowIndices.clear();
+
+        if ( remappedIndices.empty() || fetchedVertexCount == 0 ) {
+            return true;
+        }
+
+        std::vector<unsigned int> welded( remappedIndices.size() );
+        // Position only (the leading 12 bytes of every stream we hand in), which is exactly what makes the
+        // result unusable for alpha-tested draws - see GetShadowAwareIndexBuffer.
+        meshopt_generateShadowIndexBuffer( welded.data(),
+            remappedIndices.data(), remappedIndices.size(),
+            remappedVertices.data(), fetchedVertexCount, sizeof( float ) * 3, stride );
+
+        if ( welded == remappedIndices ) {
+            ++g_SkipIdentical;
+            g_BytesSaved += remappedIndices.size() * sizeof( VERTEX_INDEX );
+            ReportStats();
+            return true;
+        }
+
+        shadowIndices.resize( welded.size() );
+        if ( !convertToVertexIndex( welded, shadowIndices.data(), shadowIndices.size() ) ) {
+            LogError() << "BuildShadowIndices: shadow index exceeds VERTEX_INDEX range";
+            shadowIndices.clear();
+            ++g_SkipOverflow;
+            ReportStats();
+            return false;
+        }
+
+        ++g_Built;
+        ReportStats();
+        return true;
+    }
+
+}   // namespace MeshShadow

--- a/D3D11Engine/Shaders/D3D12/VobCull.hlsl
+++ b/D3D11Engine/Shaders/D3D12/VobCull.hlsl
@@ -23,6 +23,9 @@ struct VobCullVisual
     uint   InstanceBase;    // first instance index into the instance buffer (ring offset / sizeof(instance))
     float3 BBoxMax;
     uint   InstanceCount;
+    // 0 = keep every instance in the near run. Commands are emitted per sub-mesh, so splitting a visual
+    // whose far bucket has no command strands those instances and they vanish from the main view.
+    uint   LodSplit;
 };
 
 // Mirrors ConstantBufferStructs.h's VobInstanceInfo (144 B) — the per-instance VERTEX stream, read here as a
@@ -50,8 +53,12 @@ cbuffer VobCullCB : register( b0 )
     uint     HiZHeight;
     uint     HiZMipCount;
     uint     EnableOcclusion;   // 0 -> frustum cull only (debug toggle / no Hi-Z available)
-    uint     _cullPad0;
-    uint     _cullPad1;
+    // 0 = no LOD split. Bucketing must be per INSTANCE: Gothic reuses a few hundred visuals map-wide, so a
+    // per-visual decision would let one nearby barrel force full detail on every barrel in the world.
+    float    LodDistance;       // @88
+    uint     _cullPad0;         // @92  explicit: HLSL won't let the float3 straddle 16 B, and the C++ mirror
+    float3   CullCamPosWS;      // @96  must match field-for-field (its static_assert only checks size)
+    uint     _cullPad1;         // @108 -> 112 B == 28 root constants
 };
 
 StructuredBuffer<VobCullVisual>    Visuals       : register( t0 );
@@ -61,9 +68,9 @@ RWStructuredBuffer<uint>           VisibleCounts : register( u1 );
 
 float4x4 BuildWorldMatrix( VobInstanceGpu inst )
 {
-    // float4x4(a,b,c,d) fills ROWS, matching how the vertex stream feeds INSTANCE_WORLD_MATRIX — so
-    // mul( float4(p,1), W ) here is bit-for-bit the transform Vob.hlsl's VSMain applies.
-    return float4x4( inst.World0, inst.World1, inst.World2, inst.World3 );
+    // float4x4(a,b,c,d) fills ROWS, but Vob.hlsl reads the same bytes as a matrix vertex ATTRIBUTE, which
+    // HLSL fills one COLUMN per slot — so the constructor alone yields the transpose of the VS's matrix.
+    return transpose( float4x4( inst.World0, inst.World1, inst.World2, inst.World3 ) );
 }
 
 bool IsInstanceVisible( VobCullVisual v, VobInstanceGpu inst )
@@ -152,10 +159,14 @@ bool IsInstanceVisible( VobCullVisual v, VobInstanceGpu inst )
     return !( occluderDepth > closestDepth );
 }
 
-// One thread group per VISUAL: the group owns that visual's whole instance range, so the compaction counter
-// can live in groupshared memory and only the final count needs a buffer write (no global atomics at all).
+// One thread group per VISUAL: the group owns that visual's whole instance range, so the compaction counters
+// can live in groupshared memory and only the final counts need a buffer write (no global atomics at all).
 #define VOBCULL_GROUP_SIZE 64
-groupshared uint gVisibleInGroup;
+// Near packs FORWARD from InstanceBase, far packs BACKWARD from the end. Packing far backward is what keeps
+// this single-pass: head-to-tail would need the near total before placing the first far instance. Every
+// visible instance lands in exactly one run, so near + far <= InstanceCount and they cannot collide.
+groupshared uint gNearInGroup;
+groupshared uint gFarInGroup;
 
 [numthreads(VOBCULL_GROUP_SIZE, 1, 1)]
 void CSCull( uint3 gid : SV_GroupID, uint gtid : SV_GroupIndex )
@@ -163,7 +174,10 @@ void CSCull( uint3 gid : SV_GroupID, uint gtid : SV_GroupIndex )
     const uint visualIdx = gid.x;   // uniform across the group -> the barriers below are never divergent
 
     if ( gtid == 0 )
-        gVisibleInGroup = 0;
+    {
+        gNearInGroup = 0;
+        gFarInGroup  = 0;
+    }
     GroupMemoryBarrierWithGroupSync();
 
     if ( visualIdx < VisualCount )
@@ -174,19 +188,34 @@ void CSCull( uint3 gid : SV_GroupID, uint gtid : SV_GroupIndex )
             VobInstanceGpu inst = InInstances[v.InstanceBase + i];
             if ( IsInstanceVisible( v, inst ) )
             {
-                // Survivors are packed to the front of the SAME range the CPU uploaded into, so the
-                // per-command InstVBV (base address + size) needs no GPU patching — only InstanceCount does.
-                // Instance ORDER within a visual is irrelevant (opaque, one material per command).
+                // Bbox centre, not the origin: Gothic vob pivots are often off the mesh entirely (a door's
+                // hinge, a banner's mount point).
+                const float3 centreLocal = ( v.BBoxMin + v.BBoxMax ) * 0.5;
+                const float3 centreWorld = mul( float4( centreLocal, 1.0 ), BuildWorldMatrix( inst ) ).xyz;
+                const float  dist  = length( centreWorld - CullCamPosWS );
+                const bool   isFar = ( LodDistance > 0.0 ) && ( v.LodSplit != 0u ) && ( dist > LodDistance );
+
                 uint slot;
-                InterlockedAdd( gVisibleInGroup, 1, slot );
-                OutInstances[v.InstanceBase + slot] = inst;
+                if ( isFar )
+                {
+                    InterlockedAdd( gFarInGroup, 1, slot );
+                    OutInstances[v.InstanceBase + v.InstanceCount - 1 - slot] = inst;
+                }
+                else
+                {
+                    InterlockedAdd( gNearInGroup, 1, slot );
+                    OutInstances[v.InstanceBase + slot] = inst;
+                }
             }
         }
     }
 
     GroupMemoryBarrierWithGroupSync();
     if ( gtid == 0 && visualIdx < VisualCount )
-        VisibleCounts[visualIdx] = gVisibleInGroup;
+    {
+        VisibleCounts[visualIdx * 2u + 0u] = gNearInGroup;   // CSPatchArgs indexes (visualIdx * 2 + bucket)
+        VisibleCounts[visualIdx * 2u + 1u] = gFarInGroup;
+    }
 }
 
 //--------------------------------------------------------------------------------------
@@ -195,13 +224,19 @@ void CSCull( uint3 gid : SV_GroupID, uint gtid : SV_GroupIndex )
 cbuffer VobPatchCB : register( b0 )
 {
     uint PatchCmdCount;
-    uint PatchCmdStride;         // sizeof(VobDrawCommand)
-    uint PatchInstCountOffset;   // byte offset of Draw.InstanceCount within a command
-    uint PatchVisualIdxOffset;   // byte offset of VobDrawCommand::VisualIndex
+    uint PatchCmdStride;          // sizeof(VobDrawCommand)
+    uint PatchInstCountOffset;    // byte offset of Draw.InstanceCount within a command
+    uint PatchVisualIdxOffset;    // byte offset of VobDrawCommand::VisualIndex
+    uint PatchStartInstOffset;    // byte offset of Draw.StartInstanceLocation
+    uint PatchLodBucketOffset;    // byte offset of VobDrawCommand::LodBucket
+    uint _patchPad0;
 };
 
-StructuredBuffer<uint> PatchCounts : register( t0 );
-RWByteAddressBuffer    PatchArgs   : register( u0 );
+StructuredBuffer<uint>          PatchCounts  : register( t0 );
+// Needed only for InstanceCount: the far run is packed against the END of the visual's range, so its start
+// offset is (capacity - farCount) and cannot be derived from the counts alone.
+StructuredBuffer<VobCullVisual> PatchVisuals : register( t1 );
+RWByteAddressBuffer             PatchArgs    : register( u0 );
 
 [numthreads(64, 1, 1)]
 void CSPatchArgs( uint3 DTid : SV_DispatchThreadID )
@@ -217,5 +252,11 @@ void CSPatchArgs( uint3 DTid : SV_DispatchThreadID )
     if ( visualIdx == 0xFFFFFFFF )
         return;
 
-    PatchArgs.Store( base + PatchInstCountOffset, PatchCounts[visualIdx] );
+    const uint bucket = PatchArgs.Load( base + PatchLodBucketOffset );
+    const uint count  = PatchCounts[visualIdx * 2u + bucket];
+    // InstVBV already points at the visual's range base, so this is a plain offset within it.
+    const uint start = ( bucket == 0u ) ? 0u : ( PatchVisuals[visualIdx].InstanceCount - count );
+
+    PatchArgs.Store( base + PatchInstCountOffset, count );
+    PatchArgs.Store( base + PatchStartInstOffset, start );
 }

--- a/D3D11Engine/Shaders/D3D12/VobCull.hlsl
+++ b/D3D11Engine/Shaders/D3D12/VobCull.hlsl
@@ -24,15 +24,13 @@ struct VobCullVisual
     float3 BBoxMax;
     uint   InstanceCount;
     // 0 = keep every instance in the near run. 1 = split at LodDistance (far run draws the simplified LOD
-    // indices). 2 = split at AlphaPrepassDistance (both runs draw the same indices; only the DEPTH PREPASS
-    // skips the far one). Commands are emitted per sub-mesh, so splitting a visual whose far bucket has no
-    // command strands those instances and they vanish from the main view — which is why the CPU only raises
-    // this once it has emitted the far commands.
+    // indices). Commands are emitted per sub-mesh, so splitting a visual whose far bucket has no command
+    // strands those instances and they vanish from the main view — which is why the CPU only raises this
+    // once it has emitted the far commands.
     uint   SplitMode;
 };
 #define VOB_SPLIT_NONE  0u
 #define VOB_SPLIT_LOD   1u
-#define VOB_SPLIT_ALPHA 2u
 
 // Mirrors ConstantBufferStructs.h's VobInstanceInfo (144 B) — the per-instance VERTEX stream, read here as a
 // structured buffer instead. World/PrevWorld are stored ROW-major and consumed as `mul( float4(p,1), world )`
@@ -64,10 +62,7 @@ cbuffer VobCullCB : register( b0 )
     float    LodDistance;       // @88
     uint     _cullPad0;         // @92  explicit: HLSL won't let the float3 straddle 16 B, and the C++ mirror
     float3   CullCamPosWS;      // @96  must match field-for-field (its static_assert only checks size)
-    // Threshold for VOB_SPLIT_ALPHA. Scalar, so it fits the tail of CullCamPosWS's 16-byte row and the CB
-    // stays 112 B == 28 root constants.
-    float    AlphaPrepassDistance;  // @108 -> 112 B == 28 root constants
-};
+};                              // -> 108 B == 27 root constants
 
 StructuredBuffer<VobCullVisual>    Visuals       : register( t0 );
 StructuredBuffer<VobInstanceGpu>   InInstances   : register( t1 );
@@ -201,11 +196,7 @@ void CSCull( uint3 gid : SV_GroupID, uint gtid : SV_GroupIndex )
                 const float3 centreLocal = ( v.BBoxMin + v.BBoxMax ) * 0.5;
                 const float3 centreWorld = mul( float4( centreLocal, 1.0 ), BuildWorldMatrix( inst ) ).xyz;
                 const float  dist  = length( centreWorld - CullCamPosWS );
-                // Which distance this visual buckets by. The two modes are mutually exclusive per visual —
-                // the CPU never raises VOB_SPLIT_ALPHA on a visual it also LOD-split (see kSplitModeAlpha).
-                const float  splitDist = ( v.SplitMode == VOB_SPLIT_LOD )   ? LodDistance
-                                       : ( v.SplitMode == VOB_SPLIT_ALPHA ) ? AlphaPrepassDistance
-                                                                            : 0.0;
+                const float  splitDist = ( v.SplitMode == VOB_SPLIT_LOD ) ? LodDistance : 0.0;
                 const bool   isFar = ( splitDist > 0.0 ) && ( dist > splitDist );
 
                 uint slot;

--- a/D3D11Engine/Shaders/D3D12/VobCull.hlsl
+++ b/D3D11Engine/Shaders/D3D12/VobCull.hlsl
@@ -23,10 +23,16 @@ struct VobCullVisual
     uint   InstanceBase;    // first instance index into the instance buffer (ring offset / sizeof(instance))
     float3 BBoxMax;
     uint   InstanceCount;
-    // 0 = keep every instance in the near run. Commands are emitted per sub-mesh, so splitting a visual
-    // whose far bucket has no command strands those instances and they vanish from the main view.
-    uint   LodSplit;
+    // 0 = keep every instance in the near run. 1 = split at LodDistance (far run draws the simplified LOD
+    // indices). 2 = split at AlphaPrepassDistance (both runs draw the same indices; only the DEPTH PREPASS
+    // skips the far one). Commands are emitted per sub-mesh, so splitting a visual whose far bucket has no
+    // command strands those instances and they vanish from the main view — which is why the CPU only raises
+    // this once it has emitted the far commands.
+    uint   SplitMode;
 };
+#define VOB_SPLIT_NONE  0u
+#define VOB_SPLIT_LOD   1u
+#define VOB_SPLIT_ALPHA 2u
 
 // Mirrors ConstantBufferStructs.h's VobInstanceInfo (144 B) — the per-instance VERTEX stream, read here as a
 // structured buffer instead. World/PrevWorld are stored ROW-major and consumed as `mul( float4(p,1), world )`
@@ -58,7 +64,9 @@ cbuffer VobCullCB : register( b0 )
     float    LodDistance;       // @88
     uint     _cullPad0;         // @92  explicit: HLSL won't let the float3 straddle 16 B, and the C++ mirror
     float3   CullCamPosWS;      // @96  must match field-for-field (its static_assert only checks size)
-    uint     _cullPad1;         // @108 -> 112 B == 28 root constants
+    // Threshold for VOB_SPLIT_ALPHA. Scalar, so it fits the tail of CullCamPosWS's 16-byte row and the CB
+    // stays 112 B == 28 root constants.
+    float    AlphaPrepassDistance;  // @108 -> 112 B == 28 root constants
 };
 
 StructuredBuffer<VobCullVisual>    Visuals       : register( t0 );
@@ -193,7 +201,12 @@ void CSCull( uint3 gid : SV_GroupID, uint gtid : SV_GroupIndex )
                 const float3 centreLocal = ( v.BBoxMin + v.BBoxMax ) * 0.5;
                 const float3 centreWorld = mul( float4( centreLocal, 1.0 ), BuildWorldMatrix( inst ) ).xyz;
                 const float  dist  = length( centreWorld - CullCamPosWS );
-                const bool   isFar = ( LodDistance > 0.0 ) && ( v.LodSplit != 0u ) && ( dist > LodDistance );
+                // Which distance this visual buckets by. The two modes are mutually exclusive per visual —
+                // the CPU never raises VOB_SPLIT_ALPHA on a visual it also LOD-split (see kSplitModeAlpha).
+                const float  splitDist = ( v.SplitMode == VOB_SPLIT_LOD )   ? LodDistance
+                                       : ( v.SplitMode == VOB_SPLIT_ALPHA ) ? AlphaPrepassDistance
+                                                                            : 0.0;
+                const bool   isFar = ( splitDist > 0.0 ) && ( dist > splitDist );
 
                 uint slot;
                 if ( isFar )
@@ -233,8 +246,9 @@ cbuffer VobPatchCB : register( b0 )
 };
 
 StructuredBuffer<uint>          PatchCounts  : register( t0 );
-// Needed only for InstanceCount: the far run is packed against the END of the visual's range, so its start
-// offset is (capacity - farCount) and cannot be derived from the counts alone.
+// Needed for InstanceBase (the visual's block in the shared instance buffer) and InstanceCount (the far run
+// is packed against the END of that block, so its start is InstanceCount - farCount and cannot be derived
+// from the survivor counts alone).
 StructuredBuffer<VobCullVisual> PatchVisuals : register( t1 );
 RWByteAddressBuffer             PatchArgs    : register( u0 );
 
@@ -254,8 +268,11 @@ void CSPatchArgs( uint3 DTid : SV_DispatchThreadID )
 
     const uint bucket = PatchArgs.Load( base + PatchLodBucketOffset );
     const uint count  = PatchCounts[visualIdx * 2u + bucket];
-    // InstVBV already points at the visual's range base, so this is a plain offset within it.
-    const uint start = ( bucket == 0u ) ? 0u : ( PatchVisuals[visualIdx].InstanceCount - count );
+    // ABSOLUTE, not range-relative. With the VOB mega-buffers there is no per-command instance VBV any more
+    // — each pass binds the whole instance buffer once — so StartInstanceLocation has to carry the visual's
+    // block base itself. Near packs forward from the base, far backward from the end of the block.
+    const VobCullVisual v = PatchVisuals[visualIdx];
+    const uint start = v.InstanceBase + ( ( bucket == 0u ) ? 0u : ( v.InstanceCount - count ) );
 
     PatchArgs.Store( base + PatchInstCountOffset, count );
     PatchArgs.Store( base + PatchStartInstOffset, start );

--- a/D3D11Engine/VertexTypes.h
+++ b/D3D11Engine/VertexTypes.h
@@ -43,6 +43,23 @@ struct ExVertexStructGPU {
 };
 static_assert( sizeof( ExVertexStructGPU ) == 36, "ExVertexStructGPU must be 36 bytes to match layout1" );
 
+/** What the CPU keeps of a world-mesh vertex once the GPU buffers are built (28 bytes vs
+    ExVertexStruct's 60). The world mesh is the one geometry set we hold a full second copy of and never
+    free, so this is the largest single CPU-side item in a 32-bit address space.
+
+    Exactly the three fields something still reads after world load:
+      Position  - GothicAPI::TraceWorldMesh (ray picking) and the editor overlays.
+      TexCoord  - WorldConverter::WorldMeshCollectPolyRange rebuilds per-point-light caster meshes from
+                  this, and those get alpha-tested in the cube shadow pass, so UV0 has to be exact.
+      TexCoord2 - the editor's edge visualization (ImGuiEditorView::VisualizeMeshInfo).
+    Normal, Color and Tangent are dropped: after upload nothing reads them back except the dead
+    zCPolygon rebuild path (see GothicAPI::CreatezCPolygonsForSections). */
+struct WorldVertexCPU {
+    float3 Position;
+    float2 TexCoord;
+    float2 TexCoord2;
+};
+
 struct SimpleObjectVertexStruct {
     float3 Position;
     float2 TexCoord;

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -145,18 +145,6 @@ namespace {
         return !outIndices.empty();
     }
 
-    void CreateLodIndexBuffer( MeshInfo* meshInfo ) {
-        if ( !meshInfo || meshInfo->LodIndices.empty() ) {
-            return;
-        }
-
-        Engine::GraphicsEngine->CreateVertexBuffer( meshInfo->MeshLodIndexBuffer );
-        meshInfo->MeshLodIndexBuffer->Init( meshInfo->LodIndices.data(),
-            meshInfo->LodIndices.size() * sizeof( VERTEX_INDEX ),
-            D3D11VertexBuffer::B_INDEXBUFFER,
-            D3D11VertexBuffer::U_IMMUTABLE );
-    }
-
     /** Builds a position-only (float3) companion buffer in the same vertex ordering as the source
         interleaved vertices. Bound for opaque depth/shadow passes; indices remain valid because the
         ordering matches the mesh/shadow index buffers built from the same array. */
@@ -2325,6 +2313,12 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
         } else {
             // The reduced level is built by OptimizeVertices below (MeshLodBuilder.h), not seeded from
             // ZENGIN's progressive-mesh data - see there for why that could not be shaded.
+            //
+            // D3D12 ONLY. The D3D12 VOB arena is the sole consumer (main-view far bucket + the far
+            // shadow cascades, both as index ranges inside the mega index buffer); D3D11 has no way to
+            // draw it that does not mean one more per-sub-mesh index buffer, and D3D11 is the backend
+            // that runs closest to the 32-bit VA ceiling. Asking for no LOD here skips the meshopt
+            // simplification pass and leaves LodIndices empty, so nothing downstream allocates.
 
             // Optimize faces
             mi->MeshVertexBuffer->OptimizeFaces(&mi->Indices[0],
@@ -2340,14 +2334,13 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
                 mi->Vertices.size(),
                 sizeof( ExVertexStruct ),
                 &mi->ShadowIndices,
-                &mi->LodIndices );
+                Engine::IsD3D12Backend ? &mi->LodIndices : nullptr );
 
             // Init and fill it
             mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
         }
         mi->MeshIndexBuffer->Init( &mi->Indices[0], mi->Indices.size() * sizeof( VERTEX_INDEX ), D3D11VertexBuffer::B_INDEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
         CreateShadowIndexBuffer( mi );
-        CreateLodIndexBuffer( mi );
 
         Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize += mi->Vertices.size() * sizeof( ExVertexStruct );
         Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize += mi->Indices.size() * sizeof( VERTEX_INDEX );

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -2276,10 +2276,8 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
                 mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_DYNAMIC, D3D11VertexBuffer::CA_WRITE );
             }
         } else {
-            // Reduced caster geometry for the distant shadow cascades, rebuilt from this sub-mesh's own
-            // progressive-mesh data. Built here because it is expressed in the pre-optimization wedge
-            // numbering; OptimizeVertices below carries it through the vertex remap it applies.
-            BuildProgMeshLodIndices( s, mi->LodIndices );
+            // The reduced level is built by OptimizeVertices below (MeshLodBuilder.h), not seeded from
+            // ZENGIN's progressive-mesh data - see there for why that could not be shaded.
 
             // Optimize faces
             mi->MeshVertexBuffer->OptimizeFaces(&mi->Indices[0],

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -372,7 +372,7 @@ void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float ra
     XMVECTOR xmPosition = XMLoadFloat3( &position );
 
 
-    XMVECTOR vRange2 = XMVectorReplicate( range );
+    XMVECTOR vRange2 = XMVectorReplicate( range * range );
 
     // Generate the meshes
     for ( auto const& itx : Engine::GAPI->GetWorldSections() ) {

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -1437,13 +1437,37 @@ void WorldConverter::Extract3DSMeshFromVisual( zCProgMeshProto* visual, MeshVisu
     meshInfo->Visual = visual;
 }
 
-/** Extracts a skeletal mesh from a zCMeshSoftSkin */
+/** Extracts a skeletal mesh from a zCMeshSoftSkin. Reads the live softskin list, so main thread only
+    - the background path uses the span overload with a snapshot it holds references on. */
 void WorldConverter::ExtractSkeletalMeshFromVob( zCModel* model, SkeletalMeshVisualInfo* skeletalMeshInfo ) {
+    zCArray<zCMeshSoftSkin*>* list = model->GetMeshSoftSkinList();
+    ExtractSkeletalMeshFromVob( model, std::span<zCMeshSoftSkin* const>( list->Array, list->NumInArray ), skeletalMeshInfo );
+}
+
+void WorldConverter::ExtractSkeletalMeshFromVob( zCModel* model, std::span<zCMeshSoftSkin* const> softSkins, SkeletalMeshVisualInfo* skeletalMeshInfo ) {
     ZoneScoped;
 
     // This type has multiple skinned meshes inside
-    for ( int i = 0; i < model->GetMeshSoftSkinList()->NumInArray; i++ ) {
-        zCMeshSoftSkin* s = model->GetMeshSoftSkinList()->Array[i];
+    for ( size_t skin = 0; skin < softSkins.size(); skin++ ) {
+        zCMeshSoftSkin* s = softSkins[skin];
+
+        // ZENGIN writes the submesh count and the submesh array as two separate fields, and frees the
+        // array on cache-out without zeroing the count first. A softskin caught in that window reports
+        // submeshes it no longer has, and zCProgMeshProto::GetSubmesh is plain pointer arithmetic off
+        // the (now null) base - it hands back nullptr for index 0 and small bogus addresses after that.
+        // Dropping the mesh loses one NPC's geometry for a frame until the reload re-extracts it, which
+        // beats faulting on the worker thread.
+        if ( !s || !s->GetSubmeshes() || !s->GetVertWeightStream() ) {
+            // Deliberately no GetModelName() here: it calls into ZENGIN and allocates a zSTRING, which
+            // this function is not allowed to do from a worker thread.
+            static std::atomic<bool> loggedTornSoftSkin = false;
+            if ( !loggedTornSoftSkin.exchange( true ) ) {
+                LogWarn() << "Skipped a zCMeshSoftSkin with no submesh/weight data (model " << model
+                    << ", skin " << skin << ") - skipping further reports of this";
+            }
+            continue;
+        }
+
         std::vector<ExSkelVertexStruct> posList;
 
         // This stream is built as the following:
@@ -1566,7 +1590,10 @@ void WorldConverter::ExtractSkeletalMeshFromVob( zCModel* model, SkeletalMeshVis
         }
     }
 
-    skeletalMeshInfo->VisualName = model->GetVisualName();
+    // From the snapshot, not model->GetVisualName(): that re-reads the live softskin list, which is
+    // exactly the thing the caller took a snapshot to stop touching.
+    if ( !softSkins.empty() && softSkins[0] )
+        skeletalMeshInfo->VisualName = softSkins[0]->GetObjectNameView();
 }
 
 /** Extracts a zCProgMeshProto from a zCModel */
@@ -1951,7 +1978,14 @@ namespace {
     /** In-flight ExtractNodeVisualAsync jobs. Registered and pruned on the main thread only; the worker
         job itself never touches this list, so a waiter can hold the mutex while waiting on a job without
         ever deadlocking against it. Never more than a handful of entries (one per attachment currently
-        popping in), so a flat vector beats a map here. */
+        popping in), so a flat vector beats a map here.
+
+        'Visual' is held with a zCObject reference for as long as the job runs. Waiting for the job from
+        OnVisualDeleted is NOT enough on its own: that hook sits on ~zCVisual, the *base* destructor, so
+        by the time it runs ~zCProgMeshProto has already freed the submesh arrays the worker reads out of
+        'pm'. Owning a reference is what keeps refCtr from reaching 0 in the first place, which is the
+        only thing that stops a vob unloading and reloading inside one frame from handing the recycled
+        address straight back out. */
     struct PendingNodeVisual {
         MeshVisualInfo* MeshInfo;
         zCVisual* Visual;
@@ -1963,8 +1997,15 @@ namespace {
     /** Drops entries whose job has run to completion. Caller must hold s_PendingNodeVisualsMutex. */
     void PruneFinishedNodeVisualsLocked() {
         std::erase_if( s_PendingNodeVisuals, []( const PendingNodeVisual& p ) {
-            return !p.Task.future.valid()
-                || p.Task.future.wait_for( std::chrono::seconds( 0 ) ) == std::future_status::ready;
+            if ( p.Task.future.valid()
+                && p.Task.future.wait_for( std::chrono::seconds( 0 ) ) != std::future_status::ready ) {
+                return false;
+            }
+            // Never released inline: dropping the last reference runs the visual's destructor, which
+            // re-enters OnVisualDeleted -> WaitForPendingNodeVisuals -> s_PendingNodeVisualsMutex,
+            // which we are holding right now. That is a deadlock, not a race.
+            Engine::GAPI->QueueDeferredVisualRelease( p.Visual );
+            return true;
         } );
     }
 }
@@ -1996,8 +2037,14 @@ void WorldConverter::WaitForAllPendingNodeVisuals() {
         if ( pending.Task.future.valid() ) {
             pending.Task.future.wait();
         }
+        Engine::GAPI->QueueDeferredVisualRelease( pending.Visual );
     }
     s_PendingNodeVisuals.clear();
+}
+
+void WorldConverter::PruneFinishedNodeVisuals() {
+    std::scoped_lock lock( s_PendingNodeVisualsMutex );
+    PruneFinishedNodeVisualsLocked();
 }
 
 /** Extracts a node-visual on a worker thread. See the header for the contract. */
@@ -2052,12 +2099,18 @@ void WorldConverter::ExtractNodeVisualAsync( int index, zCModelNodeInst* node, g
         ? ResolveMorphRestSource( reinterpret_cast<zCMorphMesh*>(node->NodeVisual) )
         : MorphRestSource{};
 
+    // 'pm' lives inside nodeVisual (for .MMS it is the zCMorphMesh's inner progmesh), so the job is
+    // only allowed to read it for as long as nodeVisual is alive. Own a reference for the duration
+    // instead of hoping nothing frees it - see the PendingNodeVisual comment for why waiting on the
+    // job from OnVisualDeleted cannot cover this. Handed back when the entry is pruned.
     zCVisual* nodeVisual = node->NodeVisual;
+    zCObject_AddRef( nodeVisual );
+
     auto task = Engine::WorkerThreadPool->enqueue( [pm, mi, isMMS, restSource]( const std::stop_token& token ) {
         if ( token.stop_requested() ) {
-            // Cancelled before a worker picked it up (world change / shutdown flush) - the visual we
-            // would read from may already be gone. Clear Visual so the next frame notices the mismatch
-            // and re-extracts instead of rendering an empty attachment forever.
+            // Cancelled before a worker picked it up (world change / shutdown flush). Clear Visual so
+            // the next frame notices the mismatch and re-extracts instead of rendering an empty
+            // attachment forever.
             mi->Visual = nullptr;
             mi->Ready.store( true, std::memory_order_release );
             return;

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -1484,12 +1484,12 @@ void WorldConverter::ExtractSkeletalMeshFromVob( zCModel* model, std::span<zCMes
         // 0 and small bogus addresses after it. Dropping the mesh costs one NPC's geometry until the
         // next re-extract; dereferencing it costs the process.
         if ( !s || !s->GetSubmeshes() || !s->GetVertWeightStream() ) {
-            // No GetModelName() here - it calls into ZENGIN and allocates a zSTRING, which this
-            // function must not do from a worker thread.
+            // GetModelName() is a plain read of the prototype's own string - no ZENGIN call and no
+            // allocation - so it is safe to name the model even from a worker thread.
             static std::atomic<bool> loggedTornSoftSkin = false;
             if ( !loggedTornSoftSkin.exchange( true ) ) {
-                LogWarn() << "Skipped a zCMeshSoftSkin with no submesh/weight data (model " << model
-                    << ", skin " << skin << ") - skipping further reports of this";
+                LogWarn() << "Skipped a zCMeshSoftSkin with no submesh/weight data on '"
+                    << model->GetModelName() << "' (skin " << skin << ") - skipping further reports";
             }
             continue;
         }

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -2472,13 +2472,23 @@ void WorldConverter::IndexVertices( ExVertexStruct* input, unsigned int numInput
     std::set<std::pair<ExVertexStruct, int>, CmpClass> vertices;
     int index = 0;
 
+    // Take the index from the insert result rather than from a separate counter. CmpClass is an
+    // epsilon comparator and therefore not a strict weak ordering, so a preceding find() can miss an
+    // element that insert() then rejects as equivalent - which used to bump the counter without
+    // growing the set and emit an index >= outVertices.size(). Downstream that is not survivable:
+    // meshopt's buildTriangleAdjacency indexes its counts[] array by it with the bounds assert
+    // compiled out (NDEBUG), so the out-of-range index corrupts the heap instead of failing.
     for ( unsigned int i = 0; i < numInputVertices; i++ ) {
-        auto it = vertices.find( std::make_pair( input[i], 0/*this value doesn't matter*/ ) );
-        if ( it != vertices.end() ) outIndices.emplace_back( it->second );
-        else {
-            vertices.insert( std::make_pair( input[i], index ) );
-            outIndices.emplace_back( index++ );
-        }
+        auto [it, inserted] = vertices.insert( std::make_pair( input[i], index ) );
+        outIndices.emplace_back( static_cast<VERTEX_INDEX>(it->second) );
+        if ( inserted ) ++index;
+    }
+
+    // 16-bit indices: the per-point-light collector (WorldMeshCollectPolyRange) merges whole section
+    // neighbourhoods into one MeshInfo, so this ceiling is reachable. Truncating silently produces
+    // both wrong geometry and out-of-range indices, so say so rather than let it reach the GPU.
+    if ( static_cast<size_t>(index) > static_cast<size_t>(std::numeric_limits<VERTEX_INDEX>::max()) + 1 ) {
+        LogError() << "IndexVertices: " << index << " unique vertices exceeds the 16-bit index range - mesh truncated";
     }
 
     // Check for overlaying triangles and throw them out
@@ -2504,26 +2514,22 @@ void WorldConverter::IndexVertices( ExVertexStruct* input, unsigned int numInput
     // so you'll have to rearrange them like this:
     outVertices.clear();
     outVertices.resize( vertices.size() );
+    // No range guard needed anymore: every stored index came from an insert that actually happened,
+    // so it is < vertices.size() by construction.
     for ( auto const& it : vertices ) {
-        if ( static_cast<size_t>(it.second) >= vertices.size() ) {
-            continue;
-        }
-
         outVertices[it.second] = it.first;
     }
 }
 
 void WorldConverter::IndexVertices( ExVertexStruct* input, unsigned int numInputVertices, std::vector<ExVertexStruct>& outVertices, std::vector<unsigned int>& outIndices ) {
     std::set<std::pair<ExVertexStruct, int>, CmpClass> vertices;
-    unsigned int index = 0;
+    int index = 0;
 
+    // Same invariant as the VERTEX_INDEX overload above - see the comment there.
     for ( unsigned int i = 0; i < numInputVertices; i++ ) {
-        auto it = vertices.find( std::make_pair( input[i], 0/*this value doesn't matter*/ ) );
-        if ( it != vertices.end() ) outIndices.emplace_back( it->second );
-        else {
-            vertices.insert( std::make_pair( input[i], index ) );
-            outIndices.emplace_back( index++ );
-        }
+        auto [it, inserted] = vertices.insert( std::make_pair( input[i], index ) );
+        outIndices.emplace_back( static_cast<unsigned int>(it->second) );
+        if ( inserted ) ++index;
     }
 
     // Notice that the vertices in the set are not sorted by the index

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -402,20 +402,34 @@ void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float ra
                         m = opaqueMesh;
                     }
 
+                    // The source world mesh only keeps the slim CPU copy (see WorldVertexCPU), so the
+                    // caster vertices are rebuilt from it with Normal/Color/Tangent left zeroed. That is
+                    // lossless HERE: these meshes are only ever drawn by RenderShadowCube, which writes
+                    // depth and alpha-tests on TexCoord - it never reads a shaded attribute.
+                    const std::vector<WorldVertexCPU>& src = it.second->CpuVertices;
+                    if ( src.empty() ) {
+                        continue;
+                    }
+
                     // reserve required size beforehand to avoid multiple reallocations
-                    m->Vertices.reserve( it.second->Vertices.size() );
+                    m->Vertices.reserve( src.size() );
                     for ( unsigned int i = 0; i < it.second->Indices.size(); i += 3 ) {
                         // Check if one of them is in range
 
-                        XMVECTOR v0 = XMLoadFloat3( &it.second->Vertices[it.second->Indices[i + 0]].Position );
-                        XMVECTOR v1 = XMLoadFloat3( &it.second->Vertices[it.second->Indices[i + 1]].Position );
-                        XMVECTOR v2 = XMLoadFloat3( &it.second->Vertices[it.second->Indices[i + 2]].Position );
+                        XMVECTOR v0 = XMLoadFloat3( &src[it.second->Indices[i + 0]].Position );
+                        XMVECTOR v1 = XMLoadFloat3( &src[it.second->Indices[i + 1]].Position );
+                        XMVECTOR v2 = XMLoadFloat3( &src[it.second->Indices[i + 2]].Position );
 
                         if ( XMVector3Less( XMVector3LengthSq( XMVectorSubtract( xmPosition, v0 ) ), vRange2 ) ||
                             XMVector3Less( XMVector3LengthSq( XMVectorSubtract( xmPosition, v1 ) ), vRange2 ) ||
                             XMVector3Less( XMVector3LengthSq( XMVectorSubtract( xmPosition, v2 ) ), vRange2 ) ) {
-                            for ( int v = 0; v < 3; v++ )
-                                m->Vertices.emplace_back( it.second->Vertices[it.second->Indices[i + v]] );
+                            for ( int v = 0; v < 3; v++ ) {
+                                const WorldVertexCPU& sv = src[it.second->Indices[i + v]];
+                                ExVertexStruct& dv = m->Vertices.emplace_back();
+                                dv.Position = sv.Position;
+                                dv.TexCoord = sv.TexCoord;
+                                dv.TexCoord2 = sv.TexCoord2;
+                            }
                         }
                     }
                 }
@@ -715,6 +729,16 @@ XRESULT WorldConverter::LoadWorldMeshFromFile( const std::string& file, std::map
     BuildWrappedPositionBuffer( wmi, wrappedVertices );
 
     *outWrappedMesh = wmi;
+
+    // Same trade as ConvertWorldMesh - the readers below key on CpuVertices, so this dead cached-mesh
+    // path has to leave the sections in the same shape the live one does.
+    for ( auto& itx : *outSections ) {
+        for ( auto& ity : itx.second ) {
+            for ( auto const& it : ity.second.WorldMeshes ) {
+                it.second->ShrinkCpuVertices();
+            }
+        }
+    }
 
     // Calculate the approx midpoint of the world
     avgSections /= static_cast<float>(numSections);
@@ -1197,6 +1221,19 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
 
     *outWrappedMesh = wmi;
 
+    // Everything that needed the full 60-byte vertices has now run: the per-section buffers are uploaded
+    // and both WrapVertexBuffers passes are done. Trade them for the 28-byte slim copy - see
+    // WorldVertexCPU for the three fields that still have readers.
+    {
+        size_t slimBytes = 0;
+        for ( WorldMeshInfo* mesh : allMeshes ) {
+            mesh->ShrinkCpuVertices();
+            slimBytes += mesh->CpuVertices.size() * sizeof( WorldVertexCPU );
+        }
+        LogInfo() << "Worldmesh: CPU vertex copy shrunk to " << (slimBytes / (1024 * 1024)) << " MB (was "
+            << ((totalWorldVertices * sizeof( ExVertexStruct )) / (1024 * 1024)) << " MB)";
+    }
+
     // Calculate the approx midpoint of the world
     avgSections /= (float)numSections;
 
@@ -1244,11 +1281,13 @@ void WorldConverter::GenerateFullSectionMesh( WorldMeshSectionInfo& section ) {
             it.first.Material->HasAlphaTest() )
             continue;
 
+        // Slim CPU copy; this path only ever wanted Position anyway.
+        const std::vector<WorldVertexCPU>& src = it.second->CpuVertices;
         for ( unsigned int i = 0; i < it.second->Indices.size(); i += 3 ) {
             // Push all triangles
-            vx.emplace_back( it.second->Vertices[it.second->Indices[i]].Position );
-            vx.emplace_back( it.second->Vertices[it.second->Indices[i + 1]].Position );
-            vx.emplace_back( it.second->Vertices[it.second->Indices[i + 2]].Position );
+            vx.emplace_back( src[it.second->Indices[i]].Position );
+            vx.emplace_back( src[it.second->Indices[i + 1]].Position );
+            vx.emplace_back( src[it.second->Indices[i + 2]].Position );
         }
     }
 
@@ -1341,7 +1380,7 @@ void WorldConverter::SaveSectionsToObjUnindexed( const char* file, const std::ma
     for ( auto const& itx : sections ) {
         for ( auto const& ity : itx.second ) {
             for ( auto const& it : ity.second.WorldMeshes ) {
-                for ( auto const& vtx : it.second->Vertices ) {
+                for ( auto const& vtx : it.second->CpuVertices ) {
                     std::string ln = "v " + std::to_string( vtx.Position.x ) + " " + std::to_string( vtx.Position.y ) + " " + std::to_string( vtx.Position.z ) + "\n";
                     fputs( ln.c_str(), f );
                 }

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -402,10 +402,9 @@ void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float ra
                         m = opaqueMesh;
                     }
 
-                    // The source world mesh only keeps the slim CPU copy (see WorldVertexCPU), so the
-                    // caster vertices are rebuilt from it with Normal/Color/Tangent left zeroed. That is
-                    // lossless HERE: these meshes are only ever drawn by RenderShadowCube, which writes
-                    // depth and alpha-tests on TexCoord - it never reads a shaded attribute.
+                    // The source world mesh only keeps the slim CPU copy (see WorldVertexCPU), so the caster
+                    // vertices are rebuilt with Normal/Color/Tangent zeroed. Lossless here: these meshes are
+                    // only drawn by RenderShadowCube, which writes depth and alpha-tests on TexCoord.
                     const std::vector<WorldVertexCPU>& src = it.second->CpuVertices;
                     if ( src.empty() ) {
                         continue;
@@ -1221,9 +1220,8 @@ HRESULT WorldConverter::ConvertWorldMesh( zCPolygon** polys, unsigned int numPol
 
     *outWrappedMesh = wmi;
 
-    // Everything that needed the full 60-byte vertices has now run: the per-section buffers are uploaded
-    // and both WrapVertexBuffers passes are done. Trade them for the 28-byte slim copy - see
-    // WorldVertexCPU for the three fields that still have readers.
+    // Everything that needed the full 60-byte vertices has run (section buffers uploaded, both
+    // WrapVertexBuffers passes done); trade them for the 28-byte slim copy. See WorldVertexCPU.
     {
         size_t slimBytes = 0;
         for ( WorldMeshInfo* mesh : allMeshes ) {
@@ -1479,13 +1477,12 @@ void WorldConverter::ExtractSkeletalMeshFromVob( zCModel* model, std::span<zCMes
     for ( size_t skin = 0; skin < softSkins.size(); skin++ ) {
         zCMeshSoftSkin* s = softSkins[skin];
 
-        // A softskin being torn down still reports its old submesh count while its submesh array is
-        // already null, and GetSubmesh is plain arithmetic off that base - it returns nullptr for index
-        // 0 and small bogus addresses after it. Dropping the mesh costs one NPC's geometry until the
-        // next re-extract; dereferencing it costs the process.
+        // A softskin being torn down still reports its old submesh count while its submesh array is already
+        // null, and GetSubmesh is plain arithmetic off that base, so it hands out bogus addresses. Dropping
+        // the mesh costs one NPC's geometry until the next re-extract; dereferencing it costs the process.
         if ( !s || !s->GetSubmeshes() || !s->GetVertWeightStream() ) {
-            // GetModelName() is a plain read of the prototype's own string - no ZENGIN call and no
-            // allocation - so it is safe to name the model even from a worker thread.
+            // GetModelName() is a plain read of the prototype's own string - no ZENGIN call, no allocation -
+            // so it is safe from a worker thread.
             static std::atomic<bool> loggedTornSoftSkin = false;
             if ( !loggedTornSoftSkin.exchange( true ) ) {
                 LogWarn() << "Skipped a zCMeshSoftSkin with no submesh/weight data on '"
@@ -2350,13 +2347,9 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
                 mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_DYNAMIC, D3D11VertexBuffer::CA_WRITE );
             }
         } else {
-            // The reduced level is built by OptimizeVertices below (MeshLodBuilder.h), not seeded from
-            // ZENGIN's progressive-mesh data - see there for why that could not be shaded.
-            //
-            // D3D12 ONLY. The D3D12 VOB arena is the sole consumer (main-view far bucket + the far
-            // shadow cascades, both as index ranges inside the mega index buffer); D3D11 has no way to
-            // draw it that does not mean one more per-sub-mesh index buffer, and D3D11 is the backend
-            // that runs closest to the 32-bit VA ceiling. Asking for no LOD here skips the meshopt
+            // The reduced level is built by OptimizeVertices below (MeshLodBuilder.h). D3D12 ONLY: the VOB
+            // arena is its sole consumer, and on D3D11 it would mean one more per-sub-mesh index buffer on
+            // the backend closest to the 32-bit VA ceiling. Asking for no LOD skips the meshopt
             // simplification pass and leaves LodIndices empty, so nothing downstream allocates.
 
             // Optimize faces
@@ -2472,12 +2465,10 @@ void WorldConverter::IndexVertices( ExVertexStruct* input, unsigned int numInput
     std::set<std::pair<ExVertexStruct, int>, CmpClass> vertices;
     int index = 0;
 
-    // Take the index from the insert result rather than from a separate counter. CmpClass is an
-    // epsilon comparator and therefore not a strict weak ordering, so a preceding find() can miss an
-    // element that insert() then rejects as equivalent - which used to bump the counter without
-    // growing the set and emit an index >= outVertices.size(). Downstream that is not survivable:
-    // meshopt's buildTriangleAdjacency indexes its counts[] array by it with the bounds assert
-    // compiled out (NDEBUG), so the out-of-range index corrupts the heap instead of failing.
+    // Take the index from the insert result, not a separate counter: CmpClass is an epsilon comparator and
+    // therefore not a strict weak ordering, so a find() can miss an element insert() then rejects as
+    // equivalent, emitting an index >= outVertices.size(). meshopt's buildTriangleAdjacency indexes its
+    // counts[] by it with the bounds assert compiled out, so that corrupts the heap rather than failing.
     for ( unsigned int i = 0; i < numInputVertices; i++ ) {
         auto [it, inserted] = vertices.insert( std::make_pair( input[i], index ) );
         outIndices.emplace_back( static_cast<VERTEX_INDEX>(it->second) );
@@ -2485,8 +2476,7 @@ void WorldConverter::IndexVertices( ExVertexStruct* input, unsigned int numInput
     }
 
     // 16-bit indices: the per-point-light collector (WorldMeshCollectPolyRange) merges whole section
-    // neighbourhoods into one MeshInfo, so this ceiling is reachable. Truncating silently produces
-    // both wrong geometry and out-of-range indices, so say so rather than let it reach the GPU.
+    // neighbourhoods into one MeshInfo, so this ceiling is reachable.
     if ( static_cast<size_t>(index) > static_cast<size_t>(std::numeric_limits<VERTEX_INDEX>::max()) + 1 ) {
         LogError() << "IndexVertices: " << index << " unique vertices exceeds the 16-bit index range - mesh truncated";
     }

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -25,6 +25,7 @@
 #include <meshoptimizer/src/meshoptimizer.h>
 #include "MeshManager.h"
 #include "SharedVisualRegistry.h"
+#include "AsyncVisualExtractor.h"
 #include "MorphBlend.h"
 #include "MorphGpu.h"
 #include "ThreadPool.h"
@@ -1451,15 +1452,13 @@ void WorldConverter::ExtractSkeletalMeshFromVob( zCModel* model, std::span<zCMes
     for ( size_t skin = 0; skin < softSkins.size(); skin++ ) {
         zCMeshSoftSkin* s = softSkins[skin];
 
-        // ZENGIN writes the submesh count and the submesh array as two separate fields, and frees the
-        // array on cache-out without zeroing the count first. A softskin caught in that window reports
-        // submeshes it no longer has, and zCProgMeshProto::GetSubmesh is plain pointer arithmetic off
-        // the (now null) base - it hands back nullptr for index 0 and small bogus addresses after that.
-        // Dropping the mesh loses one NPC's geometry for a frame until the reload re-extracts it, which
-        // beats faulting on the worker thread.
+        // A softskin being torn down still reports its old submesh count while its submesh array is
+        // already null, and GetSubmesh is plain arithmetic off that base - it returns nullptr for index
+        // 0 and small bogus addresses after it. Dropping the mesh costs one NPC's geometry until the
+        // next re-extract; dereferencing it costs the process.
         if ( !s || !s->GetSubmeshes() || !s->GetVertWeightStream() ) {
-            // Deliberately no GetModelName() here: it calls into ZENGIN and allocates a zSTRING, which
-            // this function is not allowed to do from a worker thread.
+            // No GetModelName() here - it calls into ZENGIN and allocates a zSTRING, which this
+            // function must not do from a worker thread.
             static std::atomic<bool> loggedTornSoftSkin = false;
             if ( !loggedTornSoftSkin.exchange( true ) ) {
                 LogWarn() << "Skipped a zCMeshSoftSkin with no submesh/weight data (model " << model
@@ -1980,12 +1979,9 @@ namespace {
         ever deadlocking against it. Never more than a handful of entries (one per attachment currently
         popping in), so a flat vector beats a map here.
 
-        'Visual' is held with a zCObject reference for as long as the job runs. Waiting for the job from
-        OnVisualDeleted is NOT enough on its own: that hook sits on ~zCVisual, the *base* destructor, so
-        by the time it runs ~zCProgMeshProto has already freed the submesh arrays the worker reads out of
-        'pm'. Owning a reference is what keeps refCtr from reaching 0 in the first place, which is the
-        only thing that stops a vob unloading and reloading inside one frame from handing the recycled
-        address straight back out. */
+        'Visual' is held with a zCObject reference for as long as the job runs - see AsyncVisualExtractor
+        for why waiting on the job instead cannot work. Released through that same class, so the release
+        lands at a safe point rather than inside the pruner. */
     struct PendingNodeVisual {
         MeshVisualInfo* MeshInfo;
         zCVisual* Visual;
@@ -2004,7 +2000,7 @@ namespace {
             // Never released inline: dropping the last reference runs the visual's destructor, which
             // re-enters OnVisualDeleted -> WaitForPendingNodeVisuals -> s_PendingNodeVisualsMutex,
             // which we are holding right now. That is a deadlock, not a race.
-            Engine::GAPI->QueueDeferredVisualRelease( p.Visual );
+            s_AsyncVisualExtractor->QueueRelease( p.Visual );
             return true;
         } );
     }
@@ -2037,7 +2033,7 @@ void WorldConverter::WaitForAllPendingNodeVisuals() {
         if ( pending.Task.future.valid() ) {
             pending.Task.future.wait();
         }
-        Engine::GAPI->QueueDeferredVisualRelease( pending.Visual );
+        s_AsyncVisualExtractor->QueueRelease( pending.Visual );
     }
     s_PendingNodeVisuals.clear();
 }
@@ -2099,10 +2095,8 @@ void WorldConverter::ExtractNodeVisualAsync( int index, zCModelNodeInst* node, g
         ? ResolveMorphRestSource( reinterpret_cast<zCMorphMesh*>(node->NodeVisual) )
         : MorphRestSource{};
 
-    // 'pm' lives inside nodeVisual (for .MMS it is the zCMorphMesh's inner progmesh), so the job is
-    // only allowed to read it for as long as nodeVisual is alive. Own a reference for the duration
-    // instead of hoping nothing frees it - see the PendingNodeVisual comment for why waiting on the
-    // job from OnVisualDeleted cannot cover this. Handed back when the entry is pruned.
+    // 'pm' lives inside nodeVisual (for .MMS it is the zCMorphMesh's inner progmesh), so the job may
+    // only read it for as long as nodeVisual is alive. Handed back when the entry is pruned.
     zCVisual* nodeVisual = node->NodeVisual;
     zCObject_AddRef( nodeVisual );
 

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -81,8 +81,15 @@ public:
     /** Updates a Morph-Mesh visual */
     static void UpdateMorphMeshVisual( void* visual, MeshVisualInfo* meshInfo );
 
-    /** Extracts a skeletal mesh from a zCModel */
+    /** Extracts a skeletal mesh from a zCModel. Reads the model's live softskin list, so this overload
+        is main-thread only. */
     static void ExtractSkeletalMeshFromVob( zCModel* model, SkeletalMeshVisualInfo* skeletalMeshInfo );
+
+    /** Same, but over a caller-supplied snapshot of the softskin list. Background extraction must use
+        this one: the live zCArray is refilled in place on armor changes and mesh-lib swaps, so a worker
+        walking it can read an entry ZENGIN has already released. The caller owns a zCObject reference on
+        every entry for as long as the job runs. */
+    static void ExtractSkeletalMeshFromVob( zCModel* model, std::span<zCMeshSoftSkin* const> softSkins, SkeletalMeshVisualInfo* skeletalMeshInfo );
 
     /** Extracts a zCProgMeshProto from a zCModel */
     static void ExtractProgMeshProtoFromModel( zCModel* model, MeshVisualInfo* meshInfo );
@@ -113,6 +120,11 @@ public:
 
     /** Blocks until every in-flight ExtractNodeVisualAsync job has finished. */
     static void WaitForAllPendingNodeVisuals();
+
+    /** Retires jobs that have already finished, handing back the zCVisual references they held.
+        Never blocks. Called once per frame - without it, a job nobody comes back for would keep
+        its visual alive forever. */
+    static void PruneFinishedNodeVisuals();
 
     /** Updates a quadmark info */
     static void UpdateQuadMarkInfo( QuadMarkInfo* info, zCQuadMark* mark, const float3& position );

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -36,7 +36,7 @@ constexpr int SHADOW_LOD_MIN_TRIANGLES = 96;
     surface, so a cascade biased tighter than that deviation self-shadows itself black (building facades
     going dark as the camera tilts up) - cascades 0 and 1 are too tight for it.
     NOTE: D3D11's GetShadowAwareIndexBuffer still carries its own FIRST_LOD_SHADOW_CASCADE = 1. */
-constexpr int SHADOW_LOD_FIRST_CASCADE = 2;
+constexpr int SHADOW_LOD_FIRST_CASCADE = 1;
 
 class zCProgMeshProto;
 class zCModel;

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -81,6 +81,23 @@ MeshInfo::~MeshInfo() {
     MeshShadowIndexBuffer.reset();
 }
 
+void WorldMeshInfo::ShrinkCpuVertices() {
+    if ( Vertices.empty() ) {
+        return;
+    }
+
+    CpuVertices.resize( Vertices.size() );
+    for ( size_t i = 0; i < Vertices.size(); ++i ) {
+        CpuVertices[i].Position = Vertices[i].Position;
+        CpuVertices[i].TexCoord = Vertices[i].TexCoord;
+        CpuVertices[i].TexCoord2 = Vertices[i].TexCoord2;
+    }
+
+    // clear() alone keeps the capacity, which is the whole 60-bytes-per-vertex allocation we are here to
+    // give back. Swap with a temporary is the only way to actually release it.
+    std::vector<ExVertexStruct>().swap( Vertices );
+}
+
 SkeletalMeshInfo::~SkeletalMeshInfo() {
     Engine::GAPI->GetRendererState().RendererInfo.SkeletalVerticesDataSize -= Indices.size() * sizeof( VERTEX_INDEX );
     Engine::GAPI->GetRendererState().RendererInfo.SkeletalVerticesDataSize -= Vertices.size() * sizeof( ExSkelVertexStruct );

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -320,9 +320,9 @@ struct SkeletalMeshVisualInfo : public BaseVisualInfo {
     /** Submeshes of this visual */
     std::map<zCMaterial*, std::vector<std::unique_ptr<SkeletalMeshInfo>>> SkeletalMeshes;
 
-    /** False while a background LoadzCModelData(...) extraction job (GothicAPI::PendingSkeletalLoads)
-     *  is still filling SkeletalMeshes/Meshes. Draw/update code must skip vobs pointing at a
-     *  not-yet-ready visual instead of touching the (possibly still empty) mesh lists. */
+    /** False while an AsyncVisualExtractor job is still filling SkeletalMeshes/Meshes. Draw/update
+     *  code must skip vobs pointing at a not-yet-ready visual instead of touching the (possibly
+     *  still empty) mesh lists. */
     std::atomic<bool> Ready{true};
 };
 

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -107,6 +107,12 @@ struct MeshInfo {
     GfxVertexBuffer* GetMeshIndexBuffer() const { return MeshIndexBuffer.get(); }
     GfxVertexBuffer* GetMeshShadowIndexBuffer() const { return MeshShadowIndexBuffer.get(); }
 
+    /** The slim CPU-side copy, for code that is handed a MeshInfo* without knowing whether it is a world
+        mesh (the editor overlays, mostly). Null means "this mesh still has its full Vertices array" -
+        which is every mesh except a shrunk WorldMeshInfo - so callers branch once per mesh and fall back.
+        Indexed by the same Indices as Vertices was. */
+    virtual const std::vector<WorldVertexCPU>* GetCpuVertices() const { return nullptr; }
+
     std::unique_ptr<GfxVertexBuffer> MeshVertexBuffer;
     // Optional position-only (float3, 12 bytes) copy of MeshVertexBuffer, in the same vertex
     // ordering. Bound for opaque depth/shadow passes to cut vertex-fetch bandwidth (~3.6x vs the
@@ -152,6 +158,19 @@ struct WorldMeshInfo : public MeshInfo {
 
     // Offset in wrapped world mesh
     unsigned int BaseShadowIndexLocation;
+
+    /** Replaces MeshInfo::Vertices, which is dropped once the GPU buffers and the wrapped mesh have been
+        built. Empty until ShrinkCpuVertices() runs, and on any mesh that never went through it - hence the
+        fallback in GetCpuVertices(). */
+    std::vector<WorldVertexCPU> CpuVertices;
+
+    const std::vector<WorldVertexCPU>* GetCpuVertices() const override {
+        return CpuVertices.empty() ? nullptr : &CpuVertices;
+    }
+
+    /** Builds CpuVertices and frees Vertices (capacity included). Call only after the vertex buffer is
+        uploaded AND the wrapped world mesh has been assembled - WrapVertexBuffers reads Vertices. */
+    void ShrinkCpuVertices();
 };
 
 struct QuadMarkInfo {

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -127,11 +127,10 @@ struct MeshInfo {
     // indices onto surviving vertices, it never adds any), used by the main view's far bucket and by the
     // far shadow cascades. Built by MeshLodBuilder.h during visual extraction.
     //
-    // D3D12 ONLY - left empty under D3D11, on purpose. It gets no standalone index buffer: the D3D12 VOB
-    // arena copies it into the shared mega index buffer and draws it as a range, so it costs no extra
-    // allocation there, whereas D3D11 could only bind it as one more per-sub-mesh buffer and D3D11 is the
-    // backend already closest to the 32-bit address-space ceiling. Also empty for morph sub-meshes, which
-    // skip OptimizeVertices entirely.
+    // D3D12 ONLY - left empty under D3D11 on purpose. It gets no standalone index buffer: the VOB arena
+    // copies it into the shared mega index buffer and draws it as a range, whereas D3D11 could only bind it
+    // as one more per-sub-mesh buffer, and D3D11 is the backend closest to the 32-bit address-space ceiling.
+    // Also empty for morph sub-meshes, which skip OptimizeVertices entirely.
     std::vector<VERTEX_INDEX> LodIndices;
 
     // Offset in wrapped world mesh

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -106,7 +106,6 @@ struct MeshInfo {
     GfxVertexBuffer* GetMeshPositionBuffer() const { return MeshPositionBuffer.get(); }
     GfxVertexBuffer* GetMeshIndexBuffer() const { return MeshIndexBuffer.get(); }
     GfxVertexBuffer* GetMeshShadowIndexBuffer() const { return MeshShadowIndexBuffer.get(); }
-    GfxVertexBuffer* GetMeshLodIndexBuffer() const { return MeshLodIndexBuffer.get(); }
 
     std::unique_ptr<GfxVertexBuffer> MeshVertexBuffer;
     // Optional position-only (float3, 12 bytes) copy of MeshVertexBuffer, in the same vertex
@@ -115,15 +114,18 @@ struct MeshInfo {
     std::unique_ptr<GfxVertexBuffer> MeshPositionBuffer;
     std::unique_ptr<GfxVertexBuffer> MeshIndexBuffer;
     std::unique_ptr<GfxVertexBuffer> MeshShadowIndexBuffer;
-    // Optional reduced index buffer for distant shadow cascades, baked from ZENGIN's own progressive-mesh
-    // data (zCSubMesh::WedgeMap/VertexUpdates) at SHADOW_LOD_VERTEX_FRACTION. Indexes the very same
-    // MeshVertexBuffer as the other two - a collapse only ever redirects indices onto surviving vertices,
-    // it never produces new ones. Only populated for meshes that actually ship LOD data and clear the
-    // SHADOW_LOD_MIN_TRIANGLES gate, so it is nullptr far more often than not.
-    std::unique_ptr<GfxVertexBuffer> MeshLodIndexBuffer;
     std::vector<ExVertexStruct> Vertices;
     std::vector<VERTEX_INDEX> Indices;
     std::vector<VERTEX_INDEX> ShadowIndices;
+    // Reduced index list over the SAME vertex numbering as Indices (an edge collapse only ever redirects
+    // indices onto surviving vertices, it never adds any), used by the main view's far bucket and by the
+    // far shadow cascades. Built by MeshLodBuilder.h during visual extraction.
+    //
+    // D3D12 ONLY - left empty under D3D11, on purpose. It gets no standalone index buffer: the D3D12 VOB
+    // arena copies it into the shared mega index buffer and draws it as a range, so it costs no extra
+    // allocation there, whereas D3D11 could only bind it as one more per-sub-mesh buffer and D3D11 is the
+    // backend already closest to the 32-bit address-space ceiling. Also empty for morph sub-meshes, which
+    // skip OptimizeVertices entirely.
     std::vector<VERTEX_INDEX> LodIndices;
 
     // Offset in wrapped world mesh


### PR DESCRIPTION
ba07d6c - name the model in the torn-softskin warning
ce0c43c - fix crash due to broken indicies (index count > vertex count)
23aff6e - reduce memory allocation where possible by reducing on-RAM verticies.
816ebac - don't pay for shadow indicies if not necessery
bccd2c9 - fix incorrect range collection
52b50be - don't make dx11 pay for LOD because its expensive over there. (VA usage)
039b351 - dx12: add CPU side LOD for main geometry
3ffbb91 - dx12: store VOBs in big vertex/index buffer and don't re-bind when possible.
650425f - dx12: render sky after depth, to reduce over-draw. Add slider to ignore vobs smaller than X
98ec63a - configurable shadow LOD distance
24d70cc - dx12: model LOD for main geometry after culling