### PR TITLE
feat: lighting for quadmarks

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -9170,6 +9170,47 @@ void D3D11GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> item
     SetupVS_ExMeshDrawCall();
     SetupVS_ExConstantBuffer();
 
+    // Real sun+CSM-shadow+clustered-point-light shading needs the same light/shadow data the
+    // tiled-deferred and Forward+ renderers produce; fall back to the flat day-factor shader when
+    // that path isn't active (legacy per-pixel deferred point lights are out of scope here).
+    const bool useTiledLighting = !FeatureLevel10Compatibility &&
+        Engine::GAPI->GetRendererState().RendererSettings.EnableTiledLighting;
+    D3D11TiledDeferredShading* tiledDeferred = useTiledLighting ? ShadowMaps->GetTiledDeferred() : nullptr;
+    const PShaderID litShader = tiledDeferred ? PShaderID::PS_QuadMarkLitFP : PShaderID::PS_QuadMarkLit;
+
+    if ( tiledDeferred ) {
+        GSky* sky = Engine::GAPI->GetSky();
+        auto atmoCB = sky->GetAtmosphereCB();
+        BindDynamicCBToPixelShader( 1, AllocateDynamicCB( &atmoCB, sizeof( atmoCB ) ) );
+
+        DS_ScreenQuadConstantBuffer scb = ShadowMaps->FillSunCSMConstantBuffer();
+        BindDynamicCBToPixelShader( 4, AllocateDynamicCB( &scb, sizeof( scb ) ) );
+
+        auto res = GetResolution();
+        ForwardPlusTileConstantBuffer tileCB = {};
+        tileCB.ViewportSize = float2( static_cast<float>( res.x ), static_cast<float>( res.y ) );
+        tileCB.NumTilesX = ( static_cast<uint32_t>( res.x ) + 15 ) / 16;
+        tileCB.LimitLightIntensity = Engine::GAPI->GetRendererState().RendererSettings.LimitLightIntesity ? 1u : 0u;
+        tileCB.ClusterNearZ = Engine::GAPI->GetNearPlane();
+        tileCB.ClusterFarZ = std::max( CLUSTER_MIN_FAR_Z, Engine::GAPI->GetRendererState().RendererSettings.VisualFXDrawRadius );
+        BindDynamicCBToPixelShader( 5, AllocateDynamicCB( &tileCB, sizeof( tileCB ) ) );
+
+        ShadowMaps->BindToPixelShader( GetContext().Get(), 3 );
+        ShadowMaps->BindSampler( GetContext().Get(), 2 );
+        GetBlueNoiseTexture()->BindToPixelShader( 6 );
+
+        ID3D11ShaderResourceView* lightSRVs[4] = {
+            tiledDeferred->GetLightBufferSRV(),
+            tiledDeferred->GetLightGridSRV(),
+            nullptr,
+            tiledDeferred->IsShadowArrayCreated() ? tiledDeferred->GetShadowCubeArraySRV() : nullptr,
+        };
+        GetContext()->PSSetShaderResources( 8, 4, lightSRVs );
+        ID3D11ShaderResourceView* dynCubeSRV = tiledDeferred->IsDynShadowArrayCreated()
+            ? tiledDeferred->GetShadowDynCubeArraySRV() : nullptr;
+        GetContext()->PSSetShaderResources( 14, 1, &dynCubeSRV );
+    }
+
     int lastAlphaFunc = -1;
     for ( auto const& item : items ) {
         const TransparentQuadMark& quadMark = queue.GetQuadMark( item );
@@ -9189,17 +9230,19 @@ void D3D11GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> item
         if ( lastAlphaFunc != alphaFunc ) {
             auto& state = Engine::GAPI->GetRendererState();
 
-            // MUL/MUL2 are unlit (PS_Simple), everything else lit (PS_QuadMarkLit)
+            // MUL/MUL2 are unlit (PS_Simple), everything else lit (litShader)
             const bool modulate = (alphaFunc == zMAT_ALPHA_FUNC_MUL || alphaFunc == zMAT_ALPHA_FUNC_MUL2);
-            SetActivePixelShader( modulate ? PShaderID::PS_Simple : PShaderID::PS_QuadMarkLit );
+            SetActivePixelShader( modulate ? PShaderID::PS_Simple : litShader );
             BindActivePixelShader();
 
             if ( !modulate ) {
                 ActivePS->UpdateBuffer( "FFPipelineConstantBuffer", &state.GraphicsState, sizeof( state.GraphicsState ) );
 
-                const float skyLight = Engine::GAPI->GetSkyDayFactor();
-                const float4 quadMarkLight( skyLight, skyLight, skyLight, 0.0f );
-                ActivePS->UpdateBuffer( "QuadMarkLightCB", &quadMarkLight, sizeof( quadMarkLight ) );
+                if ( !tiledDeferred ) {
+                    const float skyLight = Engine::GAPI->GetSkyDayFactor();
+                    const float4 quadMarkLight( skyLight, skyLight, skyLight, 0.0f );
+                    ActivePS->UpdateBuffer( "QuadMarkLightCB", &quadMarkLight, sizeof( quadMarkLight ) );
+                }
             }
 
             switch ( alphaFunc ) {
@@ -9243,6 +9286,13 @@ void D3D11GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> item
         SetupVS_ExPerInstanceConstantBuffer();
 
         DrawVertexBuffer( quadMark.Info->Mesh.get(), quadMark.Info->NumVertices );
+    }
+
+    if ( tiledDeferred ) {
+        GetContext()->PSSetShaderResources( 3, 1, s_nullSRVs );
+        GetContext()->PSSetShaderResources( 6, 1, s_nullSRVs );
+        GetContext()->PSSetShaderResources( 8, 4, s_nullSRVs );
+        GetContext()->PSSetShaderResources( 14, 1, s_nullSRVs );
     }
 }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -9189,13 +9189,17 @@ void D3D11GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> item
         if ( lastAlphaFunc != alphaFunc ) {
             auto& state = Engine::GAPI->GetRendererState();
 
-            // MUL/MUL2 are unlit (PS_Simple), everything else lit (PS_World)
+            // MUL/MUL2 are unlit (PS_Simple), everything else lit (PS_QuadMarkLit)
             const bool modulate = (alphaFunc == zMAT_ALPHA_FUNC_MUL || alphaFunc == zMAT_ALPHA_FUNC_MUL2);
-            SetActivePixelShader( modulate ? PShaderID::PS_Simple : PShaderID::PS_World );
+            SetActivePixelShader( modulate ? PShaderID::PS_Simple : PShaderID::PS_QuadMarkLit );
             BindActivePixelShader();
 
             if ( !modulate ) {
                 ActivePS->UpdateBuffer( "FFPipelineConstantBuffer", &state.GraphicsState, sizeof( state.GraphicsState ) );
+
+                const float skyLight = Engine::GAPI->GetSkyDayFactor();
+                const float4 quadMarkLight( skyLight, skyLight, skyLight, 0.0f );
+                ActivePS->UpdateBuffer( "QuadMarkLightCB", &quadMarkLight, sizeof( quadMarkLight ) );
             }
 
             switch ( alphaFunc ) {

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -832,7 +832,7 @@ struct GothicRendererSettings {
         EnablePointlightShadows = PLS_UPDATE_DYNAMIC;
         MinLightShadowUpdateRange = 300.0f;
         PartialDynamicShadowUpdates = true;
-        EnableTiledLighting = false;
+        EnableTiledLighting = true;
         RendererMode = RM_Deferred;
         GraphicsAPI = GRAPHICS_API_D3D11;
         MSAASamples = 1;

--- a/D3D11Engine/ShaderIDs.h
+++ b/D3D11Engine/ShaderIDs.h
@@ -50,6 +50,7 @@ enum class PShaderID : size_t {
     PS_TransparencySkel,
     PS_World,
     PS_World_NoMV,
+    PS_QuadMarkLit,
     PS_Water,
     PS_ParticleDistortion,
     PS_PFX_ApplyParticleDistortion,

--- a/D3D11Engine/ShaderIDs.h
+++ b/D3D11Engine/ShaderIDs.h
@@ -51,6 +51,7 @@ enum class PShaderID : size_t {
     PS_World,
     PS_World_NoMV,
     PS_QuadMarkLit,
+    PS_QuadMarkLitFP,
     PS_Water,
     PS_ParticleDistortion,
     PS_PFX_ApplyParticleDistortion,

--- a/D3D11Engine/ShaderRegistry.cpp
+++ b/D3D11Engine/ShaderRegistry.cpp
@@ -148,6 +148,10 @@ void ShaderRegistry::Build() {
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_World>( "PS_World.hlsl" ).with_macros({ {"MOTION_VECTORS", "1"}})  );
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_World_NoMV>( "PS_World.hlsl" )  );
 
+    // Lit quad marks (blood/ground decals): modulates by baked per-vertex static light instead of
+    // PS_World's unlit deferred-fill output. See PS_QuadMarkLit.hlsl for why.
+    Shaders.push_back( ShaderInfo::make<PShaderID::PS_QuadMarkLit>( "PS_QuadMarkLit.hlsl" )  );
+
 
     Shaders.push_back( ShaderInfo::make<PShaderID::PS_Water>( "PS_Water.hlsl" )
         .with_macros( []( std::vector<D3D_SHADER_MACRO>& list ) {

--- a/D3D11Engine/ShaderRegistry.cpp
+++ b/D3D11Engine/ShaderRegistry.cpp
@@ -453,6 +453,13 @@ void ShaderRegistry::Build() {
         // Optional Forward+ smooth-normals-from-depth pass (feeds SAO/ASSAO AO producers)
         Shaders.push_back( ShaderInfo::make<CShaderID::CS_GenerateNormalsFromDepth>( "CS_GenerateNormalsFromDepth.hlsl" ));
 
+        // Lit quad marks (blood/ground decals) using the same clustered light data as the Forward+/
+        // tiled-deferred renderers. See DrawQuadMarkRun for the flat-shaded fallback used when tiled
+        // lighting isn't active.
+        Shaders.push_back( ShaderInfo::make<PShaderID::PS_QuadMarkLitFP>( "PS_QuadMarkLitFP.hlsl" )
+            .with_macros( shadowMacroBuilder )
+            .with_category( ShaderCategory::LightsAndShadows ) );
+
         // Forward+ pixel shader variants
         Shaders.push_back( ShaderInfo::make<PShaderID::PS_FP_Diffuse>( "PS_Diffuse.hlsl" )
             .with_macros(shadowMacroBuilder)

--- a/D3D11Engine/Shaders/PS_QuadMarkLit.hlsl
+++ b/D3D11Engine/Shaders/PS_QuadMarkLit.hlsl
@@ -1,0 +1,35 @@
+// Lit quad marks (blood splats, ground marks). Unlike PS_World this isn't a G-buffer fill
+// shader - it writes straight to the already-lit back buffer, so it applies the day/night
+// factor itself instead of vertex color (always (0,0,0,1) for these procedural decal polys).
+#include <FFFog.h>
+
+// b0 is FFPipelineConstantBuffer, pulled in above for DoAlphaTest.
+cbuffer QuadMarkLightCB : register( b1 )
+{
+	float3 QM_DayLight;
+	float QM_Pad;
+}
+
+SamplerState SS_Linear : register( s0 );
+Texture2D	TX_Texture0 : register( t0 );
+
+struct PS_INPUT
+{
+	float2 vTexcoord		: TEXCOORD0;
+	float2 vTexcoord2		: TEXCOORD1;
+	float4 vDiffuse			: TEXCOORD2;
+	float3 vNormalVS		: TEXCOORD4;
+	float3 vViewPosition	: TEXCOORD5;
+	float4 vCurrClipPos     : TEXCOORD6;
+	float4 vPrevClipPos     : TEXCOORD7;
+	float4 vTangent			: TEXCOORD3;
+	float4 vPosition		: SV_POSITION;
+};
+
+float4 PSMain( PS_INPUT Input ) : SV_TARGET
+{
+	float4 color = TX_Texture0.Sample(SS_Linear, Input.vTexcoord);
+	DoAlphaTest(color.a);
+	color.rgb *= QM_DayLight;
+	return color;
+}

--- a/D3D11Engine/Shaders/PS_QuadMarkLitFP.hlsl
+++ b/D3D11Engine/Shaders/PS_QuadMarkLitFP.hlsl
@@ -1,0 +1,58 @@
+// Real sun+CSM-shadow+clustered-point-light shading for lit quad marks (blood splats, ground
+// marks), using the same tiled-deferred/Forward+ light data the main scene renderers consume.
+// Falls back to PS_QuadMarkLit (flat day/night factor) when tiled lighting isn't active; see
+// DrawQuadMarkRun.
+#include <AtmosphericScattering.h>
+#include <FFFog.h>
+
+SamplerState SS_Linear : register( s0 );
+Texture2D	TX_Texture0 : register( t0 );
+
+// Must come after SS_Linear: FP_SS_Linear is a macro alias to it, used by headers pulled in below.
+#include <include/ForwardPlusLighting.hlsl>
+
+struct PS_INPUT
+{
+	float2 vTexcoord		: TEXCOORD0;
+	float2 vTexcoord2		: TEXCOORD1;
+	float4 vDiffuse			: TEXCOORD2;
+	float3 vNormalVS		: TEXCOORD4;
+	float3 vViewPosition	: TEXCOORD5;
+	float4 vCurrClipPos     : TEXCOORD6;
+	float4 vPrevClipPos     : TEXCOORD7;
+	float4 vTangent			: TEXCOORD3;
+	float4 vPosition		: SV_POSITION;
+};
+
+float4 PSMain( PS_INPUT Input ) : SV_TARGET
+{
+	float4 color = TX_Texture0.Sample(SS_Linear, Input.vTexcoord);
+	DoAlphaTest(color.a);
+
+	float3 normal = normalize(Input.vNormalVS);
+	float3 wsPosition = mul(float4(Input.vViewPosition, 1), SQ_InvView).xyz;
+	float3 wsNormal = normalize(mul(float4(normal, 0), SQ_InvView).xyz);
+
+	float shadow = 1.0f;
+#if SHD_ENABLE
+	if (AC_LightPos.y > 0)
+	{
+		float shadowNoL = saturate(dot(wsNormal, SQ_LightDirectionWS));
+		float slopeScale = sqrt(saturate(1.0f - shadowNoL * shadowNoL));
+		shadow = ComputeCascadedShadowValueSoft(wsPosition, wsNormal, slopeScale,
+			Input.vViewPosition.z, 1.0f, 0.000003f, Input.vPosition.xy);
+	}
+	else
+	{
+		shadow = saturate(wsNormal.y); // night sky ambient, matches PS_Diffuse's Forward+ branch
+	}
+#endif
+
+	float3 litPixel = FP_ComputeSunLighting(wsPosition, Input.vViewPosition, normal,
+		color.rgb, 0.0f, 1.0f, shadow, 1.0f, 1.0f);
+	litPixel = ApplyAtmosphericScatteringGround(wsPosition, litPixel);
+	litPixel += FP_ComputePointLighting(wsPosition, Input.vViewPosition, normal,
+		color.rgb, 0.0f, 1.0f, Input.vPosition.xy);
+
+	return float4(litPixel, color.a);
+}


### PR DESCRIPTION
quadmarks now get lit using a forward+ shading path.
This includes light/shadow from sun and light/shadow from pointlights.

Default Lighting mode to Tiled lighting (actually clustered lighting, but who cares)

If Enable tiled lighting is false, only basic day/night cycle lighting is applied.


All in all this means, blood decals will be darker at night or when shadowed, and will be brighter when hit by light.

Before this change, blood was always at 100% brightness, no matter if day or night, sun or shadow.