### PR TITLE
perf(dx12): use `Enhanced Barriers`, fix PBR lighting math

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -214,7 +214,8 @@ struct DS_ScreenQuadConstantBuffer {
     // World-space sun direction, precomputed on CPU (== normalize(AC_LightPos)).
     // Avoids re-deriving it per-pixel via normalize(mul(SQ_LightDirectionVS, SQ_InvView)).
     float3 SQ_LightDirectionWS;
-    float SQ_Pad0;
+    // 0/1 toggle for the sun's specular highlight (GothicRendererSettings::SH_SUN); was unused padding.
+    float SQ_SunSpecularEnabled;
 
     float4 SQ_LightColor;
     

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -944,6 +944,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="D3D12Engine\D3D12ShaderBackend.h" />
     <ClInclude Include="D3D12Engine\D3D12StateCache.h" />
     <ClInclude Include="D3D12Engine\D3D12Barrier.h" />
+    <ClInclude Include="D3D12Engine\D3D12ResourceCreate.h" />
     <ClInclude Include="D3D12Engine\D3D12RenderQueue.h" />
     <ClInclude Include="D3D12Engine\D3D12ShadowMap.h" />
     <ClInclude Include="D3D12Engine\D3D12VobArena.h" />

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -943,6 +943,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="D3D12Engine\D3D12PipelineState.h" />
     <ClInclude Include="D3D12Engine\D3D12ShaderBackend.h" />
     <ClInclude Include="D3D12Engine\D3D12StateCache.h" />
+    <ClInclude Include="D3D12Engine\D3D12Barrier.h" />
     <ClInclude Include="D3D12Engine\D3D12RenderQueue.h" />
     <ClInclude Include="D3D12Engine\D3D12ShadowMap.h" />
     <ClInclude Include="D3D12Engine\D3D12VobArena.h" />
@@ -1247,6 +1248,21 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="ShaderRegistry.cpp" />
     <ClCompile Include="TransparencyQueue.cpp" />
     <ClCompile Include="D3D12Engine\D3D12Device.cpp">
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_12f|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12Barrier.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -930,6 +930,9 @@
     <ClInclude Include="D3D12Engine\D3D12Barrier.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
+    <ClInclude Include="D3D12Engine\D3D12ResourceCreate.h">
+      <Filter>Engine\D3D12</Filter>
+    </ClInclude>
     <ClInclude Include="D3D12Engine\InstancingUtils.h" />
     <ClInclude Include="D3D12Engine\D3D12RenderQueue.h">
       <Filter>Engine\D3D12</Filter>

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -927,6 +927,9 @@
     <ClInclude Include="D3D12Engine\D3D12StateCache.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
+    <ClInclude Include="D3D12Engine\D3D12Barrier.h">
+      <Filter>Engine\D3D12</Filter>
+    </ClInclude>
     <ClInclude Include="D3D12Engine\InstancingUtils.h" />
     <ClInclude Include="D3D12Engine\D3D12RenderQueue.h">
       <Filter>Engine\D3D12</Filter>
@@ -990,6 +993,9 @@
       <Filter>Engine</Filter>
     </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12Device.cpp">
+      <Filter>Engine\D3D12</Filter>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12Barrier.cpp">
       <Filter>Engine\D3D12</Filter>
     </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12GraphicsEngine.cpp">

--- a/D3D11Engine/D3D11LegacyDeferredShading.cpp
+++ b/D3D11Engine/D3D11LegacyDeferredShading.cpp
@@ -88,7 +88,7 @@ XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
         vob->DoAnimation();
 
         plcb.PL_Color = float4( vob->GetLightColor() );
-        plcb.PL_Color.w = vob->IsStatic() ? 0.0f : 1.0f;
+        plcb.PL_Color.w = settings.PointLightSpecularScale( vob->IsStatic() );
         plcb.PL_Range = vob->GetLightRange();
         plcb.Pl_PositionWorld = vob->GetPositionWorld();
         plcb.PL_Outdoor = light->IsIndoorVob ? 0.0f : 1.0f;

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1418,6 +1418,7 @@ DS_ScreenQuadConstantBuffer D3D11ShadowMap::FillSunCSMConstantBuffer() const {
         settings.RainSunLightStrength,
         std::min( 1.0f, rain * 2.0f ) );
     scb.SQ_LightColor = float4( sunColor.x, sunColor.y, sunColor.z, sunStrength );
+    scb.SQ_SunSpecularEnabled = ( settings.SpecularHighlightsFlags & GothicRendererSettings::SH_SUN ) ? 1.0f : 0.0f;
 
     for ( size_t cascadeIdx = 0; cascadeIdx < MAX_CSM_CASCADES; ++cascadeIdx ) {
         XMStoreFloat4x4( &scb.SQ_ShadowViewProj[cascadeIdx],
@@ -1560,6 +1561,7 @@ XRESULT D3D11ShadowMap::DrawWorldLights( ID3D11ShaderResourceView* aoMaskSRV )
     // matches more with the increasing fog-density
 
     scb.SQ_LightColor = float4( sunColor.x, sunColor.y, sunColor.z, sunStrength );
+    scb.SQ_SunSpecularEnabled = ( settings.SpecularHighlightsFlags & GothicRendererSettings::SH_SUN ) ? 1.0f : 0.0f;
 
     // CSM: Alle Cascade-Matrizen setzen
 

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -418,7 +418,8 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
         TiledPointLight& tl = lightData[result.TiledLightCount];
         tl.PositionView = posView;
         tl.Range = lightRange;
-        tl.Color = XMFLOAT4( lightColor.x, lightColor.y, lightColor.z, vob->IsStatic() ? 0.0f : 1.0f );
+        tl.Color = XMFLOAT4( lightColor.x, lightColor.y, lightColor.z,
+            settings.PointLightSpecularScale( vob->IsStatic() ) );
         tl.PositionWorld = XMFLOAT3( posWorld.x, posWorld.y, posWorld.z );
 
         if ( hasShadow ) {

--- a/D3D11Engine/D3D12Engine/D3D12AO.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12AO.cpp
@@ -18,6 +18,7 @@
 // snapshot scheme by accident of running a frame behind.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 
@@ -51,7 +52,7 @@ bool D3D12GraphicsEngine::CreateAOResources( INT2 size ) {
         dd.SampleDesc.Count = 1;
         dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
         dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-        if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+        if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             nullptr, outAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( out.ReleaseAndGetAddressOf() ) ) ) ) {
             LogWarn() << "D3D12: failed to create an SSAO texture (" << size.x << "x" << size.y << ").";
             return false;

--- a/D3D11Engine/D3D12Engine/D3D12AO.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12AO.cpp
@@ -165,17 +165,13 @@ void D3D12GraphicsEngine::RenderSSAO() {
 void D3D12GraphicsEngine::BeginAoDepthRead() {
     // The prepass left m_DepthBuffer in DEPTH_WRITE; the AO compute passes read it as an SRV. Same round-trip
     // BuildHiZ does a few calls earlier — the DSV stays bound but nothing draws while it is in a read state.
-    auto b = TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE,
-        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-    m_CmdList->ResourceBarrier( 1, &b );
+    m_CmdList->TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
 }
 
 void D3D12GraphicsEngine::EndAoDepthRead() {
     // Straight back to DEPTH_WRITE: the lit geometry passes right after this re-test (and re-write) depth, and
     // every later transition of this resource asserts DEPTH_WRITE as its "before" state.
-    auto b = TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-        D3D12_RESOURCE_STATE_DEPTH_WRITE );
-    m_CmdList->ResourceBarrier( 1, &b );
+    m_CmdList->TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE );
 }
 
 void D3D12GraphicsEngine::RenderSimpleSSAO() {
@@ -202,8 +198,7 @@ void D3D12GraphicsEngine::RenderSimpleSSAO() {
     // The AO mask rests in UNORDERED_ACCESS (its creation state) except right after a prior successful run,
     // which leaves it PIXEL_SHADER_RESOURCE for the lit passes.
     if ( m_AOMaskInPixelState ) {
-        auto b = TransitionBarrier( m_AOMask.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( m_AOMask.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
         m_AOMaskInPixelState = false;
     }
 
@@ -229,8 +224,7 @@ void D3D12GraphicsEngine::RenderSimpleSSAO() {
     // same reasoning as the bloom pyramid's UAV<->SRV round-trips). Both blur-pair slot 0 entries alias
     // m_AOMask/m_AOBlurTemp respectively, so transitioning the resource covers whichever pair reads it.
     {
-        auto b = TransitionBarrier( m_AOMask.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( m_AOMask.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
     }
 
     struct BlurCB {
@@ -249,11 +243,10 @@ void D3D12GraphicsEngine::RenderSimpleSSAO() {
         m_CmdList->Dispatch( gx, gy, 1 );
     }
     {
-        D3D12_RESOURCE_BARRIER b[2] = {
-            TransitionBarrier( m_AOBlurTemp.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE ),
-            TransitionBarrier( m_AOMask.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-        };
-        m_CmdList->ResourceBarrier( 2, b );
+        m_CmdList->TransitionBarriers( {
+        	{ m_AOBlurTemp.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE },
+        	{ m_AOMask.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        } );
     }
 
     // --- Blur pass 2 (vertical): m_AOBlurTemp -> m_AOMask (final) ---
@@ -271,11 +264,10 @@ void D3D12GraphicsEngine::RenderSimpleSSAO() {
     // assert an UNORDERED_ACCESS "before" state that doesn't match reality (GPU validation:
     // "RESOURCE_BARRIER_BEFORE_AFTER_MISMATCH" on AOBlurTemp).
     {
-        D3D12_RESOURCE_BARRIER b[2] = {
-            TransitionBarrier( m_AOMask.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE ),
-            TransitionBarrier( m_AOBlurTemp.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-        };
-        m_CmdList->ResourceBarrier( 2, b );
+        m_CmdList->TransitionBarriers( {
+        	{ m_AOMask.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
+        	{ m_AOBlurTemp.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        } );
     }
 
     EndAoDepthRead();

--- a/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
@@ -2,17 +2,17 @@
 #include "D3D12Barrier.h"
 #include "D3D12StateCache.h"
 #include "../Logger.h"
+#include <d3dx12_barriers.h>
 
 // Implements the D3D12CmdList barrier methods declared in D3D12StateCache.h. Legacy
-// D3D12_RESOURCE_STATES are the only thing any call site (present or future) has to think in;
-// everything past that point -- enhanced-barrier availability, the sync/access/layout translation,
-// buffer-vs-texture dispatch -- is handled internally and is invisible to the caller.
+// D3D12_RESOURCE_STATES are the only thing any call site has to think in; everything past that
+// point -- enhanced-barrier availability, the sync/access/layout translation, buffer-vs-texture
+// dispatch -- is handled internally and is invisible to the caller.
 //
-// FOUNDATION ONLY: nothing calls these methods yet (see D3D12Barrier.h). The state->(sync, access,
-// layout) mapping below is deliberately conservative where a legacy state doesn't map cleanly onto a
-// single enhanced-barrier concept -- broad sync scope, broad access -- because a barrier that is too
-// broad is merely slower, never wrong, and the precision that enhanced barriers make possible is a
-// per-call-site tuning exercise for the future migration, not this pass.
+// The state->(sync, access, layout) mapping below is deliberately conservative where a legacy state
+// doesn't map cleanly onto a single enhanced-barrier concept -- broad sync scope, broad access --
+// because a barrier that is too broad is merely slower, never wrong. Tightening individual call
+// sites' sync scopes is a follow-up tuning pass, not part of this migration.
 
 namespace {
 
@@ -102,16 +102,19 @@ namespace {
         return resource->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER;
     }
 
-    void LegacyTransition( ID3D12GraphicsCommandList* list, ID3D12Resource* resource,
-        D3D12_RESOURCE_STATES before, D3D12_RESOURCE_STATES after, UINT subresource ) {
-        D3D12_RESOURCE_BARRIER barrier = {};
-        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-        barrier.Transition.pResource = resource;
-        barrier.Transition.StateBefore = before;
-        barrier.Transition.StateAfter = after;
-        barrier.Transition.Subresource = subresource;
-        list->ResourceBarrier( 1, &barrier );
+    CD3DX12_BARRIER_SUBRESOURCE_RANGE SubresourceRange( UINT subresource ) {
+        // NumMipLevels/NumArraySlices/NumPlanes == 0 means "all", per the enhanced-barrier spec.
+        if ( subresource == D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES ) return CD3DX12_BARRIER_SUBRESOURCE_RANGE( 0, 0, 0, 0, 0, 0 );
+        return CD3DX12_BARRIER_SUBRESOURCE_RANGE( subresource, 1, 0, 1, 0, 1 );
     }
+
+    // Batch cap for TransitionBarriers()/UAVBarriers(): every call site in this backend batches a
+    // handful of resources ahead of one dispatch/draw (post-FX ping-pong targets, cull UAV sets),
+    // never more than a few. Fixed-size stack storage keeps this off the per-frame allocation path
+    // (see CLAUDE.md's per-frame allocation rule); a batch that somehow exceeds the cap logs a
+    // warning and degrades to one Barrier()/ResourceBarrier() call per element instead of silently
+    // dropping any transition.
+    constexpr UINT kMaxBatchedBarriers = 16;
 
 } // namespace
 
@@ -124,41 +127,74 @@ void D3D12CmdList::TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_S
         if ( MapResourceState( before, syncBefore, accessBefore, layoutBefore )
             && MapResourceState( after, syncAfter, accessAfter, layoutAfter ) ) {
             if ( IsBufferResource( resource ) ) {
-                D3D12_BUFFER_BARRIER bufferBarrier = { syncBefore, syncAfter, accessBefore, accessAfter,
-                    resource, 0, UINT64_MAX };
-                D3D12_BARRIER_GROUP group = {};
-                group.Type = D3D12_BARRIER_TYPE_BUFFER;
-                group.NumBarriers = 1;
-                group.pBufferBarriers = &bufferBarrier;
+                CD3DX12_BUFFER_BARRIER bufferBarrier( syncBefore, syncAfter, accessBefore, accessAfter, resource );
+                CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_BUFFER_BARRIER*>( &bufferBarrier ) );
                 List7()->Barrier( 1, &group );
             } else {
-                // NumMipLevels/NumArraySlices/NumPlanes == 0 means "all", per the enhanced-barrier spec.
-                D3D12_BARRIER_SUBRESOURCE_RANGE range = { 0, 0, 0, 0, 0, 0 };
-                if ( subresource != D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES ) {
-                    range = { subresource, 1, 0, 1, 0, 1 };
-                }
-                D3D12_TEXTURE_BARRIER textureBarrier = { syncBefore, syncAfter, accessBefore, accessAfter,
-                    layoutBefore, layoutAfter, resource, range, D3D12_TEXTURE_BARRIER_FLAG_NONE };
-                D3D12_BARRIER_GROUP group = {};
-                group.Type = D3D12_BARRIER_TYPE_TEXTURE;
-                group.NumBarriers = 1;
-                group.pTextureBarriers = &textureBarrier;
+                CD3DX12_TEXTURE_BARRIER textureBarrier( syncBefore, syncAfter, accessBefore, accessAfter,
+                    layoutBefore, layoutAfter, resource, SubresourceRange( subresource ) );
+                CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_TEXTURE_BARRIER*>( &textureBarrier ) );
                 List7()->Barrier( 1, &group );
             }
             return;
         }
     }
-    LegacyTransition( m_List.Get(), resource, before, after, subresource );
+    CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition( resource, before, after, subresource );
+    m_List->ResourceBarrier( 1, &barrier );
 }
 
-void D3D12CmdList::TransitionBarriers( std::initializer_list<D3D12ResourceTransition> transitions ) {
-    // Kept as a simple loop over the single-transition path rather than batching into one Barrier()/
-    // ResourceBarrier() call -- this is unused foundation code with no perf-sensitive caller yet, and
-    // a real batching implementation needs separate texture/buffer/legacy arrays which is easy to add
-    // once an actual multi-transition call site exists to shape the API around.
-    for ( const D3D12ResourceTransition& t : transitions ) {
-        TransitionBarrier( t.Resource, t.Before, t.After, t.Subresource );
+void D3D12CmdList::TransitionBarriers( const D3D12ResourceTransition* transitions, UINT count ) {
+    if ( count == 0 ) return;
+    if ( count > kMaxBatchedBarriers ) {
+#ifdef DEBUG_D3D11
+        LogWarn() << "D3D12Barrier: TransitionBarriers batch of " << count
+                  << " exceeds kMaxBatchedBarriers (" << kMaxBatchedBarriers << "); issuing one barrier per element.";
+#endif
+        for ( UINT i = 0; i < count; ++i ) TransitionBarrier( transitions[i].Resource, transitions[i].Before, transitions[i].After, transitions[i].Subresource );
+        return;
     }
+
+    if ( s_DeviceSupportsEnhancedBarriers && List7() ) {
+        D3D12_TEXTURE_BARRIER textureBarriers[kMaxBatchedBarriers];
+        D3D12_BUFFER_BARRIER bufferBarriers[kMaxBatchedBarriers];
+        UINT numTexture = 0, numBuffer = 0;
+        bool ok = true;
+        for ( UINT i = 0; i < count; ++i ) {
+            const D3D12ResourceTransition& t = transitions[i];
+            D3D12_BARRIER_SYNC syncBefore, syncAfter;
+            D3D12_BARRIER_ACCESS accessBefore, accessAfter;
+            D3D12_BARRIER_LAYOUT layoutBefore, layoutAfter;
+            if ( !MapResourceState( t.Before, syncBefore, accessBefore, layoutBefore )
+                || !MapResourceState( t.After, syncAfter, accessAfter, layoutAfter ) ) {
+                ok = false;
+                break;
+            }
+            if ( IsBufferResource( t.Resource ) ) {
+                bufferBarriers[numBuffer++] = CD3DX12_BUFFER_BARRIER( syncBefore, syncAfter, accessBefore, accessAfter, t.Resource );
+            } else {
+                textureBarriers[numTexture++] = CD3DX12_TEXTURE_BARRIER( syncBefore, syncAfter, accessBefore, accessAfter,
+                    layoutBefore, layoutAfter, t.Resource, SubresourceRange( t.Subresource ) );
+            }
+        }
+        if ( ok ) {
+            D3D12_BARRIER_GROUP groups[2];
+            UINT numGroups = 0;
+            if ( numTexture > 0 ) groups[numGroups++] = CD3DX12_BARRIER_GROUP( numTexture, textureBarriers );
+            if ( numBuffer > 0 ) groups[numGroups++] = CD3DX12_BARRIER_GROUP( numBuffer, bufferBarriers );
+            if ( numGroups > 0 ) List7()->Barrier( numGroups, groups );
+            return;
+        }
+        // A mapping failure partway through: fall through to the legacy batch below rather than
+        // issuing the enhanced barriers already built and skipping the rest.
+    }
+
+    D3D12_RESOURCE_BARRIER legacyBarriers[kMaxBatchedBarriers];
+    UINT numLegacy = 0;
+    for ( UINT i = 0; i < count; ++i ) {
+        const D3D12ResourceTransition& t = transitions[i];
+        legacyBarriers[numLegacy++] = CD3DX12_RESOURCE_BARRIER::Transition( t.Resource, t.Before, t.After, t.Subresource );
+    }
+    m_List->ResourceBarrier( numLegacy, legacyBarriers );
 }
 
 void D3D12CmdList::UAVBarrier( ID3D12Resource* resource ) {
@@ -166,41 +202,71 @@ void D3D12CmdList::UAVBarrier( ID3D12Resource* resource ) {
         constexpr D3D12_BARRIER_SYNC kSync = D3D12_BARRIER_SYNC_ALL_SHADING;
         constexpr D3D12_BARRIER_ACCESS kAccess = D3D12_BARRIER_ACCESS_UNORDERED_ACCESS;
         if ( resource && IsBufferResource( resource ) ) {
-            D3D12_BUFFER_BARRIER bufferBarrier = { kSync, kSync, kAccess, kAccess, resource, 0, UINT64_MAX };
-            D3D12_BARRIER_GROUP group = {};
-            group.Type = D3D12_BARRIER_TYPE_BUFFER;
-            group.NumBarriers = 1;
-            group.pBufferBarriers = &bufferBarrier;
+            CD3DX12_BUFFER_BARRIER bufferBarrier( kSync, kSync, kAccess, kAccess, resource );
+            CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_BUFFER_BARRIER*>( &bufferBarrier ) );
             List7()->Barrier( 1, &group );
         } else if ( resource ) {
-            D3D12_BARRIER_SUBRESOURCE_RANGE range = { 0, 0, 0, 0, 0, 0 };
-            D3D12_TEXTURE_BARRIER textureBarrier = { kSync, kSync, kAccess, kAccess,
-                D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, resource, range, D3D12_TEXTURE_BARRIER_FLAG_NONE };
-            D3D12_BARRIER_GROUP group = {};
-            group.Type = D3D12_BARRIER_TYPE_TEXTURE;
-            group.NumBarriers = 1;
-            group.pTextureBarriers = &textureBarrier;
+            CD3DX12_TEXTURE_BARRIER textureBarrier( kSync, kSync, kAccess, kAccess,
+                D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, resource,
+                CD3DX12_BARRIER_SUBRESOURCE_RANGE( 0, 0, 0, 0, 0, 0 ) );
+            CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_TEXTURE_BARRIER*>( &textureBarrier ) );
             List7()->Barrier( 1, &group );
         } else {
-            D3D12_GLOBAL_BARRIER globalBarrier = { kSync, kSync, kAccess, kAccess };
-            D3D12_BARRIER_GROUP group = {};
-            group.Type = D3D12_BARRIER_TYPE_GLOBAL;
-            group.NumBarriers = 1;
-            group.pGlobalBarriers = &globalBarrier;
+            CD3DX12_GLOBAL_BARRIER globalBarrier( kSync, kSync, kAccess, kAccess );
+            CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_GLOBAL_BARRIER*>( &globalBarrier ) );
             List7()->Barrier( 1, &group );
         }
         return;
     }
-    D3D12_RESOURCE_BARRIER barrier = {};
-    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
-    barrier.UAV.pResource = resource;
+    CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::UAV( resource );
     m_List->ResourceBarrier( 1, &barrier );
 }
 
-void D3D12CmdList::UAVBarriers( std::initializer_list<ID3D12Resource*> resources ) {
-    for ( ID3D12Resource* resource : resources ) {
-        UAVBarrier( resource );
+void D3D12CmdList::UAVBarriers( ID3D12Resource* const* resources, UINT count ) {
+    if ( count == 0 ) return;
+    if ( count > kMaxBatchedBarriers ) {
+#ifdef DEBUG_D3D11
+        LogWarn() << "D3D12Barrier: UAVBarriers batch of " << count
+                  << " exceeds kMaxBatchedBarriers (" << kMaxBatchedBarriers << "); issuing one barrier per element.";
+#endif
+        for ( UINT i = 0; i < count; ++i ) UAVBarrier( resources[i] );
+        return;
     }
+
+    if ( s_DeviceSupportsEnhancedBarriers && List7() ) {
+        constexpr D3D12_BARRIER_SYNC kSync = D3D12_BARRIER_SYNC_ALL_SHADING;
+        constexpr D3D12_BARRIER_ACCESS kAccess = D3D12_BARRIER_ACCESS_UNORDERED_ACCESS;
+        D3D12_TEXTURE_BARRIER textureBarriers[kMaxBatchedBarriers];
+        D3D12_BUFFER_BARRIER bufferBarriers[kMaxBatchedBarriers];
+        D3D12_GLOBAL_BARRIER globalBarriers[kMaxBatchedBarriers];
+        UINT numTexture = 0, numBuffer = 0, numGlobal = 0;
+        for ( UINT i = 0; i < count; ++i ) {
+            ID3D12Resource* resource = resources[i];
+            if ( !resource ) {
+                globalBarriers[numGlobal++] = CD3DX12_GLOBAL_BARRIER( kSync, kSync, kAccess, kAccess );
+            } else if ( IsBufferResource( resource ) ) {
+                bufferBarriers[numBuffer++] = CD3DX12_BUFFER_BARRIER( kSync, kSync, kAccess, kAccess, resource );
+            } else {
+                textureBarriers[numTexture++] = CD3DX12_TEXTURE_BARRIER( kSync, kSync, kAccess, kAccess,
+                    D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, resource,
+                    CD3DX12_BARRIER_SUBRESOURCE_RANGE( 0, 0, 0, 0, 0, 0 ) );
+            }
+        }
+        D3D12_BARRIER_GROUP groups[3];
+        UINT numGroups = 0;
+        if ( numTexture > 0 ) groups[numGroups++] = CD3DX12_BARRIER_GROUP( numTexture, textureBarriers );
+        if ( numBuffer > 0 ) groups[numGroups++] = CD3DX12_BARRIER_GROUP( numBuffer, bufferBarriers );
+        if ( numGlobal > 0 ) groups[numGroups++] = CD3DX12_BARRIER_GROUP( numGlobal, globalBarriers );
+        if ( numGroups > 0 ) List7()->Barrier( numGroups, groups );
+        return;
+    }
+
+    D3D12_RESOURCE_BARRIER legacyBarriers[kMaxBatchedBarriers];
+    UINT numLegacy = 0;
+    for ( UINT i = 0; i < count; ++i ) {
+        legacyBarriers[numLegacy++] = CD3DX12_RESOURCE_BARRIER::UAV( resources[i] );
+    }
+    m_List->ResourceBarrier( numLegacy, legacyBarriers );
 }
 
 void D3D12CmdList::AliasingBarrier( ID3D12Resource* before, ID3D12Resource* after ) {
@@ -208,9 +274,6 @@ void D3D12CmdList::AliasingBarrier( ID3D12Resource* before, ID3D12Resource* afte
     // D3D12_BARRIER_LAYOUT_UNDEFINED on the first use of the aliased resource); no call site needs
     // that yet, so this stays on the well-understood legacy path unconditionally rather than guessing
     // at a translation nothing has exercised.
-    D3D12_RESOURCE_BARRIER barrier = {};
-    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_ALIASING;
-    barrier.Aliasing.pResourceBefore = before;
-    barrier.Aliasing.pResourceAfter = after;
+    CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Aliasing( before, after );
     m_List->ResourceBarrier( 1, &barrier );
 }

--- a/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
@@ -119,13 +119,17 @@ namespace {
 } // namespace
 
 void D3D12CmdList::TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_STATES before,
-    D3D12_RESOURCE_STATES after, UINT subresource ) {
+    D3D12_RESOURCE_STATES after, UINT subresource, D3D12_BARRIER_SYNC syncBeforeHint, D3D12_BARRIER_SYNC syncAfterHint ) {
     if ( s_DeviceSupportsEnhancedBarriers && List7() ) {
         D3D12_BARRIER_SYNC syncBefore, syncAfter;
         D3D12_BARRIER_ACCESS accessBefore, accessAfter;
         D3D12_BARRIER_LAYOUT layoutBefore, layoutAfter;
         if ( MapResourceState( before, syncBefore, accessBefore, layoutBefore )
             && MapResourceState( after, syncAfter, accessAfter, layoutAfter ) ) {
+            // A caller-supplied hint narrows the table's conservative default; access/layout are left alone
+            // since those describe the operation and resource-state itself, not which stage performs it.
+            if ( syncBeforeHint != kBarrierSyncUnspecified ) syncBefore = syncBeforeHint;
+            if ( syncAfterHint != kBarrierSyncUnspecified ) syncAfter = syncAfterHint;
             if ( IsBufferResource( resource ) ) {
                 CD3DX12_BUFFER_BARRIER bufferBarrier( syncBefore, syncAfter, accessBefore, accessAfter, resource );
                 CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_BUFFER_BARRIER*>( &bufferBarrier ) );
@@ -150,7 +154,9 @@ void D3D12CmdList::TransitionBarriers( const D3D12ResourceTransition* transition
         LogWarn() << "D3D12Barrier: TransitionBarriers batch of " << count
                   << " exceeds kMaxBatchedBarriers (" << kMaxBatchedBarriers << "); issuing one barrier per element.";
 #endif
-        for ( UINT i = 0; i < count; ++i ) TransitionBarrier( transitions[i].Resource, transitions[i].Before, transitions[i].After, transitions[i].Subresource );
+        for ( UINT i = 0; i < count; ++i )
+            TransitionBarrier( transitions[i].Resource, transitions[i].Before, transitions[i].After,
+                transitions[i].Subresource, transitions[i].SyncBefore, transitions[i].SyncAfter );
         return;
     }
 
@@ -169,6 +175,8 @@ void D3D12CmdList::TransitionBarriers( const D3D12ResourceTransition* transition
                 ok = false;
                 break;
             }
+            if ( t.SyncBefore != kBarrierSyncUnspecified ) syncBefore = t.SyncBefore;
+            if ( t.SyncAfter != kBarrierSyncUnspecified ) syncAfter = t.SyncAfter;
             if ( IsBufferResource( t.Resource ) ) {
                 bufferBarriers[numBuffer++] = CD3DX12_BUFFER_BARRIER( syncBefore, syncAfter, accessBefore, accessAfter, t.Resource );
             } else {
@@ -197,9 +205,9 @@ void D3D12CmdList::TransitionBarriers( const D3D12ResourceTransition* transition
     m_List->ResourceBarrier( numLegacy, legacyBarriers );
 }
 
-void D3D12CmdList::UAVBarrier( ID3D12Resource* resource ) {
+void D3D12CmdList::UAVBarrier( ID3D12Resource* resource, D3D12_BARRIER_SYNC syncHint ) {
     if ( s_DeviceSupportsEnhancedBarriers && List7() ) {
-        constexpr D3D12_BARRIER_SYNC kSync = D3D12_BARRIER_SYNC_ALL_SHADING;
+        const D3D12_BARRIER_SYNC kSync = ( syncHint != kBarrierSyncUnspecified ) ? syncHint : D3D12_BARRIER_SYNC_ALL_SHADING;
         constexpr D3D12_BARRIER_ACCESS kAccess = D3D12_BARRIER_ACCESS_UNORDERED_ACCESS;
         if ( resource && IsBufferResource( resource ) ) {
             CD3DX12_BUFFER_BARRIER bufferBarrier( kSync, kSync, kAccess, kAccess, resource );
@@ -222,19 +230,19 @@ void D3D12CmdList::UAVBarrier( ID3D12Resource* resource ) {
     m_List->ResourceBarrier( 1, &barrier );
 }
 
-void D3D12CmdList::UAVBarriers( ID3D12Resource* const* resources, UINT count ) {
+void D3D12CmdList::UAVBarriers( ID3D12Resource* const* resources, UINT count, D3D12_BARRIER_SYNC syncHint ) {
     if ( count == 0 ) return;
     if ( count > kMaxBatchedBarriers ) {
 #ifdef DEBUG_D3D11
         LogWarn() << "D3D12Barrier: UAVBarriers batch of " << count
                   << " exceeds kMaxBatchedBarriers (" << kMaxBatchedBarriers << "); issuing one barrier per element.";
 #endif
-        for ( UINT i = 0; i < count; ++i ) UAVBarrier( resources[i] );
+        for ( UINT i = 0; i < count; ++i ) UAVBarrier( resources[i], syncHint );
         return;
     }
 
     if ( s_DeviceSupportsEnhancedBarriers && List7() ) {
-        constexpr D3D12_BARRIER_SYNC kSync = D3D12_BARRIER_SYNC_ALL_SHADING;
+        const D3D12_BARRIER_SYNC kSync = ( syncHint != kBarrierSyncUnspecified ) ? syncHint : D3D12_BARRIER_SYNC_ALL_SHADING;
         constexpr D3D12_BARRIER_ACCESS kAccess = D3D12_BARRIER_ACCESS_UNORDERED_ACCESS;
         D3D12_TEXTURE_BARRIER textureBarriers[kMaxBatchedBarriers];
         D3D12_BUFFER_BARRIER bufferBarriers[kMaxBatchedBarriers];

--- a/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
@@ -4,15 +4,10 @@
 #include "../Logger.h"
 #include <d3dx12_barriers.h>
 
-// Implements the D3D12CmdList barrier methods declared in D3D12StateCache.h. Legacy
-// D3D12_RESOURCE_STATES are the only thing any call site has to think in; everything past that
-// point -- enhanced-barrier availability, the sync/access/layout translation, buffer-vs-texture
-// dispatch -- is handled internally and is invisible to the caller.
-//
-// The state->(sync, access, layout) mapping below is deliberately conservative where a legacy state
-// doesn't map cleanly onto a single enhanced-barrier concept -- broad sync scope, broad access --
-// because a barrier that is too broad is merely slower, never wrong. Tightening individual call
-// sites' sync scopes is a follow-up tuning pass, not part of this migration.
+// Call sites think only in legacy D3D12_RESOURCE_STATES; enhanced-barrier translation and
+// buffer-vs-texture dispatch happen here. Where a legacy state doesn't map cleanly onto one
+// enhanced-barrier concept, the mapping below is deliberately conservative (broad sync/access) --
+// a barrier that's too broad is merely slower, never wrong.
 
 namespace {
 
@@ -65,10 +60,8 @@ namespace {
     bool MapResourceState( D3D12_RESOURCE_STATES state, D3D12_BARRIER_SYNC& sync, D3D12_BARRIER_ACCESS& access,
         D3D12_BARRIER_LAYOUT& layout ) {
         if ( state == D3D12_RESOURCE_STATE_COMMON ) {
-            // Spec rule (confirmed by the debug layer's INCOMPATIBLE_BARRIER_VALUES error): ACCESS_NO_ACCESS
-            // may only pair with a non-UNDEFINED layout when Sync is SYNC_NONE. SYNC_ALL here was invalid
-            // and closed the command list on literally every frame's back-buffer PRESENT<->RENDER_TARGET
-            // transition -- the total render hang this table entry caused.
+            // Spec rule: ACCESS_NO_ACCESS may only pair with a non-UNDEFINED layout when Sync is
+            // SYNC_NONE (debug layer: INCOMPATIBLE_BARRIER_VALUES otherwise).
             sync = D3D12_BARRIER_SYNC_NONE;
             access = D3D12_BARRIER_ACCESS_NO_ACCESS;
             layout = D3D12_BARRIER_LAYOUT_COMMON;
@@ -107,23 +100,16 @@ namespace {
     }
 
     // `subresource` is a flat D3D12CalcSubresource-style index (MipSlice + ArraySlice*MipLevels +
-    // PlaneSlice*MipLevels*ArraySize), NOT a mip level -- decoding it as a bare mip level (the previous
-    // version of this function) put e.g. PointShadowCubeArray's face/slot index straight into
-    // IndexOrFirstMipLevel and blew past its real (1) mip count on every barrier past subresource 0.
+    // PlaneSlice*MipLevels*ArraySize), not a mip level.
     CD3DX12_BARRIER_SUBRESOURCE_RANGE SubresourceRange( ID3D12Resource* resource, UINT subresource ) {
         const D3D12_RESOURCE_DESC desc = resource->GetDesc();
         const UINT mipLevels = desc.MipLevels;
         const UINT arraySize = desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D ? 1 : desc.DepthOrArraySize;
         if ( subresource == D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES ) {
-            // NumMipLevels == 0 is NOT a wildcard for "all subresources" -- it is the sentinel that makes
-            // IndexOrFirstMipLevel mean a single plain subresource index instead (see
-            // CD3DX12_BARRIER_SUBRESOURCE_RANGE's single-UINT constructor in d3dx12_barriers.h, which
-            // passes {Subresource, 0, 0, 0, 0, 0} specifically to select ONE subresource). Using (0,0,0,0,0,0)
-            // here therefore only ever covered subresource 0 -- every array slice/mip past index 0 on any
-            // multi-subresource resource (shadow cascade arrays, cube arrays, mip chains) silently never
-            // received an enhanced barrier at all. Covering "all" means spelling out the real extents.
-            // Plane count is hardcoded to 1: every depth format this backend actually creates (D32_FLOAT,
-            // D16_UNORM) is single-plane; a stencil-bearing format would need a real plane count query.
+            // NumMipLevels == 0 is not a wildcard for "all subresources" in CD3DX12_BARRIER_SUBRESOURCE_RANGE
+            // -- it's the sentinel that makes IndexOrFirstMipLevel select a single subresource instead. The
+            // real extents must be spelled out to cover every slice/mip. Plane count is hardcoded to 1: every
+            // depth format this backend creates (D32_FLOAT, D16_UNORM) is single-plane.
             return CD3DX12_BARRIER_SUBRESOURCE_RANGE( 0, mipLevels, 0, arraySize, 0, 1 );
         }
         const UINT mipSlice = subresource % mipLevels;
@@ -132,12 +118,9 @@ namespace {
         return CD3DX12_BARRIER_SUBRESOURCE_RANGE( mipSlice, 1, arraySlice, 1, planeSlice, 1 );
     }
 
-    // Batch cap for TransitionBarriers()/UAVBarriers(): every call site in this backend batches a
-    // handful of resources ahead of one dispatch/draw (post-FX ping-pong targets, cull UAV sets),
-    // never more than a few. Fixed-size stack storage keeps this off the per-frame allocation path
-    // (see CLAUDE.md's per-frame allocation rule); a batch that somehow exceeds the cap logs a
-    // warning and degrades to one Barrier()/ResourceBarrier() call per element instead of silently
-    // dropping any transition.
+    // Batch cap for TransitionBarriers()/UAVBarriers(); fixed-size stack storage to stay off the
+    // per-frame allocation path. A batch that exceeds this logs a warning and falls back to one
+    // Barrier() call per element.
     constexpr UINT kMaxBatchedBarriers = 16;
 
 } // namespace
@@ -150,8 +133,8 @@ void D3D12CmdList::TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_S
         D3D12_BARRIER_LAYOUT layoutBefore, layoutAfter;
         if ( MapResourceState( before, syncBefore, accessBefore, layoutBefore )
             && MapResourceState( after, syncAfter, accessAfter, layoutAfter ) ) {
-            // A caller-supplied hint narrows the table's conservative default; access/layout are left alone
-            // since those describe the operation and resource-state itself, not which stage performs it.
+            // A caller hint narrows the table's conservative default sync scope only; access/layout
+            // describe the resource state itself, not which stage performs it.
             if ( syncBeforeHint != kBarrierSyncUnspecified ) syncBefore = syncBeforeHint;
             if ( syncAfterHint != kBarrierSyncUnspecified ) syncAfter = syncAfterHint;
             if ( IsBufferResource( resource ) ) {

--- a/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
@@ -3,6 +3,7 @@
 #include "D3D12StateCache.h"
 #include "../Logger.h"
 #include <d3dx12_barriers.h>
+#include <mutex>
 
 // Implements the D3D12CmdList barrier methods declared in D3D12StateCache.h. Legacy
 // D3D12_RESOURCE_STATES are the only thing any call site has to think in; everything past that
@@ -65,7 +66,11 @@ namespace {
     bool MapResourceState( D3D12_RESOURCE_STATES state, D3D12_BARRIER_SYNC& sync, D3D12_BARRIER_ACCESS& access,
         D3D12_BARRIER_LAYOUT& layout ) {
         if ( state == D3D12_RESOURCE_STATE_COMMON ) {
-            sync = D3D12_BARRIER_SYNC_ALL;
+            // Spec rule (confirmed by the debug layer's INCOMPATIBLE_BARRIER_VALUES error): ACCESS_NO_ACCESS
+            // may only pair with a non-UNDEFINED layout when Sync is SYNC_NONE. SYNC_ALL here was invalid
+            // and closed the command list on literally every frame's back-buffer PRESENT<->RENDER_TARGET
+            // transition -- the total render hang this table entry caused.
+            sync = D3D12_BARRIER_SYNC_NONE;
             access = D3D12_BARRIER_ACCESS_NO_ACCESS;
             layout = D3D12_BARRIER_LAYOUT_COMMON;
             return true;
@@ -102,10 +107,30 @@ namespace {
         return resource->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER;
     }
 
-    CD3DX12_BARRIER_SUBRESOURCE_RANGE SubresourceRange( UINT subresource ) {
-        // NumMipLevels/NumArraySlices/NumPlanes == 0 means "all", per the enhanced-barrier spec.
-        if ( subresource == D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES ) return CD3DX12_BARRIER_SUBRESOURCE_RANGE( 0, 0, 0, 0, 0, 0 );
-        return CD3DX12_BARRIER_SUBRESOURCE_RANGE( subresource, 1, 0, 1, 0, 1 );
+    // `subresource` is a flat D3D12CalcSubresource-style index (MipSlice + ArraySlice*MipLevels +
+    // PlaneSlice*MipLevels*ArraySize), NOT a mip level -- decoding it as a bare mip level (the previous
+    // version of this function) put e.g. PointShadowCubeArray's face/slot index straight into
+    // IndexOrFirstMipLevel and blew past its real (1) mip count on every barrier past subresource 0.
+    CD3DX12_BARRIER_SUBRESOURCE_RANGE SubresourceRange( ID3D12Resource* resource, UINT subresource ) {
+        const D3D12_RESOURCE_DESC desc = resource->GetDesc();
+        const UINT mipLevels = desc.MipLevels;
+        const UINT arraySize = desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D ? 1 : desc.DepthOrArraySize;
+        if ( subresource == D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES ) {
+            // NumMipLevels == 0 is NOT a wildcard for "all subresources" -- it is the sentinel that makes
+            // IndexOrFirstMipLevel mean a single plain subresource index instead (see
+            // CD3DX12_BARRIER_SUBRESOURCE_RANGE's single-UINT constructor in d3dx12_barriers.h, which
+            // passes {Subresource, 0, 0, 0, 0, 0} specifically to select ONE subresource). Using (0,0,0,0,0,0)
+            // here therefore only ever covered subresource 0 -- every array slice/mip past index 0 on any
+            // multi-subresource resource (shadow cascade arrays, cube arrays, mip chains) silently never
+            // received an enhanced barrier at all. Covering "all" means spelling out the real extents.
+            // Plane count is hardcoded to 1: every depth format this backend actually creates (D32_FLOAT,
+            // D16_UNORM) is single-plane; a stencil-bearing format would need a real plane count query.
+            return CD3DX12_BARRIER_SUBRESOURCE_RANGE( 0, mipLevels, 0, arraySize, 0, 1 );
+        }
+        const UINT mipSlice = subresource % mipLevels;
+        const UINT arraySlice = ( subresource / mipLevels ) % arraySize;
+        const UINT planeSlice = subresource / ( mipLevels * arraySize );
+        return CD3DX12_BARRIER_SUBRESOURCE_RANGE( mipSlice, 1, arraySlice, 1, planeSlice, 1 );
     }
 
     // Batch cap for TransitionBarriers()/UAVBarriers(): every call site in this backend batches a
@@ -116,7 +141,65 @@ namespace {
     // dropping any transition.
     constexpr UINT kMaxBatchedBarriers = 16;
 
+    // Legacy-to-enhanced handoff (BARRIER_INTEROP_INVALID_LAYOUT):
+    //
+    // Every render target/UAV texture in this backend is created via D3D12MA::Allocator::CreateResource
+    // (-> legacy CreateCommittedResource) with an InitialResourceState equal to its steady-state (e.g.
+    // GtaoWorkingDepth is born D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12GTAO.cpp:144) rather than
+    // COMMON -- a legacy-barrier-era optimization to skip a throwaway first transition. Per the
+    // enhanced-barrier spec, a texture created through the legacy path stays "legacy-tracked" until its
+    // first enhanced Barrier() call, and that handoff is only legal when the resource's real
+    // (legacy-model) state at that moment is D3D12_RESOURCE_STATE_COMMON. Since none of these textures
+    // ever pass through COMMON, their first enhanced transition was rejected outright
+    // (STATE_SETTING ERROR #1350) and the runtime silently kept applying none of our barriers to them
+    // from then on (confirmed via GPU-based validation: GtaoWorkingDepth read as SRV by a shader while
+    // still tracked UNORDERED_ACCESS).
+    //
+    // Fix: the first time (ever, per resource object) an enhanced Barrier() touches a texture, issue one
+    // genuine LEGACY ResourceBarrier transitioning it from its true current state to COMMON first, then
+    // treat COMMON as the enhanced barrier's real "before". This requires no changes to any of the ~140
+    // existing TransitionBarrier/UAVBarrier call sites -- they keep passing the resource's actual state
+    // exactly as before; the bridge is entirely internal to BridgeLegacyResourceToCommon.
+    //
+    // "First touch, ever" is tracked via SetPrivateData directly on the ID3D12Resource COM object rather
+    // than an external pointer-keyed set: the marker's lifetime is then tied exactly to that object's
+    // lifetime, so a resource recreated at the same address on resize (GTAO/AO buffers are, per
+    // D3D12GraphicsEngine.h:1318's "recreated on resize" comment) correctly needs (and gets) a fresh
+    // bridge rather than aliasing a stale "already bridged" entry for a destroyed object. Buffers are
+    // untouched by any of this -- D3D12_BUFFER_BARRIER has no Layout, so the interop rule (a LAYOUT
+    // requirement) never applies to them.
+    const GUID kEnhancedHandoffGuid = { 0xa6c1f1b0, 0x9d3e, 0x4b7a, { 0x8c, 0x2f, 0x6e, 0x1d, 0x9a, 0x3b, 0x5c, 0x7d } };
+
+    // Guards the check-and-mark below. Only ever contended by two threads racing the very first-ever
+    // touch of the SAME resource (e.g. a shadow-cascade recorder and the main list); infrequent enough
+    // (once per resource, for the resource's entire lifetime) that a global mutex costs nothing measurable.
+    std::mutex g_HandoffMutex;
+
+    bool NeedsLegacyHandoff( ID3D12Resource* resource ) {
+        std::lock_guard<std::mutex> lock( g_HandoffMutex );
+        UINT8 marker = 0;
+        UINT size = sizeof( marker );
+        if ( SUCCEEDED( resource->GetPrivateData( kEnhancedHandoffGuid, &size, &marker ) ) ) return false;
+        marker = 1;
+        resource->SetPrivateData( kEnhancedHandoffGuid, sizeof( marker ), &marker );
+        return true;
+    }
+
 } // namespace
+
+bool D3D12CmdList::BridgeLegacyResourceToCommon( ID3D12Resource* resource, D3D12_RESOURCE_STATES trueBefore ) {
+    if ( trueBefore == D3D12_RESOURCE_STATE_COMMON ) return false;   // already common; nothing to bridge
+    if ( resource->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER ) return false;   // no Layout on buffers
+    if ( !NeedsLegacyHandoff( resource ) ) return false;
+    // ALL_SUBRESOURCES regardless of which specific subresource the real transition targets: every
+    // subresource of a resource shares one InitialResourceState at creation, so `trueBefore` describes
+    // all of them uniformly -- one bridge per resource, not one per subresource, correctly hands the
+    // whole thing off in one call.
+    CD3DX12_RESOURCE_BARRIER handoff = CD3DX12_RESOURCE_BARRIER::Transition( resource, trueBefore,
+        D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES );
+    m_List->ResourceBarrier( 1, &handoff );
+    return true;
+}
 
 void D3D12CmdList::TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_STATES before,
     D3D12_RESOURCE_STATES after, UINT subresource, D3D12_BARRIER_SYNC syncBeforeHint, D3D12_BARRIER_SYNC syncAfterHint ) {
@@ -135,8 +218,13 @@ void D3D12CmdList::TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_S
                 CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_BUFFER_BARRIER*>( &bufferBarrier ) );
                 List7()->Barrier( 1, &group );
             } else {
+                if ( BridgeLegacyResourceToCommon( resource, before ) ) {
+                    syncBefore = D3D12_BARRIER_SYNC_NONE;
+                    accessBefore = D3D12_BARRIER_ACCESS_NO_ACCESS;
+                    layoutBefore = D3D12_BARRIER_LAYOUT_COMMON;
+                }
                 CD3DX12_TEXTURE_BARRIER textureBarrier( syncBefore, syncAfter, accessBefore, accessAfter,
-                    layoutBefore, layoutAfter, resource, SubresourceRange( subresource ) );
+                    layoutBefore, layoutAfter, resource, SubresourceRange( resource, subresource ) );
                 CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_TEXTURE_BARRIER*>( &textureBarrier ) );
                 List7()->Barrier( 1, &group );
             }
@@ -180,8 +268,13 @@ void D3D12CmdList::TransitionBarriers( const D3D12ResourceTransition* transition
             if ( IsBufferResource( t.Resource ) ) {
                 bufferBarriers[numBuffer++] = CD3DX12_BUFFER_BARRIER( syncBefore, syncAfter, accessBefore, accessAfter, t.Resource );
             } else {
+                if ( BridgeLegacyResourceToCommon( t.Resource, t.Before ) ) {
+                    syncBefore = D3D12_BARRIER_SYNC_NONE;
+                    accessBefore = D3D12_BARRIER_ACCESS_NO_ACCESS;
+                    layoutBefore = D3D12_BARRIER_LAYOUT_COMMON;
+                }
                 textureBarriers[numTexture++] = CD3DX12_TEXTURE_BARRIER( syncBefore, syncAfter, accessBefore, accessAfter,
-                    layoutBefore, layoutAfter, t.Resource, SubresourceRange( t.Subresource ) );
+                    layoutBefore, layoutAfter, t.Resource, SubresourceRange( t.Resource, t.Subresource ) );
             }
         }
         if ( ok ) {
@@ -214,9 +307,15 @@ void D3D12CmdList::UAVBarrier( ID3D12Resource* resource, D3D12_BARRIER_SYNC sync
             CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_BUFFER_BARRIER*>( &bufferBarrier ) );
             List7()->Barrier( 1, &group );
         } else if ( resource ) {
-            CD3DX12_TEXTURE_BARRIER textureBarrier( kSync, kSync, kAccess, kAccess,
-                D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, resource,
-                CD3DX12_BARRIER_SUBRESOURCE_RANGE( 0, 0, 0, 0, 0, 0 ) );
+            // A UAV barrier only ever makes sense on a resource already in UNORDERED_ACCESS, so that's
+            // the only possible "true before" state a bridge needs to reason about here.
+            const bool bridged = BridgeLegacyResourceToCommon( resource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+            CD3DX12_TEXTURE_BARRIER textureBarrier(
+                bridged ? D3D12_BARRIER_SYNC_NONE : kSync, kSync,
+                bridged ? D3D12_BARRIER_ACCESS_NO_ACCESS : kAccess, kAccess,
+                bridged ? D3D12_BARRIER_LAYOUT_COMMON : D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS,
+                D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, resource,
+                SubresourceRange( resource, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES ) );
             CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_TEXTURE_BARRIER*>( &textureBarrier ) );
             List7()->Barrier( 1, &group );
         } else {
@@ -255,9 +354,13 @@ void D3D12CmdList::UAVBarriers( ID3D12Resource* const* resources, UINT count, D3
             } else if ( IsBufferResource( resource ) ) {
                 bufferBarriers[numBuffer++] = CD3DX12_BUFFER_BARRIER( kSync, kSync, kAccess, kAccess, resource );
             } else {
-                textureBarriers[numTexture++] = CD3DX12_TEXTURE_BARRIER( kSync, kSync, kAccess, kAccess,
-                    D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, resource,
-                    CD3DX12_BARRIER_SUBRESOURCE_RANGE( 0, 0, 0, 0, 0, 0 ) );
+                const bool bridged = BridgeLegacyResourceToCommon( resource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+                textureBarriers[numTexture++] = CD3DX12_TEXTURE_BARRIER(
+                    bridged ? D3D12_BARRIER_SYNC_NONE : kSync, kSync,
+                    bridged ? D3D12_BARRIER_ACCESS_NO_ACCESS : kAccess, kAccess,
+                    bridged ? D3D12_BARRIER_LAYOUT_COMMON : D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS,
+                    D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, resource,
+                    SubresourceRange( resource, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES ) );
             }
         }
         D3D12_BARRIER_GROUP groups[3];

--- a/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
@@ -1,0 +1,216 @@
+#include "../pch.h"
+#include "D3D12Barrier.h"
+#include "D3D12StateCache.h"
+#include "../Logger.h"
+
+// Implements the D3D12CmdList barrier methods declared in D3D12StateCache.h. Legacy
+// D3D12_RESOURCE_STATES are the only thing any call site (present or future) has to think in;
+// everything past that point -- enhanced-barrier availability, the sync/access/layout translation,
+// buffer-vs-texture dispatch -- is handled internally and is invisible to the caller.
+//
+// FOUNDATION ONLY: nothing calls these methods yet (see D3D12Barrier.h). The state->(sync, access,
+// layout) mapping below is deliberately conservative where a legacy state doesn't map cleanly onto a
+// single enhanced-barrier concept -- broad sync scope, broad access -- because a barrier that is too
+// broad is merely slower, never wrong, and the precision that enhanced barriers make possible is a
+// per-call-site tuning exercise for the future migration, not this pass.
+
+namespace {
+
+    struct StateMapEntry {
+        D3D12_RESOURCE_STATES Bit;
+        D3D12_BARRIER_SYNC Sync;
+        D3D12_BARRIER_ACCESS Access;
+        D3D12_BARRIER_LAYOUT Layout;   // ignored when the resource is a buffer
+    };
+
+    // One row per legacy state bit this backend actually uses. Multi-bit inputs (e.g.
+    // PIXEL_SHADER_RESOURCE | NON_PIXEL_SHADER_RESOURCE) OR every matching row's sync/access
+    // together; SHADER_RESOURCE is the layout for all shader-read rows so a combined mask never
+    // produces a layout conflict.
+    constexpr StateMapEntry kStateMap[] = {
+        { D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER, D3D12_BARRIER_SYNC_ALL_SHADING,
+            D3D12_BARRIER_ACCESS_VERTEX_BUFFER | D3D12_BARRIER_ACCESS_CONSTANT_BUFFER, D3D12_BARRIER_LAYOUT_GENERIC_READ },
+        { D3D12_RESOURCE_STATE_INDEX_BUFFER, D3D12_BARRIER_SYNC_INDEX_INPUT,
+            D3D12_BARRIER_ACCESS_INDEX_BUFFER, D3D12_BARRIER_LAYOUT_GENERIC_READ },
+        { D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_BARRIER_SYNC_RENDER_TARGET,
+            D3D12_BARRIER_ACCESS_RENDER_TARGET, D3D12_BARRIER_LAYOUT_RENDER_TARGET },
+        { D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_BARRIER_SYNC_ALL_SHADING,
+            D3D12_BARRIER_ACCESS_UNORDERED_ACCESS, D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS },
+        { D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_BARRIER_SYNC_DEPTH_STENCIL,
+            D3D12_BARRIER_ACCESS_DEPTH_STENCIL_WRITE, D3D12_BARRIER_LAYOUT_DEPTH_STENCIL_WRITE },
+        { D3D12_RESOURCE_STATE_DEPTH_READ, D3D12_BARRIER_SYNC_DEPTH_STENCIL,
+            D3D12_BARRIER_ACCESS_DEPTH_STENCIL_READ, D3D12_BARRIER_LAYOUT_DEPTH_STENCIL_READ },
+        { D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_BARRIER_SYNC_NON_PIXEL_SHADING,
+            D3D12_BARRIER_ACCESS_SHADER_RESOURCE, D3D12_BARRIER_LAYOUT_SHADER_RESOURCE },
+        { D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_BARRIER_SYNC_PIXEL_SHADING,
+            D3D12_BARRIER_ACCESS_SHADER_RESOURCE, D3D12_BARRIER_LAYOUT_SHADER_RESOURCE },
+        { D3D12_RESOURCE_STATE_STREAM_OUT, D3D12_BARRIER_SYNC_VERTEX_SHADING,
+            D3D12_BARRIER_ACCESS_STREAM_OUTPUT, D3D12_BARRIER_LAYOUT_COMMON },
+        { D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT, D3D12_BARRIER_SYNC_EXECUTE_INDIRECT,
+            D3D12_BARRIER_ACCESS_INDIRECT_ARGUMENT, D3D12_BARRIER_LAYOUT_GENERIC_READ },
+        { D3D12_RESOURCE_STATE_COPY_DEST, D3D12_BARRIER_SYNC_COPY,
+            D3D12_BARRIER_ACCESS_COPY_DEST, D3D12_BARRIER_LAYOUT_COPY_DEST },
+        { D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_BARRIER_SYNC_COPY,
+            D3D12_BARRIER_ACCESS_COPY_SOURCE, D3D12_BARRIER_LAYOUT_COPY_SOURCE },
+        { D3D12_RESOURCE_STATE_RESOLVE_DEST, D3D12_BARRIER_SYNC_RESOLVE,
+            D3D12_BARRIER_ACCESS_RESOLVE_DEST, D3D12_BARRIER_LAYOUT_RESOLVE_DEST },
+        { D3D12_RESOURCE_STATE_RESOLVE_SOURCE, D3D12_BARRIER_SYNC_RESOLVE,
+            D3D12_BARRIER_ACCESS_RESOLVE_SOURCE, D3D12_BARRIER_LAYOUT_RESOLVE_SOURCE },
+    };
+
+    /** Maps a legacy D3D12_RESOURCE_STATES mask to (sync, access, layout). D3D12_RESOURCE_STATE_COMMON
+        (== PRESENT == 0) has no bits to look up and is special-cased. Returns false, leaving the
+        out-params untouched, if `state` carries a bit this table doesn't recognize -- the caller
+        must fall back to a legacy transition for that call rather than emit a wrong barrier. */
+    bool MapResourceState( D3D12_RESOURCE_STATES state, D3D12_BARRIER_SYNC& sync, D3D12_BARRIER_ACCESS& access,
+        D3D12_BARRIER_LAYOUT& layout ) {
+        if ( state == D3D12_RESOURCE_STATE_COMMON ) {
+            sync = D3D12_BARRIER_SYNC_ALL;
+            access = D3D12_BARRIER_ACCESS_NO_ACCESS;
+            layout = D3D12_BARRIER_LAYOUT_COMMON;
+            return true;
+        }
+
+        D3D12_BARRIER_SYNC outSync = D3D12_BARRIER_SYNC_NONE;
+        D3D12_BARRIER_ACCESS outAccess = D3D12_BARRIER_ACCESS_COMMON;
+        D3D12_BARRIER_LAYOUT outLayout = D3D12_BARRIER_LAYOUT_UNDEFINED;
+        D3D12_RESOURCE_STATES remaining = state;
+
+        for ( const StateMapEntry& entry : kStateMap ) {
+            if ( ( remaining & entry.Bit ) != entry.Bit ) continue;
+            remaining &= ~entry.Bit;
+            outSync |= entry.Sync;
+            outAccess |= entry.Access;
+            outLayout = entry.Layout;   // every matched row in practice shares one layout family
+        }
+
+        if ( remaining != 0 ) {
+#ifdef DEBUG_D3D11
+            LogWarn() << "D3D12Barrier: unmapped D3D12_RESOURCE_STATES bit(s) 0x" << std::hex
+                      << static_cast<UINT>( remaining ) << std::dec << "; falling back to a legacy transition.";
+#endif
+            return false;
+        }
+
+        sync = outSync;
+        access = outAccess;
+        layout = outLayout;
+        return true;
+    }
+
+    bool IsBufferResource( ID3D12Resource* resource ) {
+        return resource->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER;
+    }
+
+    void LegacyTransition( ID3D12GraphicsCommandList* list, ID3D12Resource* resource,
+        D3D12_RESOURCE_STATES before, D3D12_RESOURCE_STATES after, UINT subresource ) {
+        D3D12_RESOURCE_BARRIER barrier = {};
+        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+        barrier.Transition.pResource = resource;
+        barrier.Transition.StateBefore = before;
+        barrier.Transition.StateAfter = after;
+        barrier.Transition.Subresource = subresource;
+        list->ResourceBarrier( 1, &barrier );
+    }
+
+} // namespace
+
+void D3D12CmdList::TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_STATES before,
+    D3D12_RESOURCE_STATES after, UINT subresource ) {
+    if ( s_DeviceSupportsEnhancedBarriers && List7() ) {
+        D3D12_BARRIER_SYNC syncBefore, syncAfter;
+        D3D12_BARRIER_ACCESS accessBefore, accessAfter;
+        D3D12_BARRIER_LAYOUT layoutBefore, layoutAfter;
+        if ( MapResourceState( before, syncBefore, accessBefore, layoutBefore )
+            && MapResourceState( after, syncAfter, accessAfter, layoutAfter ) ) {
+            if ( IsBufferResource( resource ) ) {
+                D3D12_BUFFER_BARRIER bufferBarrier = { syncBefore, syncAfter, accessBefore, accessAfter,
+                    resource, 0, UINT64_MAX };
+                D3D12_BARRIER_GROUP group = {};
+                group.Type = D3D12_BARRIER_TYPE_BUFFER;
+                group.NumBarriers = 1;
+                group.pBufferBarriers = &bufferBarrier;
+                List7()->Barrier( 1, &group );
+            } else {
+                // NumMipLevels/NumArraySlices/NumPlanes == 0 means "all", per the enhanced-barrier spec.
+                D3D12_BARRIER_SUBRESOURCE_RANGE range = { 0, 0, 0, 0, 0, 0 };
+                if ( subresource != D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES ) {
+                    range = { subresource, 1, 0, 1, 0, 1 };
+                }
+                D3D12_TEXTURE_BARRIER textureBarrier = { syncBefore, syncAfter, accessBefore, accessAfter,
+                    layoutBefore, layoutAfter, resource, range, D3D12_TEXTURE_BARRIER_FLAG_NONE };
+                D3D12_BARRIER_GROUP group = {};
+                group.Type = D3D12_BARRIER_TYPE_TEXTURE;
+                group.NumBarriers = 1;
+                group.pTextureBarriers = &textureBarrier;
+                List7()->Barrier( 1, &group );
+            }
+            return;
+        }
+    }
+    LegacyTransition( m_List.Get(), resource, before, after, subresource );
+}
+
+void D3D12CmdList::TransitionBarriers( std::initializer_list<D3D12ResourceTransition> transitions ) {
+    // Kept as a simple loop over the single-transition path rather than batching into one Barrier()/
+    // ResourceBarrier() call -- this is unused foundation code with no perf-sensitive caller yet, and
+    // a real batching implementation needs separate texture/buffer/legacy arrays which is easy to add
+    // once an actual multi-transition call site exists to shape the API around.
+    for ( const D3D12ResourceTransition& t : transitions ) {
+        TransitionBarrier( t.Resource, t.Before, t.After, t.Subresource );
+    }
+}
+
+void D3D12CmdList::UAVBarrier( ID3D12Resource* resource ) {
+    if ( s_DeviceSupportsEnhancedBarriers && List7() ) {
+        constexpr D3D12_BARRIER_SYNC kSync = D3D12_BARRIER_SYNC_ALL_SHADING;
+        constexpr D3D12_BARRIER_ACCESS kAccess = D3D12_BARRIER_ACCESS_UNORDERED_ACCESS;
+        if ( resource && IsBufferResource( resource ) ) {
+            D3D12_BUFFER_BARRIER bufferBarrier = { kSync, kSync, kAccess, kAccess, resource, 0, UINT64_MAX };
+            D3D12_BARRIER_GROUP group = {};
+            group.Type = D3D12_BARRIER_TYPE_BUFFER;
+            group.NumBarriers = 1;
+            group.pBufferBarriers = &bufferBarrier;
+            List7()->Barrier( 1, &group );
+        } else if ( resource ) {
+            D3D12_BARRIER_SUBRESOURCE_RANGE range = { 0, 0, 0, 0, 0, 0 };
+            D3D12_TEXTURE_BARRIER textureBarrier = { kSync, kSync, kAccess, kAccess,
+                D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, resource, range, D3D12_TEXTURE_BARRIER_FLAG_NONE };
+            D3D12_BARRIER_GROUP group = {};
+            group.Type = D3D12_BARRIER_TYPE_TEXTURE;
+            group.NumBarriers = 1;
+            group.pTextureBarriers = &textureBarrier;
+            List7()->Barrier( 1, &group );
+        } else {
+            D3D12_GLOBAL_BARRIER globalBarrier = { kSync, kSync, kAccess, kAccess };
+            D3D12_BARRIER_GROUP group = {};
+            group.Type = D3D12_BARRIER_TYPE_GLOBAL;
+            group.NumBarriers = 1;
+            group.pGlobalBarriers = &globalBarrier;
+            List7()->Barrier( 1, &group );
+        }
+        return;
+    }
+    D3D12_RESOURCE_BARRIER barrier = {};
+    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
+    barrier.UAV.pResource = resource;
+    m_List->ResourceBarrier( 1, &barrier );
+}
+
+void D3D12CmdList::UAVBarriers( std::initializer_list<ID3D12Resource*> resources ) {
+    for ( ID3D12Resource* resource : resources ) {
+        UAVBarrier( resource );
+    }
+}
+
+void D3D12CmdList::AliasingBarrier( ID3D12Resource* before, ID3D12Resource* after ) {
+    // Enhanced barriers don't model resource aliasing 1:1 (aliasing is instead expressed through
+    // D3D12_BARRIER_LAYOUT_UNDEFINED on the first use of the aliased resource); no call site needs
+    // that yet, so this stays on the well-understood legacy path unconditionally rather than guessing
+    // at a translation nothing has exercised.
+    D3D12_RESOURCE_BARRIER barrier = {};
+    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_ALIASING;
+    barrier.Aliasing.pResourceBefore = before;
+    barrier.Aliasing.pResourceAfter = after;
+    m_List->ResourceBarrier( 1, &barrier );
+}

--- a/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
@@ -3,7 +3,6 @@
 #include "D3D12StateCache.h"
 #include "../Logger.h"
 #include <d3dx12_barriers.h>
-#include <mutex>
 
 // Implements the D3D12CmdList barrier methods declared in D3D12StateCache.h. Legacy
 // D3D12_RESOURCE_STATES are the only thing any call site has to think in; everything past that
@@ -141,65 +140,7 @@ namespace {
     // dropping any transition.
     constexpr UINT kMaxBatchedBarriers = 16;
 
-    // Legacy-to-enhanced handoff (BARRIER_INTEROP_INVALID_LAYOUT):
-    //
-    // Every render target/UAV texture in this backend is created via D3D12MA::Allocator::CreateResource
-    // (-> legacy CreateCommittedResource) with an InitialResourceState equal to its steady-state (e.g.
-    // GtaoWorkingDepth is born D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12GTAO.cpp:144) rather than
-    // COMMON -- a legacy-barrier-era optimization to skip a throwaway first transition. Per the
-    // enhanced-barrier spec, a texture created through the legacy path stays "legacy-tracked" until its
-    // first enhanced Barrier() call, and that handoff is only legal when the resource's real
-    // (legacy-model) state at that moment is D3D12_RESOURCE_STATE_COMMON. Since none of these textures
-    // ever pass through COMMON, their first enhanced transition was rejected outright
-    // (STATE_SETTING ERROR #1350) and the runtime silently kept applying none of our barriers to them
-    // from then on (confirmed via GPU-based validation: GtaoWorkingDepth read as SRV by a shader while
-    // still tracked UNORDERED_ACCESS).
-    //
-    // Fix: the first time (ever, per resource object) an enhanced Barrier() touches a texture, issue one
-    // genuine LEGACY ResourceBarrier transitioning it from its true current state to COMMON first, then
-    // treat COMMON as the enhanced barrier's real "before". This requires no changes to any of the ~140
-    // existing TransitionBarrier/UAVBarrier call sites -- they keep passing the resource's actual state
-    // exactly as before; the bridge is entirely internal to BridgeLegacyResourceToCommon.
-    //
-    // "First touch, ever" is tracked via SetPrivateData directly on the ID3D12Resource COM object rather
-    // than an external pointer-keyed set: the marker's lifetime is then tied exactly to that object's
-    // lifetime, so a resource recreated at the same address on resize (GTAO/AO buffers are, per
-    // D3D12GraphicsEngine.h:1318's "recreated on resize" comment) correctly needs (and gets) a fresh
-    // bridge rather than aliasing a stale "already bridged" entry for a destroyed object. Buffers are
-    // untouched by any of this -- D3D12_BUFFER_BARRIER has no Layout, so the interop rule (a LAYOUT
-    // requirement) never applies to them.
-    const GUID kEnhancedHandoffGuid = { 0xa6c1f1b0, 0x9d3e, 0x4b7a, { 0x8c, 0x2f, 0x6e, 0x1d, 0x9a, 0x3b, 0x5c, 0x7d } };
-
-    // Guards the check-and-mark below. Only ever contended by two threads racing the very first-ever
-    // touch of the SAME resource (e.g. a shadow-cascade recorder and the main list); infrequent enough
-    // (once per resource, for the resource's entire lifetime) that a global mutex costs nothing measurable.
-    std::mutex g_HandoffMutex;
-
-    bool NeedsLegacyHandoff( ID3D12Resource* resource ) {
-        std::lock_guard<std::mutex> lock( g_HandoffMutex );
-        UINT8 marker = 0;
-        UINT size = sizeof( marker );
-        if ( SUCCEEDED( resource->GetPrivateData( kEnhancedHandoffGuid, &size, &marker ) ) ) return false;
-        marker = 1;
-        resource->SetPrivateData( kEnhancedHandoffGuid, sizeof( marker ), &marker );
-        return true;
-    }
-
 } // namespace
-
-bool D3D12CmdList::BridgeLegacyResourceToCommon( ID3D12Resource* resource, D3D12_RESOURCE_STATES trueBefore ) {
-    if ( trueBefore == D3D12_RESOURCE_STATE_COMMON ) return false;   // already common; nothing to bridge
-    if ( resource->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER ) return false;   // no Layout on buffers
-    if ( !NeedsLegacyHandoff( resource ) ) return false;
-    // ALL_SUBRESOURCES regardless of which specific subresource the real transition targets: every
-    // subresource of a resource shares one InitialResourceState at creation, so `trueBefore` describes
-    // all of them uniformly -- one bridge per resource, not one per subresource, correctly hands the
-    // whole thing off in one call.
-    CD3DX12_RESOURCE_BARRIER handoff = CD3DX12_RESOURCE_BARRIER::Transition( resource, trueBefore,
-        D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES );
-    m_List->ResourceBarrier( 1, &handoff );
-    return true;
-}
 
 void D3D12CmdList::TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_STATES before,
     D3D12_RESOURCE_STATES after, UINT subresource, D3D12_BARRIER_SYNC syncBeforeHint, D3D12_BARRIER_SYNC syncAfterHint ) {
@@ -218,11 +159,6 @@ void D3D12CmdList::TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_S
                 CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_BUFFER_BARRIER*>( &bufferBarrier ) );
                 List7()->Barrier( 1, &group );
             } else {
-                if ( BridgeLegacyResourceToCommon( resource, before ) ) {
-                    syncBefore = D3D12_BARRIER_SYNC_NONE;
-                    accessBefore = D3D12_BARRIER_ACCESS_NO_ACCESS;
-                    layoutBefore = D3D12_BARRIER_LAYOUT_COMMON;
-                }
                 CD3DX12_TEXTURE_BARRIER textureBarrier( syncBefore, syncAfter, accessBefore, accessAfter,
                     layoutBefore, layoutAfter, resource, SubresourceRange( resource, subresource ) );
                 CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_TEXTURE_BARRIER*>( &textureBarrier ) );
@@ -268,11 +204,6 @@ void D3D12CmdList::TransitionBarriers( const D3D12ResourceTransition* transition
             if ( IsBufferResource( t.Resource ) ) {
                 bufferBarriers[numBuffer++] = CD3DX12_BUFFER_BARRIER( syncBefore, syncAfter, accessBefore, accessAfter, t.Resource );
             } else {
-                if ( BridgeLegacyResourceToCommon( t.Resource, t.Before ) ) {
-                    syncBefore = D3D12_BARRIER_SYNC_NONE;
-                    accessBefore = D3D12_BARRIER_ACCESS_NO_ACCESS;
-                    layoutBefore = D3D12_BARRIER_LAYOUT_COMMON;
-                }
                 textureBarriers[numTexture++] = CD3DX12_TEXTURE_BARRIER( syncBefore, syncAfter, accessBefore, accessAfter,
                     layoutBefore, layoutAfter, t.Resource, SubresourceRange( t.Resource, t.Subresource ) );
             }
@@ -307,14 +238,8 @@ void D3D12CmdList::UAVBarrier( ID3D12Resource* resource, D3D12_BARRIER_SYNC sync
             CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_BUFFER_BARRIER*>( &bufferBarrier ) );
             List7()->Barrier( 1, &group );
         } else if ( resource ) {
-            // A UAV barrier only ever makes sense on a resource already in UNORDERED_ACCESS, so that's
-            // the only possible "true before" state a bridge needs to reason about here.
-            const bool bridged = BridgeLegacyResourceToCommon( resource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-            CD3DX12_TEXTURE_BARRIER textureBarrier(
-                bridged ? D3D12_BARRIER_SYNC_NONE : kSync, kSync,
-                bridged ? D3D12_BARRIER_ACCESS_NO_ACCESS : kAccess, kAccess,
-                bridged ? D3D12_BARRIER_LAYOUT_COMMON : D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS,
-                D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, resource,
+            CD3DX12_TEXTURE_BARRIER textureBarrier( kSync, kSync, kAccess, kAccess,
+                D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, resource,
                 SubresourceRange( resource, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES ) );
             CD3DX12_BARRIER_GROUP group( 1u, static_cast<const D3D12_TEXTURE_BARRIER*>( &textureBarrier ) );
             List7()->Barrier( 1, &group );
@@ -354,12 +279,8 @@ void D3D12CmdList::UAVBarriers( ID3D12Resource* const* resources, UINT count, D3
             } else if ( IsBufferResource( resource ) ) {
                 bufferBarriers[numBuffer++] = CD3DX12_BUFFER_BARRIER( kSync, kSync, kAccess, kAccess, resource );
             } else {
-                const bool bridged = BridgeLegacyResourceToCommon( resource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-                textureBarriers[numTexture++] = CD3DX12_TEXTURE_BARRIER(
-                    bridged ? D3D12_BARRIER_SYNC_NONE : kSync, kSync,
-                    bridged ? D3D12_BARRIER_ACCESS_NO_ACCESS : kAccess, kAccess,
-                    bridged ? D3D12_BARRIER_LAYOUT_COMMON : D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS,
-                    D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, resource,
+                textureBarriers[numTexture++] = CD3DX12_TEXTURE_BARRIER( kSync, kSync, kAccess, kAccess,
+                    D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS, resource,
                     SubresourceRange( resource, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES ) );
             }
         }

--- a/D3D11Engine/D3D12Engine/D3D12Barrier.h
+++ b/D3D11Engine/D3D12Engine/D3D12Barrier.h
@@ -4,25 +4,15 @@
 // Enhanced-barrier support for D3D12CmdList (see D3D12StateCache.h). Kept in its own translation
 // unit because the legacy-state -> (sync, access, layout) translation table is real domain logic,
 // not a one-line filter forward like everything else D3D12CmdList wraps.
-//
-// Every D3D12CmdList::TransitionBarrier/TransitionBarriers/UAVBarrier/UAVBarriers call site in the
-// backend speaks legacy D3D12_RESOURCE_STATES; whether the machine actually has enhanced barriers is
-// decided once per process and is invisible at the call site. When it does, the state pair is mapped
-// through a conservative table (broadest sync/access that's still correct for that state) unless the
-// caller supplies an explicit sync-scope hint -- see SyncScope below -- to narrow it for a call site
-// whose actual pipeline-stage usage is known (e.g. a UAV only ever touched from compute).
 
 /** Sentinel meaning "no hint -- use the table's conservative default for this state." Not a valid
-    D3D12_BARRIER_SYNC value on its own (every real table entry is a small handful of set bits, never
-    all of them), so it can't collide with an intentional value. */
+    D3D12_BARRIER_SYNC value on its own, so it can't collide with an intentional value. */
 inline constexpr D3D12_BARRIER_SYNC kBarrierSyncUnspecified = static_cast<D3D12_BARRIER_SYNC>( ~0u );
 
 /** One transition in a batched D3D12CmdList::TransitionBarriers() call. SyncBefore/SyncAfter are
-    optional narrowing hints (see kBarrierSyncUnspecified) for callers that know precisely which
-    pipeline stage(s) touch the resource on each side of the transition -- e.g. a bloom mip that is
-    only ever read/written from a compute dispatch doesn't need the table's default ALL_SHADING scope
-    for D3D12_RESOURCE_STATE_UNORDERED_ACCESS. Ignored on the legacy-fallback path: legacy transitions
-    have no sync-scope concept, so an unsupported machine gets the same barrier either way. */
+    optional narrowing hints for callers that know precisely which pipeline stage(s) touch the
+    resource on each side -- e.g. a UAV only ever touched from compute doesn't need the table's
+    default ALL_SHADING scope. Ignored on the legacy-fallback path. */
 struct D3D12ResourceTransition {
     ID3D12Resource* Resource = nullptr;
     D3D12_RESOURCE_STATES Before = D3D12_RESOURCE_STATE_COMMON;

--- a/D3D11Engine/D3D12Engine/D3D12Barrier.h
+++ b/D3D11Engine/D3D12Engine/D3D12Barrier.h
@@ -5,16 +5,29 @@
 // unit because the legacy-state -> (sync, access, layout) translation table is real domain logic,
 // not a one-line filter forward like everything else D3D12CmdList wraps.
 //
-// This is a FOUNDATION ONLY: nothing in the backend calls D3D12CmdList::TransitionBarrier /
-// UAVBarrier / AliasingBarrier yet. All 146 existing call sites keep using the legacy
-// CD3DX12_RESOURCE_BARRIER + ResourceBarrier() path untouched. New/future call sites can adopt the
-// methods declared here without needing to know whether enhanced barriers are actually available on
-// the running machine -- that's decided once per process and handled internally.
+// Every D3D12CmdList::TransitionBarrier/TransitionBarriers/UAVBarrier/UAVBarriers call site in the
+// backend speaks legacy D3D12_RESOURCE_STATES; whether the machine actually has enhanced barriers is
+// decided once per process and is invisible at the call site. When it does, the state pair is mapped
+// through a conservative table (broadest sync/access that's still correct for that state) unless the
+// caller supplies an explicit sync-scope hint -- see SyncScope below -- to narrow it for a call site
+// whose actual pipeline-stage usage is known (e.g. a UAV only ever touched from compute).
 
-/** One transition in a batched D3D12CmdList::TransitionBarriers() call. */
+/** Sentinel meaning "no hint -- use the table's conservative default for this state." Not a valid
+    D3D12_BARRIER_SYNC value on its own (every real table entry is a small handful of set bits, never
+    all of them), so it can't collide with an intentional value. */
+inline constexpr D3D12_BARRIER_SYNC kBarrierSyncUnspecified = static_cast<D3D12_BARRIER_SYNC>( ~0u );
+
+/** One transition in a batched D3D12CmdList::TransitionBarriers() call. SyncBefore/SyncAfter are
+    optional narrowing hints (see kBarrierSyncUnspecified) for callers that know precisely which
+    pipeline stage(s) touch the resource on each side of the transition -- e.g. a bloom mip that is
+    only ever read/written from a compute dispatch doesn't need the table's default ALL_SHADING scope
+    for D3D12_RESOURCE_STATE_UNORDERED_ACCESS. Ignored on the legacy-fallback path: legacy transitions
+    have no sync-scope concept, so an unsupported machine gets the same barrier either way. */
 struct D3D12ResourceTransition {
     ID3D12Resource* Resource = nullptr;
     D3D12_RESOURCE_STATES Before = D3D12_RESOURCE_STATE_COMMON;
     D3D12_RESOURCE_STATES After = D3D12_RESOURCE_STATE_COMMON;
     UINT Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    D3D12_BARRIER_SYNC SyncBefore = kBarrierSyncUnspecified;
+    D3D12_BARRIER_SYNC SyncAfter = kBarrierSyncUnspecified;
 };

--- a/D3D11Engine/D3D12Engine/D3D12Barrier.h
+++ b/D3D11Engine/D3D12Engine/D3D12Barrier.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <d3d12.h>
+
+// Enhanced-barrier support for D3D12CmdList (see D3D12StateCache.h). Kept in its own translation
+// unit because the legacy-state -> (sync, access, layout) translation table is real domain logic,
+// not a one-line filter forward like everything else D3D12CmdList wraps.
+//
+// This is a FOUNDATION ONLY: nothing in the backend calls D3D12CmdList::TransitionBarrier /
+// UAVBarrier / AliasingBarrier yet. All 146 existing call sites keep using the legacy
+// CD3DX12_RESOURCE_BARRIER + ResourceBarrier() path untouched. New/future call sites can adopt the
+// methods declared here without needing to know whether enhanced barriers are actually available on
+// the running machine -- that's decided once per process and handled internally.
+
+/** One transition in a batched D3D12CmdList::TransitionBarriers() call. */
+struct D3D12ResourceTransition {
+    ID3D12Resource* Resource = nullptr;
+    D3D12_RESOURCE_STATES Before = D3D12_RESOURCE_STATE_COMMON;
+    D3D12_RESOURCE_STATES After = D3D12_RESOURCE_STATE_COMMON;
+    UINT Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+};

--- a/D3D11Engine/D3D12Engine/D3D12Cull.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Cull.cpp
@@ -228,9 +228,8 @@ void D3D12GraphicsEngine::BuildHiZ() {
     // Depth prepass left it in DEPTH_WRITE; make it readable for the copy pass and hand it straight back at the
     // end (the VOB/skeletal prepass draws right after need DEPTH_WRITE). Same round-trip DispatchLightCulling
     // and RenderSSAO already do — the DSV stays bound but nothing draws while it is in a read state.
-    // Both sides of this whole function are compute-only (HiZCopyPSO/HiZReducePSO dispatches and, on the far
-    // end, CSCull) -- m_HiZ never leaves this file and m_DepthBuffer's read window here is scoped tightly to
-    // the copy dispatch below, so narrowing sync to compute-only is safe on both transitions.
+    // Both sides here are compute-only (HiZCopyPSO/HiZReducePSO, and CSCull further down), so the sync
+    // scope is narrowed to compute rather than the table's broader default.
     pre[preCount++] = { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
         D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, kBarrierSyncUnspecified, D3D12_BARRIER_SYNC_COMPUTE_SHADING };
     if ( m_HiZInSrvState ) {
@@ -253,8 +252,8 @@ void D3D12GraphicsEngine::BuildHiZ() {
     // --- mip N-1 -> mip N ---
     m_CmdList->SetPipelineState( m_Pipelines.Cull.HiZReducePSO.Get() );
     for ( UINT m = 1; m < m_HiZMipCount; ++m ) {
-        // The parent level is read through its UAV, so a UAV barrier (not a transition) is what orders the
-        // previous dispatch's writes against this one's reads. Both dispatches are HiZReducePSO -- compute-only.
+        // The parent level is read through its UAV, so a UAV barrier (not a transition) orders the
+        // previous dispatch's writes against this one's reads; both sides are compute-only.
         m_CmdList->UAVBarrier( m_HiZ.Get(), D3D12_BARRIER_SYNC_COMPUTE_SHADING );
 
         const uint32_t consts[4] = { m_HiZMipUavSlot[m - 1], m_HiZMipUavSlot[m], 0u, 0u };
@@ -264,8 +263,8 @@ void D3D12GraphicsEngine::BuildHiZ() {
         m_CmdList->Dispatch( ( w + 7 ) / 8, ( h + 7 ) / 8, 1 );
     }
 
-    // CSCull reads the pyramid as an SRV (it needs per-level Load(); an RWTexture2D cannot select a mip). The
-    // depth buffer's read here was compute-only (HiZCopyPSO, above); CSCull's read of m_HiZ is compute too.
+    // CSCull reads the pyramid as an SRV (it needs per-level Load(); an RWTexture2D can't select a mip);
+    // both this and the depth buffer's read are compute-only.
     m_CmdList->TransitionBarriers( {
         { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE,
             D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, D3D12_BARRIER_SYNC_COMPUTE_SHADING, kBarrierSyncUnspecified },

--- a/D3D11Engine/D3D12Engine/D3D12Cull.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Cull.cpp
@@ -227,9 +227,14 @@ void D3D12GraphicsEngine::BuildHiZ() {
     // Depth prepass left it in DEPTH_WRITE; make it readable for the copy pass and hand it straight back at the
     // end (the VOB/skeletal prepass draws right after need DEPTH_WRITE). Same round-trip DispatchLightCulling
     // and RenderSSAO already do — the DSV stays bound but nothing draws while it is in a read state.
-    pre[preCount++] = { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE };
+    // Both sides of this whole function are compute-only (HiZCopyPSO/HiZReducePSO dispatches and, on the far
+    // end, CSCull) -- m_HiZ never leaves this file and m_DepthBuffer's read window here is scoped tightly to
+    // the copy dispatch below, so narrowing sync to compute-only is safe on both transitions.
+    pre[preCount++] = { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+        D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, kBarrierSyncUnspecified, D3D12_BARRIER_SYNC_COMPUTE_SHADING };
     if ( m_HiZInSrvState ) {
-        pre[preCount++] = { m_HiZ.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS };
+        pre[preCount++] = { m_HiZ.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+            D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, D3D12_BARRIER_SYNC_COMPUTE_SHADING, D3D12_BARRIER_SYNC_COMPUTE_SHADING };
         m_HiZInSrvState = false;
     }
     m_CmdList->TransitionBarriers( pre, preCount );
@@ -248,8 +253,8 @@ void D3D12GraphicsEngine::BuildHiZ() {
     m_CmdList->SetPipelineState( m_Pipelines.Cull.HiZReducePSO.Get() );
     for ( UINT m = 1; m < m_HiZMipCount; ++m ) {
         // The parent level is read through its UAV, so a UAV barrier (not a transition) is what orders the
-        // previous dispatch's writes against this one's reads.
-        m_CmdList->UAVBarrier( m_HiZ.Get() );
+        // previous dispatch's writes against this one's reads. Both dispatches are HiZReducePSO -- compute-only.
+        m_CmdList->UAVBarrier( m_HiZ.Get(), D3D12_BARRIER_SYNC_COMPUTE_SHADING );
 
         const uint32_t consts[4] = { m_HiZMipUavSlot[m - 1], m_HiZMipUavSlot[m], 0u, 0u };
         m_CmdList->SetComputeRoot32BitConstants( 0, 4, consts, 0 );
@@ -258,10 +263,13 @@ void D3D12GraphicsEngine::BuildHiZ() {
         m_CmdList->Dispatch( ( w + 7 ) / 8, ( h + 7 ) / 8, 1 );
     }
 
-    // CSCull reads the pyramid as an SRV (it needs per-level Load(); an RWTexture2D cannot select a mip).
+    // CSCull reads the pyramid as an SRV (it needs per-level Load(); an RWTexture2D cannot select a mip). The
+    // depth buffer's read here was compute-only (HiZCopyPSO, above); CSCull's read of m_HiZ is compute too.
     m_CmdList->TransitionBarriers( {
-        { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE },
-        { m_HiZ.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE },
+        { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE,
+            D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, D3D12_BARRIER_SYNC_COMPUTE_SHADING, kBarrierSyncUnspecified },
+        { m_HiZ.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+            D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, D3D12_BARRIER_SYNC_COMPUTE_SHADING, D3D12_BARRIER_SYNC_COMPUTE_SHADING },
     } );
     m_HiZInSrvState = true;
 }

--- a/D3D11Engine/D3D12Engine/D3D12Cull.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Cull.cpp
@@ -222,17 +222,17 @@ void D3D12GraphicsEngine::BuildHiZ() {
 
     DX_ZONE( m_CmdList.Get(), "Hi-Z build" );
 
-    D3D12_RESOURCE_BARRIER pre[2] = {};
+    D3D12ResourceTransition pre[2] = {};
     UINT preCount = 0;
     // Depth prepass left it in DEPTH_WRITE; make it readable for the copy pass and hand it straight back at the
     // end (the VOB/skeletal prepass draws right after need DEPTH_WRITE). Same round-trip DispatchLightCulling
     // and RenderSSAO already do — the DSV stays bound but nothing draws while it is in a read state.
-    pre[preCount++] = TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+    pre[preCount++] = { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE };
     if ( m_HiZInSrvState ) {
-        pre[preCount++] = TransitionBarrier( m_HiZ.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+        pre[preCount++] = { m_HiZ.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS };
         m_HiZInSrvState = false;
     }
-    m_CmdList->ResourceBarrier( preCount, pre );
+    m_CmdList->TransitionBarriers( pre, preCount );
 
     m_CmdList->SetComputeRootSignature( m_Pipelines.Cull.HiZRootSig.Get() );
 
@@ -249,10 +249,7 @@ void D3D12GraphicsEngine::BuildHiZ() {
     for ( UINT m = 1; m < m_HiZMipCount; ++m ) {
         // The parent level is read through its UAV, so a UAV barrier (not a transition) is what orders the
         // previous dispatch's writes against this one's reads.
-        D3D12_RESOURCE_BARRIER uavBarrier = {};
-        uavBarrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
-        uavBarrier.UAV.pResource = m_HiZ.Get();
-        m_CmdList->ResourceBarrier( 1, &uavBarrier );
+        m_CmdList->UAVBarrier( m_HiZ.Get() );
 
         const uint32_t consts[4] = { m_HiZMipUavSlot[m - 1], m_HiZMipUavSlot[m], 0u, 0u };
         m_CmdList->SetComputeRoot32BitConstants( 0, 4, consts, 0 );
@@ -261,12 +258,11 @@ void D3D12GraphicsEngine::BuildHiZ() {
         m_CmdList->Dispatch( ( w + 7 ) / 8, ( h + 7 ) / 8, 1 );
     }
 
-    D3D12_RESOURCE_BARRIER post[2] = {
-        TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE ),
-        // CSCull reads the pyramid as an SRV (it needs per-level Load(); an RWTexture2D cannot select a mip).
-        TransitionBarrier( m_HiZ.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE ),
-    };
-    m_CmdList->ResourceBarrier( 2, post );
+    // CSCull reads the pyramid as an SRV (it needs per-level Load(); an RWTexture2D cannot select a mip).
+    m_CmdList->TransitionBarriers( {
+        { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE },
+        { m_HiZ.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE },
+    } );
     m_HiZInSrvState = true;
 }
 
@@ -282,10 +278,10 @@ void D3D12GraphicsEngine::CullVobsGPU() {
 
     // --- Restore rest states the previous frame's draws left behind (same pattern as m_LightGridInPixelState) ---
     {
-        D3D12_RESOURCE_BARRIER pre[3] = {};
+        D3D12ResourceTransition pre[3] = {};
         UINT n = 0;
         if ( m_VobDrawArgsGpuInIndirectState ) {
-            pre[n++] = TransitionBarrier( m_VobDrawArgsGpu.Get(), D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT, D3D12_RESOURCE_STATE_COPY_DEST );
+            pre[n++] = { m_VobDrawArgsGpu.Get(), D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT, D3D12_RESOURCE_STATE_COPY_DEST };
             m_VobDrawArgsGpuInIndirectState = false;
         }
         // Cull-record overflow safety net: a visual that didn't fit kMaxCullVisuals keeps VisualIndex
@@ -298,23 +294,22 @@ void D3D12GraphicsEngine::CullVobsGPU() {
         // frame that actually overflowed — i.e. essentially never, since the cap is 16384 visuals.
         const bool seedCulled = m_VobCullVisualOverflowed && m_VobInstanceBufferOffset > 0;
         if ( m_VobCulledInstancesInVertexState ) {
-            pre[n++] = TransitionBarrier( m_VobCulledInstances.Get(), D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER,
-                seedCulled ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+            pre[n++] = { m_VobCulledInstances.Get(), D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER,
+                seedCulled ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_UNORDERED_ACCESS };
             m_VobCulledInstancesInVertexState = false;
         }
         if ( m_VobVisibleCountsInSrvState ) {
-            pre[n++] = TransitionBarrier( m_VobVisibleCounts.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+            pre[n++] = { m_VobVisibleCounts.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS };
             m_VobVisibleCountsInSrvState = false;
         }
-        if ( n ) m_CmdList->ResourceBarrier( n, pre );
+        m_CmdList->TransitionBarriers( pre, n );
 
         if ( seedCulled ) {
             m_CmdList->CopyBufferRegion( m_VobCulledInstances.Get(), 0, m_VobInstanceBuffer[m_FrameIndex].Get(), 0,
                 m_VobInstanceBufferOffset );
             // Back to UNORDERED_ACCESS for CSCull, which is about to overwrite the compacted prefixes.
-            D3D12_RESOURCE_BARRIER toUav = TransitionBarrier( m_VobCulledInstances.Get(),
+            m_CmdList->TransitionBarrier( m_VobCulledInstances.Get(),
                 D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-            m_CmdList->ResourceBarrier( 1, &toUav );
         }
     }
 
@@ -370,11 +365,10 @@ void D3D12GraphicsEngine::CullVobsGPU() {
 
     // --- Pass 2: write the surviving counts into the indirect arguments ---
     {
-        D3D12_RESOURCE_BARRIER mid[2] = {
-            TransitionBarrier( m_VobVisibleCounts.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE ),
-            TransitionBarrier( m_VobDrawArgsGpu.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-        };
-        m_CmdList->ResourceBarrier( 2, mid );
+        m_CmdList->TransitionBarriers( {
+        	{ m_VobVisibleCounts.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE },
+        	{ m_VobDrawArgsGpu.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        } );
         m_VobVisibleCountsInSrvState = true;
     }
 
@@ -399,11 +393,10 @@ void D3D12GraphicsEngine::CullVobsGPU() {
     m_CmdList->Dispatch( ( m_VobDrawCount + 63 ) / 64, 1, 1 );
 
     // --- Hand both buffers to the two VOB passes ---
-    D3D12_RESOURCE_BARRIER post[2] = {
-        TransitionBarrier( m_VobDrawArgsGpu.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT ),
-        TransitionBarrier( m_VobCulledInstances.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER ),
-    };
-    m_CmdList->ResourceBarrier( 2, post );
+    m_CmdList->TransitionBarriers( {
+    	{ m_VobDrawArgsGpu.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT },
+    	{ m_VobCulledInstances.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER },
+    } );
     m_VobDrawArgsGpuInIndirectState = true;
     m_VobCulledInstancesInVertexState = true;
 }

--- a/D3D11Engine/D3D12Engine/D3D12Cull.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Cull.cpp
@@ -15,6 +15,7 @@
 // their own CPU cull against their own frustum (a caster outside the player's view still casts into it).
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 
@@ -54,7 +55,7 @@ bool D3D12GraphicsEngine::CreateHiZResources( INT2 size ) {
     dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
     dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
 
-    if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr,
+    if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr,
         m_HiZAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( m_HiZ.ReleaseAndGetAddressOf() ) ) ) ) {
         LogWarn() << "D3D12: failed to create the Hi-Z pyramid (" << m_HiZWidth << "x" << m_HiZHeight << ").";
         return false;

--- a/D3D11Engine/D3D12Engine/D3D12Device.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Device.cpp
@@ -298,17 +298,22 @@ bool D3D12Device::Init() {
     }
 
 #ifdef DEBUG_D3D11
+    constexpr bool DEBUG_D3D11_ENABLED = true;
+#else
+    constexpr bool DEBUG_D3D11_ENABLED = false;
+#endif
+
     // Enable the debug layer before device creation when available (best-effort).
     if ( HMODULE d3d12 = GetModuleHandleA( "d3d12.dll" ) ) {
         auto getDebug = reinterpret_cast<PFN_D3D12_GET_DEBUG_INTERFACE>( GetProcAddress( d3d12, "D3D12GetDebugInterface" ) );
         ComPtr<ID3D12Debug> debug;
-        if ( getDebug && SUCCEEDED( getDebug( IID_PPV_ARGS( debug.ReleaseAndGetAddressOf() ) ) ) ) {
+        if ( DEBUG_D3D11_ENABLED && getDebug && SUCCEEDED( getDebug( IID_PPV_ARGS( debug.ReleaseAndGetAddressOf() ) ) ) ) {
             debug->EnableDebugLayer();
             LogInfo() << "D3D12 debug layer enabled.";
         }
 
         ComPtr<ID3D12Debug1> debug1;
-        if ( SUCCEEDED( debug.As( &debug1 ) ) ) {
+        if ( DEBUG_D3D11_ENABLED && SUCCEEDED( debug.As( &debug1 ) ) ) {
             debug1->SetEnableGPUBasedValidation( FALSE ); // NOTE: This is REALLY expensive. Only use when actually debugging hard crashes.
         }
 
@@ -318,11 +323,11 @@ bool D3D12Device::Init() {
             // Turn on auto-breadcrumbs and page fault reporting
             pDredSettings->SetAutoBreadcrumbsEnablement( D3D12_DRED_ENABLEMENT_FORCED_ON );
             pDredSettings->SetBreadcrumbContextEnablement( D3D12_DRED_ENABLEMENT_FORCED_ON );
-            pDredSettings->SetPageFaultEnablement( D3D12_DRED_ENABLEMENT_FORCED_ON );
-            pDredSettings->Release();
+            if ( DEBUG_D3D11_ENABLED ) {
+                pDredSettings->SetPageFaultEnablement( D3D12_DRED_ENABLEMENT_FORCED_ON );
+            }
         }
     }
-#endif
 
     if ( !CreateFactory( m_Factory ) ) {
         LogWarn() << "D3D12Device::Init: failed to create DXGI factory.";

--- a/D3D11Engine/D3D12Engine/D3D12Device.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Device.cpp
@@ -171,12 +171,6 @@ namespace {
         return true;
     }
 
-    // Enhanced barriers (D3D12_FEATURE_D3D12_OPTIONS12.EnhancedBarriersSupported) replace legacy
-    // D3D12_RESOURCE_BARRIER transitions with explicit sync/access/layout groups and drop most of
-    // the split-barrier/subresource-state bookkeeping. This is a pure runtime capability query — it
-    // needs no new proc address (CheckFeatureSupport is already resolved through the base
-    // ID3D12Device interface we already have), so it works regardless of whether the Agility SDK
-    // core is active. Optional, never required: callers without it keep using legacy transitions.
     bool DeviceSupportsEnhancedBarriers( ID3D12Device* device, std::string* outReason ) {
         D3D12_FEATURE_DATA_D3D12_OPTIONS12 options12 = {};
         if ( FAILED( device->CheckFeatureSupport( D3D12_FEATURE_D3D12_OPTIONS12, &options12, sizeof( options12 ) ) )

--- a/D3D11Engine/D3D12Engine/D3D12Device.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Device.cpp
@@ -171,6 +171,22 @@ namespace {
         return true;
     }
 
+    // Enhanced barriers (D3D12_FEATURE_D3D12_OPTIONS12.EnhancedBarriersSupported) replace legacy
+    // D3D12_RESOURCE_BARRIER transitions with explicit sync/access/layout groups and drop most of
+    // the split-barrier/subresource-state bookkeeping. This is a pure runtime capability query — it
+    // needs no new proc address (CheckFeatureSupport is already resolved through the base
+    // ID3D12Device interface we already have), so it works regardless of whether the Agility SDK
+    // core is active. Optional, never required: callers without it keep using legacy transitions.
+    bool DeviceSupportsEnhancedBarriers( ID3D12Device* device, std::string* outReason ) {
+        D3D12_FEATURE_DATA_D3D12_OPTIONS12 options12 = {};
+        if ( FAILED( device->CheckFeatureSupport( D3D12_FEATURE_D3D12_OPTIONS12, &options12, sizeof( options12 ) ) )
+            || !options12.EnhancedBarriersSupported ) {
+            if ( outReason ) *outReason = "the driver/runtime does not report D3D12_OPTIONS12.EnhancedBarriersSupported";
+            return false;
+        }
+        return true;
+    }
+
     /** Returns true if the adapter supports a FL12_0 D3D12 device that can also do SM6.6 bindless
         (capability check only — the temporary device is dropped again). */
     bool AdapterSupportsD3D12( PFN_D3D12_CREATE_DEVICE createDevice, IDXGIAdapter1* adapter,
@@ -332,6 +348,14 @@ bool D3D12Device::Init() {
         return false;
     }
     LogInfo() << "D3D12 device created on: " << m_DeviceDescription.c_str();
+
+    std::string barrierReason;
+    m_EnhancedBarriersSupported = DeviceSupportsEnhancedBarriers( m_Device.Get(), &barrierReason );
+    if ( m_EnhancedBarriersSupported ) {
+        LogInfo() << "D3D12: enhanced barriers supported.";
+    } else {
+        LogInfo() << "D3D12: enhanced barriers unavailable (" << barrierReason.c_str() << "); using legacy transitions.";
+    }
 
     // Direct (graphics) queue
     D3D12_COMMAND_QUEUE_DESC directDesc = {};

--- a/D3D11Engine/D3D12Engine/D3D12Device.h
+++ b/D3D11Engine/D3D12Engine/D3D12Device.h
@@ -32,6 +32,10 @@ public:
 
     const std::string& GetDeviceDescription() const { return m_DeviceDescription; }
 
+    /** True if the device reports D3D12_OPTIONS12.EnhancedBarriersSupported. Purely informational —
+        enhanced barriers are optional, never required, so this doesn't affect Init()'s success. */
+    bool EnhancedBarriersSupported() const { return m_EnhancedBarriersSupported; }
+
     ID3D12Device*       GetDevice()      const { return m_Device.Get(); }
     ID3D12CommandQueue* GetDirectQueue() const { return m_DirectQueue.Get(); }
     ID3D12CommandQueue* GetCopyQueue()   const { return m_CopyQueue.Get(); }
@@ -45,4 +49,5 @@ private:
     Microsoft::WRL::ComPtr<ID3D12CommandQueue>  m_DirectQueue;
     Microsoft::WRL::ComPtr<ID3D12CommandQueue>  m_CopyQueue;
     std::string m_DeviceDescription;
+    bool m_EnhancedBarriersSupported = false;
 };

--- a/D3D11Engine/D3D12Engine/D3D12DoF.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12DoF.cpp
@@ -14,6 +14,7 @@
 // texture and is copied back), so nothing downstream has to know the pass ran.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 
@@ -66,7 +67,7 @@ bool D3D12GraphicsEngine::CreateDoFResources( INT2 size ) {
         dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
         // Every one of these rests in UNORDERED_ACCESS between frames (see RenderDepthOfField), so create them
         // in it — that makes the "before" state at the top of the pass deterministic on the very first frame.
-        if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+        if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             nullptr, outAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( out.ReleaseAndGetAddressOf() ) ) ) ) {
             LogWarn() << "D3D12: failed to create a depth-of-field texture (" << w << "x" << h << ").";
             return false;

--- a/D3D11Engine/D3D12Engine/D3D12DoF.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12DoF.cpp
@@ -200,16 +200,16 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
     // an SRV (same dance RenderTAA / RenderBloom / RenderFogAndGodRays do).
     m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
     {
-        D3D12_RESOURCE_BARRIER pre[3];
+        D3D12ResourceTransition pre[3];
         UINT n = 0;
         if ( !m_SceneColorInPixelState ) {
-            pre[n++] = TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
-                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+            pre[n++] = { m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
+                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE };
         }
-        pre[n++] = TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, kDoFDepthRead );
-        pre[n++] = TransitionBarrier( m_DoFFocus[prevIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-        m_CmdList->ResourceBarrier( n, pre );
+        pre[n++] = { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, kDoFDepthRead };
+        pre[n++] = { m_DoFFocus[prevIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE };
+        m_CmdList->TransitionBarriers( pre, n );
         m_SceneColorInPixelState = true;
     }
 
@@ -226,13 +226,10 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
     // resting UAV state. A UAV-write -> SRV-read handover needs a real state transition, not a UAV barrier: a
     // UAV barrier only orders UAV access and performs no cache flush, so the SRV read would be undefined.
     {
-        D3D12_RESOURCE_BARRIER b[2] = {
-            TransitionBarrier( m_DoFFocus[curIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE ),
-            TransitionBarrier( m_DoFFocus[prevIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-        };
-        m_CmdList->ResourceBarrier( 2, b );
+        m_CmdList->TransitionBarriers( {
+        	{ m_DoFFocus[curIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE },
+        	{ m_DoFFocus[prevIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        } );
     }
     m_DoFFocusIndex = curIdx;
     m_DoFFocusValid = true;
@@ -246,9 +243,7 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
     m_CmdList->Dispatch( ( m_DoFHalfSize.x + 7 ) / 8, ( m_DoFHalfSize.y + 7 ) / 8, 1 );
 
     {
-        auto b = TransitionBarrier( m_DoFHalf.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( m_DoFHalf.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
     }
 
     // --- Pass 2: full-res composite into the scratch texture ---
@@ -261,31 +256,23 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
 
     // Hand the result back to the scene colour. Both are kSceneColorFormat, so this is a straight CopyResource.
     {
-        D3D12_RESOURCE_BARRIER toCopy[2] = {
-            TransitionBarrier( m_DoFComposite.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-                D3D12_RESOURCE_STATE_COPY_SOURCE ),
-            TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_COPY_DEST ),
-        };
-        m_CmdList->ResourceBarrier( 2, toCopy );
+        m_CmdList->TransitionBarriers( {
+        	{ m_DoFComposite.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE },
+        	{ m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST },
+        } );
         m_CmdList->CopyResource( m_SceneColor.Get(), m_DoFComposite.Get() );
     }
 
     // Resting states for the next frame: every DoF texture back to UNORDERED_ACCESS, depth back to DEPTH_WRITE,
     // scene colour back to RENDER_TARGET for bloom / the tonemap.
     {
-        D3D12_RESOURCE_BARRIER post[5] = {
-            TransitionBarrier( m_DoFComposite.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-            TransitionBarrier( m_DoFHalf.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-            TransitionBarrier( m_DoFFocus[curIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-            TransitionBarrier( m_DepthBuffer.Get(), kDoFDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE ),
-            TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_COPY_DEST,
-                D3D12_RESOURCE_STATE_RENDER_TARGET ),
-        };
-        m_CmdList->ResourceBarrier( 5, post );
+        m_CmdList->TransitionBarriers( {
+        	{ m_DoFComposite.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        	{ m_DoFHalf.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        	{ m_DoFFocus[curIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        	{ m_DepthBuffer.Get(), kDoFDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE },
+        	{ m_SceneColor.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_RENDER_TARGET },
+        } );
         m_SceneColorInPixelState = false;
     }
 

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -272,6 +272,9 @@ struct CPUBreadcrumbContext {
 inline thread_local std::array<CPUBreadcrumbContext, 2048> g_CpuContextHistory;
 inline thread_local UINT g_CurrentRecordingOpIndex = 0;
 
+#define DX_MARKER_VALUE(x) x, std::sizeof(x)
+#define SetMarkerStr(x) SetMarker(x, std::sizeof(x))
+
 struct DXMarker {
     DXMarker( const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList, const wchar_t* text ) :
         DXMarker( commandList.Get(), text )
@@ -284,25 +287,20 @@ struct DXMarker {
     DXMarker( ID3D12GraphicsCommandList* commandList, const wchar_t* text ) :
         c( commandList )
     {
-        if ( c && text ) {
+        if ( text ) {
             // Track exactly what string context we are assigning to the CURRENT command slot
             if ( g_CurrentRecordingOpIndex < g_CpuContextHistory.size() ) {
                 g_CpuContextHistory[g_CurrentRecordingOpIndex] = { g_CurrentRecordingOpIndex, text };
             }
 
             UINT byteSize = static_cast<UINT>( (wcslen( text ) + 1) * sizeof( wchar_t ) );
-            c->BeginEvent( 0, text, byteSize );
-
-            // Increment tracking slot to match what DRED maps under the hood
-            g_CurrentRecordingOpIndex++;
+            c->SetMarker( 0, text, byteSize );
         }
+        g_CurrentRecordingOpIndex++;
     }
 
     ~DXMarker() {
-        if ( c ) {
-            c->EndEvent();
-            g_CurrentRecordingOpIndex++;
-        }
+        g_CurrentRecordingOpIndex++;
     }
 
     DXMarker( const DXMarker& ) = delete;

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -281,10 +281,19 @@ struct DXMarker {
     {
     }
 
+    template<UINT TTextLen>
+    inline static DXMarker Create( ID3D12GraphicsCommandList* commandList, const wchar_t( &text )[TTextLen] ) {
+        return DXMarker( commandList, text, TTextLen );
+    }
+
     // Raw-pointer overload: the MT shadow-cascade recorder (PrepareSunShadows / RecordShadowCascade) is handed a
     // bare ID3D12GraphicsCommandList* so the same body can record into m_CmdList or into a per-cascade list.
     // The breadcrumb ring this writes is thread_local, so concurrent recorders don't collide.
     DXMarker( ID3D12GraphicsCommandList* commandList, const wchar_t* text ) :
+        DXMarker( commandList, text, wcslen( text ) )
+    {}
+
+    DXMarker( ID3D12GraphicsCommandList* commandList, const wchar_t* text, size_t len ) :
         c( commandList )
     {
         if ( c && text ) {
@@ -293,7 +302,7 @@ struct DXMarker {
                 g_CpuContextHistory[g_CurrentRecordingOpIndex] = { g_CurrentRecordingOpIndex, text };
             }
 
-            UINT byteSize = static_cast<UINT>( (wcslen( text ) + 1) * sizeof( wchar_t ) );
+            UINT byteSize = static_cast<UINT>( (len + 1) * sizeof( wchar_t ) );
             c->SetMarker( 0, text, byteSize );
             c->BeginEvent( 0, text, byteSize );
 
@@ -324,7 +333,7 @@ inline void ResetCpuContextTracker() {
     }
 }
 
-#define DX_ZONE(cmdList, nameStr) DXMarker marker_local_evt_##__LINE__(cmdList, L##nameStr)
+#define DX_ZONE(cmdList, nameStr) DXMarker marker_local_evt_##__LINE__ = DXMarker::Create(cmdList, L##nameStr)
 
 // Simple whole-resource transition barrier (legacy barriers; no enhanced-barrier path on inbox D3D12).
 inline D3D12_RESOURCE_BARRIER TransitionBarrier( ID3D12Resource* res, D3D12_RESOURCE_STATES before, D3D12_RESOURCE_STATES after ) {

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -287,7 +287,7 @@ struct DXMarker {
     DXMarker( ID3D12GraphicsCommandList* commandList, const wchar_t* text ) :
         c( commandList )
     {
-        if ( text ) {
+        if ( c && text ) {
             // Track exactly what string context we are assigning to the CURRENT command slot
             if ( g_CurrentRecordingOpIndex < g_CpuContextHistory.size() ) {
                 g_CpuContextHistory[g_CurrentRecordingOpIndex] = { g_CurrentRecordingOpIndex, text };
@@ -295,12 +295,18 @@ struct DXMarker {
 
             UINT byteSize = static_cast<UINT>( (wcslen( text ) + 1) * sizeof( wchar_t ) );
             c->SetMarker( 0, text, byteSize );
+            c->BeginEvent( 0, text, byteSize );
+
+            // Increment tracking slot to match what DRED maps under the hood
+            g_CurrentRecordingOpIndex++;
         }
-        g_CurrentRecordingOpIndex++;
     }
 
     ~DXMarker() {
-        g_CurrentRecordingOpIndex++;
+        if ( c ) {
+            c->EndEvent();
+            g_CurrentRecordingOpIndex++;
+        }
     }
 
     DXMarker( const DXMarker& ) = delete;

--- a/D3D11Engine/D3D12Engine/D3D12Fog.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Fog.cpp
@@ -12,6 +12,7 @@
 // exactly like D3D11 (`DrawFog && isOutdoor`, `EnableGodRays && isOutdoor`).
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 #include "../GSky.h"
@@ -122,7 +123,7 @@ bool D3D12GraphicsEngine::CreateFogResources( INT2 size ) {
         dd.SampleDesc.Count = 1;
         dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
         dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-        if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+        if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             nullptr, outAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( out.ReleaseAndGetAddressOf() ) ) ) ) {
             LogWarn() << "D3D12: failed to create a god-ray texture (" << ds4.x << "x" << ds4.y << ").";
             return false;

--- a/D3D11Engine/D3D12Engine/D3D12Fog.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Fog.cpp
@@ -255,8 +255,7 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
         D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
     {
         m_CmdList->OMSetRenderTargets( 1, &m_SceneColorRtv, FALSE, nullptr );
-        auto b = TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, kDepthRead );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, kDepthRead );
     }
 
     // ---------------------------------------------------------------------------------------------------
@@ -265,9 +264,7 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
     if ( godRays ) {
         // Scene color must be readable by the mask CS; compute can't run with it bound as an RTV.
         if ( !m_SceneColorInPixelState ) {
-            auto toSrv = TransitionBarrier( m_SceneColor.Get(),
-                D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-            m_CmdList->ResourceBarrier( 1, &toSrv );
+            m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
             m_SceneColorInPixelState = true;
         }
         m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
@@ -285,9 +282,7 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
 
         // UAV write -> SRV read needs a real state transition, not just a UAV barrier (see RenderBloom).
         {
-            auto b = TransitionBarrier( m_GodRayMask.Get(),
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-            m_CmdList->ResourceBarrier( 1, &b );
+            m_CmdList->TransitionBarrier( m_GodRayMask.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
         }
 
         // --- Pass 2: radial blur (m_GodRayMask -> m_GodRayZoom) ---
@@ -297,11 +292,10 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
 
         // Result -> pixel-shader readable for the composition; mask back to its resting UNORDERED_ACCESS.
         {
-            D3D12_RESOURCE_BARRIER b[2] = {
-                TransitionBarrier( m_GodRayZoom.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE ),
-                TransitionBarrier( m_GodRayMask.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-            };
-            m_CmdList->ResourceBarrier( 2, b );
+            m_CmdList->TransitionBarriers( {
+            	{ m_GodRayZoom.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
+            	{ m_GodRayMask.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+            } );
         }
     }
 
@@ -383,9 +377,7 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
 
     // Scene color back to RENDER_TARGET (the god-ray mask pass may have flipped it to a read state).
     if ( m_SceneColorInPixelState ) {
-        auto toRt = TransitionBarrier( m_SceneColor.Get(),
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
-        m_CmdList->ResourceBarrier( 1, &toRt );
+        m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
         m_SceneColorInPixelState = false;
     }
 
@@ -413,12 +405,12 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
     // UNORDERED_ACCESS, depth back to DEPTH_WRITE. The scene color stays bound as the RTV, which is exactly
     // what RenderBloom (the next pass) assumes.
     {
-        D3D12_RESOURCE_BARRIER b[2];
+        D3D12ResourceTransition b[2];
         UINT n = 0;
         if ( godRays )
-            b[n++] = TransitionBarrier( m_GodRayZoom.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-        b[n++] = TransitionBarrier( m_DepthBuffer.Get(), kDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE );
-        m_CmdList->ResourceBarrier( n, b );
+            b[n++] = { m_GodRayZoom.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS };
+        b[n++] = { m_DepthBuffer.Get(), kDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE };
+        m_CmdList->TransitionBarriers( b, n );
     }
 
     m_ColorTargetIsHDR = true;

--- a/D3D11Engine/D3D12Engine/D3D12GTAO.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GTAO.cpp
@@ -419,23 +419,18 @@ void D3D12GraphicsEngine::RenderGTAO() {
     // which is what the next barrier on each asserts as its "before" state. Skipping any of these produces a
     // GPU-validation RESOURCE_BARRIER_BEFORE_AFTER_MISMATCH rather than a visible artifact.
     {
-        D3D12_RESOURCE_BARRIER post[5] = {
-            TransitionBarrier( m_AOMask.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE ),
-            TransitionBarrier( m_GtaoWorkingDepth.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-            TransitionBarrier( m_GtaoEdges.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-            TransitionBarrier( m_GtaoAOTerm[srcTerm].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
+        D3D12ResourceTransition post[5] = {
+            { m_AOMask.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
+            { m_GtaoWorkingDepth.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+            { m_GtaoEdges.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+            { m_GtaoAOTerm[srcTerm].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
             {},   // m_GtaoNormals, only when the reconstruction path actually ran (see below)
         };
         UINT postCount = 4;
         if ( !gbufNormals ) {
-            post[postCount++] = TransitionBarrier( m_GtaoNormals.Get(),
-                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+            post[postCount++] = { m_GtaoNormals.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS };
         }
-        m_CmdList->ResourceBarrier( postCount, post );
+        m_CmdList->TransitionBarriers( post, postCount );
     }
     if ( gbufNormals ) {
         m_CmdList->TransitionBarrier( m_NormalBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );

--- a/D3D11Engine/D3D12Engine/D3D12GTAO.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GTAO.cpp
@@ -330,27 +330,19 @@ void D3D12GraphicsEngine::RenderGTAO() {
     // frame is what normally moves it and still expects to find it there.
     BeginAoDepthRead();
     if ( gbufNormals ) {
-        auto b = TransitionBarrier( m_NormalBuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( m_NormalBuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
     }
     // ...and flip m_AOMask back if a previous successful AO run left it readable for the lit passes.
     if ( m_AOMaskInPixelState ) {
-        auto b = TransitionBarrier( m_AOMask.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-            D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( m_AOMask.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
         m_AOMaskInPixelState = false;
     }
 
     auto toRead = [&]( ID3D12Resource* res ) {
-        auto b = TransitionBarrier( res, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( res, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
         };
     auto toWrite = [&]( ID3D12Resource* res ) {
-        auto b = TransitionBarrier( res, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-            D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( res, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
         };
 
     // --- 1. Prefilter depths ---------------------------------------------------------------------------------
@@ -446,9 +438,7 @@ void D3D12GraphicsEngine::RenderGTAO() {
         m_CmdList->ResourceBarrier( postCount, post );
     }
     if ( gbufNormals ) {
-        auto b = TransitionBarrier( m_NormalBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-            D3D12_RESOURCE_STATE_RENDER_TARGET );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( m_NormalBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
     }
     EndAoDepthRead();
 

--- a/D3D11Engine/D3D12Engine/D3D12GTAO.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GTAO.cpp
@@ -25,6 +25,7 @@
 // binds nothing but two root-constant blocks — there is no descriptor table and no per-frame heap churn.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 
@@ -141,7 +142,7 @@ bool D3D12GraphicsEngine::CreateGtaoResources( INT2 size ) {
             dd.SampleDesc.Count = 1;
             dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
             dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-            if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+            if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
                 nullptr, outAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( out.ReleaseAndGetAddressOf() ) ) ) ) {
                 LogWarn() << "D3D12: failed to create an XeGTAO texture (" << size.x << "x" << size.y << ").";
                 return false;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -1,6 +1,7 @@
 // D3D12GraphicsEngine — core: device/queues/swapchain/frame/present/uploads/resources.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "D3D12LineRenderer.h"
 #include "D3D12VertexBuffer.h"
 #include "D3D12Texture.h"
@@ -1062,7 +1063,7 @@ bool D3D12GraphicsEngine::CreateDepthBuffer( INT2 size ) {
 
 	// Born in DEPTH_WRITE. Now also SRV-readable: DispatchLightCulling brackets a NON_PIXEL_SHADER_RESOURCE
 	// read of it (per-tile far-Z) and transitions back to DEPTH_WRITE, so it is DEPTH_WRITE at every other point.
-	if ( FAILED( m_Allocator->CreateResource( &allocDesc, &dd,
+	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), allocDesc, dd,
 		D3D12_RESOURCE_STATE_DEPTH_WRITE, &clear, m_DepthBufferAlloc.ReleaseAndGetAddressOf(),
 		IID_PPV_ARGS( m_DepthBuffer.ReleaseAndGetAddressOf() ) ) ) ) {
 		LogWarn() << "D3D12: failed to create the depth buffer (" << size.x << "x" << size.y << ").";
@@ -1142,7 +1143,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE D3D12GraphicsEngine::GetPreviewDsv() {
 	clear.Format = DXGI_FORMAT_D32_FLOAT;
 	clear.DepthStencil.Depth = 0.0f;   // reversed-Z far, same as the scene depth
 
-	if ( FAILED( m_Allocator->CreateResource( &allocDesc, &dd, D3D12_RESOURCE_STATE_DEPTH_WRITE, &clear,
+	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), allocDesc, dd, D3D12_RESOURCE_STATE_DEPTH_WRITE, &clear,
 		m_PreviewDepthAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( m_PreviewDepthBuffer.ReleaseAndGetAddressOf() ) ) ) ) {
 		LogWarn() << "D3D12: failed to create the inventory-preview depth buffer ("
 			<< m_BackbufferResolution.x << "x" << m_BackbufferResolution.y << ") — item previews will not render.";
@@ -1189,7 +1190,7 @@ bool D3D12GraphicsEngine::CreateSceneColorTarget( INT2 size ) {
 
 	// Born in RENDER_TARGET (the world pass renders straight into it; ResolveSceneToBackBuffer flips it to
 	// PIXEL_SHADER_RESOURCE and back next frame). GPU is idle at every call site (init / post-WaitForGpuIdle resize).
-	if ( FAILED( m_Allocator->CreateResource( &allocDesc, &dd,
+	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), allocDesc, dd,
 		D3D12_RESOURCE_STATE_RENDER_TARGET, nullptr, m_SceneColorAlloc.ReleaseAndGetAddressOf(),
 		IID_PPV_ARGS( m_SceneColor.ReleaseAndGetAddressOf() ) ) ) ) {
 		LogWarn() << "D3D12: failed to create the HDR scene-color target (" << size.x << "x" << size.y << ").";
@@ -1455,7 +1456,7 @@ bool D3D12GraphicsEngine::CreateHdrDisplayTarget( INT2 size ) {
 	clearValue.Format = kHdrDisplayFormat;
 	memcpy( clearValue.Color, m_ClearColor, sizeof( clearValue.Color ) );
 
-	if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, D3D12_RESOURCE_STATE_RENDER_TARGET, &clearValue,
+	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_RENDER_TARGET, &clearValue,
 		m_HdrDisplayAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( m_HdrDisplay.ReleaseAndGetAddressOf() ) ) ) ) {
 		LogWarn() << "D3D12: failed to create the HDR display composite target (" << size.x << "x" << size.y << ").";
 		return false;
@@ -2546,7 +2547,7 @@ void D3D12GraphicsEngine::GetBackbufferData( bool thumbnail, byte** data, INT2& 
 
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> captureAlloc;
     Microsoft::WRL::ComPtr<ID3D12Resource> captureTex;
-    if ( FAILED( m_Allocator->CreateResource( &allocDesc, &td, D3D12_RESOURCE_STATE_RENDER_TARGET,
+    if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), allocDesc, td, D3D12_RESOURCE_STATE_RENDER_TARGET,
         &clearValue, captureAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( captureTex.ReleaseAndGetAddressOf() ) ) ) ) {
         LogInfo() << (thumbnail ? "Thumbnail failed. Capture texture could not be created" : "GetBackbufferData failed. Capture texture could not be created");
         RestoreFrameRenderTarget();

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -2025,8 +2025,6 @@ XRESULT D3D12GraphicsEngine::OnEndFrame() {
 }
 
 
-#ifdef DEBUG_D3D11
-
 static const wchar_t* GetOpName( D3D12_AUTO_BREADCRUMB_OP op ) {
     switch ( op ) {
     case D3D12_AUTO_BREADCRUMB_OP_SETMARKER: return L"SetMarker";
@@ -2089,7 +2087,7 @@ static void PrintNode( const D3D12_AUTO_BREADCRUMB_NODE1* node ) {
     builder.append( L"--- Outstanding Command List GPU Breadcrumbs ---\n" );
     builder.append( L"Command List Debug Name: " ).append( SafeWideString( node->pCommandListDebugNameW ) ).append( L"\n" );
     builder.append( L"Command Queue Debug Name: " ).append( SafeWideString( node->pCommandQueueDebugNameW ) ).append( L"\n" );
-    OutputDebugStringW( builder.c_str() );
+    LogInfo() << builder.c_str();
 
     // Log out the History of GPU Operations recorded
     // Note: pLastBreadcrumbValue points to the number of completed operations.
@@ -2098,7 +2096,7 @@ static void PrintNode( const D3D12_AUTO_BREADCRUMB_NODE1* node ) {
 
     builder.clear();
     builder.append( L"Completed Op Count: " ).append( std::to_wstring( completedOps ) ).append( L" / " ).append( std::to_wstring( node->BreadcrumbCount ) ).append( L"\n" );
-    OutputDebugStringW( builder.c_str() );
+    LogInfo() << builder.c_str();
 
     for ( UINT i = 0; i < node->BreadcrumbCount; ++i ) {
         builder.clear();
@@ -2124,7 +2122,7 @@ static void PrintNode( const D3D12_AUTO_BREADCRUMB_NODE1* node ) {
         }
 
         builder.append( L"\n" );
-        OutputDebugStringW( builder.c_str() );
+        LogInfo() << builder.c_str();
     }
 
     if ( node->pNext ) {
@@ -2148,8 +2146,6 @@ static void DiagnoseErrors(ID3D12Device* device) {
         }
     }
 }
-
-#endif
 
 XRESULT D3D12GraphicsEngine::Present() {
     if ( !m_SwapChainReady || !m_FrameOpen ) return XR_SUCCESS;
@@ -2211,9 +2207,8 @@ XRESULT D3D12GraphicsEngine::Present() {
     if ( FAILED( hr ) ) {
         auto r = static_cast<uint32_t>(hr);
         if ( hr == DXGI_ERROR_DEVICE_REMOVED) {
-#ifdef DEBUG_D3D11
             DiagnoseErrors( m_Device.GetDevice() );
-#endif
+
             auto removedReason = m_Device.GetDevice()->GetDeviceRemovedReason();
             auto msg = std::format( "D3D12 Present failed (0x{:08X}, reason: 0x{:08X})", r, static_cast<uint32_t>(removedReason) );
             LogWarn() << "D3D12 Present failed (0x" << std::hex << r << ").";

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -461,8 +461,7 @@ void D3D12GraphicsEngine::TransitionTextureToSRVOnDirectQueue( ID3D12Resource* t
 
     // Use the active frame's existing command list instead of creating temporary allocators & command lists
     if ( m_FrameOpen && m_CmdList ) {
-        auto toSRV = TransitionBarrier( texture, D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-        m_CmdList->ResourceBarrier( 1, &toSRV );
+        m_CmdList->TransitionBarrier( texture, D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
         return;
     }
 
@@ -478,6 +477,8 @@ void D3D12GraphicsEngine::TransitionTextureToSRVOnDirectQueue( ID3D12Resource* t
         transitionAllocator.Get(), nullptr, IID_PPV_ARGS( transitionCmdList.ReleaseAndGetAddressOf() ) ) ) )
         return;
 
+    // Bare ID3D12GraphicsCommandList (not the D3D12CmdList wrapper) -- this transient list is built and thrown
+    // away outside the normal per-frame recording path, so it stays on the legacy transition API.
     auto toSRV = TransitionBarrier( texture, D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
     transitionCmdList->ResourceBarrier( 1, &toSRV );
     if ( FAILED( transitionCmdList->Close() ) ) return;
@@ -1225,9 +1226,7 @@ void D3D12GraphicsEngine::BindSceneColorTarget() {
 	// it back from PIXEL_SHADER_RESOURCE (last frame's resolve left it there) to RENDER_TARGET when needed.
 	if ( !m_SceneColor || !m_CmdList ) return;
 	if ( m_SceneColorInPixelState ) {
-		auto toRT = TransitionBarrier( m_SceneColor.Get(),
-			D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
-		m_CmdList->ResourceBarrier( 1, &toRT );
+		m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
 		m_SceneColorInPixelState = false;
 	}
 	const bool haveDepth = m_DepthBuffer && m_DsvHeap;
@@ -1276,9 +1275,7 @@ void D3D12GraphicsEngine::ResolveSceneToBackBuffer() {
 	DX_ZONE( m_CmdList.Get(), "Tonemap resolve (HDR->display)" );
 
 	if ( !m_SceneColorInPixelState ) {
-		auto toSrv = TransitionBarrier( m_SceneColor.Get(),
-			D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-		m_CmdList->ResourceBarrier( 1, &toSrv );
+		m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
 		m_SceneColorInPixelState = true;
 	}
 
@@ -1492,9 +1489,7 @@ void D3D12GraphicsEngine::EncodeHdrDisplayToBackBuffer() {
 	if ( !m_Pipelines.HdrEncode.PSO || !m_Pipelines.HdrEncode.RootSig || m_HdrDisplaySrvSlot == UINT_MAX ) return;
 	DX_ZONE( m_CmdList.Get(), "HDR scanout encode (display->swapchain)" );
 
-	auto toSrv = TransitionBarrier( m_HdrDisplay.Get(),
-		D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-	m_CmdList->ResourceBarrier( 1, &toSrv );
+	m_CmdList->TransitionBarrier( m_HdrDisplay.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
 
 	D3D12_CPU_DESCRIPTOR_HANDLE backRtv = m_RtvHeap->GetCPUDescriptorHandleForHeapStart();
 	backRtv.ptr += static_cast<SIZE_T>( m_FrameIndex ) * m_RtvDescriptorSize;
@@ -1524,9 +1519,7 @@ void D3D12GraphicsEngine::EncodeHdrDisplayToBackBuffer() {
 	m_CmdList->DrawInstanced( 3, 1, 0, 0 );
 
 	// Back to the resting state the next frame's OnBeginFrame expects to clear.
-	auto toRt = TransitionBarrier( m_HdrDisplay.Get(),
-		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
-	m_CmdList->ResourceBarrier( 1, &toRt );
+	m_CmdList->TransitionBarrier( m_HdrDisplay.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
 }
 
 
@@ -1937,9 +1930,7 @@ XRESULT D3D12GraphicsEngine::OnBeginFrame() {
     m_CmdList.ResetStats();
     for ( UINT s = 0; s < kShadowRecordSlots; ++s ) m_ShadowCmdLists[s][m_FrameIndex].ResetStats();
 
-    auto toRT = TransitionBarrier( m_BackBuffers[m_FrameIndex].Get(),
-        D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET );
-    m_CmdList->ResourceBarrier( 1, &toRT );
+    m_CmdList->TransitionBarrier( m_BackBuffers[m_FrameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET );
 
     // The swapchain stays transitioned to RENDER_TARGET even in HDR mode — EncodeHdrDisplayToBackBuffer
     // writes it at the end of Present — but everything the frame draws goes to the display target.
@@ -2195,9 +2186,7 @@ XRESULT D3D12GraphicsEngine::Present() {
     // it into the ST.2084 signal the swapchain scans out. No-op in SDR (the display target IS the backbuffer).
     EncodeHdrDisplayToBackBuffer();
 
-    auto toPresent = TransitionBarrier( m_BackBuffers[m_FrameIndex].Get(),
-        D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT );
-    m_CmdList->ResourceBarrier( 1, &toPresent );
+    m_CmdList->TransitionBarrier( m_BackBuffers[m_FrameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT );
 
     // Submit any batched texture/buffer uploads accumulated this frame and insert the single
     // copy->direct cross-queue wait BEFORE the frame's graphics execute, so everything sampled below
@@ -2604,8 +2593,7 @@ void D3D12GraphicsEngine::GetBackbufferData( bool thumbnail, byte** data, INT2& 
     m_CmdList->IASetVertexBuffers( 0, 0, nullptr );
     m_CmdList->DrawInstanced( 3, 1, 0, 0 );
 
-    auto toCopySrc = TransitionBarrier( captureTex.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
-    m_CmdList->ResourceBarrier( 1, &toCopySrc );
+    m_CmdList->TransitionBarrier( captureTex.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
 
     D3D12_RESOURCE_DESC capDesc = captureTex->GetDesc();
     D3D12_PLACED_SUBRESOURCE_FOOTPRINT footprint = {};

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -4,6 +4,7 @@
 #include "D3D12LineRenderer.h"
 #include "D3D12VertexBuffer.h"
 #include "D3D12Texture.h"
+#include <d3dx12_barriers.h>
 #include "../Engine.h"
 #include "../GothicAPI.h"
 #include "../zCView.h"
@@ -80,6 +81,7 @@ XRESULT D3D12GraphicsEngine::Init() {
         LogWarn() << "D3D12GraphicsEngine::Init: device creation failed.";
         return XR_FAILED;
     }
+    D3D12CmdList::SetEnhancedBarriersDeviceSupport( m_Device.EnhancedBarriersSupported() );
     if ( !CreateAllocators() ) {
         LogWarn() << "D3D12GraphicsEngine::Init: failed to create allocators.";
         return XR_FAILED;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -1043,7 +1043,7 @@ private:
         Microsoft::WRL::ComPtr<D3D12MA::Allocation> IndicesAlloc;
     };
     std::unordered_map<const void*, MorphTableGpu> m_MorphTables;
-    std::vector<D3D12_RESOURCE_BARRIER> m_MorphBarriers;   // scratch; keeps its capacity across frames
+    std::vector<D3D12ResourceTransition> m_MorphBarriers;   // scratch; keeps its capacity across frames
     // This frame's queue, moved out of MorphGpu by DispatchMorphFold (see MorphGpu::TakeJobs). Members rather
     // than locals so they keep their capacity across frames.
     std::vector<MorphGpu::Job> m_MorphJobs;

--- a/D3D11Engine/D3D12Engine/D3D12MorphFold.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12MorphFold.cpp
@@ -202,7 +202,7 @@ void D3D12GraphicsEngine::DispatchMorphFold() {
         // first fold was legal too), VERTEX_AND_CONSTANT_BUFFER on every fold after it.
         const D3D12_RESOURCE_STATES from = ( out->GetUavState() == D3D12VertexBuffer::EUavState::Vertex )
             ? D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER : D3D12_RESOURCE_STATE_COMMON;
-        m_MorphBarriers.push_back( TransitionBarrier( out->GetResource(), from, D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) );
+        m_MorphBarriers.push_back( { out->GetResource(), from, D3D12_RESOURCE_STATE_UNORDERED_ACCESS } );
         out->SetUavState( D3D12VertexBuffer::EUavState::Unordered );
 
         resolved.push_back( { &job,
@@ -220,7 +220,7 @@ void D3D12GraphicsEngine::DispatchMorphFold() {
         // submitted later on the direct queue) could read the tables before the copies land.
         FlushTextureUploads();
     }
-    m_CmdList->ResourceBarrier( static_cast<UINT>( m_MorphBarriers.size() ), m_MorphBarriers.data() );
+    m_CmdList->TransitionBarriers( m_MorphBarriers.data(), static_cast<UINT>( m_MorphBarriers.size() ) );
 
     // --- One dispatch per submesh ---
     m_CmdList->SetPipelineState( m_Pipelines.MorphFold.PSO.Get() );
@@ -257,11 +257,11 @@ void D3D12GraphicsEngine::DispatchMorphFold() {
     // --- Hand every folded buffer to the geometry passes ---
     m_MorphBarriers.clear();
     for ( const ResolvedJob& r : resolved ) {
-        m_MorphBarriers.push_back( TransitionBarrier( r.Out->GetResource(),
-            D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER ) );
+        m_MorphBarriers.push_back( { r.Out->GetResource(),
+            D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER } );
         r.Out->SetUavState( D3D12VertexBuffer::EUavState::Vertex );
     }
-    m_CmdList->ResourceBarrier( static_cast<UINT>( m_MorphBarriers.size() ), m_MorphBarriers.data() );
+    m_CmdList->TransitionBarriers( m_MorphBarriers.data(), static_cast<UINT>( m_MorphBarriers.size() ) );
 
     m_MorphFoldSubmeshCount = static_cast<UINT>( resolved.size() );
     // How much a crowded frame actually folds, and how much table memory the world's head types add up to.

--- a/D3D11Engine/D3D12Engine/D3D12Motion.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Motion.cpp
@@ -258,15 +258,14 @@ void D3D12GraphicsEngine::BeginMotionGBuffer() {
 
     // FillCameraVelocity left the velocity target in a shader-read state at the end of last frame; flip it back.
     if ( m_VelocityInPixelState ) {
-        D3D12_RESOURCE_BARRIER toRT[] = {
-            TransitionBarrier( m_VelocityBuffer.Get(),
+        m_CmdList->TransitionBarriers( {
+            { m_VelocityBuffer.Get(),
                 D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_RENDER_TARGET ),
-            TransitionBarrier( m_NormalBuffer.Get(),
+                D3D12_RESOURCE_STATE_RENDER_TARGET },
+            { m_NormalBuffer.Get(),
                 D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_RENDER_TARGET ),
-        };
-        m_CmdList->ResourceBarrier( _countof( toRT ), toRT );
+                D3D12_RESOURCE_STATE_RENDER_TARGET },
+        } );
         m_VelocityInPixelState = false;
     }
 
@@ -313,13 +312,10 @@ void D3D12GraphicsEngine::FillCameraVelocity() {
     // Velocity RENDER_TARGET -> UAV (the compute pass writes it), depth DEPTH_WRITE -> shader-read. The DSV must
     // be unbound before the depth buffer leaves DEPTH_WRITE, same dance RenderBloom/RenderFogAndGodRays do.
     m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
-    D3D12_RESOURCE_BARRIER toCompute[] = {
-        TransitionBarrier( m_VelocityBuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
-            D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-        TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE ),
-    };
-    m_CmdList->ResourceBarrier( _countof( toCompute ), toCompute );
+    m_CmdList->TransitionBarriers( {
+        { m_VelocityBuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE },
+    } );
 
     m_CmdList->SetPipelineState( m_Pipelines.Motion.FillPSO.Get() );
     m_CmdList->SetComputeRootSignature( m_Pipelines.Motion.FillRootSig.Get() );
@@ -334,15 +330,13 @@ void D3D12GraphicsEngine::FillCameraVelocity() {
     // Depth back to DEPTH_WRITE (the fog/god-ray block downstream expects it there);
     // velocity to the combined shader-read state, which is where the debug overlay and next frame's
     // BeginMotionGBuffer both expect to find it.
-    D3D12_RESOURCE_BARRIER toRead[] = {
-        TransitionBarrier( m_VelocityBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE ),
-        TransitionBarrier( m_NormalBuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE ),
-        TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-            D3D12_RESOURCE_STATE_DEPTH_WRITE ),
-    };
-    m_CmdList->ResourceBarrier( _countof( toRead ), toRead );
+    m_CmdList->TransitionBarriers( {
+        { m_VelocityBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
+        { m_NormalBuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
+            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
+        { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE },
+    } );
     m_VelocityInPixelState = true;
 
     // Restore the render target the caller had bound (the scene color + depth), so the fog/god-ray and post

--- a/D3D11Engine/D3D12Engine/D3D12Motion.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Motion.cpp
@@ -35,6 +35,7 @@
 // RenderMotionDebugOverlay renders either one for the DebugSettings.TAA.Display* flags.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 #include "../zCCamera.h"
@@ -83,7 +84,7 @@ bool D3D12GraphicsEngine::CreateMotionResources( INT2 size ) {
         clear.Format = format;
         memcpy( clear.Color, clearColor, sizeof( clear.Color ) );
 
-        if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, D3D12_RESOURCE_STATE_RENDER_TARGET,
+        if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_RENDER_TARGET,
             &clear, outAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( out.ReleaseAndGetAddressOf() ) ) ) ) {
             LogWarn() << "D3D12: failed to create a motion G-buffer target (" << size.x << "x" << size.y << ").";
             return false;

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -376,14 +376,17 @@ ID3D12PipelineState* D3D12PipelineState::GetOrCreateWorldTransparencyPipeline( c
         ps = WorldTransparency.EnvPsBlob.Get();
     }
 
-    // Same packed 36-byte world vertex the opaque pass consumes; VSTransparent just doesn't read NORMAL.
+    // Same packed 36-byte world vertex the opaque pass consumes; VSTransparent just doesn't read NORMAL/TANGENT.
     // (Kept as a superset of what the VS declares so the color and depth-fill PSOs are byte-identical apart
-    // from blend/depth state — see the water Z-prepass lesson about ULP-divergent depth.)
+    // from blend/depth state — see the water Z-prepass lesson about ULP-divergent depth.) VS_IN in World.hlsl
+    // (shared by VSTransparent/VSTransparentEnv/VSTransparentPortal) now declares TANGENT — must match or
+    // CreateGraphicsPipelineState fails E_INVALIDARG (signature/layout mismatch).
     const D3D12_INPUT_ELEMENT_DESC layout[] = {
-        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0,  0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "NORMAL",   0, DXGI_FORMAT_R16G16_SNORM,    0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 20, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "DIFFUSE",  0, DXGI_FORMAT_R8G8B8A8_UNORM,  0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT,   0,  0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "NORMAL",   0, DXGI_FORMAT_R16G16_SNORM,      0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "TANGENT",  0, DXGI_FORMAT_R10G10B10A2_UNORM, 0, 16, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,      0, 20, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "DIFFUSE",  0, DXGI_FORMAT_R8G8B8A8_UNORM,    0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
     };
 
     D3D12_GRAPHICS_PIPELINE_STATE_DESC pso = {};

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -191,18 +191,24 @@ bool D3D12PipelineState::CreateWorld() {
         { World.QuadMarkVsBlob.Get(),"World.hlsl:VSQuadMark", D3D12_SHADER_VISIBILITY_VERTEX },
     } );
 
-    // Bind Position/TexCoord0/Color from the packed 36-byte ExVertexStructGPU via explicit offsets;
-    // the packed normal (@12), tangent (@16) and uv2 (@28) are skipped (not read by this PS yet).
+    // Bind Position/Normal/Tangent/TexCoord0/Color from the packed 36-byte ExVertexStructGPU via explicit
+    // offsets; uv2 (@28) is still skipped (not read by this PS). TANGENT feeds PerturbNormal's tangent-space
+    // overload (PBRLighting.hlsl) — the real, precomputed MikkTSpace basis D3D11's PS_Diffuse.hlsl uses via
+    // VS_ExPacked, instead of the screen-space ddx/ddy CotangentFrame fallback, which degenerates (ill-
+    // conditioned T/B, rsqrt blow-up) at grazing view angles across near-planar sun-facing ground — see
+    // World.hlsl's VSMain/PSMain for the decode + call site.
     //   Position float3   @ 0
-    //   [Normal  i16x2    @12]   [Tangent R10G10B10A2 @16]  (skipped)
+    //   Normal   i16x2    @12   (octahedral, world-space)
+    //   Tangent  R10G10B10A2 @16   (xyz unit tangent, w = handedness; world-space, matches Normal)
     //   TexCoord float2   @20
     //   [TexCoord2 half2  @28]                              (skipped)
     //   Color    R8G8B8A8 @32
     const D3D12_INPUT_ELEMENT_DESC layout[] = {
-        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0,  0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "NORMAL",   0, DXGI_FORMAT_R16G16_SNORM,    0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },  // octahedral, world-space
-        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 20, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "DIFFUSE",  0, DXGI_FORMAT_R8G8B8A8_UNORM,  0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT,     0,  0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "NORMAL",   0, DXGI_FORMAT_R16G16_SNORM,        0, 12, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },  // octahedral, world-space
+        { "TANGENT",  0, DXGI_FORMAT_R10G10B10A2_UNORM,   0, 16, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,        0, 20, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "DIFFUSE",  0, DXGI_FORMAT_R8G8B8A8_UNORM,      0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
     };
 
     D3D12_GRAPHICS_PIPELINE_STATE_DESC pso = {};

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -3,6 +3,7 @@
 #include "../pch.h"
 #include "D3D12PointShadows.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "D3D12VertexBuffer.h"
 #include "D3D12Texture.h"
 #include "../Engine.h"
@@ -117,7 +118,7 @@ bool D3D12PointShadows::Init() {
 	D3D12_CLEAR_VALUE clear = {};
 	clear.Format = DXGI_FORMAT_D16_UNORM;
 	clear.DepthStencil.Depth = 1.0f;
-	if ( FAILED( m_E->m_Allocator->CreateResource( &defaultAlloc, &dd,
+	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_E->m_Allocator.Get(), defaultAlloc, dd,
 		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &clear, m_CubeAlloc.ReleaseAndGetAddressOf(),
 		IID_PPV_ARGS( m_Cube.ReleaseAndGetAddressOf() ) ) ) )
 		return false;
@@ -147,7 +148,7 @@ bool D3D12PointShadows::Init() {
 	// composite — m_Cube above is the static base and the two are min'd in the shader). Born in
 	// PIXEL_SHADER_RESOURCE, same as the static one, because it IS sampled now; it also gets its own bindless SRV
 	// below. Cleared to far on creation, so a slot that has never had an overlay reads as fully unoccluded.
-	if ( FAILED( m_E->m_Allocator->CreateResource( &defaultAlloc, &dd,
+	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_E->m_Allocator.Get(), defaultAlloc, dd,
 		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &clear, m_DynCubeAlloc.ReleaseAndGetAddressOf(),
 		IID_PPV_ARGS( m_DynCube.ReleaseAndGetAddressOf() ) ) ) )
 		return false;
@@ -196,7 +197,7 @@ bool D3D12PointShadows::Init() {
 	ld.Width = kStaticCubeSize;
 	ld.Height = kStaticCubeSize;
 	ld.DepthOrArraySize = static_cast<UINT16>(kMaxStaticCubes * 6);
-	if ( FAILED( m_E->m_Allocator->CreateResource( &defaultAlloc, &ld,
+	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_E->m_Allocator.Get(), defaultAlloc, ld,
 		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &clear, m_LowCubeAlloc.ReleaseAndGetAddressOf(),
 		IID_PPV_ARGS( m_LowCube.ReleaseAndGetAddressOf() ) ) ) )
 		return false;

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -83,7 +83,7 @@ namespace {
 	// Barrier scratch for Record()'s per-slot (6-subresource) transitions. Reused across frames — the
 	// point-shadow pass is single-consumer (one recorder list) and the project's standing rule is no per-frame
 	// (re)allocations on the frame path.
-	std::vector<D3D12_RESOURCE_BARRIER> g_PsBarriers;
+	std::vector<D3D12ResourceTransition> g_PsBarriers;
 }
 
 
@@ -1025,21 +1025,14 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 	// per phase so the GPU pays one pipeline flush per phase rather than one per slot.
 	auto pushSlot = [&]( ID3D12Resource* res, D3D12_RESOURCE_STATES* slotStates, UINT slot, D3D12_RESOURCE_STATES after ) {
 		if ( slotStates[slot] == after ) return;   // already there — no redundant barrier
-		D3D12_RESOURCE_BARRIER b = {};
-		b.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-		b.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
-		b.Transition.pResource = res;
-		b.Transition.StateBefore = slotStates[slot];
-		b.Transition.StateAfter = after;
 		for ( UINT face = 0; face < 6; ++face ) {
-			b.Transition.Subresource = slot * 6 + face;
-			g_PsBarriers.push_back( b );
+			g_PsBarriers.push_back( { res, slotStates[slot], after, slot * 6 + face } );
 		}
 		slotStates[slot] = after;
 		};
 	auto flushBarriers = [&]() {
 		if ( g_PsBarriers.empty() ) return;
-		cmdList->ResourceBarrier( static_cast<UINT>( g_PsBarriers.size() ), g_PsBarriers.data() );
+		cmdList->TransitionBarriers( g_PsBarriers.data(), static_cast<UINT>( g_PsBarriers.size() ) );
 		g_PsBarriers.clear();
 		};
 	g_PsBarriers.clear();

--- a/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
@@ -177,8 +177,7 @@ void D3D12GraphicsEngine::RenderBloom() {
 	// PIXEL_SHADER_RESOURCE — reading a resource through an SRV while it is in the wrong state returns garbage on
 	// real hardware (this, plus the bloom-mip UAV-vs-SRV state bug below, was the flickering-black-screen cause).
 	if ( !m_SceneColorInPixelState ) {
-		auto toSrv = TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-		m_CmdList->ResourceBarrier( 1, &toSrv );
+		m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
 		m_SceneColorInPixelState = true;
 	}
 	m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
@@ -192,8 +191,7 @@ void D3D12GraphicsEngine::RenderBloom() {
 	constexpr D3D12_RESOURCE_STATES kBloomRead =
 		D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 	auto toBloomRead = [&]( ID3D12Resource* res ) {
-		auto b = TransitionBarrier( res, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, kBloomRead );
-		m_CmdList->ResourceBarrier( 1, &b );
+		m_CmdList->TransitionBarrier( res, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, kBloomRead );
 		};
 
 	// --- Prefilter: scene color -> down[0] ---
@@ -270,8 +268,7 @@ void D3D12GraphicsEngine::RenderBloom() {
 	m_CmdList->SetGraphicsRootDescriptorTable( 0, GetSrvGpuHandle( finalBloomSrvSlot ) );
 	m_CmdList->SetGraphicsRoot32BitConstant( 1, *reinterpret_cast<const UINT*>( &settings.BloomStrength ), 0 );
 
-	auto toRt = TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
-	m_CmdList->ResourceBarrier( 1, &toRt );
+	m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
 	m_SceneColorInPixelState = false;
 
 	const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>(m_Resolution.x), static_cast<float>(m_Resolution.y), 0.0f, 1.0f };
@@ -287,13 +284,13 @@ void D3D12GraphicsEngine::RenderBloom() {
 	// so the "before" state is deterministic at the top of the next RenderBloom (the toBloomRead transitions
 	// above all assume UNORDERED_ACCESS). Done AFTER the composite, which still reads the final mip as an SRV.
 	{
-		D3D12_RESOURCE_BARRIER resets[2 * kBloomMaxMips];
+		D3D12ResourceTransition resets[2 * kBloomMaxMips];
 		UINT n = 0;
 		for ( int i = 0; i < mipCount; ++i )
-			resets[n++] = TransitionBarrier( m_BloomDown[i].Get(), kBloomRead, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+			resets[n++] = { m_BloomDown[i].Get(), kBloomRead, D3D12_RESOURCE_STATE_UNORDERED_ACCESS };
 		for ( int i = 0; i < mipCount - 1; ++i )
-			resets[n++] = TransitionBarrier( m_BloomUp[i].Get(), kBloomRead, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-		if ( n ) m_CmdList->ResourceBarrier( n, resets );
+			resets[n++] = { m_BloomUp[i].Get(), kBloomRead, D3D12_RESOURCE_STATE_UNORDERED_ACCESS };
+		m_CmdList->TransitionBarriers( resets, n );
 	}
 
 	m_ColorTargetIsHDR = true;   // just rebound m_SceneColor as RTV above
@@ -386,14 +383,12 @@ void D3D12GraphicsEngine::RenderLuminanceAdapt() {
 	DX_ZONE( m_CmdList.Get(), "Dynamic Exposure (luminance reduce+adapt)" );
 
 	if ( !m_SceneColorInPixelState ) {
-		auto toSrv = TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-		m_CmdList->ResourceBarrier( 1, &toSrv );
+		m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
 		m_SceneColorInPixelState = true;
 	}
 	m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
 
-	auto toUav = TransitionBarrier( m_LumAdaptedBuffer.Get(), m_LumAdaptedBufferState, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-	m_CmdList->ResourceBarrier( 1, &toUav );
+	m_CmdList->TransitionBarrier( m_LumAdaptedBuffer.Get(), m_LumAdaptedBufferState, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
 	m_LumAdaptedBufferState = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
 
 	// --- Level 1: reduce scene color -> per-group partial sums ---
@@ -407,13 +402,11 @@ void D3D12GraphicsEngine::RenderLuminanceAdapt() {
 	m_CmdList->Dispatch( m_LumGroupsX, m_LumGroupsY, 1 );
 
 	// Scene color is done being read (compute) this pass; hand it back to RENDER_TARGET for ResolveSceneToBackBuffer.
-	auto toRt = TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
-	m_CmdList->ResourceBarrier( 1, &toRt );
+	m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
 	m_SceneColorInPixelState = false;
 
 	// PartialSums: UAV write (above) -> SRV read (below) needs a real state transition, not just a UAV barrier.
-	auto partialToSrv = TransitionBarrier( m_LumPartialBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-	m_CmdList->ResourceBarrier( 1, &partialToSrv );
+	m_CmdList->TransitionBarrier( m_LumPartialBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
 
 	// --- Level 2: reduce partial sums -> one temporally-adapted luminance value ---
 	struct LumAdaptCB { UINT NumPartials; float DeltaTime; UINT FirstFrame; float Tau; };
@@ -429,11 +422,10 @@ void D3D12GraphicsEngine::RenderLuminanceAdapt() {
 
 	// Reset PartialSums to UNORDERED_ACCESS for next frame's reduce write; AdaptedLum to a PS-readable state for
 	// Tonemap (both ResolveSceneToBackBuffer and the thumbnail/screenshot re-tonemap read it later this frame).
-	D3D12_RESOURCE_BARRIER post[2] = {
-		TransitionBarrier( m_LumPartialBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-		TransitionBarrier( m_LumAdaptedBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE ),
-	};
-	m_CmdList->ResourceBarrier( 2, post );
+	m_CmdList->TransitionBarriers( {
+		{ m_LumPartialBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+		{ m_LumAdaptedBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
+	} );
 	m_LumAdaptedBufferState = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 }
 
@@ -613,16 +605,14 @@ void D3D12GraphicsEngine::RenderSMAA() {
 	// --- Copy the tonemapped display image into m_LdrCopy (the SMAA color input). ---
 	// Display target: RENDER_TARGET -> COPY_SOURCE; m_LdrCopy rests in COPY_DEST.
 	{
-		auto b = TransitionBarrier( backBuffer, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
-		m_CmdList->ResourceBarrier( 1, &b );
+		m_CmdList->TransitionBarrier( backBuffer, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
 	}
 	m_CmdList->CopyResource( m_LdrCopy.Get(), backBuffer );
 	{
-		D3D12_RESOURCE_BARRIER b[2] = {
-			TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE ),
-			TransitionBarrier( backBuffer, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET ),
-		};
-		m_CmdList->ResourceBarrier( 2, b );
+		m_CmdList->TransitionBarriers( {
+			{ m_LdrCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
+			{ backBuffer, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
+		} );
 	}
 
 	// Common state for all three fullscreen-triangle passes.
@@ -652,8 +642,7 @@ void D3D12GraphicsEngine::RenderSMAA() {
 	m_CmdList->ClearRenderTargetView( m_SmaaEdgesRtv, clearZero, 0, nullptr );
 	m_CmdList->DrawInstanced( 3, 1, 0, 0 );
 	{
-		auto b = TransitionBarrier( m_SmaaEdges.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-		m_CmdList->ResourceBarrier( 1, &b );
+		m_CmdList->TransitionBarrier( m_SmaaEdges.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
 	}
 
 	// --- Pass 2: blend-weight calculation (edges + area + search -> blend). blend rests in RENDER_TARGET. ---
@@ -663,8 +652,7 @@ void D3D12GraphicsEngine::RenderSMAA() {
 	m_CmdList->ClearRenderTargetView( m_SmaaBlendRtv, clearZero, 0, nullptr );
 	m_CmdList->DrawInstanced( 3, 1, 0, 0 );
 	{
-		auto b = TransitionBarrier( m_SmaaBlend.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-		m_CmdList->ResourceBarrier( 1, &b );
+		m_CmdList->TransitionBarrier( m_SmaaBlend.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
 	}
 
 	// --- Pass 3: neighborhood blending (color + blend -> swapchain). ---
@@ -676,12 +664,11 @@ void D3D12GraphicsEngine::RenderSMAA() {
 	// Restore resting states for next frame: color -> COPY_DEST, edges/blend -> RENDER_TARGET. Swapchain stays
 	// RENDER_TARGET (bound above), ready for Gothic's 2D UI/HUD to composite on top.
 	{
-		D3D12_RESOURCE_BARRIER b[3] = {
-			TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST ),
-			TransitionBarrier( m_SmaaEdges.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET ),
-			TransitionBarrier( m_SmaaBlend.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET ),
-		};
-		m_CmdList->ResourceBarrier( 3, b );
+		m_CmdList->TransitionBarriers( {
+			{ m_LdrCopy.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST },
+			{ m_SmaaEdges.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
+			{ m_SmaaBlend.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
+		} );
 	}
 }
 
@@ -715,16 +702,14 @@ void D3D12GraphicsEngine::RenderSharpen() {
 	// A texture can't be its own SRV and RTV, so sharpen a copy of the display target back onto itself.
 	// Same shape as D3D11 (both of its modes copy into the pfx temp buffer first). m_LdrCopy rests in COPY_DEST.
 	{
-		auto b = TransitionBarrier( backBuffer, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
-		m_CmdList->ResourceBarrier( 1, &b );
+		m_CmdList->TransitionBarrier( backBuffer, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
 	}
 	m_CmdList->CopyResource( m_LdrCopy.Get(), backBuffer );
 	{
-		D3D12_RESOURCE_BARRIER b[2] = {
-			TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE ),
-			TransitionBarrier( backBuffer, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET ),
-		};
-		m_CmdList->ResourceBarrier( 2, b );
+		m_CmdList->TransitionBarriers( {
+			{ m_LdrCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
+			{ backBuffer, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
+		} );
 	}
 
 	// b0: { uint4 CasConst0; uint4 CasConst1; uint SrcIndex; float SharpenStrength; float2 TextureSize }.
@@ -762,7 +747,6 @@ void D3D12GraphicsEngine::RenderSharpen() {
 	// Back to the resting state so the next user of the scratch copy (next frame's SMAA/sharpen) finds it in
 	// COPY_DEST. The swapchain stays RENDER_TARGET for Gothic's 2D UI/HUD.
 	{
-		auto b = TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST );
-		m_CmdList->ResourceBarrier( 1, &b );
+		m_CmdList->TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST );
 	}
 }

--- a/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
@@ -178,8 +178,7 @@ void D3D12GraphicsEngine::RenderBloom() {
 	// PIXEL_SHADER_RESOURCE — reading a resource through an SRV while it is in the wrong state returns garbage on
 	// real hardware (this, plus the bloom-mip UAV-vs-SRV state bug below, was the flickering-black-screen cause).
 	if ( !m_SceneColorInPixelState ) {
-		// The prefilter dispatch immediately below is the ONLY consumer of this transition -- narrow the
-		// enhanced-barrier "after" sync from the table's default (every non-pixel stage) to compute alone.
+		// Only the prefilter dispatch below consumes this, so the "after" sync is narrowed to compute.
 		m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
 			D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, kBarrierSyncUnspecified, D3D12_BARRIER_SYNC_COMPUTE_SHADING );
 		m_SceneColorInPixelState = true;
@@ -193,11 +192,9 @@ void D3D12GraphicsEngine::RenderBloom() {
 	// can read it. The bloom mips start each frame in UNORDERED_ACCESS (created that way, and reset back at the
 	// end of this function) so "before" is always UNORDERED_ACCESS here.
 	//
-	// NOT sync-scope-hinted: every intermediate mip is read by the next COMPUTE step, but the one mip that ends
-	// up as finalBloomSrvSlot (down[0] when mipCount==1, else up[0]) is ALSO read by the composite PIXEL shader
-	// below -- narrowing this call's "after" sync to compute-only would under-synchronize that read. Telling the
-	// two cases apart here is exactly the kind of per-call precision this pass deliberately didn't risk without
-	// GPU/debug-layer verification, given this file's own history with bloom-state races (see the comment above).
+	// Not sync-scope-hinted: every intermediate mip is read by the next compute step, but the mip that ends up
+	// as finalBloomSrvSlot is also read by the composite pixel shader below, so a compute-only hint here would
+	// under-synchronize that read.
 	constexpr D3D12_RESOURCE_STATES kBloomRead =
 		D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 	auto toBloomRead = [&]( ID3D12Resource* res ) {

--- a/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
@@ -177,7 +177,10 @@ void D3D12GraphicsEngine::RenderBloom() {
 	// PIXEL_SHADER_RESOURCE — reading a resource through an SRV while it is in the wrong state returns garbage on
 	// real hardware (this, plus the bloom-mip UAV-vs-SRV state bug below, was the flickering-black-screen cause).
 	if ( !m_SceneColorInPixelState ) {
-		m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+		// The prefilter dispatch immediately below is the ONLY consumer of this transition -- narrow the
+		// enhanced-barrier "after" sync from the table's default (every non-pixel stage) to compute alone.
+		m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+			D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, kBarrierSyncUnspecified, D3D12_BARRIER_SYNC_COMPUTE_SHADING );
 		m_SceneColorInPixelState = true;
 	}
 	m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
@@ -188,6 +191,12 @@ void D3D12GraphicsEngine::RenderBloom() {
 	// texture is undefined. Combined NON_PIXEL|PIXEL so both the compute chain (t0/t1) and the graphics composite
 	// can read it. The bloom mips start each frame in UNORDERED_ACCESS (created that way, and reset back at the
 	// end of this function) so "before" is always UNORDERED_ACCESS here.
+	//
+	// NOT sync-scope-hinted: every intermediate mip is read by the next COMPUTE step, but the one mip that ends
+	// up as finalBloomSrvSlot (down[0] when mipCount==1, else up[0]) is ALSO read by the composite PIXEL shader
+	// below -- narrowing this call's "after" sync to compute-only would under-synchronize that read. Telling the
+	// two cases apart here is exactly the kind of per-call precision this pass deliberately didn't risk without
+	// GPU/debug-layer verification, given this file's own history with bloom-state races (see the comment above).
 	constexpr D3D12_RESOURCE_STATES kBloomRead =
 		D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 	auto toBloomRead = [&]( ID3D12Resource* res ) {

--- a/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
@@ -1,6 +1,7 @@
 // D3D12GraphicsEngine — post-FX: bloom pyramid, luminance auto-exposure, SMAA, sharpen.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "D3D12LineRenderer.h"
 #include "D3D12VertexBuffer.h"
 #include "D3D12Texture.h"
@@ -92,7 +93,7 @@ bool D3D12GraphicsEngine::CreateBloomResources( INT2 size ) {
 		dd.SampleDesc.Count = 1;
 		dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
 		dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-		if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd,
+		if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd,
 			D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr, outAlloc.ReleaseAndGetAddressOf(),
 			IID_PPV_ARGS( out.ReleaseAndGetAddressOf() ) ) ) ) {
 			LogWarn() << "D3D12: failed to create a bloom pyramid texture (" << w << "x" << h << ").";
@@ -497,7 +498,7 @@ bool D3D12GraphicsEngine::CreateLdrCopyResource( INT2 size ) {
 	dd.SampleDesc.Count = 1;
 	dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
 	dd.Flags = D3D12_RESOURCE_FLAG_NONE;
-	if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
+	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
 		m_LdrCopyAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( m_LdrCopy.ReleaseAndGetAddressOf() ) ) ) ) {
 		LogWarn() << "D3D12: failed to create the LDR post-FX scratch copy (SMAA/sharpen will be unavailable).";
 		return false;

--- a/D3D11Engine/D3D12Engine/D3D12Rain.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Rain.cpp
@@ -191,13 +191,11 @@ void D3D12GraphicsEngine::AdvanceRain() {
     // otherwise a paused/stationary first frame would leave the buffer in COMMON/NON_PIXEL_SHADER_RESOURCE
     // with no dispatch ever running to flip it, and the draw's SRV read would be reading stale state.
     if ( m_RainDynamicNeedsInitialBarrier ) {
-        auto b = TransitionBarrier( m_RainBufferDynamic.Get(), D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( m_RainBufferDynamic.Get(), D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
         m_RainDynamicNeedsInitialBarrier = false;
     } else if ( m_RainDynamicInReadState ) {
         // DrawRainParticles left it in NON_PIXEL_SHADER_RESOURCE last frame — flip back before this CS writes it.
-        auto b = TransitionBarrier( m_RainBufferDynamic.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( m_RainBufferDynamic.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
         m_RainDynamicInReadState = false;
     }
 
@@ -252,8 +250,7 @@ void D3D12GraphicsEngine::DrawRainParticles() {
     // Flip the dynamic buffer UAV -> NON_PIXEL_SHADER_RESOURCE for the VS's root-SRV read (AdvanceRain
     // guarantees it's in UNORDERED_ACCESS by the time it returns, whether or not it actually dispatched).
     {
-        auto b = TransitionBarrier( m_RainBufferDynamic.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( m_RainBufferDynamic.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
         m_RainDynamicInReadState = true;
     }
 
@@ -781,8 +778,7 @@ void D3D12GraphicsEngine::RecordRainShadowmap( D3D12CmdList& cmdList ) {
 
     // Return the map to DEPTH_WRITE if last frame's readers left it in ALL_SHADER_RESOURCE.
     if ( m_RainShadowInReadState ) {
-        auto toDepth = TransitionBarrier( m_RainShadowMap.Get(), D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE );
-        cmdList->ResourceBarrier( 1, &toDepth );
+        cmdList->TransitionBarrier( m_RainShadowMap.Get(), D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE );
         m_RainShadowInReadState = false;
     }
 
@@ -868,7 +864,6 @@ void D3D12GraphicsEngine::RecordRainShadowmap( D3D12CmdList& cmdList ) {
     // resource leaves DEPTH_WRITE fails GPU validation on the next draw ("resource state ... invalid for use as
     // depth-read/depth-write"). The caller re-establishes the scene-color RT for the lit passes.
     cmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
-    auto toRead = TransitionBarrier( m_RainShadowMap.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE );
-    cmdList->ResourceBarrier( 1, &toRead );
+    cmdList->TransitionBarrier( m_RainShadowMap.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE );
     m_RainShadowInReadState = true;
 }

--- a/D3D11Engine/D3D12Engine/D3D12Rain.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Rain.cpp
@@ -6,6 +6,7 @@
 // resources do.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 #include "../WorldObjects.h"
@@ -460,7 +461,7 @@ bool D3D12GraphicsEngine::CreateRainShadowResources() {
     clear.Format = DXGI_FORMAT_D32_FLOAT;
     clear.DepthStencil.Depth = 1.0f;   // normal-Z: 1.0 == far (not reversed-Z, matches the CSM sun map)
 
-    if ( FAILED( m_Allocator->CreateResource( &allocDesc, &dd, D3D12_RESOURCE_STATE_DEPTH_WRITE, &clear,
+    if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), allocDesc, dd, D3D12_RESOURCE_STATE_DEPTH_WRITE, &clear,
         m_RainShadowMapAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( m_RainShadowMap.ReleaseAndGetAddressOf() ) ) ) ) {
         LogWarn() << "D3D12: failed to create the rain shadow map resource.";
         return false;

--- a/D3D11Engine/D3D12Engine/D3D12ResourceCreate.h
+++ b/D3D11Engine/D3D12Engine/D3D12ResourceCreate.h
@@ -1,0 +1,67 @@
+#pragma once
+#include <D3D12MemAlloc.h>
+#include "D3D12StateCache.h"
+
+// Shared helper for creating textures that are exempt from the legacy-to-enhanced-barrier handoff
+// (D3D12Barrier.cpp's BridgeLegacyResourceToCommon / BARRIER_INTEROP_INVALID_LAYOUT) entirely, rather
+// than needing that bridge at all. When the device supports enhanced barriers, the resource is created
+// directly in D3D12_BARRIER_LAYOUT tracking (ID3D12Device10::CreateCommittedResource3, via
+// D3D12MA::Allocator::CreateResource3) instead of legacy D3D12_RESOURCE_STATES tracking -- it never has
+// legacy-tracked history to hand off from, so its first TransitionBarrier()/UAVBarrier() call finds it
+// already enhanced-tracked and BridgeLegacyResourceToCommon's NeedsLegacyHandoff correctly never fires
+// for it. Falls back to the legacy CreateResource(D3D12_RESOURCE_STATES) when enhanced barriers are
+// unavailable, same "always have a fallback" policy as every other enhanced-barrier code path here.
+//
+// NOT for resources that must stay on the fully-legacy barrier path on purpose (D3D12Fsr3.cpp's FFX
+// interop resources -- FFX's own DX12 backend issues legacy barriers against them and expects the
+// exact legacy state, see the comment in D3D12Fsr3.cpp) -- those keep calling CreateResource directly.
+namespace D3D12ResourceCreate {
+
+    /** Maps a creation-time initial D3D12_RESOURCE_STATES to the equivalent D3D12_BARRIER_LAYOUT. Covers
+        only the states actually used as creation-time initial states in this backend; extend as needed
+        rather than guessing at unused ones. */
+    inline D3D12_BARRIER_LAYOUT ToInitialLayout( D3D12_RESOURCE_STATES state ) {
+        // Combined shader-read mask (e.g. D3D12Taa.cpp's kPrevDepthReadState = PIXEL | NON_PIXEL) checked
+        // first via a bit test rather than the switch below, since neither individual case label equals
+        // the OR'd value.
+        constexpr D3D12_RESOURCE_STATES kAnyShaderRead =
+            D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+        if ( ( state & kAnyShaderRead ) != 0 && ( state & ~kAnyShaderRead ) == 0 )
+            return D3D12_BARRIER_LAYOUT_SHADER_RESOURCE;
+
+        switch ( state ) {
+            case D3D12_RESOURCE_STATE_RENDER_TARGET: return D3D12_BARRIER_LAYOUT_RENDER_TARGET;
+            case D3D12_RESOURCE_STATE_DEPTH_WRITE: return D3D12_BARRIER_LAYOUT_DEPTH_STENCIL_WRITE;
+            case D3D12_RESOURCE_STATE_DEPTH_READ: return D3D12_BARRIER_LAYOUT_DEPTH_STENCIL_READ;
+            case D3D12_RESOURCE_STATE_UNORDERED_ACCESS: return D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS;
+            case D3D12_RESOURCE_STATE_COPY_DEST: return D3D12_BARRIER_LAYOUT_COPY_DEST;
+            case D3D12_RESOURCE_STATE_COPY_SOURCE: return D3D12_BARRIER_LAYOUT_COPY_SOURCE;
+            case D3D12_RESOURCE_STATE_COMMON: return D3D12_BARRIER_LAYOUT_COMMON;
+            default: return D3D12_BARRIER_LAYOUT_COMMON;   // caller should transition explicitly afterward
+        }
+    }
+
+    /** D3D12_RESOURCE_DESC1 shares D3D12_RESOURCE_DESC's field layout exactly except for the trailing
+        SamplerFeedbackMipRegion, which nothing in this backend uses (left zeroed). */
+    inline D3D12_RESOURCE_DESC1 ToDesc1( const D3D12_RESOURCE_DESC& desc ) {
+        D3D12_RESOURCE_DESC1 desc1 = {};
+        std::memcpy( &desc1, &desc, sizeof( D3D12_RESOURCE_DESC ) );
+        return desc1;
+    }
+
+    inline HRESULT CreateTexture( D3D12MA::Allocator* allocator, const D3D12MA::ALLOCATION_DESC& allocDesc,
+        const D3D12_RESOURCE_DESC& desc, D3D12_RESOURCE_STATES legacyState, const D3D12_CLEAR_VALUE* clearValue,
+        D3D12MA::Allocation** outAlloc, REFIID riid, void** outResource ) {
+        if ( D3D12CmdList::EnhancedBarriersSupported() ) {
+            const D3D12_RESOURCE_DESC1 desc1 = ToDesc1( desc );
+            const HRESULT hr = allocator->CreateResource3( &allocDesc, &desc1, ToInitialLayout( legacyState ),
+                clearValue, 0, nullptr, outAlloc, riid, outResource );
+            if ( SUCCEEDED( hr ) ) return hr;
+            // CreateResource3 failing despite EnhancedBarriersSupported() shouldn't happen (that flag is
+            // itself gated on device capability), but fall through to the legacy call rather than fail
+            // outright -- consistent with the rest of this backend's fallback policy.
+        }
+        return allocator->CreateResource( &allocDesc, &desc, legacyState, clearValue, outAlloc, riid, outResource );
+    }
+
+} // namespace D3D12ResourceCreate

--- a/D3D11Engine/D3D12Engine/D3D12ResourceCreate.h
+++ b/D3D11Engine/D3D12Engine/D3D12ResourceCreate.h
@@ -2,19 +2,14 @@
 #include <D3D12MemAlloc.h>
 #include "D3D12StateCache.h"
 
-// Shared helper for creating textures that are exempt from the legacy-to-enhanced-barrier handoff
-// (D3D12Barrier.cpp's BridgeLegacyResourceToCommon / BARRIER_INTEROP_INVALID_LAYOUT) entirely, rather
-// than needing that bridge at all. When the device supports enhanced barriers, the resource is created
-// directly in D3D12_BARRIER_LAYOUT tracking (ID3D12Device10::CreateCommittedResource3, via
-// D3D12MA::Allocator::CreateResource3) instead of legacy D3D12_RESOURCE_STATES tracking -- it never has
-// legacy-tracked history to hand off from, so its first TransitionBarrier()/UAVBarrier() call finds it
-// already enhanced-tracked and BridgeLegacyResourceToCommon's NeedsLegacyHandoff correctly never fires
-// for it. Falls back to the legacy CreateResource(D3D12_RESOURCE_STATES) when enhanced barriers are
-// unavailable, same "always have a fallback" policy as every other enhanced-barrier code path here.
+// Texture creation helper: when the device supports enhanced barriers, creates the resource directly
+// in D3D12_BARRIER_LAYOUT tracking (D3D12MA::Allocator::CreateResource3) instead of legacy
+// D3D12_RESOURCE_STATES tracking, so its first barrier call already finds it enhanced-tracked. Falls
+// back to the legacy CreateResource() when enhanced barriers are unavailable.
 //
-// NOT for resources that must stay on the fully-legacy barrier path on purpose (D3D12Fsr3.cpp's FFX
-// interop resources -- FFX's own DX12 backend issues legacy barriers against them and expects the
-// exact legacy state, see the comment in D3D12Fsr3.cpp) -- those keep calling CreateResource directly.
+// Not for resources that must stay on the legacy barrier path on purpose (e.g. FFX/FSR3 interop
+// resources, which FFX's own DX12 backend transitions with legacy barriers) -- those call
+// CreateResource directly.
 namespace D3D12ResourceCreate {
 
     /** Maps a creation-time initial D3D12_RESOURCE_STATES to the equivalent D3D12_BARRIER_LAYOUT. Covers
@@ -57,9 +52,8 @@ namespace D3D12ResourceCreate {
             const HRESULT hr = allocator->CreateResource3( &allocDesc, &desc1, ToInitialLayout( legacyState ),
                 clearValue, 0, nullptr, outAlloc, riid, outResource );
             if ( SUCCEEDED( hr ) ) return hr;
-            // CreateResource3 failing despite EnhancedBarriersSupported() shouldn't happen (that flag is
-            // itself gated on device capability), but fall through to the legacy call rather than fail
-            // outright -- consistent with the rest of this backend's fallback policy.
+            // Shouldn't happen given EnhancedBarriersSupported(), but fall through to the legacy call
+            // rather than fail outright.
         }
         return allocator->CreateResource( &allocDesc, &desc, legacyState, clearValue, outAlloc, riid, outResource );
     }

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -3006,7 +3006,7 @@ void D3D12GraphicsEngine::RefreshDynamicVobArena() {
 
     DX_ZONE( m_CmdList.Get(), "Morph arena refresh" );
 
-    static std::vector<D3D12_RESOURCE_BARRIER> barriers;
+    static std::vector<D3D12ResourceTransition> barriers;
     static std::vector<std::pair<MeshInfo*, D3D12VertexBuffer*>> copies;
     barriers.clear();
     copies.clear();
@@ -3021,14 +3021,13 @@ void D3D12GraphicsEngine::RefreshDynamicVobArena() {
         if ( src->IsUavCapable() ) {
             const D3D12_RESOURCE_STATES from = ( src->GetUavState() == D3D12VertexBuffer::EUavState::Vertex )
                 ? D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER : D3D12_RESOURCE_STATE_COMMON;
-            barriers.push_back( TransitionBarrier( src->GetResource(), from, D3D12_RESOURCE_STATE_COPY_SOURCE ) );
+            barriers.push_back( { src->GetResource(), from, D3D12_RESOURCE_STATE_COPY_SOURCE } );
         }
         copies.emplace_back( mi, src );
     }
     if ( copies.empty() ) return;
 
-    if ( !barriers.empty() )
-        m_CmdList->ResourceBarrier( static_cast<UINT>( barriers.size() ), barriers.data() );
+    m_CmdList->TransitionBarriers( barriers.data(), static_cast<UINT>( barriers.size() ) );
 
     for ( auto const& [mi, src] : copies ) {
         const D3D12VobArena::Range* range = m_VobArena.Find( mi );
@@ -3046,13 +3045,13 @@ void D3D12GraphicsEngine::RefreshDynamicVobArena() {
     barriers.clear();
     for ( auto const& [mi, src] : copies ) {
         if ( !src->IsUavCapable() ) continue;
-        barriers.push_back( TransitionBarrier( src->GetResource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
-            D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER ) );
+        barriers.push_back( { src->GetResource(), D3D12_RESOURCE_STATE_COPY_SOURCE,
+            D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER } );
         src->SetUavState( D3D12VertexBuffer::EUavState::Vertex );
     }
-    barriers.push_back( TransitionBarrier( m_VobArena.GetVertexBuffer(), D3D12_RESOURCE_STATE_COPY_DEST,
-        D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER ) );
-    m_CmdList->ResourceBarrier( static_cast<UINT>( barriers.size() ), barriers.data() );
+    barriers.push_back( { m_VobArena.GetVertexBuffer(), D3D12_RESOURCE_STATE_COPY_DEST,
+        D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER } );
+    m_CmdList->TransitionBarriers( barriers.data(), static_cast<UINT>( barriers.size() ) );
 }
 
 
@@ -3807,8 +3806,7 @@ void D3D12GraphicsEngine::DispatchLightCulling() {
     // UNORDERED_ACCESS so the cull CS can write it as a root UAV. Skipped on the first dispatch after
     // (re)creation, when it's already in UAV (see CreateLightCullBuffers / m_LightGridInPixelState).
     if ( m_LightGridInPixelState ) {
-        D3D12_RESOURCE_BARRIER pre = TransitionBarrier( m_LightGridBuffer.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-        m_CmdList->ResourceBarrier( 1, &pre );
+        m_CmdList->TransitionBarrier( m_LightGridBuffer.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
         m_LightGridInPixelState = false;
     }
 
@@ -3843,8 +3841,7 @@ void D3D12GraphicsEngine::DispatchLightCulling() {
     // XY bounds. Do NOT re-add the Z dimension without changing LightCull.hlsl.
     m_CmdList->Dispatch( m_NumTilesX, m_NumTilesY, 1 );
 
-    D3D12_RESOURCE_BARRIER post = TransitionBarrier( m_LightGridBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-    m_CmdList->ResourceBarrier( 1, &post );
+    m_CmdList->TransitionBarrier( m_LightGridBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
     m_LightGridInPixelState = true;
 }
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2829,6 +2829,10 @@ void D3D12GraphicsEngine::BuildWorldDrawCommands() {
             uint32_t normalIdx  = 0xFFFFFFFFu;
             uint32_t ormIdx     = GetDefaultOrmSrvSlot();
             float normalStrength = 1.0f;
+            if (auto info = Engine::GAPI->GetMaterialInfoFrom(meshKey.Material)) {
+                normalStrength = info->buffer.NormalmapStrength;
+            }
+            
             if ( tex && tex->CacheIn( 0.6f ) == zRES_CACHED_IN ) {
                 if ( MyDirectDrawSurface7* s = tex->GetSurface() ) {
                     if ( GfxTexture* gfx = s->GetEngineTexture() ) {

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -1025,7 +1025,8 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 		GPULight& L = dst[count];
 		XMStoreFloat3( &L.PositionView, XMVector3TransformCoord( XMLoadFloat3( &pw ), view ) );
 		L.Range = cand.range;
-		L.Color = XMFLOAT4( r * lightFactor, g * lightFactor, b * lightFactor, cand.isStatic ? 0.0f : 1.0f );
+		L.Color = XMFLOAT4( r * lightFactor, g * lightFactor, b * lightFactor,
+			lightSettings.PointLightSpecularScale( cand.isStatic ) );
 		L.PositionWorld = pw;
 		L.ShadowCubeIndex = -1;
 		L.ShadowOrigin = cand.shadowOrigin;

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -775,9 +775,8 @@ void D3D12ShadowMap::Prepare() {
 
 	// Return the map to DEPTH_WRITE if last frame's lit sampling left it in PIXEL_SHADER_RESOURCE.
 	if ( m_InPixelState ) {
-		auto toDepth = TransitionBarrier( m_Map.Get(),
+		m_E->m_CmdList->TransitionBarrier( m_Map.Get(),
 			D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE );
-		m_E->m_CmdList->ResourceBarrier( 1, &toDepth );
 		m_InPixelState = false;
 	}
 
@@ -1427,8 +1426,6 @@ void D3D12ShadowMap::TransitionToReadState( D3D12CmdList& cmdList ) {
 	// frame's Prepare(). (The point-shadow cube and the rain map do their own transition inside their own pass,
 	// which is self-contained in one list.)
 	if ( !cmdList || !m_Map || m_InPixelState ) return;
-	auto toSrv = TransitionBarrier( m_Map.Get(),
-		D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-	cmdList->ResourceBarrier( 1, &toSrv );
+	cmdList->TransitionBarrier( m_Map.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
 	m_InPixelState = true;
 }

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -689,7 +689,7 @@ void D3D12ShadowMap::UploadSamplingConstants( bool sunUp ) {
 		XMFLOAT3   SunDirWS;          float ShadowMapSize;
 		XMFLOAT3   SunColor;          float SunIntensity;
 		XMFLOAT3   CascadeTexelWorld; float AmbientStrength;
-		float ShadowAOStrength; float WorldAOStrength; float SkyOccStrength; float _pad1;
+		float ShadowAOStrength; float WorldAOStrength; float SkyOccStrength; float SunSpecularEnabled;
 	} cb;
 	static_assert( sizeof( cb ) == D3D12GraphicsEngine::kWetnessCbOffset, "ShadowCB head size must match the HLSL layout" );
 	const auto& set = Engine::GAPI->GetRendererState().RendererSettings;
@@ -734,7 +734,7 @@ void D3D12ShadowMap::UploadSamplingConstants( bool sunUp ) {
 	// PBRLighting.hlsl ComputeSunLightingPBR. Only the IBL branch reads it; the flat fallback already carries
 	// vertLighting through shadowAO.
 	cb.SkyOccStrength = std::clamp( set.SkyOcclusionStrength, 0.0f, 1.0f );
-	cb._pad1 = 0.0f;
+	cb.SunSpecularEnabled = ( set.SpecularHighlightsFlags & GothicRendererSettings::SH_SUN ) ? 1.0f : 0.0f;
 	memcpy( mapped, &cb, sizeof( cb ) );
 }
 

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -3,6 +3,7 @@
 #include "../pch.h"
 #include "D3D12ShadowMap.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "D3D12VertexBuffer.h"
 #include "D3D12Texture.h"
 #include "../Engine.h"
@@ -120,7 +121,7 @@ bool D3D12ShadowMap::CreateTextureAndViews( UINT size ) {
 	// Born in DEPTH_WRITE; each frame Prepare() writes then transitions to PIXEL_SHADER_RESOURCE and back.
 	m_MapAlloc.Reset();
 	m_Map.Reset();
-	if ( FAILED( m_E->m_Allocator->CreateResource( &allocDesc, &dd,
+	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_E->m_Allocator.Get(), allocDesc, dd,
 		D3D12_RESOURCE_STATE_DEPTH_WRITE, &clear, m_MapAlloc.ReleaseAndGetAddressOf(),
 		IID_PPV_ARGS( m_Map.ReleaseAndGetAddressOf() ) ) ) )
 		return false;

--- a/D3D11Engine/D3D12Engine/D3D12SkyIbl.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12SkyIbl.cpp
@@ -23,6 +23,7 @@
 // address-space budget, which is exactly why this stage comes before a probe grid.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 #include "../GSky.h"
@@ -113,7 +114,7 @@ bool D3D12GraphicsEngine::CreateSkyIblResources() {
         dd.SampleDesc.Count = 1;
         dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
         dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-        if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+        if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             nullptr, outAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( out.ReleaseAndGetAddressOf() ) ) ) ) {
             LogWarn() << "D3D12: failed to create a sky-IBL cubemap (" << size << "^2, " << mips << " mips).";
             return false;

--- a/D3D11Engine/D3D12Engine/D3D12SkyIbl.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12SkyIbl.cpp
@@ -343,13 +343,10 @@ void D3D12GraphicsEngine::RenderSkyIBL() {
     // claim a "before" state it was not in (RESOURCE_BARRIER_BEFORE_AFTER_MISMATCH on every rebuild — i.e.
     // continuously, as Gothic's day cycle keeps the sky colours dirty).
     if ( m_SkyEnvInReadState ) {
-        D3D12_RESOURCE_BARRIER toUav[2] = {
-            TransitionBarrier( m_SkyEnvCube.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-            TransitionBarrier( m_SkyIrradCube.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-        };
-        m_CmdList->ResourceBarrier( 2, toUav );
+        m_CmdList->TransitionBarriers( {
+        	{ m_SkyEnvCube.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        	{ m_SkyIrradCube.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        } );
         m_SkyEnvInReadState = false;
     }
 
@@ -388,13 +385,13 @@ void D3D12GraphicsEngine::RenderSkyIBL() {
     // writes them while sampling mip 0. That is why m_SkyEnvMip0SrvSlot is a mip-0-only view — a full-chain SRV
     // would require the whole resource in one state.
     {
-        D3D12_RESOURCE_BARRIER b = TransitionBarrier( m_SkyEnvCube.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
         // Subresource index for a mip-mapped array is mip + face * mipCount — mip 0 of all 6 faces.
+        D3D12ResourceTransition mip0[6];
         for ( UINT face = 0; face < 6; ++face ) {
-            b.Transition.Subresource = face * kSkyEnvMips + 0;
-            m_CmdList->ResourceBarrier( 1, &b );
+            mip0[face] = { m_SkyEnvCube.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, face * kSkyEnvMips + 0 };
         }
+        m_CmdList->TransitionBarriers( mip0, 6 );
     }
 
     // --- Pass 2: GGX prefilter -> env cube mips 1..N -------------------------------------------------------
@@ -434,20 +431,17 @@ void D3D12GraphicsEngine::RenderSkyIBL() {
     // Mip 0 is currently NON_PIXEL_SHADER_RESOURCE and mips 1..N UNORDERED_ACCESS; bring the whole resource to
     // PIXEL_SHADER_RESOURCE with per-subresource transitions that state the correct "before" for each.
     {
-        std::vector<D3D12_RESOURCE_BARRIER> barriers;
-        barriers.reserve( 6 * kSkyEnvMips + 1 );
+        D3D12ResourceTransition barriers[6 * kSkyEnvMips + 1];
+        UINT n = 0;
         for ( UINT face = 0; face < 6; ++face ) {
             for ( UINT m = 0; m < kSkyEnvMips; ++m ) {
-                auto b = TransitionBarrier( m_SkyEnvCube.Get(),
+                barriers[n++] = { m_SkyEnvCube.Get(),
                     m == 0 ? D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-                    D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-                b.Transition.Subresource = face * kSkyEnvMips + m;
-                barriers.push_back( b );
+                    D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, face * kSkyEnvMips + m };
             }
         }
-        barriers.push_back( TransitionBarrier( m_SkyIrradCube.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE ) );
-        m_CmdList->ResourceBarrier( static_cast<UINT>( barriers.size() ), barriers.data() );
+        barriers[n++] = { m_SkyIrradCube.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE };
+        m_CmdList->TransitionBarriers( barriers, n );
     }
 
     m_SkyEnvInReadState = true;

--- a/D3D11Engine/D3D12Engine/D3D12StateCache.h
+++ b/D3D11Engine/D3D12Engine/D3D12StateCache.h
@@ -366,6 +366,10 @@ public:
         D3D12RootLayout.cpp's HighestRootSignatureVersion cache) is enough -- no per-instance plumbing
         needed on every D3D12CmdList. */
     static void SetEnhancedBarriersDeviceSupport( bool supported ) noexcept { s_DeviceSupportsEnhancedBarriers = supported; }
+    /** Queried by resource-creation call sites (D3D12ResourceCreate.h) to decide CreateResource3
+        (D3D12_BARRIER_LAYOUT initial layout, no legacy-tracking handoff ever needed) vs. the legacy
+        CreateResource (D3D12_RESOURCE_STATES). Same flag that gates every barrier call. */
+    static bool EnhancedBarriersSupported() noexcept { return s_DeviceSupportsEnhancedBarriers; }
 
     // ---- Untracked passthrough -----------------------------------------------------------------
     // None of these mutate the pipeline state the shadow tracks.

--- a/D3D11Engine/D3D12Engine/D3D12StateCache.h
+++ b/D3D11Engine/D3D12Engine/D3D12StateCache.h
@@ -340,14 +340,15 @@ public:
     // implemented out-of-line in D3D12Barrier.cpp. Callers still speak legacy D3D12_RESOURCE_STATES;
     // whether the machine actually has enhanced barriers is decided internally (see
     // SetEnhancedBarriersDeviceSupport / List7 below) and is invisible at the call site.
-    //
-    // FOUNDATION ONLY as of this writing: no call site in the backend uses these yet. All existing
-    // barrier traffic still goes through the legacy ResourceBarrier() passthrough just below.
     void TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_STATES before, D3D12_RESOURCE_STATES after,
         UINT subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES );
-    void TransitionBarriers( std::initializer_list<D3D12ResourceTransition> transitions );
+    void TransitionBarriers( std::initializer_list<D3D12ResourceTransition> transitions ) { TransitionBarriers( transitions.begin(), static_cast<UINT>( transitions.size() ) ); }
+    /** Runtime-sized counterpart of the initializer_list overload above, for call sites that build a
+        variable-length batch in a loop (e.g. a per-mip reset pass) rather than writing it out literally. */
+    void TransitionBarriers( const D3D12ResourceTransition* transitions, UINT count );
     void UAVBarrier( ID3D12Resource* resource );
-    void UAVBarriers( std::initializer_list<ID3D12Resource*> resources );
+    void UAVBarriers( std::initializer_list<ID3D12Resource*> resources ) { UAVBarriers( resources.begin(), static_cast<UINT>( resources.size() ) ); }
+    void UAVBarriers( ID3D12Resource* const* resources, UINT count );
     /** Stays on the legacy D3D12_RESOURCE_BARRIER_TYPE_ALIASING path unconditionally -- see
         D3D12Barrier.cpp for why aliasing doesn't map cleanly onto the enhanced-barrier model. */
     void AliasingBarrier( ID3D12Resource* before, ID3D12Resource* after );

--- a/D3D11Engine/D3D12Engine/D3D12StateCache.h
+++ b/D3D11Engine/D3D12Engine/D3D12StateCache.h
@@ -3,6 +3,8 @@
 #include <wrl/client.h>
 #include <cstdint>
 #include <cstring>
+#include <initializer_list>
+#include "D3D12Barrier.h"
 
 // Engine-wide redundant-state filter for the D3D12 backend.
 //
@@ -76,6 +78,9 @@ public:
     void Attach( ID3D12GraphicsCommandList* list ) noexcept {
         InvalidateAll();
         m_List = list;
+        // New COM object -> any cached ID3D12GraphicsCommandList7 QueryInterface result is stale.
+        m_List7Queried = false;
+        m_List7.Reset();
     }
 
     const Stats& GetStats() const noexcept { return m_Stats; }
@@ -329,6 +334,30 @@ public:
         m_List->SetComputeRootUnorderedAccessView( param, address );
     }
 
+    // ---- Barriers --------------------------------------------------------------------------------
+    // Like ResourceBarrier below, these don't mutate any state the shadow tracks -- they are grouped
+    // separately only because they carry real logic (the enhanced-barrier translation and fallback),
+    // implemented out-of-line in D3D12Barrier.cpp. Callers still speak legacy D3D12_RESOURCE_STATES;
+    // whether the machine actually has enhanced barriers is decided internally (see
+    // SetEnhancedBarriersDeviceSupport / List7 below) and is invisible at the call site.
+    //
+    // FOUNDATION ONLY as of this writing: no call site in the backend uses these yet. All existing
+    // barrier traffic still goes through the legacy ResourceBarrier() passthrough just below.
+    void TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_STATES before, D3D12_RESOURCE_STATES after,
+        UINT subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES );
+    void TransitionBarriers( std::initializer_list<D3D12ResourceTransition> transitions );
+    void UAVBarrier( ID3D12Resource* resource );
+    void UAVBarriers( std::initializer_list<ID3D12Resource*> resources );
+    /** Stays on the legacy D3D12_RESOURCE_BARRIER_TYPE_ALIASING path unconditionally -- see
+        D3D12Barrier.cpp for why aliasing doesn't map cleanly onto the enhanced-barrier model. */
+    void AliasingBarrier( ID3D12Resource* before, ID3D12Resource* after );
+
+    /** Set once at backend startup from the device's D3D12Device::EnhancedBarriersSupported(). The
+        backend drives exactly one device per process, so a single process-wide flag (mirroring
+        D3D12RootLayout.cpp's HighestRootSignatureVersion cache) is enough -- no per-instance plumbing
+        needed on every D3D12CmdList. */
+    static void SetEnhancedBarriersDeviceSupport( bool supported ) noexcept { s_DeviceSupportsEnhancedBarriers = supported; }
+
     // ---- Untracked passthrough -----------------------------------------------------------------
     // None of these mutate the pipeline state the shadow tracks.
     void ResourceBarrier( UINT num, const D3D12_RESOURCE_BARRIER* barriers ) { m_List->ResourceBarrier( num, barriers ); }
@@ -476,4 +505,24 @@ private:
     RootArgs m_Gfx;
     RootArgs m_Compute;
     Stats m_Stats;
+
+    // ---- Enhanced-barrier support ----------------------------------------------------------------
+    // Queried lazily, once per underlying list object (see Attach() above for the invalidation).
+    // ID3D12GraphicsCommandList7::Barrier is a pure COM interface -- QueryInterface, no new proc
+    // address -- so this needs nothing beyond what device/list creation already resolved.
+    mutable Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList7> m_List7;
+    mutable bool m_List7Queried = false;
+
+    ID3D12GraphicsCommandList7* List7() const noexcept {
+        if ( !m_List7Queried ) {
+            m_List7Queried = true;
+            m_List.As( &m_List7 );   // best-effort; leaves m_List7 null on an older runtime
+        }
+        return m_List7.Get();
+    }
+
+    // Whether the device this backend drives reports EnhancedBarriersSupported; see
+    // SetEnhancedBarriersDeviceSupport above. Defaults to false, so barrier calls safely take the
+    // legacy path even if the one call site that sets this were somehow skipped.
+    static inline bool s_DeviceSupportsEnhancedBarriers = false;
 };

--- a/D3D11Engine/D3D12Engine/D3D12StateCache.h
+++ b/D3D11Engine/D3D12Engine/D3D12StateCache.h
@@ -335,40 +335,26 @@ public:
     }
 
     // ---- Barriers --------------------------------------------------------------------------------
-    // Like ResourceBarrier below, these don't mutate any state the shadow tracks -- they are grouped
-    // separately only because they carry real logic (the enhanced-barrier translation and fallback),
-    // implemented out-of-line in D3D12Barrier.cpp. Callers still speak legacy D3D12_RESOURCE_STATES;
-    // whether the machine actually has enhanced barriers is decided internally (see
-    // SetEnhancedBarriersDeviceSupport / List7 below) and is invisible at the call site.
+    // Grouped separately from the passthrough section below because these carry real logic (enhanced-
+    // barrier translation + legacy fallback, in D3D12Barrier.cpp) though they don't touch the shadow.
     /** syncBeforeHint/syncAfterHint narrow the enhanced-barrier sync scope for callers that know exactly
-        which pipeline stage(s) touch the resource on each side (see D3D12ResourceTransition in
-        D3D12Barrier.h for why); leave at the kBarrierSyncUnspecified default to get the table's
-        conservative (but always-correct) scope for the state pair. */
+        which pipeline stage(s) touch the resource on each side; leave at kBarrierSyncUnspecified for the
+        table's conservative (but always-correct) scope. */
     void TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_STATES before, D3D12_RESOURCE_STATES after,
         UINT subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
         D3D12_BARRIER_SYNC syncBeforeHint = kBarrierSyncUnspecified, D3D12_BARRIER_SYNC syncAfterHint = kBarrierSyncUnspecified );
     void TransitionBarriers( std::initializer_list<D3D12ResourceTransition> transitions ) { TransitionBarriers( transitions.begin(), static_cast<UINT>( transitions.size() ) ); }
-    /** Runtime-sized counterpart of the initializer_list overload above, for call sites that build a
-        variable-length batch in a loop (e.g. a per-mip reset pass) rather than writing it out literally. */
     void TransitionBarriers( const D3D12ResourceTransition* transitions, UINT count );
-    /** syncHint narrows the UAV barrier's sync scope the same way TransitionBarrier's hints do (both
-        sides of a UAV barrier share one scope, since it orders one dispatch's writes against another's
-        reads on the SAME resource). Defaults to the table's D3D12_BARRIER_SYNC_ALL_SHADING. */
     void UAVBarrier( ID3D12Resource* resource, D3D12_BARRIER_SYNC syncHint = kBarrierSyncUnspecified );
     void UAVBarriers( std::initializer_list<ID3D12Resource*> resources ) { UAVBarriers( resources.begin(), static_cast<UINT>( resources.size() ) ); }
     void UAVBarriers( ID3D12Resource* const* resources, UINT count, D3D12_BARRIER_SYNC syncHint = kBarrierSyncUnspecified );
-    /** Stays on the legacy D3D12_RESOURCE_BARRIER_TYPE_ALIASING path unconditionally -- see
-        D3D12Barrier.cpp for why aliasing doesn't map cleanly onto the enhanced-barrier model. */
+    /** Stays on the legacy D3D12_RESOURCE_BARRIER_TYPE_ALIASING path -- see D3D12Barrier.cpp for why
+        aliasing doesn't map cleanly onto the enhanced-barrier model. */
     void AliasingBarrier( ID3D12Resource* before, ID3D12Resource* after );
 
-    /** Set once at backend startup from the device's D3D12Device::EnhancedBarriersSupported(). The
-        backend drives exactly one device per process, so a single process-wide flag (mirroring
-        D3D12RootLayout.cpp's HighestRootSignatureVersion cache) is enough -- no per-instance plumbing
-        needed on every D3D12CmdList. */
     static void SetEnhancedBarriersDeviceSupport( bool supported ) noexcept { s_DeviceSupportsEnhancedBarriers = supported; }
-    /** Queried by resource-creation call sites (D3D12ResourceCreate.h) to decide CreateResource3
-        (D3D12_BARRIER_LAYOUT initial layout, no legacy-tracking handoff ever needed) vs. the legacy
-        CreateResource (D3D12_RESOURCE_STATES). Same flag that gates every barrier call. */
+    /** Queried by D3D12ResourceCreate.h to decide CreateResource3 (D3D12_BARRIER_LAYOUT initial layout)
+        vs. legacy CreateResource (D3D12_RESOURCE_STATES). Same flag that gates every barrier call. */
     static bool EnhancedBarriersSupported() noexcept { return s_DeviceSupportsEnhancedBarriers; }
 
     // ---- Untracked passthrough -----------------------------------------------------------------
@@ -520,9 +506,7 @@ private:
     Stats m_Stats;
 
     // ---- Enhanced-barrier support ----------------------------------------------------------------
-    // Queried lazily, once per underlying list object (see Attach() above for the invalidation).
-    // ID3D12GraphicsCommandList7::Barrier is a pure COM interface -- QueryInterface, no new proc
-    // address -- so this needs nothing beyond what device/list creation already resolved.
+    // Queried lazily once per underlying list object (see Attach() for the invalidation).
     mutable Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList7> m_List7;
     mutable bool m_List7Queried = false;
 
@@ -534,8 +518,6 @@ private:
         return m_List7.Get();
     }
 
-    // Whether the device this backend drives reports EnhancedBarriersSupported; see
-    // SetEnhancedBarriersDeviceSupport above. Defaults to false, so barrier calls safely take the
-    // legacy path even if the one call site that sets this were somehow skipped.
+    // Defaults to false, so barrier calls safely take the legacy path until set.
     static inline bool s_DeviceSupportsEnhancedBarriers = false;
 };

--- a/D3D11Engine/D3D12Engine/D3D12StateCache.h
+++ b/D3D11Engine/D3D12Engine/D3D12StateCache.h
@@ -340,15 +340,23 @@ public:
     // implemented out-of-line in D3D12Barrier.cpp. Callers still speak legacy D3D12_RESOURCE_STATES;
     // whether the machine actually has enhanced barriers is decided internally (see
     // SetEnhancedBarriersDeviceSupport / List7 below) and is invisible at the call site.
+    /** syncBeforeHint/syncAfterHint narrow the enhanced-barrier sync scope for callers that know exactly
+        which pipeline stage(s) touch the resource on each side (see D3D12ResourceTransition in
+        D3D12Barrier.h for why); leave at the kBarrierSyncUnspecified default to get the table's
+        conservative (but always-correct) scope for the state pair. */
     void TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_STATES before, D3D12_RESOURCE_STATES after,
-        UINT subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES );
+        UINT subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
+        D3D12_BARRIER_SYNC syncBeforeHint = kBarrierSyncUnspecified, D3D12_BARRIER_SYNC syncAfterHint = kBarrierSyncUnspecified );
     void TransitionBarriers( std::initializer_list<D3D12ResourceTransition> transitions ) { TransitionBarriers( transitions.begin(), static_cast<UINT>( transitions.size() ) ); }
     /** Runtime-sized counterpart of the initializer_list overload above, for call sites that build a
         variable-length batch in a loop (e.g. a per-mip reset pass) rather than writing it out literally. */
     void TransitionBarriers( const D3D12ResourceTransition* transitions, UINT count );
-    void UAVBarrier( ID3D12Resource* resource );
+    /** syncHint narrows the UAV barrier's sync scope the same way TransitionBarrier's hints do (both
+        sides of a UAV barrier share one scope, since it orders one dispatch's writes against another's
+        reads on the SAME resource). Defaults to the table's D3D12_BARRIER_SYNC_ALL_SHADING. */
+    void UAVBarrier( ID3D12Resource* resource, D3D12_BARRIER_SYNC syncHint = kBarrierSyncUnspecified );
     void UAVBarriers( std::initializer_list<ID3D12Resource*> resources ) { UAVBarriers( resources.begin(), static_cast<UINT>( resources.size() ) ); }
-    void UAVBarriers( ID3D12Resource* const* resources, UINT count );
+    void UAVBarriers( ID3D12Resource* const* resources, UINT count, D3D12_BARRIER_SYNC syncHint = kBarrierSyncUnspecified );
     /** Stays on the legacy D3D12_RESOURCE_BARRIER_TYPE_ALIASING path unconditionally -- see
         D3D12Barrier.cpp for why aliasing doesn't map cleanly onto the enhanced-barrier model. */
     void AliasingBarrier( ID3D12Resource* before, ID3D12Resource* after );

--- a/D3D11Engine/D3D12Engine/D3D12StateCache.h
+++ b/D3D11Engine/D3D12Engine/D3D12StateCache.h
@@ -405,6 +405,18 @@ public:
     }
 
 private:
+    // Bridges a texture resource from legacy state tracking into enhanced-barrier tracking the first
+    // time (ever, for that resource object) an enhanced Barrier() touches it. Implemented in
+    // D3D12Barrier.cpp; see the comment there for why this is required at all (BARRIER_INTEROP_INVALID_LAYOUT)
+    // and why identity is tracked via SetPrivateData on the resource rather than an external set.
+    // `trueBefore` must be the resource's actual current (legacy-model) state -- for TransitionBarrier
+    // that's simply the caller's `before` argument; for UAVBarrier it's always UNORDERED_ACCESS, since a
+    // UAV barrier only ever makes sense on a resource already in that state. Returns true (and has
+    // already issued one legacy ResourceBarrier to COMMON on `m_List`) if a bridge was needed, in which
+    // case the caller must treat the enhanced barrier's "before" side as
+    // {SYNC_NONE, ACCESS_NO_ACCESS, LAYOUT_COMMON} instead of whatever the state table produced.
+    bool BridgeLegacyResourceToCommon( ID3D12Resource* resource, D3D12_RESOURCE_STATES trueBefore );
+
     static constexpr UINT kMaxViewports = 4;
     static constexpr UINT kInvalidCount = 0xFFFFFFFFu;
 

--- a/D3D11Engine/D3D12Engine/D3D12StateCache.h
+++ b/D3D11Engine/D3D12Engine/D3D12StateCache.h
@@ -409,18 +409,6 @@ public:
     }
 
 private:
-    // Bridges a texture resource from legacy state tracking into enhanced-barrier tracking the first
-    // time (ever, for that resource object) an enhanced Barrier() touches it. Implemented in
-    // D3D12Barrier.cpp; see the comment there for why this is required at all (BARRIER_INTEROP_INVALID_LAYOUT)
-    // and why identity is tracked via SetPrivateData on the resource rather than an external set.
-    // `trueBefore` must be the resource's actual current (legacy-model) state -- for TransitionBarrier
-    // that's simply the caller's `before` argument; for UAVBarrier it's always UNORDERED_ACCESS, since a
-    // UAV barrier only ever makes sense on a resource already in that state. Returns true (and has
-    // already issued one legacy ResourceBarrier to COMMON on `m_List`) if a bridge was needed, in which
-    // case the caller must treat the enhanced barrier's "before" side as
-    // {SYNC_NONE, ACCESS_NO_ACCESS, LAYOUT_COMMON} instead of whatever the state table produced.
-    bool BridgeLegacyResourceToCommon( ID3D12Resource* resource, D3D12_RESOURCE_STATES trueBefore );
-
     static constexpr UINT kMaxViewports = 4;
     static constexpr UINT kInvalidCount = 0xFFFFFFFFu;
 

--- a/D3D11Engine/D3D12Engine/D3D12Taa.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Taa.cpp
@@ -237,17 +237,17 @@ void D3D12GraphicsEngine::RenderTAA() {
     // Depth leaves DEPTH_WRITE, so unbind the DSV first (same dance RenderBloom / RenderFogAndGodRays do).
     m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
     {
-        D3D12_RESOURCE_BARRIER pre[4];
+        D3D12ResourceTransition pre[4];
         UINT n = 0;
         if ( !m_SceneColorInPixelState ) {
-            pre[n++] = TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
-                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+            pre[n++] = { m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
+                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE };
         }
-        pre[n++] = TransitionBarrier( m_TaaHistory[readIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-        pre[n++] = TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-        if ( n ) m_CmdList->ResourceBarrier( n, pre );
+        pre[n++] = { m_TaaHistory[readIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE };
+        pre[n++] = { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE,
+            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE };
+        m_CmdList->TransitionBarriers( pre, n );
         m_SceneColorInPixelState = true;
     }
 
@@ -311,50 +311,37 @@ void D3D12GraphicsEngine::RenderTAA() {
     // Nothing downstream on this backend reads scene-colour alpha (bloom, luminance and the tonemap all take
     // .rgb), and the fog composition only preserves alpha rather than consuming it.
     {
-        D3D12_RESOURCE_BARRIER toCopy[] = {
-            TransitionBarrier( m_TaaHistory[writeIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-                D3D12_RESOURCE_STATE_COPY_SOURCE ),
-            TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_COPY_DEST ),
-        };
-        m_CmdList->ResourceBarrier( _countof( toCopy ), toCopy );
+        m_CmdList->TransitionBarriers( {
+            { m_TaaHistory[writeIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE },
+            { m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST },
+        } );
         m_CmdList->CopyResource( m_SceneColor.Get(), m_TaaHistory[writeIdx].Get() );
     }
 
     // Snapshot this frame's depth for the NEXT frame's disocclusion test. Nothing else in the frame keeps a
     // previous-frame depth, so this pass owns the copy.
     if ( m_TaaPrevDepth ) {
-        D3D12_RESOURCE_BARRIER toCopy[] = {
-            TransitionBarrier( m_TaaPrevDepth.Get(), kPrevDepthReadState, D3D12_RESOURCE_STATE_COPY_DEST ),
-            TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_COPY_SOURCE ),
-        };
-        m_CmdList->ResourceBarrier( _countof( toCopy ), toCopy );
+        m_CmdList->TransitionBarriers( {
+            { m_TaaPrevDepth.Get(), kPrevDepthReadState, D3D12_RESOURCE_STATE_COPY_DEST },
+            { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_SOURCE },
+        } );
         m_CmdList->CopyResource( m_TaaPrevDepth.Get(), m_DepthBuffer.Get() );
-        D3D12_RESOURCE_BARRIER back[] = {
-            TransitionBarrier( m_TaaPrevDepth.Get(), D3D12_RESOURCE_STATE_COPY_DEST, kPrevDepthReadState ),
-            TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE,
-                D3D12_RESOURCE_STATE_DEPTH_WRITE ),
-        };
-        m_CmdList->ResourceBarrier( _countof( back ), back );
+        m_CmdList->TransitionBarriers( {
+            { m_TaaPrevDepth.Get(), D3D12_RESOURCE_STATE_COPY_DEST, kPrevDepthReadState },
+            { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE },
+        } );
         m_TaaPrevDepthValid = true;
     } else {
-        auto depthBack = TransitionBarrier( m_DepthBuffer.Get(),
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE );
-        m_CmdList->ResourceBarrier( 1, &depthBack );
+        m_CmdList->TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE );
     }
 
     // Rest states for the next frame: history back to UAV (both slots), scene colour back to RENDER_TARGET.
     {
-        D3D12_RESOURCE_BARRIER post[] = {
-            TransitionBarrier( m_TaaHistory[writeIdx].Get(), D3D12_RESOURCE_STATE_COPY_SOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-            TransitionBarrier( m_TaaHistory[readIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-            TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_COPY_DEST,
-                D3D12_RESOURCE_STATE_RENDER_TARGET ),
-        };
-        m_CmdList->ResourceBarrier( _countof( post ), post );
+        m_CmdList->TransitionBarriers( {
+            { m_TaaHistory[writeIdx].Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+            { m_TaaHistory[readIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+            { m_SceneColor.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_RENDER_TARGET },
+        } );
         m_SceneColorInPixelState = false;
     }
 

--- a/D3D11Engine/D3D12Engine/D3D12Taa.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Taa.cpp
@@ -23,6 +23,7 @@
 // MotionCB::UnjitteredViewProj deliberately stays clean so motion vectors do not encode the jitter as motion.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 #include "../zCCamera.h"
@@ -76,7 +77,7 @@ bool D3D12GraphicsEngine::CreateTaaResources( INT2 size ) {
         dd.SampleDesc.Count = 1;
         dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
         dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-        if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+        if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             nullptr, m_TaaHistoryAlloc[i].ReleaseAndGetAddressOf(),
             IID_PPV_ARGS( m_TaaHistory[i].ReleaseAndGetAddressOf() ) ) ) ) {
             LogWarn() << "D3D12: failed to create a TAA history buffer (" << size.x << "x" << size.y << ").";
@@ -101,7 +102,7 @@ bool D3D12GraphicsEngine::CreateTaaResources( INT2 size ) {
         D3D12_CLEAR_VALUE clear = {};
         clear.Format = DXGI_FORMAT_D32_FLOAT;
         clear.DepthStencil.Depth = 0.0f;   // reversed-Z
-        if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, kPrevDepthReadState, &clear,
+        if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, kPrevDepthReadState, &clear,
             m_TaaPrevDepthAlloc.ReleaseAndGetAddressOf(),
             IID_PPV_ARGS( m_TaaPrevDepth.ReleaseAndGetAddressOf() ) ) ) ) {
             LogWarn() << "D3D12: failed to create the TAA previous-depth snapshot.";

--- a/D3D11Engine/D3D12Engine/D3D12Underwater.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Underwater.cpp
@@ -19,6 +19,7 @@
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
 #include "D3D12Texture.h"
+#include "D3D12ResourceCreate.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 
@@ -85,7 +86,7 @@ bool D3D12GraphicsEngine::CreateUnderwaterResources( INT2 size ) {
         dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
         // Both rest in UNORDERED_ACCESS between frames (see DrawUnderwaterEffects), so create them in it —
         // that makes the "before" state at the top of the pass deterministic on the very first frame.
-        if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+        if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             nullptr, m_UnderwaterBlurAlloc[i].ReleaseAndGetAddressOf(),
             IID_PPV_ARGS( m_UnderwaterBlur[i].ReleaseAndGetAddressOf() ) ) ) ) {
             LogWarn() << "D3D12: failed to create an underwater blur texture ("

--- a/D3D11Engine/D3D12Engine/D3D12Underwater.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Underwater.cpp
@@ -148,17 +148,15 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects() {
     // A texture cannot be its own SRV and RTV, and the composite below writes the display target — same
     // copy-then-read shape RenderSMAA / RenderSharpen use. m_LdrCopy rests in COPY_DEST.
     {
-        auto b = TransitionBarrier( displayTarget, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( displayTarget, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
     }
     m_CmdList->CopyResource( m_LdrCopy.Get(), displayTarget );
     {
-        D3D12_RESOURCE_BARRIER b[2] = {
-            // NON_PIXEL: the two blur passes read it from compute.
-            TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE ),
-            TransitionBarrier( displayTarget, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET ),
-        };
-        m_CmdList->ResourceBarrier( 2, b );
+        // NON_PIXEL: the two blur passes read it from compute.
+        m_CmdList->TransitionBarriers( {
+            { m_LdrCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE },
+            { displayTarget, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
+        } );
     }
 
     // b0 UnderwaterBlurCB — see Shaders/D3D12/Underwater.hlsl. Only the source/destination and the step
@@ -199,9 +197,7 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects() {
     // UAV-write -> SRV-read needs a real state transition, not a UAV barrier: a UAV barrier only orders access
     // and performs no cache flush, so the SRV read would be undefined.
     {
-        auto b = TransitionBarrier( m_UnderwaterBlur[0].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-        m_CmdList->ResourceBarrier( 1, &b );
+        m_CmdList->TransitionBarrier( m_UnderwaterBlur[0].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
     }
 
     // --- Pass 2: vertical, blur[0] -> blur[1]. ---
@@ -213,13 +209,10 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects() {
     m_CmdList->Dispatch( groupsX, groupsY, 1 );
 
     {
-        D3D12_RESOURCE_BARRIER b[2] = {
-            TransitionBarrier( m_UnderwaterBlur[1].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE ),
-            TransitionBarrier( m_UnderwaterBlur[0].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-        };
-        m_CmdList->ResourceBarrier( 2, b );
+        m_CmdList->TransitionBarriers( {
+        	{ m_UnderwaterBlur[1].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
+        	{ m_UnderwaterBlur[0].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        } );
     }
 
     // --- Pass 3: full-res distorted composite back over the display target. ---
@@ -251,12 +244,9 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects() {
     // there), the blur pair back to UNORDERED_ACCESS. The display target stays RENDER_TARGET and bound, ready
     // for Gothic's 2D UI/HUD to composite on top.
     {
-        D3D12_RESOURCE_BARRIER b[2] = {
-            TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_COPY_DEST ),
-            TransitionBarrier( m_UnderwaterBlur[1].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-                D3D12_RESOURCE_STATE_UNORDERED_ACCESS ),
-        };
-        m_CmdList->ResourceBarrier( 2, b );
+        m_CmdList->TransitionBarriers( {
+        	{ m_LdrCopy.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST },
+        	{ m_UnderwaterBlur[1].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        } );
     }
 }

--- a/D3D11Engine/D3D12Engine/D3D12Water.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Water.cpp
@@ -387,24 +387,22 @@ void D3D12GraphicsEngine::DrawWaterSurfaces() {
 
         const D3D12_RESOURCE_STATES sceneFrom = m_SceneColorInPixelState
             ? D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_RENDER_TARGET;
-        D3D12_RESOURCE_BARRIER pre[4] = {
-            TransitionBarrier( m_SceneColor.Get(), sceneFrom, D3D12_RESOURCE_STATE_COPY_SOURCE ),
-            TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_COPY_SOURCE ),
-            TransitionBarrier( m_WaterSceneCopy.Get(), kWaterCopyReadState, D3D12_RESOURCE_STATE_COPY_DEST ),
-            TransitionBarrier( m_WaterDepthCopy.Get(), kWaterCopyReadState, D3D12_RESOURCE_STATE_COPY_DEST ),
-        };
-        m_CmdList->ResourceBarrier( _countof( pre ), pre );
+        m_CmdList->TransitionBarriers( {
+        	{ m_SceneColor.Get(), sceneFrom, D3D12_RESOURCE_STATE_COPY_SOURCE },
+        	{ m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_COPY_SOURCE },
+        	{ m_WaterSceneCopy.Get(), kWaterCopyReadState, D3D12_RESOURCE_STATE_COPY_DEST },
+        	{ m_WaterDepthCopy.Get(), kWaterCopyReadState, D3D12_RESOURCE_STATE_COPY_DEST },
+        } );
 
         m_CmdList->CopyResource( m_WaterSceneCopy.Get(), m_SceneColor.Get() );
         m_CmdList->CopyResource( m_WaterDepthCopy.Get(), m_DepthBuffer.Get() );
 
-        D3D12_RESOURCE_BARRIER post[4] = {
-            TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET ),
-            TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE ),
-            TransitionBarrier( m_WaterSceneCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, kWaterCopyReadState ),
-            TransitionBarrier( m_WaterDepthCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, kWaterCopyReadState ),
-        };
-        m_CmdList->ResourceBarrier( _countof( post ), post );
+        m_CmdList->TransitionBarriers( {
+        	{ m_SceneColor.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
+        	{ m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE },
+        	{ m_WaterSceneCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, kWaterCopyReadState },
+        	{ m_WaterDepthCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, kWaterCopyReadState },
+        } );
         m_SceneColorInPixelState = false;   // the scene target is back to RENDER_TARGET regardless of before
 
         // Re-bind what the geometry passes had: HDR scene RTV + the main DSV.

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5876,6 +5876,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "Shadows", "CasterMinTexels", to_string_locale_independent( s.DebugSettings.ShadowCascades.CasterMinTexels ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "AllowSelfShadowingPointlights", to_string_locale_independent( s.AllowSelfShadowingPointlights ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Shadows", "DisableStaticPointlights", to_string_locale_independent( s.DisableStaticPointlights ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Shadows", "SpecularHighlightsFlags", to_string_locale_independent( s.SpecularHighlightsFlags ).c_str(), ini.c_str() );
 
     // WritePrivateProfileStringA( "SMAA", "Enabled", to_string_locale_independent( s.EnableSMAA ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "AntiAliasing", to_string_locale_independent( (int)s.AntiAliasingMode ).c_str(), ini.c_str() );
@@ -6038,6 +6039,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.DebugSettings.ShadowCascades.CasterMinTexels = std::clamp( GetPrivateProfileFloatA( "Shadows", "CasterMinTexels", ds.DebugSettings.ShadowCascades.CasterMinTexels, ini ), 0.0f, 32.0f );
         s.AllowSelfShadowingPointlights = GetPrivateProfileBoolA( "Shadows", "AllowSelfShadowingPointlights", ds.AllowSelfShadowingPointlights, ini );
         s.DisableStaticPointlights = GetPrivateProfileBoolA( "Shadows", "DisableStaticPointlights", ds.DisableStaticPointlights, ini );
+        s.SpecularHighlightsFlags = GetPrivateProfileSignedIntA( "Shadows", "SpecularHighlightsFlags", ds.SpecularHighlightsFlags, ini );
 
         INT2 res = {};
         RECT desktopRect;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -920,7 +920,8 @@ struct GothicRendererSettings {
         GraphicsPreset = E_GraphicsPreset::GRAPHICS_MEDIUM;
         AllowSelfShadowingPointlights = false;
         DisableStaticPointlights = false;
-        
+        SpecularHighlightsFlags = SH_SUN | SH_POINTLIGHTS;
+
         ApplyGraphicsPreset();
         ApplyAssaoPreset(1);
 
@@ -1296,6 +1297,20 @@ struct GothicRendererSettings {
     // with 10-30 co-located "atmospheric" static fill lights that exist only to raise the ambient level; under
     // an HDR pipeline they stack into a badly over-bright interior. D3D12 backend only (see BuildFrameLightBuffer).
     bool DisableStaticPointlights;
+    // Which lights are allowed to produce a specular highlight, as an OR of flags. Some players find specular
+    // highlights visually distracting (torches/spell-light glints on every surface) and want them gone without
+    // losing diffuse lighting entirely. Reuses the existing "isStatic -> Color.w=0" suppression D3D11/D3D12
+    // already apply to atmospheric fill lights (see BuildFrameLightBuffer / D3D11TiledDeferredShading) - that
+    // trick just becomes flag-driven instead of hardcoded, and the sun gets the same treatment via a new
+    // SQ_SunSpecularEnabled / SunSpecularEnabled constant (see D3D11ShadowMap::Upload*Constants / D3D12ShadowMap::
+    // UploadSamplingConstants). Both backends.
+    enum ESpecularHighlights : int {
+        SH_NONE = 0,
+        SH_SUN = 1 << 0,
+        SH_POINTLIGHTS = 1 << 1,
+        SH_ATMOSPHERIC = 1 << 2,
+    };
+    int SpecularHighlightsFlags;
     
     struct {
         struct {
@@ -1345,6 +1360,13 @@ struct GothicRendererSettings {
     bool GetIsTAAEnabled() const {
         return AntiAliasingMode == E_AntiAliasingMode::AA_TAA
             || AntiAliasingMode == E_AntiAliasingMode::AA_FSR;
+    }
+
+    // Specular scale (0/1) for a point light's Color.w, per SpecularHighlightsFlags. Static lights are Gothic's
+    // "atmospheric" fill lights; everything else is a regular dynamic/static point light.
+    float PointLightSpecularScale( bool isStatic ) const {
+        const int flag = isStatic ? SH_ATMOSPHERIC : SH_POINTLIGHTS;
+        return ( SpecularHighlightsFlags & flag ) ? 1.0f : 0.0f;
     }
 };
 

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1646,6 +1646,16 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
             "Gothic fills rooms and caves with 10-30 co-located 'atmospheric' static lights that only raise the\n"
             "ambient level; with HDR output they stack up and make interiors far too bright.");
 
+        ImGui::Text( "Specular Highlights" );
+        ImGui::SetItemTooltip("Some players find specular highlights (bright glints on lit surfaces) visually\n"
+            "distracting. Untick a category to keep its diffuse lighting but drop its specular highlight.");
+        ImGui::CheckboxFlags( "Sun##SpecSun", &settings.SpecularHighlightsFlags, GothicRendererSettings::SH_SUN );
+        ImGui::SameLine();
+        ImGui::CheckboxFlags( "Pointlights##SpecPointlights", &settings.SpecularHighlightsFlags, GothicRendererSettings::SH_POINTLIGHTS );
+        ImGui::SameLine();
+        ImGui::CheckboxFlags( "Atmospheric Lights##SpecAtmospheric", &settings.SpecularHighlightsFlags, GothicRendererSettings::SH_ATMOSPHERIC );
+        ImGui::SetItemTooltip("The static, co-located fill lights Gothic pre-places to brighten rooms/caves.");
+
         // ImGui::Checkbox("FastShadows", &settings.FastShadows );	
         ImGui::Checkbox( "DrawShadowGeometry", &settings.DrawShadowGeometry );
         if ( settings.RendererMode != GothicRendererSettings::RM_ForwardPlus) {

--- a/D3D11Engine/Shaders/D3D12/Decal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Decal.hlsl
@@ -40,7 +40,7 @@ cbuffer ShadowCB : register(b3)
     float3   SunColor;          float SunIntensity;
     float3   CascadeTexelWorld; float AmbientStrength;
     float    ShadowAOStrength;  float WorldAOStrength;
-    float    SkyOccStrength;    float _shpad;
+    float    SkyOccStrength;    float SunSpecularEnabled;
     float4x4 RainViewProj;
     float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
     uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;

--- a/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
@@ -47,7 +47,7 @@ cbuffer ShadowCB : register(b5)
     float    ShadowAOStrength;  float WorldAOStrength;   // vertLighting -> AO modulation weights
     // How hard baked vertex light gates the sky-IBL AMBIENT term (PBRLighting.hlsl ComputeSunLightingPBR).
     // 0 = the old unoccluded behaviour, 1 = interiors get no sky ambient at all. See the note there.
-    float    SkyOccStrength;    float _shpad;
+    float    SkyOccStrength;    float SunSpecularEnabled;
     // Scene-wetness (rain) tail — see World.hlsl for the layout notes; must stay identical in all three
     // lit shaders and in the CPU-side WetnessCBData.
     float4x4 RainViewProj;

--- a/D3D11Engine/Shaders/D3D12/Vegetation.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Vegetation.hlsl
@@ -37,7 +37,7 @@ cbuffer ShadowCB : register(b4)
     float    ShadowAOStrength;  float WorldAOStrength;   // vertLighting -> AO modulation weights
     // How hard baked vertex light gates the sky-IBL AMBIENT term (PBRLighting.hlsl ComputeSunLightingPBR).
     // 0 = the old unoccluded behaviour, 1 = interiors get no sky ambient at all. See the note there.
-    float    SkyOccStrength;    float _shpad;
+    float    SkyOccStrength;    float SunSpecularEnabled;
     // Scene-wetness (rain) block. Grass applies no wetness (no Wetness.hlsl include here), but the fields must
     // be declared so the sky-IBL tail below lands at the byte offset UploadSkyIblConstants writes it to — this
     // CB is the same 512-byte resource World/Vob/Skeletal bind, three disjoint writers into one layout.

--- a/D3D11Engine/Shaders/D3D12/Vob.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Vob.hlsl
@@ -34,7 +34,7 @@ cbuffer ShadowCB : register(b3)
     float    ShadowAOStrength;  float WorldAOStrength;   // vertLighting -> AO modulation weights
     // How hard baked vertex light gates the sky-IBL AMBIENT term (PBRLighting.hlsl ComputeSunLightingPBR).
     // 0 = the old unoccluded behaviour, 1 = interiors get no sky ambient at all. See the note there.
-    float    SkyOccStrength;    float _shpad;
+    float    SkyOccStrength;    float SunSpecularEnabled;
     // Scene-wetness (rain) tail — see World.hlsl for the layout notes; must stay identical in all three
     // lit shaders and in the CPU-side WetnessCBData.
     float4x4 RainViewProj;

--- a/D3D11Engine/Shaders/D3D12/World.hlsl
+++ b/D3D11Engine/Shaders/D3D12/World.hlsl
@@ -90,6 +90,16 @@ float3 DecodeOctNormal( float2 e )
     return normalize( n );
 }
 
+// Packed tangent decode — matches Shaders/VertexPacking.h DecodeTangent / CPU VertexPacking::EncodeTangent
+// (R10G10B10A2_UNORM at offset 16, already world-space like the normal — the world mesh has no per-instance
+// transform). xyz = unit tangent, w = bitangent handedness sign; PerturbNormal reconstructs B as cross(N,T)*w.
+float4 DecodeTangent( float4 packed )
+{
+    float3 t = packed.xyz * 2.0 - 1.0;
+    float sign = packed.w > 0.5 ? 1.0 : -1.0;
+    return float4( normalize( t ), sign );
+}
+
 // DelightDiffuse, SamplePointShadow, ComputeSunShadow, the Cook-Torrance PBR helpers, PerturbNormal/
 // CotangentFrame, ComputeSunLightingPBR and AccumTiledPointLights are shared with Vob.hlsl/Skeletal.hlsl.
 #include "include/PBRLighting.hlsl"
@@ -97,8 +107,8 @@ float3 DecodeOctNormal( float2 e )
 // the additive wet sheen. Needs the ShadowCB wetness tail above plus `smp`/`shadowCmp`.
 #include "include/Wetness.hlsl"
 
-struct VS_IN  { float3 pos : POSITION; float2 nrm : NORMAL; float2 uv : TEXCOORD0; float4 col : DIFFUSE; };
-struct VS_OUT { float4 clip : SV_POSITION; float2 uv : TEXCOORD0; float4 col : TEXCOORD1; float fogDist : TEXCOORD2; float3 wpos : TEXCOORD3; float3 wnrm : TEXCOORD4; };
+struct VS_IN  { float3 pos : POSITION; float2 nrm : NORMAL; float4 tan : TANGENT; float2 uv : TEXCOORD0; float4 col : DIFFUSE; };
+struct VS_OUT { float4 clip : SV_POSITION; float2 uv : TEXCOORD0; float4 col : TEXCOORD1; float fogDist : TEXCOORD2; float3 wpos : TEXCOORD3; float3 wnrm : TEXCOORD4; float4 wtan : TEXCOORD5; };
 
 VS_OUT VSMain( VS_IN i )
 {
@@ -108,6 +118,7 @@ VS_OUT VSMain( VS_IN i )
     o.col = i.col;
     o.wpos = i.pos;                          // world verts are already world-space
     o.wnrm = DecodeOctNormal( i.nrm );       // already world-space
+    o.wtan = DecodeTangent( i.tan );         // already world-space, same basis as wnrm
     o.fogDist = length( i.pos - CamPosWS );
     return o;
 }
@@ -147,6 +158,8 @@ VS_OUT VSQuadMark( VS_IN_QUADMARK i )
     o.col = i.col;
     o.wpos = wpos;
     o.wnrm = normalize( wnrm );
+    o.wtan = float4( 0, 0, 0, 0 );   // no packed tangent on this CPU-side vertex — PerturbNormal falls back
+                                      // to the derivative frame here, same as D3D11's untangented quad marks.
     o.fogDist = length( wpos - CamPosWS );
     return o;
 }
@@ -160,7 +173,7 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     if ( MatNormalIndex != 0xffffffff )       // bindless normal map (BC5/BC1, Z reconstructed) if this material has one
     {
         Texture2D nrmTex = ResourceDescriptorHeap[MatNormalIndex];
-        N = PerturbNormal( N, i.wpos, nrmTex, i.uv, smp, MatNormalStrength );
+        N = PerturbNormal( N, i.wpos, i.wtan, nrmTex, i.uv, smp, MatNormalStrength );
     }
     float3 orm = SampleOrm( MatOrmIndex, i.uv );   // AO/Roughness/Metallic, decoded per the material's FxMap layout
     float3 albedo = SrgbToLinear( t.rgb );    // linearize for PBR (all HDR-buffer values are linear now)

--- a/D3D11Engine/Shaders/D3D12/World.hlsl
+++ b/D3D11Engine/Shaders/D3D12/World.hlsl
@@ -33,7 +33,7 @@ cbuffer ShadowCB : register(b3)
     float    ShadowAOStrength;  float WorldAOStrength;   // vertLighting -> AO modulation weights
     // How hard baked vertex light gates the sky-IBL AMBIENT term (PBRLighting.hlsl ComputeSunLightingPBR).
     // 0 = the old unoccluded behaviour, 1 = interiors get no sky ambient at all. See the note there.
-    float    SkyOccStrength;    float _shpad;
+    float    SkyOccStrength;    float SunSpecularEnabled;
     // --- Scene wetness (rain) tail, uploaded separately by UploadWetnessConstants after the rain shadow
     // pass has computed this frame's rain camera. Keep in sync with Vob.hlsl/Skeletal.hlsl and the
     // WetnessCBData struct on the CPU side. RainShadowIndex/DistortionIndex are 0xFFFFFFFF when the rain

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -435,6 +435,47 @@ float3 PerturbNormal( float3 N, float3 p, Texture2D nrmTex, float2 uv, SamplerSt
     return normalize( mul( nrm, CotangentFrame( N, -p, uv ) ) );
 }
 
+// Builds a TBN from a precomputed (MikkTSpace) vertex tangent. tangent.w is the bitangent handedness sign.
+// N and tangent.xyz must be in the same space (world space here). Direct port of Toolbox.h's
+// tangent_frame_explicit (D3D11's view-space equivalent) — same Gram-Schmidt re-orthonormalization, same
+// single place (the caller's packed handedness sign) that controls handedness.
+float3x3 TangentFrameExplicit( float3 N, float3 T, float sign )
+{
+    T = normalize( T - N * dot( N, T ) );
+    float3 B = cross( N, T ) * sign;
+    return float3x3( T, B, N );
+}
+
+// perturb_normal variant that prefers a precomputed vertex tangent and falls back to the screen-space-
+// derivative CotangentFrame when the tangent is absent/degenerate (e.g. quad marks, VOBs, skeletals — none
+// of which carry a packed tangent) — mirrors Toolbox.h's tangent-taking perturb_normal overload exactly,
+// including its dot(T,T) < 0.25 threshold for "no real tangent here".
+float3 PerturbNormal( float3 N, float3 p, float4 vertexTangent, Texture2D nrmTex, float2 uv, SamplerState samp, float strength = 1.0 )
+{
+    if ( dot( vertexTangent.xyz, vertexTangent.xyz ) < 0.25 )
+    {
+        return PerturbNormal( N, p, nrmTex, uv, samp, strength );
+    }
+
+#if NORMAL_MAP_RESTORE_Z == 1
+    float2 nxy = nrmTex.Sample( samp, uv ).xy * 2.0 - 1.0;
+  #if NORMAL_MAP_MODE == 2
+    nxy.y = -nxy.y;
+  #endif
+    nxy *= strength;
+    float  nz  = sqrt( saturate( 1.0 - dot( nxy, nxy ) ) );
+    float3 nrm = normalize( float3( nxy, nz ) );
+#else
+    float3 nrm = nrmTex.Sample( samp, uv ).xyz * 2.0 - 1.0;
+  #if NORMAL_MAP_MODE == 2
+    nrm.y = -nrm.y;
+  #endif
+    nrm.xy *= strength;
+    nrm = normalize( nrm );
+#endif
+    return normalize( mul( nrm, TangentFrameExplicit( normalize( N ), vertexTangent.xyz, vertexTangent.w ) ) );
+}
+
 // PBR sun lighting (matches DX11 lighting mix and ground/vertex lighting modulation)
 float3 ComputeSunLightingPBR( float3 wpos, float3 N, float3 albedo, float vertLighting, float shadow,
                               float roughness, float metallic, float ao, float ssao )

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -444,10 +444,6 @@ float3 ComputeSunLightingPBR( float3 wpos, float3 N, float3 albedo, float vertLi
     float3 sunCol = SrgbToLinear( SunColor );
     float  sunLum = dot( sunCol, float3( 0.3333, 0.3333, 0.3333 ) );
 
-    // Direct sun term N.L
-    float NdotL = saturate( dot( N, L ) );
-    float sun = NdotL * shadow;
-
     // AO factors driven by Gothic's vertex/ground light
     float shadowAO = lerp( 1.0, vertLighting, ShadowAOStrength ) * ao;
     float worldAO  = lerp( 1.0, vertLighting, WorldAOStrength ) * ao;
@@ -492,8 +488,14 @@ float3 ComputeSunLightingPBR( float3 wpos, float3 N, float3 albedo, float vertLi
     else
         ambientSun = albedo * AmbientStrength * sunLum * shadowAO * ssao;
 
-    // Direct Sun term
-    float sunAtten = sun * worldAO * SunIntensity;
+    // Direct Sun term. PBR_DirectLighting saturates dot(N,L) and folds it in ONCE itself (see its final
+    // `NdotL * attenuation`) — `attenuation` here must therefore be everything EXCEPT N.L (shadow/AO/
+    // intensity only), or the cosine term gets applied twice (NdotL^2). That used to be exactly the bug:
+    // `sun = NdotL * shadow` was folded into this attenuation, squaring N.L inside PBR_DirectLighting.
+    // NdotL^2 vs NdotL is close to identity at grazing-to-normal incidence (NdotL~1) but crushes moderately
+    // sun-facing slopes hard (e.g. NdotL 0.75 -> 0.56, a 25% cut on top of an already-dim baked-light gate) —
+    // which is exactly the "sloped roofs go dark under full sun, no shadow, no normal map involved" symptom.
+    float sunAtten = shadow * worldAO * SunIntensity;
     float3 directSun = PBR_DirectLighting( albedo, sunCol, N, V, L, roughness, metallic, sunAtten, 1.0 );
 
     return ambientSun + directSun;

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -544,7 +544,7 @@ float3 ComputeSunLightingPBR( float3 wpos, float3 N, float3 albedo, float vertLi
     // sun-facing slopes hard (e.g. NdotL 0.75 -> 0.56, a 25% cut on top of an already-dim baked-light gate) —
     // which is exactly the "sloped roofs go dark under full sun, no shadow, no normal map involved" symptom.
     float sunAtten = shadow * worldAO * SunIntensity;
-    float3 directSun = PBR_DirectLighting( albedo, sunCol, N, V, L, roughness, metallic, sunAtten, 1.0 );
+    float3 directSun = PBR_DirectLighting( albedo, sunCol, N, V, L, roughness, metallic, sunAtten, SunSpecularEnabled );
 
     return ambientSun + directSun;
 }

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -296,8 +296,15 @@ float3 PBR_DirectLighting( float3 baseColor, float3 lightColor, float3 N, float3
                            float roughness, float metallic, float attenuation, float specularScale )
 {
     float NdotL = saturate( dot( N, L ) );
-    float NdotV = saturate( dot( N, V ) );
-    if ( NdotL <= 0.0 || NdotV <= 0.0 || attenuation <= 0.0 ) return 0.0;
+    // NdotV deliberately does NOT gate the whole function (D3D11's FP_ComputeSunLighting has no view-
+    // dependent cutoff on its diffuse/ambient response either — only its specular term reads V at all).
+    // saturate(dot(N,V)) legitimately touches exactly 0 at ordinary shading-normal/silhouette grazing —
+    // e.g. standing in the street looking up along a shallow roof pitch — and early-returning 0.0 there
+    // used to black out the ENTIRE direct contribution (diffuse included) on exactly those grazing-viewed
+    // slopes, which is a much harder failure than mere dimming. Only the specular denominator below needs
+    // NdotV guarded against zero, and it already is (max(...,1e-4)).
+    if ( NdotL <= 0.0 || attenuation <= 0.0 ) return 0.0;
+    float  NdotV = saturate( dot( N, V ) );
     float3 H = normalize( V + L );
     float NdotH = saturate( dot( N, H ) );
     float VdotH = saturate( dot( V, H ) );
@@ -309,7 +316,12 @@ float3 PBR_DirectLighting( float3 baseColor, float3 lightColor, float3 N, float3
     float3 F = PBR_FresnelSchlick( VdotH, F0 );
     float3 specular = ( D * G * F ) / max( 4.0 * NdotV * NdotL, 1e-4 ) * specularScale;
     float3 kD = ( 1.0 - F ) * ( 1.0 - cm );
-    float3 diffuse = kD * baseColor / PBR_PI;
+    // NOT divided by PI: D3D11's tuned light-intensity constants this shares verbatim (SunLightStrength,
+    // the point-light 1.2 scale in D3D12Scene.cpp) were calibrated for a non-energy-normalized diffuse
+    // response, matching this file's OWN EvaluateSkyIBL ambient diffuse (`irradiance*albedo*kD*ao`, also
+    // no /PI). Adding the textbook Lambertian /PI here without re-tuning those constants made every direct
+    // light (sun AND point lights) ~pi times too dark relative to D3D11 for the same authored values.
+    float3 diffuse = kD * baseColor;
     return ( diffuse + specular ) * lightColor * ( NdotL * attenuation );
 }
 

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -304,7 +304,7 @@ float3 PBR_DirectLighting( float3 baseColor, float3 lightColor, float3 N, float3
     // slopes, which is a much harder failure than mere dimming. Only the specular denominator below needs
     // NdotV guarded against zero, and it already is (max(...,1e-4)).
     if ( NdotL <= 0.0 || attenuation <= 0.0 ) return 0.0;
-    float  NdotV = saturate( dot( N, V ) );
+    float NdotV = saturate( dot( N, V ) );
     float3 H = normalize( V + L );
     float NdotH = saturate( dot( N, H ) );
     float VdotH = saturate( dot( V, H ) );
@@ -316,12 +316,7 @@ float3 PBR_DirectLighting( float3 baseColor, float3 lightColor, float3 N, float3
     float3 F = PBR_FresnelSchlick( VdotH, F0 );
     float3 specular = ( D * G * F ) / max( 4.0 * NdotV * NdotL, 1e-4 ) * specularScale;
     float3 kD = ( 1.0 - F ) * ( 1.0 - cm );
-    // NOT divided by PI: D3D11's tuned light-intensity constants this shares verbatim (SunLightStrength,
-    // the point-light 1.2 scale in D3D12Scene.cpp) were calibrated for a non-energy-normalized diffuse
-    // response, matching this file's OWN EvaluateSkyIBL ambient diffuse (`irradiance*albedo*kD*ao`, also
-    // no /PI). Adding the textbook Lambertian /PI here without re-tuning those constants made every direct
-    // light (sun AND point lights) ~pi times too dark relative to D3D11 for the same authored values.
-    float3 diffuse = kD * baseColor;
+    float3 diffuse = kD * baseColor / PBR_PI;
     return ( diffuse + specular ) * lightColor * ( NdotL * attenuation );
 }
 

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -22,7 +22,7 @@ cbuffer DS_ScreenQuadConstantBuffer : register(b0)
     float SQ_ShadowmapSize;
 
     float3 SQ_LightDirectionWS;
-    float SQ_Pad0;
+    float SQ_SunSpecularEnabled;   // 0/1 toggle for the sun's specular highlight
 
     float4 SQ_LightColor;
     matrix SQ_ShadowViewProj[MAX_CSM_CASCADES];
@@ -340,7 +340,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
     // so it doesn't produce deep shadows on ground/objects that are lit strongly by the sun.
     float ssao = TX_AO.Sample(SS_Linear, uv).r;
 
-    spec = pow(spec, specPower) * specIntensity;
+    spec = pow(spec, specPower) * specIntensity * SQ_SunSpecularEnabled;
     float3 specBare = spec * lightColor.rgb * sun + specWet * lightColor.rgb;
     float3 specColored = saturate(lerp(specBare, specBare * diffuse.rgb, specMod));
 	

--- a/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
+++ b/D3D11Engine/Shaders/PS_FP_ShadowMask.hlsl
@@ -27,7 +27,7 @@ cbuffer DS_ScreenQuadConstantBuffer : register( b0 )
     float  SQ_ShadowmapSize;
 
     float3 SQ_LightDirectionWS;
-    float  SQ_Pad0;
+    float  SQ_SunSpecularEnabled;
 
     float4 SQ_LightColor;
     matrix SQ_ShadowViewProj[MAX_CSM_CASCADES];

--- a/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
+++ b/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
@@ -50,7 +50,7 @@ cbuffer FP_ScreenQuadConstantBuffer : register( b4 )
     float3 SQ_LightDirectionVS;
     float SQ_ShadowmapSize;
     float3 SQ_LightDirectionWS;
-    float SQ_Pad0;
+    float SQ_SunSpecularEnabled;   // 0/1 toggle for the sun's specular highlight
     float4 SQ_LightColor;
     matrix SQ_ShadowViewProj[MAX_CSM_CASCADES];
     float SQ_ShadowStrength;
@@ -236,7 +236,7 @@ float3 FP_ComputeSunLighting(
     float sunStrength = dot( lightColor.rgb, float3( 0.333f, 0.333f, 0.333f ) );
     float sun = saturate( dot( normalize( SQ_LightDirectionVS ), normal ) * shadow );
 
-    spec = pow( spec, specPower ) * specIntensity;
+    spec = pow( spec, specPower ) * specIntensity * SQ_SunSpecularEnabled;
     float3 specBare = spec * lightColor.rgb * sun;
     float3 specColored = saturate( lerp( specBare, specBare * diffuseColor, specMod ) );
 


### PR DESCRIPTION
- reduces GPU utilization at 60 fps from 50% to 30% at the same spot in khorinis city.
- allows for finer grained control of resource barriers, not needing to flush all pipelines
- dx12: fix non-working normalmap strength from F1 editor
- fix #427 specular highlights can now be toggled per category <img width="582" height="242" alt="image" src="https://github.com/user-attachments/assets/8633ea46-5823-4f30-b19b-7ca63920b847" />


Dx12 lighting
- fix accidentally applying NdotL twice in light calculation
- remove NdotL black-out, causing steep angles like city roofs, to be blackened when facing the sun.
- use cpu-computed normal tangents if available (world mesh) instead of a screen space derivative