### PR TITLE
(6/7) Transparency render-order fixed, EnvMap/Cubemap for glossy ground (like Ice)

### DIFF
--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -318,8 +318,7 @@ public:
     virtual XRESULT DrawVOBs( bool noTextures = false ) { return XR_SUCCESS; }
 
     /** Draws PolyStrips (weapon and particle trails) */
-    // Poly strips (weapon/spell trails, lightning) are drawn out of the frame's sorted transparency queue
-    // by each backend's DrawPolyStripRun, not through a virtual on this interface.
+    // Poly strips are drawn by each backend's DrawPolyStripRun out of the transparency queue.
 
     /** Draws the sky using the GSky-Object */
     virtual XRESULT DrawSky() { return XR_SUCCESS; }

--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -318,7 +318,8 @@ public:
     virtual XRESULT DrawVOBs( bool noTextures = false ) { return XR_SUCCESS; }
 
     /** Draws PolyStrips (weapon and particle trails) */
-    virtual XRESULT DrawPolyStrips( bool noTextures = false ) { return XR_SUCCESS; };
+    // Poly strips (weapon/spell trails, lightning) are drawn out of the frame's sorted transparency queue
+    // by each backend's DrawPolyStripRun, not through a virtual on this interface.
 
     /** Draws the sky using the GSky-Object */
     virtual XRESULT DrawSky() { return XR_SUCCESS; }

--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -460,5 +460,11 @@ struct PsSimpleFFdata {
     float4 textureFactor;
 };
 
+/** cbEnvMap of PS_EnvMap.hlsl — the env-map overlay stage (ZenGin zRenderManager.cpp:671-712). */
+struct PsEnvMapData {
+    XMFLOAT4X4 InvView;     // view -> world, takes the reflection vector into cube space
+    float4 Params;          // x = stage alpha (EnvMapStrength * luma(fogColor)), yzw unused
+};
+
 #pragma pack (pop)
 

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -945,7 +945,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="D3D12Engine\D3D12StateCache.h" />
     <ClInclude Include="D3D12Engine\D3D12RenderQueue.h" />
     <ClInclude Include="D3D12Engine\D3D12ShadowMap.h" />
-<ClInclude Include="D3D12Engine\D3D12VobArena.h" />
+    <ClInclude Include="D3D12Engine\D3D12VobArena.h" />
     <ClInclude Include="D3D12Engine\D3D12PointShadows.h" />
     <ClInclude Include="D3D12Engine\InstancingUtils.h" />
     <ClInclude Include="D3D12Engine\D3D12TracyDebug.h" />
@@ -1106,6 +1106,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="RGTextureDesc.h" />
     <ClInclude Include="ShaderCategory.h" />
     <ClInclude Include="ShaderRegistry.h" />
+    <ClInclude Include="TransparencyQueue.h" />
     <ClInclude Include="D3D12Engine\D3D12Device.h" />
     <ClInclude Include="D3D12Engine\D3D12GraphicsEngine.h" />
     <ClInclude Include="D3D12Engine\D3D12EngineCommon.h" />
@@ -1244,6 +1245,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="BspPortalCuller.cpp" />
     <ClCompile Include="HorizonCuller.cpp" />
     <ClCompile Include="ShaderRegistry.cpp" />
+    <ClCompile Include="TransparencyQueue.cpp" />
     <ClCompile Include="D3D12Engine\D3D12Device.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
@@ -1499,7 +1501,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
     </ClCompile>
-<ClCompile Include="D3D12Engine\D3D12VobArena.cpp">
+    <ClCompile Include="D3D12Engine\D3D12VobArena.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -777,7 +777,7 @@
     <ClInclude Include="D3D12Engine\D3D12ShadowMap.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
-<ClInclude Include="D3D12Engine\D3D12VobArena.h">
+    <ClInclude Include="D3D12Engine\D3D12VobArena.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
     <ClInclude Include="D3D12Engine\D3D12PointShadows.h">
@@ -937,6 +937,7 @@
     <ClInclude Include="AsyncVisualExtractor.h" />
     <ClInclude Include="SharedVisualRegistry.h" />
     <ClInclude Include="MorphGpu.h" />
+    <ClInclude Include="zCPathSearch.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -771,6 +771,9 @@
     <ClInclude Include="ShaderRegistry.h">
       <Filter>Engine</Filter>
     </ClInclude>
+    <ClInclude Include="TransparencyQueue.h">
+      <Filter>Engine</Filter>
+    </ClInclude>
     <ClInclude Include="D3D12Engine\D3D12Device.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
@@ -981,6 +984,9 @@
       <Filter>Engine\D3D11</Filter>
     </ClCompile>
     <ClCompile Include="ShaderRegistry.cpp">
+      <Filter>Engine</Filter>
+    </ClCompile>
+    <ClCompile Include="TransparencyQueue.cpp">
       <Filter>Engine</Filter>
     </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12Device.cpp">

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -27,6 +27,8 @@
 #include "zCTexture.h"
 #include "zCView.h"
 #include "zCVobLight.h"
+#include "zCSkyController_Outdoor.h"   // ComputeEnvMapAlpha: resultFogColor drives the env-map stage
+#include "oCGame.h"
 #include "oCNPC.h"
 #include <DDSTextureLoader.h>
 #include <ScreenGrab.h>
@@ -4864,7 +4866,17 @@ void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
     // Draw the list
     PsSimpleFFdata ffdata = { };
     ffdata.textureFactor = float4( 1.0f, 1.0f, 1.0f, 1.0f );
-    
+
+    // Env-map overlay stage (see ComputeEnvMapAlpha). Only the Simple variant runs it: PS_PortalDiffuse
+    // and PS_WaterfallFoam are their own effects, and ZenGin never env-maps a portal either.
+    // The inverse view is constant for the whole run, so build it once.
+    const bool envMapEnabled = variant == EWorldTransparencyVariant::Normal;
+    PsEnvMapData envData = { };
+    if ( envMapEnabled ) {
+        Engine::GAPI->GetInverseViewMatrixXM( &envData.InvView );
+    }
+    bool envCubeBound = false;
+
     void* lastTex = nullptr;
     void* lastMat = nullptr;
     for ( auto const& item : items ) {
@@ -4942,26 +4954,16 @@ void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
                 lastAlphaFunc = alphaFunc;
             }
 
-            if ( mat->GetEnvMapEnabled()) {
-                if (Engine::GAPI->GetSky()->GetAtmosphereCB().AC_LightPos.y > 0) {
-                    // sun is up
-
-                    float sunHeight = Engine::GAPI->GetSky()->GetAtmosphereCB().AC_LightPos.y;
-                    const float maxSunHeight = 1.0f;
-                    float lerpFactor = std::clamp( sunHeight / maxSunHeight, 0.0f, 1.0f );
-
-                    float minIntensity = 0.1f;
-                    float maxIntensity = 0.7f;
-                    float currentIntensity = std::clamp( meshKey.Material->GetEnvMapStrength() * std::lerp( minIntensity, maxIntensity, lerpFactor ), 0.0f, 1.0f);
-                    ffdata.textureFactor = zColor( 255, 255, 255, (uint8_t)(255.0f * currentIntensity) ).ToFloat4();
-                } else {
-                    ffdata.textureFactor = zColor( 255, 255, 255, (uint8_t)(255.0f * meshKey.Material->GetEnvMapStrength() * 0.1f) ).ToFloat4();
-                }
-            } else {
-                if ( zColor( meshKey.Material->GetColor() ).bgra.alpha < 255 ) {
-                    ffdata.textureFactor = zColor( meshKey.Material->GetColor() ).ToFloat4();
-                }
-            }
+            // The base surface's alpha is the material color's alpha, full stop. ZenGin sets the
+            // TFACTOR to zCMaterial::GetColor() (zRenderManager.cpp:609, alphaGen=FACTOR) and the
+            // D3D7 poly path multiplies vertex-light alpha by mat->GetAlpha() == color.alpha
+            // (zRndD3D_Render.cpp:1049). GetEnvMapStrength() is deliberately NOT part of this:
+            // env-mapping is an *additional* stage drawn on top of the opaque/blended base pass
+            // (zRenderManager.cpp:701-703), which the PS_EnvMap draw below renders. Folding the env
+            // strength into the base alpha here is what made ice near-invisible instead of thick.
+            ffdata.textureFactor = zColor( meshKey.Material->GetColor() ).bgra.alpha < 255
+                ? zColor( meshKey.Material->GetColor() ).ToFloat4()
+                : float4( 1.0f, 1.0f, 1.0f, 1.0f );
 
             ActivePS->UpdateBuffer("cbFFData", &ffdata, sizeof(ffdata));
 
@@ -4971,6 +4973,41 @@ void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
             DrawVertexBufferIndexedUINT( nullptr, nullptr, meshInfo->Indices.size(),
                 meshInfo->BaseIndexLocation );
 
+            // ZenGin draws the env-map stage immediately after the base stage of the same shader
+            // (zRenderManager.cpp:671 adds it to the same zCShader; DrawVertexBuffer walks the stages
+            // back to back), so it goes inline here rather than as a second sweep of the run — that
+            // keeps the painter's order of the surrounding blended surfaces intact.
+            if ( envMapEnabled && mat->GetEnvMapEnabled() ) {
+                if ( !envCubeBound ) {
+                    GetContext()->PSSetShaderResources( 4, 1, ReflectionCube.GetAddressOf() );
+                    envCubeBound = true;
+                }
+
+                SetActivePixelShader( PShaderID::PS_EnvMap );
+                ActivePS->Apply();
+
+                // Water gets an additive stage in ZenGin (zRenderManager.cpp:709); everything else
+                // blends. Depth state is left as the base pass set it (test on, write off).
+                if ( mat->GetMatGroup() == zMAT_GROUP_WATER ) {
+                    Engine::GAPI->GetRendererState().BlendState.SetAdditiveBlending();
+                } else {
+                    Engine::GAPI->GetRendererState().BlendState.SetAlphaBlending();
+                }
+                Engine::GAPI->GetRendererState().BlendState.SetDirty();
+                UpdateRenderStates();
+
+                envData.Params = float4( Engine::GAPI->GetEnvMapStageAlpha( mat ), 0.0f, 0.0f, 0.0f );
+                ActivePS->UpdateBuffer( "cbEnvMap", &envData, sizeof( envData ) );
+
+                DrawVertexBufferIndexedUINT( nullptr, nullptr, meshInfo->Indices.size(),
+                    meshInfo->BaseIndexLocation );
+
+                // The overlay clobbered the shader, its texture bindings and the blend state, so the
+                // next item has to re-establish all three instead of hitting these caches.
+                lastTex = nullptr;
+                lastMat = nullptr;
+                lastAlphaFunc = -1;
+            }
         }
     }
 }

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4247,7 +4247,41 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
             SetViewport( ViewportInfo( 0, 0, GetResolution() ) );
         };
     });
-    
+
+    // Everything alpha-blended in one pass, sorted back to front across all categories: world
+    // transparency meshes (normal / portal / waterfall), instanced alpha VOBs, ghosts, blended
+    // decals, quad marks and poly strips.
+    //
+    // Frame order is geometry -> alpha -> fog/pfx: this sits after the opaque scene, the sky and
+    // water, but BEFORE the height fog, god rays and the particle passes. That is what gets fog onto
+    // alpha-blended surfaces at all - drawn after the composition (where it used to sit) they were
+    // pasted on top of an already-fogged scene and stayed unfogged at any distance. It is also what
+    // makes DrawWorldTransparencyDepthOnly meaningful: the depth it re-lays is exactly what the fog
+    // and god-ray passes downstream sample, so they fog the glass surface instead of whatever stands
+    // behind it. Particle distortion still copies the finished scene afterwards, so it picks the
+    // transparent surfaces up as well.
+    graph.AddPass( RG_PASS_NAME( "Draw Transparency" ), [&]( RGBuilder& builder, RenderPass& pass ) {
+        builder.Read( backBufferHandle );
+        builder.Write( backBufferHandle );
+
+        pass.m_executeCallback = [this, backBufferHandle]( const RenderGraph& graph ) {
+            // Bind the depth buffer explicitly: render-graph passes inherit whatever OM state the
+            // previous one left, and several of the passes that can precede this end on a PfxRenderer
+            // blit with an RTV and no DSV, which would silently kill depth testing here.
+            auto backBuffer = graph.GetPhysicalTexture( backBufferHandle );
+            GetContext()->PSSetShaderResources( 0, 4, s_nullSRVs ); // depth may still be bound as SRV
+            GetContext()->OMSetRenderTargets( 1, backBuffer->GetRenderTargetView().GetAddressOf(),
+                DepthStencilBuffer->GetDepthStencilView().Get() );
+
+            zCCamera::GetCamera()->Activate();
+            // Camera->Activate breaks the viewport
+            SetViewport( ViewportInfo( 0, 0, GetResolution() ) );
+
+            CollectTransparencyQueue();
+            DrawTransparencyQueue();
+        };
+    } );
+
     if (rendererState.RendererSettings.DrawFog &&
                 Engine::GAPI->GetLoadedWorldInfo()->BspTree->GetBspTreeMode() ==
                 zBSP_MODE_OUTDOOR && !compositionActive) {
@@ -4436,32 +4470,6 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
             TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw Debug Lines" );
             LineRenderer->Flush();
             LineRenderer->FlushScreenSpace();
-        };
-    } );
-
-    // Everything alpha-blended in one pass, sorted back to front across all categories: world
-    // transparency meshes (normal / portal / waterfall), instanced alpha VOBs, ghosts, blended
-    // decals, quad marks and poly strips. This slot is where the world transparency meshes already
-    // sat - after water, particles and the fog/god-rays composition - so the refraction-based passes
-    // keep the scene they expect to read.
-    graph.AddPass( RG_PASS_NAME( "Draw Transparency" ), [&]( RGBuilder& builder, RenderPass& pass ) {
-        builder.Read( backBufferHandle );
-        builder.Write( backBufferHandle );
-
-        pass.m_executeCallback = [this, backBufferHandle]( const RenderGraph& graph ) {
-            // Re-bind the depth buffer: the preceding particle pass ends on a PfxRenderer blit that
-            // leaves the OM with an RTV and no DSV, which used to make trails draw through walls.
-            auto backBuffer = graph.GetPhysicalTexture( backBufferHandle );
-            GetContext()->PSSetShaderResources( 0, 4, s_nullSRVs ); // depth may still be bound as SRV
-            GetContext()->OMSetRenderTargets( 1, backBuffer->GetRenderTargetView().GetAddressOf(),
-                DepthStencilBuffer->GetDepthStencilView().Get() );
-
-            zCCamera::GetCamera()->Activate();
-            // Camera->Activate breaks the viewport
-            SetViewport( ViewportInfo( 0, 0, GetResolution() ) );
-
-            CollectTransparencyQueue();
-            DrawTransparencyQueue();
         };
     } );
 
@@ -4870,6 +4878,11 @@ void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
     // Env-map overlay stage (see ComputeEnvMapAlpha). Only the Simple variant runs it: PS_PortalDiffuse
     // and PS_WaterfallFoam are their own effects, and ZenGin never env-maps a portal either.
     // The inverse view is constant for the whole run, so build it once.
+    // Constant for the whole run - the base stage's stand-in for the time-of-day lighting these
+    // unlit surfaces never receive (see the textureFactor comment below). Exactly 1.0 while the sun
+    // is up, so this cannot dim anything in daylight.
+    const float skyLight = Engine::GAPI->GetSkyDayFactor();
+
     const bool envMapEnabled = variant == EWorldTransparencyVariant::Normal;
     PsEnvMapData envData = { };
     if ( envMapEnabled ) {
@@ -4954,16 +4967,30 @@ void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
                 lastAlphaFunc = alphaFunc;
             }
 
-            // The base surface's alpha is the material color's alpha, full stop. ZenGin sets the
-            // TFACTOR to zCMaterial::GetColor() (zRenderManager.cpp:609, alphaGen=FACTOR) and the
-            // D3D7 poly path multiplies vertex-light alpha by mat->GetAlpha() == color.alpha
-            // (zRndD3D_Render.cpp:1049). GetEnvMapStrength() is deliberately NOT part of this:
-            // env-mapping is an *additional* stage drawn on top of the opaque/blended base pass
-            // (zRenderManager.cpp:701-703), which the PS_EnvMap draw below renders. Folding the env
-            // strength into the base alpha here is what made ice near-invisible instead of thick.
-            ffdata.textureFactor = zColor( meshKey.Material->GetColor() ).bgra.alpha < 255
-                ? zColor( meshKey.Material->GetColor() ).ToFloat4()
-                : float4( 1.0f, 1.0f, 1.0f, 1.0f );
+            // The material color contributes ALPHA ONLY, never RGB. ZenGin's base stage is
+            // rgbGen=VERTEX / alphaGen=FACTOR (zRenderManager.cpp:601-610), and the D3D7 poly path
+            // spells that out: the vertex color's RGB is the vertex light and only its alpha gets
+            // the material factor folded in — `intalpha = lightDyn.GetAlphaByte() * mat->GetAlpha()`,
+            // `a_color = (intalpha<<24) | lightDyn.rgb` (zRndD3D_Render.cpp:1049). The material
+            // color's RGB is used only for UNTEXTURED polys ("Verwende Materialfarbe falls keine
+            // Textur vorhanden"), which cannot reach this loop — we are inside `if (GetAniTexture())`.
+            //
+            // Multiplying the RGB in as well is what made dark-tinted additive surfaces vanish: the
+            // magic barrier's material color is (4,45,26,155), so its texture was being scaled to
+            // 1.6%/17.6%/10% before an additive blend that then multiplies by src alpha too.
+            //
+            // GetEnvMapStrength() is deliberately NOT part of this either: env-mapping is an
+            // *additional* stage drawn on top of the base pass (zRenderManager.cpp:701-703), which
+            // the PS_EnvMap draw below renders. Folding the env strength into the base alpha here is
+            // what made ice near-invisible instead of thick.
+            //
+            // The RGB carries the day/night factor instead of the material color: these surfaces are
+            // drawn UNLIT (D3D11ForwardPlusRenderer::BindShaderForTexture sends every BLEND/ADD material
+            // to the non-lit fallback shaders) over a world-mesh vertex color that is the static, baked
+            // daylight light, so without it ice and waterfall foam stay noon-bright at midnight. See
+            // GothicAPI::GetSkyDayFactor for why this stands in for ZenGin's relit vertex lighting.
+            ffdata.textureFactor = float4( skyLight, skyLight, skyLight,
+                zColor( mat->GetColor() ).bgra.alpha * (1.0f / 255.0f) );
 
             ActivePS->UpdateBuffer("cbFFData", &ffdata, sizeof(ffdata));
 
@@ -5018,9 +5045,9 @@ void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
     interleaving the lists it has to happen once, after the whole replay, or a nearer transparency
     mesh would depth-reject a farther one that is drawn later. Portals are excluded, same as before.
 
-    Note the fog/god-rays justification the original comment gave is stale: both of those passes run
-    earlier in the frame now. This is kept for the depth-consuming post effects that still come
-    after the transparency pass (DoF, TAA). */
+    The original justification holds: the height fog and god rays run right after the transparency
+    pass and reconstruct world positions from this depth buffer, so without the re-lay they would fog
+    whatever stands BEHIND the glass instead of the glass itself. DoF and TAA read it too. */
 void D3D11GraphicsEngine::DrawWorldTransparencyDepthOnly() {
     const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4237,59 +4237,6 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         };
     });
     
-    graph.AddPass( RG_PASS_NAME("Draw FrameTransparencyMeshes"), [&]( RGBuilder& builder, RenderPass& pass ) {
-        builder.Read( backBufferHandle );
-        builder.Write( backBufferHandle );
-
-        pass.m_executeCallback = [this](const RenderGraph&) {
-            TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw FrameTransparencyMeshes" );
-
-            SetDefaultStates();
-
-            // Setup renderstates
-            Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
-            Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
-
-            DrawMeshInfoListAlphablended( FrameTransparencyMeshes );
-        };
-    });
-    
-    if ( rendererState.RendererSettings.DrawG1ForestPortals ) {
-        graph.AddPass( RG_PASS_NAME("Draw ForestPortals"), [&]( RGBuilder& builder, RenderPass& pass ) {
-            builder.Read( backBufferHandle );
-            builder.Write( backBufferHandle );
-
-            pass.m_executeCallback = [this](const RenderGraph&) {
-                TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw ForestPortals" );
-
-                SetDefaultStates();
-
-                // Setup renderstates
-                Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
-                Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
-
-                DrawMeshInfoListAlphablended( FrameTransparencyMeshesPortal );
-            };
-        });
-    }
-    
-    graph.AddPass( RG_PASS_NAME("Draw FrameTransparencyMeshesWaterfall"), [&]( RGBuilder& builder, RenderPass& pass ) {
-        builder.Read( backBufferHandle );
-        builder.Write( backBufferHandle );
-
-        pass.m_executeCallback = [this](const RenderGraph&) {
-            TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw FrameTransparencyMeshesWaterfall" );
-
-            SetDefaultStates();
-
-            // Setup renderstates
-            Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
-            Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
-
-            DrawMeshInfoListAlphablended( FrameTransparencyMeshesWaterfall );
-        };
-    });
-    
     graph.AddPass( RG_PASS_NAME("Draw ghosts"), [&]( RGBuilder& builder, RenderPass& pass ) {
         builder.Read( backBufferHandle );
         builder.Write( backBufferHandle );
@@ -4547,6 +4494,59 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
             LineRenderer->Flush();
             LineRenderer->FlushScreenSpace();
         };
+    } );
+
+    graph.AddPass( RG_PASS_NAME( "Draw FrameTransparencyMeshes" ), [&]( RGBuilder& builder, RenderPass& pass ) {
+        builder.Read( backBufferHandle );
+        builder.Write( backBufferHandle );
+
+        pass.m_executeCallback = [this]( const RenderGraph& ) {
+            TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw FrameTransparencyMeshes" );
+
+            SetDefaultStates();
+
+            // Setup renderstates
+            Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
+            Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+
+            DrawMeshInfoListAlphablended( FrameTransparencyMeshes );
+            };
+    } );
+
+    if ( rendererState.RendererSettings.DrawG1ForestPortals ) {
+        graph.AddPass( RG_PASS_NAME( "Draw ForestPortals" ), [&]( RGBuilder& builder, RenderPass& pass ) {
+            builder.Read( backBufferHandle );
+            builder.Write( backBufferHandle );
+
+            pass.m_executeCallback = [this]( const RenderGraph& ) {
+                TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw ForestPortals" );
+
+                SetDefaultStates();
+
+                // Setup renderstates
+                Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
+                Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+
+                DrawMeshInfoListAlphablended( FrameTransparencyMeshesPortal );
+            };
+        } );
+    }
+
+    graph.AddPass( RG_PASS_NAME( "Draw FrameTransparencyMeshesWaterfall" ), [&]( RGBuilder& builder, RenderPass& pass ) {
+        builder.Read( backBufferHandle );
+        builder.Write( backBufferHandle );
+
+        pass.m_executeCallback = [this]( const RenderGraph& ) {
+            TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw FrameTransparencyMeshesWaterfall" );
+
+            SetDefaultStates();
+
+            // Setup renderstates
+            Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
+            Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+
+            DrawMeshInfoListAlphablended( FrameTransparencyMeshesWaterfall );
+            };
     } );
 
     // Draw debug lines

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4068,8 +4068,7 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     FrameWaterSurfaces.clear();
     m_FrameGeometryCache.Reset();
 
-    // Producers push into this all through the frame (world mesh build, VOB collection); the sorted
-    // transparency pass at the end of the graph drains it.
+    // Producers push all through the frame; the transparency pass drains it.
     Engine::GAPI->GetTransparencyQueue().BeginFrame();
     Engine::GAPI->GetTransparencyVobs().clear();
 
@@ -4172,8 +4171,7 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
 
             Engine::GAPI->ResetRenderStates();
 
-            // Only the lit (alpha-tested, never blended) decals belong here, before lighting.
-            // Quad marks moved into the sorted transparency pass at the end of the frame.
+            // Lit (alpha-tested, never blended) decals only; the rest is transparency-queue content.
             DrawDecalList( decals, true );
         };
     });    
@@ -4239,8 +4237,7 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         pass.m_executeCallback = [this](const RenderGraph&) {
             TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw SkeletalVN" );
 
-            // Ghosts themselves moved into the sorted transparency pass near the end of the frame
-            Engine::GAPI->DrawSkeletalVN();
+            Engine::GAPI->DrawSkeletalVN();   // ghosts themselves are transparency-queue content
 
             // for Post-Processing FX we use the full viewport for now
             // TODO: introduce UV-scaling to PostFX
@@ -4248,26 +4245,17 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         };
     });
 
-    // Everything alpha-blended in one pass, sorted back to front across all categories: world
-    // transparency meshes (normal / portal / waterfall), instanced alpha VOBs, ghosts, blended
-    // decals, quad marks and poly strips.
-    //
-    // Frame order is geometry -> alpha -> fog/pfx: this sits after the opaque scene, the sky and
-    // water, but BEFORE the height fog, god rays and the particle passes. That is what gets fog onto
-    // alpha-blended surfaces at all - drawn after the composition (where it used to sit) they were
-    // pasted on top of an already-fogged scene and stayed unfogged at any distance. It is also what
-    // makes DrawWorldTransparencyDepthOnly meaningful: the depth it re-lays is exactly what the fog
-    // and god-ray passes downstream sample, so they fog the glass surface instead of whatever stands
-    // behind it. Particle distortion still copies the finished scene afterwards, so it picks the
-    // transparent surfaces up as well.
+    // Everything alpha-blended in one back-to-front pass. Frame order is geometry -> alpha -> fog/pfx:
+    // after the opaque scene, sky and water, but BEFORE the fog, god rays and particles - drawn after
+    // those (where it used to sit) alpha surfaces were pasted onto an already-fogged scene and never
+    // fogged themselves.
     graph.AddPass( RG_PASS_NAME( "Draw Transparency" ), [&]( RGBuilder& builder, RenderPass& pass ) {
         builder.Read( backBufferHandle );
         builder.Write( backBufferHandle );
 
         pass.m_executeCallback = [this, backBufferHandle]( const RenderGraph& graph ) {
-            // Bind the depth buffer explicitly: render-graph passes inherit whatever OM state the
-            // previous one left, and several of the passes that can precede this end on a PfxRenderer
-            // blit with an RTV and no DSV, which would silently kill depth testing here.
+            // Bind depth explicitly: passes inherit OM state, and a preceding PfxRenderer blit can
+            // leave an RTV with no DSV, silently killing depth testing here.
             auto backBuffer = graph.GetPhysicalTexture( backBufferHandle );
             GetContext()->PSSetShaderResources( 0, 4, s_nullSRVs ); // depth may still be bound as SRV
             GetContext()->OMSetRenderTargets( 1, backBuffer->GetRenderTargetView().GetAddressOf(),
@@ -4351,8 +4339,6 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         };
     });
     
-    // Unlit decals and the modulate quad marks used to be drawn here, in a second particle-FX pass.
-    // Both are alpha-blended and now go through the sorted transparency pass instead.
     
     if (rendererState.RendererSettings.EnableGodRays &&
         Engine::GAPI->GetLoadedWorldInfo()->BspTree->GetBspTreeMode() ==
@@ -4818,13 +4804,8 @@ void D3D11GraphicsEngine::UpdateColorSpace_SwapChain()
     }
 }
 
-/** Draws a list of mesh infos */
-/** Draws a run of alpha-blended world mesh sections in the order the transparency queue produced.
-
-    The three world transparency variants (normal / portal / waterfall) all run through this one
-    body: the pixel shader is picked per material from MaterialInfo::MaterialType inside
-    BindShaderForTexture, so the variant only decides whether the run is drawn at all (portals are
-    gated behind DrawG1ForestPortals) and whether it re-writes depth afterwards. */
+/** One run of alpha-blended world mesh sections, in queue order. All three variants share this body;
+    BindShaderForTexture picks the pixel shader from MaterialInfo::MaterialType. */
 void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentItem> items,
     EWorldTransparencyVariant variant ) {
     if ( items.empty() ) {
@@ -4875,14 +4856,10 @@ void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
     PsSimpleFFdata ffdata = { };
     ffdata.textureFactor = float4( 1.0f, 1.0f, 1.0f, 1.0f );
 
-    // Env-map overlay stage (see ComputeEnvMapAlpha). Only the Simple variant runs it: PS_PortalDiffuse
-    // and PS_WaterfallFoam are their own effects, and ZenGin never env-maps a portal either.
-    // The inverse view is constant for the whole run, so build it once.
-    // Constant for the whole run - the base stage's stand-in for the time-of-day lighting these
-    // unlit surfaces never receive (see the textureFactor comment below). Exactly 1.0 while the sun
-    // is up, so this cannot dim anything in daylight.
+    // Stand-in for the lighting these unlit surfaces never get; 1.0 in daylight. See GetSkyDayFactor.
     const float skyLight = Engine::GAPI->GetSkyDayFactor();
 
+    // Env-map overlay stage. Simple variant only - portals/foam are their own effects.
     const bool envMapEnabled = variant == EWorldTransparencyVariant::Normal;
     PsEnvMapData envData = { };
     if ( envMapEnabled ) {
@@ -4967,28 +4944,11 @@ void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
                 lastAlphaFunc = alphaFunc;
             }
 
-            // The material color contributes ALPHA ONLY, never RGB. ZenGin's base stage is
-            // rgbGen=VERTEX / alphaGen=FACTOR (zRenderManager.cpp:601-610), and the D3D7 poly path
-            // spells that out: the vertex color's RGB is the vertex light and only its alpha gets
-            // the material factor folded in — `intalpha = lightDyn.GetAlphaByte() * mat->GetAlpha()`,
-            // `a_color = (intalpha<<24) | lightDyn.rgb` (zRndD3D_Render.cpp:1049). The material
-            // color's RGB is used only for UNTEXTURED polys ("Verwende Materialfarbe falls keine
-            // Textur vorhanden"), which cannot reach this loop — we are inside `if (GetAniTexture())`.
-            //
-            // Multiplying the RGB in as well is what made dark-tinted additive surfaces vanish: the
-            // magic barrier's material color is (4,45,26,155), so its texture was being scaled to
-            // 1.6%/17.6%/10% before an additive blend that then multiplies by src alpha too.
-            //
-            // GetEnvMapStrength() is deliberately NOT part of this either: env-mapping is an
-            // *additional* stage drawn on top of the base pass (zRenderManager.cpp:701-703), which
-            // the PS_EnvMap draw below renders. Folding the env strength into the base alpha here is
-            // what made ice near-invisible instead of thick.
-            //
-            // The RGB carries the day/night factor instead of the material color: these surfaces are
-            // drawn UNLIT (D3D11ForwardPlusRenderer::BindShaderForTexture sends every BLEND/ADD material
-            // to the non-lit fallback shaders) over a world-mesh vertex color that is the static, baked
-            // daylight light, so without it ice and waterfall foam stay noon-bright at midnight. See
-            // GothicAPI::GetSkyDayFactor for why this stands in for ZenGin's relit vertex lighting.
+            // Material color contributes ALPHA only: ZenGin's base stage is rgbGen=VERTEX /
+            // alphaGen=FACTOR (zRenderManager.cpp:601-610, zRndD3D_Render.cpp:1049); its RGB is for
+            // untextured polys, which cannot reach this loop. Multiplying the RGB in made dark-tinted
+            // additive surfaces (magic barrier, 4,45,26,155) vanish. Env strength is a separate stage
+            // below, not part of the base alpha.
             ffdata.textureFactor = float4( skyLight, skyLight, skyLight,
                 zColor( mat->GetColor() ).bgra.alpha * (1.0f / 255.0f) );
 
@@ -5039,15 +4999,10 @@ void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
     }
 }
 
-/** Re-writes the depth of every world transparency mesh of this frame with color writes off.
-
-    This used to be the tail of DrawMeshInfoListAlphablended and ran once per list; with the queue
-    interleaving the lists it has to happen once, after the whole replay, or a nearer transparency
-    mesh would depth-reject a farther one that is drawn later. Portals are excluded, same as before.
-
-    The original justification holds: the height fog and god rays run right after the transparency
-    pass and reconstruct world positions from this depth buffer, so without the re-lay they would fog
-    whatever stands BEHIND the glass instead of the glass itself. DoF and TAA read it too. */
+/** Depth of this frame's world transparency meshes, color writes off. Must run ONCE after the whole
+    replay, not per run, or a nearer mesh would depth-reject a farther one drawn later. The fog/god-ray
+    passes right after reconstruct world positions from this, so without it they would fog what stands
+    behind the glass. Portals excluded - a fade-in curtain must not push fog depth to itself. */
 void D3D11GraphicsEngine::DrawWorldTransparencyDepthOnly() {
     const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
 
@@ -5090,7 +5045,7 @@ void D3D11GraphicsEngine::DrawWorldTransparencyDepthOnly() {
     }
 }
 
-/** Draws a run of ghost vobs (invisible-potion / fade-out items and NPCs). */
+/** One run of ghost vobs (invisible-potion / fade-out items and NPCs). */
 void D3D11GraphicsEngine::DrawGhostRun( std::span<const TransparentItem> items ) {
     if ( items.empty() ) return;
 
@@ -5113,8 +5068,7 @@ void D3D11GraphicsEngine::DrawGhostRun( std::span<const TransparentItem> items )
     SetRenderingStage( oldStage );
 }
 
-/** Draws a run of blended decals. The existing list-based path already batches consecutive
-    same-material decals without reordering them, which is exactly what a queue run needs. */
+/** One run of blended decals; DrawDecalList already batches same-material runs without reordering. */
 void D3D11GraphicsEngine::DrawDecalRun( std::span<const TransparentItem> items ) {
     if ( items.empty() ) return;
 
@@ -5130,10 +5084,8 @@ void D3D11GraphicsEngine::DrawDecalRun( std::span<const TransparentItem> items )
     DrawDecalList( decalRun, false );
 }
 
-/** Fills the frame's transparency queue with everything that is not pushed at production time and
-    sorts it. World transparency meshes (DrawWorldMesh) and alpha VOB instances (DrawVOBsInstanced)
-    are already in by the time this runs; ghosts, decals, quad marks and poly strips are gathered
-    here, right before the replay, so no producer has to care about pass ordering. */
+/** Fills the queue with the kinds not pushed at production time and sorts it. World meshes
+    (DrawWorldMesh) and alpha VOB instances (DrawVOBsInstanced) are already in. */
 void D3D11GraphicsEngine::CollectTransparencyQueue() {
     ZoneScopedN( "CollectTransparencyQueue" );
 
@@ -5141,8 +5093,7 @@ void D3D11GraphicsEngine::CollectTransparencyQueue() {
     auto& renderSettings = Engine::GAPI->GetRendererState().RendererSettings;
     const XMVECTOR camPos = Engine::GAPI->GetCameraPositionXM();
 
-    // Ghosts. TransparencyVobInfo::distance is linear (DrawSkeletalMeshVob wants it that way),
-    // the queue sorts on squared distances.
+    // TransparencyVobInfo::distance is linear (DrawSkeletalMeshVob needs it that way).
     auto& transparencyVobs = Engine::GAPI->GetTransparencyVobs();
     for ( size_t i = 0; i < transparencyVobs.size(); ++i ) {
         const float distance = transparencyVobs[i].distance;
@@ -5150,8 +5101,7 @@ void D3D11GraphicsEngine::CollectTransparencyQueue() {
     }
 
     if ( renderSettings.DrawParticleEffects ) {
-        // Unlit (blended) decals. The lit/alpha-tested ones are not part of the queue - they are
-        // drawn opaque before lighting and never blend.
+        // Blended decals only; the lit/alpha-tested ones draw opaque before lighting.
         static std::vector<zCVob*> decals; // static to get around reallocations
         decals.clear();
         Engine::GAPI->GetVisibleDecalList( decals );
@@ -5175,8 +5125,7 @@ void D3D11GraphicsEngine::CollectTransparencyQueue() {
     }
 
 #if (defined BUILD_GOTHIC_2_6_fix || defined BUILD_GOTHIC_1_08k)
-    // Poly strips (weapon/effect trails and the barrier's lightning). The mesh data has to be built
-    // before we can take a depth for it.
+    // Mesh data has to exist before we can take a depth for it.
     Engine::GAPI->CalcPolyStripMeshes();
     Engine::GAPI->CalcFlashMeshes();
 
@@ -5184,7 +5133,7 @@ void D3D11GraphicsEngine::CollectTransparencyQueue() {
         const std::vector<ExVertexStruct>& vertices = it.second.vertices;
         if ( vertices.empty() || !it.second.material || !it.first ) continue;
 
-        // One strip group per texture, so its depth is the centroid of everything in it
+        // One group per texture -> centroid depth
         XMVECTOR center = XMVectorZero();
         for ( auto const& vertex : vertices ) {
             center = XMVectorAdd( center, XMLoadFloat3( &vertex.Position ) );
@@ -5201,14 +5150,14 @@ void D3D11GraphicsEngine::CollectTransparencyQueue() {
     queue.Sort( !renderSettings.SortedTransparency );
 }
 
-/** Replays the sorted transparency queue. */
+/** Replays the sorted queue, one call per maximal same-kind run. */
 void D3D11GraphicsEngine::DrawTransparencyQueue() {
     TracyD3D11ZoneCGX( "D3D11GraphicsEngine::DrawTransparencyQueue" );
     auto _scopeTransparency = RecordGraphicsEvent( GE_NAME( "DrawTransparencyQueue" ) );
 
     const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
 
-    // One buffer for every alpha VOB batch of this frame, so it cannot live in a per-run emitter
+    // One buffer for all alpha VOB batches, so it cannot live in a per-run emitter
     PrepareAlphaMeshWindMetadata();
     m_AlphaVobDrawsThisFrame = 0;
 
@@ -5242,19 +5191,16 @@ void D3D11GraphicsEngine::DrawTransparencyQueue() {
             }
         } );
 
-    // Depth of the world transparency meshes, once, after everything blended has been drawn
     DrawWorldTransparencyDepthOnly();
 
-    // The alpha VOB visuals could not be reset inside the emitter: the queue can hand out a single
-    // batch's instances in more than one run.
+    // Not resettable inside the emitter: one batch's instances can span several runs.
     for ( auto const& alphaMesh : m_AlphaMeshes ) {
         if ( alphaMesh.vi ) alphaMesh.vi->StartNewFrame();
     }
     m_AlphaMeshes.clear();
     Engine::GAPI->GetTransparencyVobs().clear();
 
-    // A run count close to the item count means batching collapsed - the thing to watch when this
-    // gets profiled on real hardware.
+    // Run count close to the item count means batching collapsed.
     static unsigned int transparencyLogCounter = 0;
     if ( !queue.Empty() && (transparencyLogCounter++ % 1800) == 0 ) {
         LogInfo() << "Transparency queue: " << queue.Size() << " items in " << runs
@@ -5340,9 +5286,7 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
     meshList.clear();
     if ( meshList.capacity() == 0 ) meshList.reserve( 4096 );
 
-    // Alpha-blended world sections go straight into the frame's transparency queue, which sorts them
-    // against every other blended drawable (ghosts, alpha VOBs, decals, ...) instead of just against
-    // each other. Nothing is sorted here anymore.
+    // Sorted later, against every other blended drawable, by the transparency queue.
     TransparencyQueue& transparencyQueue = Engine::GAPI->GetTransparencyQueue();
 
     GetContext()->IASetPrimitiveTopology( D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
@@ -7784,9 +7728,8 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                             alphaMesh.StartInstanceNum = cachedVisual->StartInstanceNum;
                             alphaMesh.instances = cachedVisual->Instances;
 
-                            // One queue item per *instance*: a batch's instances are scattered across the
-                            // world, so a single depth for the whole batch would sort nothing. The emitter
-                            // re-merges consecutive items of the same batch back into one instanced draw.
+                            // Per instance, not per batch: a batch's instances are scattered across the
+                            // world, so one depth for the whole batch would sort nothing.
                             TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
                             const uint32_t batchKey = TransparencyQueue::MakeBatchKey( meshKey.Material );
                             for ( size_t i = 0; i < alphaMesh.instances.size(); ++i ) {
@@ -8003,11 +7946,9 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
 }
 
 /** Draws the static VOBs */
-/** Builds and uploads the per-visual wind metadata for this frame's alpha VOB batches.
-
-    One buffer covers all batches, so this cannot live inside a per-run emitter - the transparency
-    queue can hand out a batch's instances in several runs. It also stamps the metadata index into
-    the instance data, which has to happen before the first alpha VOB draw. */
+/** Per-visual wind metadata for this frame's alpha VOB batches. One buffer covers all of them, so it
+    cannot live in a per-run emitter, and it stamps the metadata index into the instance data - both
+    have to happen before the first alpha VOB draw. */
 void D3D11GraphicsEngine::PrepareAlphaMeshWindMetadata()
 {
     m_AlphaMeshWindMetadataValid = false;
@@ -8077,11 +8018,8 @@ void D3D11GraphicsEngine::PrepareAlphaMeshWindMetadata()
     m_AlphaMeshWindMetadataValid = useWindMetadata;
 }
 
-/** Draws a run of alpha-blended VOB instances the transparency queue handed over.
-
-    Items are per instance, so consecutive items of the same batch with consecutive instance indices
-    are merged back into one instanced draw here - a scattered run degrades to single-instance draws,
-    which is what correct depth order costs. */
+/** One run of alpha-blended VOB instances. Items are per instance; consecutive items of the same
+    batch re-merge into one instanced draw, a scattered run degrades to single-instance draws. */
 void D3D11GraphicsEngine::DrawAlphaVobRun( std::span<const TransparentItem> items )
 {
     if ( items.empty() ) {
@@ -8195,8 +8133,7 @@ void D3D11GraphicsEngine::DrawAlphaVobRun( std::span<const TransparentItem> item
                 BindDynamicCBToVertexShader(windBuffer, AllocateDynamicCB(&g_windBuffer));
             }
 
-            // Draw the merged instances. StartInstanceLocation is absolute in the frame's shared
-            // instancing buffer, so a sub-range of a batch just shifts the base.
+            // StartInstanceLocation is absolute in the shared instancing buffer
             DrawInstanced( mi->GetMeshVertexBuffer(), mi->GetMeshIndexBuffer(), mi->Indices.size(),
                 instancingBuffer, sizeof( VobInstanceInfo ),
                 instanceCount, sizeof( ExVertexStruct ),
@@ -8216,10 +8153,8 @@ XRESULT D3D11GraphicsEngine::DrawVOBs( bool noTextures ) {
     return DrawVOBsInstanced();
 }
 
-/** Draws a run of poly strips (weapon/spell trails, barrier lightning) in queue order.
-
-    Poly strips are accumulated per texture by CalcPolyStripMeshes, so one queue item is one
-    texture's worth of strips, sorted on the centroid of its vertices. */
+/** One run of poly strips. CalcPolyStripMeshes accumulates per texture, so one item is one texture's
+    worth of strips, sorted on its vertex centroid. */
 void D3D11GraphicsEngine::DrawPolyStripRun( std::span<const TransparentItem> items ) {
     if ( items.empty() ) {
         return;
@@ -9090,11 +9025,8 @@ void D3D11GraphicsEngine::DrawDecalList( const std::vector<zCVob*>& decals,
     Context->IASetVertexBuffers( 1, 1, &nullBuf, &nullStride, &nullOffset );
 }
 
-/** Draws a run of quad marks (blood, spell ground marks) in queue order.
-
-    This replaces the old DrawQuadMarks/DrawMQuadMarks split: MUL/MUL2 marks used to be deferred
-    into a second pass after the ghosts, which is exactly the kind of category-wide reordering the
-    transparency queue exists to remove. All blend modes are handled per item here. */
+/** One run of quad marks (blood, spell ground marks). Replaces the old DrawQuadMarks/DrawMQuadMarks
+    split - MUL/MUL2 are no longer deferred to a later pass, every blend mode is handled per item. */
 void D3D11GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> items ) {
     if ( items.empty() ) return;
 
@@ -9131,7 +9063,7 @@ void D3D11GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> item
         if ( lastAlphaFunc != alphaFunc ) {
             auto& state = Engine::GAPI->GetRendererState();
 
-            // MUL/MUL2 ran through PS_Simple in the old deferred pass, everything else through PS_World
+            // MUL/MUL2 are unlit (PS_Simple), everything else lit (PS_World)
             const bool modulate = (alphaFunc == zMAT_ALPHA_FUNC_MUL || alphaFunc == zMAT_ALPHA_FUNC_MUL2);
             SetActivePixelShader( modulate ? PShaderID::PS_Simple : PShaderID::PS_World );
             if ( !modulate ) {
@@ -9164,8 +9096,8 @@ void D3D11GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> item
                 continue;
             }
 
-            // Opaque quad marks keep writing depth, as they did in the old first pass; every blended
-            // mode must not, or a mark would depth-reject the transparent geometry drawn after it.
+            // Opaque marks keep writing depth; blended ones must not, or they would depth-reject
+            // the transparent geometry drawn after them.
             state.DepthState.DepthWriteEnabled =
                 (alphaFunc == zMAT_ALPHA_FUNC_NONE || alphaFunc == zMAT_ALPHA_FUNC_TEST);
             state.DepthState.SetDirty();

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4245,10 +4245,9 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         };
     });
 
-    // Everything alpha-blended in one back-to-front pass. Frame order is geometry -> alpha -> fog/pfx:
-    // after the opaque scene, sky and water, but BEFORE the fog, god rays and particles - drawn after
-    // those (where it used to sit) alpha surfaces were pasted onto an already-fogged scene and never
-    // fogged themselves.
+    // Everything alpha-blended in one back-to-front pass: after the opaque scene, sky and water, but BEFORE
+    // the fog, god rays and particles - drawn after those, alpha surfaces get pasted onto an already-fogged
+    // scene and never fog themselves.
     graph.AddPass( RG_PASS_NAME( "Draw Transparency" ), [&]( RGBuilder& builder, RenderPass& pass ) {
         builder.Read( backBufferHandle );
         builder.Write( backBufferHandle );
@@ -4944,11 +4943,9 @@ void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
                 lastAlphaFunc = alphaFunc;
             }
 
-            // Material color contributes ALPHA only: ZenGin's base stage is rgbGen=VERTEX /
-            // alphaGen=FACTOR (zRenderManager.cpp:601-610, zRndD3D_Render.cpp:1049); its RGB is for
-            // untextured polys, which cannot reach this loop. Multiplying the RGB in made dark-tinted
-            // additive surfaces (magic barrier, 4,45,26,155) vanish. Env strength is a separate stage
-            // below, not part of the base alpha.
+            // Material color contributes ALPHA only: ZenGin's base stage is rgbGen=VERTEX / alphaGen=FACTOR
+            // (zRenderManager.cpp:601-610), and its RGB is for untextured polys, which cannot reach this
+            // loop. Multiplying the RGB in made dark-tinted additive surfaces (the magic barrier) vanish.
             ffdata.textureFactor = float4( skyLight, skyLight, skyLight,
                 zColor( mat->GetColor() ).bgra.alpha * (1.0f / 255.0f) );
 
@@ -4961,9 +4958,8 @@ void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
                 meshInfo->BaseIndexLocation );
 
             // ZenGin draws the env-map stage immediately after the base stage of the same shader
-            // (zRenderManager.cpp:671 adds it to the same zCShader; DrawVertexBuffer walks the stages
-            // back to back), so it goes inline here rather than as a second sweep of the run — that
-            // keeps the painter's order of the surrounding blended surfaces intact.
+            // (zRenderManager.cpp:671), so it goes inline here rather than as a second sweep of the run,
+            // which keeps the painter's order of the surrounding blended surfaces intact.
             if ( envMapEnabled && mat->GetEnvMapEnabled() ) {
                 if ( !envCubeBound ) {
                     GetContext()->PSSetShaderResources( 4, 1, ReflectionCube.GetAddressOf() );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -4064,10 +4064,12 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     // Clear textures from the last frame
     RenderedVobs.clear();
     FrameWaterSurfaces.clear();
-    FrameTransparencyMeshes.clear();
-    FrameTransparencyMeshesPortal.clear();
-    FrameTransparencyMeshesWaterfall.clear();
     m_FrameGeometryCache.Reset();
+
+    // Producers push into this all through the frame (world mesh build, VOB collection); the sorted
+    // transparency pass at the end of the graph drains it.
+    Engine::GAPI->GetTransparencyQueue().BeginFrame();
+    Engine::GAPI->GetTransparencyVobs().clear();
 
     // TODO: TODO: Hack for texture caching!
     zCTextureCacheHack::NumNotCachedTexturesInFrame = 0;
@@ -4167,8 +4169,10 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
             Engine::GAPI->GetVisibleDecalList( decals );
 
             Engine::GAPI->ResetRenderStates();
+
+            // Only the lit (alpha-tested, never blended) decals belong here, before lighting.
+            // Quad marks moved into the sorted transparency pass at the end of the frame.
             DrawDecalList( decals, true );
-            DrawQuadMarks();
         };
     });    
     
@@ -4181,17 +4185,6 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
     ActiveSceneRenderer->AddLightingPasses( graph, *this,
         colorResource, normalsResource, specularResource,
         backBufferHandle, aoMaskResource, m_FrameLights );
-
-    graph.AddPass( RG_PASS_NAME("Draw Frame AlphaMeshes"), [&]( RGBuilder& builder, RenderPass& pass ) {
-        // Setup / Declare
-        builder.Write( backBufferHandle );
-
-        pass.m_executeCallback = [this](const RenderGraph&)-> void {
-            TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw Frame AlphaMeshes" );
-            DrawFrameAlphaMeshes();
-            };
-        }
-    );
 
     // Ambient occlusion is now produced before lighting (AddAmbientOcclusionPass) and applied
     // to indirect light inside the lighting shaders — no post-lighting darkening pass here.
@@ -4237,19 +4230,16 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         };
     });
     
-    graph.AddPass( RG_PASS_NAME("Draw ghosts"), [&]( RGBuilder& builder, RenderPass& pass ) {
+    graph.AddPass( RG_PASS_NAME("Draw SkeletalVN"), [&]( RGBuilder& builder, RenderPass& pass ) {
         builder.Read( backBufferHandle );
         builder.Write( backBufferHandle );
 
         pass.m_executeCallback = [this](const RenderGraph&) {
-            TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw Ghosts" );
+            TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw SkeletalVN" );
 
-            D3D11ENGINE_RENDER_STAGE oldStage = RenderingStage;
-            SetRenderingStage( DES_GHOST );
-            Engine::GAPI->DrawTransparencyVobs();
-            SetRenderingStage( oldStage );
+            // Ghosts themselves moved into the sorted transparency pass near the end of the frame
             Engine::GAPI->DrawSkeletalVN();
-            
+
             // for Post-Processing FX we use the full viewport for now
             // TODO: introduce UV-scaling to PostFX
             SetViewport( ViewportInfo( 0, 0, GetResolution() ) );
@@ -4325,29 +4315,8 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         };
     });
     
-    if (rendererState.RendererSettings.DrawParticleEffects) {
-        graph.AddPass( RG_PASS_NAME("Draw ParticleFX #2"), [&]( RGBuilder& builder, RenderPass& pass ) {
-            builder.Read( backBufferHandle );
-            builder.Write( backBufferHandle );
-
-            pass.m_executeCallback = [this](const RenderGraph&) {
-                TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw ParticleFX #2" );
-
-                // Draw unlit decals 
-                // TODO: Only get them once!
-                std::vector<zCVob*> decals;
-                zCCamera::GetCamera()->Activate();
-                // Camera->Activate breaks viewport
-                SetViewport( ViewportInfo( 0, 0, GetResolution() ) );
-
-                Engine::GAPI->GetVisibleDecalList( decals );
-
-                // Draw stuff like candle-flames
-                DrawDecalList( decals, false );
-                DrawMQuadMarks();
-            };
-        });
-    }
+    // Unlit decals and the modulate quad marks used to be drawn here, in a second particle-FX pass.
+    // Both are alpha-blended and now go through the sorted transparency pass instead.
     
     if (rendererState.RendererSettings.EnableGodRays &&
         Engine::GAPI->GetLoadedWorldInfo()->BspTree->GetBspTreeMode() ==
@@ -4457,34 +4426,6 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         };
     });
 
-#if (defined BUILD_GOTHIC_2_6_fix || defined BUILD_GOTHIC_1_08k)
-
-    graph.AddPass( RG_PASS_NAME("Draw PolyStrips"), [&]( RGBuilder& builder, RenderPass& pass ) {
-        builder.Write( backBufferHandle );
-
-        pass.m_executeCallback = [this, backBufferHandle](const RenderGraph& graph) {
-            TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw PolyStrips" );
-
-            // Calc weapon/effect trail mesh data
-            Engine::GAPI->CalcPolyStripMeshes();
-            // Calc lightning flashes mesh data
-            Engine::GAPI->CalcFlashMeshes();
-
-            // Re-bind the depth buffer: the preceding particle pass ends on a PfxRenderer blit that leaves
-            // the OM with an RTV and no DSV, so trails and lightning drew through walls.
-            auto backBuffer = graph.GetPhysicalTexture( backBufferHandle );
-            GetContext()->PSSetShaderResources( 0, 4, s_nullSRVs ); // depth may still be bound as SRV
-            GetContext()->OMSetRenderTargets( 1, backBuffer->GetRenderTargetView().GetAddressOf(),
-                DepthStencilBuffer->GetDepthStencilView().Get() );
-
-            // For some reasons the viewport gets messed up, so set it again
-            SetViewport( ViewportInfo( 0, 0, GetResolution() ) );
-            DrawPolyStrips();
-        };
-    } );
-
-#endif
-
     // Draw debug lines
     graph.AddPass( RG_PASS_NAME("Draw Debug Lines"), [&]( RGBuilder& builder, RenderPass& pass ) {
         builder.Write( backBufferHandle );
@@ -4496,57 +4437,30 @@ XRESULT D3D11GraphicsEngine::OnStartWorldRendering() {
         };
     } );
 
-    graph.AddPass( RG_PASS_NAME( "Draw FrameTransparencyMeshes" ), [&]( RGBuilder& builder, RenderPass& pass ) {
+    // Everything alpha-blended in one pass, sorted back to front across all categories: world
+    // transparency meshes (normal / portal / waterfall), instanced alpha VOBs, ghosts, blended
+    // decals, quad marks and poly strips. This slot is where the world transparency meshes already
+    // sat - after water, particles and the fog/god-rays composition - so the refraction-based passes
+    // keep the scene they expect to read.
+    graph.AddPass( RG_PASS_NAME( "Draw Transparency" ), [&]( RGBuilder& builder, RenderPass& pass ) {
         builder.Read( backBufferHandle );
         builder.Write( backBufferHandle );
 
-        pass.m_executeCallback = [this]( const RenderGraph& ) {
-            TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw FrameTransparencyMeshes" );
+        pass.m_executeCallback = [this, backBufferHandle]( const RenderGraph& graph ) {
+            // Re-bind the depth buffer: the preceding particle pass ends on a PfxRenderer blit that
+            // leaves the OM with an RTV and no DSV, which used to make trails draw through walls.
+            auto backBuffer = graph.GetPhysicalTexture( backBufferHandle );
+            GetContext()->PSSetShaderResources( 0, 4, s_nullSRVs ); // depth may still be bound as SRV
+            GetContext()->OMSetRenderTargets( 1, backBuffer->GetRenderTargetView().GetAddressOf(),
+                DepthStencilBuffer->GetDepthStencilView().Get() );
 
-            SetDefaultStates();
+            zCCamera::GetCamera()->Activate();
+            // Camera->Activate breaks the viewport
+            SetViewport( ViewportInfo( 0, 0, GetResolution() ) );
 
-            // Setup renderstates
-            Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
-            Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
-
-            DrawMeshInfoListAlphablended( FrameTransparencyMeshes );
-            };
-    } );
-
-    if ( rendererState.RendererSettings.DrawG1ForestPortals ) {
-        graph.AddPass( RG_PASS_NAME( "Draw ForestPortals" ), [&]( RGBuilder& builder, RenderPass& pass ) {
-            builder.Read( backBufferHandle );
-            builder.Write( backBufferHandle );
-
-            pass.m_executeCallback = [this]( const RenderGraph& ) {
-                TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw ForestPortals" );
-
-                SetDefaultStates();
-
-                // Setup renderstates
-                Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
-                Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
-
-                DrawMeshInfoListAlphablended( FrameTransparencyMeshesPortal );
-            };
-        } );
-    }
-
-    graph.AddPass( RG_PASS_NAME( "Draw FrameTransparencyMeshesWaterfall" ), [&]( RGBuilder& builder, RenderPass& pass ) {
-        builder.Read( backBufferHandle );
-        builder.Write( backBufferHandle );
-
-        pass.m_executeCallback = [this]( const RenderGraph& ) {
-            TracyD3D11ZoneCGX( "D3D11GraphicsEngine::Draw FrameTransparencyMeshesWaterfall" );
-
-            SetDefaultStates();
-
-            // Setup renderstates
-            Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
-            Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
-
-            DrawMeshInfoListAlphablended( FrameTransparencyMeshesWaterfall );
-            };
+            CollectTransparencyQueue();
+            DrawTransparencyQueue();
+        };
     } );
 
     // Draw debug lines
@@ -4895,11 +4809,30 @@ void D3D11GraphicsEngine::UpdateColorSpace_SwapChain()
 }
 
 /** Draws a list of mesh infos */
-XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
-    const std::vector<std::pair<MeshKey, MeshInfo*>>& list ) {
-    if ( list.empty() ) {
-        return XR_SUCCESS;
+/** Draws a run of alpha-blended world mesh sections in the order the transparency queue produced.
+
+    The three world transparency variants (normal / portal / waterfall) all run through this one
+    body: the pixel shader is picked per material from MaterialInfo::MaterialType inside
+    BindShaderForTexture, so the variant only decides whether the run is drawn at all (portals are
+    gated behind DrawG1ForestPortals) and whether it re-writes depth afterwards. */
+void D3D11GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentItem> items,
+    EWorldTransparencyVariant variant ) {
+    if ( items.empty() ) {
+        return;
     }
+
+    if ( variant == EWorldTransparencyVariant::Portal &&
+        !Engine::GAPI->GetRendererState().RendererSettings.DrawG1ForestPortals ) {
+        return;
+    }
+
+    TracyD3D11ZoneCGX( "D3D11GraphicsEngine::DrawWorldTransparencyRun" );
+
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+
+    SetDefaultStates();
+    Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_BACK;
+    Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
 
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
     Engine::GAPI->SetViewTransformXM( view );
@@ -4934,8 +4867,8 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
     
     void* lastTex = nullptr;
     void* lastMat = nullptr;
-    MaterialInfo* lastInfo = nullptr;
-    for ( auto const& [meshKey, meshInfo] : list ) {
+    for ( auto const& item : items ) {
+        auto const& [meshKey, meshInfo] = queue.GetWorldMesh( item );
         zCMaterial* const mat = meshKey.Material;
         if ( !mat ) {
             continue;
@@ -5033,12 +4966,6 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
             ActivePS->UpdateBuffer("cbFFData", &ffdata, sizeof(ffdata));
 
             // TODO: Do we even need/use material-info for transparent meshes?
-            /*MaterialInfo* info = meshKey.Info;
-            if (info != lastInfo) {
-                if (!lastInfo || !lastInfo->IsSame(info)) {
-                    lastInfo = info;
-                }
-            }*/
 
             // Draw the section-part
             DrawVertexBufferIndexedUINT( nullptr, nullptr, meshInfo->Indices.size(),
@@ -5046,25 +4973,229 @@ XRESULT D3D11GraphicsEngine::DrawMeshInfoListAlphablended(
 
         }
     }
+}
 
-    Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled = true;
-    Engine::GAPI->GetRendererState().DepthState.SetDirty();
-    Engine::GAPI->GetRendererState().BlendState.ColorWritesEnabled = false;
-    Engine::GAPI->GetRendererState().BlendState.SetDirty();
+/** Re-writes the depth of every world transparency mesh of this frame with color writes off.
 
-    UpdateRenderStates();
+    This used to be the tail of DrawMeshInfoListAlphablended and ran once per list; with the queue
+    interleaving the lists it has to happen once, after the whole replay, or a nearer transparency
+    mesh would depth-reject a farther one that is drawn later. Portals are excluded, same as before.
 
-    // Draw again, but only to depthbuffer this time to make them work with
-    // fogging
-    for ( auto const& [meshKey, meshInfo] : list ) {
-        if ( meshKey.Material->GetAniTexture() != nullptr && meshKey.Info->MaterialType != MaterialInfo::MT_Portal ) {
-            // Draw the section-part
-            DrawVertexBufferIndexedUINT( nullptr, nullptr, meshInfo->Indices.size(),
-                meshInfo->BaseIndexLocation );
+    Note the fog/god-rays justification the original comment gave is stale: both of those passes run
+    earlier in the frame now. This is kept for the depth-consuming post effects that still come
+    after the transparency pass (DoF, TAA). */
+void D3D11GraphicsEngine::DrawWorldTransparencyDepthOnly() {
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+
+    bool anyDrawn = false;
+    for ( auto const& item : queue.GetItems() ) {
+        if ( item.Kind != ETransparentKind::WorldMesh ||
+            static_cast<EWorldTransparencyVariant>(item.SubKind) == EWorldTransparencyVariant::Portal ) {
+            continue;
+        }
+
+        auto const& [meshKey, meshInfo] = queue.GetWorldMesh( item );
+        if ( !meshKey.Material || !meshKey.Material->GetAniTexture() ) {
+            continue;
+        }
+
+        if ( !anyDrawn ) {
+            // Same pipeline as the color pass, just depth-only
+            SetActivePixelShader( PShaderID::PS_Diffuse );
+            SetActiveVertexShader( VShaderID::VS_ExPacked );
+            SetupVS_ExMeshDrawCall();
+            SetupVS_ExConstantBuffer();
+            BindWrappedWorldMeshPacked( Engine::GAPI->GetWrappedWorldMesh() );
+
+            Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled = true;
+            Engine::GAPI->GetRendererState().DepthState.SetDirty();
+            Engine::GAPI->GetRendererState().BlendState.ColorWritesEnabled = false;
+            Engine::GAPI->GetRendererState().BlendState.SetDirty();
+            UpdateRenderStates();
+            anyDrawn = true;
+        }
+
+        DrawVertexBufferIndexedUINT( nullptr, nullptr, meshInfo->Indices.size(),
+            meshInfo->BaseIndexLocation );
+    }
+
+    if ( anyDrawn ) {
+        Engine::GAPI->GetRendererState().BlendState.ColorWritesEnabled = true;
+        Engine::GAPI->GetRendererState().BlendState.SetDirty();
+        UpdateRenderStates();
+    }
+}
+
+/** Draws a run of ghost vobs (invisible-potion / fade-out items and NPCs). */
+void D3D11GraphicsEngine::DrawGhostRun( std::span<const TransparentItem> items ) {
+    if ( items.empty() ) return;
+
+    TracyD3D11ZoneCGX( "D3D11GraphicsEngine::DrawGhostRun" );
+
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+    auto& transparencyVobs = Engine::GAPI->GetTransparencyVobs();
+
+    D3D11ENGINE_RENDER_STAGE oldStage = RenderingStage;
+    SetRenderingStage( DES_GHOST );
+
+    Engine::GAPI->BeginTransparencyVobRun();
+    for ( auto const& item : items ) {
+        const uint32_t index = queue.GetGhostIndex( item );
+        if ( index < transparencyVobs.size() ) {
+            Engine::GAPI->DrawTransparencyVob( transparencyVobs[index] );
         }
     }
 
-    return XR_SUCCESS;
+    SetRenderingStage( oldStage );
+}
+
+/** Draws a run of blended decals. The existing list-based path already batches consecutive
+    same-material decals without reordering them, which is exactly what a queue run needs. */
+void D3D11GraphicsEngine::DrawDecalRun( std::span<const TransparentItem> items ) {
+    if ( items.empty() ) return;
+
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+
+    static std::vector<zCVob*> decalRun; // static to get around reallocations
+    decalRun.clear();
+    decalRun.reserve( items.size() );
+    for ( auto const& item : items ) {
+        decalRun.push_back( queue.GetDecal( item ) );
+    }
+
+    DrawDecalList( decalRun, false );
+}
+
+/** Fills the frame's transparency queue with everything that is not pushed at production time and
+    sorts it. World transparency meshes (DrawWorldMesh) and alpha VOB instances (DrawVOBsInstanced)
+    are already in by the time this runs; ghosts, decals, quad marks and poly strips are gathered
+    here, right before the replay, so no producer has to care about pass ordering. */
+void D3D11GraphicsEngine::CollectTransparencyQueue() {
+    ZoneScopedN( "CollectTransparencyQueue" );
+
+    TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+    auto& renderSettings = Engine::GAPI->GetRendererState().RendererSettings;
+    const XMVECTOR camPos = Engine::GAPI->GetCameraPositionXM();
+
+    // Ghosts. TransparencyVobInfo::distance is linear (DrawSkeletalMeshVob wants it that way),
+    // the queue sorts on squared distances.
+    auto& transparencyVobs = Engine::GAPI->GetTransparencyVobs();
+    for ( size_t i = 0; i < transparencyVobs.size(); ++i ) {
+        const float distance = transparencyVobs[i].distance;
+        queue.AddGhost( distance * distance, static_cast<uint32_t>(i) );
+    }
+
+    if ( renderSettings.DrawParticleEffects ) {
+        // Unlit (blended) decals. The lit/alpha-tested ones are not part of the queue - they are
+        // drawn opaque before lighting and never blend.
+        static std::vector<zCVob*> decals; // static to get around reallocations
+        decals.clear();
+        Engine::GAPI->GetVisibleDecalList( decals );
+        for ( zCVob* decal : decals ) {
+            float distanceSq;
+            XMStoreFloat( &distanceSq, XMVector3LengthSq( decal->GetPositionWorldXM() - camPos ) );
+            queue.AddDecal( distanceSq, decal );
+        }
+
+        // Quad marks (blood, spell ground marks)
+        const float vfxRadiusSq = renderSettings.VisualFXDrawRadius * renderSettings.VisualFXDrawRadius;
+        for ( auto const& it : Engine::GAPI->GetQuadMarks() ) {
+            if ( !it.first->GetConnectedVob() ) continue;
+
+            float distanceSq;
+            XMStoreFloat( &distanceSq, XMVector3LengthSq( camPos - XMLoadFloat3( &it.second.Position ) ) );
+            if ( distanceSq > vfxRadiusSq ) continue;
+
+            queue.AddQuadMark( distanceSq, it.first, &it.second );
+        }
+    }
+
+#if (defined BUILD_GOTHIC_2_6_fix || defined BUILD_GOTHIC_1_08k)
+    // Poly strips (weapon/effect trails and the barrier's lightning). The mesh data has to be built
+    // before we can take a depth for it.
+    Engine::GAPI->CalcPolyStripMeshes();
+    Engine::GAPI->CalcFlashMeshes();
+
+    for ( auto const& it : Engine::GAPI->GetPolyStripInfos() ) {
+        const std::vector<ExVertexStruct>& vertices = it.second.vertices;
+        if ( vertices.empty() || !it.second.material || !it.first ) continue;
+
+        // One strip group per texture, so its depth is the centroid of everything in it
+        XMVECTOR center = XMVectorZero();
+        for ( auto const& vertex : vertices ) {
+            center = XMVectorAdd( center, XMLoadFloat3( &vertex.Position ) );
+        }
+        center = XMVectorScale( center, 1.0f / static_cast<float>(vertices.size()) );
+
+        float distanceSq;
+        XMStoreFloat( &distanceSq, XMVector3LengthSq( center - camPos ) );
+        queue.AddPolyStrip( distanceSq, it.first, &it.second );
+    }
+#endif
+
+    // categoryMajor reproduces the old per-category pass order without a second set of emitters
+    queue.Sort( !renderSettings.SortedTransparency );
+}
+
+/** Replays the sorted transparency queue. */
+void D3D11GraphicsEngine::DrawTransparencyQueue() {
+    TracyD3D11ZoneCGX( "D3D11GraphicsEngine::DrawTransparencyQueue" );
+    auto _scopeTransparency = RecordGraphicsEvent( GE_NAME( "DrawTransparencyQueue" ) );
+
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+
+    // One buffer for every alpha VOB batch of this frame, so it cannot live in a per-run emitter
+    PrepareAlphaMeshWindMetadata();
+    m_AlphaVobDrawsThisFrame = 0;
+
+    GetContext()->OMSetRenderTargets( 1, HDRBackBuffer->GetRenderTargetView().GetAddressOf(),
+        DepthStencilBuffer->GetDepthStencilView().Get() );
+    SetViewport( ViewportInfo( 0, 0, GetResolution() ) );
+
+    const size_t runs = queue.ForEachRun( [&]( ETransparentKind kind, uint8_t subKind,
+        std::span<const TransparentItem> items ) {
+            switch ( kind ) {
+            case ETransparentKind::WorldMesh:
+                DrawWorldTransparencyRun( items, static_cast<EWorldTransparencyVariant>(subKind) );
+                break;
+            case ETransparentKind::AlphaVob:
+                DrawAlphaVobRun( items );
+                break;
+            case ETransparentKind::Ghost:
+                DrawGhostRun( items );
+                break;
+            case ETransparentKind::Decal:
+                DrawDecalRun( items );
+                break;
+            case ETransparentKind::QuadMark:
+                DrawQuadMarkRun( items );
+                break;
+            case ETransparentKind::PolyStrip:
+                DrawPolyStripRun( items );
+                break;
+            default:
+                break;
+            }
+        } );
+
+    // Depth of the world transparency meshes, once, after everything blended has been drawn
+    DrawWorldTransparencyDepthOnly();
+
+    // The alpha VOB visuals could not be reset inside the emitter: the queue can hand out a single
+    // batch's instances in more than one run.
+    for ( auto const& alphaMesh : m_AlphaMeshes ) {
+        if ( alphaMesh.vi ) alphaMesh.vi->StartNewFrame();
+    }
+    m_AlphaMeshes.clear();
+    Engine::GAPI->GetTransparencyVobs().clear();
+
+    // A run count close to the item count means batching collapsed - the thing to watch when this
+    // gets profiled on real hardware.
+    static unsigned int transparencyLogCounter = 0;
+    if ( !queue.Empty() && (transparencyLogCounter++ % 1800) == 0 ) {
+        LogInfo() << "Transparency queue: " << queue.Size() << " items in " << runs
+            << " runs, " << m_AlphaVobDrawsThisFrame << " alpha VOB draws";
+    }
 }
 
 
@@ -5141,18 +5272,14 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
         //zCLightmap* Lightmap;
     };
 
-    struct TransparencyWorldMeshEntry {
-        std::pair<MeshKey, MeshInfo*> Mesh;
-        float DistanceSq;
-    };
-
     static std::vector<std::pair<WorldMeshKey, MeshInfo*>> meshList;
     meshList.clear();
     if ( meshList.capacity() == 0 ) meshList.reserve( 4096 );
 
-    std::vector<TransparencyWorldMeshEntry> transparencyMeshes;
-    std::vector<TransparencyWorldMeshEntry> portalTransparencyMeshes;
-    std::vector<TransparencyWorldMeshEntry> waterfallTransparencyMeshes;
+    // Alpha-blended world sections go straight into the frame's transparency queue, which sorts them
+    // against every other blended drawable (ghosts, alpha VOBs, decals, ...) instead of just against
+    // each other. Nothing is sorted here anymore.
+    TransparencyQueue& transparencyQueue = Engine::GAPI->GetTransparencyQueue();
 
     GetContext()->IASetPrimitiveTopology( D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
     GetContext()->DSSetShader( nullptr, nullptr, 0 );
@@ -5182,16 +5309,17 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                     }
 
                     const float distanceSq = ComputeWorldMeshDistanceSqFromCamera( renderItem, worldMesh.second, cameraPosition );
-                    const std::pair<MeshKey, MeshInfo*> transparencyMesh = { worldMesh.first, worldMesh.second };
 
                     if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_Portal ) {
                         if ( !isZPrepass ) {
-                            portalTransparencyMeshes.push_back( { transparencyMesh, distanceSq } );
+                            transparencyQueue.AddWorldMesh( distanceSq, EWorldTransparencyVariant::Portal,
+                                worldMesh.first, worldMesh.second );
                         }
                         continue;
                     } else if ( worldMesh.first.Info->MaterialType == MaterialInfo::MT_WaterfallFoam ) {
                         if ( !isZPrepass ) {
-                            waterfallTransparencyMeshes.push_back( { transparencyMesh, distanceSq } );
+                            transparencyQueue.AddWorldMesh( distanceSq, EWorldTransparencyVariant::Waterfall,
+                                worldMesh.first, worldMesh.second );
                         }
                         continue;
                     }
@@ -5202,7 +5330,8 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                         // || (worldMesh.first.Material->GetEnvMapEnabled())
                         ) {
                         if ( !isZPrepass ) {
-                            transparencyMeshes.push_back( { transparencyMesh, distanceSq } );
+                            transparencyQueue.AddWorldMesh( distanceSq, EWorldTransparencyVariant::Normal,
+                                worldMesh.first, worldMesh.second );
                         }
                         continue;
                     } else {
@@ -5233,39 +5362,6 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
             }
         }
 
-        auto sortAndAppendTransparencyMeshes = []( std::vector<TransparencyWorldMeshEntry>& source,
-            std::vector<std::pair<MeshKey, MeshInfo*>>& destination ) {
-            if ( source.empty() ) {
-                return;
-            }
-
-            std::sort( source.begin(), source.end(),
-                []( const TransparencyWorldMeshEntry& a, const TransparencyWorldMeshEntry& b ) {
-                    if ( a.DistanceSq > b.DistanceSq )
-                        return true;
-                    if ( a.DistanceSq < b.DistanceSq )
-                        return false;
-                    if ( a.Mesh.first.Material != b.Mesh.first.Material )
-                        return a.Mesh.first.Material < b.Mesh.first.Material;
-                    if ( a.Mesh.first.Texture != b.Mesh.first.Texture )
-                        return a.Mesh.first.Texture < b.Mesh.first.Texture;
-                    if ( a.Mesh.first.Info != b.Mesh.first.Info )
-                        return a.Mesh.first.Info < b.Mesh.first.Info;
-
-                    const unsigned int aBaseIndex = a.Mesh.second ? a.Mesh.second->BaseIndexLocation : 0u;
-                    const unsigned int bBaseIndex = b.Mesh.second ? b.Mesh.second->BaseIndexLocation : 0u;
-                    return aBaseIndex < bBaseIndex;
-                } );
-
-            destination.reserve( destination.size() + source.size() );
-            for ( auto& entry : source ) {
-                destination.emplace_back( std::move( entry.Mesh ) );
-            }
-        };
-
-        sortAndAppendTransparencyMeshes( transparencyMeshes, FrameTransparencyMeshes );
-        sortAndAppendTransparencyMeshes( portalTransparencyMeshes, FrameTransparencyMeshesPortal );
-        sortAndAppendTransparencyMeshes( waterfallTransparencyMeshes, FrameTransparencyMeshesWaterfall );
     }
     auto CompareMesh = []( std::pair<WorldMeshKey, MeshInfo*>& a, std::pair<WorldMeshKey, MeshInfo*>& b ) -> bool {
         if ( a.first.AlphaLevel != b.first.AlphaLevel )
@@ -7615,12 +7711,27 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
 
                     if ( isAlphaBlendMesh ) {
                         if ( !isZPrepass ) {
+                            const uint32_t batchIndex = static_cast<uint32_t>(m_AlphaMeshes.size());
+
                             AlphaMeshData alphaMesh;
                             alphaMesh.mk = meshKey;
                             alphaMesh.mi = meshInfo;
                             alphaMesh.vi = cachedVisual->Visual;
                             alphaMesh.StartInstanceNum = cachedVisual->StartInstanceNum;
                             alphaMesh.instances = cachedVisual->Instances;
+
+                            // One queue item per *instance*: a batch's instances are scattered across the
+                            // world, so a single depth for the whole batch would sort nothing. The emitter
+                            // re-merges consecutive items of the same batch back into one instanced draw.
+                            TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+                            const uint32_t batchKey = TransparencyQueue::MakeBatchKey( meshKey.Material );
+                            for ( size_t i = 0; i < alphaMesh.instances.size(); ++i ) {
+                                const XMFLOAT4X4& world = alphaMesh.instances[i].world;
+                                const XMFLOAT3 position( world._14, world._24, world._34 );
+                                queue.AddAlphaVob( TransparencyQueue::DistanceSqFromCamera( position ),
+                                    batchIndex, static_cast<uint32_t>(i), batchKey );
+                            }
+
                             m_AlphaMeshes.push_back( std::move( alphaMesh ) );
                         }
                         continue;
@@ -7828,29 +7939,25 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
 }
 
 /** Draws the static VOBs */
-XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
+/** Builds and uploads the per-visual wind metadata for this frame's alpha VOB batches.
+
+    One buffer covers all batches, so this cannot live inside a per-run emitter - the transparency
+    queue can hand out a batch's instances in several runs. It also stamps the metadata index into
+    the instance data, which has to happen before the first alpha VOB draw. */
+void D3D11GraphicsEngine::PrepareAlphaMeshWindMetadata()
 {
+    m_AlphaMeshWindMetadataValid = false;
     if ( m_AlphaMeshes.empty() ) {
-        return XR_SUCCESS;
+        return;
     }
 
-    TracyD3D11ZoneCGX("DrawFrameAlphaMeshes");
-    auto _scopeDrawFrameAlphaMeshes = RecordGraphicsEvent( GE_NAME( "DrawFrameAlphaMeshes" ) );
+    TracyD3D11ZoneCGX("PrepareAlphaMeshWindMetadata");
 
-    // Make sure lighting doesn't mess up our state
-    SetDefaultStates();
-
-    SetActivePixelShader( PShaderID::PS_Simple );
+    // The metadata SRV is bound by name on VS_ExInstancedObj, the shader the alpha VOB run uses.
     SetActiveVertexShader( VShaderID::VS_ExInstancedObj );
 
-    SetupVS_ExMeshDrawCall();
-    SetupVS_ExConstantBuffer();
-
-    GetContext()->OMSetRenderTargets( 1, HDRBackBuffer->GetRenderTargetView().GetAddressOf(),
-        DepthStencilBuffer->GetDepthStencilView().Get() );
-
     bool useWindMetadata = false;
-    if ( ActiveVS && ActiveVS->GetInputIndex( "WindMetaData" ) != -1 && !m_AlphaMeshes.empty() ) {
+    if ( ActiveVS && ActiveVS->GetInputIndex( "WindMetaData" ) != -1 ) {
         std::unordered_map<MeshVisualInfo*, DWORD> metadataByVisual;
         metadataByVisual.reserve( m_AlphaMeshes.size() );
 
@@ -7898,17 +8005,51 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
 
             if ( WindMetadataBuffer
                 && XR_SUCCESS == WindMetadataBuffer->UpdateBuffer( m_WindMetadataStaging.data(), requiredSize ) ) {
-                ActiveVS->BindResource( "WindMetaData", WindMetadataBuffer->GetShaderResourceView().Get() );
                 useWindMetadata = true;
             }
         }
     }
 
+    m_AlphaMeshWindMetadataValid = useWindMetadata;
+}
+
+/** Draws a run of alpha-blended VOB instances the transparency queue handed over.
+
+    Items are per instance, so consecutive items of the same batch with consecutive instance indices
+    are merged back into one instanced draw here - a scattered run degrades to single-instance draws,
+    which is what correct depth order costs. */
+void D3D11GraphicsEngine::DrawAlphaVobRun( std::span<const TransparentItem> items )
+{
+    if ( items.empty() ) {
+        return;
+    }
+
+    TracyD3D11ZoneCGX("DrawAlphaVobRun");
+    auto _scopeDrawAlphaVobs = RecordGraphicsEvent( GE_NAME( "DrawAlphaVobRun" ) );
+
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
 
     D3D11VertexBuffer* instancingBuffer = m_FrameGeometryCache.MainVobInstancingBuffer;
     if ( !instancingBuffer ) {
         LogError() << "Missing main vob instancing buffer for alpha mesh rendering.";
-        return XR_FAILED;
+        return;
+    }
+
+    // Make sure lighting doesn't mess up our state
+    SetDefaultStates();
+
+    SetActivePixelShader( PShaderID::PS_Simple );
+    SetActiveVertexShader( VShaderID::VS_ExInstancedObj );
+
+    SetupVS_ExMeshDrawCall();
+    SetupVS_ExConstantBuffer();
+
+    GetContext()->OMSetRenderTargets( 1, HDRBackBuffer->GetRenderTargetView().GetAddressOf(),
+        DepthStencilBuffer->GetDepthStencilView().Get() );
+
+    const bool useWindMetadata = m_AlphaMeshWindMetadataValid && ActiveVS && WindMetadataBuffer;
+    if ( useWindMetadata ) {
+        ActiveVS->BindResource( "WindMetaData", WindMetadataBuffer->GetShaderResourceView().Get() );
     }
 
     ConstantBufferSlot windBuffer = INVALID_SHADER_CB_SLOT;
@@ -7919,10 +8060,27 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
     }
 
     {
-        TracyD3D11ZoneCGX( "DrawFrameAlphaMeshes::Replay" );
-        auto _scopeAlphaReplay = RecordGraphicsEvent( GE_NAME( "DrawFrameAlphaMeshes::Replay" ) );
-        for ( auto const& alphaMesh : m_AlphaMeshes ) {
+        for ( size_t i = 0; i < items.size(); ) {
+            const TransparentAlphaVob& first = queue.GetAlphaVob( items[i] );
+
+            // Merge the consecutive same-batch instances of this run into one draw
+            size_t end = i + 1;
+            while ( end < items.size() ) {
+                const TransparentAlphaVob& next = queue.GetAlphaVob( items[end] );
+                if ( next.BatchIndex != first.BatchIndex ||
+                    next.InstanceIndex != queue.GetAlphaVob( items[end - 1] ).InstanceIndex + 1 ) {
+                    break;
+                }
+                ++end;
+            }
+            const unsigned int instanceCount = static_cast<unsigned int>(end - i);
+            i = end;
+
+            if ( first.BatchIndex >= m_AlphaMeshes.size() ) continue;
+            const AlphaMeshData& alphaMesh = m_AlphaMeshes[first.BatchIndex];
+
             const MeshKey& mk = alphaMesh.mk;
+            if ( !mk.Material ) continue;
             zCTexture* tx = mk.Material->GetAniTexture();
             if ( !tx ) continue;
 
@@ -7933,7 +8091,6 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
             // Bind texture
             MeshInfo* mi = alphaMesh.mi;
             MeshVisualInfo* vi = alphaMesh.vi;
-            auto& instances = alphaMesh.instances;
 
             if ( tx->CacheIn( 0.6f ) != zRES_CACHED_IN ) {
                 continue;
@@ -7974,39 +8131,39 @@ XRESULT D3D11GraphicsEngine::DrawFrameAlphaMeshes()
                 BindDynamicCBToVertexShader(windBuffer, AllocateDynamicCB(&g_windBuffer));
             }
 
-            // Draw batch
+            // Draw the merged instances. StartInstanceLocation is absolute in the frame's shared
+            // instancing buffer, so a sub-range of a batch just shifts the base.
             DrawInstanced( mi->GetMeshVertexBuffer(), mi->GetMeshIndexBuffer(), mi->Indices.size(),
                 instancingBuffer, sizeof( VobInstanceInfo ),
-                instances.size(), sizeof( ExVertexStruct ),
-                alphaMesh.StartInstanceNum, 0,
+                instanceCount, sizeof( ExVertexStruct ),
+                alphaMesh.StartInstanceNum + first.InstanceIndex, 0,
                 m_FrameGeometryCache.MainVobInstancingBufferOffset );
 
-            // Reset visual
-            vi->StartNewFrame();
+            m_AlphaVobDrawsThisFrame++;
         }
     }
 
     if ( useWindMetadata ) {
         UnbindWindMetadata();
     }
-
-    m_AlphaMeshes.clear();
-    
-    return XR_SUCCESS;
 }
 
 XRESULT D3D11GraphicsEngine::DrawVOBs( bool noTextures ) {
     return DrawVOBsInstanced();
 }
 
-XRESULT D3D11GraphicsEngine::DrawPolyStrips( bool noTextures ) {
-    //DrawMeshInfoListAlphablended was mostly used as an example to write everything below
-    const std::map<zCTexture*, PolyStripInfo>& polyStripInfos = Engine::GAPI->GetPolyStripInfos();
+/** Draws a run of poly strips (weapon/spell trails, barrier lightning) in queue order.
 
-    // No need to do a bunch of work for nothing!
-    if ( polyStripInfos.empty() ) {
-        return XR_SUCCESS;
+    Poly strips are accumulated per texture by CalcPolyStripMeshes, so one queue item is one
+    texture's worth of strips, sorted on the centroid of its vertices. */
+void D3D11GraphicsEngine::DrawPolyStripRun( std::span<const TransparentItem> items ) {
+    if ( items.empty() ) {
+        return;
     }
+
+    TracyD3D11ZoneCGX( "D3D11GraphicsEngine::DrawPolyStripRun" );
+
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
 
     SetDefaultStates();
 
@@ -8055,13 +8212,14 @@ XRESULT D3D11GraphicsEngine::DrawPolyStrips( bool noTextures ) {
     ActiveVS->UpdateBuffer(vsBufMPI, &identityMatrix, sizeof(identityMatrix) );
 
     zCMaterial* lastMat = nullptr;
-    for ( auto it = polyStripInfos.begin(); it != polyStripInfos.end(); it++ ) {
-        zCMaterial* mat = it->second.material;
-        zCTexture* tx = it->first;
+    for ( auto const& item : items ) {
+        const TransparentPolyStrip& strip = queue.GetPolyStrip( item );
+        zCMaterial* mat = strip.Info->material;
+        zCTexture* tx = strip.Texture;
 
-        const std::vector<ExVertexStruct>& vertices = it->second.vertices;
+        const std::vector<ExVertexStruct>& vertices = strip.Info->vertices;
 
-        if ( !vertices.size() ) continue;
+        if ( !mat || !tx || vertices.empty() ) continue;
 
         //Setting world transform matrix/////////////
 
@@ -8124,8 +8282,6 @@ XRESULT D3D11GraphicsEngine::DrawPolyStrips( bool noTextures ) {
     }
 
     SetDefaultStates();
-
-    return XR_SUCCESS;
 }
 
 /** Sets up the default rendering state */
@@ -8870,14 +9026,20 @@ void D3D11GraphicsEngine::DrawDecalList( const std::vector<zCVob*>& decals,
     Context->IASetVertexBuffers( 1, 1, &nullBuf, &nullStride, &nullOffset );
 }
 
-/** Draws quadmarks in a simple way */
-void D3D11GraphicsEngine::DrawQuadMarks() {
-    const auto& quadMarks = Engine::GAPI->GetQuadMarks();
-    if ( quadMarks.empty() ) return;
+/** Draws a run of quad marks (blood, spell ground marks) in queue order.
+
+    This replaces the old DrawQuadMarks/DrawMQuadMarks split: MUL/MUL2 marks used to be deferred
+    into a second pass after the ghosts, which is exactly the kind of category-wide reordering the
+    transparency queue exists to remove. All blend modes are handled per item here. */
+void D3D11GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> items ) {
+    if ( items.empty() ) return;
+
+    auto _ = RecordGraphicsEvent( GE_NAME( "DrawQuadMarkRun" ) );
+    TracyD3D11ZoneCGX( "DrawQuadMarkRun" );
+
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
 
     SetActiveVertexShader( VShaderID::VS_Ex );
-    SetActivePixelShader( PShaderID::PS_World );
-
     SetDefaultStates();
 
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
@@ -8886,124 +9048,74 @@ void D3D11GraphicsEngine::DrawQuadMarks() {
     Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_NONE;
     Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
 
-    ActivePS->UpdateBuffer("FFPipelineConstantBuffer", &Engine::GAPI->GetRendererState().GraphicsState, sizeof(Engine::GAPI->GetRendererState().GraphicsState));
-
     SetupVS_ExMeshDrawCall();
     SetupVS_ExConstantBuffer();
 
-    int alphaFunc = zMAT_ALPHA_FUNC_NONE;
+    int lastAlphaFunc = -1;
+    for ( auto const& item : items ) {
+        const TransparentQuadMark& quadMark = queue.GetQuadMark( item );
+        if ( !quadMark.Mark->GetConnectedVob() ) continue;
 
-    auto vfxRadiusSq = Engine::GAPI->GetRendererState().RendererSettings.VisualFXDrawRadius * Engine::GAPI->GetRendererState().RendererSettings.VisualFXDrawRadius;
-    auto vVfxRadiusSq = XMVectorReplicate(vfxRadiusSq);
-    const auto camPos = Engine::GAPI->GetCameraPositionXM();
-    for ( auto const& it : quadMarks ) {
-        if ( !it.first->GetConnectedVob() ) continue;
-
-        if ( XMVector3Greater(XMVector3LengthSq( camPos - XMLoadFloat3( &it.second.Position ) ), vVfxRadiusSq) ) {
-            continue;
-        }
-
-        zCMesh* mesh = it.first->GetQuadMesh();
+        zCMesh* mesh = quadMark.Mark->GetQuadMesh();
         int numPolys = mesh->GetNumPolygons();
         zCPolygon** polys = mesh->GetPolygons();
-        zCMaterial* mat = (numPolys > 0 ? polys[0]->GetMaterial() : it.first->GetMaterial());
-        if ( mat ) mat->BindTexture( 0 );
+        zCMaterial* mat = (numPolys > 0 ? polys[0]->GetMaterial() : quadMark.Mark->GetMaterial());
+        if ( !mat ) continue;
+        mat->BindTexture( 0 );
 
-        if ( alphaFunc != mat->GetAlphaFunc() ) {
-            // Change alpha-func
-            switch ( mat->GetAlphaFunc() ) {
+        const int alphaFunc = mat->GetAlphaFunc();
+        if ( lastAlphaFunc != alphaFunc ) {
+            auto& state = Engine::GAPI->GetRendererState();
+
+            // MUL/MUL2 ran through PS_Simple in the old deferred pass, everything else through PS_World
+            const bool modulate = (alphaFunc == zMAT_ALPHA_FUNC_MUL || alphaFunc == zMAT_ALPHA_FUNC_MUL2);
+            SetActivePixelShader( modulate ? PShaderID::PS_Simple : PShaderID::PS_World );
+            if ( !modulate ) {
+                ActivePS->UpdateBuffer( "FFPipelineConstantBuffer", &state.GraphicsState, sizeof( state.GraphicsState ) );
+            }
+
+            switch ( alphaFunc ) {
             case zMAT_ALPHA_FUNC_ADD:
-                Engine::GAPI->GetRendererState().BlendState.SetAdditiveBlending();
+                state.BlendState.SetAdditiveBlending();
                 break;
 
             case zMAT_ALPHA_FUNC_BLEND:
-                Engine::GAPI->GetRendererState().BlendState.SetAlphaBlending();
+                state.BlendState.SetAlphaBlending();
                 break;
 
             case zMAT_ALPHA_FUNC_NONE:
             case zMAT_ALPHA_FUNC_TEST:
-                Engine::GAPI->GetRendererState().BlendState.SetDefault();
+                state.BlendState.SetDefault();
                 break;
 
             case zMAT_ALPHA_FUNC_MUL:
-            case zMAT_ALPHA_FUNC_MUL2:
-                MulQuadMarks.emplace_back( it.first, &it.second );
-                continue;
-
-            default:
-                continue;
-            }
-
-            alphaFunc = mat->GetAlphaFunc();
-
-            Engine::GAPI->GetRendererState().BlendState.SetDirty();
-            UpdateRenderStates();
-        }
-
-        Engine::GAPI->SetWorldTransformXM( it.first->GetConnectedVob()->GetWorldMatrixXM() );
-        SetupVS_ExPerInstanceConstantBuffer();
-
-        DrawVertexBuffer( it.second.Mesh.get(), it.second.NumVertices );
-    }
-}
-
-void D3D11GraphicsEngine::DrawMQuadMarks() {
-    if ( MulQuadMarks.empty() ) return;
-
-    auto _ = RecordGraphicsEvent( GE_NAME( "DrawMQuadMarks" ) );
-    TracyD3D11ZoneCGX( "DrawMQuadMarks" );
-    
-    SetActiveVertexShader( VShaderID::VS_Ex );
-    SetActivePixelShader( PShaderID::PS_Simple );
-
-    SetDefaultStates();
-
-    XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
-    Engine::GAPI->SetViewTransformXM( view );  // Update view transform
-
-    Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_NONE;
-    Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
-    Engine::GAPI->GetRendererState().DepthState.DepthWriteEnabled = false;
-    Engine::GAPI->GetRendererState().DepthState.SetDirty();
-
-    SetupVS_ExMeshDrawCall();
-    SetupVS_ExConstantBuffer();
-
-    int alphaFunc = 0;
-    for ( auto const& it : MulQuadMarks ) {
-        zCMesh* mesh = it.first->GetQuadMesh();
-        int numPolys = mesh->GetNumPolygons();
-        zCPolygon** polys = mesh->GetPolygons();
-        zCMaterial* mat = (numPolys > 0 ? polys[0]->GetMaterial() : it.first->GetMaterial());
-        if ( mat ) mat->BindTexture( 0 );
-
-        if ( alphaFunc != mat->GetAlphaFunc() ) {
-            // Change alpha-func
-            switch ( mat->GetAlphaFunc() ) {
-            case zMAT_ALPHA_FUNC_MUL:
-                Engine::GAPI->GetRendererState().BlendState.SetModulateBlending();
+                state.BlendState.SetModulateBlending();
                 break;
 
             case zMAT_ALPHA_FUNC_MUL2:
-                Engine::GAPI->GetRendererState().BlendState.SetModulate2Blending();
+                state.BlendState.SetModulate2Blending();
                 break;
 
             default:
                 continue;
             }
 
-            alphaFunc = mat->GetAlphaFunc();
+            // Opaque quad marks keep writing depth, as they did in the old first pass; every blended
+            // mode must not, or a mark would depth-reject the transparent geometry drawn after it.
+            state.DepthState.DepthWriteEnabled =
+                (alphaFunc == zMAT_ALPHA_FUNC_NONE || alphaFunc == zMAT_ALPHA_FUNC_TEST);
+            state.DepthState.SetDirty();
 
-            Engine::GAPI->GetRendererState().BlendState.SetDirty();
+            state.BlendState.SetDirty();
             UpdateRenderStates();
+            lastAlphaFunc = alphaFunc;
         }
 
-        Engine::GAPI->SetWorldTransformXM( it.first->GetConnectedVob()->GetWorldMatrixXM() );
+        Engine::GAPI->SetWorldTransformXM( quadMark.Mark->GetConnectedVob()->GetWorldMatrixXM() );
         SetupVS_ExPerInstanceConstantBuffer();
 
-        DrawVertexBuffer( it.second->Mesh.get(), it.second->NumVertices );
+        DrawVertexBuffer( quadMark.Info->Mesh.get(), quadMark.Info->NumVertices );
     }
-    MulQuadMarks.clear();
 }
 
 /** Copies the depth stencil buffer to DepthStencilBufferCopy */

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -196,12 +196,10 @@ public:
 
     /** ---------------- Sorted transparency -------------------- */
 
-    /** Fills the frame's transparency queue with the drawables that are not pushed at production
-        time (ghosts, decals, quad marks, poly strips) and sorts the whole queue back to front. */
+    /** Adds the late kinds (ghosts, decals, quad marks, poly strips) and sorts back to front. */
     void CollectTransparencyQueue();
 
-    /** Replays the sorted queue: every maximal run of consecutive same-kind items goes to the
-        matching emitter below, so batching survives while the global order stays painter's. */
+    /** Replays the sorted queue, one call per maximal same-kind run. */
     void DrawTransparencyQueue();
 
     void DrawWorldTransparencyRun( std::span<const TransparentItem> items, EWorldTransparencyVariant variant );
@@ -211,8 +209,8 @@ public:
     void DrawQuadMarkRun( std::span<const TransparentItem> items );
     void DrawPolyStripRun( std::span<const TransparentItem> items );
 
-    /** Re-writes the depth of the world transparency meshes (color writes off) after the queue has
-        been replayed, so depth-consuming post effects still see them. */
+    /** Depth re-lay for the world transparency meshes, once, after the replay - the fog/god-ray
+        passes downstream sample it. */
     void DrawWorldTransparencyDepthOnly();
 
     /** Gets the depthbuffer */
@@ -290,8 +288,7 @@ public:
     /** Draws the static vobs instanced */
     XRESULT DrawVOBsInstanced();
 
-    /** Uploads the per-visual wind metadata for this frame's alpha VOB batches. Runs once before the
-        queue is replayed - the emitter only binds what this produced. */
+    /** Per-visual wind metadata for this frame's alpha VOB batches; once, before the replay. */
     void PrepareAlphaMeshWindMetadata();
 
     /** Set wind props in const buffer */
@@ -565,11 +562,9 @@ private:
 
     std::vector<AlphaMeshData> m_AlphaMeshes;
 
-    /** Set by PrepareAlphaMeshWindMetadata when this frame's wind metadata buffer is usable */
     bool m_AlphaMeshWindMetadataValid = false;
 
-    /** Instanced draws the alpha VOB emitter needed this frame. Compared against the instance count
-        it shows how much of the batching survived the back-to-front sort. */
+    /** Instanced draws the alpha VOB emitter needed; vs. the instance count = surviving batching. */
     unsigned int m_AlphaVobDrawsThisFrame = 0;
 
     std::vector<VobLightInfo*> m_FrameLights;

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -194,9 +194,26 @@ public:
     XRESULT BindActivePixelShader() override;
     XRESULT BindActiveVertexShader() override;
 
-    /** Draws quadmarks in a simple way */
-    void DrawQuadMarks();
-    void DrawMQuadMarks();
+    /** ---------------- Sorted transparency -------------------- */
+
+    /** Fills the frame's transparency queue with the drawables that are not pushed at production
+        time (ghosts, decals, quad marks, poly strips) and sorts the whole queue back to front. */
+    void CollectTransparencyQueue();
+
+    /** Replays the sorted queue: every maximal run of consecutive same-kind items goes to the
+        matching emitter below, so batching survives while the global order stays painter's. */
+    void DrawTransparencyQueue();
+
+    void DrawWorldTransparencyRun( std::span<const TransparentItem> items, EWorldTransparencyVariant variant );
+    void DrawAlphaVobRun( std::span<const TransparentItem> items );
+    void DrawGhostRun( std::span<const TransparentItem> items );
+    void DrawDecalRun( std::span<const TransparentItem> items );
+    void DrawQuadMarkRun( std::span<const TransparentItem> items );
+    void DrawPolyStripRun( std::span<const TransparentItem> items );
+
+    /** Re-writes the depth of the world transparency meshes (color writes off) after the queue has
+        been replayed, so depth-consuming post effects still see them. */
+    void DrawWorldTransparencyDepthOnly();
 
     /** Gets the depthbuffer */
     RenderToDepthStencilBuffer* GetDepthBuffer() const { return DepthStencilBuffer.get(); }
@@ -238,14 +255,8 @@ public:
     /** Draws the world mesh */
     XRESULT DrawWorldMesh( bool noTextures = false ) override;
 
-    /** Draws a list of mesh infos */
-    XRESULT DrawMeshInfoListAlphablended( const std::vector<std::pair<MeshKey, MeshInfo*>>& list );
-
     /** Draws the static VOBs */
     XRESULT DrawVOBs( bool noTextures = false ) override;
-
-    /** Draws PolyStrips (weapon and particle trails) */
-    XRESULT DrawPolyStrips( bool noTextures = false ) override;
 
     /** Draws a VOB (used for inventory) */
     void DrawVobSingle( VobInfo* vob, zCCamera& camera ) override;
@@ -278,7 +289,10 @@ public:
 
     /** Draws the static vobs instanced */
     XRESULT DrawVOBsInstanced();
-    XRESULT DrawFrameAlphaMeshes();
+
+    /** Uploads the per-visual wind metadata for this frame's alpha VOB batches. Runs once before the
+        queue is replayed - the emitter only binds what this produced. */
+    void PrepareAlphaMeshWindMetadata();
 
     /** Set wind props in const buffer */
     void ApplyWindProps( VS_ExConstantBuffer_Wind& windBuff );
@@ -531,23 +545,11 @@ protected:
     /** Shadowing */
     std::vector<VobInfo*> RenderedVobs;
 
-    /** Modulate Quad Marks */
-    std::vector<std::pair<zCQuadMark*, const QuadMarkInfo*>> MulQuadMarks;
-
     /** The current rendering stage */
     D3D11ENGINE_RENDER_STAGE RenderingStage;
 
     /** List of water surfaces for this frame */
     std::unordered_map<zCTexture*, std::vector<MeshInfo*>> FrameWaterSurfaces;
-
-    /** List of worldmeshes we have to render using alphablending */
-    std::vector<std::pair<MeshKey, MeshInfo*>> FrameTransparencyMeshes;
-
-    /** List of portal worldmeshes we have to render using alphablending */
-    std::vector<std::pair<MeshKey, MeshInfo*>> FrameTransparencyMeshesPortal;
-
-    /** List of waterfall worldmeshes we have to render using alphablending */
-    std::vector<std::pair<MeshKey, MeshInfo*>> FrameTransparencyMeshesWaterfall;
 
     INT2 m_scaledResolution;
 
@@ -562,6 +564,14 @@ private:
     void UnbindWindMetadata();
 
     std::vector<AlphaMeshData> m_AlphaMeshes;
+
+    /** Set by PrepareAlphaMeshWindMetadata when this frame's wind metadata buffer is usable */
+    bool m_AlphaMeshWindMetadataValid = false;
+
+    /** Instanced draws the alpha VOB emitter needed this frame. Compared against the instance count
+        it shows how much of the batching survived the back-to-front sort. */
+    unsigned int m_AlphaVobDrawsThisFrame = 0;
+
     std::vector<VobLightInfo*> m_FrameLights;
     std::vector<VobWindMetadata> m_WindMetadataStaging;
 

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -190,10 +190,8 @@ struct VobAlphaMesh {
     UINT     IndexCount;
     UINT     NumInstances;
     bool     Additive;                       // zMAT_ALPHA_FUNC_ADD -> additive blend, else plain alpha blending
-    // Depth this batch sorts on in the frame's transparency queue: the distance to its NEAREST instance.
-    // Batch granularity, not per instance as on D3D11 - the instance ring is partitioned near/far while it is
-    // uploaded, so ring slot i is not visual->Instances[i] and a per-instance draw range cannot be addressed
-    // from the CPU list. Nearest-instance keeps the common cases (one web, one cluster) in the right place.
+    // Transparency-queue depth: distance to the NEAREST instance. Batch granularity, not per instance as on
+    // D3D11 - the instance ring is partitioned near/far on upload, so ring slot i is not Instances[i].
     float    DistanceSq;
 };
 extern std::vector<VobAlphaMesh> g_FrameVobAlpha;

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -159,7 +159,7 @@ extern size_t g_SkelMatSrvCount;
 extern std::unordered_map<zCTexture*, std::vector<MeshInfo*>> g_FrameWaterSurfaces;
 
 // Alpha-blended world-mesh surfaces (ice, glass, magic barriers) peeled out of the opaque world pass by
-// BuildWorldDrawCommands (D3D12Scene.cpp) and drawn back-to-front by DrawWorldTransparencyMeshes
+// BuildWorldDrawCommands (D3D12Scene.cpp) and drawn back-to-front by DrawWorldTransparencyRun
 // (D3D12Transparency.cpp), which also owns the definition. Mirrors D3D11's FrameTransparencyMeshes.
 // Same single-threaded per-frame lifetime as g_FrameWaterSurfaces above.
 class zCMaterial;
@@ -175,7 +175,7 @@ extern std::vector<WorldTransparencyMesh> g_FrameWorldTransparencyPortal;   // M
 extern std::vector<WorldTransparencyMesh> g_FrameWorldTransparencyFoam;     // MT_WaterfallFoam
 
 // Blended instanced VOBs (cobwebs, hanging cloth, magic sheets) peeled out of the opaque VOB ExecuteIndirect
-// set by BuildVobDrawCommands (D3D12Scene.cpp) and replayed by DrawVobAlphaMeshes (D3D12Transparency.cpp,
+// set by BuildVobDrawCommands (D3D12Scene.cpp) and replayed by DrawVobAlphaRun (D3D12Transparency.cpp,
 // which owns the definition). Mirrors D3D11's m_AlphaMeshes / DrawFrameAlphaMeshes. Everything is resolved at
 // build time so the pass itself only switches PSO + a handful of root constants per entry; the buffer views
 // point into this frame's instance ring, so the list is strictly single-frame (same lifetime as
@@ -190,6 +190,11 @@ struct VobAlphaMesh {
     UINT     IndexCount;
     UINT     NumInstances;
     bool     Additive;                       // zMAT_ALPHA_FUNC_ADD -> additive blend, else plain alpha blending
+    // Depth this batch sorts on in the frame's transparency queue: the distance to its NEAREST instance.
+    // Batch granularity, not per instance as on D3D11 - the instance ring is partitioned near/far while it is
+    // uploaded, so ring slot i is not visual->Instances[i] and a per-instance draw range cannot be addressed
+    // from the CPU list. Nearest-instance keeps the common cases (one web, one cluster) in the right place.
+    float    DistanceSq;
 };
 extern std::vector<VobAlphaMesh> g_FrameVobAlpha;
 

--- a/D3D11Engine/D3D12Engine/D3D12Fx.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Fx.cpp
@@ -1,24 +1,12 @@
-// D3D12GraphicsEngine — Gothic FX geometry: quad marks and poly strips.
+// D3D12GraphicsEngine — Gothic FX geometry: quad marks, poly strips and mesh-shaped particle effects.
+// CPU-built ExVertexStruct triangle lists with a per-material blend mode, sharing one root signature, one
+// shader (Shaders/D3D12/Fx.hlsl) and one blend-keyed PSO cache (D3D12PipelineState::CreateFx).
 //
-// Ports three D3D11 passes that had no D3D12 counterpart at all (the base-class DrawPolyStrips is a silent
-// `return XR_SUCCESS`, and nothing on D3D12 ever looked at GothicAPI's quad-mark list), so blood splatter,
-// spell ground marks, weapon/spell trails and lightning flashes were simply missing from the frame:
-//   * quad marks — zCQuadMark geometry in every blend mode (D3D11's DrawQuadMarkRun)
-//   * poly strips — zCPolyStrip trails + lightning flashes (D3D11's DrawPolyStripRun)
-//   * D3D11GraphicsEngine::DrawFrameParticleMeshes (:9066) — mesh-shaped particle effects (visShpType 5)
+// Geometry sources differ: quad marks own a per-mark static GfxVertexBuffer (already a D3D12VertexBuffer,
+// bind it directly), poly strips are rebuilt every frame and stream through m_FxVertexBuffer.
 //
-// All three are CPU-built ExVertexStruct triangle lists drawn unlit with a per-material blend mode, so they
-// share one root signature, one shader (Shaders/D3D12/Fx.hlsl) and one blend-keyed PSO cache
-// (D3D12PipelineState::CreateFx / GetOrCreateFxPipeline).
-//
-// Geometry sources differ, and that is the only real difference between the passes:
-//   * quad marks own a per-mark static GfxVertexBuffer, filled by WorldConverter::UpdateQuadMarkInfo when
-//     Gothic creates the mark (so it is already a D3D12VertexBuffer — bind it directly)
-//   * poly-strip meshes are rebuilt on the CPU every frame, so they stream through a per-frame upload ring
-//     (m_FxVertexBuffer). D3D11 instead grows one shared TempPolysVertexBuffer on demand.
-//
-// Quad marks follow D3D11's shader split: the lit world pixel shader (PS_World) for the opaque/add/blend
-// marks and the unlit Fx one (PS_Simple) for MUL/MUL2. Poly strips are always unlit, as in D3D11.
+// Quad marks follow D3D11's shader split - lit PS_World for opaque/add/blend, unlit Fx PS_Simple for
+// MUL/MUL2. Poly strips are always unlit.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
 #include "D3D12Texture.h"
@@ -114,13 +102,9 @@ bool D3D12GraphicsEngine::CreateFxVertexBuffers() {
 }
 
 
-/** Draws a run of quad marks (blood splatter, spell ground marks) in transparency-queue order.
-
-    Replaces the old DrawQuadMarks/DrawMQuadMarks split. The two blend classes still use different pipelines
-    — the lit World.RootSig one (sRGB->linear albedo, DelightDiffuse, CSM shadows, tiled point lights, SSAO,
-    wetness, sky IBL, what D3D11's PS_World gives them) and the unlit Fx one for MUL/MUL2 (D3D11's PS_Simple)
-    — but a mark no longer gets moved to a later pass just because of its blend mode: the class switches
-    inside the run, in depth order. Each mark draws straight out of its own static VB. */
+/** One run of quad marks. Replaces the old DrawQuadMarks/DrawMQuadMarks split: the two blend classes still
+    use different pipelines (lit World.RootSig vs the unlit Fx one for MUL/MUL2) but a mark is no longer
+    deferred to a later pass for its blend mode - the class switches inside the run, in depth order. */
 void D3D12GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> items ) {
     if ( items.empty() ) return;
     if ( !m_FrameOpen || !m_Pipelines.World.RootSig || !m_Pipelines.Fx.RootSig || !m_DepthBuffer ) return;
@@ -143,8 +127,7 @@ void D3D12GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> item
     m_CmdList->RSSetScissorRects( 1, &sc );
     m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
-    // D3D11's state machine: start from SetDefaultStates() (no blending, depth-write ON), then follow the
-    // CURRENT material's alpha func, but only re-create the PSO when it CHANGES.
+    // Follow the current material's alpha func, but only re-create the PSO when it changes.
     GothicBlendStateInfo blend;
     blend.SetDefault();
     int alphaFunc = -1;
@@ -161,7 +144,7 @@ void D3D12GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> item
         zCMaterial* mat = QuadMarkMaterial( mark );
         if ( !mat ) continue;
 
-        // Modulate marks stay unlit, exactly as D3D11's PS_Simple path did; everything else is lit.
+        // Modulate marks stay unlit (PS_Simple), everything else is lit.
         const int wantLit = ( mat->GetAlphaFunc() == zMAT_ALPHA_FUNC_MUL
             || mat->GetAlphaFunc() == zMAT_ALPHA_FUNC_MUL2 ) ? 0 : 1;
 
@@ -199,8 +182,8 @@ void D3D12GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> item
             }
             alphaFunc = mat->GetAlphaFunc();
 
-            // Opaque marks keep writing depth as they did in D3D11's first pass; every blended mode must not,
-            // or a mark would depth-reject the transparent geometry drawn after it.
+            // Opaque marks keep writing depth; blended ones must not, or they would depth-reject the
+            // transparent geometry drawn after them.
             const bool depthWrite = ( alphaFunc == zMAT_ALPHA_FUNC_NONE || alphaFunc == zMAT_ALPHA_FUNC_TEST );
             ID3D12PipelineState* next = litClass
                 ? m_Pipelines.GetOrCreateQuadMarkPipeline( blend, depthWrite )
@@ -248,8 +231,7 @@ void D3D12GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> item
 }
 
 
-/** Draws a run of poly strips (weapon/spell trails, lightning flashes) in transparency-queue order.
-    The strip/flash meshes themselves are rebuilt by CollectTransparencyQueue, before anything is sorted. */
+/** One run of poly strips. CollectTransparencyQueue rebuilds the strip/flash meshes before sorting. */
 void D3D12GraphicsEngine::DrawPolyStripRun( std::span<const TransparentItem> items ) {
     if ( items.empty() ) return;
     if ( !m_FrameOpen || !m_Pipelines.Fx.RootSig || !m_FxVertexBuffer[m_FrameIndex] ) return;

--- a/D3D11Engine/D3D12Engine/D3D12Fx.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Fx.cpp
@@ -3,9 +3,8 @@
 // Ports three D3D11 passes that had no D3D12 counterpart at all (the base-class DrawPolyStrips is a silent
 // `return XR_SUCCESS`, and nothing on D3D12 ever looked at GothicAPI's quad-mark list), so blood splatter,
 // spell ground marks, weapon/spell trails and lightning flashes were simply missing from the frame:
-//   * D3D11GraphicsEngine::DrawQuadMarks   (:8741) — zCQuadMark geometry, opaque/add/blend modes
-//   * D3D11GraphicsEngine::DrawMQuadMarks  (:8817) — the MUL/MUL2 marks the first pass defers
-//   * D3D11GraphicsEngine::DrawPolyStrips  (:7912) — zCPolyStrip trails + lightning flashes
+//   * quad marks — zCQuadMark geometry in every blend mode (D3D11's DrawQuadMarkRun)
+//   * poly strips — zCPolyStrip trails + lightning flashes (D3D11's DrawPolyStripRun)
 //   * D3D11GraphicsEngine::DrawFrameParticleMeshes (:9066) — mesh-shaped particle effects (visShpType 5)
 //
 // All three are CPU-built ExVertexStruct triangle lists drawn unlit with a per-material blend mode, so they
@@ -18,10 +17,8 @@
 //   * poly-strip meshes are rebuilt on the CPU every frame, so they stream through a per-frame upload ring
 //     (m_FxVertexBuffer). D3D11 instead grows one shared TempPolysVertexBuffer on demand.
 //
-// Deliberate divergence, also documented in Fx.hlsl: D3D11's DrawQuadMarks binds the LIT world pixel shader
-// (PS_World) while its MUL/MUL2 marks and all poly strips use the unlit PS_Simple. D3D12 draws every one of
-// them unlit — the vertices already carry Gothic's baked static lighting in their vertex color, and plumbing
-// the Forward+ tile grid/cascades into a pass that draws a handful of blood splats is not worth it.
+// Quad marks follow D3D11's shader split: the lit world pixel shader (PS_World) for the opaque/add/blend
+// marks and the unlit Fx one (PS_Simple) for MUL/MUL2. Poly strips are always unlit, as in D3D11.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
 #include "D3D12Texture.h"
@@ -48,11 +45,6 @@ namespace {
     // Gothic's trails and lightning flashes produce (a few hundred verts per strip), and overflow drops the
     // rest of the frame's strips with a one-shot warning rather than reallocating on the frame path.
     constexpr UINT kFxVertexBufferBytes = 2 * 1024 * 1024;
-
-    // D3D11 spec: DrawQuadMarks defers MUL/MUL2 marks into the MulQuadMarks member and DrawMQuadMarks drains
-    // it in the later transparent pass. Same lifetime here: filled by DrawQuadMarks, cleared by DrawMQuadMarks.
-    struct MulQuadMark { zCQuadMark* Mark; const QuadMarkInfo* Info; };
-    std::vector<MulQuadMark> g_MulQuadMarks;
 
     // b2 Flags — must match Fx.hlsl's FX_* defines. Each D3D11 pass binds a different pixel shader; these
     // pick the matching behaviour. Never combined: PS_World alpha-tests and ignores the vertex color for RGB,
@@ -122,20 +114,21 @@ bool D3D12GraphicsEngine::CreateFxVertexBuffers() {
 }
 
 
-void D3D12GraphicsEngine::DrawQuadMarks() {
-    // Port of D3D11GraphicsEngine::DrawQuadMarks. Runs with the opaque decals (D3D11's "Draw ParticleFX #1"
-    // pass calls the two back to back), i.e. on the HDR scene target with the opaque scene already laid down.
-    const auto& quadMarks = Engine::GAPI->GetQuadMarks();
-    g_MulQuadMarks.clear();
-    if ( quadMarks.empty() ) return;
-    if ( !m_FrameOpen || !m_Pipelines.World.RootSig || !m_DepthBuffer ) return;
+/** Draws a run of quad marks (blood splatter, spell ground marks) in transparency-queue order.
+
+    Replaces the old DrawQuadMarks/DrawMQuadMarks split. The two blend classes still use different pipelines
+    — the lit World.RootSig one (sRGB->linear albedo, DelightDiffuse, CSM shadows, tiled point lights, SSAO,
+    wetness, sky IBL, what D3D11's PS_World gives them) and the unlit Fx one for MUL/MUL2 (D3D11's PS_Simple)
+    — but a mark no longer gets moved to a later pass just because of its blend mode: the class switches
+    inside the run, in depth order. Each mark draws straight out of its own static VB. */
+void D3D12GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> items ) {
+    if ( items.empty() ) return;
+    if ( !m_FrameOpen || !m_Pipelines.World.RootSig || !m_Pipelines.Fx.RootSig || !m_DepthBuffer ) return;
 
     DX_ZONE( m_CmdList.Get(), "Draw quad marks" );
 
-    // LIT pass: World.RootSig + World.hlsl's VSQuadMark/PSMain, i.e. the exact same lighting the world mesh
-    // gets — sRGB->linear albedo, DelightDiffuse, CSM shadows, tiled point lights, SSAO, wetness, sky IBL.
-    // D3D11 does the same thing structurally (DrawQuadMarks binds PS_World, its lit world shader). Each mark
-    // draws straight out of its own static VB with its world matrix in b4; nothing is streamed or re-uploaded.
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
     Engine::GAPI->SetViewTransformXM( view );
     Engine::GAPI->ResetWorldTransform();
@@ -144,41 +137,44 @@ void D3D12GraphicsEngine::DrawQuadMarks() {
     XMFLOAT4X4 viewProj;
     XMStoreFloat4x4( &viewProj, XMMatrixMultiply( XMLoadFloat4x4( &projM ), XMLoadFloat4x4( &viewM ) ) );
 
-    BindWorldFrameRootState( viewProj );
-    m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
-
     const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_Resolution.x ), static_cast<float>( m_Resolution.y ), 0.0f, 1.0f };
     const D3D12_RECT     sc = { 0, 0, m_Resolution.x, m_Resolution.y };
     m_CmdList->RSSetViewports( 1, &vp );
     m_CmdList->RSSetScissorRects( 1, &sc );
+    m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
-    // D3D11's state machine: SetDefaultStates() (no blending, depth-write ON), then the blend state follows
-    // whatever the CURRENT material's alpha func says — but only when it CHANGES, so a run of same-func marks
-    // costs one PSO switch. Depth-write stays on for this pass (only DrawMQuadMarks turns it off).
+    // D3D11's state machine: start from SetDefaultStates() (no blending, depth-write ON), then follow the
+    // CURRENT material's alpha func, but only re-create the PSO when it CHANGES.
     GothicBlendStateInfo blend;
     blend.SetDefault();
-    ID3D12PipelineState* pso = m_Pipelines.GetOrCreateQuadMarkPipeline( blend, true );
-    if ( !pso ) return;
-    m_CmdList->SetPipelineState( pso );
-
-    int alphaFunc = zMAT_ALPHA_FUNC_NONE;
-
-    const float vfxRadius = Engine::GAPI->GetRendererState().RendererSettings.VisualFXDrawRadius;
-    const XMVECTOR vVfxRadiusSq = XMVectorReplicate( vfxRadius * vfxRadius );
-    const XMVECTOR camPos = Engine::GAPI->GetCameraPositionXM();
+    int alphaFunc = -1;
+    int litClass = -1;   // -1 = nothing bound yet, 1 = lit World pipeline, 0 = unlit Fx pipeline
 
     unsigned int drawnVertices = 0;
-    for ( auto const& it : quadMarks ) {
-        zCQuadMark* mark = it.first;
-        const QuadMarkInfo& info = it.second;
+    for ( const TransparentItem& item : items ) {
+        const TransparentQuadMark& entry = queue.GetQuadMark( item );
+        zCQuadMark* mark = entry.Mark;
+        const QuadMarkInfo& info = *entry.Info;
         if ( !mark->GetConnectedVob() ) continue;
         if ( !info.Mesh || info.NumVertices <= 0 ) continue;
 
-        if ( XMVector3Greater( XMVector3LengthSq( camPos - XMLoadFloat3( &info.Position ) ), vVfxRadiusSq ) )
-            continue;
-
         zCMaterial* mat = QuadMarkMaterial( mark );
         if ( !mat ) continue;
+
+        // Modulate marks stay unlit, exactly as D3D11's PS_Simple path did; everything else is lit.
+        const int wantLit = ( mat->GetAlphaFunc() == zMAT_ALPHA_FUNC_MUL
+            || mat->GetAlphaFunc() == zMAT_ALPHA_FUNC_MUL2 ) ? 0 : 1;
+
+        if ( wantLit != litClass ) {
+            if ( wantLit ) {
+                BindWorldFrameRootState( viewProj );
+            } else {
+                m_CmdList->SetGraphicsRootSignature( m_Pipelines.Fx.RootSig.Get() );
+                m_CmdList->SetGraphicsRoot32BitConstants( 0, 16, &viewProj, 0 );
+            }
+            litClass = wantLit;
+            alphaFunc = -1;   // the PSO belongs to the other pipeline family, force a re-select
+        }
 
         if ( alphaFunc != mat->GetAlphaFunc() ) {
             switch ( mat->GetAlphaFunc() ) {
@@ -193,16 +189,22 @@ void D3D12GraphicsEngine::DrawQuadMarks() {
                 blend.SetDefault();
                 break;
             case zMAT_ALPHA_FUNC_MUL:
+                blend.SetModulateBlending();
+                break;
             case zMAT_ALPHA_FUNC_MUL2:
-                // Deferred to DrawMQuadMarks — modulate blending has to happen over the finished scene, and
-                // those stay UNLIT (D3D11's DrawMQuadMarks binds PS_Simple, not PS_World).
-                g_MulQuadMarks.push_back( { mark, &info } );
-                continue;
+                blend.SetModulate2Blending();
+                break;
             default:
                 continue;
             }
             alphaFunc = mat->GetAlphaFunc();
-            ID3D12PipelineState* next = m_Pipelines.GetOrCreateQuadMarkPipeline( blend, true );
+
+            // Opaque marks keep writing depth as they did in D3D11's first pass; every blended mode must not,
+            // or a mark would depth-reject the transparent geometry drawn after it.
+            const bool depthWrite = ( alphaFunc == zMAT_ALPHA_FUNC_NONE || alphaFunc == zMAT_ALPHA_FUNC_TEST );
+            ID3D12PipelineState* next = litClass
+                ? m_Pipelines.GetOrCreateQuadMarkPipeline( blend, depthWrite )
+                : m_Pipelines.GetOrCreateFxPipeline( blend, false );
             if ( !next ) continue;
             m_CmdList->SetPipelineState( next );
         }
@@ -213,17 +215,27 @@ void D3D12GraphicsEngine::DrawQuadMarks() {
         D3D12VertexBuffer* vb = D3D12VertexBuffer::From( info.Mesh.get() );
         if ( !vb->GetResource() ) continue;
 
-        // b4: rows 0-2 of the mark's world matrix (see World.hlsl's QuadMarkCB for why only three, and why
-        // this borrows the wind slot). Uploaded verbatim like every other matrix here — the vob matrix is
-        // column-vector form, translation at _14/_24/_34.
         const XMFLOAT4X4 world = *mark->GetConnectedVob()->GetWorldMatrixPtr();
-        m_CmdList->SetGraphicsRoot32BitConstants( 11, 12, &world, 0 );
+        if ( litClass ) {
+            // b4: rows 0-2 of the mark's world matrix (see World.hlsl's QuadMarkCB for why only three, and
+            // why this borrows the wind slot). Uploaded verbatim like every other matrix here — the vob
+            // matrix is column-vector form, translation at _14/_24/_34.
+            m_CmdList->SetGraphicsRoot32BitConstants( 11, 12, &world, 0 );
 
-        // b6 MaterialCB, the same four root constants the world ExecuteIndirect commands push per draw:
-        // no normal map (0xFFFFFFFF -> PSMain skips the perturb), the 1x1 default ORM (AO 1 / rough .5 /
-        // metal 0, channel layout 0 = full RGB ORM), the mark's diffuse, and a zero normal strength.
-        const uint32_t matCb[4] = { 0xFFFFFFFFu, GetDefaultOrmSrvSlot(), diffuseSlot, 0u };
-        m_CmdList->SetGraphicsRoot32BitConstants( 10, 4, matCb, 0 );
+            // b6 MaterialCB, the same four root constants the world ExecuteIndirect commands push per draw:
+            // no normal map (0xFFFFFFFF -> PSMain skips the perturb), the 1x1 default ORM (AO 1 / rough .5 /
+            // metal 0, channel layout 0 = full RGB ORM), the mark's diffuse, and a zero normal strength.
+            const uint32_t matCb[4] = { 0xFFFFFFFFu, GetDefaultOrmSrvSlot(), diffuseSlot, 0u };
+            m_CmdList->SetGraphicsRoot32BitConstants( 10, 4, matCb, 0 );
+        } else {
+            m_CmdList->SetGraphicsRoot32BitConstants( 1, 16, &world, 0 );
+
+            // PS_Simple semantics (what D3D11's DrawMQuadMarks binds): modulate by the vertex color, no alpha
+            // test. UpdateQuadMarkInfo forces the vertex color to white for MUL/MUL2 materials anyway, so this
+            // is a no-op multiply in practice — kept because it is what the D3D11 shader does.
+            const FxMaterialConsts matCb = { diffuseSlot, kFxVertexColor, 0.0f, 0.0f };
+            m_CmdList->SetGraphicsRoot32BitConstants( 2, 4, &matCb, 0 );
+        }
 
         const UINT numVerts = static_cast<UINT>( info.NumVertices );
         const D3D12_VERTEX_BUFFER_VIEW vbv = { vb->GetGpuVirtualAddress(), vb->GetSizeInBytes(), sizeof( ExVertexStruct ) };
@@ -236,100 +248,13 @@ void D3D12GraphicsEngine::DrawQuadMarks() {
 }
 
 
-void D3D12GraphicsEngine::DrawMQuadMarks() {
-    // Port of D3D11GraphicsEngine::DrawMQuadMarks — the MUL/MUL2 marks DrawQuadMarks deferred, drawn with the
-    // transparent decals over the finished scene. Depth-write OFF here (D3D11 sets it explicitly).
-    if ( g_MulQuadMarks.empty() ) return;
-    if ( !m_FrameOpen || !m_Pipelines.Fx.RootSig ) { g_MulQuadMarks.clear(); return; }
+/** Draws a run of poly strips (weapon/spell trails, lightning flashes) in transparency-queue order.
+    The strip/flash meshes themselves are rebuilt by CollectTransparencyQueue, before anything is sorted. */
+void D3D12GraphicsEngine::DrawPolyStripRun( std::span<const TransparentItem> items ) {
+    if ( items.empty() ) return;
+    if ( !m_FrameOpen || !m_Pipelines.Fx.RootSig || !m_FxVertexBuffer[m_FrameIndex] ) return;
 
-    DX_ZONE( m_CmdList.Get(), "Draw quad marks (modulate)" );
-    TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw quad marks (modulate)" );
-
-    XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
-    Engine::GAPI->SetViewTransformXM( view );
-    const XMFLOAT4X4& viewM = Engine::GAPI->GetRendererState().TransformState.TransformView;
-    const XMFLOAT4X4& projM = Engine::GAPI->GetProjectionMatrix();
-    XMFLOAT4X4 viewProj;
-    XMStoreFloat4x4( &viewProj, XMMatrixMultiply( XMLoadFloat4x4( &projM ), XMLoadFloat4x4( &viewM ) ) );
-
-    m_CmdList->SetGraphicsRootSignature( m_Pipelines.Fx.RootSig.Get() );
-    m_CmdList->SetGraphicsRoot32BitConstants( 0, 16, &viewProj, 0 );
-    m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
-
-    const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_Resolution.x ), static_cast<float>( m_Resolution.y ), 0.0f, 1.0f };
-    const D3D12_RECT     sc = { 0, 0, m_Resolution.x, m_Resolution.y };
-    m_CmdList->RSSetViewports( 1, &vp );
-    m_CmdList->RSSetScissorRects( 1, &sc );
-
-    GothicBlendStateInfo blend;
-    blend.SetDefault();
-    int alphaFunc = 0;   // D3D11 starts at 0 here, so the first mark always switches (0 is never MUL/MUL2)
-    ID3D12PipelineState* pso = m_Pipelines.GetOrCreateFxPipeline( blend, false );
-    if ( !pso ) { g_MulQuadMarks.clear(); return; }
-    m_CmdList->SetPipelineState( pso );
-
-    unsigned int drawnVertices = 0;
-    for ( auto const& entry : g_MulQuadMarks ) {
-        zCMaterial* mat = QuadMarkMaterial( entry.Mark );
-        if ( !mat || !entry.Mark->GetConnectedVob() ) continue;
-        if ( !entry.Info->Mesh || entry.Info->NumVertices <= 0 ) continue;
-
-        if ( alphaFunc != mat->GetAlphaFunc() ) {
-            switch ( mat->GetAlphaFunc() ) {
-            case zMAT_ALPHA_FUNC_MUL:
-                blend.SetModulateBlending();
-                break;
-            case zMAT_ALPHA_FUNC_MUL2:
-                blend.SetModulate2Blending();
-                break;
-            default:
-                continue;
-            }
-            alphaFunc = mat->GetAlphaFunc();
-            ID3D12PipelineState* next = m_Pipelines.GetOrCreateFxPipeline( blend, false );
-            if ( !next ) continue;
-            m_CmdList->SetPipelineState( next );
-        }
-
-        const UINT diffuseSlot = ResolveDiffuseSlot( mat );
-        if ( diffuseSlot == UINT_MAX ) continue;
-
-        D3D12VertexBuffer* vb = D3D12VertexBuffer::From( entry.Info->Mesh.get() );
-        if ( !vb->GetResource() ) continue;
-
-        XMFLOAT4X4 world;
-        XMStoreFloat4x4( &world, entry.Mark->GetConnectedVob()->GetWorldMatrixXM() );
-        m_CmdList->SetGraphicsRoot32BitConstants( 1, 16, &world, 0 );
-
-        // PS_Simple semantics (what D3D11's DrawMQuadMarks binds): modulate by the vertex color, no alpha
-        // test. UpdateQuadMarkInfo forces the vertex color to white for MUL/MUL2 materials anyway, so this
-        // is a no-op multiply in practice — kept because it is what the D3D11 shader does.
-        const FxMaterialConsts matCb = { diffuseSlot, kFxVertexColor, 0.0f, 0.0f };
-        m_CmdList->SetGraphicsRoot32BitConstants( 2, 4, &matCb, 0 );
-
-        const D3D12_VERTEX_BUFFER_VIEW vbv = { vb->GetGpuVirtualAddress(), vb->GetSizeInBytes(), sizeof( ExVertexStruct ) };
-        m_CmdList->IASetVertexBuffers( 0, 1, &vbv );
-        m_CmdList->DrawInstanced( static_cast<UINT>( entry.Info->NumVertices ), 1, 0, 0 );
-        drawnVertices += static_cast<unsigned int>( entry.Info->NumVertices );
-    }
-
-    Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnTriangles += drawnVertices / 3;
-    g_MulQuadMarks.clear();
-}
-
-
-XRESULT D3D12GraphicsEngine::DrawPolyStrips( bool noTextures ) {
-    // Port of D3D11GraphicsEngine::DrawPolyStrips — weapon/spell trails and lightning flashes. D3D11 rebuilds
-    // both mesh sets at the top of its own "Draw PolyStrips" render-graph pass; that CPU work is backend-
-    // neutral GothicAPI code, so it happens here for the same reason (nothing else calls it).
-#if (defined BUILD_GOTHIC_2_6_fix || defined BUILD_GOTHIC_1_08k)
-    Engine::GAPI->CalcPolyStripMeshes();   // weapon/effect trails
-    Engine::GAPI->CalcFlashMeshes();       // lightning flashes
-#endif
-
-    const std::map<zCTexture*, PolyStripInfo>& polyStripInfos = Engine::GAPI->GetPolyStripInfos();
-    if ( polyStripInfos.empty() ) return XR_SUCCESS;
-    if ( !m_FrameOpen || !m_Pipelines.Fx.RootSig || !m_FxVertexBuffer[m_FrameIndex] ) return XR_SUCCESS;
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
 
     DX_ZONE( m_CmdList.Get(), "Draw poly strips" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw poly strips" );
@@ -361,21 +286,22 @@ XRESULT D3D12GraphicsEngine::DrawPolyStrips( bool noTextures ) {
     int lastAlphaFunc = -1;
     constexpr bool depthWrite = false;
     ID3D12PipelineState* pso = m_Pipelines.GetOrCreateFxPipeline( blend, depthWrite );
-    if ( !pso ) return XR_SUCCESS;
+    if ( !pso ) return;
     m_CmdList->SetPipelineState( pso );
 
     const UINT frame = m_FrameIndex;
     unsigned int drawnVertices = 0;
-    for ( auto const& it : polyStripInfos ) {
-        zCMaterial* mat = it.second.material;
-        const std::vector<ExVertexStruct>& vertices = it.second.vertices;
+    for ( const TransparentItem& item : items ) {
+        const TransparentPolyStrip& strip = queue.GetPolyStrip( item );
+        zCMaterial* mat = strip.Info->material;
+        const std::vector<ExVertexStruct>& vertices = strip.Info->vertices;
         if ( !mat || vertices.empty() ) continue;
 
         // The MAP KEY is the texture to draw with, not mat->GetAniTexture() — CalcPolyStripMeshes falls back
         // to GetTextureSingle() when a strip material has no animated texture, and keys the map on the result.
         // D3D11 does the same (`zCTexture* tx = it->first`). It also skips strips whose texture is not cached
         // in yet ("Don't draw if texture is not yet cached").
-        const UINT diffuseSlot = noTextures ? m_WhiteTexture->GetSrvSlot() : ResolveDiffuseSlot( it.first );
+        const UINT diffuseSlot = ResolveDiffuseSlot( strip.Texture );
         if ( diffuseSlot == UINT_MAX ) continue;
 
         const int matAlphaFunc = mat->GetAlphaFunc();
@@ -418,7 +344,6 @@ XRESULT D3D12GraphicsEngine::DrawPolyStrips( bool noTextures ) {
     }
 
     Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnTriangles += drawnVertices / 3;
-    return XR_SUCCESS;
 }
 
 

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -126,7 +126,7 @@ XRESULT D3D12GraphicsEngine::Init() {
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreateWorldTransparency() ) {
-        // Non-fatal: DrawWorldTransparencyMeshes early-outs on a missing root sig, which leaves the peeled
+        // Non-fatal: DrawWorldTransparencyRun early-outs on a missing root sig, which leaves the peeled
         // alpha-blended world surfaces (ice/glass) simply undrawn — the same as before this pass existed,
         // minus their opaque stand-in. Everything else keeps rendering.
         LogWarn() << "D3D12GraphicsEngine::Init: failed to create the alpha-blended world-mesh pipeline "

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -7,7 +7,9 @@
 #include "../BaseGraphicsEngine.h"
 #include "../Frustum.h"
 #include "../MorphGpu.h"         // MorphGpu::Job / ChannelRecord (the morph-fold queue members below)
+#include "../TransparencyQueue.h" // the frame's sorted alpha-blended draw list
 #include "../WorldConverter.h"   // SHADOW_LOD_FIRST_CASCADE
+#include <span>
 #include "D3D12Device.h"
 #include <memory>
 #include <unordered_map>
@@ -337,9 +339,8 @@ private:
     void DrawDecalList( const std::vector<zCVob*>& decals, bool lighting );
     // Ghost/transparency VOBs (invisible-potion/fade items — GothicAPI::TransparencyVobs, populated every frame
     // by CollectVisibleVobs' GetVisualAlpha() branch). Mirrors D3D11's GothicAPI::DrawTransparencyVobs (unlit
-    // diffuse sample, alpha *= per-vob GhostAlpha) but MUST run regardless of feature support: nothing else
-    // drains this list, so skipping the call would leak one entry per ghost vob per frame forever.
-    void DrawGhostVobs();
+    // diffuse sample, alpha *= per-vob GhostAlpha). Drawn by DrawGhostRun out of the transparency queue; the
+    // list itself is cleared by DrawTransparencyQueue, which runs unconditionally so it can never leak.
     void DrawVegetation();    // GVegetationBox instanced grass cards (own PSO — see D3D12PipelineState::CreateGrass)
     // Grass in the Forward+ DEPTH PREPASS. Runs from the prepass block, after the skeletal draws. Its whole
     // purpose is the AO mask: RenderSSAO builds that from the prepass depth, so without this a grass pixel
@@ -371,14 +372,13 @@ private:
     // zCQuadMark decals (blood splatter, spell ground marks). Split in two exactly like D3D11: the opaque /
     // additive / alpha-blended marks draw with the opaque decals (depth-write on), while MUL/MUL2 marks are
     // deferred to DrawMQuadMarks and drawn with the transparent decals (depth-write off).
-    void DrawQuadMarks();
-    void DrawMQuadMarks();
+    // Both blend classes are handled by DrawQuadMarkRun now: the MUL/MUL2 marks are no longer deferred into
+    // a second pass, they just carry their own pipeline inside the run.
     // Mesh-shaped particle effects (zCParticleFX emitters with visShpType 5, e.g. swarms of solid debris).
     // Called back from GothicAPI::DrawParticlesSimple, i.e. from inside DrawParticleEffects.
     void DrawFrameParticleMeshes( std::unordered_map<zCVob*, std::unique_ptr<MeshVisualInfo>>& progMeshes ) override;
-    // Weapon/spell trails + lightning flashes (zCPolyStrip). Recomputes the strip/flash meshes first, exactly
-    // like D3D11's "Draw PolyStrips" pass, then draws one dynamic-ring batch per texture.
-    XRESULT DrawPolyStrips( bool noTextures = false ) override;
+    // Weapon/spell trails + lightning flashes (zCPolyStrip) are drawn by DrawPolyStripRun, one dynamic-ring
+    // batch per texture, in transparency-queue order.
     // Bink cutscene YUV quad (zBinkPlayer.cpp) — DrawVertexArray's PS_Video special case. Same pre-transformed
     // vertex ring as the FF/UI path, but binds m_VideoTextures[0..2] through Video.RootSig/PSO instead.
     XRESULT DrawVideoVertexArray( ExVertexStruct* vertices, unsigned int numVertices, unsigned int startVertex, unsigned int stride );
@@ -730,16 +730,32 @@ private:
     // MT_Portal (G1 forest portals) and MT_WaterfallFoam are peeled by material TYPE into their own lists
     // and drawn as extra sub-passes with their own pixel shaders — same three-list split D3D11 has.
     static bool IsWorldMeshAlphaBlended( zCMaterial* mat );   // "does this material belong in that list?"
-    void SortWorldTransparencyMeshes();                       // painter's order (far -> near), once per frame
-    void DrawWorldTransparencyMeshes();                       // the pass itself (drains all three lists)
-    void DrawWorldTransparencyList( std::vector<struct WorldTransparencyMesh>& list,
-        D3D12PipelineState::WorldTransparencyPipeline::EKind kind, bool depthFill );   // one sub-pass
+    void DrawWorldTransparencyRun( std::span<const TransparentItem> items,
+        EWorldTransparencyVariant variant );                  // one run out of the transparency queue
+    // Root signature + frame root args + world VB/IB for a world-transparency draw. Re-done per run, since
+    // the queue interleaves these with kinds that bind their own root signature. False = cannot draw.
+    bool BindWorldTransparencyFrameState();
+    void DrawWorldTransparencyDepthOnly();                    // depth re-lay, once, after the whole replay
+
+    // ---- The frame's sorted transparency queue (D3D12Transparency.cpp).
+    //
+    // Every alpha-blended thing used to be its own pass in a fixed sequence, each sorted at best against
+    // itself - so a cobweb always painted before a ghost and a ghost before a glass pane, whatever the actual
+    // depth order was. Collect fills the backend-neutral TransparencyQueue (GothicAPI) from this frame's
+    // per-kind lists, sorts it once back-to-front, and Draw replays it, batching maximal consecutive runs of
+    // the same kind. Same design as D3D11's; the payloads are indices into this backend's own arrays.
+    void CollectTransparencyQueue();
+    void DrawTransparencyQueue();
+    void DrawGhostRun( std::span<const TransparentItem> items );
+    void DrawDecalRun( std::span<const TransparentItem> items );
+    void DrawQuadMarkRun( std::span<const TransparentItem> items );
+    void DrawPolyStripRun( std::span<const TransparentItem> items );
+    void DrawVobAlphaRun( std::span<const TransparentItem> items );
 
     // ---- Blended instanced VOBs (cobwebs, hanging cloth) — port of D3D11's DrawFrameAlphaMeshes.
     // BuildVobDrawCommands peels every VOB material with a BLEND/ADD alpha func out of the opaque
-    // ExecuteIndirect set into g_FrameVobAlpha (D3D12EngineCommon.h); this pass replays them unlit and blended,
-    // depth-tested but never depth-writing. Also in D3D12Transparency.cpp.
-    void DrawVobAlphaMeshes();
+    // ExecuteIndirect set into g_FrameVobAlpha (D3D12EngineCommon.h); DrawVobAlphaRun above replays them unlit
+    // and blended, depth-tested but never depth-writing, in transparency-queue order.
 
     // ---- GPU-driven instanced VOBs (P2.12): ExecuteIndirect + bindless diffuse + the VOB mega-buffer arena.
     //

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -339,8 +339,8 @@ private:
     void DrawDecalList( const std::vector<zCVob*>& decals, bool lighting );
     // Ghost/transparency VOBs (invisible-potion/fade items — GothicAPI::TransparencyVobs, populated every frame
     // by CollectVisibleVobs' GetVisualAlpha() branch). Mirrors D3D11's GothicAPI::DrawTransparencyVobs (unlit
-    // diffuse sample, alpha *= per-vob GhostAlpha). Drawn by DrawGhostRun out of the transparency queue; the
-    // list itself is cleared by DrawTransparencyQueue, which runs unconditionally so it can never leak.
+    // diffuse sample, alpha *= per-vob GhostAlpha). Drawn by DrawGhostRun; DrawTransparencyQueue clears the
+    // list unconditionally, so it cannot leak.
     void DrawVegetation();    // GVegetationBox instanced grass cards (own PSO — see D3D12PipelineState::CreateGrass)
     // Grass in the Forward+ DEPTH PREPASS. Runs from the prepass block, after the skeletal draws. Its whole
     // purpose is the AO mask: RenderSSAO builds that from the prepass depth, so without this a grass pixel
@@ -372,13 +372,11 @@ private:
     // zCQuadMark decals (blood splatter, spell ground marks). Split in two exactly like D3D11: the opaque /
     // additive / alpha-blended marks draw with the opaque decals (depth-write on), while MUL/MUL2 marks are
     // deferred to DrawMQuadMarks and drawn with the transparent decals (depth-write off).
-    // Both blend classes are handled by DrawQuadMarkRun now: the MUL/MUL2 marks are no longer deferred into
-    // a second pass, they just carry their own pipeline inside the run.
+    // Both blend classes go through DrawQuadMarkRun; MUL/MUL2 is no longer deferred to a second pass.
     // Mesh-shaped particle effects (zCParticleFX emitters with visShpType 5, e.g. swarms of solid debris).
     // Called back from GothicAPI::DrawParticlesSimple, i.e. from inside DrawParticleEffects.
     void DrawFrameParticleMeshes( std::unordered_map<zCVob*, std::unique_ptr<MeshVisualInfo>>& progMeshes ) override;
-    // Weapon/spell trails + lightning flashes (zCPolyStrip) are drawn by DrawPolyStripRun, one dynamic-ring
-    // batch per texture, in transparency-queue order.
+    // Weapon/spell trails + lightning flashes: DrawPolyStripRun, one dynamic-ring batch per texture.
     // Bink cutscene YUV quad (zBinkPlayer.cpp) — DrawVertexArray's PS_Video special case. Same pre-transformed
     // vertex ring as the FF/UI path, but binds m_VideoTextures[0..2] through Video.RootSig/PSO instead.
     XRESULT DrawVideoVertexArray( ExVertexStruct* vertices, unsigned int numVertices, unsigned int startVertex, unsigned int stride );
@@ -732,18 +730,13 @@ private:
     static bool IsWorldMeshAlphaBlended( zCMaterial* mat );   // "does this material belong in that list?"
     void DrawWorldTransparencyRun( std::span<const TransparentItem> items,
         EWorldTransparencyVariant variant );                  // one run out of the transparency queue
-    // Root signature + frame root args + world VB/IB for a world-transparency draw. Re-done per run, since
-    // the queue interleaves these with kinds that bind their own root signature. False = cannot draw.
+    // Per run, since the queue interleaves kinds that bind their own root signature. False = cannot draw.
     bool BindWorldTransparencyFrameState();
     void DrawWorldTransparencyDepthOnly();                    // depth re-lay, once, after the whole replay
 
-    // ---- The frame's sorted transparency queue (D3D12Transparency.cpp).
-    //
-    // Every alpha-blended thing used to be its own pass in a fixed sequence, each sorted at best against
-    // itself - so a cobweb always painted before a ghost and a ghost before a glass pane, whatever the actual
-    // depth order was. Collect fills the backend-neutral TransparencyQueue (GothicAPI) from this frame's
-    // per-kind lists, sorts it once back-to-front, and Draw replays it, batching maximal consecutive runs of
-    // the same kind. Same design as D3D11's; the payloads are indices into this backend's own arrays.
+    // ---- The frame's sorted transparency queue (D3D12Transparency.cpp). Collect fills the backend-neutral
+    // TransparencyQueue from this frame's per-kind lists and sorts it back-to-front; Draw replays it,
+    // batching maximal same-kind runs. Payloads are indices into this backend's own arrays.
     void CollectTransparencyQueue();
     void DrawTransparencyQueue();
     void DrawGhostRun( std::span<const TransparentItem> items );

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -271,8 +271,9 @@ bool D3D12PipelineState::CreateWorldTransparency() {
 
     D3D12RootLayout& rs = Layout( "WorldTransparency" );
     rs.AddConstants( 0, 16, D3D12_SHADER_VISIBILITY_VERTEX );  // 0: b0 ViewProj
-    // 1: b5 TransparencyCB { float4 TextureFactor; float SunHeight; float3 pad }
-    rs.AddConstants( 5, 8, D3D12_SHADER_VISIBILITY_PIXEL );
+    // 1: b5 TransparencyCB { float4 TextureFactor; float SunHeight; float3 EnvCamPosWS; uint EnvCubeIndex; float3 pad }
+    // The env tail is written only by the env-map overlay draw; the first 5 DWORDs keep their old meaning.
+    rs.AddConstants( 5, 12, D3D12_SHADER_VISIBILITY_PIXEL );
     rs.AddConstants( 6, 4, D3D12_SHADER_VISIBILITY_PIXEL );    // 2: b6 MaterialCB { normal, orm, diffuse, normalStrength }
     // 3: b4 TransparencyViewCB { float4x4 View } — portal VS only
     rs.AddConstants( 4, 16, D3D12_SHADER_VISIBILITY_VERTEX );
@@ -306,6 +307,14 @@ bool D3D12PipelineState::CreateWorldTransparency() {
         WorldTransparency.PortalVsBlob.Reset();
         WorldTransparency.PortalPsBlob.Reset();
     }
+    // Env-map overlay stage. Non-fatal in the same way: the caller checks these blobs and simply skips the
+    // overlay, leaving the base blended surface — which is exactly what shipped before the stage existed.
+    if ( !m_Shaders->CompileFromFile( "World.hlsl", "VSTransparentEnv", Shadermodel_VS, WorldTransparency.EnvVsBlob.ReleaseAndGetAddressOf() )
+      || !m_Shaders->CompileFromFile( "World.hlsl", "PSTransparentEnv", Shadermodel_PS, WorldTransparency.EnvPsBlob.ReleaseAndGetAddressOf() ) ) {
+        LogWarn() << "D3D12: the env-map transparency shaders failed to compile — env-mapped surfaces lose their sheen.";
+        WorldTransparency.EnvVsBlob.Reset();
+        WorldTransparency.EnvPsBlob.Reset();
+    }
 
     rs.ValidateShaders( {
         { WorldTransparency.VsBlob.Get(),       "World.hlsl:VSTransparent",       D3D12_SHADER_VISIBILITY_VERTEX },
@@ -313,6 +322,8 @@ bool D3D12PipelineState::CreateWorldTransparency() {
         { WorldTransparency.FoamPsBlob.Get(),   "World.hlsl:PSTransparentFoam",   D3D12_SHADER_VISIBILITY_PIXEL  },
         { WorldTransparency.PortalVsBlob.Get(), "World.hlsl:VSTransparentPortal", D3D12_SHADER_VISIBILITY_VERTEX },
         { WorldTransparency.PortalPsBlob.Get(), "World.hlsl:PSTransparentPortal", D3D12_SHADER_VISIBILITY_PIXEL  },
+        { WorldTransparency.EnvVsBlob.Get(),    "World.hlsl:VSTransparentEnv",    D3D12_SHADER_VISIBILITY_VERTEX },
+        { WorldTransparency.EnvPsBlob.Get(),    "World.hlsl:PSTransparentEnv",    D3D12_SHADER_VISIBILITY_PIXEL  },
     } );
 
     // Warm the two states every transparent world frame needs: plain alpha blending (by far the most common
@@ -353,6 +364,10 @@ ID3D12PipelineState* D3D12PipelineState::GetOrCreateWorldTransparencyPipeline( c
         && WorldTransparency.PortalVsBlob && WorldTransparency.PortalPsBlob ) {
         vs = WorldTransparency.PortalVsBlob.Get();
         ps = WorldTransparency.PortalPsBlob.Get();
+    } else if ( kind == WorldTransparencyPipeline::EKind::Env
+        && WorldTransparency.EnvVsBlob && WorldTransparency.EnvPsBlob ) {
+        vs = WorldTransparency.EnvVsBlob.Get();
+        ps = WorldTransparency.EnvPsBlob.Get();
     }
 
     // Same packed 36-byte world vertex the opaque pass consumes; VSTransparent just doesn't read NORMAL.

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.h
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.h
@@ -467,13 +467,16 @@ public:
             Simple = 0,   // PS_Simple_FF     — blended world surfaces (ice, glass); reads the FF texture factor
             Foam   = 1,   // PS_WaterfallFoam — MT_WaterfallFoam; own day/night tint, ignores the texture factor
             Portal = 2,   // PS_PortalDiffuse — MT_Portal (G1 forest portals); distance fade, needs a VIEW-space VS
+            Env    = 3,   // PS_EnvMap        — ZenGin's env-map overlay stage, drawn ON TOP of a Simple draw
         };
         Microsoft::WRL::ComPtr<ID3D12RootSignature> RootSig;
         Microsoft::WRL::ComPtr<ID3DBlob>            VsBlob;         // VSTransparent — Simple + Foam + the depth fill
         Microsoft::WRL::ComPtr<ID3DBlob>            PortalVsBlob;   // VSTransparentPortal (also outputs view-space pos)
+        Microsoft::WRL::ComPtr<ID3DBlob>            EnvVsBlob;      // VSTransparentEnv (outputs world pos + normal)
         Microsoft::WRL::ComPtr<ID3DBlob>            PsBlob;         // PSTransparent
         Microsoft::WRL::ComPtr<ID3DBlob>            FoamPsBlob;     // PSTransparentFoam
         Microsoft::WRL::ComPtr<ID3DBlob>            PortalPsBlob;   // PSTransparentPortal
+        Microsoft::WRL::ComPtr<ID3DBlob>            EnvPsBlob;      // PSTransparentEnv
         Microsoft::WRL::ComPtr<ID3D12PipelineState> DepthFillPSO;
         std::unordered_map<uint32_t, Microsoft::WRL::ComPtr<ID3D12PipelineState>> BlendPipelines; // key = BlendKey | kind<<29 | depthWrite<<31
     };

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -1544,8 +1544,7 @@ void D3D12GraphicsEngine::DrawDecalList( const std::vector<zCVob*>& decals, bool
 
 
 void D3D12GraphicsEngine::DrawGhostRun( std::span<const TransparentItem> items ) {
-	// TransparencyVobs is filled by CollectVisibleVobs' GetVisualAlpha() branch; the queue holds indices
-	// into it and DrawTransparencyQueue clears it unconditionally, so it cannot leak.
+	// Filled by CollectVisibleVobs' GetVisualAlpha() branch; the queue holds indices into it.
 	auto& transparencyVobs = Engine::GAPI->GetTransparencyVobs();
 	if ( items.empty() ) return;
 
@@ -2335,9 +2334,9 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	DrawWaterSurfaces();
 
 	// Everything else that blends, in ONE back-to-front pass: world transparency surfaces, blended instanced
-	// VOBs, ghosts, blended decals, quad marks and poly strips. Frame order is geometry -> alpha -> fog/pfx,
-	// same as D3D11: BEFORE the particles and RenderFogAndGodRays below, or alpha surfaces get pasted onto an
-	// already-fogged scene and never fog themselves. MUST run every frame - it drains the per-kind lists.
+	// VOBs, ghosts, blended decals, quad marks and poly strips. Before the particles and RenderFogAndGodRays,
+	// or alpha surfaces get pasted onto an already-fogged scene and never fog themselves. Must run every frame
+	// - it drains the per-kind lists.
 	CollectTransparencyQueue();
 	DrawTransparencyQueue();
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -36,7 +36,7 @@
 
 #include <array>
 #include <future>
-#include <algorithm>   // std::ranges::sort — DrawGhostVobs' back-to-front ordering
+#include <algorithm>
 
 // imgui_impl_dx12 calls CreateDXGIFactory1 directly (for tearing detection). dxgi.dll is present on
 // every Windows 7+ and the D3D11 fallback swapchain already needs it at runtime, so a load-time link
@@ -1543,19 +1543,18 @@ void D3D12GraphicsEngine::DrawDecalList( const std::vector<zCVob*>& decals, bool
 }
 
 
-void D3D12GraphicsEngine::DrawGhostVobs() {
+void D3D12GraphicsEngine::DrawGhostRun( std::span<const TransparentItem> items ) {
 	// GothicAPI::TransparencyVobs is populated every frame by CollectVisibleVobs' GetVisualAlpha() branch
-	// (invisible-potion/fade-out items) and is otherwise ONLY drained by D3D11's GothicAPI::DrawTransparencyVobs
-	// (hard-wired to D3D11GraphicsEngine — never called on this backend). Without a consumer here the list grows
-	// unbounded, one entry per ghost vob per frame, forever — so this function MUST run every frame regardless
-	// of whether the Ghost PSO exists.
+	// (invisible-potion/fade-out items); the transparency queue holds indices into it and
+	// DrawTransparencyQueue clears it afterwards, unconditionally, so it can never leak.
 	auto& transparencyVobs = Engine::GAPI->GetTransparencyVobs();
-	if ( transparencyVobs.empty() ) return;
+	if ( items.empty() ) return;
 
 	if ( !m_FrameOpen || ( !m_Pipelines.Ghost.PSO && !m_Pipelines.GhostSkeletal.PSO ) ) {
-		transparencyVobs.clear();   // drop this frame's ghosts rather than leak; drawing is unavailable right now
 		return;
 	}
+
+	const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
 
 	// Reversed-Z ViewProj — identical derivation to DrawVobsInstanced/DrawWorldMesh.
 	GothicRendererState& rs = Engine::GAPI->GetRendererState();
@@ -1579,19 +1578,12 @@ void D3D12GraphicsEngine::DrawGhostVobs() {
 	const auto now = Engine::GAPI->GetFrameNumber();
 	static std::vector<XMFLOAT4X4> ghostBoneCache;
 
-	// D3D11 draws these back-to-front (painter's algorithm) via a min/max-heap drain; the legacy
-	// CollectVisibleVobs path (used by this backend, GothicAPI.cpp's std::ranges::sort(TransparencyVobs,
-	// CompareGhostDistance)) instead leaves the vector plain-sorted NEAREST-first, so iterate it in reverse.
-	//
-	// That sort only covers the STATIC ghosts CollectVisibleVobs pushed; PrepareFrameSkeletals appends the
-	// skeletal ghosts afterwards, leaving an unsorted tail. Re-sort here (nearest-first, matching
-	// GothicAPI's CompareGhostDistance) so the reverse walk below is a correct far-to-near order across both
-	// sources — otherwise overlapping ghosts blend in collection order rather than depth order.
-	std::ranges::sort( transparencyVobs,
-		[]( const TransparencyVobInfo& a, const TransparencyVobInfo& b ) { return a.distance < b.distance; } );
-
-	for ( auto it = transparencyVobs.rbegin(); it != transparencyVobs.rend(); ++it ) {
-		const TransparencyVobInfo& info = *it;
+	// Order comes from the frame's transparency queue, which sorts ghosts against every other blended
+	// drawable rather than only against each other (that is what the old local re-sort did here).
+	for ( const TransparentItem& item : items ) {
+		const uint32_t ghostIndex = queue.GetGhostIndex( item );
+		if ( ghostIndex >= transparencyVobs.size() ) continue;
+		const TransparencyVobInfo& info = transparencyVobs[ghostIndex];
 
 		// Skeletal ghosts (invisible/fading NPCs) — mirrors D3D11's DrawTransparencyVobs skeletalVob branch, minus
 		// its same-mesh Z-prepass (same simplification the non-skeletal ghost path already made). Bone transforms
@@ -1819,7 +1811,6 @@ void D3D12GraphicsEngine::DrawGhostVobs() {
 		}
 	}
 
-	transparencyVobs.clear();
 	rs.RendererInfo.FrameDrawnTriangles += drawnTris;
 }
 
@@ -2331,49 +2322,24 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	    DrawVegetation();
     }
 
-	// Blended instanced VOBs (cobwebs, hanging cloth) that BuildVobDrawCommands peeled out of the opaque VOB
-	// command set: unlit and blended over the finished lit scene, depth-tested but not depth-writing. Same slot
-	// D3D11 draws its "Draw Frame AlphaMeshes" pass in — straight after the lit geometry, before the decals
-	// and water. See D3D12Transparency.cpp.
-	DrawVobAlphaMeshes();
-
-	// Decals (blood, arrows, sprites): collect the visible, back-to-front-sorted list once, then draw the
-	// opaque/alpha-test ones here (with the opaque scene, depth-write) and the transparent ones after water
-	// (blended over the finished scene). Mirrors D3D11's two-pass DrawDecalList.
-	static std::vector<zCVob*> decals;
-	decals.clear();
-	Engine::GAPI->GetVisibleDecalList( decals );
+	// Decals (blood, arrows, sprites): the opaque/alpha-test ones draw here, with the opaque scene and
+	// depth-write on. The blended ones are transparency-queue content and are drawn further down.
 	{
+		static std::vector<zCVob*> decals;
+		decals.clear();
+		Engine::GAPI->GetVisibleDecalList( decals );
+
 		DX_ZONE( m_CmdList.Get(), "Draw decals (opaque)" );
 		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw decals (opaque)" );
 		DrawDecalList( decals, true );
 	}
 
-	// Quad marks (blood splatter, spell ground marks) — D3D11's "Draw ParticleFX #1" pass calls DrawQuadMarks
-	// immediately after the lit DrawDecalList, same slot. MUL/MUL2 marks are deferred to DrawMQuadMarks below.
-	DrawQuadMarks();
-
-	// Water: alpha-blended over the finished opaque scene (world + NPCs + VOBs + opaque decals).
+	// Water: alpha-blended over the finished opaque scene (world + NPCs + VOBs + opaque decals). Stays out of
+	// the transparency queue - it samples the scene behind it, so it cannot be re-ordered freely.
 	DrawWaterSurfaces();
 
-	// Alpha-blended world-mesh surfaces (ice, glass, magic barriers) peeled out of the opaque command set by
-	// BuildWorldDrawCommands: blended back-to-front over the finished scene, then re-laid into depth so the
-	// height fog/god rays see them. Same slot D3D11 draws FrameTransparencyMeshes in (right after water,
-	// before the transparent decals). See D3D12Transparency.cpp.
-	DrawWorldTransparencyMeshes();
-
-	{
-		DX_ZONE( m_CmdList.Get(), "Draw decals (transparent)" );
-		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw decals (transparent)" );
-		DrawDecalList( decals, false );
-	}
-
-	// The modulate-blended quad marks DrawQuadMarks deferred — D3D11's "Draw ParticleFX #2" pass draws them
-	// right after the unlit decals, for the same reason (MUL/MUL2 must land on the finished scene).
-	DrawMQuadMarks();
-
-	// Particles last: billboarded PFX (fire, smoke, magic, dust) blended over everything, depth-tested
-	// against the opaque scene but not writing depth. Mirrors D3D11's late DrawParticlesSimple pass.
+	// Particles: billboarded PFX (fire, smoke, magic, dust) blended over everything, depth-tested against the
+	// opaque scene but not writing depth. Not queue content yet — same staging as D3D11.
 	{
 		DX_ZONE( m_CmdList.Get(), "Draw particles" );
 		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw particles" );
@@ -2388,19 +2354,14 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 		DrawRainParticles();
 	}
 
-	// Weapon/spell trails + lightning flashes. D3D11 draws its "Draw PolyStrips" pass right after the
-	// particle pass and before the debug lines; on D3D12 the rain billboards sit in between, which is
-	// immaterial (both are late alpha content that doesn't write depth).
-	DrawPolyStrips();
-
-	// Ghosts (invisible-potion/fade-out items): drawn last of the alpha content, mirrors D3D11's "Draw ghosts"
-	// pass placement (after the transparency waterfall/decals, before post-FX). MUST run every frame even if
-	// EnableBloom/etc. are off — it also drains GothicAPI::TransparencyVobs, which nothing else consumes.
-	{
-		DX_ZONE( m_CmdList.Get(), "Draw ghosts" );
-		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw ghosts" );
-		DrawGhostVobs();
-	}
+	// Everything else that blends, in ONE pass sorted strictly back to front: world transparency surfaces
+	// (ice, glass, magic barriers, forest portals, waterfall foam), blended instanced VOBs (cobwebs, hanging
+	// cloth), ghosts, blended decals, quad marks and poly strips. Each of those used to be its own pass in a
+	// fixed sequence, so their depth order against each other was whatever the sequence happened to be — a
+	// cobweb always painted before a ghost and a ghost before a glass pane. Same slot and same design as
+	// D3D11's "Draw Transparency" pass. MUST run every frame: it also drains the per-kind frame lists.
+	CollectTransparencyQueue();
+	DrawTransparencyQueue();
 
 	// Clear the per-visual instance lists so next frame's CollectVisibleVobs starts fresh (mirrors D3D11).
 	// Done here (not in DrawVobsInstanced) so it runs even when DrawVOBs is off and that pass early-outs.
@@ -2894,8 +2855,8 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
         ? CoalesceWorldDepthCommands( opaqueCmds, cmds + count, kMaxWorldDrawCommands - count )
         : 0;
 
-    // Painter's order for the peeled alpha-blended surfaces (far -> near), once per frame.
-    SortWorldTransparencyMeshes();
+    // The peeled alpha-blended surfaces are not sorted here anymore: the frame's transparency queue orders
+    // them against every other blended drawable, not just against each other.
 }
 
 
@@ -3169,6 +3130,10 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
         const float maxH = visual->BBox.Max.y;
         staged.clear();
 
+        // Depth for this visual's blended sub-meshes, resolved lazily below (only blended materials pay
+        // for it). Distance to the nearest instance - see VobAlphaMesh::DistanceSq.
+        float alphaDistanceSq = -1.0f;
+
         for ( auto const& [meshKey, meshList] : visual->MeshesByTexture ) {
             zCTexture* tex = meshKey.Material->GetAniTexture();
             uint32_t diffuseIdx = whiteSlot;
@@ -3216,6 +3181,18 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                 if ( !mi || mi->Indices.empty() ) continue;
 
                 if ( blended ) {
+                    if ( alphaDistanceSq < 0.0f ) {
+                        const XMVECTOR camPos = Engine::GAPI->GetCameraPositionXM();
+                        alphaDistanceSq = FLT_MAX;
+                        for ( const VobInstanceInfo& inst : visual->Instances ) {
+                            const XMFLOAT3 position( inst.world._14, inst.world._24, inst.world._34 );
+                            float d;
+                            XMStoreFloat( &d, XMVector3LengthSq( XMLoadFloat3( &position ) - camPos ) );
+                            alphaDistanceSq = std::min( alphaDistanceSq, d );
+                        }
+                        if ( alphaDistanceSq == FLT_MAX ) alphaDistanceSq = 0.0f;
+                    }
+
                     if ( !mi->GetMeshVertexBuffer() || !mi->GetMeshIndexBuffer() ) continue;
                     D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( mi->GetMeshVertexBuffer() );
                     D3D12VertexBuffer* mib = D3D12VertexBuffer::From( mi->GetMeshIndexBuffer() );
@@ -3235,6 +3212,7 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
                     a.IndexCount = static_cast<UINT>( mi->Indices.size() );
                     a.NumInstances = up.numInstances;
                     a.Additive = ( alphaFunc == zMAT_ALPHA_FUNC_ADD );
+                    a.DistanceSq = alphaDistanceSq;
                     g_FrameVobAlpha.push_back( a );
                     continue;
                 }

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -1544,9 +1544,8 @@ void D3D12GraphicsEngine::DrawDecalList( const std::vector<zCVob*>& decals, bool
 
 
 void D3D12GraphicsEngine::DrawGhostRun( std::span<const TransparentItem> items ) {
-	// GothicAPI::TransparencyVobs is populated every frame by CollectVisibleVobs' GetVisualAlpha() branch
-	// (invisible-potion/fade-out items); the transparency queue holds indices into it and
-	// DrawTransparencyQueue clears it afterwards, unconditionally, so it can never leak.
+	// TransparencyVobs is filled by CollectVisibleVobs' GetVisualAlpha() branch; the queue holds indices
+	// into it and DrawTransparencyQueue clears it unconditionally, so it cannot leak.
 	auto& transparencyVobs = Engine::GAPI->GetTransparencyVobs();
 	if ( items.empty() ) return;
 
@@ -1578,8 +1577,7 @@ void D3D12GraphicsEngine::DrawGhostRun( std::span<const TransparentItem> items )
 	const auto now = Engine::GAPI->GetFrameNumber();
 	static std::vector<XMFLOAT4X4> ghostBoneCache;
 
-	// Order comes from the frame's transparency queue, which sorts ghosts against every other blended
-	// drawable rather than only against each other (that is what the old local re-sort did here).
+	// Order comes from the transparency queue, which sorts ghosts against every other blended drawable.
 	for ( const TransparentItem& item : items ) {
 		const uint32_t ghostIndex = queue.GetGhostIndex( item );
 		if ( ghostIndex >= transparencyVobs.size() ) continue;
@@ -2322,8 +2320,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	    DrawVegetation();
     }
 
-	// Decals (blood, arrows, sprites): the opaque/alpha-test ones draw here, with the opaque scene and
-	// depth-write on. The blended ones are transparency-queue content and are drawn further down.
+	// Opaque/alpha-test decals only; the blended ones are transparency-queue content.
 	{
 		static std::vector<zCVob*> decals;
 		decals.clear();
@@ -2334,28 +2331,17 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 		DrawDecalList( decals, true );
 	}
 
-	// Water: alpha-blended over the finished opaque scene (world + NPCs + VOBs + opaque decals). Stays out of
-	// the transparency queue - it samples the scene behind it, so it cannot be re-ordered freely.
+	// Water stays out of the queue: it samples the scene behind it, so it cannot be re-ordered freely.
 	DrawWaterSurfaces();
 
-	// Everything else that blends, in ONE pass sorted strictly back to front: world transparency surfaces
-	// (ice, glass, magic barriers, forest portals, waterfall foam), blended instanced VOBs (cobwebs, hanging
-	// cloth), ghosts, blended decals, quad marks and poly strips. Each of those used to be its own pass in a
-	// fixed sequence, so their depth order against each other was whatever the sequence happened to be — a
-	// cobweb always painted before a ghost and a ghost before a glass pane.
-	//
-	// Frame order is geometry -> alpha -> fog/pfx, same as D3D11's "Draw Transparency" pass: after the opaque
-	// scene, the sky and water, but BEFORE the particles and RenderFogAndGodRays below. Drawn after the fog
-	// (where this used to sit) alpha surfaces were pasted onto an already-fogged scene and never fogged
-	// themselves; here the depth DrawWorldTransparencyDepthOnly re-lays is what the fog samples, so it fogs
-	// the glass rather than what stands behind it.
-	//
-	// MUST run every frame: it also drains the per-kind frame lists.
+	// Everything else that blends, in ONE back-to-front pass: world transparency surfaces, blended instanced
+	// VOBs, ghosts, blended decals, quad marks and poly strips. Frame order is geometry -> alpha -> fog/pfx,
+	// same as D3D11: BEFORE the particles and RenderFogAndGodRays below, or alpha surfaces get pasted onto an
+	// already-fogged scene and never fog themselves. MUST run every frame - it drains the per-kind lists.
 	CollectTransparencyQueue();
 	DrawTransparencyQueue();
 
-	// Particles: billboarded PFX (fire, smoke, magic, dust) blended over everything, depth-tested against the
-	// opaque scene but not writing depth. Not queue content yet — same staging as D3D11.
+	// Billboarded PFX, depth-tested but not depth-writing. Not queue content yet, same as D3D11.
 	{
 		DX_ZONE( m_CmdList.Get(), "Draw particles" );
 		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw particles" );
@@ -2862,8 +2848,7 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
         ? CoalesceWorldDepthCommands( opaqueCmds, cmds + count, kMaxWorldDrawCommands - count )
         : 0;
 
-    // The peeled alpha-blended surfaces are not sorted here anymore: the frame's transparency queue orders
-    // them against every other blended drawable, not just against each other.
+    // Not sorted here: the transparency queue orders them against every other blended drawable.
 }
 
 
@@ -3137,8 +3122,7 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
         const float maxH = visual->BBox.Max.y;
         staged.clear();
 
-        // Depth for this visual's blended sub-meshes, resolved lazily below (only blended materials pay
-        // for it). Distance to the nearest instance - see VobAlphaMesh::DistanceSq.
+        // Lazily resolved below; only blended materials pay for it. See VobAlphaMesh::DistanceSq.
         float alphaDistanceSq = -1.0f;
 
         for ( auto const& [meshKey, meshList] : visual->MeshesByTexture ) {

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2338,6 +2338,22 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// the transparency queue - it samples the scene behind it, so it cannot be re-ordered freely.
 	DrawWaterSurfaces();
 
+	// Everything else that blends, in ONE pass sorted strictly back to front: world transparency surfaces
+	// (ice, glass, magic barriers, forest portals, waterfall foam), blended instanced VOBs (cobwebs, hanging
+	// cloth), ghosts, blended decals, quad marks and poly strips. Each of those used to be its own pass in a
+	// fixed sequence, so their depth order against each other was whatever the sequence happened to be — a
+	// cobweb always painted before a ghost and a ghost before a glass pane.
+	//
+	// Frame order is geometry -> alpha -> fog/pfx, same as D3D11's "Draw Transparency" pass: after the opaque
+	// scene, the sky and water, but BEFORE the particles and RenderFogAndGodRays below. Drawn after the fog
+	// (where this used to sit) alpha surfaces were pasted onto an already-fogged scene and never fogged
+	// themselves; here the depth DrawWorldTransparencyDepthOnly re-lays is what the fog samples, so it fogs
+	// the glass rather than what stands behind it.
+	//
+	// MUST run every frame: it also drains the per-kind frame lists.
+	CollectTransparencyQueue();
+	DrawTransparencyQueue();
+
 	// Particles: billboarded PFX (fire, smoke, magic, dust) blended over everything, depth-tested against the
 	// opaque scene but not writing depth. Not queue content yet — same staging as D3D11.
 	{
@@ -2353,15 +2369,6 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw rain" );
 		DrawRainParticles();
 	}
-
-	// Everything else that blends, in ONE pass sorted strictly back to front: world transparency surfaces
-	// (ice, glass, magic barriers, forest portals, waterfall foam), blended instanced VOBs (cobwebs, hanging
-	// cloth), ghosts, blended decals, quad marks and poly strips. Each of those used to be its own pass in a
-	// fixed sequence, so their depth order against each other was whatever the sequence happened to be — a
-	// cobweb always painted before a ghost and a ghost before a glass pane. Same slot and same design as
-	// D3D11's "Draw Transparency" pass. MUST run every frame: it also drains the per-kind frame lists.
-	CollectTransparencyQueue();
-	DrawTransparencyQueue();
 
 	// Clear the per-visual instance lists so next frame's CollectVisibleVobs starts fresh (mirrors D3D11).
 	// Done here (not in DrawVobsInstanced) so it runs even when DrawVOBs is off and that pass early-outs.

--- a/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
@@ -39,6 +39,8 @@
 #include "../WorldObjects.h"
 #include "../zCMaterial.h"
 #include "../zCTexture.h"
+#include "../zCVob.h"          // CollectTransparencyQueue: decal world positions
+#include "../zCQuadMark.h"     // CollectTransparencyQueue: quad-mark connected vob
 #include "../D3D7/MyDirectDrawSurface7.h"
 
 #include <algorithm>
@@ -53,7 +55,7 @@ std::vector<WorldTransparencyMesh> g_FrameWorldTransparencyPortal;
 std::vector<WorldTransparencyMesh> g_FrameWorldTransparencyFoam;
 
 // Declared in D3D12EngineCommon.h; filled by BuildVobDrawCommands (D3D12Scene.cpp), drained by
-// DrawVobAlphaMeshes at the bottom of this file.
+// DrawVobAlphaRun below.
 std::vector<VobAlphaMesh> g_FrameVobAlpha;
 
 namespace {
@@ -120,20 +122,13 @@ namespace {
         }
     }
 
-    // D3D11 spec: sortAndAppendTransparencyMeshes. Painter's order — farthest first — with a stable
-    // material/index tiebreak so same-distance surfaces don't shuffle between frames (which would flicker,
-    // since these are blended).
-    void SortTransparencyList( std::vector<WorldTransparencyMesh>& list ) {
-        if ( list.empty() ) return;
-        std::sort( list.begin(), list.end(),
-            []( const WorldTransparencyMesh& a, const WorldTransparencyMesh& b ) {
-                if ( a.DistanceSq > b.DistanceSq ) return true;
-                if ( a.DistanceSq < b.DistanceSq ) return false;
-                if ( a.Material != b.Material ) return a.Material < b.Material;
-                const unsigned int aBase = a.Mesh ? a.Mesh->BaseIndexLocation : 0u;
-                const unsigned int bBase = b.Mesh ? b.Mesh->BaseIndexLocation : 0u;
-                return aBase < bBase;
-            } );
+    // The three lists the queue's WorldMesh SubKind selects between.
+    std::vector<WorldTransparencyMesh>& WorldTransparencyListFor( EWorldTransparencyVariant variant ) {
+        switch ( variant ) {
+        case EWorldTransparencyVariant::Portal:    return g_FrameWorldTransparencyPortal;
+        case EWorldTransparencyVariant::Waterfall: return g_FrameWorldTransparencyFoam;
+        default:                                   return g_FrameWorldTransparency;
+        }
     }
 }
 
@@ -150,22 +145,35 @@ bool D3D12GraphicsEngine::IsWorldMeshAlphaBlended( zCMaterial* mat ) {
 }
 
 
-void D3D12GraphicsEngine::SortWorldTransparencyMeshes() {
-    // Each list is sorted independently and drawn as its own sub-pass, exactly as D3D11 does.
-    SortTransparencyList( g_FrameWorldTransparency );
-    SortTransparencyList( g_FrameWorldTransparencyPortal );
-    SortTransparencyList( g_FrameWorldTransparencyFoam );
-}
+/** Draws one run of alpha-blended world mesh sections the transparency queue produced.
 
-
-void D3D12GraphicsEngine::DrawWorldTransparencyList( std::vector<WorldTransparencyMesh>& list,
-    D3D12PipelineState::WorldTransparencyPipeline::EKind kind, bool depthFill ) {
-    // One list == one D3D11 DrawMeshInfoListAlphablended call. The caller has already bound the root
-    // signature, the frame-constant root args (b0 ViewProj, b4 view, b5's sun height) and the shared world
-    // VB/IB — only per-material state and the PSO change in here.
-    if ( list.empty() ) return;
-
+    Replaces the old three-list DrawWorldTransparencyList: the lists still exist as the payload store, but
+    which of them an item belongs to is now just the queue item's SubKind, and the runs interleave with every
+    other blended kind instead of forming three fixed sub-passes. */
+void D3D12GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentItem> items,
+    EWorldTransparencyVariant variant ) {
     using EKind = D3D12PipelineState::WorldTransparencyPipeline::EKind;
+
+    if ( items.empty() ) return;
+    if ( !m_FrameOpen || !m_Pipelines.WorldTransparency.RootSig || !m_DepthBuffer ) return;
+
+    const EKind kind =
+        variant == EWorldTransparencyVariant::Portal    ? EKind::Portal :
+        variant == EWorldTransparencyVariant::Waterfall ? EKind::Foam   : EKind::Simple;
+
+    if ( variant == EWorldTransparencyVariant::Portal ) {
+        // Gated the same way D3D11 gates its forest portals; the blob check keeps a failed shader compile
+        // from dropping into the wrong pixel shader.
+        if ( !Engine::GAPI->GetRendererState().RendererSettings.DrawG1ForestPortals
+            || !m_Pipelines.WorldTransparency.PortalVsBlob || !m_Pipelines.WorldTransparency.PortalPsBlob ) {
+            return;
+        }
+    }
+
+    if ( !BindWorldTransparencyFrameState() ) return;
+
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+    const std::vector<WorldTransparencyMesh>& list = WorldTransparencyListFor( variant );
     const bool readsTextureFactor = ( kind == EKind::Simple );   // PS_PortalDiffuse/PS_WaterfallFoam ignore it
 
     // D3D11's state machine, reproduced exactly: each list starts from SetDefaultStates() (no blending,
@@ -184,7 +192,11 @@ void D3D12GraphicsEngine::DrawWorldTransparencyList( std::vector<WorldTransparen
 
     unsigned int drawnIndices = 0;
     zCMaterial* lastMat = nullptr;
-    for ( const WorldTransparencyMesh& entry : list ) {
+    for ( const TransparentItem& item : items ) {
+        const uint32_t entryIndex = queue.GetIndices( item ).BatchIndex;
+        if ( entryIndex >= list.size() ) continue;
+        const WorldTransparencyMesh& entry = list[entryIndex];
+
         zCMaterial* mat = entry.Material;
         if ( !mat || !entry.Mesh || entry.Mesh->Indices.empty() ) continue;
 
@@ -226,64 +238,60 @@ void D3D12GraphicsEngine::DrawWorldTransparencyList( std::vector<WorldTransparen
         drawnIndices += static_cast<unsigned int>( entry.Mesh->Indices.size() );
     }
 
-    // Second loop: depth only. D3D11 does exactly this ("Draw again, but only to depthbuffer this time to
-    // make them work with fogging") — without it the height-fog / god-ray passes reconstruct world
-    // positions from whatever lies BEHIND the glass. Same VB/IB and the same VS blob, so the depth written
-    // here is bit-identical to what the blended loop tested against.
-    // Skipped for MT_Portal (depthFill == false): D3D11's loop filters those out explicitly
-    // (Info->MaterialType != MT_Portal) — a forest portal is a fade-in curtain you see the forest THROUGH,
-    // so it must not push the fog depth up to its own surface. Its VS is a different blob anyway, so its
-    // depth would not be bit-identical to the color pass either.
-    if ( depthFill && m_Pipelines.WorldTransparency.DepthFillPSO ) {
-        m_CmdList->SetPipelineState( m_Pipelines.WorldTransparency.DepthFillPSO.Get() );
-        // The depth-fill PSO reuses PSTransparent (color writes masked off) rather than a null PS, so the
-        // shader still runs its bindless ResourceDescriptorHeap[MatDiffuseIndex] fetch even though the
-        // result is discarded. Stamp a known-good slot: the loop below is less strict than the color loop
-        // (it accepts materials whose texture failed to cache in), so b6 could otherwise still hold
-        // uninitialized root constants if the color loop drew nothing at all — an out-of-range descriptor
-        // index, i.e. a GPU fault, not just a wrong pixel.
-        const uint32_t safeMat6[4] = { 0xFFFFFFFFu, 0u, m_BlackTexture->GetSrvSlot(), 0u };
-        m_CmdList->SetGraphicsRoot32BitConstants( 2, 4, safeMat6, 0 );
-        for ( const WorldTransparencyMesh& entry : list ) {
+    Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnTriangles += drawnIndices / 3;
+}
+
+
+/** Re-lays the depth of every world transparency surface of this frame, color writes off.
+
+    D3D11 does exactly this ("Draw again, but only to depthbuffer this time to make them work with fogging")
+    — without it the depth-consuming post passes reconstruct world positions from whatever lies BEHIND the
+    glass. It used to be the tail of each list's sub-pass; with the queue interleaving them it has to run
+    once, after the whole replay, or a nearer surface would depth-reject a farther one drawn later.
+
+    MT_Portal stays out, as it did before: a forest portal is a fade-in curtain you see the forest THROUGH,
+    so it must not push the fog depth up to its own surface. */
+void D3D12GraphicsEngine::DrawWorldTransparencyDepthOnly() {
+    if ( !m_FrameOpen || !m_Pipelines.WorldTransparency.DepthFillPSO || !m_DepthBuffer ) return;
+    if ( g_FrameWorldTransparency.empty() && g_FrameWorldTransparencyFoam.empty() ) return;
+    if ( !BindWorldTransparencyFrameState() ) return;
+
+    DX_ZONE( m_CmdList.Get(), "World transparency (depth re-lay)" );
+
+    m_CmdList->SetPipelineState( m_Pipelines.WorldTransparency.DepthFillPSO.Get() );
+    // The depth-fill PSO reuses PSTransparent (color writes masked off) rather than a null PS, so the
+    // shader still runs its bindless ResourceDescriptorHeap[MatDiffuseIndex] fetch even though the
+    // result is discarded. Stamp a known-good slot: the loop below is less strict than the color loop
+    // (it accepts materials whose texture failed to cache in), so b6 could otherwise still hold
+    // uninitialized root constants if the color loop drew nothing at all — an out-of-range descriptor
+    // index, i.e. a GPU fault, not just a wrong pixel.
+    const uint32_t safeMat6[4] = { 0xFFFFFFFFu, 0u, m_BlackTexture->GetSrvSlot(), 0u };
+    m_CmdList->SetGraphicsRoot32BitConstants( 2, 4, safeMat6, 0 );
+
+    for ( const std::vector<WorldTransparencyMesh>* list :
+        { &g_FrameWorldTransparency, &g_FrameWorldTransparencyFoam } ) {
+        for ( const WorldTransparencyMesh& entry : *list ) {
             if ( !entry.Material || !entry.Mesh || entry.Mesh->Indices.empty() ) continue;
             if ( !entry.Material->GetAniTexture() ) continue;
             m_CmdList->DrawIndexedInstanced( static_cast<UINT>( entry.Mesh->Indices.size() ), 1,
                 entry.Mesh->BaseIndexLocation, 0, 0 );
         }
     }
-
-    Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnTriangles += drawnIndices / 3;
 }
 
 
-void D3D12GraphicsEngine::DrawWorldTransparencyMeshes() {
-    using EKind = D3D12PipelineState::WorldTransparencyPipeline::EKind;
+/** Binds everything a world-transparency draw needs that does not change within a frame: the root
+    signature, b0/b3/b5, the viewport and the shared world VB/IB.
 
-    auto clearLists = []() {
-        g_FrameWorldTransparency.clear();
-        g_FrameWorldTransparencyPortal.clear();
-        g_FrameWorldTransparencyFoam.clear();
-    };
-
-    // Portals are gated the same way D3D11 gates its "Draw ForestPortals" pass; the blob check keeps a
-    // failed shader compile from dropping into the wrong pixel shader.
-    const bool drawPortals = Engine::GAPI->GetRendererState().RendererSettings.DrawG1ForestPortals
-        && m_Pipelines.WorldTransparency.PortalVsBlob && m_Pipelines.WorldTransparency.PortalPsBlob;
-
-    if ( g_FrameWorldTransparency.empty() && g_FrameWorldTransparencyFoam.empty()
-        && ( !drawPortals || g_FrameWorldTransparencyPortal.empty() ) ) {
-        clearLists();
-        return;
-    }
-    if ( !m_FrameOpen || !m_Pipelines.WorldTransparency.RootSig || !m_DepthBuffer ) { clearLists(); return; }
-
+    This used to be the prologue of the one DrawWorldTransparencyMeshes pass. The transparency queue can
+    interleave world transparency runs with other kinds (each of which binds its own root signature), so it
+    has to be re-done per run instead. Returns false when the pass cannot draw at all. */
+bool D3D12GraphicsEngine::BindWorldTransparencyFrameState() {
     MeshInfo* wm = Engine::GAPI->GetWrappedWorldMesh();
-    if ( !wm || !wm->GetMeshVertexBuffer() || !wm->GetMeshIndexBuffer() ) { clearLists(); return; }
+    if ( !wm || !wm->GetMeshVertexBuffer() || !wm->GetMeshIndexBuffer() ) return false;
     D3D12VertexBuffer* vb = D3D12VertexBuffer::From( wm->GetMeshVertexBuffer() );
     D3D12VertexBuffer* ib = D3D12VertexBuffer::From( wm->GetMeshIndexBuffer() );
-    if ( !vb->GetResource() || !ib->GetResource() ) { clearLists(); return; }
-
-    DX_ZONE( m_CmdList.Get(), "DrawWorldTransparencyMeshes" );
+    if ( !vb->GetResource() || !ib->GetResource() ) return false;
 
     // ViewProj — identical derivation to DrawWorldMesh/DrawWaterSurfaces (world verts are world-space).
     XMMATRIX view = Engine::GAPI->GetViewMatrixXM();
@@ -321,27 +329,11 @@ void D3D12GraphicsEngine::DrawWorldTransparencyMeshes() {
     m_CmdList->IASetVertexBuffers( 0, 1, &vbv );
     m_CmdList->IASetIndexBuffer( &ibv );
     m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
-
-    // Sub-pass order is D3D11's render-graph order: blended surfaces, then the forest portals, then the
-    // waterfall foam.
-    {
-        DX_ZONE( m_CmdList.Get(), "World transparency (blended)" );
-        DrawWorldTransparencyList( g_FrameWorldTransparency, EKind::Simple, true );
-    }
-    if ( drawPortals ) {
-        DX_ZONE( m_CmdList.Get(), "World transparency (forest portals)" );
-        DrawWorldTransparencyList( g_FrameWorldTransparencyPortal, EKind::Portal, false );
-    }
-    {
-        DX_ZONE( m_CmdList.Get(), "World transparency (waterfall foam)" );
-        DrawWorldTransparencyList( g_FrameWorldTransparencyFoam, EKind::Foam, true );
-    }
-
-    clearLists();
+    return true;
 }
 
 
-void D3D12GraphicsEngine::DrawVobAlphaMeshes() {
+void D3D12GraphicsEngine::DrawVobAlphaRun( std::span<const TransparentItem> items ) {
     // Port of D3D11GraphicsEngine::DrawFrameAlphaMeshes (D3D11GraphicsEngine.cpp:7741) for the instanced-VOB
     // path: the cobwebs, hanging cloth and magic sheets whose material carries a BLEND/ADD alpha func.
     //
@@ -353,15 +345,16 @@ void D3D12GraphicsEngine::DrawVobAlphaMeshes() {
     // wants) and resolves every buffer view / bindless index, so this is a short CPU draw loop — same shape as
     // D3D11's, and the entry count is a handful per frame.
     //
-    // Not sorted, exactly like D3D11's m_AlphaMeshes: the list comes out in visual/material order. Sorting it
-    // back-to-front is the obvious follow-up if inter-web overlap ever reads wrong.
-    if ( g_FrameVobAlpha.empty() ) return;
+    // Ordered by the frame's transparency queue now, at batch granularity (see VobAlphaMesh::DistanceSq for
+    // why this backend cannot go per instance the way D3D11 does).
+    if ( items.empty() ) return;
     if ( !m_FrameOpen || !m_Pipelines.World.RootSig || !m_Pipelines.World.VobAlphaBlendPSO || !m_DepthBuffer ) {
-        g_FrameVobAlpha.clear();
         return;
     }
 
-    DX_ZONE( m_CmdList.Get(), "DrawVobAlphaMeshes" );
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+
+    DX_ZONE( m_CmdList.Get(), "DrawVobAlphaRun" );
     TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw Vobs (blended)" );
 
     // ViewProj — identical derivation to DrawVobsInstanced, so a peeled mesh lands on exactly the pixels it
@@ -404,7 +397,10 @@ void D3D12GraphicsEngine::DrawVobAlphaMeshes() {
 
     ID3D12PipelineState* current = nullptr;
     unsigned int drawnTriangles = 0;
-    for ( const VobAlphaMesh& e : g_FrameVobAlpha ) {
+    for ( const TransparentItem& item : items ) {
+        const uint32_t entryIndex = queue.GetIndices( item ).BatchIndex;
+        if ( entryIndex >= g_FrameVobAlpha.size() ) continue;
+        const VobAlphaMesh& e = g_FrameVobAlpha[entryIndex];
         if ( e.NumInstances == 0 || e.IndexCount == 0 ) continue;
 
         ID3D12PipelineState* want = e.Additive ? addPso : blendPso;
@@ -425,7 +421,161 @@ void D3D12GraphicsEngine::DrawVobAlphaMeshes() {
     }
 
     Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnTriangles += drawnTriangles;
-    g_FrameVobAlpha.clear();
 }
 
 
+
+/** Fills the frame's transparency queue from this backend's per-kind lists and sorts it.
+
+    World transparency meshes and alpha VOB batches were collected during the command build; ghosts, decals,
+    quad marks and poly strips are gathered here, right before the replay, so no producer has to know where
+    in the frame the transparency pass sits. Payloads are indices into the lists that already exist - nothing
+    is copied. */
+void D3D12GraphicsEngine::CollectTransparencyQueue() {
+    TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+    queue.BeginFrame();
+
+    auto& renderSettings = Engine::GAPI->GetRendererState().RendererSettings;
+    const XMVECTOR camPos = Engine::GAPI->GetCameraPositionXM();
+
+    // World transparency surfaces, one item per entry of each of the three lists
+    const std::pair<const std::vector<WorldTransparencyMesh>*, EWorldTransparencyVariant> worldLists[] = {
+        { &g_FrameWorldTransparency,       EWorldTransparencyVariant::Normal },
+        { &g_FrameWorldTransparencyPortal, EWorldTransparencyVariant::Portal },
+        { &g_FrameWorldTransparencyFoam,   EWorldTransparencyVariant::Waterfall },
+    };
+    for ( auto const& [list, variant] : worldLists ) {
+        for ( size_t i = 0; i < list->size(); ++i ) {
+            const WorldTransparencyMesh& entry = ( *list )[i];
+            queue.AddIndexed( entry.DistanceSq, ETransparentKind::WorldMesh, static_cast<uint8_t>( variant ),
+                static_cast<uint32_t>( i ), 0, TransparencyQueue::MakeBatchKey( entry.Material ) );
+        }
+    }
+
+    // Blended instanced VOBs, one item per batch (see VobAlphaMesh::DistanceSq)
+    for ( size_t i = 0; i < g_FrameVobAlpha.size(); ++i ) {
+        queue.AddIndexed( g_FrameVobAlpha[i].DistanceSq, ETransparentKind::AlphaVob, 0,
+            static_cast<uint32_t>( i ), 0, g_FrameVobAlpha[i].MatIndices[2] );
+    }
+
+    // Ghosts. TransparencyVobInfo::distance is linear, the queue sorts on squared distances.
+    auto& transparencyVobs = Engine::GAPI->GetTransparencyVobs();
+    for ( size_t i = 0; i < transparencyVobs.size(); ++i ) {
+        const float distance = transparencyVobs[i].distance;
+        queue.AddGhost( distance * distance, static_cast<uint32_t>( i ) );
+    }
+
+    if ( renderSettings.DrawParticleEffects ) {
+        // Blended decals only — the opaque/alpha-test ones were drawn with the opaque scene and never blend.
+        static std::vector<zCVob*> decals;   // static to get around reallocations
+        decals.clear();
+        Engine::GAPI->GetVisibleDecalList( decals );
+        for ( zCVob* decal : decals ) {
+            float distanceSq;
+            XMStoreFloat( &distanceSq, XMVector3LengthSq( decal->GetPositionWorldXM() - camPos ) );
+            queue.AddDecal( distanceSq, decal );
+        }
+
+        const float vfxRadiusSq = renderSettings.VisualFXDrawRadius * renderSettings.VisualFXDrawRadius;
+        for ( auto const& it : Engine::GAPI->GetQuadMarks() ) {
+            if ( !it.first->GetConnectedVob() ) continue;
+
+            float distanceSq;
+            XMStoreFloat( &distanceSq, XMVector3LengthSq( camPos - XMLoadFloat3( &it.second.Position ) ) );
+            if ( distanceSq > vfxRadiusSq ) continue;
+
+            queue.AddQuadMark( distanceSq, it.first, &it.second );
+        }
+    }
+
+#if (defined BUILD_GOTHIC_2_6_fix || defined BUILD_GOTHIC_1_08k)
+    // The strip/flash meshes have to exist before we can take a depth for them.
+    Engine::GAPI->CalcPolyStripMeshes();   // weapon/effect trails
+    Engine::GAPI->CalcFlashMeshes();       // lightning flashes
+
+    for ( auto const& it : Engine::GAPI->GetPolyStripInfos() ) {
+        const std::vector<ExVertexStruct>& vertices = it.second.vertices;
+        if ( vertices.empty() || !it.second.material || !it.first ) continue;
+
+        // One strip group per texture, so its depth is the centroid of everything in it
+        XMVECTOR center = XMVectorZero();
+        for ( auto const& vertex : vertices ) {
+            center = XMVectorAdd( center, XMLoadFloat3( &vertex.Position ) );
+        }
+        center = XMVectorScale( center, 1.0f / static_cast<float>( vertices.size() ) );
+
+        float distanceSq;
+        XMStoreFloat( &distanceSq, XMVector3LengthSq( center - camPos ) );
+        queue.AddPolyStrip( distanceSq, it.first, &it.second );
+    }
+#endif
+
+    // categoryMajor reproduces the old per-category pass order without a second set of emitters
+    queue.Sort( !renderSettings.SortedTransparency );
+}
+
+
+/** Replays the sorted transparency queue: one call per maximal run of consecutive same-kind items. */
+void D3D12GraphicsEngine::DrawTransparencyQueue() {
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+
+    if ( m_FrameOpen && !queue.Empty() ) {
+        DX_ZONE( m_CmdList.Get(), "DrawTransparencyQueue" );
+        TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw transparency (sorted)" );
+
+        queue.ForEachRun( [&]( ETransparentKind kind, uint8_t subKind,
+            std::span<const TransparentItem> items ) {
+                switch ( kind ) {
+                case ETransparentKind::WorldMesh:
+                    DrawWorldTransparencyRun( items, static_cast<EWorldTransparencyVariant>( subKind ) );
+                    break;
+                case ETransparentKind::AlphaVob:
+                    DrawVobAlphaRun( items );
+                    break;
+                case ETransparentKind::Ghost:
+                    DrawGhostRun( items );
+                    break;
+                case ETransparentKind::Decal:
+                    DrawDecalRun( items );
+                    break;
+                case ETransparentKind::QuadMark:
+                    DrawQuadMarkRun( items );
+                    break;
+                case ETransparentKind::PolyStrip:
+                    DrawPolyStripRun( items );
+                    break;
+                default:
+                    break;
+                }
+            } );
+
+        // Depth of the world transparency surfaces, once, after everything blended has been drawn
+        DrawWorldTransparencyDepthOnly();
+    }
+
+    // Unconditional: these lists are single-frame and nothing else drains them, so an early-out above must
+    // still leave them empty or they grow forever.
+    g_FrameWorldTransparency.clear();
+    g_FrameWorldTransparencyPortal.clear();
+    g_FrameWorldTransparencyFoam.clear();
+    g_FrameVobAlpha.clear();
+    Engine::GAPI->GetTransparencyVobs().clear();
+}
+
+
+/** Draws a run of blended decals. The list-based path already batches consecutive same-material decals
+    without reordering them, which is exactly what a queue run needs. */
+void D3D12GraphicsEngine::DrawDecalRun( std::span<const TransparentItem> items ) {
+    if ( items.empty() ) return;
+
+    const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
+
+    static std::vector<zCVob*> decalRun;   // static to get around reallocations
+    decalRun.clear();
+    decalRun.reserve( items.size() );
+    for ( const TransparentItem& item : items ) {
+        decalRun.push_back( queue.GetDecal( item ) );
+    }
+
+    DrawDecalList( decalRun, false );
+}

--- a/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
@@ -1,33 +1,15 @@
-// D3D12GraphicsEngine — alpha-blended world-mesh surfaces (ice, glass, magic barriers, water-fall style
-// overlays). This is the port of D3D11GraphicsEngine::DrawMeshInfoListAlphablended
-// (D3D11GraphicsEngine.cpp:4840) plus the peel-out half of its DrawWorldMesh mesh-list build
-// (D3D11GraphicsEngine.cpp:5138).
+// D3D12GraphicsEngine — the frame's sorted transparency queue and the alpha-blended world-mesh surfaces
+// (ice, glass, magic barriers, waterfall foam). Port of D3D11's DrawWorldTransparencyRun + the queue.
 //
-// Why the surfaces need their own pass at all: they were previously swept into D3D12's opaque world
-// ExecuteIndirect command set, which renders every material fully opaque with a fixed alpha-test cutout —
-// so Gothic's ice slabs read as solid rock. D3D11 instead peels any material whose alpha func is a real
-// blend mode out of the opaque set entirely, sorts it back-to-front, and draws it after the opaque scene
-// (and after water) with the material's own blend mode and depth-write off.
+// Three lists feed the WorldMesh kind, selected by the item's SubKind:
+//   * g_FrameWorldTransparency       — real blend alpha func (ice, glass)      -> PS_Simple_FF
+//   * g_FrameWorldTransparencyPortal — MT_Portal, gated on DrawG1ForestPortals -> PS_PortalDiffuse
+//   * g_FrameWorldTransparencyFoam   — MT_WaterfallFoam                        -> PS_WaterfallFoam
+// The latter two are collected by material TYPE regardless of alpha func, which is what keeps
+// ResolveAlphaFunc's "0 -> derive from the material color's alpha" fixup live.
 //
-// Shape of the pass, mirrored one-to-one from D3D11:
-//   1. per-material: derive the effective alpha func (0 == "material default" -> BLEND when the material
-//      color's alpha is < 255, else stay opaque)
-//   2. compute the FF `textureFactor` tint — the material color when translucent
-//   3. draw with the blend mode that alpha func maps to, depth-tested but NOT depth-writing
-//   3b. for an env-mapped material, draw ZenGin's env-map overlay stage straight on top of that draw
-//   4. re-draw the whole list depth-only (color writes off, depth-write on) so the depth-reading post
-//      passes (height fog, god rays) see these surfaces instead of whatever is behind them
-//
-// Deliberate divergences from D3D11, both documented at their site: the vertex color is swizzled .bgra
-// (D3D11's PS_Simple reads the BGRA DWORD unswizzled, i.e. with R/B transposed), and the sampled texel is
-// linearized because D3D12's scene target is linear HDR.
-//
-// Three lists run through this one body, exactly as D3D11 makes three DrawMeshInfoListAlphablended calls:
-//   * g_FrameWorldTransparency       — materials with a real blend alpha func (ice, glass)  -> PS_Simple_FF
-//   * g_FrameWorldTransparencyPortal — MT_Portal, gated on DrawG1ForestPortals              -> PS_PortalDiffuse
-//   * g_FrameWorldTransparencyFoam   — MT_WaterfallFoam                                     -> PS_WaterfallFoam
-// The latter two are collected by material TYPE regardless of their alpha func, which is what makes
-// DrawMeshInfoListAlphablended's `alphaFunc == 0 -> derive from the material color's alpha` fixup live.
+// Deliberate divergences from D3D11, documented at their site: the vertex color is swizzled .bgra and the
+// sampled texel is linearized (D3D12's scene target is linear HDR).
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
 #include "D3D12Texture.h"
@@ -59,8 +41,7 @@ std::vector<WorldTransparencyMesh> g_FrameWorldTransparencyFoam;
 std::vector<VobAlphaMesh> g_FrameVobAlpha;
 
 namespace {
-    // D3D11 spec: DrawMeshInfoListAlphablended's `alphaFunc == 0` fixup. zMAT_ALPHA_FUNC_MAT_DEFAULT (0)
-    // means "whatever the material color says": translucent color -> blend, opaque color -> leave it alone.
+    // alphaFunc 0 (MAT_DEFAULT) means "whatever the material color says": translucent -> blend.
     int ResolveAlphaFunc( zCMaterial* mat ) {
         int alphaFunc = mat->GetAlphaFunc();
         if ( alphaFunc == zMAT_ALPHA_FUNC_MAT_DEFAULT ) {
@@ -71,34 +52,19 @@ namespace {
         return alphaFunc;
     }
 
-    // D3D11 spec: the `ffdata.textureFactor` block of DrawMeshInfoListAlphablended.
-    //
-    // The base surface's alpha is the material color's alpha, full stop. ZenGin sets the TFACTOR to
-    // zCMaterial::GetColor() (zRenderManager.cpp:609, alphaGen=FACTOR) and the D3D7 poly path
-    // multiplies vertex-light alpha by mat->GetAlpha() == color.alpha (zRndD3D_Render.cpp:1049).
-    // GetEnvMapStrength() is deliberately NOT part of this: env-mapping is an *additional* stage
-    // drawn on top of the base pass (zRenderManager.cpp:671-712), which DrawWorldTransparencyRun
-    // below now renders as EKind::Env. Folding the env strength into the base alpha is what made ice
-    // near-invisible instead of thick.
+    // Material color contributes ALPHA only: ZenGin's base stage is rgbGen=VERTEX / alphaGen=FACTOR
+    // (zRenderManager.cpp:601-610, zRndD3D_Render.cpp:1049); its RGB is for untextured polys, which never
+    // get here. Multiplying the RGB in made dark-tinted additive surfaces (magic barrier, 4,45,26,155)
+    // vanish. Env strength is the separate EKind::Env stage, not part of the base alpha.
     float4 ComputeTextureFactor( zCMaterial* mat ) {
-        // The material color contributes ALPHA ONLY, never RGB — ZenGin's base stage is rgbGen=VERTEX /
-        // alphaGen=FACTOR (zRenderManager.cpp:601-610); the D3D7 poly path folds only mat->GetAlpha()
-        // into the vertex color's alpha and leaves its RGB as the vertex light
-        // (zRndD3D_Render.cpp:1049). The material RGB is for UNTEXTURED polys, which never get here.
-        // Multiplying it in made dark-tinted additive surfaces (the magic barrier, color 4,45,26,155)
-        // scale their texture to near-black and disappear.
-        //
-        // The RGB instead carries the day/night factor: these surfaces are drawn unlit over a static,
-        // baked-daylight vertex color, so without it ice and waterfall foam stay noon-bright at midnight.
-        // Exactly 1.0 while the sun is up, so daylight is unaffected. See GothicAPI::GetSkyDayFactor.
+        // RGB carries the day/night factor: unlit surfaces over a baked-daylight vertex color would
+        // otherwise stay noon-bright at midnight. 1.0 in daylight. See GothicAPI::GetSkyDayFactor.
         const float skyLight = Engine::GAPI->GetSkyDayFactor();
         return float4( skyLight, skyLight, skyLight,
             zColor( mat->GetColor() ).bgra.alpha * (1.0f / 255.0f) );
     }
 
-    // D3D11 spec: the alpha-func -> blend-state switch in DrawMeshInfoListAlphablended. Returns false for
-    // the `default:` arm, which in D3D11 leaves the previously-set blend state alone (it only turns
-    // depth-write off) — the caller reproduces that by keeping its current blend state.
+    // False on the `default:` arm, where D3D11 leaves the current blend state alone.
     bool BlendStateForAlphaFunc( int alphaFunc, GothicBlendStateInfo& blend ) {
         switch ( alphaFunc ) {
         case zMAT_ALPHA_FUNC_BLEND:
@@ -131,22 +97,16 @@ namespace {
 
 
 bool D3D12GraphicsEngine::IsWorldMeshAlphaBlended( zCMaterial* mat ) {
-    // D3D11 spec: the "Check for alphablending" test in DrawWorldMesh's BuildMeshList — any real blend mode
-    // (BLEND/ADD/SUB/MUL/MUL2/BLEND_TEST) is peeled out of the opaque set. zMAT_ALPHA_FUNC_TEST is a cutout,
-    // not a blend, and stays opaque; so does zMAT_ALPHA_FUNC_MAT_DEFAULT (0), because the material color's
-    // alpha only becomes a blend factor for the material types D3D11 collects by MaterialType (portals,
-    // waterfall foam) — which have their own branches in BuildWorldDrawCommands.
+    // Any real blend mode is peeled out of the opaque set. TEST is a cutout, not a blend; MAT_DEFAULT (0)
+    // only blends for the types collected by MaterialType (portals, foam), which have their own branches.
     if ( !mat ) return false;
     const int alphaFunc = mat->GetAlphaFunc();
     return alphaFunc > zMAT_ALPHA_FUNC_NONE && alphaFunc != zMAT_ALPHA_FUNC_TEST;
 }
 
 
-/** Draws one run of alpha-blended world mesh sections the transparency queue produced.
-
-    Replaces the old three-list DrawWorldTransparencyList: the lists still exist as the payload store, but
-    which of them an item belongs to is now just the queue item's SubKind, and the runs interleave with every
-    other blended kind instead of forming three fixed sub-passes. */
+/** One run of alpha-blended world mesh sections. The three lists are just the payload store now; SubKind
+    picks between them and runs interleave with every other blended kind. */
 void D3D12GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentItem> items,
     EWorldTransparencyVariant variant ) {
     using EKind = D3D12PipelineState::WorldTransparencyPipeline::EKind;
@@ -282,15 +242,9 @@ void D3D12GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
 }
 
 
-/** Re-lays the depth of every world transparency surface of this frame, color writes off.
-
-    D3D11 does exactly this ("Draw again, but only to depthbuffer this time to make them work with fogging")
-    — without it the depth-consuming post passes reconstruct world positions from whatever lies BEHIND the
-    glass. It used to be the tail of each list's sub-pass; with the queue interleaving them it has to run
-    once, after the whole replay, or a nearer surface would depth-reject a farther one drawn later.
-
-    MT_Portal stays out, as it did before: a forest portal is a fade-in curtain you see the forest THROUGH,
-    so it must not push the fog depth up to its own surface. */
+/** Depth of this frame's world transparency surfaces, color writes off. ONCE after the whole replay, or a
+    nearer surface would depth-reject a farther one drawn later. The fog/god-ray passes reconstruct world
+    positions from this. MT_Portal stays out - a fade-in curtain must not push fog depth to itself. */
 void D3D12GraphicsEngine::DrawWorldTransparencyDepthOnly() {
     if ( !m_FrameOpen || !m_Pipelines.WorldTransparency.DepthFillPSO || !m_DepthBuffer ) return;
     if ( g_FrameWorldTransparency.empty() && g_FrameWorldTransparencyFoam.empty() ) return;
@@ -320,12 +274,8 @@ void D3D12GraphicsEngine::DrawWorldTransparencyDepthOnly() {
 }
 
 
-/** Binds everything a world-transparency draw needs that does not change within a frame: the root
-    signature, b0/b3/b5, the viewport and the shared world VB/IB.
-
-    This used to be the prologue of the one DrawWorldTransparencyMeshes pass. The transparency queue can
-    interleave world transparency runs with other kinds (each of which binds its own root signature), so it
-    has to be re-done per run instead. Returns false when the pass cannot draw at all. */
+/** Root signature, b0/b3/b5, viewport and the shared world VB/IB. Re-done per run, since the queue
+    interleaves kinds that bind their own root signature. False = cannot draw. */
 bool D3D12GraphicsEngine::BindWorldTransparencyFrameState() {
     MeshInfo* wm = Engine::GAPI->GetWrappedWorldMesh();
     if ( !wm || !wm->GetMeshVertexBuffer() || !wm->GetMeshIndexBuffer() ) return false;
@@ -465,12 +415,8 @@ void D3D12GraphicsEngine::DrawVobAlphaRun( std::span<const TransparentItem> item
 
 
 
-/** Fills the frame's transparency queue from this backend's per-kind lists and sorts it.
-
-    World transparency meshes and alpha VOB batches were collected during the command build; ghosts, decals,
-    quad marks and poly strips are gathered here, right before the replay, so no producer has to know where
-    in the frame the transparency pass sits. Payloads are indices into the lists that already exist - nothing
-    is copied. */
+/** Fills the queue from this backend's per-kind lists and sorts it. World meshes and alpha VOB batches were
+    collected during the command build; the rest is gathered here. Payloads are plain indices. */
 void D3D12GraphicsEngine::CollectTransparencyQueue() {
     TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
     queue.BeginFrame();
@@ -478,7 +424,7 @@ void D3D12GraphicsEngine::CollectTransparencyQueue() {
     auto& renderSettings = Engine::GAPI->GetRendererState().RendererSettings;
     const XMVECTOR camPos = Engine::GAPI->GetCameraPositionXM();
 
-    // World transparency surfaces, one item per entry of each of the three lists
+    // One item per entry of each of the three lists
     const std::pair<const std::vector<WorldTransparencyMesh>*, EWorldTransparencyVariant> worldLists[] = {
         { &g_FrameWorldTransparency,       EWorldTransparencyVariant::Normal },
         { &g_FrameWorldTransparencyPortal, EWorldTransparencyVariant::Portal },
@@ -492,13 +438,13 @@ void D3D12GraphicsEngine::CollectTransparencyQueue() {
         }
     }
 
-    // Blended instanced VOBs, one item per batch (see VobAlphaMesh::DistanceSq)
+    // One item per batch (see VobAlphaMesh::DistanceSq)
     for ( size_t i = 0; i < g_FrameVobAlpha.size(); ++i ) {
         queue.AddIndexed( g_FrameVobAlpha[i].DistanceSq, ETransparentKind::AlphaVob, 0,
             static_cast<uint32_t>( i ), 0, g_FrameVobAlpha[i].MatIndices[2] );
     }
 
-    // Ghosts. TransparencyVobInfo::distance is linear, the queue sorts on squared distances.
+    // TransparencyVobInfo::distance is linear; the queue sorts on squared distances.
     auto& transparencyVobs = Engine::GAPI->GetTransparencyVobs();
     for ( size_t i = 0; i < transparencyVobs.size(); ++i ) {
         const float distance = transparencyVobs[i].distance;
@@ -506,7 +452,7 @@ void D3D12GraphicsEngine::CollectTransparencyQueue() {
     }
 
     if ( renderSettings.DrawParticleEffects ) {
-        // Blended decals only — the opaque/alpha-test ones were drawn with the opaque scene and never blend.
+        // Blended decals only; the opaque/alpha-test ones drew with the opaque scene.
         static std::vector<zCVob*> decals;   // static to get around reallocations
         decals.clear();
         Engine::GAPI->GetVisibleDecalList( decals );
@@ -529,7 +475,7 @@ void D3D12GraphicsEngine::CollectTransparencyQueue() {
     }
 
 #if (defined BUILD_GOTHIC_2_6_fix || defined BUILD_GOTHIC_1_08k)
-    // The strip/flash meshes have to exist before we can take a depth for them.
+    // Mesh data has to exist before we can take a depth for it.
     Engine::GAPI->CalcPolyStripMeshes();   // weapon/effect trails
     Engine::GAPI->CalcFlashMeshes();       // lightning flashes
 
@@ -537,7 +483,7 @@ void D3D12GraphicsEngine::CollectTransparencyQueue() {
         const std::vector<ExVertexStruct>& vertices = it.second.vertices;
         if ( vertices.empty() || !it.second.material || !it.first ) continue;
 
-        // One strip group per texture, so its depth is the centroid of everything in it
+        // One group per texture -> centroid depth
         XMVECTOR center = XMVectorZero();
         for ( auto const& vertex : vertices ) {
             center = XMVectorAdd( center, XMLoadFloat3( &vertex.Position ) );
@@ -555,7 +501,7 @@ void D3D12GraphicsEngine::CollectTransparencyQueue() {
 }
 
 
-/** Replays the sorted transparency queue: one call per maximal run of consecutive same-kind items. */
+/** Replays the sorted queue, one call per maximal same-kind run. */
 void D3D12GraphicsEngine::DrawTransparencyQueue() {
     const TransparencyQueue& queue = Engine::GAPI->GetTransparencyQueue();
 
@@ -593,8 +539,7 @@ void D3D12GraphicsEngine::DrawTransparencyQueue() {
         DrawWorldTransparencyDepthOnly();
     }
 
-    // Unconditional: these lists are single-frame and nothing else drains them, so an early-out above must
-    // still leave them empty or they grow forever.
+    // Unconditional: single-frame lists nothing else drains, so an early-out must still empty them.
     g_FrameWorldTransparency.clear();
     g_FrameWorldTransparencyPortal.clear();
     g_FrameWorldTransparencyFoam.clear();
@@ -603,8 +548,7 @@ void D3D12GraphicsEngine::DrawTransparencyQueue() {
 }
 
 
-/** Draws a run of blended decals. The list-based path already batches consecutive same-material decals
-    without reordering them, which is exactly what a queue run needs. */
+/** One run of blended decals; DrawDecalList already batches same-material runs without reordering. */
 void D3D12GraphicsEngine::DrawDecalRun( std::span<const TransparentItem> items ) {
     if ( items.empty() ) return;
 

--- a/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
@@ -53,9 +53,8 @@ namespace {
     }
 
     // Material color contributes ALPHA only: ZenGin's base stage is rgbGen=VERTEX / alphaGen=FACTOR
-    // (zRenderManager.cpp:601-610, zRndD3D_Render.cpp:1049); its RGB is for untextured polys, which never
-    // get here. Multiplying the RGB in made dark-tinted additive surfaces (magic barrier, 4,45,26,155)
-    // vanish. Env strength is the separate EKind::Env stage, not part of the base alpha.
+    // (zRenderManager.cpp:601-610), and its RGB is for untextured polys, which never get here. Multiplying
+    // the RGB in made dark-tinted additive surfaces (the magic barrier) vanish.
     float4 ComputeTextureFactor( zCMaterial* mat ) {
         // RGB carries the day/night factor: unlit surfaces over a baked-daylight vertex color would
         // otherwise stay noon-bright at midnight. 1.0 in daylight. See GothicAPI::GetSkyDayFactor.
@@ -138,10 +137,10 @@ void D3D12GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
     // for the rest of the list. Materials whose effective alpha func is 0 therefore draw opaque + depth-
     // writing when they come first — order-dependent, but faithful. That case is live for portals/foam,
     // which are collected by TYPE and so may well carry alpha func 0.
-    // Env-map overlay stage (see ComputeEnvMapAlpha). Only the Simple variant runs it: PSTransparentPortal
-    // and PSTransparentFoam are their own effects, and ZenGin never env-maps a portal either. Needs both
-    // blobs (GetOrCreateWorldTransparencyPipeline silently degrades a kind with a missing blob to the plain
-    // shader, which here would re-draw the base surface) and the reflection cube the water pass loads.
+    // Env-map overlay stage (see ComputeEnvMapAlpha). Simple variant only — portals and foam are their own
+    // effects, and ZenGin never env-maps a portal. Both blobs are required because
+    // GetOrCreateWorldTransparencyPipeline degrades a missing blob to the plain shader, which here would
+    // re-draw the base surface.
     const bool envOverlayAvailable = kind == EKind::Simple
         && m_Pipelines.WorldTransparency.EnvVsBlob && m_Pipelines.WorldTransparency.EnvPsBlob
         && m_ReflectionCubeSrvSlot != UINT_MAX;
@@ -203,9 +202,8 @@ void D3D12GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
             entry.Mesh->BaseIndexLocation, 0, 0 );
         drawnIndices += static_cast<unsigned int>( entry.Mesh->Indices.size() );
 
-        // ZenGin appends the env-map stage to the SAME zCShader and DrawVertexBuffer walks the stages back
-        // to back (zRenderManager.cpp:671 / :1057), so the overlay goes inline here rather than as a second
-        // sweep — that keeps the painter's order of the surrounding blended surfaces intact.
+        // ZenGin appends the env-map stage to the SAME zCShader (zRenderManager.cpp:671), so the overlay
+        // goes inline here rather than as a second sweep, keeping the painter's order intact.
         if ( envOverlayAvailable && mat->GetEnvMapEnabled() ) {
             GothicBlendStateInfo envBlend;
             // Water gets an additive stage in ZenGin (zRenderManager.cpp:709); everything else blends.
@@ -324,16 +322,14 @@ bool D3D12GraphicsEngine::BindWorldTransparencyFrameState() {
 
 
 void D3D12GraphicsEngine::DrawVobAlphaRun( std::span<const TransparentItem> items ) {
-    // Port of D3D11GraphicsEngine::DrawFrameAlphaMeshes (D3D11GraphicsEngine.cpp:7741) for the instanced-VOB
-    // path: the cobwebs, hanging cloth and magic sheets whose material carries a BLEND/ADD alpha func.
+    // Port of D3D11GraphicsEngine::DrawFrameAlphaMeshes for the instanced-VOB path: cobwebs, hanging cloth and
+    // magic sheets whose material carries a BLEND/ADD alpha func.
     //
-    // Why they need their own pass: the opaque VOB set is one ExecuteIndirect through a single PSO that alpha-
-    // CLIPS at 0.5, writes depth and returns alpha 1 — so a spider web's soft, half-transparent texel became a
-    // fully opaque white one. D3D11 peels exactly these two alpha funcs out of its instanced pass and re-draws
-    // them here: blended, unlit (PS_Simple), depth-tested but NOT depth-writing. BuildVobDrawCommands does the
-    // peeling (they are consequently absent from the VOB depth prepass too, which is what a blended surface
-    // wants) and resolves every buffer view / bindless index, so this is a short CPU draw loop — same shape as
-    // D3D11's, and the entry count is a handful per frame.
+    // They need their own pass because the opaque VOB set is one ExecuteIndirect through a PSO that alpha-
+    // CLIPS at 0.5, writes depth and returns alpha 1 — which turns a spider web's half-transparent texel into
+    // an opaque white one. Drawn here blended, unlit and depth-tested but NOT depth-writing.
+    // BuildVobDrawCommands does the peeling (so they miss the VOB depth prepass too, as a blended surface
+    // wants) and resolves every buffer view, leaving this a short CPU draw loop.
     //
     // Ordered by the frame's transparency queue now, at batch granularity (see VobAlphaMesh::DistanceSq for
     // why this backend cannot go per instance the way D3D11 does).

--- a/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
@@ -81,10 +81,19 @@ namespace {
     // below now renders as EKind::Env. Folding the env strength into the base alpha is what made ice
     // near-invisible instead of thick.
     float4 ComputeTextureFactor( zCMaterial* mat ) {
-        if ( zColor( mat->GetColor() ).bgra.alpha < 255 ) {
-            return zColor( mat->GetColor() ).ToFloat4();
-        }
-        return float4( 1.0f, 1.0f, 1.0f, 1.0f );
+        // The material color contributes ALPHA ONLY, never RGB — ZenGin's base stage is rgbGen=VERTEX /
+        // alphaGen=FACTOR (zRenderManager.cpp:601-610); the D3D7 poly path folds only mat->GetAlpha()
+        // into the vertex color's alpha and leaves its RGB as the vertex light
+        // (zRndD3D_Render.cpp:1049). The material RGB is for UNTEXTURED polys, which never get here.
+        // Multiplying it in made dark-tinted additive surfaces (the magic barrier, color 4,45,26,155)
+        // scale their texture to near-black and disappear.
+        //
+        // The RGB instead carries the day/night factor: these surfaces are drawn unlit over a static,
+        // baked-daylight vertex color, so without it ice and waterfall foam stay noon-bright at midnight.
+        // Exactly 1.0 while the sun is up, so daylight is unaffected. See GothicAPI::GetSkyDayFactor.
+        const float skyLight = Engine::GAPI->GetSkyDayFactor();
+        return float4( skyLight, skyLight, skyLight,
+            zColor( mat->GetColor() ).bgra.alpha * (1.0f / 255.0f) );
     }
 
     // D3D11 spec: the alpha-func -> blend-state switch in DrawMeshInfoListAlphablended. Returns false for

--- a/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Transparency.cpp
@@ -12,9 +12,9 @@
 // Shape of the pass, mirrored one-to-one from D3D11:
 //   1. per-material: derive the effective alpha func (0 == "material default" -> BLEND when the material
 //      color's alpha is < 255, else stay opaque)
-//   2. compute the FF `textureFactor` tint — the material color when translucent, or the env-map strength
-//      ramped by the sun height for env-mapped materials
+//   2. compute the FF `textureFactor` tint — the material color when translucent
 //   3. draw with the blend mode that alpha func maps to, depth-tested but NOT depth-writing
+//   3b. for an env-mapped material, draw ZenGin's env-map overlay stage straight on top of that draw
 //   4. re-draw the whole list depth-only (color writes off, depth-write on) so the depth-reading post
 //      passes (height fog, god rays) see these surfaces instead of whatever is behind them
 //
@@ -71,28 +71,16 @@ namespace {
         return alphaFunc;
     }
 
-    // D3D11 spec: the `ffdata.textureFactor` block of DrawMeshInfoListAlphablended, verbatim. Env-mapped
-    // materials get a white tint whose ALPHA is the env-map strength ramped by how high the sun stands
-    // (that is what makes ice/glass reflective at noon and near-invisible at night); everything else uses
-    // the material color when it is translucent, and stays untinted otherwise.
+    // D3D11 spec: the `ffdata.textureFactor` block of DrawMeshInfoListAlphablended.
+    //
+    // The base surface's alpha is the material color's alpha, full stop. ZenGin sets the TFACTOR to
+    // zCMaterial::GetColor() (zRenderManager.cpp:609, alphaGen=FACTOR) and the D3D7 poly path
+    // multiplies vertex-light alpha by mat->GetAlpha() == color.alpha (zRndD3D_Render.cpp:1049).
+    // GetEnvMapStrength() is deliberately NOT part of this: env-mapping is an *additional* stage
+    // drawn on top of the base pass (zRenderManager.cpp:671-712), which DrawWorldTransparencyRun
+    // below now renders as EKind::Env. Folding the env strength into the base alpha is what made ice
+    // near-invisible instead of thick.
     float4 ComputeTextureFactor( zCMaterial* mat ) {
-        if ( mat->GetEnvMapEnabled() ) {
-            GSky* sky = Engine::GAPI->GetSky();
-            const float sunHeight = sky ? sky->GetAtmosphereCB().AC_LightPos.y : 0.0f;
-            if ( sunHeight > 0 ) {
-                // sun is up
-                const float maxSunHeight = 1.0f;
-                const float lerpFactor = std::clamp( sunHeight / maxSunHeight, 0.0f, 1.0f );
-
-                const float minIntensity = 0.1f;
-                const float maxIntensity = 0.7f;
-                const float currentIntensity = std::clamp(
-                    mat->GetEnvMapStrength() * std::lerp( minIntensity, maxIntensity, lerpFactor ), 0.0f, 1.0f );
-                return zColor( 255, 255, 255, static_cast<uint8_t>( 255.0f * currentIntensity ) ).ToFloat4();
-            }
-            return zColor( 255, 255, 255,
-                static_cast<uint8_t>( 255.0f * mat->GetEnvMapStrength() * 0.1f ) ).ToFloat4();
-        }
         if ( zColor( mat->GetColor() ).bgra.alpha < 255 ) {
             return zColor( mat->GetColor() ).ToFloat4();
         }
@@ -181,6 +169,15 @@ void D3D12GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
     // for the rest of the list. Materials whose effective alpha func is 0 therefore draw opaque + depth-
     // writing when they come first — order-dependent, but faithful. That case is live for portals/foam,
     // which are collected by TYPE and so may well carry alpha func 0.
+    // Env-map overlay stage (see ComputeEnvMapAlpha). Only the Simple variant runs it: PSTransparentPortal
+    // and PSTransparentFoam are their own effects, and ZenGin never env-maps a portal either. Needs both
+    // blobs (GetOrCreateWorldTransparencyPipeline silently degrades a kind with a missing blob to the plain
+    // shader, which here would re-draw the base surface) and the reflection cube the water pass loads.
+    const bool envOverlayAvailable = kind == EKind::Simple
+        && m_Pipelines.WorldTransparency.EnvVsBlob && m_Pipelines.WorldTransparency.EnvPsBlob
+        && m_ReflectionCubeSrvSlot != UINT_MAX;
+    const XMFLOAT3 camPosWS = Engine::GAPI->GetCameraPosition();
+
     GothicBlendStateInfo blend;
     blend.SetDefault();
     bool depthWrite = true;
@@ -236,6 +233,40 @@ void D3D12GraphicsEngine::DrawWorldTransparencyRun( std::span<const TransparentI
         m_CmdList->DrawIndexedInstanced( static_cast<UINT>( entry.Mesh->Indices.size() ), 1,
             entry.Mesh->BaseIndexLocation, 0, 0 );
         drawnIndices += static_cast<unsigned int>( entry.Mesh->Indices.size() );
+
+        // ZenGin appends the env-map stage to the SAME zCShader and DrawVertexBuffer walks the stages back
+        // to back (zRenderManager.cpp:671 / :1057), so the overlay goes inline here rather than as a second
+        // sweep — that keeps the painter's order of the surrounding blended surfaces intact.
+        if ( envOverlayAvailable && mat->GetEnvMapEnabled() ) {
+            GothicBlendStateInfo envBlend;
+            // Water gets an additive stage in ZenGin (zRenderManager.cpp:709); everything else blends.
+            if ( mat->GetMatGroup() == zMAT_GROUP_WATER ) envBlend.SetAdditiveBlending();
+            else                                         envBlend.SetAlphaBlending();
+
+            ID3D12PipelineState* envPso = m_Pipelines.GetOrCreateWorldTransparencyPipeline(
+                envBlend, false, EKind::Env );
+            if ( envPso ) {
+                m_CmdList->SetPipelineState( envPso );
+
+                // b5 tail: [4] SunHeight is left alone (PSTransparentEnv doesn't read it), [5..7] camera
+                // world position, [8] the bindless cube slot. TextureFactor.a carries the stage alpha.
+                const float envAlpha = Engine::GAPI->GetEnvMapStageAlpha( mat );
+                const float4 envFactor( 1.0f, 1.0f, 1.0f, envAlpha );
+                m_CmdList->SetGraphicsRoot32BitConstants( 1, 4, &envFactor, 0 );
+                m_CmdList->SetGraphicsRoot32BitConstants( 1, 3, &camPosWS, 5 );
+                m_CmdList->SetGraphicsRoot32BitConstants( 1, 1, &m_ReflectionCubeSrvSlot, 8 );
+
+                m_CmdList->DrawIndexedInstanced( static_cast<UINT>( entry.Mesh->Indices.size() ), 1,
+                    entry.Mesh->BaseIndexLocation, 0, 0 );
+                drawnIndices += static_cast<unsigned int>( entry.Mesh->Indices.size() );
+
+                // The overlay replaced the PSO and overwrote b5's TextureFactor, so the next item has to
+                // re-establish both instead of hitting these caches.
+                ID3D12PipelineState* restore = m_Pipelines.GetOrCreateWorldTransparencyPipeline( blend, depthWrite, kind );
+                if ( restore ) m_CmdList->SetPipelineState( restore );
+                lastMat = nullptr;
+            }
+        }
     }
 
     Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnTriangles += drawnIndices / 3;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -66,7 +66,6 @@
 const DWORD SCENE_WETNESS_DURATION_MS = 20 * 1000;
 
 // Draw ghost from back to front of our camera
-auto CompareGhostDistance = []( const TransparencyVobInfo& a, const TransparencyVobInfo& b ) -> bool { return a.distance < b.distance; };
 
 extern float vobAnimation_WindStrength;
 
@@ -1451,7 +1450,6 @@ void GothicAPI::DrawWorldMeshNaive() {
             // Schedule for drawing in later stage if this vob is ghost
             if ( vobInfo->Vob->GetVisualAlpha() ) {
                 TransparencyVobs.emplace_back( dist, vobInfo->Vob->GetVobTransparency(), vobInfo, nullptr );
-                std::ranges::push_heap(TransparencyVobs, CompareGhostDistance );
                 continue;
             }
 
@@ -3245,27 +3243,25 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
 }
 
 
-void GothicAPI::DrawTransparencyVobs() {
-    ZoneScopedN( "GothicAPI::DrawTransparencyVobs" );
+void GothicAPI::BeginTransparencyVobRun() {
+    // Setup alpha blending
+    RendererState.RasterizerState.SetDefault();
+    RendererState.RasterizerState.SetDirty();
+    RendererState.BlendState.SetAlphaBlending();
+    RendererState.BlendState.SetDirty();
+    RendererState.DepthState.SetDefault();
+    RendererState.DepthState.SetDirty();
+}
+
+void GothicAPI::DrawTransparencyVob( const TransparencyVobInfo& TransVobInfo ) {
+    ZoneScopedN( "GothicAPI::DrawTransparencyVob" );
     D3D11GraphicsEngine* g = AsD3D11Engine(Engine::GraphicsEngine);
-    if ( !TransparencyVobs.empty() ) {
-        // Setup alpha blending
-        RendererState.RasterizerState.SetDefault();
-        RendererState.RasterizerState.SetDirty();
-        RendererState.BlendState.SetAlphaBlending();
-        RendererState.BlendState.SetDirty();
-        RendererState.DepthState.SetDefault();
-        RendererState.DepthState.SetDirty();
-    }
 
     auto cbPool = g->GetConstantBufferPool();
     auto psBufGAI = g->GetShaderManager().GetPShader( PShaderID::PS_Transparency )->GetInputIndex( "GhostAlphaInfo" );
 
-
     VS_ExConstantBuffer_PerInstance cbPerInstance;
-    while ( !TransparencyVobs.empty() ) {
-        auto const& TransVobInfo = TransparencyVobs.front();
-
+    {
         if ( TransVobInfo.skeletalVob ) {
             // We need to do Z-prepass first
             g->UnbindActivePS();
@@ -3339,9 +3335,6 @@ void GothicAPI::DrawTransparencyVobs() {
                 }
             }
         }
-
-        std::ranges::pop_heap(TransparencyVobs, CompareGhostDistance );
-        TransparencyVobs.pop_back();
     }
 }
 
@@ -4479,13 +4472,12 @@ void GothicAPI::CollectVisibleVobs(
         }
 
         if ( renderQueue.transparent.size() ) {
-            TransparencyVobs.insert( TransparencyVobs.end(), 
-                std::make_move_iterator(renderQueue.transparent.begin()), 
+            TransparencyVobs.insert( TransparencyVobs.end(),
+                std::make_move_iterator(renderQueue.transparent.begin()),
                 std::make_move_iterator(renderQueue.transparent.end()) );
             // ignore dead items in renderQueue.transparent after move-insert
-
-            // sort back to front
-            std::ranges::sort(TransparencyVobs, CompareGhostDistance );
+            // No sort here anymore - the transparency queue orders ghosts against every other
+            // blended drawable, not just against each other.
         }
 
         float minDynamicUpdateLightRange = Engine::GAPI->GetRendererState().RendererSettings.MinLightShadowUpdateRange;
@@ -5753,6 +5745,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "General", "DrawWorldSectionIntersections", to_string_locale_independent( s.DrawSectionIntersections ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "DrawWorldOccluders", to_string_locale_independent( s.DrawWorldOccluders ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "SunLightStrength", to_string_locale_independent( s.SunLightStrength ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "SortedTransparency", to_string_locale_independent( s.SortedTransparency ? TRUE : FALSE ).c_str(), ini.c_str() );
 #ifdef BUILD_GOTHIC_1_08k
     WritePrivateProfileStringA( "General", "DrawG1ForestPortals", to_string_locale_independent( s.DrawG1ForestPortals ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "G1HighlightInteractiveFocus", to_string_locale_independent( s.G1HighlightInteractiveFocus ? TRUE : FALSE ).c_str(), ini.c_str() );
@@ -5936,6 +5929,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.DrawSectionIntersections = GetPrivateProfileBoolA( "General", "DrawWorldSectionIntersections", ds.DrawSectionIntersections, ini );
         s.DrawWorldOccluders = GetPrivateProfileBoolA( "General", "DrawWorldOccluders", ds.DrawWorldOccluders, ini );
         s.SunLightStrength = GetPrivateProfileFloatA( "General", "SunLightStrength", ds.SunLightStrength, ini );
+        s.SortedTransparency = GetPrivateProfileBoolA( "General", "SortedTransparency", ds.SortedTransparency, ini );
 #ifdef BUILD_GOTHIC_1_08k
         s.DrawG1ForestPortals = GetPrivateProfileBoolA( "General", "DrawG1ForestPortals", ds.DrawG1ForestPortals, ini );
         s.G1HighlightInteractiveFocus = GetPrivateProfileBoolA( "General", "G1HighlightInteractiveFocus", ds.G1HighlightInteractiveFocus, ini );

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -671,6 +671,38 @@ bool GothicAPI::IsCameraIndoor() {
     return ogame->_zCSession_camVob->GetGroundPoly()->GetLightmap() != nullptr;
 }
 
+/** Alpha of ZenGin's env-map overlay stage, verbatim from zCRenderManager::BuildShader
+    (zRenderManager.cpp:701-703):
+
+        if (!bInSector) skyFogColor = GetActiveSkyControler()->GetBackgroundColor();
+        else            skyFogColor.SetRGBA(100,100,100,255);
+        colorFactor = zCOLOR(255,255,255,
+            (zBYTE)(255.0f * mat->GetEnvMapStrength() * skyFogColor.GetIntensityFloat() / 255.0f));
+
+    with GetIntensityFloat() = 0.299r + 0.587g + 0.114b over 0..255 (zTypes3D.h:128). So the sheen tracks
+    the sky: bright at noon, dark at night, pinned to 100/255 indoors. The old sun-height lerp in the
+    renderers was a rough stand-in for this, applied to the wrong thing (the base surface's own alpha).
+
+    ZenGin's bInSector is per-polygon (the BSP sector the section sits in). We only have a cheap global
+    answer, so the camera stands in for it; the difference shows only while straddling a portal. */
+float GothicAPI::GetEnvMapStageAlpha( zCMaterial* mat ) {
+    if ( !mat ) return 0.0f;
+
+    float lumaFog = 100.0f * (0.299f + 0.587f + 0.114f);   // the in-sector zCOLOR(100,100,100)
+
+    if ( !IsCameraIndoor() ) {
+        oCGame* ogame = oCGame::GetGame();
+        zCSkyController_Outdoor* sc = ogame && ogame->_zCSession_world
+            ? ogame->_zCSession_world->GetSkyControllerOutdoor() : nullptr;
+        if ( sc ) {
+            zColor fog = sc->GetBackgroundColor();
+            lumaFog = 0.299f * fog.bgra.r + 0.587f * fog.bgra.g + 0.114f * fog.bgra.b;
+        }
+    }
+
+    return std::clamp( mat->GetEnvMapStrength() * lumaFog * (1.0f / 255.0f), 0.0f, 1.0f );
+}
+
 /** Returns whether the loaded world itself is an indoor level (mines, dungeons, ...) */
 bool GothicAPI::IsIndoorWorld() const {
     if ( !LoadedWorldInfo || !LoadedWorldInfo->BspTree )

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -671,30 +671,17 @@ bool GothicAPI::IsCameraIndoor() {
     return ogame->_zCSession_camVob->GetGroundPoly()->GetLightmap() != nullptr;
 }
 
-/** Alpha of ZenGin's env-map overlay stage, verbatim from zCRenderManager::BuildShader
-    (zRenderManager.cpp:701-703):
-
-        if (!bInSector) skyFogColor = GetActiveSkyControler()->GetBackgroundColor();
-        else            skyFogColor.SetRGBA(100,100,100,255);
-        colorFactor = zCOLOR(255,255,255,
-            (zBYTE)(255.0f * mat->GetEnvMapStrength() * skyFogColor.GetIntensityFloat() / 255.0f));
-
-    with GetIntensityFloat() = 0.299r + 0.587g + 0.114b over 0..255 (zTypes3D.h:128). So the sheen tracks
-    the sky: bright at noon, dark at night, pinned to 100/255 indoors. The old sun-height lerp in the
-    renderers was a rough stand-in for this, applied to the wrong thing (the base surface's own alpha).
-
-    ZenGin's bInSector is per-polygon (the BSP sector the section sits in). We only have a cheap global
-    answer, so the camera stands in for it; the difference shows only while straddling a portal. */
+/** Alpha of ZenGin's env-map overlay stage: envMapStrength * skyFogIntensity
+    (zRenderManager.cpp:701-703). ZenGin's bInSector is per-polygon; the camera stands in for it, which
+    differs only while straddling a portal. */
 float GothicAPI::GetEnvMapStageAlpha( zCMaterial* mat ) {
     if ( !mat ) return 0.0f;
     return std::clamp( mat->GetEnvMapStrength() * GetSkyLightIntensity(), 0.0f, 1.0f );
 }
 
-/** The `skyFogColor.GetIntensityFloat() / 255` factor of the block above, on its own: how bright the
-    sky FOG is right now, 0..1. Pinned to the in-sector zCOLOR(100,100,100) indoors, exactly as ZenGin
-    does. This is the env-map stage's term and nothing else — note it peaks well below 1.0 even at
-    noon (Gothic's daytime fog color is a hazy blue-grey), so it is NOT a usable brightness multiplier:
-    used as one it darkens surfaces in broad daylight. GetSkyDayFactor below is that. */
+/** Sky-fog intensity 0..1 (0.299r+0.587g+0.114b, zTypes3D.h:128), pinned to zCOLOR(100,100,100)
+    indoors as ZenGin does. Peaks well below 1.0 even at noon, so it is NOT a brightness multiplier -
+    used as one it darkens surfaces in broad daylight. GetSkyDayFactor is that. */
 float GothicAPI::GetSkyLightIntensity() {
     float lumaFog = 100.0f * (0.299f + 0.587f + 0.114f);   // the in-sector zCOLOR(100,100,100)
 
@@ -711,20 +698,11 @@ float GothicAPI::GetSkyLightIntensity() {
     return std::clamp( lumaFog * (1.0f / 255.0f), 0.0f, 1.0f );
 }
 
-/** Day/night brightness for surfaces that never receive lighting: 1.0 whenever the sun is properly up,
-    falling to kNightFactor after dusk.
-
-    Alpha-blended world surfaces are drawn unlit — D3D11ForwardPlusRenderer::BindShaderForTexture sends
-    every BLEND/ADD material (and MT_Portal / MT_WaterfallFoam) to the non-lit fallback shaders — over a
-    world-mesh vertex color that is the STATIC light baked into the .zen at full daylight. Nothing in
-    that path darkens them, so ice sheets and waterfall foam sat at noon brightness at midnight.
-
-    ZenGin has no equivalent because it does not need one: its blended base stage is rgbGen=VERTEX and
-    its per-vertex lightDyn already carries the time of day, since ZenGin relights world vertices from
-    the sky. This is our stand-in for that missing term, so the shape is chosen rather than ported:
-    pinned to exactly 1.0 while the sun is up (daylight must look identical to before this existed) and
-    eased down to a floor at night rather than to black — Gothic nights are moonlit, not pitch dark.
-    Both constants are pure look tuning; change them freely. */
+/** Day/night brightness for the alpha-blended world surfaces that never receive lighting
+    (D3D11ForwardPlusRenderer::BindShaderForTexture routes every BLEND/ADD material to the unlit
+    fallbacks) over a vertex color baked at full daylight - without it ice and foam stay noon-bright at
+    midnight. ZenGin needs no equivalent: its lightDyn already carries the time of day. CHOSEN, not
+    ported - exactly 1.0 while the sun is up so daylight is unchanged. Both constants are look tuning. */
 float GothicAPI::GetSkyDayFactor() {
     constexpr float kNightFactor = 0.35f;   // brightness after dusk
     constexpr float kDuskSharpness = 4.0f;  // how fast it crosses over around the horizon

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -687,7 +687,15 @@ bool GothicAPI::IsCameraIndoor() {
     answer, so the camera stands in for it; the difference shows only while straddling a portal. */
 float GothicAPI::GetEnvMapStageAlpha( zCMaterial* mat ) {
     if ( !mat ) return 0.0f;
+    return std::clamp( mat->GetEnvMapStrength() * GetSkyLightIntensity(), 0.0f, 1.0f );
+}
 
+/** The `skyFogColor.GetIntensityFloat() / 255` factor of the block above, on its own: how bright the
+    sky FOG is right now, 0..1. Pinned to the in-sector zCOLOR(100,100,100) indoors, exactly as ZenGin
+    does. This is the env-map stage's term and nothing else — note it peaks well below 1.0 even at
+    noon (Gothic's daytime fog color is a hazy blue-grey), so it is NOT a usable brightness multiplier:
+    used as one it darkens surfaces in broad daylight. GetSkyDayFactor below is that. */
+float GothicAPI::GetSkyLightIntensity() {
     float lumaFog = 100.0f * (0.299f + 0.587f + 0.114f);   // the in-sector zCOLOR(100,100,100)
 
     if ( !IsCameraIndoor() ) {
@@ -700,7 +708,34 @@ float GothicAPI::GetEnvMapStageAlpha( zCMaterial* mat ) {
         }
     }
 
-    return std::clamp( mat->GetEnvMapStrength() * lumaFog * (1.0f / 255.0f), 0.0f, 1.0f );
+    return std::clamp( lumaFog * (1.0f / 255.0f), 0.0f, 1.0f );
+}
+
+/** Day/night brightness for surfaces that never receive lighting: 1.0 whenever the sun is properly up,
+    falling to kNightFactor after dusk.
+
+    Alpha-blended world surfaces are drawn unlit — D3D11ForwardPlusRenderer::BindShaderForTexture sends
+    every BLEND/ADD material (and MT_Portal / MT_WaterfallFoam) to the non-lit fallback shaders — over a
+    world-mesh vertex color that is the STATIC light baked into the .zen at full daylight. Nothing in
+    that path darkens them, so ice sheets and waterfall foam sat at noon brightness at midnight.
+
+    ZenGin has no equivalent because it does not need one: its blended base stage is rgbGen=VERTEX and
+    its per-vertex lightDyn already carries the time of day, since ZenGin relights world vertices from
+    the sky. This is our stand-in for that missing term, so the shape is chosen rather than ported:
+    pinned to exactly 1.0 while the sun is up (daylight must look identical to before this existed) and
+    eased down to a floor at night rather than to black — Gothic nights are moonlit, not pitch dark.
+    Both constants are pure look tuning; change them freely. */
+float GothicAPI::GetSkyDayFactor() {
+    constexpr float kNightFactor = 0.35f;   // brightness after dusk
+    constexpr float kDuskSharpness = 4.0f;  // how fast it crosses over around the horizon
+
+    GSky* sky = GetSky();
+    if ( !sky ) return 1.0f;
+
+    // AC_LightPos.y is the sun height, -1 (midnight) .. 1 (noon)
+    const float sunHeight = sky->GetAtmosphereCB().AC_LightPos.y;
+    const float day = std::clamp( sunHeight * kDuskSharpness, 0.0f, 1.0f );
+    return std::lerp( kNightFactor, 1.0f, day );
 }
 
 /** Returns whether the loaded world itself is an indoor level (mines, dungeons, ...) */

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -646,6 +646,10 @@ public:
     /** Returns wether the camera is indoor or not */
     bool IsCameraIndoor();
 
+    /** Alpha of ZenGin's env-map overlay stage for this material — see zCRenderManager::BuildShader
+        (zRenderManager.cpp:701-703). Backend-neutral because both renderers draw the same stage. */
+    float GetEnvMapStageAlpha( zCMaterial* mat );
+
     /** Returns whether the loaded world itself is an indoor level (mines, dungeons, ...).
         This is a per-world property baked into the compiled BSP-tree, not a per-frame camera
         test - ZenGin swaps in a zCSkyControler_Indoor for these worlds, which renders no sky

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -12,6 +12,7 @@
 #include "zTypes.h"
 #include "RenderQueue.h"
 #include "ShaderIDs.h"
+#include "TransparencyQueue.h"
 #include "ThreadPool.h"
 #include <shared_mutex>
 
@@ -442,12 +443,21 @@ public:
 
     void DrawSkeletalMeshVob_Layered( SkeletalVobInfo* vi, float distance, bool updateState = true, const std::move_only_function<bool( const zCVob* ) const>& ignoreVob = nullptr );
 
-    void DrawTransparencyVobs();
+    /** Sets up the shared render state a run of ghost draws needs. The transparency queue can
+        interleave ghosts with other kinds, so this runs once per run, not once per frame. */
+    void BeginTransparencyVobRun();
+
+    /** Draws one ghost vob (z-prepass with a null PS, then the transparency shader). Hard-wired to
+        D3D11GraphicsEngine; D3D12 has its own equivalent. */
+    void DrawTransparencyVob( const TransparencyVobInfo& info );
+
     void DrawSkeletalVN();
 
-    /** Backend-neutral accessor so a non-D3D11 backend can drain TransparencyVobs itself
-        (DrawTransparencyVobs() above is hard-wired to D3D11GraphicsEngine). */
+    /** Backend-neutral accessor: the transparency queue stores indices into this. */
     std::vector<TransparencyVobInfo>& GetTransparencyVobs() { return TransparencyVobs; }
+
+    /** Every alpha-blended drawable of this frame, sorted back to front by the transparency pass. */
+    TransparencyQueue& GetTransparencyQueue() { return TransparencyQueueData; }
 
     /** Draws the inventory */
     void DrawInventory( zCWorld* world, zCCamera& camera );
@@ -1056,6 +1066,9 @@ private:
     std::vector<SkeletalVobInfo*> AnimatedSkeletalVobs;
     std::vector<TransparencyVobInfo> TransparencyVobs;
     std::vector<SkeletalVobInfo*> VNSkeletalVobs;
+
+    /** Collection point for everything drawn alpha-blended this frame */
+    TransparencyQueue TransparencyQueueData;
 
     /** List of Vobs having a zCParticleFX-Visual */
     std::vector<zCVob*> ParticleEffectVobs;

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -650,6 +650,14 @@ public:
         (zRenderManager.cpp:701-703). Backend-neutral because both renderers draw the same stage. */
     float GetEnvMapStageAlpha( zCMaterial* mat );
 
+    /** Sky-fog intensity (0..1) ZenGin's env-map stage scales its sheen by. Peaks well below 1.0
+        even at noon - not a brightness multiplier, see GetSkyDayFactor for that. */
+    float GetSkyLightIntensity();
+
+    /** Day/night brightness (kNightFactor..1.0) for the alpha-blended world surfaces that are drawn
+        unlit over static, baked-daylight vertex colors. Exactly 1.0 while the sun is up. */
+    float GetSkyDayFactor();
+
     /** Returns whether the loaded world itself is an indoor level (mines, dungeons, ...).
         This is a per-world property baked into the compiled BSP-tree, not a per-frame camera
         test - ZenGin swaps in a zCSkyControler_Indoor for these worlds, which renders no sky

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -443,20 +443,17 @@ public:
 
     void DrawSkeletalMeshVob_Layered( SkeletalVobInfo* vi, float distance, bool updateState = true, const std::move_only_function<bool( const zCVob* ) const>& ignoreVob = nullptr );
 
-    /** Sets up the shared render state a run of ghost draws needs. The transparency queue can
-        interleave ghosts with other kinds, so this runs once per run, not once per frame. */
+    /** Shared state for a run of ghost draws; per run, since the queue interleaves kinds. */
     void BeginTransparencyVobRun();
 
-    /** Draws one ghost vob (z-prepass with a null PS, then the transparency shader). Hard-wired to
-        D3D11GraphicsEngine; D3D12 has its own equivalent. */
+    /** One ghost vob (z-prepass with a null PS, then the transparency shader). D3D11 only. */
     void DrawTransparencyVob( const TransparencyVobInfo& info );
 
     void DrawSkeletalVN();
 
-    /** Backend-neutral accessor: the transparency queue stores indices into this. */
+    /** The transparency queue stores indices into this. */
     std::vector<TransparencyVobInfo>& GetTransparencyVobs() { return TransparencyVobs; }
 
-    /** Every alpha-blended drawable of this frame, sorted back to front by the transparency pass. */
     TransparencyQueue& GetTransparencyQueue() { return TransparencyQueueData; }
 
     /** Draws the inventory */
@@ -1079,7 +1076,6 @@ private:
     std::vector<TransparencyVobInfo> TransparencyVobs;
     std::vector<SkeletalVobInfo*> VNSkeletalVobs;
 
-    /** Collection point for everything drawn alpha-blended this frame */
     TransparencyQueue TransparencyQueueData;
 
     /** List of Vobs having a zCParticleFX-Visual */

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -713,6 +713,9 @@ struct GothicRendererSettings {
         ShowSkeletalVertexNormals = false;
         EnableDynamicLighting = true;
 
+        SortedTransparency = true;      // draw every alpha-blended thing in one back-to-front pass instead
+                                        // of one fixed pass per category (cobwebs, ghosts, glass, decals, ...)
+
         DrawG1ForestPortals = false;    //enables the textures around forests and some doors to darken them
                                         //these are only applicable to G1, they don't appear to have been used in G2
         G1HighlightInteractiveFocus = true; // G1 only: toggles the interactive focus which brightens up focus vobs/mobs
@@ -1050,6 +1053,7 @@ struct GothicRendererSettings {
     float FogRange;
     int WindQuality;
     bool HeroAffectsObjects;
+    bool SortedTransparency;
     bool DrawG1ForestPortals;
     bool G1HighlightInteractiveFocus;
     bool DrawRainThroughTransformFeedback;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -713,8 +713,7 @@ struct GothicRendererSettings {
         ShowSkeletalVertexNormals = false;
         EnableDynamicLighting = true;
 
-        SortedTransparency = true;      // draw every alpha-blended thing in one back-to-front pass instead
-                                        // of one fixed pass per category (cobwebs, ghosts, glass, decals, ...)
+        SortedTransparency = true;      // one back-to-front pass instead of one fixed pass per category
 
         DrawG1ForestPortals = false;    //enables the textures around forests and some doors to darken them
                                         //these are only applicable to G1, they don't appear to have been used in G2

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -118,6 +118,8 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_SkyLayerState1 = 0x124;
         static const unsigned int Offset_OverrideColor = 0x558;
         static const unsigned int Offset_OverrideFlag = 0x564;
+        // zCOLOR resultFogColor — same class layout as the retail 2.6fix build (see Offset_Planets above).
+        static const unsigned int Offset_Color = 0x594;
         //static const unsigned int Interpolate = 0x005E8C20;
         static const unsigned int Offset_InitDone = 0x7C;
         //static const unsigned int Init = 0x005E6A00;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1819,6 +1819,11 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         ImGui::DragFloat( "FOVHoriz", &settings.FOVHoriz, 1.0f, 1.0f, 360.0f, "%.0f" );
         ImGui::DragFloat( "FOVVert", &settings.FOVVert, 1.0f, 1.0f, 360.0f, "%.0f" );
         ImGui::Checkbox( "ForceFOV", &settings.ForceFOV );
+        ImGui::Checkbox( "Sorted transparency", &settings.SortedTransparency );
+        if ( ImGui::IsItemHovered() ) {
+            ImGui::SetTooltip( "Draw all alpha-blended geometry in one back-to-front pass.\n"
+                "Off: the old fixed per-category pass order (faster to batch, wrong depth order between categories)." );
+        }
 #ifdef BUILD_GOTHIC_1_08k
         ImGui::Checkbox( "DrawForestPortals", &settings.DrawG1ForestPortals );
         ImGui::Checkbox( "Highlight interactive focus", &settings.G1HighlightInteractiveFocus );

--- a/D3D11Engine/ShaderIDs.h
+++ b/D3D11Engine/ShaderIDs.h
@@ -43,6 +43,7 @@ enum class PShaderID : size_t {
     PS_LinesSel,
     PS_Simple,
     PS_Simple_FF,
+    PS_EnvMap,
     PS_Rain,
     PS_Rain_Snow,
     PS_Transparency,

--- a/D3D11Engine/ShaderRegistry.cpp
+++ b/D3D11Engine/ShaderRegistry.cpp
@@ -134,6 +134,9 @@ void ShaderRegistry::Build() {
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Simple_FF>( "PS_Simple.hlsl" )
         .with_macros( { { "USE_FFDATA", "1" } } ) );
 
+    // ZenGin's env-map overlay stage, drawn on top of an alpha-blended world surface.
+    Shaders.push_back( ShaderInfo::make<PShaderID::PS_EnvMap>( "PS_EnvMap.hlsl" ) );
+
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Rain>( "PS_Rain.hlsl" ) );
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Rain_Snow>( "PS_Rain.hlsl" )

--- a/D3D11Engine/Shaders/D3D12/World.hlsl
+++ b/D3D11Engine/Shaders/D3D12/World.hlsl
@@ -198,7 +198,15 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
 // SunHeight is Gothic's AC_LightPos.y (sun height above the horizon), which the portal/waterfall-foam
 // variants below need for their day/night darkening. It is passed as a scalar root constant rather than
 // pulling in the whole Atmosphere CB the D3D11 shaders include, since that is all either one reads.
-cbuffer TransparencyCB : register(b5) { float4 TextureFactor; float SunHeight; float3 _tpad; };
+// EnvCamPosWS/EnvCubeIndex are read only by PSTransparentEnv (the env-map overlay stage). They live here
+// rather than in a CB of their own because this pass's root signature is private to it, and CamPosWS is
+// otherwise only in FogCB (b1) which this root signature does not carry — referencing that would emit a b1
+// binding the PSO has no root parameter for. EnvCubeIndex == 0xFFFFFFFF means the cube is unavailable.
+cbuffer TransparencyCB : register(b5) {
+    float4 TextureFactor;
+    float SunHeight; float3 EnvCamPosWS;
+    uint EnvCubeIndex; float3 _tpad;
+};
 // World->view, VS only, used ONLY by VSTransparentPortal (see below). World.hlsl declares nothing else at
 // b4 — the shared World.RootSig's b4 (wind) is never read by this file, and an unused declaration emits no
 // binding, so this cannot collide with the opaque world/VOB PSOs.
@@ -231,6 +239,43 @@ float4 PSTransparent( VST_OUT i ) : SV_TARGET
     // The scene target is linear HDR on D3D12, so the sampled sRGB texel has to be linearized like every
     // other albedo read; the alpha rides through untouched for the blend.
     return float4( SrgbToLinear( c.rgb ), c.a );
+}
+
+// --- Env-map overlay stage (ZenGin zRenderManager.cpp:671-712, D3D11: PS_EnvMap.hlsl) ----------------
+// ZenGin does not fold env mapping into the base surface: it appends an EXTRA stage to the same zCShader,
+// drawn immediately after the base pass over the same geometry with rgbGen IDENTITY (the env texture
+// alone, unlit) and alphaGen FACTOR (alpha = env-map strength scaled by the sky fog color's luma, which
+// the CPU computes and passes in TextureFactor.a). That is what gives ice its sheen while the base pass
+// keeps the material's own thickness.
+//
+// Divergence shared with D3D11's PS_EnvMap: ZenGin sphere-maps zFlare1.tga by the CAMERA-space reflection
+// vector, which swims with the camera; we sample the reflect_cube.dds the water pass already loads, by the
+// WORLD-space reflection vector. Needs the world normal, so this gets its own VS.
+struct VSTE_OUT { float4 clip : SV_POSITION; float3 wpos : TEXCOORD0; float3 wnrm : TEXCOORD1; };
+
+VSTE_OUT VSTransparentEnv( VS_IN i )
+{
+    VSTE_OUT o;
+    o.clip = mul( float4( i.pos, 1.0 ), ViewProj );
+    o.wpos = i.pos;                          // world verts are already world-space
+    o.wnrm = DecodeOctNormal( i.nrm );       // already world-space
+    return o;
+}
+
+float4 PSTransparentEnv( VSTE_OUT i ) : SV_TARGET
+{
+    if ( EnvCubeIndex == 0xFFFFFFFF ) discard;
+
+    float3 eye = normalize( i.wpos - EnvCamPosWS );
+    float3 r = normalize( reflect( eye, normalize( i.wnrm ) ) );
+
+    TextureCube envTex = ResourceDescriptorHeap[EnvCubeIndex];
+    float3 env = envTex.Sample( smp, r ).rgb;
+
+    // rgbGen IDENTITY: emitted unlit and unmodulated, only the alpha is driven. The scene target is linear
+    // HDR here, so the sRGB cube texel is linearized like every other albedo read (same rule PSTransparent
+    // follows above).
+    return float4( SrgbToLinear( env ), TextureFactor.a );
 }
 
 // --- MT_WaterfallFoam (D3D11: PS_WaterfallFoam.hlsl) -------------------------------------------------

--- a/D3D11Engine/Shaders/PS_EnvMap.hlsl
+++ b/D3D11Engine/Shaders/PS_EnvMap.hlsl
@@ -2,17 +2,13 @@
 // Env-map overlay stage — the port of ZenGin's zCRenderManager::BuildShader env stage
 // (zRenderManager.cpp:671-712).
 //
-// In ZenGin env mapping is NOT a property of the base surface: it is an extra shader stage drawn
-// straight after the base pass over the same geometry, with rgbGen IDENTITY (COLOROP = SELECTARG1,
-// i.e. the env texture alone, unlit) and alphaGen FACTOR (alpha = TFACTOR.a = env-map strength
-// scaled by the sky fog color's luma). That is what gives ice/glass its sheen while the base pass
-// keeps the material's own thickness.
+// In ZenGin env mapping is NOT a property of the base surface: it is an extra shader stage drawn straight
+// after the base pass over the same geometry, with rgbGen IDENTITY (the env texture alone, unlit) and
+// alphaGen FACTOR (alpha = env-map strength scaled by the sky fog color's luma).
 //
-// Deliberate divergence: ZenGin uses a 2D sphere map (zFlare1.tga) addressed by the CAMERA-space
-// reflection vector (TCI_CAMERASPACEREFLECTIONVECTOR + the 0.5-scale/0.5-bias texture matrix), which
-// makes the reflection swim with the camera. GD3D11 already ships and loads reflect_cube.dds and uses
-// it for exactly this purpose in PS_Water/PS_DS_AtmosphericScattering, so we sample that cube with
-// the WORLD-space reflection vector instead: same stage, same alpha, stable reflection.
+// Deliberate divergence: ZenGin uses a 2D sphere map (zFlare1.tga) addressed by the CAMERA-space reflection
+// vector, which makes the reflection swim with the camera. We sample the already-loaded reflect_cube.dds
+// with the WORLD-space reflection vector instead: same stage, same alpha, stable reflection.
 //--------------------------------------------------------------------------------------
 
 SamplerState SS_Linear : register( s0 );

--- a/D3D11Engine/Shaders/PS_EnvMap.hlsl
+++ b/D3D11Engine/Shaders/PS_EnvMap.hlsl
@@ -1,0 +1,60 @@
+//--------------------------------------------------------------------------------------
+// Env-map overlay stage — the port of ZenGin's zCRenderManager::BuildShader env stage
+// (zRenderManager.cpp:671-712).
+//
+// In ZenGin env mapping is NOT a property of the base surface: it is an extra shader stage drawn
+// straight after the base pass over the same geometry, with rgbGen IDENTITY (COLOROP = SELECTARG1,
+// i.e. the env texture alone, unlit) and alphaGen FACTOR (alpha = TFACTOR.a = env-map strength
+// scaled by the sky fog color's luma). That is what gives ice/glass its sheen while the base pass
+// keeps the material's own thickness.
+//
+// Deliberate divergence: ZenGin uses a 2D sphere map (zFlare1.tga) addressed by the CAMERA-space
+// reflection vector (TCI_CAMERASPACEREFLECTIONVECTOR + the 0.5-scale/0.5-bias texture matrix), which
+// makes the reflection swim with the camera. GD3D11 already ships and loads reflect_cube.dds and uses
+// it for exactly this purpose in PS_Water/PS_DS_AtmosphericScattering, so we sample that cube with
+// the WORLD-space reflection vector instead: same stage, same alpha, stable reflection.
+//--------------------------------------------------------------------------------------
+
+SamplerState SS_Linear : register( s0 );
+// t4, matching the slot PS_Diffuse reserves for the reflection cube.
+TextureCube	TX_ReflectionCube : register( t4 );
+
+cbuffer cbEnvMap : register( b0 )
+{
+	matrix EM_InvView;      // view -> world, to take the reflection vector into cube space
+	float4 EM_Params;       // x = stage alpha (EnvMapStrength * luma(fogColor)), yzw unused
+};
+
+//--------------------------------------------------------------------------------------
+// Input / Output structures
+//--------------------------------------------------------------------------------------
+// Must stay signature-compatible with the VS_Ex family (VS_ExPacked drives this pass).
+struct PS_INPUT
+{
+	float2 vTexcoord		: TEXCOORD0;
+	float2 vTexcoord2		: TEXCOORD1;
+	float4 vDiffuse			: TEXCOORD2;
+	float3 vNormalVS		: TEXCOORD4;
+	float3 vViewPosition	: TEXCOORD5;
+	float4 vCurrClipPos     : TEXCOORD6;
+	float4 vPrevClipPos     : TEXCOORD7;
+	float4 vTangent			: TEXCOORD3;  // present so the signature matches the VS_Ex family (unused here)
+	float4 vPosition		: SV_POSITION;
+};
+
+//--------------------------------------------------------------------------------------
+// Pixel Shader
+//--------------------------------------------------------------------------------------
+float4 PSMain( PS_INPUT Input ) : SV_TARGET
+{
+	// vViewPosition is the surface position in view space, so normalizing it gives the eye->surface
+	// direction (the eye sits at the view-space origin).
+	float3 nrmVS  = normalize( Input.vNormalVS );
+	float3 eyeVS  = normalize( Input.vViewPosition );
+	float3 reflWS = normalize( mul( float4( reflect( eyeVS, nrmVS ), 0.0f ), EM_InvView ).xyz );
+
+	float3 env = TX_ReflectionCube.Sample( SS_Linear, reflWS ).rgb;
+
+	// rgbGen IDENTITY: the env texture is emitted unlit and unmodulated; only the alpha is driven.
+	return float4( env, EM_Params.x );
+}

--- a/D3D11Engine/TransparencyQueue.cpp
+++ b/D3D11Engine/TransparencyQueue.cpp
@@ -1,0 +1,115 @@
+#include "pch.h"
+#include "TransparencyQueue.h"
+#include "GothicAPI.h"
+
+#include <algorithm>
+
+namespace {
+    /** Order the kinds were drawn in before the queue existed, used by the categoryMajor fallback.
+        Approximate: quad marks used to be split over two passes by blend mode (ADD/BLEND before the
+        alpha VOBs, MUL/MUL2 after the ghosts) - they are one category here. */
+    constexpr uint8_t LegacyRank( ETransparentKind kind ) {
+        switch ( kind ) {
+        case ETransparentKind::AlphaVob:  return 0;
+        case ETransparentKind::Ghost:     return 1;
+        case ETransparentKind::Decal:     return 2;
+        case ETransparentKind::QuadMark:  return 3;
+        case ETransparentKind::PolyStrip: return 4;
+        case ETransparentKind::WorldMesh: return 5;
+        default:                          return 6;
+        }
+    }
+
+    /** Back to front, then grouped by material so equidistant items still batch. */
+    bool BackToFront( const TransparentItem& a, const TransparentItem& b ) {
+        if ( a.DistanceSq != b.DistanceSq )
+            return a.DistanceSq > b.DistanceSq;
+        if ( a.Kind != b.Kind )
+            return a.Kind < b.Kind;
+        if ( a.BatchKey != b.BatchKey )
+            return a.BatchKey < b.BatchKey;
+        return a.PayloadIndex < b.PayloadIndex;
+    }
+}
+
+void TransparencyQueue::BeginFrame() {
+    if ( Items.capacity() == 0 ) {
+        Items.reserve( 2048 );
+        WorldMeshes.reserve( 512 );
+        AlphaVobs.reserve( 1024 );
+        GhostIndices.reserve( 32 );
+        Decals.reserve( 256 );
+        QuadMarks.reserve( 128 );
+        PolyStrips.reserve( 32 );
+    }
+
+    Items.clear();
+    WorldMeshes.clear();
+    AlphaVobs.clear();
+    GhostIndices.clear();
+    Decals.clear();
+    QuadMarks.clear();
+    PolyStrips.clear();
+}
+
+void TransparencyQueue::AddWorldMesh( float distanceSq, EWorldTransparencyVariant variant, const MeshKey& key, MeshInfo* mesh ) {
+    Items.push_back( { distanceSq, MakeBatchKey( key.Material ), static_cast<uint32_t>(WorldMeshes.size()),
+        ETransparentKind::WorldMesh, static_cast<uint8_t>(variant) } );
+    WorldMeshes.push_back( { key, mesh } );
+}
+
+void TransparencyQueue::AddAlphaVob( float distanceSq, uint32_t batchIndex, uint32_t instanceIndex, uint32_t batchKey ) {
+    AddIndexed( distanceSq, ETransparentKind::AlphaVob, 0, batchIndex, instanceIndex, batchKey );
+}
+
+void TransparencyQueue::AddIndexed( float distanceSq, ETransparentKind kind, uint8_t subKind,
+    uint32_t index0, uint32_t index1, uint32_t batchKey ) {
+    Items.push_back( { distanceSq, batchKey, static_cast<uint32_t>(AlphaVobs.size()), kind, subKind } );
+    AlphaVobs.push_back( { index0, index1 } );
+}
+
+void TransparencyQueue::AddGhost( float distanceSq, uint32_t transparencyVobIndex ) {
+    Items.push_back( { distanceSq, transparencyVobIndex, static_cast<uint32_t>(GhostIndices.size()),
+        ETransparentKind::Ghost, 0 } );
+    GhostIndices.push_back( transparencyVobIndex );
+}
+
+void TransparencyQueue::AddDecal( float distanceSq, zCVob* vob ) {
+    Items.push_back( { distanceSq, MakeBatchKey( vob ), static_cast<uint32_t>(Decals.size()),
+        ETransparentKind::Decal, 0 } );
+    Decals.push_back( vob );
+}
+
+void TransparencyQueue::AddQuadMark( float distanceSq, zCQuadMark* mark, const QuadMarkInfo* info ) {
+    Items.push_back( { distanceSq, MakeBatchKey( mark ), static_cast<uint32_t>(QuadMarks.size()),
+        ETransparentKind::QuadMark, 0 } );
+    QuadMarks.push_back( { mark, info } );
+}
+
+void TransparencyQueue::AddPolyStrip( float distanceSq, zCTexture* texture, const PolyStripInfo* info ) {
+    Items.push_back( { distanceSq, MakeBatchKey( texture ), static_cast<uint32_t>(PolyStrips.size()),
+        ETransparentKind::PolyStrip, 0 } );
+    PolyStrips.push_back( { texture, info } );
+}
+
+void TransparencyQueue::Sort( bool categoryMajor ) {
+    if ( categoryMajor ) {
+        std::sort( Items.begin(), Items.end(), []( const TransparentItem& a, const TransparentItem& b ) {
+            const uint8_t ra = LegacyRank( a.Kind );
+            const uint8_t rb = LegacyRank( b.Kind );
+            if ( ra != rb )
+                return ra < rb;
+            return BackToFront( a, b );
+            } );
+        return;
+    }
+
+    std::sort( Items.begin(), Items.end(), BackToFront );
+}
+
+float TransparencyQueue::DistanceSqFromCamera( const XMFLOAT3& worldPosition ) {
+    float distanceSq;
+    XMStoreFloat( &distanceSq,
+        XMVector3LengthSq( XMLoadFloat3( &worldPosition ) - Engine::GAPI->GetCameraPositionXM() ) );
+    return distanceSq;
+}

--- a/D3D11Engine/TransparencyQueue.cpp
+++ b/D3D11Engine/TransparencyQueue.cpp
@@ -5,9 +5,8 @@
 #include <algorithm>
 
 namespace {
-    /** Order the kinds were drawn in before the queue existed, used by the categoryMajor fallback.
-        Approximate: quad marks used to be split over two passes by blend mode (ADD/BLEND before the
-        alpha VOBs, MUL/MUL2 after the ghosts) - they are one category here. */
+    /** Pre-queue pass order, for the categoryMajor fallback. Approximate: quad marks used to be
+        split over two passes by blend mode; they are one category here. */
     constexpr uint8_t LegacyRank( ETransparentKind kind ) {
         switch ( kind ) {
         case ETransparentKind::AlphaVob:  return 0;

--- a/D3D11Engine/TransparencyQueue.h
+++ b/D3D11Engine/TransparencyQueue.h
@@ -10,21 +10,10 @@ class zCQuadMark;
 class zCTexture;
 struct PolyStripInfo;
 
-/** Backend-neutral collection point for everything that gets drawn alpha-blended.
-
-    Before this existed every category of transparent geometry (world mesh sections, instanced
-    alpha VOBs, ghosts, decals, quad marks, poly strips) had its own render pass in a hard-coded
-    sequence, and each of them sorted - at best - only within itself. A cobweb therefore always
-    painted before a ghost and a ghost always before a glass window, no matter what stood in front
-    of what.
-
-    Producers now push their drawables in here during the frame; the transparency pass sorts the
-    whole set strictly back-to-front once and replays it. Batching survives because the emitters
-    draw maximal *consecutive* runs of the same kind in one go (see ForEachRun) - the same
-    painter's-order rule the decal path has always followed.
-
-    Only the small Items array is sorted; the payload vectors never move. Every vector is cleared
-    (never freed) per frame and reserved once, per the project's no-per-frame-allocation rule. */
+/** Backend-neutral collection point for everything drawn alpha-blended. Producers push during the
+    frame; the transparency pass sorts back-to-front once and replays it, batching maximal
+    consecutive same-kind runs (ForEachRun). Only Items is sorted - payloads never move, and every
+    vector is cleared (never freed) per frame. */
 
 enum class ETransparentKind : uint8_t {
     WorldMesh,      // world mesh section, SubKind = EWorldTransparencyVariant
@@ -36,9 +25,8 @@ enum class ETransparentKind : uint8_t {
     Count
 };
 
-/** World transparency meshes all run through the same draw code - the pixel shader is picked from
-    MaterialInfo::MaterialType - but portals are gated behind a setting and are excluded from the
-    depth-only re-draw, so the variant has to survive the sort. */
+/** One draw path for all three; the variant only gates portals behind DrawG1ForestPortals and
+    excludes them from the depth re-lay. The pixel shader comes from MaterialInfo::MaterialType. */
 enum class EWorldTransparencyVariant : uint8_t {
     Normal,
     Portal,
@@ -58,9 +46,8 @@ struct TransparentWorldMesh {
     MeshInfo* Mesh;
 };
 
-/** Backend-neutral reference into the backend's own alpha-VOB batch array (D3D11: m_AlphaMeshes,
-    D3D12: its equivalent). Instances of one batch are contiguous in the instancing buffer, so
-    consecutive items of the same batch re-merge into a single instanced draw at emit time. */
+/** Index into the backend's own alpha-VOB batch array. A batch's instances are contiguous in the
+    instancing buffer, so consecutive items re-merge into one instanced draw at emit time. */
 struct TransparentAlphaVob {
     uint32_t BatchIndex;
     uint32_t InstanceIndex;
@@ -84,9 +71,8 @@ public:
     void AddWorldMesh( float distanceSq, EWorldTransparencyVariant variant, const MeshKey& key, MeshInfo* mesh );
     void AddAlphaVob( float distanceSq, uint32_t batchIndex, uint32_t instanceIndex, uint32_t batchKey );
 
-    /** For a backend that keeps a kind's data in its own arrays (D3D12 resolves every buffer view and
-        bindless index at build time) the queue only has to carry two indices into those. Read back
-        with GetIndices; the typed getters above do not apply to items added this way. */
+    /** For backends keeping a kind's data in their own arrays (D3D12). Read back with GetIndices;
+        the typed getters do not apply to items added this way. */
     void AddIndexed( float distanceSq, ETransparentKind kind, uint8_t subKind,
         uint32_t index0, uint32_t index1, uint32_t batchKey );
 
@@ -95,17 +81,16 @@ public:
     void AddQuadMark( float distanceSq, zCQuadMark* mark, const QuadMarkInfo* info );
     void AddPolyStrip( float distanceSq, zCTexture* texture, const PolyStripInfo* info );
 
-    /** Back-to-front by distance. With categoryMajor the kinds are kept apart and drawn in the
-        legacy pass order instead - the fallback the SortedTransparency setting selects, which
-        needs no second copy of the emitters. */
+    /** Back-to-front by distance. categoryMajor instead keeps the kinds apart in the legacy pass
+        order - the SortedTransparency=0 fallback, which needs no second copy of the emitters. */
     void Sort( bool categoryMajor );
 
     bool Empty() const { return Items.empty(); }
     size_t Size() const { return Items.size(); }
     std::span<const TransparentItem> GetItems() const { return Items; }
 
-    /** Calls emit(kind, subKind, span) for every maximal run of consecutive same-kind items.
-        Returns the number of runs - a run count approaching Size() means batching collapsed. */
+    /** emit(kind, subKind, span) per maximal same-kind run. Returns the run count; approaching
+        Size() means batching collapsed. */
     template<class F> size_t ForEachRun( F&& emit ) const {
         size_t runs = 0;
         for ( size_t i = 0; i < Items.size(); ) {

--- a/D3D11Engine/TransparencyQueue.h
+++ b/D3D11Engine/TransparencyQueue.h
@@ -1,0 +1,148 @@
+#pragma once
+#include "WorldObjects.h"
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+class zCVob;
+class zCQuadMark;
+class zCTexture;
+struct PolyStripInfo;
+
+/** Backend-neutral collection point for everything that gets drawn alpha-blended.
+
+    Before this existed every category of transparent geometry (world mesh sections, instanced
+    alpha VOBs, ghosts, decals, quad marks, poly strips) had its own render pass in a hard-coded
+    sequence, and each of them sorted - at best - only within itself. A cobweb therefore always
+    painted before a ghost and a ghost always before a glass window, no matter what stood in front
+    of what.
+
+    Producers now push their drawables in here during the frame; the transparency pass sorts the
+    whole set strictly back-to-front once and replays it. Batching survives because the emitters
+    draw maximal *consecutive* runs of the same kind in one go (see ForEachRun) - the same
+    painter's-order rule the decal path has always followed.
+
+    Only the small Items array is sorted; the payload vectors never move. Every vector is cleared
+    (never freed) per frame and reserved once, per the project's no-per-frame-allocation rule. */
+
+enum class ETransparentKind : uint8_t {
+    WorldMesh,      // world mesh section, SubKind = EWorldTransparencyVariant
+    AlphaVob,       // one instance of an instanced alpha-blended VOB batch
+    Ghost,          // fading/ghosted vob, index into GothicAPI::TransparencyVobs
+    Decal,          // unlit (blended) decal vob
+    QuadMark,       // blood / spell ground marks, all blend modes
+    PolyStrip,      // weapon trails, barrier lightning
+    Count
+};
+
+/** World transparency meshes all run through the same draw code - the pixel shader is picked from
+    MaterialInfo::MaterialType - but portals are gated behind a setting and are excluded from the
+    depth-only re-draw, so the variant has to survive the sort. */
+enum class EWorldTransparencyVariant : uint8_t {
+    Normal,
+    Portal,
+    Waterfall
+};
+
+struct TransparentItem {
+    float DistanceSq;               // camera -> representative world-space center
+    uint32_t BatchKey;              // material/texture derived, tie-break only: keeps batching intact
+    uint32_t PayloadIndex;          // index into the payload vector of this Kind
+    ETransparentKind Kind;
+    uint8_t SubKind;
+};
+
+struct TransparentWorldMesh {
+    MeshKey Key;
+    MeshInfo* Mesh;
+};
+
+/** Backend-neutral reference into the backend's own alpha-VOB batch array (D3D11: m_AlphaMeshes,
+    D3D12: its equivalent). Instances of one batch are contiguous in the instancing buffer, so
+    consecutive items of the same batch re-merge into a single instanced draw at emit time. */
+struct TransparentAlphaVob {
+    uint32_t BatchIndex;
+    uint32_t InstanceIndex;
+};
+
+struct TransparentQuadMark {
+    zCQuadMark* Mark;
+    const QuadMarkInfo* Info;
+};
+
+struct TransparentPolyStrip {
+    zCTexture* Texture;
+    const PolyStripInfo* Info;
+};
+
+class TransparencyQueue {
+public:
+    /** Drops last frame's contents, keeping all capacity. */
+    void BeginFrame();
+
+    void AddWorldMesh( float distanceSq, EWorldTransparencyVariant variant, const MeshKey& key, MeshInfo* mesh );
+    void AddAlphaVob( float distanceSq, uint32_t batchIndex, uint32_t instanceIndex, uint32_t batchKey );
+
+    /** For a backend that keeps a kind's data in its own arrays (D3D12 resolves every buffer view and
+        bindless index at build time) the queue only has to carry two indices into those. Read back
+        with GetIndices; the typed getters above do not apply to items added this way. */
+    void AddIndexed( float distanceSq, ETransparentKind kind, uint8_t subKind,
+        uint32_t index0, uint32_t index1, uint32_t batchKey );
+
+    void AddGhost( float distanceSq, uint32_t transparencyVobIndex );
+    void AddDecal( float distanceSq, zCVob* vob );
+    void AddQuadMark( float distanceSq, zCQuadMark* mark, const QuadMarkInfo* info );
+    void AddPolyStrip( float distanceSq, zCTexture* texture, const PolyStripInfo* info );
+
+    /** Back-to-front by distance. With categoryMajor the kinds are kept apart and drawn in the
+        legacy pass order instead - the fallback the SortedTransparency setting selects, which
+        needs no second copy of the emitters. */
+    void Sort( bool categoryMajor );
+
+    bool Empty() const { return Items.empty(); }
+    size_t Size() const { return Items.size(); }
+    std::span<const TransparentItem> GetItems() const { return Items; }
+
+    /** Calls emit(kind, subKind, span) for every maximal run of consecutive same-kind items.
+        Returns the number of runs - a run count approaching Size() means batching collapsed. */
+    template<class F> size_t ForEachRun( F&& emit ) const {
+        size_t runs = 0;
+        for ( size_t i = 0; i < Items.size(); ) {
+            const ETransparentKind kind = Items[i].Kind;
+            const uint8_t subKind = Items[i].SubKind;
+            size_t end = i + 1;
+            while ( end < Items.size() && Items[end].Kind == kind && Items[end].SubKind == subKind ) {
+                ++end;
+            }
+            emit( kind, subKind, std::span<const TransparentItem>( Items.data() + i, end - i ) );
+            ++runs;
+            i = end;
+        }
+        return runs;
+    }
+
+    const TransparentWorldMesh& GetWorldMesh( const TransparentItem& item ) const { return WorldMeshes[item.PayloadIndex]; }
+    const TransparentAlphaVob& GetAlphaVob( const TransparentItem& item ) const { return AlphaVobs[item.PayloadIndex]; }
+    const TransparentAlphaVob& GetIndices( const TransparentItem& item ) const { return AlphaVobs[item.PayloadIndex]; }
+    uint32_t GetGhostIndex( const TransparentItem& item ) const { return GhostIndices[item.PayloadIndex]; }
+    zCVob* GetDecal( const TransparentItem& item ) const { return Decals[item.PayloadIndex]; }
+    const TransparentQuadMark& GetQuadMark( const TransparentItem& item ) const { return QuadMarks[item.PayloadIndex]; }
+    const TransparentPolyStrip& GetPolyStrip( const TransparentItem& item ) const { return PolyStrips[item.PayloadIndex]; }
+
+    /** Squared distance from the camera to a point, the depth every producer sorts on. */
+    static float DistanceSqFromCamera( const XMFLOAT3& worldPosition );
+
+    /** Pointer-derived tie-break key. The game is 32-bit, so a pointer fits without folding. */
+    static uint32_t MakeBatchKey( const void* p ) { return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(p)); }
+
+private:
+    std::vector<TransparentItem> Items;
+
+    std::vector<TransparentWorldMesh> WorldMeshes;
+    std::vector<TransparentAlphaVob> AlphaVobs;
+    std::vector<uint32_t> GhostIndices;
+    std::vector<zCVob*> Decals;
+    std::vector<TransparentQuadMark> QuadMarks;
+    std::vector<TransparentPolyStrip> PolyStrips;
+};

--- a/D3D11Engine/zCSkyController_Outdoor.h
+++ b/D3D11Engine/zCSkyController_Outdoor.h
@@ -310,6 +310,24 @@ public:
         );
     }
 
+    /** ZenGin's zCSkyControler_Outdoor::GetBackgroundColorDef() — the `resultFogColor` member
+        (zSky_Outdoor.h:154). This is the sky/fog color the engine feeds the env-map stage:
+        `skyFogColor.GetIntensityFloat()` scales the env-map strength in zCRenderManager::BuildShader
+        (zRenderManager.cpp:703).
+
+        Offset_Color is that member: it lands exactly Offset_ResultFogScale + 0x20 in both games
+        (resultFogScale, heightFogMinY, heightFogMaxY, userFogFar(=Offset_FarZ), resultFogNear,
+        resultFogFar, resultFogSkyNear, resultFogSkyFar, resultFogColor), and the G1 branch of
+        GetOverrideColor() below already reads it as a zColor.
+
+        We deliberately take the *Def* variant, i.e. we ignore m_bOverrideColorFlag /
+        resultFogColorOverride. The override is a script-driven tint whose flag GD3D11 only models
+        properly on G2 (GetOverrideFlag() is hardcoded to 1 on G1), and the plain fog color is the
+        stable input the env sheen wants. */
+    zColor GetBackgroundColor() {
+        return *reinterpret_cast<zColor*>(THISPTR_OFFSET( GothicMemoryLocations::zCSkyController_Outdoor::Offset_Color ));
+    }
+
     XMFLOAT3 GetOverrideColor() {
 #ifndef BUILD_GOTHIC_1_08k
         return *reinterpret_cast<XMFLOAT3*>(THISPTR_OFFSET( GothicMemoryLocations::zCSkyController_Outdoor::Offset_OverrideColor ));


### PR DESCRIPTION
- Transparency is now no longer rendered by category, instead its always rendered back to front across all categories. Which is more expensive but also more correct.
  - fixes bug where particle FX and other transparent effects were broken if a big transparent (like a world-mesh barrier) effect was around them.
- Implements missing Environmental Map feature from dx7: some "Env mapped" meshes will now reflect our worlds cubemap.