### PR TITLE
feat(dx11): on-disk shader cache., Moon rotation, dx11 Clustered lighting fix, fix dx12 static shadow cache invalidated early, ...

### DIFF
--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -342,6 +342,13 @@ public:
     /** Called when a vob was removed from the world */
     virtual XRESULT OnVobRemovedFromWorld( zCVob* vob ) { return XR_SUCCESS; }
 
+    /** Called from MeshInfo::~MeshInfo(), right before its buffers/CPU vectors are torn down. A MeshInfo can
+        be freed independently of any world (re)load - e.g. a shared MeshVisualInfo's last VOB reference
+        dropping via SharedVisualRegistry::Release() - so any backend that caches raw MeshInfo* pointers
+        outside the mesh's own owner (D3D12's VOB arena mega-buffer) MUST use this to drop them; otherwise a
+        later pass walking that cache dereferences freed memory. No-op by default (D3D11 keeps no such cache). */
+    virtual void OnMeshInfoDestroyed( MeshInfo* mesh ) {}
+
     /** Reloads shaders */
     virtual XRESULT ReloadShaders( ShaderCategory categories = ShaderCategory::All ) { return XR_SUCCESS; }
 

--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -497,6 +497,8 @@ struct MoonCB {
     XMFLOAT2 Moon_CenterPx;     // sprite centre, in pixels of the scaled render target
     XMFLOAT2 Moon_HalfSizePx;   // sprite half-extents, same space
     XMFLOAT4 Moon_Color;        // rgb = planet tint by height, a = accumulated fade (horizon, fog, rain)
+    float Moon_RotationAngle;   // radians, clockwise from screen-up - see MoonSpriteInfo::RotationAngle
+    XMFLOAT3 Moon_Pad0;
 };
 
 #pragma pack (pop)

--- a/D3D11Engine/D3D11FileRelativeInclude.cpp
+++ b/D3D11Engine/D3D11FileRelativeInclude.cpp
@@ -1,4 +1,6 @@
 #include "D3D11FileRelativeInclude.h"
+#include "ShaderCacheHash.h"
+#include <algorithm>
 
 HRESULT __stdcall D3D11FileRelativeInclude::Open( D3D_INCLUDE_TYPE includeType, LPCSTR pFileName, LPCVOID pParentData, LPCVOID* ppData, UINT* pBytes )
 {
@@ -51,6 +53,12 @@ HRESULT __stdcall D3D11FileRelativeInclude::Open( D3D_INCLUDE_TYPE includeType, 
 
     // Track the directory of THIS include, so nested includes resolve against it.
     ParentDirByData.emplace( dataPtr, fullPath.parent_path() );
+
+    // FXC re-opens the same header once per #include site; dedup.
+    const std::string pathStr = fullPath.string();
+    if ( std::none_of( m_Deps.begin(), m_Deps.end(), [&]( const auto& d ) { return d.first == pathStr; } ) ) {
+        m_Deps.emplace_back( pathStr, ShaderCacheHash::HashBytes( buffer.get(), static_cast<size_t>( size ) ) );
+    }
 
     OwnedBuffers.emplace_back( std::move( buffer ) );
     return S_OK;

--- a/D3D11Engine/D3D11FileRelativeInclude.h
+++ b/D3D11Engine/D3D11FileRelativeInclude.h
@@ -1,8 +1,11 @@
 #pragma once
+#include <cstdint>
 #include <d3d11.h>
 #include <filesystem>
 #include <fstream>
+#include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 #include <memory>
 
@@ -11,12 +14,17 @@
 class D3D11FileRelativeInclude final : public ID3DInclude
 {
 public:
+    // (absolute path, content hash) of every file resolved; feeds the on-disk shader cache key.
+    using Deps = std::vector<std::pair<std::string, uint64_t>>;
+
     explicit D3D11FileRelativeInclude( std::filesystem::path rootDir )
         : RootDir( std::move( rootDir ) )
     {
     }
 
     HRESULT __declspec(nothrow) __stdcall Open( D3D_INCLUDE_TYPE includeType, LPCSTR pFileName, LPCVOID pParentData, LPCVOID* ppData, UINT* pBytes ) override;
+
+    const Deps& Dependencies() const { return m_Deps; }
 
     HRESULT __declspec(nothrow) __stdcall Close( LPCVOID pData ) override
     {
@@ -38,4 +46,6 @@ private:
 
     // keep memory alive for duration of compilation
     std::vector<std::unique_ptr<uint8_t[]>> OwnedBuffers;
+
+    Deps m_Deps;
 };

--- a/D3D11Engine/D3D11ForwardPlusRenderer.cpp
+++ b/D3D11Engine/D3D11ForwardPlusRenderer.cpp
@@ -323,6 +323,11 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
                 ID3D11ShaderResourceView* dynCubeSRV = tiledDeferred->IsDynShadowArrayCreated()
                     ? tiledDeferred->GetShadowDynCubeArraySRV() : nullptr;
                 context->PSSetShaderResources( 14, 1, &dynCubeSRV );
+
+                // --- Low-res static-only shadow tier at t15 ---
+                ID3D11ShaderResourceView* staticCubeSRV = tiledDeferred->IsStaticShadowArrayCreated()
+                    ? tiledDeferred->GetShadowStaticCubeArraySRV() : nullptr;
+                context->PSSetShaderResources( 15, 1, &staticCubeSRV );
             }
 
             // --- Bind shadow mask at t12 ---
@@ -348,7 +353,7 @@ void D3D11ForwardPlusRenderer::AddGeometryPasses(
             context->PSSetShaderResources( 3, 1, s_nullSRVs );
             context->PSSetShaderResources( 6, 1, s_nullSRVs );
             context->PSSetShaderResources( 8, 4, s_nullSRVs );
-            context->PSSetShaderResources( 12, 3, s_nullSRVs ); // shadow mask, AO mask, dynamic shadow cubes
+            context->PSSetShaderResources( 12, 4, s_nullSRVs ); // shadow mask, AO mask, dynamic + static-only shadow cubes
 
             // Restore default depth comparison
             depthState.SetDefault();

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -9218,6 +9218,9 @@ void D3D11GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> item
         ID3D11ShaderResourceView* dynCubeSRV = tiledDeferred->IsDynShadowArrayCreated()
             ? tiledDeferred->GetShadowDynCubeArraySRV() : nullptr;
         GetContext()->PSSetShaderResources( 14, 1, &dynCubeSRV );
+        ID3D11ShaderResourceView* staticCubeSRV = tiledDeferred->IsStaticShadowArrayCreated()
+            ? tiledDeferred->GetShadowStaticCubeArraySRV() : nullptr;
+        GetContext()->PSSetShaderResources( 15, 1, &staticCubeSRV );
     }
 
     int lastAlphaFunc = -1;
@@ -9301,7 +9304,7 @@ void D3D11GraphicsEngine::DrawQuadMarkRun( std::span<const TransparentItem> item
         GetContext()->PSSetShaderResources( 3, 1, s_nullSRVs );
         GetContext()->PSSetShaderResources( 6, 1, s_nullSRVs );
         GetContext()->PSSetShaderResources( 8, 4, s_nullSRVs );
-        GetContext()->PSSetShaderResources( 14, 1, s_nullSRVs );
+        GetContext()->PSSetShaderResources( 14, 2, s_nullSRVs ); // dynamic + static-only shadow cubes
     }
 }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -8456,6 +8456,7 @@ XRESULT D3D11GraphicsEngine::DrawSky() {
                 moonCb.Moon_CenterPx = XMFLOAT2( moon.CenterPx[0], moon.CenterPx[1] );
                 moonCb.Moon_HalfSizePx = XMFLOAT2( moon.HalfSizePx[0], moon.HalfSizePx[1] );
                 moonCb.Moon_Color = XMFLOAT4( moon.Color[0], moon.Color[1], moon.Color[2], moon.Color[3] );
+                moonCb.Moon_RotationAngle = moon.RotationAngle;
             }
         }
     }

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -8444,9 +8444,7 @@ XRESULT D3D11GraphicsEngine::DrawSky() {
     if ( rendererState.RendererSettings.AtmosphericScattering ) {
         if ( auto loadedWorld = Engine::GAPI->GetLoadedWorldInfo(); loadedWorld && loadedWorld->MainWorld ) {
             if ( auto skyCtrl = loadedWorld->MainWorld->GetSkyControllerOutdoor(); skyCtrl ) {
-                if ( auto planet = skyCtrl->GetPlanet( 1 ); planet && planet->mesh == nullptr ) {
-                    skyCtrl->RenderSkyPre();
-                }
+                skyCtrl->EnsureInit();
             }
         }
     }

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -141,8 +141,9 @@ void D3D11PointLight::ReleaseShadowMap() {
 
 }
 
-void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner ) {
+void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner, bool lowRes ) {
     m_TiledSlotIndex = slot;
+    m_TiledSlotLowRes = lowRes;
     m_TiledDepthTarget = target;
     m_TiledOwner = owner;
 
@@ -154,9 +155,14 @@ void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target
 
 void D3D11PointLight::ClearTiledSlot() {
     if ( m_TiledSlotIndex >= 0 && m_TiledOwner ) {
-        m_TiledOwner->FreeSlot( m_TiledSlotIndex );
+        if ( m_TiledSlotLowRes ) {
+            m_TiledOwner->FreeStaticSlot( m_TiledSlotIndex );
+        } else {
+            m_TiledOwner->FreeSlot( m_TiledSlotIndex );
+        }
     }
     m_TiledSlotIndex = -1;
+    m_TiledSlotLowRes = false;
     m_TiledDepthTarget = nullptr;
     m_TiledOwner = nullptr;
     m_StaticShadowReady = false;

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -62,20 +62,27 @@ public:
             && GetCurrentShadowMode() == GothicRendererSettings::PLS_UPDATE_DYNAMIC;
     }
 
-    bool HasShadowMap(int shadowMapKind ) const { 
+    bool HasShadowMap(int shadowMapKind ) const {
         if ( shadowMapKind == 0 ) return m_DepthCubemap != nullptr;
         return m_TiledDepthTarget != nullptr;
     }
     int GetShadowMapResolution() const { return m_CurrentResolution; }
     ID3D11Texture2D* GetShadowCubeTexture() const { return m_DepthCubemap ? m_DepthCubemap->GetTexture().Get() : nullptr; }
 
+    /** Whether this light belongs in the low-res static-only tiled tier rather than the full-res one. */
+    bool WantsStaticOnlySlot() const {
+        return GetCurrentShadowMode() == GothicRendererSettings::PLS_STATIC_ONLY;
+    }
+
     void AcquireShadowMap( DepthStencilPool* pool, int resolution );
     void ReleaseShadowMap();
 
-    // Tiled deferred slot management (renders directly into shared TextureCubeArray)
-    void SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner );
+    // Tiled deferred slot management (renders directly into a shared TextureCubeArray). `lowRes` selects
+    // which of the two independent slot pools this came from - see WantsStaticOnlySlot().
+    void SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner, bool lowRes );
     void ClearTiledSlot();
     int GetTiledSlot() const { return m_TiledSlotIndex; }
+    bool IsTiledSlotLowRes() const { return m_TiledSlotLowRes; }
     void SetCurrentResolution( int r ) { m_CurrentResolution = r; }
 
 protected:
@@ -122,6 +129,7 @@ protected:
 
     // Tiled deferred slot (non-owning, owned by D3D11TiledDeferredShading)
     int m_TiledSlotIndex = -1;
+    bool m_TiledSlotLowRes = false; // which of the two independent slot pools m_TiledSlotIndex indexes into
     RenderToDepthStencilBuffer* m_TiledDepthTarget = nullptr;
     D3D11TiledDeferredShading* m_TiledOwner = nullptr;
     TaskHandle<void> m_PendingInit;

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -15,6 +15,7 @@
 #include <d3dcompiler.h>
 #include "D3D11PFX_TAA.h"
 #include "D3D11FileRelativeInclude.h"
+#include "ShaderCacheHash.h"
 
 #pragma comment(lib, "d3d11.lib")
 #pragma comment(lib, "d3dcompiler.lib")
@@ -36,6 +37,166 @@ extern bool FeatureRTArrayIndexFromAnyShader;
 extern bool haveWindAnimations;
 #endif
 
+namespace {
+    // #includes aren't known until D3D11FileRelativeInclude resolves them, so they aren't part of the
+    // cache key itself -- a lookup instead re-hashes every recorded #include, which stays correct
+    // transitively for free. A newly added #include changes the top-level source text (and thus the
+    // key) on its own. Editing a shader orphans its old cache entries; deleting the shadercache
+    // directory is always safe.
+    using ShaderDeps = D3D11ShaderManager::ShaderDeps;
+
+    // Bump when the D3DCOMPILE_* flags below change in a way that alters codegen.
+    constexpr uint32_t kDxbcCacheArgsRevision = 1;
+    constexpr uint32_t kDxbcCacheFormatVersion = 1;
+    const char* kDxbcCacheDirRel = "\\system\\GD3D11\\shadercache\\D3D11\\";
+
+    int g_CacheHits = 0;
+    int g_CacheMisses = 0;
+
+    uint64_t HashFileContents( const std::string& path ) {
+        std::ifstream in( path, std::ios::binary );
+        if ( !in ) return 0;
+        std::string data;
+        data.assign( std::istreambuf_iterator<char>( in ), std::istreambuf_iterator<char>() );
+        if ( data.empty() ) return 0;
+        const uint64_t h = ShaderCacheHash::HashBytes( data.data(), data.size() );
+        return h ? h : 1;
+    }
+
+    // Deliberately not the GPU adapter/driver identity: DXBC is portable IR produced by this DLL
+    // alone; the driver JITs it to native ISA later using its own separate, self-invalidating cache.
+    uint64_t FxcVersionHash() {
+        static uint64_t s_hash = [] () -> uint64_t {
+            HMODULE hMod = nullptr;
+            if ( !GetModuleHandleExA( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+                    reinterpret_cast<LPCSTR>( &D3DCompileFromFile ), &hMod ) || !hMod ) {
+                return 0;
+            }
+            char path[MAX_PATH] = {};
+            if ( !GetModuleFileNameA( hMod, path, MAX_PATH ) ) return 0;
+            return HashFileContents( path );
+        }( );
+        return s_hash;
+    }
+
+    uint64_t ComputeCacheKey( const std::string& relFileName, const std::string& source, const char* entryPoint,
+        const char* target, const std::vector<D3D_SHADER_MACRO>& macros ) {
+        uint64_t h = ShaderCacheHash::HashString( relFileName.c_str() );
+        h = ShaderCacheHash::HashBytes( source.data(), source.size(), h );
+        h = ShaderCacheHash::HashString( entryPoint, h );
+        h = ShaderCacheHash::HashString( target, h );
+        for ( const auto& m : macros ) {
+            if ( !m.Name ) continue;
+            h = ShaderCacheHash::HashString( m.Name, h );
+            h = ShaderCacheHash::HashString( m.Definition ? m.Definition : "", h );
+        }
+        const uint32_t argsRev = kDxbcCacheArgsRevision;
+        h = ShaderCacheHash::HashBytes( &argsRev, sizeof( argsRev ), h );
+#ifdef DEBUG_D3D11
+        h = ShaderCacheHash::HashString( "dbg", h );   // never share debug (-Zi -Od) blobs with release
+#else
+        h = ShaderCacheHash::HashString( "rel", h );
+#endif
+        const uint64_t fxc = FxcVersionHash();
+        return ShaderCacheHash::HashBytes( &fxc, sizeof( fxc ), h );
+    }
+
+    std::string CacheFilePath( uint64_t key, bool createDir ) {
+        const std::string dir = Engine::GAPI->GetStartDirectory() + kDxbcCacheDirRel;
+        if ( createDir ) {
+            // CreateDirectory has no "create parents" flag; both levels may be missing.
+            const std::string parent = Engine::GAPI->GetStartDirectory() + "\\system\\GD3D11\\shadercache";
+            CreateDirectoryA( parent.c_str(), nullptr );
+            if ( !CreateDirectoryA( dir.c_str(), nullptr ) && GetLastError() != ERROR_ALREADY_EXISTS )
+                return "";
+        }
+        char name[32] = {};
+        sprintf_s( name, "%016llx.dxbc", static_cast<unsigned long long>( key ) );
+        return dir + name;
+    }
+
+    template<typename T> bool ReadPod( std::ifstream& in, T& out ) {
+        return static_cast<bool>( in.read( reinterpret_cast<char*>( &out ), sizeof( T ) ) );
+    }
+    template<typename T> void WritePod( std::ofstream& out, const T& value ) {
+        out.write( reinterpret_cast<const char*>( &value ), sizeof( T ) );
+    }
+
+    // Deps are stored relative to the start directory so the cache is portable across installs.
+    bool TryLoadCachedBlob( uint64_t key, ID3DBlob** ppCode ) {
+        const std::string path = CacheFilePath( key, false );
+        if ( path.empty() ) return false;
+        std::ifstream in( path, std::ios::binary );
+        if ( !in ) return false;
+
+        char magic[4] = {};
+        uint32_t version = 0;
+        uint64_t storedKey = 0;
+        uint32_t depCount = 0;
+        if ( !in.read( magic, 4 ) || memcmp( magic, "GDBC", 4 ) != 0 ) return false;
+        if ( !ReadPod( in, version ) || version != kDxbcCacheFormatVersion ) return false;
+        if ( !ReadPod( in, storedKey ) || storedKey != key ) return false;
+        if ( !ReadPod( in, depCount ) || depCount > 256 ) return false;
+
+        const std::string startDir = Engine::GAPI->GetStartDirectory();
+        for ( uint32_t i = 0; i < depCount; ++i ) {
+            uint32_t nameLen = 0;
+            uint64_t storedHash = 0;
+            if ( !ReadPod( in, nameLen ) || nameLen == 0 || nameLen > 512 ) return false;
+            std::string relName( nameLen, '\0' );
+            if ( !in.read( relName.data(), nameLen ) ) return false;
+            if ( !ReadPod( in, storedHash ) ) return false;
+
+            std::ifstream depIn( startDir + "\\" + relName, std::ios::binary );
+            if ( !depIn ) return false;   // include vanished
+            std::string depSource;
+            depSource.assign( std::istreambuf_iterator<char>( depIn ), std::istreambuf_iterator<char>() );
+            if ( ShaderCacheHash::HashBytes( depSource.data(), depSource.size() ) != storedHash ) return false;   // include edited
+        }
+
+        uint32_t blobSize = 0;
+        if ( !ReadPod( in, blobSize ) || blobSize == 0 || blobSize > ( 64u << 20 ) ) return false;
+
+        Microsoft::WRL::ComPtr<ID3DBlob> blob;
+        if ( FAILED( D3DCreateBlob( blobSize, blob.GetAddressOf() ) ) ) return false;
+        if ( !in.read( static_cast<char*>( blob->GetBufferPointer() ), blobSize ) ) return false;
+        *ppCode = blob.Detach();
+        return true;
+    }
+
+    // Writes to a temp file and renames, so a crash mid-write can't leave a torn entry.
+    void StoreCachedBlob( uint64_t key, const ShaderDeps& deps, ID3DBlob* code ) {
+        if ( !code || code->GetBufferSize() == 0 || deps.size() > 256 ) return;
+        const std::string path = CacheFilePath( key, true );
+        if ( path.empty() ) return;
+        const std::string tmp = path + ".tmp";
+
+        const std::string startDir = Engine::GAPI->GetStartDirectory();
+        {
+            std::ofstream out( tmp, std::ios::binary | std::ios::trunc );
+            if ( !out ) return;
+            out.write( "GDBC", 4 );
+            WritePod( out, kDxbcCacheFormatVersion );
+            WritePod( out, key );
+            WritePod( out, static_cast<uint32_t>( deps.size() ) );
+            for ( const auto& [absPath, hash] : deps ) {
+                std::error_code ec;
+                std::string relStr = std::filesystem::relative( absPath, startDir, ec ).string();
+                if ( ec || relStr.empty() ) relStr = absPath;   // fallback: dep lives outside StartDirectory
+                WritePod( out, static_cast<uint32_t>( relStr.size() ) );
+                out.write( relStr.data(), static_cast<std::streamsize>( relStr.size() ) );
+                WritePod( out, hash );
+            }
+            WritePod( out, static_cast<uint32_t>( code->GetBufferSize() ) );
+            out.write( static_cast<const char*>( code->GetBufferPointer() ),
+                static_cast<std::streamsize>( code->GetBufferSize() ) );
+            if ( !out ) { out.close(); DeleteFileA( tmp.c_str() ); return; }
+        }
+        if ( !MoveFileExA( tmp.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING ) )
+            DeleteFileA( tmp.c_str() );
+    }
+}
+
 D3D11ShaderManager::D3D11ShaderManager()
     : VShaders( static_cast<size_t>(VShaderID::COUNT) )
     , PShaders( static_cast<size_t>(PShaderID::COUNT) )
@@ -54,17 +215,48 @@ D3D11ShaderManager::~D3D11ShaderManager() {
 // Find and compile the specified shader
 //--------------------------------------------------------------------------------------
 HRESULT D3D11ShaderManager::CompileShaderFromFile( const CHAR* szFileName, LPCSTR szEntryPoint, LPCSTR szShaderModel, ID3DBlob** ppBlobOut, const std::vector<D3D_SHADER_MACRO>& makros ) {
-    auto shaderFile = Toolbox::ToWideChar( szFileName );
+    const std::string relFileName = szFileName;
+    const std::string fullPath = Engine::GAPI->GetStartDirectory() + "\\" + relFileName;
 
-    return CompileShaderFromFile(
-        shaderFile.c_str(),
-        szEntryPoint,
-        szShaderModel,
-        ppBlobOut,
-        makros);
+    std::ifstream srcIn( fullPath, std::ios::binary );
+    if ( !srcIn ) {
+        // Let the raw compiler produce its usual "file not found"-style error/log.
+        auto shaderFile = Toolbox::ToWideChar( szFileName );
+        return CompileShaderFromFileRaw( shaderFile.c_str(), szEntryPoint, szShaderModel, ppBlobOut, makros, nullptr );
+    }
+    std::string source;
+    source.assign( std::istreambuf_iterator<char>( srcIn ), std::istreambuf_iterator<char>() );
+
+    const uint64_t cacheKey = ComputeCacheKey( relFileName, source, szEntryPoint, szShaderModel, makros );
+    if ( TryLoadCachedBlob( cacheKey, ppBlobOut ) ) {
+        ++g_CacheHits;
+        return S_OK;
+    }
+    ++g_CacheMisses;
+
+    auto shaderFile = Toolbox::ToWideChar( szFileName );
+    ShaderDeps deps;
+    HRESULT hr = CompileShaderFromFileRaw( shaderFile.c_str(), szEntryPoint, szShaderModel, ppBlobOut, makros, &deps );
+    if ( SUCCEEDED( hr ) ) {
+        StoreCachedBlob( cacheKey, deps, *ppBlobOut );
+    }
+    return hr;
+}
+
+void D3D11ShaderManager::LogAndResetCacheStats( const char* context ) {
+    if ( g_CacheHits == 0 && g_CacheMisses == 0 ) return;
+    LogInfo() << "D3D11 shader cache (" << ( context ? context : "" ) << "): " << g_CacheHits
+        << " reused from disk, " << g_CacheMisses << " compiled."
+        << ( g_CacheHits == 0 ? " (first run for these shaders, or d3dcompiler_47.dll changed)" : "" );
+    g_CacheHits = 0;
+    g_CacheMisses = 0;
 }
 
 HRESULT D3D11ShaderManager::CompileShaderFromFile( const WCHAR* szFileName, LPCSTR szEntryPoint, LPCSTR szShaderModel, ID3DBlob** ppBlobOut, const std::vector<D3D_SHADER_MACRO>& makros ) {
+    return CompileShaderFromFileRaw( szFileName, szEntryPoint, szShaderModel, ppBlobOut, makros, nullptr );
+}
+
+HRESULT D3D11ShaderManager::CompileShaderFromFileRaw( const WCHAR* szFileName, LPCSTR szEntryPoint, LPCSTR szShaderModel, ID3DBlob** ppBlobOut, const std::vector<D3D_SHADER_MACRO>& makros, ShaderDeps* outDeps ) {
     HRESULT hr = S_OK;
 
     DWORD dwShaderFlags = D3DCOMPILE_ENABLE_STRICTNESS;
@@ -104,6 +296,8 @@ HRESULT D3D11ShaderManager::CompileShaderFromFile( const WCHAR* szFileName, LPCS
 
         return hr;
     }
+
+    if ( outDeps ) *outDeps = includeHandler.Dependencies();
 
     return S_OK;
 }
@@ -310,6 +504,8 @@ XRESULT D3D11ShaderManager::LoadShaders( ShaderCategory categories ) {
 
     // Join all threads (call Threadpool destructor)
     // compilationTP.reset();
+
+    LogAndResetCacheStats( "LoadShaders" );
 
     return XR_SUCCESS;
 }

--- a/D3D11Engine/D3D11ShaderManager.h
+++ b/D3D11Engine/D3D11ShaderManager.h
@@ -5,15 +5,23 @@
 #include "D3D11HDShader.h"
 #include "D3D11GShader.h"
 #include "D3D11CShader.h"
+#include <cstdint>
+#include <string>
+#include <utility>
 
 class D3D11ShaderManager {
 public:
     D3D11ShaderManager();
     ~D3D11ShaderManager();
 
-    /** Compiles the shader from file and outputs error messages if needed */
+    // Compiles the shader from file and outputs error messages if needed. Cached on disk in
+    // system\GD3D11\shadercache\D3D11\; delete that directory to force a full recompile.
     static HRESULT CompileShaderFromFile( const CHAR* szFileName, LPCSTR szEntryPoint, LPCSTR szShaderModel, ID3DBlob** ppBlobOut, const std::vector<D3D_SHADER_MACRO>& makros );
     static HRESULT CompileShaderFromFile( const WCHAR* szFileName, LPCSTR szEntryPoint, LPCSTR szShaderModel, ID3DBlob** ppBlobOut, const std::vector<D3D_SHADER_MACRO>& makros );
+
+    static void LogAndResetCacheStats( const char* context );
+
+    using ShaderDeps = std::vector<std::pair<std::string, uint64_t>>;
 
     /** Creates list with ShaderInfos */
     XRESULT Init();
@@ -39,6 +47,10 @@ public:
     std::shared_ptr<D3D11CShader>& GetCShader( CShaderID id ) { return CShaders[static_cast<size_t>(id)]; }
 
 private:
+    // Uncached compile; outDeps, when non-null, receives every #include resolved.
+    static HRESULT CompileShaderFromFileRaw( const WCHAR* szFileName, LPCSTR szEntryPoint, LPCSTR szShaderModel,
+        ID3DBlob** ppBlobOut, const std::vector<D3D_SHADER_MACRO>& makros, ShaderDeps* outDeps );
+
     XRESULT CompileShader( ShaderInfo& si );
 
     void UpdateVShader( size_t index, D3D11VShader* shader ) { std::unique_lock<std::mutex> lock( _VShaderMutex ); VShaders[index].reset( shader ); }

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -947,12 +947,82 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
     const bool staticOnlyMode = settings.EnablePointlightShadows == GothicRendererSettings::PLS_STATIC_ONLY;
 
     // Draw pointlight shadows
-    std::list<VobLightInfo*> importantUpdates;
+    static std::vector<std::pair<float, VobLightInfo*>> importantUpdates;
+    importantUpdates.clear();
 
     DepthStencilPool* dsPool = graphicsEngine->GetPfxRenderer()->GetDepthStencilPool();
-    
+
     const bool isTiledShadingEnabled = m_TiledDeferred && settings.EnableTiledLighting;
     const int requiredShadowMapKind = isTiledShadingEnabled ? 1 : 0;
+
+    // Tiled lights share small fixed-size cube-array pools (unlike legacy, where every light gets its own
+    // unbounded DepthStencilPool allocation), so requests are ranked closest-to-player and may evict the
+    // farthest current occupant under pressure - mirrors D3D12PointShadows' SelectShadowedLights. Two
+    // independent pools: WantsStaticOnlySlot() lights route to the low-res MAX_STATIC_SHADOW_CUBEMAPS pool
+    // instead of the full-res MAX_SHADOW_CUBEMAPS one.
+    struct PendingAcquire { VobLightInfo* light; D3D11PointLight* pl; float distSq; int desiredResolution; bool wantsLowTier; };
+    static std::vector<PendingAcquire> candidates;
+    candidates.clear();
+
+    static std::array<VobLightInfo*, MAX_SHADOW_CUBEMAPS> slotOwnerLightHigh;
+    slotOwnerLightHigh.fill( nullptr );
+    static std::array<VobLightInfo*, MAX_STATIC_SHADOW_CUBEMAPS> slotOwnerLightLow;
+    slotOwnerLightLow.fill( nullptr );
+
+    // A slot must be held by a light ~1.7x farther than a challenger to be evicted, to avoid thrashing
+    // between similarly-distant lights every frame (mirrors D3D12PointShadows' kIncumbentBias).
+    constexpr float kPointShadowIncumbentBias = 0.35f;
+
+    auto allocateOrEvictSlot = [&]( float requesterDistSq, auto& slotOwnerArray, uint32_t poolSize, auto&& allocate ) -> int {
+        int slot = allocate();
+        if ( slot >= 0 ) return slot;
+
+        int worstSlot = -1;
+        float worstDistSq = -1.0f;
+        for ( uint32_t s = 0; s < poolSize; s++ ) {
+            VobLightInfo* owner = slotOwnerArray[s];
+            if ( !owner ) continue;
+            const float ownerDistSq = XMVectorGetX( XMVector3LengthSq( owner->Vob->GetPositionWorldXM() - vPlayerPosition ) );
+            if ( ownerDistSq > worstDistSq ) {
+                worstDistSq = ownerDistSq;
+                worstSlot = static_cast<int>(s);
+            }
+        }
+        if ( worstSlot < 0 || requesterDistSq * kPointShadowIncumbentBias >= worstDistSq ) {
+            return -1;
+        }
+        VobLightInfo* worstOwner = slotOwnerArray[worstSlot];
+        D3D11PointLight* worstPl = dynamic_cast<D3D11PointLight*>(worstOwner->LightShadowBuffers.get());
+        if ( !worstPl ) return -1;
+
+        worstPl->ClearTiledSlot();
+        slotOwnerArray[worstSlot] = nullptr;
+        return allocate();
+    };
+
+    auto classifyLight = [&]( VobLightInfo* light, D3D11PointLight* pl, float distSq ) {
+        bool needsUpdate = pl->NeedsUpdate();
+        bool isInited = pl->IsInited();
+
+        if ( isInited ) {
+            if ( needsUpdate || light->UpdateShadows ) {
+                importantUpdates.emplace_back( distSq, light );
+            }
+            else if ( partialShadowUpdate && !staticOnlyMode ) {
+                auto& queue = graphicsEngine->FrameShadowUpdateLights;
+                if ( std::find( queue.begin(), queue.end(), light ) == queue.end() ) {
+                    queue.emplace_back( light );
+                }
+            } else if ( staticOnlyMode ) {
+                auto& queue = graphicsEngine->FrameShadowUpdateLights;
+                auto queued = std::find( queue.begin(), queue.end(), light );
+                if ( queued != queue.end() ) {
+                    queue.erase( queued );
+                }
+            }
+        }
+    };
+
     for ( auto const& light : lights ) {
         if ( !light->Vob->IsEnabled() || !light->VisibleInFrame ) {
             continue;
@@ -966,6 +1036,19 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
         }
 
         if ( D3D11PointLight* pl = dynamic_cast<D3D11PointLight*>(light->LightShadowBuffers.get()) ) {
+            bool wantsLowTier = isTiledShadingEnabled && pl->WantsStaticOnlySlot();
+
+            if ( isTiledShadingEnabled ) {
+                int ownSlot = pl->GetTiledSlot();
+                if ( ownSlot >= 0 ) {
+                    if ( pl->IsTiledSlotLowRes() && static_cast<uint32_t>(ownSlot) < MAX_STATIC_SHADOW_CUBEMAPS ) {
+                        slotOwnerLightLow[ownSlot] = light;
+                    } else if ( !pl->IsTiledSlotLowRes() && static_cast<uint32_t>(ownSlot) < MAX_SHADOW_CUBEMAPS ) {
+                        slotOwnerLightHigh[ownSlot] = light;
+                    }
+                }
+            }
+
             const float d = XMVectorGetX( XMVector3LengthSq( light->Vob->GetPositionWorldXM() - vPlayerPosition ) );
             float range = light->Vob->GetLightRange();
             const float rangeSq = range * range;
@@ -973,8 +1056,9 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
             float distVeryCloseSq = (range * 0.8f) * (range * 0.8f);
             float distMaxShadowSq = (range * 9.0f) * (range * 9.0f); // Fade out entirely after this
 
-            // pick shadow resolution based on distance.
-            int desiredResolution = SHADOW_CUBE_SIZE; // Fallback / far distance
+            // Resolution also doubles as the tier-mismatch check below: a light whose tier flipped no longer
+            // matches its current GetShadowMapResolution(), so it re-acquires into the right tier automatically.
+            int desiredResolution = wantsLowTier ? STATIC_SHADOW_CUBE_SIZE : SHADOW_CUBE_SIZE;
             if ( d < distVeryCloseSq && !staticOnlyMode ) {
                 light->UpdateShadows = true;
                 // for now, keep all lights/shadows the same size, otherwise they change their "volume"
@@ -983,74 +1067,77 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
 
             bool inShadowRange = d < distMaxShadowSq;
             if ( inShadowRange ) {
-                // Acquire memory if it doesn't have it (or resolution changed)
                 if ( !pl->HasShadowMap( requiredShadowMapKind ) || pl->GetShadowMapResolution() != desiredResolution ) {
-                    pl->ClearTiledSlot();
-                    pl->ReleaseShadowMap();
-
-                    // Try tiled slot for small (64×64) lights when tiled lighting is active
-                    if ( isTiledShadingEnabled ) {
-                        if ( desiredResolution != SHADOW_CUBE_SIZE ) {
-                            light->UpdateShadows = false;
-                            continue; // should never happen, as we currently only use one resolution, but just in case, don't try to put bigger shadowmaps into tiled slots
-                        }
-                        int slot = m_TiledDeferred->AllocateSlot();
-                        if ( slot >= 0 ) {
-                            pl->SetTiledSlot( slot, m_TiledDeferred->GetSlotTarget( slot ), m_TiledDeferred.get() );
-                            pl->SetCurrentResolution( desiredResolution );
-                        } else {
-                            light->UpdateShadows = false;
-                            continue; // failed to allocate tiled slot, skip shadow rendering for this light this frame
-                        }
-                    } else {
-                        pl->AcquireShadowMap( dsPool, desiredResolution );
-                    }
-
-                    light->UpdateShadows = true; // Force an immediate render this frame
+                    candidates.push_back( { light, pl, d, desiredResolution, wantsLowTier } );
+                    continue;
                 }
 
-                bool needsUpdate = pl->NeedsUpdate();
-                bool isInited = pl->IsInited();
-
-                // Sort into Important vs Background Queue
-                if ( isInited ) {
-                    // Immediate Priority: Light moved, was just created, or explicit flag set
-                    if ( needsUpdate || light->UpdateShadows ) {
-                        importantUpdates.emplace_back( light );
-                    }
-                    // Background Priority: Add to round-robin queue if not already there
-                    else if ( partialShadowUpdate && !staticOnlyMode ) {
-                        auto& queue = graphicsEngine->FrameShadowUpdateLights;
-                        if ( std::find( queue.begin(), queue.end(), light ) == queue.end() ) {
-                            queue.emplace_back( light );
-                        }
-                    } else if ( staticOnlyMode ) {
-                        auto& queue = graphicsEngine->FrameShadowUpdateLights;
-                        auto queued = std::find( queue.begin(), queue.end(), light );
-                        if ( queued != queue.end() ) {
-                            queue.erase( queued );
-                        }
-                    }
-                }
+                classifyLight( light, pl, d );
             } else {
-                // Out of range: Return VRAM to the pool!
                 if ( pl->HasAnyShadowMap() ) {
                     pl->ClearTiledSlot();
                     pl->ReleaseShadowMap();
 
-                    // Erase from the update queue if it happens to be pending
                     auto it = std::find( graphicsEngine->FrameShadowUpdateLights.begin(), graphicsEngine->FrameShadowUpdateLights.end(), light );
                     if ( it != graphicsEngine->FrameShadowUpdateLights.end() ) {
                         graphicsEngine->FrameShadowUpdateLights.erase( it );
                     }
 
-                    auto importantIt = std::find( importantUpdates.begin(), importantUpdates.end(), light );
+                    auto importantIt = std::find_if( importantUpdates.begin(), importantUpdates.end(),
+                        [&]( const auto& entry ) { return entry.second == light; } );
                     if ( importantIt != importantUpdates.end() ) {
                         importantUpdates.erase( importantIt );
                     }
                 }
             }
         }
+    }
+
+    std::sort( candidates.begin(), candidates.end(), []( const PendingAcquire& a, const PendingAcquire& b ) {
+        return a.distSq < b.distSq;
+    } );
+
+    for ( auto& c : candidates ) {
+        D3D11PointLight* pl = c.pl;
+        VobLightInfo* light = c.light;
+
+        pl->ClearTiledSlot();
+        pl->ReleaseShadowMap();
+
+        if ( isTiledShadingEnabled ) {
+            int slot;
+            if ( c.wantsLowTier ) {
+                slot = allocateOrEvictSlot( c.distSq, slotOwnerLightLow, MAX_STATIC_SHADOW_CUBEMAPS,
+                    [&] { return m_TiledDeferred->AllocateStaticSlot(); } );
+            } else {
+                if ( c.desiredResolution != SHADOW_CUBE_SIZE ) {
+                    // only one high-tier resolution is ever used; don't put a mismatched size into a tiled slot
+                    light->UpdateShadows = false;
+                    continue;
+                }
+                slot = allocateOrEvictSlot( c.distSq, slotOwnerLightHigh, MAX_SHADOW_CUBEMAPS,
+                    [&] { return m_TiledDeferred->AllocateSlot(); } );
+            }
+
+            if ( slot < 0 ) {
+                light->UpdateShadows = false;
+                continue;
+            }
+
+            if ( c.wantsLowTier ) {
+                pl->SetTiledSlot( slot, m_TiledDeferred->GetStaticSlotTarget( slot ), m_TiledDeferred.get(), true );
+                slotOwnerLightLow[slot] = light;
+            } else {
+                pl->SetTiledSlot( slot, m_TiledDeferred->GetSlotTarget( slot ), m_TiledDeferred.get(), false );
+                slotOwnerLightHigh[slot] = light;
+            }
+            pl->SetCurrentResolution( c.desiredResolution );
+        } else {
+            pl->AcquireShadowMap( dsPool, c.desiredResolution );
+        }
+
+        light->UpdateShadows = true;
+        classifyLight( light, pl, c.distSq );
     }
 
     // Render the immediate priority lights - but never more than a handful in one frame.
@@ -1062,9 +1149,13 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
     // matrices are replaced mid-frame, so their cubes finish rendering with another light's projection -
     // which shows up as point-light shadows randomly cut off along a cube-face edge, on a different set of
     // lights every time. Overflow keeps its UpdateShadows flag and drains through the round-robin below.
+    std::sort( importantUpdates.begin(), importantUpdates.end(), []( const auto& a, const auto& b ) {
+        return a.first < b.first;
+    } );
+
     constexpr int maxImportantUpdates = 8;
     int importantDone = 0;
-    for ( auto const& importantUpdate : importantUpdates ) {
+    for ( auto const& [distSq, importantUpdate] : importantUpdates ) {
         if ( importantDone >= maxImportantUpdates ) {
             auto& queue = graphicsEngine->FrameShadowUpdateLights;
             if ( std::find( queue.begin(), queue.end(), importantUpdate ) == queue.end() ) {

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -158,6 +158,80 @@ void D3D11TiledDeferredShading::EnsureDynShadowArray() {
     }
 }
 
+void D3D11TiledDeferredShading::EnsureStaticShadowArray() {
+    if ( m_StaticShadowArrayCreated ) return;
+    m_StaticShadowArrayCreated = true;
+
+    D3D11_TEXTURE2D_DESC desc = {};
+    desc.Width = STATIC_SHADOW_CUBE_SIZE;
+    desc.Height = STATIC_SHADOW_CUBE_SIZE;
+    desc.MipLevels = 1;
+    desc.ArraySize = MAX_STATIC_SHADOW_CUBEMAPS * 6;
+    desc.Format = DXGI_FORMAT_R16_TYPELESS;
+    desc.SampleDesc.Count = 1;
+    desc.Usage = D3D11_USAGE_DEFAULT;
+    desc.BindFlags = D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE;
+    desc.MiscFlags = D3D11_RESOURCE_MISC_TEXTURECUBE;
+
+    // Fail closed rather than build an SRV/DSVs from a null resource - see MAX_STATIC_SHADOW_CUBEMAPS in the header.
+    if ( FAILED( m_device->CreateTexture2D( &desc, nullptr, m_ShadowStaticCubeArray.ReleaseAndGetAddressOf() ) ) ) {
+        LogWarn() << "Failed to create the low-res static-only point-light shadow array; static point lights "
+            "will render unshadowed.";
+        m_ShadowStaticCubeArray.Reset();
+        return;
+    }
+    SetDebugName( m_ShadowStaticCubeArray.Get(), "TiledDeferred_ShadowStaticCubeArray" );
+
+    D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+    srvDesc.Format = DXGI_FORMAT_R16_UNORM;
+    srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBEARRAY;
+    srvDesc.TextureCubeArray.MostDetailedMip = 0;
+    srvDesc.TextureCubeArray.MipLevels = 1;
+    srvDesc.TextureCubeArray.First2DArrayFace = 0;
+    srvDesc.TextureCubeArray.NumCubes = MAX_STATIC_SHADOW_CUBEMAPS;
+
+    m_device->CreateShaderResourceView( m_ShadowStaticCubeArray.Get(), &srvDesc, m_ShadowStaticCubeArraySRV.ReleaseAndGetAddressOf() );
+    SetDebugName( m_ShadowStaticCubeArraySRV.Get(), "TiledDeferred_ShadowStaticCubeArray_SRV" );
+
+    for ( uint32_t slot = 0; slot < MAX_STATIC_SHADOW_CUBEMAPS; slot++ ) {
+        D3D11_DEPTH_STENCIL_VIEW_DESC dsvDesc = {};
+        dsvDesc.Format = DXGI_FORMAT_D16_UNORM;
+        dsvDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
+        dsvDesc.Texture2DArray.FirstArraySlice = slot * 6;
+        dsvDesc.Texture2DArray.ArraySize = 6;
+        dsvDesc.Texture2DArray.MipSlice = 0;
+
+        m_device->CreateDepthStencilView( m_ShadowStaticCubeArray.Get(), &dsvDesc, m_StaticSlotDSVs[slot].ReleaseAndGetAddressOf() );
+
+        m_StaticSlotViews[slot] = std::make_unique<RenderToDepthStencilBuffer>(
+            m_ShadowStaticCubeArray, m_StaticSlotDSVs[slot], nullptr,
+            STATIC_SHADOW_CUBE_SIZE, STATIC_SHADOW_CUBE_SIZE );
+    }
+}
+
+int D3D11TiledDeferredShading::AllocateStaticSlot() {
+    EnsureStaticShadowArray();
+    if ( !m_ShadowStaticCubeArray ) return -1;
+    for ( uint32_t i = 0; i < MAX_STATIC_SHADOW_CUBEMAPS; i++ ) {
+        if ( !m_StaticSlotInUse[i] ) {
+            m_StaticSlotInUse[i] = true;
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+void D3D11TiledDeferredShading::FreeStaticSlot( int slot ) {
+    if ( slot >= 0 && static_cast<uint32_t>(slot) < MAX_STATIC_SHADOW_CUBEMAPS )
+        m_StaticSlotInUse[slot] = false;
+}
+
+RenderToDepthStencilBuffer* D3D11TiledDeferredShading::GetStaticSlotTarget( int slot ) {
+    if ( slot >= 0 && static_cast<uint32_t>(slot) < MAX_STATIC_SHADOW_CUBEMAPS && m_StaticShadowArrayCreated )
+        return m_StaticSlotViews[slot].get();
+    return nullptr;
+}
+
 int D3D11TiledDeferredShading::AllocateSlot() {
     EnsureShadowArray();
     for ( uint32_t i = 0; i < MAX_SHADOW_CUBEMAPS; i++ ) {
@@ -292,12 +366,14 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
         // even if the shader branches around SampleCmpLevelZero
         graphicsEngine->GetShadowMaps()->BindSamplerToCS( context.Get(), 2 );
 
-        // Bind shadow cubemap array SRVs (static at t11, dynamic overlay at t12). The overlay array may not
-        // exist yet - a null SRV is fine, no light can carry SHADOW_CUBE_HAS_DYNAMIC before it is created.
+        // Static at t11, dynamic overlay at t12, low-res static-only tier at t13.
         if ( cullResult.HasShadowedTiledLights && m_ShadowArrayCreated ) {
             context->CSSetShaderResources( 11, 1, m_ShadowCubeArraySRV.GetAddressOf() );
             ID3D11ShaderResourceView* dynSRV = m_ShadowDynArrayCreated ? m_ShadowDynCubeArraySRV.Get() : nullptr;
             context->CSSetShaderResources( 12, 1, &dynSRV );
+        }
+        if ( cullResult.HasShadowedTiledLights && m_StaticShadowArrayCreated ) {
+            context->CSSetShaderResources( 13, 1, m_ShadowStaticCubeArraySRV.GetAddressOf() );
         }
 
         // Bind HDR UAV
@@ -309,8 +385,8 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
         // Unbind everything
         ID3D11UnorderedAccessView* nullUAV = nullptr;
         context->CSSetUnorderedAccessViews( 0, 1, &nullUAV, nullptr );
-        ID3D11ShaderResourceView* nullSRVs[13] = {};
-        context->CSSetShaderResources( 0, 13, nullSRVs ); // t0-t12, incl. both shadow cube arrays
+        ID3D11ShaderResourceView* nullSRVs[14] = {};
+        context->CSSetShaderResources( 0, 14, nullSRVs ); // t0-t13
         context->CSSetShader( nullptr, nullptr, 0 );
 
         // Restore HDR as RTV
@@ -423,9 +499,8 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
         tl.PositionWorld = XMFLOAT3( posWorld.x, posWorld.y, posWorld.z );
 
         if ( hasShadow ) {
-            // The slot's static depth lives in the main array; flag the ones that also have this frame's
-            // skeletal overlay in the dynamic array so the shader knows to take the second sample.
             tl.ShadowCubeIndex = pl->GetTiledSlot()
+                | ( pl->IsTiledSlotLowRes() ? SHADOW_CUBE_TIER_LOW : 0 )
                 | ( pl->HasDynamicShadowOverlay() ? SHADOW_CUBE_HAS_DYNAMIC : 0 );
             hasShadowedTiledLights = true;
         } else {

--- a/D3D11Engine/D3D11TiledDeferredShading.h
+++ b/D3D11Engine/D3D11TiledDeferredShading.h
@@ -16,12 +16,26 @@ constexpr uint32_t MAX_TILED_LIGHTS = 400;
 constexpr uint32_t MAX_SHADOW_CUBEMAPS = 128;
 constexpr uint32_t SHADOW_CUBE_SIZE = 128; // Must match POINTLIGHT_SHADOWMAP_SIZE
 
-// ShadowCubeIndex encoding: -1 = unshadowed, else (slot | flags). Bit 30 marks that the slot also has a valid
-// dynamic (skeletal overlay) cube in the second array, which the shader samples and min's with the static one.
-// Keeping the flag in bit 30 leaves the value positive, so "ShadowCubeIndex >= 0" still means shadowed.
-// Mirrors PLS_SHADOW_HAS_DYNAMIC / PLS_SHADOW_SLOT_MASK in Shaders/include/PointLightShadows.h.
+// Low-res STATIC-ONLY tier: WantsStaticOnlySlot() lights never receive a dynamic overlay and cache their
+// cube forever once rendered, so they don't need full resolution and get their own budget instead of
+// competing with the full-res pool above.
+//
+// 340 is a HARD CEILING: a cube array is a Texture2DArray of slot*6 slices, and D3D11 caps a Texture2D
+// array at D3D11_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION (2048) slices - 2048/6 = 341. Exceeding it fails
+// CreateTexture2D, and since EnsureStaticShadowArray() marks the array "created" before that call, the
+// failure is silent: every static light still gets a slot and a non-null target wrapping null D3D11
+// resources, so its shadow SRV binds null and samples as 0 - i.e. fully black/occluded, not unshadowed.
+constexpr uint32_t MAX_STATIC_SHADOW_CUBEMAPS = 340;
+constexpr uint32_t STATIC_SHADOW_CUBE_SIZE = 32;
+static_assert( MAX_STATIC_SHADOW_CUBEMAPS * 6 <= 2048, "static shadow cube array exceeds D3D11_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION" );
+static_assert( MAX_SHADOW_CUBEMAPS * 6 <= 2048, "dynamic shadow cube array exceeds D3D11_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION" );
+
+// ShadowCubeIndex encoding: -1 = unshadowed, else (slot | flags). Bit 30 = slot also has a dynamic overlay
+// in the second array (min'd with the static sample). Bit 29 = slot lives in the low-res static array
+// instead of the full-res one (never set together with bit 30). Mirrors PLS_SHADOW_* in PointLightShadows.h.
 constexpr int32_t SHADOW_CUBE_HAS_DYNAMIC = 0x40000000;
-constexpr int32_t SHADOW_CUBE_SLOT_MASK = 0x3FFFFFFF;
+constexpr int32_t SHADOW_CUBE_TIER_LOW = 0x20000000;
+constexpr int32_t SHADOW_CUBE_SLOT_MASK = 0x1FFFFFFF;
 
 struct TiledPointLight {
     DirectX::XMFLOAT3 PositionView;
@@ -84,6 +98,8 @@ public:
     bool IsShadowArrayCreated() const { return m_ShadowArrayCreated; }
     ID3D11ShaderResourceView* GetShadowDynCubeArraySRV() const { return m_ShadowDynCubeArraySRV.Get(); }
     bool IsDynShadowArrayCreated() const { return m_ShadowDynArrayCreated; }
+    ID3D11ShaderResourceView* GetShadowStaticCubeArraySRV() const { return m_ShadowStaticCubeArraySRV.Get(); }
+    bool IsStaticShadowArrayCreated() const { return m_StaticShadowArrayCreated; }
 
     // Shadow cubemap array slot management
     int AllocateSlot();
@@ -93,10 +109,16 @@ public:
         so worlds that never render a moving caster into a point-light cube never pay for it. */
     RenderToDepthStencilBuffer* GetDynSlotTarget( int slot );
 
+    // Low-res static-only tier - see WantsStaticOnlySlot()/SHADOW_CUBE_TIER_LOW.
+    int AllocateStaticSlot();
+    void FreeStaticSlot( int slot );
+    RenderToDepthStencilBuffer* GetStaticSlotTarget( int slot );
+
 private:
     void EnsureBuffers( uint32_t numTilesX, uint32_t numTilesY );
     void EnsureShadowArray();
     void EnsureDynShadowArray();
+    void EnsureStaticShadowArray();
 
     Microsoft::WRL::ComPtr<ID3D11Device1> m_device;
     Microsoft::WRL::ComPtr<ID3D11DeviceContext1> m_context;
@@ -127,6 +149,14 @@ private:
     std::array<Microsoft::WRL::ComPtr<ID3D11DepthStencilView>, MAX_SHADOW_CUBEMAPS> m_SlotDynDSVs;
     std::array<std::unique_ptr<RenderToDepthStencilBuffer>, MAX_SHADOW_CUBEMAPS> m_SlotDynViews;
     bool m_ShadowDynArrayCreated = false;
+
+    // Low-res static-only cube array (see WantsStaticOnlySlot()). Lazy-created like the arrays above.
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> m_ShadowStaticCubeArray;
+    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_ShadowStaticCubeArraySRV;
+    std::bitset<MAX_STATIC_SHADOW_CUBEMAPS> m_StaticSlotInUse;
+    std::array<Microsoft::WRL::ComPtr<ID3D11DepthStencilView>, MAX_STATIC_SHADOW_CUBEMAPS> m_StaticSlotDSVs;
+    std::array<std::unique_ptr<RenderToDepthStencilBuffer>, MAX_STATIC_SHADOW_CUBEMAPS> m_StaticSlotViews;
+    bool m_StaticShadowArrayCreated = false;
 
     uint32_t m_lastNumTilesX = 0;
     uint32_t m_lastNumTilesY = 0;

--- a/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Barrier.cpp
@@ -118,10 +118,11 @@ namespace {
         return CD3DX12_BARRIER_SUBRESOURCE_RANGE( mipSlice, 1, arraySlice, 1, planeSlice, 1 );
     }
 
-    // Batch cap for TransitionBarriers()/UAVBarriers(); fixed-size stack storage to stay off the
-    // per-frame allocation path. A batch that exceeds this logs a warning and falls back to one
-    // Barrier() call per element.
-    constexpr UINT kMaxBatchedBarriers = 16;
+    // Chunk size for TransitionBarriers()/UAVBarriers(); fixed-size stack storage to stay off the
+    // per-frame allocation path. Batches larger than this (e.g. point-shadow slot transitions,
+    // up to kMaxCubes*6 faces) are split into multiple grouped Barrier() calls rather than
+    // degrading to one Barrier() per element -- that would defeat the point of batching.
+    constexpr UINT kMaxBatchedBarriers = 64;
 
 } // namespace
 
@@ -155,17 +156,17 @@ void D3D12CmdList::TransitionBarrier( ID3D12Resource* resource, D3D12_RESOURCE_S
 }
 
 void D3D12CmdList::TransitionBarriers( const D3D12ResourceTransition* transitions, UINT count ) {
-    if ( count == 0 ) return;
-    if ( count > kMaxBatchedBarriers ) {
-#ifdef DEBUG_D3D11
-        LogWarn() << "D3D12Barrier: TransitionBarriers batch of " << count
-                  << " exceeds kMaxBatchedBarriers (" << kMaxBatchedBarriers << "); issuing one barrier per element.";
-#endif
-        for ( UINT i = 0; i < count; ++i )
-            TransitionBarrier( transitions[i].Resource, transitions[i].Before, transitions[i].After,
-                transitions[i].Subresource, transitions[i].SyncBefore, transitions[i].SyncAfter );
-        return;
+    // Batches larger than kMaxBatchedBarriers are issued as multiple grouped Barrier() calls
+    // (still far fewer than one call per element) rather than degrading to one Barrier() per
+    // transition, which would defeat the point of batching for e.g. point-shadow slot updates.
+    for ( UINT offset = 0; offset < count; offset += kMaxBatchedBarriers ) {
+        const UINT chunk = std::min( count - offset, kMaxBatchedBarriers );
+        TransitionBarriersChunk( transitions + offset, chunk );
     }
+}
+
+void D3D12CmdList::TransitionBarriersChunk( const D3D12ResourceTransition* transitions, UINT count ) {
+    if ( count == 0 ) return;
 
     if ( s_DeviceSupportsEnhancedBarriers && List7() ) {
         D3D12_TEXTURE_BARRIER textureBarriers[kMaxBatchedBarriers];
@@ -238,15 +239,15 @@ void D3D12CmdList::UAVBarrier( ID3D12Resource* resource, D3D12_BARRIER_SYNC sync
 }
 
 void D3D12CmdList::UAVBarriers( ID3D12Resource* const* resources, UINT count, D3D12_BARRIER_SYNC syncHint ) {
-    if ( count == 0 ) return;
-    if ( count > kMaxBatchedBarriers ) {
-#ifdef DEBUG_D3D11
-        LogWarn() << "D3D12Barrier: UAVBarriers batch of " << count
-                  << " exceeds kMaxBatchedBarriers (" << kMaxBatchedBarriers << "); issuing one barrier per element.";
-#endif
-        for ( UINT i = 0; i < count; ++i ) UAVBarrier( resources[i], syncHint );
-        return;
+    // See TransitionBarriers() -- chunk rather than degrade to one Barrier() per element.
+    for ( UINT offset = 0; offset < count; offset += kMaxBatchedBarriers ) {
+        const UINT chunk = std::min( count - offset, kMaxBatchedBarriers );
+        UAVBarriersChunk( resources + offset, chunk, syncHint );
     }
+}
+
+void D3D12CmdList::UAVBarriersChunk( ID3D12Resource* const* resources, UINT count, D3D12_BARRIER_SYNC syncHint ) {
+    if ( count == 0 ) return;
 
     if ( s_DeviceSupportsEnhancedBarriers && List7() ) {
         const D3D12_BARRIER_SYNC kSync = ( syncHint != kBarrierSyncUnspecified ) ? syncHint : D3D12_BARRIER_SYNC_ALL_SHADING;

--- a/D3D11Engine/D3D12Engine/D3D12Device.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Device.cpp
@@ -320,7 +320,10 @@ bool D3D12Device::Init() {
         // Enable DRED
         ComPtr<ID3D12DeviceRemovedExtendedDataSettings1> pDredSettings;
         if ( getDebug && SUCCEEDED( getDebug( IID_PPV_ARGS( pDredSettings.ReleaseAndGetAddressOf() ) ) ) ) {
-            // Turn on auto-breadcrumbs and page fault reporting
+            // Auto-breadcrumbs + their CPU-side context are always on: cheap, and they're what
+            // D3D12GraphicsEngine::DiagnoseErrors dumps to Log.txt on device removal on every machine.
+            // Page-fault tracking stays debug-only — it walks the whole resource residency set on GPU
+            // crash, which is not something to pay for (or rely on) on a player's machine.
             pDredSettings->SetAutoBreadcrumbsEnablement( D3D12_DRED_ENABLEMENT_FORCED_ON );
             pDredSettings->SetBreadcrumbContextEnablement( D3D12_DRED_ENABLEMENT_FORCED_ON );
             if ( DEBUG_D3D11_ENABLED ) {

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -2133,18 +2133,34 @@ static void PrintNode( const D3D12_AUTO_BREADCRUMB_NODE1* node ) {
 
 
 static void DiagnoseErrors(ID3D12Device* device) {
-    // Enable the debug layer before device creation when available (best-effort).
-    if ( HMODULE d3d12 = GetModuleHandleA( "d3d12.dll" ) ) {
-        auto getDebug = reinterpret_cast<PFN_D3D12_GET_DEBUG_INTERFACE>(GetProcAddress( d3d12, "D3D12GetDebugInterface" ));
-
-        ComPtr<ID3D12DeviceRemovedExtendedData1> pRemovedExtendedData;
-        if ( SUCCEEDED( device->QueryInterface( IID_PPV_ARGS( pRemovedExtendedData.ReleaseAndGetAddressOf() ) ) ) ) {
-            D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1 output;
-            if (SUCCEEDED( pRemovedExtendedData->GetAutoBreadcrumbsOutput1( &output ) )) {
-                PrintNode( output.pHeadAutoBreadcrumbNode );
-            }
-        }
+    // Deliberately does NOT read GetPageFaultAllocationOutput: page-fault tracking is only ever turned on
+    // under DEBUG_D3D11 (see D3D12Device::Init) and must never be relied on for player-machine diagnostics.
+    // Auto-breadcrumbs + breadcrumb context are FORCED_ON unconditionally, so this is always available.
+    ComPtr<ID3D12DeviceRemovedExtendedData1> pRemovedExtendedData;
+    if ( !device || FAILED( device->QueryInterface( IID_PPV_ARGS( pRemovedExtendedData.ReleaseAndGetAddressOf() ) ) ) ) {
+        LogWarn() << "D3D12 DiagnoseErrors: ID3D12DeviceRemovedExtendedData1 unavailable, no breadcrumbs to dump.";
+        return;
     }
+
+    D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1 output;
+    if ( SUCCEEDED( pRemovedExtendedData->GetAutoBreadcrumbsOutput1( &output ) ) ) {
+        PrintNode( output.pHeadAutoBreadcrumbNode );
+    } else {
+        LogWarn() << "D3D12 DiagnoseErrors: GetAutoBreadcrumbsOutput1 failed, no breadcrumbs to dump.";
+    }
+}
+
+
+void D3D12GraphicsEngine::HandleDeviceRemoved( HRESULT removedReason, const char* context ) {
+    // Best-effort: the device may itself be in a state where this queries nothing, but DiagnoseErrors
+    // handles that (logs and returns) rather than crashing here on top of the original failure.
+    DiagnoseErrors( m_Device.GetDevice() );
+
+    auto msg = std::format( "D3D12 device removed at {} (reason: 0x{:08X}). See Log.txt for GPU breadcrumbs.",
+        context, static_cast<uint32_t>( removedReason ) );
+    LogWarn() << msg.c_str();
+    MessageBoxA( NULL, msg.c_str(), "GD3D11 (DX12): Device Removed", MB_OK );
+    exit( removedReason );
 }
 
 XRESULT D3D12GraphicsEngine::Present() {
@@ -2207,12 +2223,8 @@ XRESULT D3D12GraphicsEngine::Present() {
     if ( FAILED( hr ) ) {
         auto r = static_cast<uint32_t>(hr);
         if ( hr == DXGI_ERROR_DEVICE_REMOVED) {
-            DiagnoseErrors( m_Device.GetDevice() );
-
             auto removedReason = m_Device.GetDevice()->GetDeviceRemovedReason();
-            auto msg = std::format( "D3D12 Present failed (0x{:08X}, reason: 0x{:08X})", r, static_cast<uint32_t>(removedReason) );
-            LogWarn() << "D3D12 Present failed (0x" << std::hex << r << ").";
-            MessageBoxA( NULL, msg.c_str(), "GD3D11 (DX12): Error", MB_OK );
+            HandleDeviceRemoved( removedReason, "Present" ); // [[noreturn]]
         } else {
             auto msg = std::format( "D3D12 Present failed (0x{:08X})", r );
             LogWarn() << "D3D12 Present failed (0x" << std::hex << r << ").";
@@ -2255,9 +2267,11 @@ bool D3D12GraphicsEngine::WaitOnFrameFence( UINT64 value, const char* site ) {
             << ". Device removed reason: 0x" << std::hex << static_cast<uint32_t>( removedReason ) << std::dec << ".";
 
         if ( FAILED( removedReason ) ) {
-            // The fence can no longer advance — waiting more only extends the freeze.
+            // The fence can no longer advance — waiting more only extends the freeze. Diagnose + terminate
+            // here rather than returning false: every caller of WaitOnFrameFence ignores that return value
+            // and would otherwise carry on resetting allocators/lists against a dead device.
             LogWarn() << "D3D12: giving up on frame fence " << value << " — the device is gone.";
-            return false;
+            HandleDeviceRemoved( removedReason, site ); // [[noreturn]]
         }
     }
 }

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -220,6 +220,8 @@ public:
 
     void OnAddVob(VobInfo* vi) override;
     XRESULT OnVobRemovedFromWorld( zCVob* vob ) override;
+    // Purges the VOB arena's cache of this MeshInfo* before it's freed - see BaseGraphicsEngine's doc comment.
+    void OnMeshInfoDestroyed( MeshInfo* mesh ) override { m_VobArena.Forget( mesh ); }
     void OnLoadWorld() override;
     void DrawVobSingle( VobInfo* vob, zCCamera& camera ) override;  // inventory item preview (GInventory), drawn straight onto the backbuffer
     D3D12MA::Allocator* GetAllocator() const { return m_Allocator.Get(); }

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -409,6 +409,12 @@ private:
     bool WaitOnFrameFence( UINT64 value, const char* site );
     static constexpr DWORD kFenceWaitTimeoutMs = 2000;
 
+    /** Dumps DRED auto-breadcrumbs (+ the CPU-side scope context recorded alongside them) to Log.txt,
+        shows the player a message box with the removed-reason code, then terminates the process. Called
+        from every path that observes the device is gone (Present() returning DXGI_ERROR_DEVICE_REMOVED,
+        and WaitOnFrameFence giving up) so a lost device is never silently swallowed. */
+    [[noreturn]] void HandleDeviceRemoved( HRESULT removedReason, const char* context );
+
     // Mid-frame synchronous flush for GetBackbufferData: closes + executes the currently-recorded m_CmdList
     // and blocks until the GPU has consumed it, then Resets the same allocator/list so recording can
     // continue for the rest of the frame. Unlike Present()/MoveToNextFrame() this does NOT transition the

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -317,7 +317,7 @@ void D3D12PointShadows::InvalidateStaticForVobRemoved( const zTBBox3D& bb ) {
 		const float cz = std::min( std::max( ss.pos.z, bb.Min.z ), bb.Max.z );
 		const float dx = ss.pos.x - cx, dy = ss.pos.y - cy, dz = ss.pos.z - cz;
 		if ( dx * dx + dy * dy + dz * dz < ss.range * ss.range )
-			ss.staticValid = false;   // removed vob was within this light's static coverage → re-cache
+			ss.staticValid = false;   // removed vob was within this light's static coverage -- re-cache
 	}
 }
 
@@ -705,7 +705,8 @@ void D3D12PointShadows::Prepare() {
 	}
 	auto faceCb = [&]( UINT slot ) { return m_FaceCBGpu[frame] + static_cast<UINT64>( slot ) * 512; };
 
-	// Reset the tight VOB-instance ring — only static-VOB gathers use it (the dynamic pass has no VOBs).
+	// Reset the tight VOB-instance ring — shared by the static-VOB gather (Phase A) and the dynamic overlay's
+	// mesh-vob gather (Phase C).
 	m_VobInstOffset = 0;
 	uint8_t* const viBase = m_VobInstPtr[frame];
 	const D3D12_GPU_VIRTUAL_ADDRESS viGpu = haveVobs ? m_VobInstGpu[frame] : 0;
@@ -790,10 +791,11 @@ void D3D12PointShadows::Prepare() {
 			rec.staticWorldEnd = static_cast<UINT>( g_PsStaticWorldDraws.size() );
 
 			// --- Instanced VOBs (static decoration): range-cull instances, pack 64B world matrices into the
-			// tight ring, draw count*6 (InstanceDataStepRate=6 -> 6 faces per real instance). Skipped for
-			// isStatic() lights — mirrors D3D11's RenderStaticShadowPass staticCasterMask, which restricts a
-			// static light's (cached) cube to world-mesh-only casters, no VOBs/MOBS. ---
-			if ( haveVobs && !m_Slots[ps.slot].isStatic ) {
+			// tight ring, draw count*6. An isStatic() slot additionally requires GP_Slot bit 30 (ZENGIN's own
+			// StaticVob flag) per instance — items are always StaticVob==false and would otherwise get baked
+			// into a cube that never re-renders. Items cast via the dynamic overlay (Phase C) instead. ---
+			if ( haveVobs ) {
+				const bool staticTier = m_Slots[ps.slot].isStatic;
 				for ( const FrameVobUpload& up : g_FrameVobUploads ) {
 					MeshVisualInfo* visual = up.visual;
 					if ( !visual || visual->Instances.empty() ) continue;
@@ -804,6 +806,7 @@ void D3D12PointShadows::Prepare() {
 					UINT count = 0;
 					bool overflow = false;
 					for ( const VobInstanceInfo& inst : visual->Instances ) {
+						if ( staticTier && !( inst.GP_Slot & ( 1u << 30 ) ) ) continue;   // not a StaticVob — see above
 						float dx = inst.world._14 - ps.posWS.x, dy = inst.world._24 - ps.posWS.y, dz = inst.world._34 - ps.posWS.z;
 						if ( dx * dx + dy * dy + dz * dz >= cullRSq ) continue;
 						if ( m_VobInstOffset + sizeof( XMFLOAT4X4 ) > m_VobInstCapacity ) {
@@ -859,12 +862,12 @@ void D3D12PointShadows::Prepare() {
 		// slot's active cube is exactly its static depth, rendered in place.
 		// The round-robin gate (P2.10h) is ps.renderDynamic: far/less-important dynamic lights only get the
 		// skeletal overlay on their scheduled frame (see SelectShadowedLights).
-		if ( haveSkel && ps.renderDynamic && ps.overlayEligible ) {
-			// Self-shadow exclusion: a light carried by an NPC (e.g. a torch in its hand) otherwise casts that
-			// NPC's own body as a huge shadow blob into its own cube — see BuildExcludeList / D3D11's
-			// GetHasOriginVob+SetupVobsToExclude.
+		if ( ps.renderDynamic && ps.overlayEligible ) {
+			// Self-shadow exclusion (see BuildExcludeList) — shared by the skeletal/attachment gather and the
+			// dynamic-mesh-vob gather below.
 			const bool hasExclusions = BuildExcludeList( m_Slots[ps.slot].owner, excludeVobs );
 
+		if ( haveSkel ) {
 			// Sphere-cull the FULL registered skeletal-vob list against THIS light (parity with the CSM cascade
 			// fix — a caster invisible to the player, but within a torch's range, can still cast a shadow into
 			// it), reusing g_SkelUploadCache so an NPC already prepared for the main view/a cascade this frame
@@ -940,6 +943,64 @@ void D3D12PointShadows::Prepare() {
 					g_PsDynAttachDraws.push_back( d );
 				}
 			}
+		}   // haveSkel
+
+			// --- Dynamic (non-skeletal) mesh vobs: items (StaticVob clear, see GetDynamicMeshVobs), excluded
+			// from the static-only tier and drawn here instead, same as a node attachment. Independent of
+			// haveSkel — no NPC required. ---
+			if ( psPipe.CasterVobPSO ) {
+				for ( VobInfo* vi : Engine::GAPI->GetDynamicMeshVobs() ) {
+					if ( !vi || !vi->Vob || !vi->VisualInfo ) continue;
+					if ( hasExclusions && std::find( excludeVobs.begin(), excludeVobs.end(), vi->Vob ) != excludeVobs.end() )
+						continue;
+					MeshVisualInfo* visual = static_cast<MeshVisualInfo*>( vi->VisualInfo );
+					const XMFLOAT3 pos = vi->Vob->GetPositionWorld();
+					const float cullR = ps.range + visual->MeshSize * 0.5f;
+					float dx = pos.x - ps.posWS.x, dy = pos.y - ps.posWS.y, dz = pos.z - ps.posWS.z;
+					if ( dx * dx + dy * dy + dz * dz >= cullR * cullR ) continue;
+					if ( m_VobInstOffset + sizeof( XMFLOAT4X4 ) > m_VobInstCapacity ) {
+						if ( !m_VobInstOverflowLogged ) {
+							LogWarn() << "D3D12: point-shadow VOB instance ring overflow ("
+								<< m_VobInstCapacity << " bytes/frame); some dynamic-item cube casters dropped.";
+							m_VobInstOverflowLogged = true;
+						}
+						break;
+					}
+
+					// Live transform, not a cached one — an interact-slot item's position is synced onto its
+					// NPC's hand bone every tick regardless of whether it's on screen.
+					const UINT instOffset = m_VobInstOffset;
+					XMFLOAT4X4 world;
+					XMStoreFloat4x4( &world, vi->Vob->GetWorldMatrixXM() );
+					memcpy( viBase + instOffset, &world, sizeof( XMFLOAT4X4 ) );
+					m_VobInstOffset += sizeof( XMFLOAT4X4 );
+					const D3D12_VERTEX_BUFFER_VIEW instView = { m_VobInstGpu[frame] + instOffset, sizeof( XMFLOAT4X4 ), sizeof( XMFLOAT4X4 ) };
+
+					for ( auto const& [meshKey, meshList] : visual->MeshesByTexture ) {
+						zCTexture* const matTex = meshKey.Material->GetAniTexture();
+						const D3D12_GPU_DESCRIPTOR_HANDLE srv = resolveDiffuse( matTex );
+						const bool matAlphaTested = ( matTex && matTex->HasAlphaChannel() )
+							|| meshKey.Material->HasAlphaTest();
+						for ( MeshInfo* mi : meshList ) {
+							if ( !mi || mi->Indices.empty() || !mi->GetMeshVertexBuffer() || !mi->GetMeshIndexBuffer() ) continue;
+							D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( mi->GetMeshVertexBuffer() );
+							D3D12VertexBuffer* mib = D3D12VertexBuffer::From( mi->GetMeshIndexBuffer() );
+							if ( !mvb->GetResource() || !mib->GetResource() ) continue;
+
+							PointShadowDraw d;
+							d.vb = mvb; d.ib = mib;
+							d.stride = sizeof( ExVertexStruct );
+							d.indexCount = static_cast<UINT>( mi->Indices.size() );
+							d.instanceCount = 6;
+							d.srv = srv;
+							d.instView = instView;
+							d.alphaTested = matAlphaTested;
+							g_PsDynAttachDraws.push_back( d );
+						}
+					}
+				}
+			}
+
 			rec.dynSkelEnd   = static_cast<UINT>( g_PsDynSkelDraws.size() );
 			rec.dynAttachEnd = static_cast<UINT>( g_PsDynAttachDraws.size() );
 		}

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.h
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.h
@@ -218,10 +218,9 @@ private:
                                              // low-tier slot ever reaches — so a cluster leaving it null is safe.
         DirectX::XMFLOAT3 pos = {};          // last static-rendered cube origin (move detection)
         float             range = 0.0f;      // last static-rendered range (range-change detection)
-        bool              isStatic = false;  // Vob->IsStatic(): gates Prepare() — static lights get a
-                                             // world-mesh-only static-aside cache (no VOB casters) and never
-                                             // receive the per-frame skeletal dynamic overlay (mirrors D3D11's
-                                             // GetCurrentShadowMode forcing PLS_STATIC_ONLY for static lights).
+        bool              isStatic = false;  // Vob->IsStatic(): gates Prepare() — static lights cache world mesh
+                                             // plus StaticVob-flagged decoration once, forever; never receive the
+                                             // per-frame dynamic overlay (mirrors D3D11's PLS_STATIC_ONLY).
         bool              staticValid = false; // the slot's CURRENT static target (aside if usesAside, else the active
                                              // cube itself) holds valid static-only depth; false => must re-render static
         bool              dynamicValid = false; // this slot's DYNAMIC cube holds a valid skeletal overlay, as of the

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -307,7 +307,10 @@ void D3D12GraphicsEngine::OnAddVob(VobInfo* vi) {
     // shadow slots and invalidate any whose light range the new VOB reaches, forcing a one-time static re-render
     // next frame (staticValid=false → renderStatic). Slots are empty during world load (owner==nullptr) so this is
     // a no-op then; the margin mirrors the static-VOB gather's cull (ps.range + visual->MeshSize * 0.5f).
-    if ( vi->Vob && vi->VisualInfo )
+    // Gated on StaticVob: items are always StaticVob==false (even ones just lying around, since oItem clears it
+    // unconditionally), and an NPC eating/drinking spawns/despawns one constantly -- without this gate that
+    // forced a full re-render of every nearby cached slot, causing a visible one-frame shadow blackout.
+    if ( vi->Vob && vi->VisualInfo && vi->Vob->GetFlags().StaticVob )
         m_PointShadows.InvalidateStaticForVobAdded( vi->Vob->GetPositionWorld(), vi->VisualInfo->MeshSize * 0.5f );
 }
 
@@ -320,7 +323,8 @@ XRESULT D3D12GraphicsEngine::OnVobRemovedFromWorld( zCVob* vob ) {
     // uses) and force a one-time static re-render (staticValid=false) for any slot it intersects. Over-invalidation
     // is harmless (one extra static pass); under-invalidation would leave the removed vob's shadow frozen in the
     // cache. Slots are empty during world load (owner==nullptr) so this is a no-op then.
-    if ( vob ) m_PointShadows.InvalidateStaticForVobRemoved( vob->GetBBox() );
+    // Gated on StaticVob -- see OnAddVob.
+    if ( vob && vob->GetFlags().StaticVob ) m_PointShadows.InvalidateStaticForVobRemoved( vob->GetBBox() );
     return XR_SUCCESS;
 }
 

--- a/D3D11Engine/D3D12Engine/D3D12ShaderBackend.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShaderBackend.cpp
@@ -15,6 +15,7 @@
 #include "../Engine.h"
 #include "../GothicAPI.h"
 #include "../zFILE_VDFS.h"
+#include "../ShaderCacheHash.h"
 
 using Microsoft::WRL::ComPtr;
 
@@ -82,64 +83,56 @@ namespace {
         return str;
     }
 
-    // ---- On-disk DXIL cache ---------------------------------------------------------------------------
-    // Every launch and every ReloadAll recompiles ~60 entry points, so each successful compile is persisted.
-    // The key covers the top-level source, entry point, target, macros, the args revision below and the DXC
-    // version. #includes can't be in the key (they aren't known until DXC asks for them), so the include
-    // handler records each resolved file + its hash into the entry and a lookup re-hashes them; that is
-    // transitive for free. A newly ADDED #include changes the source text, hence the key, on its own.
-    //
-    // Editing a shader orphans its old entries rather than replacing them. Deleting the shadercache
-    // directory is always safe and is how you reclaim that space or force a full recompile.
+    // #includes can't be in the cache key directly (they aren't known until DXC asks for them); the
+    // include handler records each resolved file + its hash instead, and a lookup re-hashes them,
+    // staying correct transitively for free. Editing a shader orphans its old entries; deleting the
+    // shadercache directory is always safe.
     using ShaderDeps = std::vector<std::pair<std::string, uint64_t>>;
 
-    // Bump when the DXC argument list in CompileSource changes in a way that alters codegen (a new -D, an
-    // optimization level, -enable-16bit-types...). Entries written by an older revision then simply miss.
+    // Bump when the DXC argument list in CompileSource changes in a way that alters codegen.
     constexpr uint32_t kDxilCacheArgsRevision = 1;
     constexpr uint32_t kDxilCacheFormatVersion = 1;
     const char* kDxilCacheDirRel = "\\system\\GD3D11\\shadercache\\D3D12\\";
 
-    // Tally for LogAndResetCacheStats. Compilation is single-threaded, so plain ints are enough.
     int g_CacheHits = 0;
     int g_CacheMisses = 0;
 
-    // FNV-1a 64. These only have to notice a file the user edited; a collision costs a stale shader.
-    constexpr uint64_t kFnvOffset = 1469598103934665603ull;
-    constexpr uint64_t kFnvPrime = 1099511628211ull;
+    using ShaderCacheHash::HashBytes;
+    using ShaderCacheHash::HashString;
 
-    uint64_t HashBytes( const void* data, size_t size, uint64_t seed = kFnvOffset ) {
-        const unsigned char* p = static_cast<const unsigned char*>( data );
-        uint64_t h = seed;
-        for ( size_t i = 0; i < size; ++i ) { h ^= p[i]; h *= kFnvPrime; }
-        return h;
-    }
-    uint64_t HashString( const char* str, uint64_t seed = kFnvOffset ) {
-        return str ? HashBytes( str, strlen( str ), seed ) : HashBytes( "", 0, seed );
+    uint64_t HashFileContents( const std::string& path ) {
+        std::ifstream in( path, std::ios::binary );
+        if ( !in ) return 0;
+        std::string data;
+        data.assign( std::istreambuf_iterator<char>( in ), std::istreambuf_iterator<char>() );
+        if ( data.empty() ) return 0;
+        const uint64_t h = HashBytes( data.data(), data.size() );
+        return h ? h : 1;
     }
 
-    /** DXC's own version, so upgrading dxcompiler.dll invalidates everything it produced. Queried once;
-        0 when DXC is unavailable. */
+    // Deliberately not the GPU adapter/driver identity: DXIL is portable IR produced by these two
+    // DLLs alone; the driver JITs it to native ISA later using its own separate, self-invalidating cache.
     uint64_t DxcVersionHash() {
         static uint64_t s_hash = [] () -> uint64_t {
-            PFN_DXC_CREATE_INSTANCE create = ResolveDxcCreateInstance();
-            if ( !create ) return 0;
-            ComPtr<IDxcCompiler3> compiler;
-            if ( FAILED( create( kClsidDxcCompiler, IID_PPV_ARGS( compiler.GetAddressOf() ) ) ) ) return 0;
-            ComPtr<IDxcVersionInfo> version;
-            if ( FAILED( compiler.As( &version ) ) ) return 0;
-            UINT32 major = 0, minor = 0;
-            version->GetVersion( &major, &minor );
-            uint64_t h = HashBytes( &major, sizeof( major ) );
-            h = HashBytes( &minor, sizeof( minor ), h );
-            // Two builds of the same 1.x.y differ in codegen often enough to fold in the commit too.
-            ComPtr<IDxcVersionInfo2> version2;
-            if ( SUCCEEDED( version.As( &version2 ) ) ) {
-                UINT32 commitCount = 0; char* commitHash = nullptr;
-                if ( SUCCEEDED( version2->GetCommitInfo( &commitCount, &commitHash ) ) ) {
-                    h = HashBytes( &commitCount, sizeof( commitCount ), h );
-                    if ( commitHash ) { h = HashString( commitHash, h ); CoTaskMemFree( commitHash ); }
-                }
+            if ( !ResolveDxcCreateInstance() ) return 0;   // ensures dxcompiler.dll + dxil.dll are loaded
+
+            HMODULE hCompiler = GetModuleHandleA( "dxcompiler.dll" );
+            HMODULE hDxil = GetModuleHandleA( "dxil.dll" );
+            if ( !hCompiler || !hDxil ) return 0;
+
+            char compilerPath[MAX_PATH] = {};
+            char dxilPath[MAX_PATH] = {};
+            if ( !GetModuleFileNameA( hCompiler, compilerPath, MAX_PATH ) ||
+                !GetModuleFileNameA( hDxil, dxilPath, MAX_PATH ) ) {
+                return 0;
             }
+
+            const uint64_t hCompilerFile = HashFileContents( compilerPath );
+            const uint64_t hDxilFile = HashFileContents( dxilPath );
+            if ( hCompilerFile == 0 || hDxilFile == 0 ) return 0;
+
+            uint64_t h = HashBytes( &hCompilerFile, sizeof( hCompilerFile ) );
+            h = HashBytes( &hDxilFile, sizeof( hDxilFile ), h );
             return h ? h : 1;   // never 0 on success — 0 is the "unavailable" sentinel
         }( );
         return s_hash;

--- a/D3D11Engine/D3D12Engine/D3D12Sky.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Sky.cpp
@@ -47,7 +47,7 @@ namespace {
         UINT  CloudIndex;
         UINT  NightIndex;
         UINT  MoonIndex;
-        UINT  Pad0;
+        float MoonRotationAngle;   // radians, clockwise from screen-up - see MoonSpriteInfo::RotationAngle
         float MoonCenterPx[2];
         float MoonHalfSizePx[2];
         float MoonColor[4];
@@ -192,6 +192,7 @@ bool D3D12GraphicsEngine::DrawAtmosphereSkyDome() {
     matCb.CloudIndex = SkyTextureSlot( sky->GetCloudTextureGfx() );
     matCb.NightIndex = SkyTextureSlot( sky->GetNightTextureGfx() );
     matCb.MoonIndex = ZenTextureSlot( moon.Texture );
+    matCb.MoonRotationAngle = moon.RotationAngle;
     matCb.MoonCenterPx[0] = moon.CenterPx[0];
     matCb.MoonCenterPx[1] = moon.CenterPx[1];
     matCb.MoonHalfSizePx[0] = moon.HalfSizePx[0];

--- a/D3D11Engine/D3D12Engine/D3D12Sky.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Sky.cpp
@@ -31,6 +31,7 @@
 #include "../GMesh.h"
 #include "../WorldObjects.h"
 #include "../VertexTypes.h"
+#include "../zCWorld.h"
 #include "../zCTexture.h"
 #include "../D3D7/MyDirectDrawSurface7.h"
 
@@ -178,6 +179,13 @@ bool D3D12GraphicsEngine::DrawAtmosphereSkyDome() {
     // The moon (planets[1]) — the one thing the fixed-function sky drew that the bare scattering dome does
     // not. GSky resolves the placement (shared with D3D11's sky, which composites the same sprite); all this
     // backend adds is the bindless slot. Composited by the dome's own pixel shader, so it costs no extra draw.
+    // EnsureInit() forces planets[1].mesh to exist, since this path never calls RenderSkyPre() itself.
+    if ( auto loadedWorld = Engine::GAPI->GetLoadedWorldInfo(); loadedWorld && loadedWorld->MainWorld ) {
+        if ( auto skyCtrl = loadedWorld->MainWorld->GetSkyControllerOutdoor(); skyCtrl ) {
+            skyCtrl->EnsureInit();
+        }
+    }
+
     const MoonSpriteInfo moon = sky->ResolveMoonSprite( m_Resolution );
 
     SkyMaterialConsts matCb = {};

--- a/D3D11Engine/D3D12Engine/D3D12StateCache.h
+++ b/D3D11Engine/D3D12Engine/D3D12StateCache.h
@@ -395,6 +395,11 @@ public:
     }
 
 private:
+    // TransitionBarriers()/UAVBarriers() split a caller's batch into chunks of at most
+    // kMaxBatchedBarriers (see D3D12Barrier.cpp) and issue one grouped Barrier() call per chunk.
+    void TransitionBarriersChunk( const D3D12ResourceTransition* transitions, UINT count );
+    void UAVBarriersChunk( ID3D12Resource* const* resources, UINT count, D3D12_BARRIER_SYNC syncHint );
+
     static constexpr UINT kMaxViewports = 4;
     static constexpr UINT kInvalidCount = 0xFFFFFFFFu;
 

--- a/D3D11Engine/D3D12Engine/D3D12VobArena.h
+++ b/D3D11Engine/D3D12Engine/D3D12VobArena.h
@@ -79,6 +79,25 @@ public:
         return it == m_Ranges.end() ? nullptr : &it->second;
     }
 
+    /** Drops `mesh` from every list the arena tracks it in - called from D3D12GraphicsEngine::
+        OnMeshInfoDestroyed right before the MeshInfo (and its Vertices/Indices) are freed. A MeshInfo can be
+        deleted independently of Reset() (e.g. a shared MeshVisualInfo's last VOB reference dropping via
+        SharedVisualRegistry::Release() while the world stays loaded), and without this the next Reallocate()
+        walks m_Resident and re-uploads from freed memory - a use-after-free that surfaces as a garbage
+        `sizeInBytes` in UploadBufferData. Leaves the mesh's reserved vertex/index range as dead space in the
+        buffers (no compaction) rather than reflow every later range; cheap and safe, and the next full world
+        reload (Reset()) reclaims it anyway. Safe to call from any thread - takes the same lock QueueVisual
+        does and only otherwise touches state that only Flush() (main thread) mutates, exactly like Find(). */
+    void Forget( const MeshInfo* mesh ) {
+        {
+            std::lock_guard<std::mutex> lock( m_PendingMutex );
+            std::erase_if( m_Pending, [mesh]( const PendingMesh& p ) { return p.Mesh == mesh; } );
+        }
+        m_Ranges.erase( mesh );
+        std::erase( m_Resident, mesh );
+        std::erase( m_Dynamic, mesh );
+    }
+
     /** Sub-meshes whose vertices are rewritten every frame (animated static VOBs built from an .MMS —
         either ZENGIN's CPU deform or the GPU morph fold). Their arena range holds the CONVERSION pose
         after upload and has to be refreshed from the mesh's own vertex buffer once per frame; the engine

--- a/D3D11Engine/GSky.cpp
+++ b/D3D11Engine/GSky.cpp
@@ -518,21 +518,44 @@ MoonSpriteInfo GSky::ResolveMoonSprite( const INT2& resolution ) {
     const float scale = moon->size / viewPos.z;
     const XMVECTOR centreView = XMVectorSet( viewPos.x * scale, viewPos.y * scale, moon->size, 1.0f );
     constexpr float kQuadHalfExtent = 50.0f;   // CreateQuadMesh spans -50..+50 on both axes
-    const XMVECTOR edgeXView = XMVectorAdd( centreView, XMVectorSet( kQuadHalfExtent, 0.0f, 0.0f, 0.0f ) );
     const XMVECTOR edgeYView = XMVectorAdd( centreView, XMVectorSet( 0.0f, kQuadHalfExtent, 0.0f, 0.0f ) );
 
-    XMFLOAT3 c, ex, ey;
+    XMFLOAT3 c, ey;
     XMStoreFloat3( &c, XMVector3TransformCoord( centreView, proj ) );
-    XMStoreFloat3( &ex, XMVector3TransformCoord( edgeXView, proj ) );
     XMStoreFloat3( &ey, XMVector3TransformCoord( edgeYView, proj ) );
 
     const float w = static_cast<float>( resolution.x );
     const float h = static_cast<float>( resolution.y );
     out.CenterPx[0] = ( c.x * 0.5f + 0.5f ) * w;
     out.CenterPx[1] = ( c.y * -0.5f + 0.5f ) * h;
-    out.HalfSizePx[0] = std::abs( ex.x - c.x ) * 0.5f * w;
-    out.HalfSizePx[1] = std::abs( ey.y - c.y ) * 0.5f * h;
-    if ( out.HalfSizePx[0] < 0.5f || out.HalfSizePx[1] < 0.5f ) return out;   // sub-pixel: nothing to draw
+
+    // Derived from the Y edge only and reused for both axes: zCCamera's fovV = fovH*(ydim/xdim) (a
+    // degree-linear, not tan-linear, approximation) makes proj._11 and proj._22 disagree off 4:3, so
+    // per-axis half-sizes stretched the sprite with screen aspect. This keeps it a uniform square.
+    const float halfSizePx = std::abs( ey.y - c.y ) * 0.5f * h;
+    out.HalfSizePx[0] = halfSizePx;
+    out.HalfSizePx[1] = halfSizePx;
+    if ( halfSizePx < 0.5f ) return out;   // sub-pixel: nothing to draw
+
+    // Parallactic tilt: RenderDecal is screen-locked (never rotates), but a real moon's "up" tracks world-up
+    // projected onto the sky at its position. Build that tangent-space up axis and measure its on-screen tilt.
+    constexpr XMVECTORF32 kWorldUp = { 0.0f, 1.0f, 0.0f, 0.0f };
+    const XMVECTOR dirV = XMLoadFloat3( &dirWS );
+    XMVECTOR rightAxisWorld = XMVector3Cross( kWorldUp, dirV );
+    if ( XMVectorGetX( XMVector3LengthSq( rightAxisWorld ) ) > 1e-6f ) {   // else: moon at the zenith, singular
+        rightAxisWorld = XMVector3Normalize( rightAxisWorld );
+        const XMVECTOR upAxisWorld = XMVector3Cross( dirV, rightAxisWorld );
+        const XMVECTOR upAxisView = XMVector3TransformNormal( upAxisWorld, view );
+
+        const XMVECTOR tiltPointView = XMVectorAdd( centreView, XMVectorScale( upAxisView, kQuadHalfExtent ) );
+        XMFLOAT3 tiltNdc;
+        XMStoreFloat3( &tiltNdc, XMVector3TransformCoord( tiltPointView, proj ) );
+
+        const float dx = ( tiltNdc.x - c.x ) * w;
+        const float dy = ( tiltNdc.y - c.y ) * -h;
+        if ( dx != 0.0f || dy != 0.0f )
+            out.RotationAngle = atan2f( dx, -dy );
+    }
 
     out.Texture = tex;
     out.Color[0] = res.x / 255.0f;

--- a/D3D11Engine/GSky.h
+++ b/D3D11Engine/GSky.h
@@ -32,6 +32,9 @@ struct MoonSpriteInfo {
     float CenterPx[2] = { 0.0f, 0.0f };
     float HalfSizePx[2] = { 0.0f, 0.0f };
     float Color[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+
+    /** Radians, clockwise from screen-up - the moon's parallactic tilt. 0 at the zenith (tilt undefined). */
+    float RotationAngle = 0.0f;
 };
 
 class zCTexture;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -936,6 +936,7 @@ void GothicAPI::ResetVobs() {
     // Holds indices into the (now gone) sector arrays and BspInfo::SectorIds - must not outlive them.
     PortalCuller.Clear();
     DynamicallyAddedVobs.clear();
+    DynamicMeshVobs.clear();   // non-owning, aliases VobMap's VobInfo* -- deleted below via VobMap, not here
     DecalVobs.clear();
     VobsByVisual.clear();
     SkeletalVobMap.clear();
@@ -2319,6 +2320,14 @@ void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world, bool tearDownLight ) {
         }
     }
 
+    for ( size_t i = 0; i< DynamicMeshVobs.size(); ++i ) {
+        if ( DynamicMeshVobs[i]->Vob == vob ) {
+            DynamicMeshVobs[i] = DynamicMeshVobs.back();
+            DynamicMeshVobs.pop_back();
+            break;
+        }
+    }
+
     // Erase it from vob-map
     auto vit = VobMap.find( vob );
     if ( vit != VobMap.end() ) {
@@ -2432,6 +2441,9 @@ void GothicAPI::OnAddVob( zCVob* vob, zCWorld* world ) {
                 }
                 // Add to map
                 VobsByVisual[vob->GetVisual()].push_back( vi );
+
+                // Non-static (StaticVob==false) registry for the D3D12 point-shadow dynamic overlay; see GetDynamicMeshVobs().
+                if ( !vob->GetFlags().StaticVob ) DynamicMeshVobs.push_back( vi );
 
                 // Inventory vobs are deliberately left out of this: they are added and removed once per slot per
                 // frame while a container is open, and the engine-side notification is world-scoped work
@@ -4516,6 +4528,8 @@ void GothicAPI::CollectVisibleVobs(
             vii.windStrenth = 0.0f;
             vii.canBeAffectedByPlayer = 0;
             vii.GP_Slot |= playerFocusVob == it->Vob ? 1 << 31 : 0;
+            // Bit 30: StaticVob flag, read by the D3D12 point-shadow static-VOB gather (CPU-only, no shader use).
+            vii.GP_Slot |= it->Vob->GetFlags().StaticVob ? 1u << 30 : 0;
 
             zTAnimationMode aniMode = it->Vob->GetVisualAniMode();
             if ( aniMode != zVISUAL_ANIMODE_NONE ) {
@@ -5428,6 +5442,10 @@ std::vector<SkeletalVobInfo*>& GothicAPI::GetAnimatedSkeletalMeshVobs() {
 
 std::vector<VobInfo*>& GothicAPI::GetDynamicallyAddedVobs() {
     return DynamicallyAddedVobs;
+}
+
+std::vector<VobInfo*>& GothicAPI::GetDynamicMeshVobs() {
+    return DynamicMeshVobs;
 }
     
 /** Returns a texture from the given surface */

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -564,6 +564,10 @@ public:
     std::vector<SkeletalVobInfo*>& GetAnimatedSkeletalMeshVobs();
     std::vector<VobInfo*>& GetDynamicallyAddedVobs();
 
+    /** Non-skeletal mesh vobs with StaticVob clear (items) -- moving-caster source for the D3D12
+     *  point-shadow dynamic overlay, mirroring GetSkeletalMeshVobs. */
+    std::vector<VobInfo*>& GetDynamicMeshVobs();
+
     /** Returns the current cameraposition */
     XMFLOAT3 GetCameraPosition();
     XMVECTOR XM_CALLCONV GetCameraPositionXM();
@@ -1111,6 +1115,8 @@ private:
     /** List of vobs with skeletal meshes (Having a zCModel-Visual) */
     std::vector<SkeletalVobInfo*> SkeletalMeshVobs;
     std::vector<SkeletalVobInfo*> AnimatedSkeletalVobs;
+    /** Non-skeletal mesh vobs added with GetFlags().StaticVob clear -- see GetDynamicMeshVobs(). */
+    std::vector<VobInfo*> DynamicMeshVobs;
     std::vector<TransparencyVobInfo> TransparencyVobs;
     std::vector<SkeletalVobInfo*> VNSkeletalVobs;
 

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -176,9 +176,10 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_SkyLayerState = 0x5A0;
         static const unsigned int Offset_SkyLayerState0 = 0x120;
         static const unsigned int Offset_SkyLayerState1 = 0x124;
-        static const unsigned int Interpolate = 0x005E8C20;
-        static const unsigned int Offset_InitDone = 0x7C;
-        static const unsigned int Init = 0x005E6A00;*/
+        static const unsigned int Interpolate = 0x005E8C20;*/
+
+        static const unsigned int Offset_InitDone = 0x68;
+        static const unsigned int Init = 0x005BCA80;
 
         static const unsigned int GetUnderwaterFX = 0x5baaa0;
         static const unsigned int Offset_FarZ = 0x56C;

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -137,6 +137,9 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_LastMasterTime = 0x70;
         static const unsigned int Offset_MasterState = 0x74;
 
+        static const unsigned int Offset_InitDone = 0x68;
+        static const unsigned int Init = 0x005DA640;
+
         static const unsigned int GetUnderwaterFX = 0x5D8600;
 		static const unsigned int Offset_FarZ = 0x56C;
         static const unsigned int Offset_Color = 0x580;

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -122,7 +122,7 @@ struct GothicMemoryLocations {
         static const unsigned int Offset_Color = 0x594;
         //static const unsigned int Interpolate = 0x005E8C20;
         static const unsigned int Offset_InitDone = 0x7C;
-        //static const unsigned int Init = 0x005E6A00;
+        static const unsigned int Init = 0; // not determined for Spacer.exe
         static const unsigned int GetUnderwaterFX = 0x0076AE40;
 
         static const unsigned int SetCameraLocationHint = 0x00526860;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1642,7 +1642,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         ImGui::SetItemTooltip("Lets things like torches and lights from players also cast shadow for players.");
 
         ImGui::Checkbox( "Disable static Pointlights", &settings.DisableStaticPointlights );
-        ImGui::SetItemTooltip("D3D12 only. Drops every static light from the scene.\n"
+        ImGui::SetItemTooltip("Drops every static light from the scene.\n"
             "Gothic fills rooms and caves with 10-30 co-located 'atmospheric' static lights that only raise the\n"
             "ambient level; with HDR output they stack up and make interiors far too bright.");
 

--- a/D3D11Engine/ShaderCacheHash.h
+++ b/D3D11Engine/ShaderCacheHash.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <cstdint>
+#include <cstddef>
+#include <cstring>
+
+// Shared FNV-1a 64 hashing for the D3D11/D3D12 on-disk shader caches.
+namespace ShaderCacheHash {
+    constexpr uint64_t kOffset = 1469598103934665603ull;
+    constexpr uint64_t kPrime = 1099511628211ull;
+
+    inline uint64_t HashBytes( const void* data, size_t size, uint64_t seed = kOffset ) {
+        const unsigned char* p = static_cast<const unsigned char*>( data );
+        uint64_t h = seed;
+        for ( size_t i = 0; i < size; ++i ) { h ^= p[i]; h *= kPrime; }
+        return h;
+    }
+    inline uint64_t HashString( const char* str, uint64_t seed = kOffset ) {
+        return str ? HashBytes( str, strlen( str ), seed ) : HashBytes( "", 0, seed );
+    }
+}

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -45,6 +45,7 @@ TextureCubeArray TX_ShadowCubeArray : register( t11 );
 // Per-slot overlay holding ONLY this frame's moving (skeletal) casters; min'd with the static cube above.
 // See PLS_SHADOW_HAS_DYNAMIC in include/PointLightShadows.h.
 TextureCubeArray TX_ShadowDynCubeArray : register( t12 );
+TextureCubeArray TX_ShadowStaticCubeArray : register( t13 ); // low-res static-only tier, PLS_SHADOW_TIER_LOW
 
 RWTexture2D<float4> RW_HDR : register( u0 );
 
@@ -122,7 +123,7 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
 
             // Apply shadow if this light has a shadow cubemap and contribution is non-negligible
             if ( light.ShadowCubeIndex >= 0 && any( lighting > 0.001f ) ) {
-                float shadow = PLS_SampleShadowCubeArray( TX_ShadowCubeArray, TX_ShadowDynCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex );
+                float shadow = PLS_SampleShadowCubeArray( TX_ShadowCubeArray, TX_ShadowDynCubeArray, TX_ShadowStaticCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex );
                 lighting *= shadow;
             }
 

--- a/D3D11Engine/Shaders/D3D12/Sky.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Sky.hlsl
@@ -31,7 +31,7 @@ cbuffer SkyMaterialCB : register( b3 )
     uint CloudIndex;   // SRV heap slot of the cloud/day texture (bindless); 0xFFFFFFFF = none
     uint NightIndex;   // SRV heap slot of the star/night texture (bindless); 0xFFFFFFFF = none
     uint MoonIndex;    // SRV heap slot of the moon texture (bindless); 0xFFFFFFFF = don't draw the moon
-    uint _SkyPad0;
+    float MoonRotationAngle;   // radians, clockwise from screen-up - see MoonSpriteInfo::RotationAngle
 
     // The moon is composited as a screen-space sprite rather than drawn as geometry, because that is exactly
     // what the fixed-function sky does: zCSkyControler_Outdoor::RenderPlanets projects the planet DIRECTION to
@@ -113,9 +113,12 @@ float3 ApplyMoon( float3 atmoColor, float2 pixelPos )
 {
     if ( MoonIndex == 0xFFFFFFFF ) return atmoColor;
 
-    // Pixel -> sprite UV. The sprite is axis-aligned in screen space (RenderDecal resets the camera rotation,
-    // making the quad parallel to the screen plane), so this is a plain rect map.
-    float2 uv = ( pixelPos - MoonCenterPx ) / MoonHalfSizePx * 0.5f + 0.5f;
+    // Pixel -> sprite UV, counter-rotated by MoonRotationAngle to apply the parallactic tilt.
+    float2 delta = pixelPos - MoonCenterPx;
+    float sinR, cosR;
+    sincos( MoonRotationAngle, sinR, cosR );
+    delta = float2( delta.x * cosR + delta.y * sinR, delta.y * cosR - delta.x * sinR );
+    float2 uv = delta / MoonHalfSizePx * 0.5f + 0.5f;
     if ( any( uv != saturate( uv ) ) ) return atmoColor;   // outside the sprite
 
     Texture2D<float4> moonTex = ResourceDescriptorHeap[MoonIndex];

--- a/D3D11Engine/Shaders/PS_Atmosphere.hlsl
+++ b/D3D11Engine/Shaders/PS_Atmosphere.hlsl
@@ -27,6 +27,9 @@ cbuffer MoonCB : register( b2 )
 	// rgb = RenderPlanets' color0->color1 tint by moon height, a = its accumulated fade (horizon, fog, rain).
 	// a == 0 means "not visible this frame" and no moon texture is bound.
 	float4 Moon_Color;
+
+	float Moon_RotationAngle;   // radians, clockwise from screen-up - the moon's parallactic tilt
+	float3 Moon_Pad0;
 };
 
 //--------------------------------------------------------------------------------------
@@ -106,9 +109,12 @@ PS_OUTPUT PSMain( PS_INPUT Input )
 	// deliberately no phase logic here.
 	if ( Moon_Color.a > 0.0f )
 	{
-		// Pixel -> sprite UV. The sprite is axis-aligned in screen space (RenderDecal resets the camera
-		// rotation, making the quad parallel to the screen plane), so this is a plain rect map.
-		float2 moonUV = ( Input.vPosition.xy - Moon_CenterPx ) / Moon_HalfSizePx * 0.5f + 0.5f;
+		// Pixel -> sprite UV, counter-rotated by Moon_RotationAngle to apply the parallactic tilt.
+		float2 delta = Input.vPosition.xy - Moon_CenterPx;
+		float sinR, cosR;
+		sincos( Moon_RotationAngle, sinR, cosR );
+		delta = float2( delta.x * cosR + delta.y * sinR, delta.y * cosR - delta.x * sinR );
+		float2 moonUV = delta / Moon_HalfSizePx * 0.5f + 0.5f;
 		if ( all( moonUV == saturate( moonUV ) ) )
 		{
 			float4 m = TX_Moon.Sample( SS_Clamp, moonUV );

--- a/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
+++ b/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
@@ -139,6 +139,7 @@ TextureCubeArray FP_ShadowCubeArray : register( t11 );
 // Per-slot overlay holding ONLY this frame's moving (skeletal) casters; min'd with the static cube above.
 // t12/t13 are the shadow and AO masks, so this lands at t14. See PLS_SHADOW_HAS_DYNAMIC in PointLightShadows.h.
 TextureCubeArray FP_ShadowDynCubeArray : register( t14 );
+TextureCubeArray FP_ShadowStaticCubeArray : register( t15 ); // low-res static-only tier, PLS_SHADOW_TIER_LOW
 
 // ============================================
 // Point Light Accumulation (matches CS_TiledShading.hlsl)
@@ -205,7 +206,7 @@ float3 FP_ComputePointLighting(
             // Don't fetch shadows if the light contribution is effectively zero.
             if ( light.ShadowCubeIndex >= 0 && any(lighting > 0.001f) )
             {
-                float shadow = PLS_SampleShadowCubeArray( FP_ShadowCubeArray, FP_ShadowDynCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex );
+                float shadow = PLS_SampleShadowCubeArray( FP_ShadowCubeArray, FP_ShadowDynCubeArray, FP_ShadowStaticCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex );
                 lighting *= shadow;
             }
 

--- a/D3D11Engine/Shaders/include/PointLightShadows.h
+++ b/D3D11Engine/Shaders/include/PointLightShadows.h
@@ -6,12 +6,12 @@
 
 #if !defined(__cplusplus)
 
-// TiledPointLight::ShadowCubeIndex encoding: -1 = unshadowed, else (slot | flags). Bit 30 marks that the slot
-// also has a valid dynamic (skeletal overlay) cube in the SECOND array, which must be sampled and min'd with
-// the static one. Keeping the flag in bit 30 leaves the value positive, so "ShadowCubeIndex >= 0" still means
-// shadowed. Mirrors D3D11TiledDeferredShading.h.
+// TiledPointLight::ShadowCubeIndex encoding: -1 = unshadowed, else (slot | flags). Bit 30 = slot also has a
+// dynamic overlay cube (min'd with the static sample). Bit 29 = slot lives in the low-res static-only tier
+// instead of the full-res one (never set together with bit 30). Mirrors D3D11TiledDeferredShading.h.
 static const int PLS_SHADOW_HAS_DYNAMIC = 0x40000000;
-static const int PLS_SHADOW_SLOT_MASK = 0x3FFFFFFF;
+static const int PLS_SHADOW_TIER_LOW = 0x20000000;
+static const int PLS_SHADOW_SLOT_MASK = 0x1FFFFFFF;
 
 static const int PLS_SHADOW_BLUR_COUNT = 8;
 static const float2 PLS_SHADOW_BLUR_OFFSETS[PLS_SHADOW_BLUR_COUNT] = {
@@ -175,6 +175,7 @@ float PLS_SampleShadowCube(
 float PLS_SampleShadowCubeArray(
     TextureCubeArray shadowCubeArray,
     TextureCubeArray dynShadowCubeArray,
+    TextureCubeArray staticOnlyCubeArray,
     SamplerComparisonState samplerState,
     float3 wsPosition,
     float3 N,
@@ -183,7 +184,8 @@ float PLS_SampleShadowCubeArray(
     int encodedIndex )
 {
     int cubeIndex = encodedIndex & PLS_SHADOW_SLOT_MASK;
-    bool hasDyn = ( encodedIndex & PLS_SHADOW_HAS_DYNAMIC ) != 0;
+    bool tierLow = ( encodedIndex & PLS_SHADOW_TIER_LOW ) != 0;
+    bool hasDyn = !tierLow && ( encodedIndex & PLS_SHADOW_HAS_DYNAMIC ) != 0;
 
     float3 dir;
     float compareDistance;
@@ -207,15 +209,20 @@ float PLS_SampleShadowCubeArray(
         float3 perturbedDir = normalize( dir + (right * rotatedKernel.x + up * rotatedKernel.y) * fixedBlurScale );
         float4 sampleCoord = float4( perturbedDir, (float)cubeIndex );
 
-        // The slot keeps its STATIC depth in shadowCubeArray and this frame's moving (skeletal) casters in a
-        // SEPARATE array; taking the min of the two comparisons is "occluded by either", which is exactly what
-        // the old composited cube produced - minus the per-slot CopySubresourceRegion that used to build it
-        // every update. The flag is only set for slots whose overlay was actually rendered, so a light with no
-        // NPC nearby pays for no extra sample at all.
-        float s = shadowCubeArray.SampleCmpLevelZero( samplerState, sampleCoord, compareDistance - fixedBias );
-        if ( hasDyn )
+        float s;
+        if ( tierLow )
         {
-            s = min( s, dynShadowCubeArray.SampleCmpLevelZero( samplerState, sampleCoord, compareDistance - fixedBias ) );
+            s = staticOnlyCubeArray.SampleCmpLevelZero( samplerState, sampleCoord, compareDistance - fixedBias );
+        }
+        else
+        {
+            // min() of the static and moving-caster samples reproduces the old composited cube without
+            // needing to re-copy the static depth into it on every dynamic update.
+            s = shadowCubeArray.SampleCmpLevelZero( samplerState, sampleCoord, compareDistance - fixedBias );
+            if ( hasDyn )
+            {
+                s = min( s, dynShadowCubeArray.SampleCmpLevelZero( samplerState, sampleCoord, compareDistance - fixedBias ) );
+            }
         }
         shd += s;
     }
@@ -225,7 +232,7 @@ float PLS_SampleShadowCubeArray(
     // Shadow Distance Fading
     float distanceToLight = length(wsPosition - lightPosWorld);
     float normalizedDist = saturate(distanceToLight / lightRange);
-    
+
     return PLS_ApplyShadowDistanceFade( finalShadow, normalizedDist );
 }
 

--- a/D3D11Engine/Shaders/include/PointLightShadows.h
+++ b/D3D11Engine/Shaders/include/PointLightShadows.h
@@ -82,9 +82,10 @@ float3 PLS_ComputePointLightLighting(
 
 void PLS_PrepareShadowSampling(
     float3 wsPosition,
-    float3 N, 
+    float3 N,
     float3 lightPosWorld,
     float lightRange,
+    bool tierLow,
     out float3 dir,
     out float compareDistance,
     out float fixedBias,
@@ -119,6 +120,15 @@ void PLS_PrepareShadowSampling(
 
     float baseBlur = lerp( 0.02f, 0.08f, depthCurve );
 
+    // The low-res static-only tier packs the same 90-deg cube face into 1/4 the texels per axis, so its
+    // texels cover ~4x more world space at the same distance. Widen the bias/blur to match (mirrors D3D12's
+    // `coarse` factor in PBRLighting.hlsl's SamplePointShadow) - otherwise the kernel tuned for the full-res
+    // array is far narrower than that tier's actual texel footprint and the PCF barely blurs anything,
+    // leaving the low-res cube's texel edges visibly blocky.
+    float tierScale = tierLow ? 4.0f : 1.0f;
+    fixedBias *= tierScale;
+    baseBlur *= tierScale;
+
     float noise = PLS_AggressiveNoise(wsPosition * 50.0f);
     fixedBlurScale = baseBlur * lerp(0.5f, 1.5f, noise);
 
@@ -148,7 +158,7 @@ float PLS_SampleShadowCube(
     float cosA;
 
     PLS_PrepareShadowSampling(
-        wsPosition, N, lightPosWorld, lightRange,
+        wsPosition, N, lightPosWorld, lightRange, false,
         dir, compareDistance, fixedBias, fixedBlurScale,
         right, up, sinA, cosA );
 
@@ -197,7 +207,7 @@ float PLS_SampleShadowCubeArray(
     float cosA;
 
     PLS_PrepareShadowSampling(
-        wsPosition, N, lightPosWorld, lightRange,
+        wsPosition, N, lightPosWorld, lightRange, tierLow,
         dir, compareDistance, fixedBias, fixedBlurScale,
         right, up, sinA, cosA );
 

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -75,6 +75,10 @@ MeshInfo::~MeshInfo() {
     //Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize -= Indices.size() * sizeof(VERTEX_INDEX);
     //Engine::GAPI->GetRendererState().RendererInfo.VOBVerticesDataSize -= Vertices.size() * sizeof(ExVertexStruct);
 
+    // Drop any raw MeshInfo* a backend cached outside this object's own owner (D3D12's VOB arena
+    // mega-buffer) BEFORE Vertices/Indices below are torn down - see OnMeshInfoDestroyed's comment.
+    if ( Engine::GraphicsEngine ) Engine::GraphicsEngine->OnMeshInfoDestroyed( this );
+
     MeshVertexBuffer.reset();
     MeshPositionBuffer.reset();
     MeshIndexBuffer.reset();

--- a/D3D11Engine/oCNPC.h
+++ b/D3D11Engine/oCNPC.h
@@ -50,10 +50,16 @@ public:
 
         hook_infunc
 
-            if ( /*((zCVob *)thisptr)->GetVisual() || */Engine::GAPI->GetSkeletalVobByVob( thisptr ) ) {
-                // This may causes the vob to be added and removed multiple times, but makes sure we get all changes of armor
-                Engine::GAPI->OnRemovedVob( thisptr, thisptr->GetHomeWorld() );
-                Engine::GAPI->OnAddVob( thisptr, thisptr->GetHomeWorld() );
+            // oCNpc::InitModel only rewrites the zCModel's mesh library in place (RemoveMeshLibAll +
+            // ApplyMeshLib on armor equip/unequip) - the vob's visual identity doesn't change, so there's
+            // no need to tear the vob out of the BSP/light/instancing state via Remove+Add. Re-run the
+            // extraction and re-assign it explicitly (mirroring OnAddVob) rather than relying on
+            // LoadzCModelData reusing the same cached SkeletalMeshVisualInfo - OnVisualDeleted can null
+            // out and drop that cache entry (a genuine SetVisual model swap), and if that raced ahead of
+            // this call, re-pointing VisualInfo is what keeps the already-registered vob from going stuck
+            // on a null/stale visual instead of picking up the freshly re-created one.
+            if ( SkeletalVobInfo* svi = Engine::GAPI->GetSkeletalVobByVob( thisptr ) ) {
+                svi->VisualInfo = Engine::GAPI->LoadzCModelData( static_cast<oCNPC*>(thisptr) );
             }
 
         hook_outfunc

--- a/D3D11Engine/zCSkyController_Outdoor.h
+++ b/D3D11Engine/zCSkyController_Outdoor.h
@@ -431,6 +431,20 @@ public:
         return pos;
     }
 
+    bool IsInitDone() {
+        return *reinterpret_cast<int*>(THISPTR_OFFSET( GothicMemoryLocations::zCSkyController_Outdoor::Offset_InitDone )) != 0;
+    }
+
+    /** zCSkyControler_Outdoor::Init() - what RenderSkyPre() lazily calls if !initDone, minus the full FF sky
+        prep RenderSkyPre() does afterwards. No-op if the address isn't known for this build (Spacer). */
+    void EnsureInit() {
+        if ( IsInitDone() ) return;
+        if constexpr ( GothicMemoryLocations::zCSkyController_Outdoor::Init != 0 ) {
+            reinterpret_cast<void( __fastcall* )( zCSkyController_Outdoor* )>
+                ( GothicMemoryLocations::zCSkyController_Outdoor::Init )( this );
+        }
+    }
+
     /** planets[i] — [0] sun, [1] moon. Live engine data, so Gothic.ini's zMoonSize/zMoonName and any
         script/mod tweak to the tint or size are picked up automatically. */
     zCSkyPlanet* GetPlanet( int index ) {


### PR DESCRIPTION
general:
- simplify Moon init code to just calling `zCSkyController_Outdoor::Init` instead of a whole `PreRenderSky`
- `original_oCNPCInitModel` no longer Remove+Adds the Npc vob, instead it just calls `LoadzCModelData` again on it.
- Moon is no longer a upwards-facing billboard, but is rotated/tilted acoording to its position

dx11:
- feat: on-disk shader cache
  - dx12 already had an on-disk shader cache, so naturally itranslated the caching to also work for  x11.
  - improves future startup times if a shader was already cached.
  - also improves settings switch time, like number of shadow cascades or shadow filtering, everything that needs a full shader-reload
- fix: clustered lighting backport from dx12.
  - split static lights from dynamic lights
  - sort dynamic light sources by distance to camera, to prioritize near lights

dx12:
- fix crash due to cached `MeshInfo*` going stale
- Chunk the pointlight barriers instead of falling back to per-subresource barrier.
- fix static shadow cache being invalidated when NPCs smoked or drank beer.
  - static shadow cache now also caches all static mesh vobs of worlds (not items), not just world mesh.
- more DRED information. Log DRED information into log.txt instead of Debug output.