### PR TITLE
fix SpacerNET compat for G2, make TexturePool/DepthStencilPool hand out hand crafted RAII handles instead of relying on std::unique_ptr<,Deleter>

### DIFF
--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -1356,6 +1356,7 @@
     <ClCompile Include="D3D12Engine\D3D12VobArena.cpp" />
     <ClCompile Include="include\meshoptimizer\src\simplifier.cpp" />
     <ClCompile Include="MorphGpu.cpp" />
+    <ClCompile Include="D3D12Engine\D3D12Fsr3.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ddraw.def">

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -9708,6 +9708,20 @@ XRESULT D3D11GraphicsEngine::OnVobRemovedFromWorld( zCVob* vob ) {
         }
     }
 
+    if ( auto vobLight = vob->As<zCVobLight>() ) {
+        auto found = Engine::GAPI->VobLightMap.find( vobLight );
+    }
+
+    LogInfo() << "OnVobRemovedFromWorld: " << vob->GetName() << " (" << std::hex << reinterpret_cast<DWORD>(vob) << ")";
+    // Spacer can delete/undo a light vob mid-frame.
+    // TODO(diagnostic, remove once root-caused): log whenever this actually removes something, so a
+    // crash log tells us whether this scrub path is even reached before the D3D11ShadowMap dynamic_cast
+    // crash, or whether the removal is happening through a path that never calls OnVobRemovedFromWorld.
+    if ( size_t removed = std::erase_if( m_FrameLights, [vob]( VobLightInfo* li ) { return li->Vob == vob; } ) ) {
+        LogWarn() << "D3D11GraphicsEngine::OnVobRemovedFromWorld: scrubbed " << removed
+            << " stale light(s) from m_FrameLights mid-frame (vob=" << vob << ")";
+    }
+
     DebugPointlight = nullptr;
 
     return XR_SUCCESS;

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -604,6 +604,19 @@ void D3D11PointLight::StartReInit() {
     }
 
     if ( !DynamicLight ) {
+        // cancel() only sets the stop flag for a job that hasn't started reading it yet - it can't
+        // interrupt one that's already inside InitResources(). If that job is still running when we
+        // get called again (e.g. AcquireShadowMap re-evaluating resolution every frame, or a nearby
+        // vob move invalidating the cache again before the previous refresh landed), enqueuing another
+        // one here would race a second InitResources() against the first on the same WorldMeshCache/
+        // VobCache/SkeletalVobCache vectors - unsynchronized concurrent mutation, real heap corruption,
+        // not just staleness. Let the in-flight job finish; WorldCacheInvalid stays true until it does,
+        // so the next StartReInit() call (from wherever) will pick up the invalidation then.
+        if ( m_PendingInit.future.valid()
+            && m_PendingInit.future.wait_for( std::chrono::seconds( 0 ) ) != std::future_status::ready ) {
+            return;
+        }
+
         InitDone = false;
 
         // Add to queue

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -959,7 +959,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
         }
         // Create shadowmap in case we should have one but haven't got it yet
         if ( !light->LightShadowBuffers && light->UpdateShadows ) {
-            BaseShadowedPointLight* bpl;
+            BaseShadowedPointLight* bpl = nullptr;
             // assume this is a dynamic light
             graphicsEngine->CreateShadowedPointLight( &bpl, light, /*dynamic light*/ true );
             light->LightShadowBuffers.reset(bpl);

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -2154,7 +2154,7 @@ static void EraseVobFromLeafList( std::vector<LeafVobEntry>& list, const VobInfo
 }
 
 /** Called when a VOB got removed from the world */
-void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world ) {
+void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world, bool tearDownLight ) {
     //LogInfo() << "Removing vob: " << vob;
 
     // Symmetric to the OnAddVob side: an inventory preview vob never entered the engine's world-scoped state, so
@@ -2206,7 +2206,9 @@ void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world ) {
     VobInfo* vi = VobMap[vob];
     SkeletalVobInfo* svi = SkeletalVobMap[vob];
 
-    // Tell all dynamic lights that we removed a vob they could have cached
+    // Tell all dynamic lights that we removed a vob they could have cached. This is about other
+    // lights' shadow-caster caches referencing vi/svi, not about `vob` itself being a light, so it
+    // always applies regardless of tearDownLight.
     for ( auto& vlit : VobLightMap ) {
         if ( vi && vlit.second->LightShadowBuffers )
             vlit.second->LightShadowBuffers->OnVobRemovedFromWorld( vi );
@@ -2215,7 +2217,12 @@ void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world ) {
             vlit.second->LightShadowBuffers->OnVobRemovedFromWorld( svi );
     }
 
-    VobLightInfo* li = VobLightMap[static_cast<zCVobLight*>(vob)];
+    // A disabled zCVobLight keeps its slot in the BSP leaf's LightVobList (that array mirrors the
+    // world's static light layout, not enabled state) and can be re-enabled with the same zCVob*.
+    // Tearing its VobLightInfo down here would delete state that CollectLeafVobs' mirror
+    // (base->Lights) and VobLightMap still expect to find, and that the vob's own IsEnabled() check
+    // is what's supposed to filter out of rendering - not us deleting and recreating it every toggle.
+    VobLightInfo* li = tearDownLight ? VobLightMap[static_cast<zCVobLight*>(vob)] : nullptr;
 
     // Erase it from the particle-effect list
     auto pit = std::ranges::find(ParticleEffectVobs, vob );
@@ -2230,8 +2237,10 @@ void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world ) {
         DecalVobs.pop_back();
     }
 
-    // Erase it from the list of lights
-    VobLightMap.erase( static_cast<zCVobLight*>(vob) );
+    // Erase it from the list of lights - only on a real removal (see tearDownLight comment above).
+    if ( tearDownLight ) {
+        VobLightMap.erase( static_cast<zCVobLight*>(vob) );
+    }
 
     // Remove from BSP-Cache
     std::vector<BspInfo*>* nodes = nullptr;
@@ -2339,7 +2348,7 @@ void GothicAPI::OnSetVisual( zCVob* vob ) {
             }
         }
         // This one is already there. Re-Add it!
-        OnRemovedVob( vob, vob->GetHomeWorld() );
+        OnRemovedVob( vob, vob->GetHomeWorld(), /*tearDownLight:*/ false);
     }
 
     OnAddVob( vob, vob->GetHomeWorld() );
@@ -5156,7 +5165,7 @@ void GothicAPI::BuildBspVobMapCacheHelper( zCBspBase* base ) {
                 if ( RendererState.RendererSettings.EnablePointlightShadows >= GothicRendererSettings::PLS_STATIC_ONLY
                     && vi->Vob->GetLightRange() > minDynamicUpdateLightRange ) {
                     // Create shadowcubemap, if wanted
-                    BaseShadowedPointLight* bpl;
+                    BaseShadowedPointLight* bpl = nullptr;
                     Engine::GraphicsEngine->CreateShadowedPointLight( &bpl, vi );
                     vi->LightShadowBuffers.reset(bpl);
                 }
@@ -6936,7 +6945,7 @@ static void CollectLeafVobs(
 
                     // Create shadow-buffers for these lights since it was dynamically added to the world
                     if ( !nvi->IsPFXVobLight && rendererSettings.EnablePointlightShadows >= GothicRendererSettings::PLS_STATIC_ONLY ) {
-                        BaseShadowedPointLight* bpl;
+                        BaseShadowedPointLight* bpl = nullptr;
                         Engine::GraphicsEngine->CreateShadowedPointLight( &bpl, nvi, true ); // Also flag as dynamic
                         nvi->LightShadowBuffers.reset(bpl);
                     }

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -402,8 +402,12 @@ public:
     /** Called when a VOB got added to the BSP-Tree or the world */
     void OnAddVob( zCVob* vob, zCWorld* world );
 
-    /** Called when a VOB got removed from the world */
-    void OnRemovedVob( zCVob* vob, zCWorld* world );
+    /** Called when a VOB got removed from the world. tearDownLight=false is for vobs that are merely
+        being hidden (zCVobLight can be enabled/disabled at will, reusing the same zCVob* both times)
+        rather than actually destroyed - the light's VobLightInfo/shadow buffers must survive that, since
+        light collection expects them to persist and relies on zCVobLight::IsEnabled() to filter hidden
+        lights out of rendering, not on the VobLightInfo being torn down and recreated every toggle. */
+    void OnRemovedVob( zCVob* vob, zCWorld* world, bool tearDownLight = true );
 
     /** Called on a SetVisual-Call of a vob */
     void OnSetVisual( zCVob* vob );

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -646,6 +646,7 @@ struct GothicMemoryLocations {
         static const unsigned int oCVisualFX = 0x008AF438;
         static const unsigned int oCMobInter = 0;
         static const unsigned int oCMOB = 0;
+        static const unsigned int zCVobLight = 0;
     };
 
     struct oCInformationManager

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -566,6 +566,7 @@ struct GothicMemoryLocations {
         static const unsigned int zCTexture = 0x00B18D18;
         static const unsigned int oCMobInter = 0;
         static const unsigned int oCMOB = 0;
+        static const unsigned int zCVobLight = 0;
     };
 
     struct oCItemContainer {

--- a/D3D11Engine/TexturePool.h
+++ b/D3D11Engine/TexturePool.h
@@ -9,11 +9,6 @@
 
 using Microsoft::WRL::ComPtr;
 
-namespace {
-    using TextureHandle = std::unique_ptr<RenderToTextureBuffer, std::function<void( RenderToTextureBuffer* )>>;
-    using DepthStencilHandle = std::unique_ptr<RenderToDepthStencilBuffer, std::function<void( RenderToDepthStencilBuffer* )>>;
-}
-
 class TexturePool {
 public:
     struct Description {
@@ -29,14 +24,47 @@ public:
                 && textureFlags == other.textureFlags;
         }
     };
-
-private:
     struct PooledTexture {
         std::shared_ptr<RenderToTextureBuffer> Texture;
         Description Desc;
         uint64_t LastFrameUsed;
         bool InUse;
     };
+
+    // RAII handle: releasing it just clears the pooled entry's InUse flag rather than
+    // destroying the resource, so "returning" a texture to the pool is O(1) and allocation-free.
+    class Handle {
+    public:
+        Handle() noexcept = default;
+        Handle( std::nullptr_t ) noexcept {}
+        explicit Handle( PooledTexture* entry ) noexcept : m_entry( entry ) {}
+        Handle( const Handle& ) = delete;
+        Handle& operator=( const Handle& ) = delete;
+        Handle( Handle&& other ) noexcept : m_entry( other.m_entry ) { other.m_entry = nullptr; }
+        Handle& operator=( Handle&& other ) noexcept {
+            if ( this != &other ) {
+                Release();
+                m_entry = other.m_entry;
+                other.m_entry = nullptr;
+            }
+            return *this;
+        }
+        ~Handle() { Release(); }
+
+        RenderToTextureBuffer* operator->() const { return m_entry->Texture.get(); }
+        RenderToTextureBuffer& operator*() const { return *m_entry->Texture; }
+        RenderToTextureBuffer* get() const { return m_entry ? m_entry->Texture.get() : nullptr; }
+        explicit operator bool() const { return m_entry != nullptr; }
+        friend bool operator==( const Handle& h, std::nullptr_t ) { return h.m_entry == nullptr; }
+        friend bool operator!=( const Handle& h, std::nullptr_t ) { return h.m_entry != nullptr; }
+        void reset() { Release(); m_entry = nullptr; }
+
+    private:
+        void Release() { if ( m_entry ) m_entry->InUse = false; }
+        PooledTexture* m_entry = nullptr;
+    };
+
+private:
 
     ID3D11Device* m_device;
     std::vector<std::unique_ptr<PooledTexture>> m_pool;
@@ -46,10 +74,7 @@ private:
 public:
     TexturePool( ID3D11Device* device ) : m_device( device ) {}
 
-    // The RAII handle the user holds
-    // using TextureHandle = std::unique_ptr<RenderToTextureBuffer, std::function<void( RenderToTextureBuffer* )>>;
-
-    TextureHandle Acquire( const Description& desc ) {
+    Handle Acquire( const Description& desc ) {
         PooledTexture* found = nullptr;
 
         for ( auto& entry : m_pool ) {
@@ -76,10 +101,8 @@ public:
         found->InUse = true;
         found->LastFrameUsed = m_currentFrame;
 
-        // Return RAII handle with custom deleter to "return" to pool
-        return TextureHandle( found->Texture.get(), [found]( RenderToTextureBuffer* ) {
-            found->InUse = false;
-        } );
+        // Return RAII handle; releasing it just clears InUse, the pooled entry stays alive
+        return Handle( found );
     }
 
     void GiveTick() {
@@ -103,6 +126,8 @@ public:
     }
 };
 
+using TextureHandle = TexturePool::Handle;
+
 
 class DepthStencilPool {
 public:
@@ -124,13 +149,47 @@ public:
         }
     };
 
-private:
     struct PooledDepthStencil {
         std::shared_ptr<RenderToDepthStencilBuffer> Buffer;
         Description Desc;
         uint64_t LastFrameUsed;
         bool InUse;
     };
+
+    // RAII handle: releasing it just clears the pooled entry's InUse flag rather than
+    // destroying the resource, so "returning" a buffer to the pool is O(1) and allocation-free.
+    class Handle {
+    public:
+        Handle() noexcept = default;
+        Handle( std::nullptr_t ) noexcept {}
+        explicit Handle( PooledDepthStencil* entry ) noexcept : m_entry( entry ) {}
+        Handle( const Handle& ) = delete;
+        Handle& operator=( const Handle& ) = delete;
+        Handle( Handle&& other ) noexcept : m_entry( other.m_entry ) { other.m_entry = nullptr; }
+        Handle& operator=( Handle&& other ) noexcept {
+            if ( this != &other ) {
+                Release();
+                m_entry = other.m_entry;
+                other.m_entry = nullptr;
+            }
+            return *this;
+        }
+        ~Handle() { Release(); }
+
+        RenderToDepthStencilBuffer* operator->() const { return m_entry->Buffer.get(); }
+        RenderToDepthStencilBuffer& operator*() const { return *m_entry->Buffer; }
+        RenderToDepthStencilBuffer* get() const { return m_entry ? m_entry->Buffer.get() : nullptr; }
+        explicit operator bool() const { return m_entry != nullptr; }
+        friend bool operator==( const Handle& h, std::nullptr_t ) { return h.m_entry == nullptr; }
+        friend bool operator!=( const Handle& h, std::nullptr_t ) { return h.m_entry != nullptr; }
+        void reset() { Release(); m_entry = nullptr; }
+
+    private:
+        void Release() { if ( m_entry ) m_entry->InUse = false; }
+        PooledDepthStencil* m_entry = nullptr;
+    };
+
+private:
 
     ID3D11Device* m_device;
     std::vector<std::unique_ptr<PooledDepthStencil>> m_pool;
@@ -140,7 +199,7 @@ private:
 public:
     DepthStencilPool( ID3D11Device* device ) : m_device( device ) {}
 
-    DepthStencilHandle Acquire( const Description& desc ) {
+    Handle Acquire( const Description& desc ) {
         PooledDepthStencil* found = nullptr;
 
         for ( auto& entry : m_pool ) {
@@ -179,10 +238,8 @@ public:
         found->InUse = true;
         found->LastFrameUsed = m_currentFrame;
 
-        // Return RAII handle with custom deleter to "return" to pool
-        return DepthStencilHandle( found->Buffer.get(), [found]( RenderToDepthStencilBuffer* ) {
-            found->InUse = false;
-        } );
+        // Return RAII handle; releasing it just clears InUse, the pooled entry stays alive
+        return Handle( found );
     }
 
     void GiveTick() {
@@ -257,3 +314,5 @@ public:
         return count;
     }
 };
+
+using DepthStencilHandle = DepthStencilPool::Handle;

--- a/D3D11Engine/zCVobLight.h
+++ b/D3D11Engine/zCVobLight.h
@@ -3,6 +3,9 @@
 
 class zCVobLight : public zCVob {
 public:
+    static const zCClassDef* GetStaticClassDef() {
+        return reinterpret_cast<const zCClassDef*>(GothicMemoryLocations::zCClassDef::zCVobLight);
+    }
 
     struct LightInfoFlags {
         uint8_t isStatic : 1;

--- a/D3D11Engine/zCWorld.h
+++ b/D3D11Engine/zCWorld.h
@@ -77,8 +77,9 @@ public:
     static void __fastcall hooked_oCWorldDisableVob( zCWorld* thisptr, void* unknwn, zCVob* vob ) {
         hook_infunc
 
-            // Remove it
-            Engine::GAPI->OnRemovedVob( vob, thisptr );
+            // Disable is a temporary hide, not destruction - the same zCVob* can come back via
+            // oCWorldEnableVob, so don't tear down its VobLightInfo/shadow buffers (tearDownLight=false).
+            Engine::GAPI->OnRemovedVob( vob, thisptr, /*tearDownLight*/ false );
 
         hook_outfunc
             

--- a/D3D11Engine/zCWorld.h
+++ b/D3D11Engine/zCWorld.h
@@ -188,7 +188,12 @@ public:
         }
     }
 
-    static void __fastcall hooked_Render( zCWorld* thisptr, void* unknwn, zCCamera& camera ) {
+    static void __fastcall hooked_Render( zCWorld* thisptr, void* unknwn, zCCamera* cam ) {
+        if ( cam == nullptr ) {
+            return;
+        }
+        auto& camera = *cam;
+
         if ( thisptr != Engine::GAPI->GetLoadedWorldInfo()->MainWorld ) {
             // Inventory. ZenGin draws every single item slot by spinning up a throwaway pseudo-world and running
             // a *full* zCWorld::Render on it (oCItem::RenderItem: zNEW camvob -> AddVob -> Render -> RemoveVobSubtree),


### PR DESCRIPTION
- Fixes crashes in Spacer.NET
  - nullptr zCCamera on world render
  - OnVobRemoved/OnVobAdded in SetVisual causing VobLightInfo to be prematurely deleted.
- reduce mid-frame memory allocations a tiny bit by handing out RAII handles instead of std::unique_ptr