### PR TITLE
pointlights: Layered path now also uses packed-wrapped world mesh, improve "static-only" dynamic shadow filtering

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -6240,8 +6240,39 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
 
     void* lastTex = nullptr;
     if ( drawWorldCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh ) {
-        ActiveVS->UpdateBuffer( "Matrices_PerInstances", &identityMatrix, sizeof( identityMatrix ) );
         auto _ = RecordGraphicsEvent( GE_NAME( "DrawWorldMesh::Layered" ) );
+
+        // World-mesh sub-meshes don't own standalone GPU buffers - section->WorldMeshes /
+        // worldMeshCache only carry an index range (MeshInfo::BaseIndexLocation) into the single
+        // wrapped world mesh (Engine::GAPI->GetWrappedWorldMesh()), packed as ExVertexStructGPU -
+        // the same buffer ShadowPass_DrawWorldMesh/CSM draw from. VS_ExLayered's plain VS_INPUT
+        // can't decode that stream, so switch to the packed-decoding layered variant and bind the
+        // wrapped mesh once for this block; VOBs drawn afterward are unpacked ExVertexStruct and
+        // need VS_ExLayered back. FullStaticMesh (the FastShadows branch below) is the one
+        // exception - it's built as plain ExVertexStruct with its own buffer, so it keeps using
+        // whatever VS is already active.
+        //
+        // First pass: always draw the full (non-welded) index range - GetShadowAwareIndexCount(mesh,
+        // true) / mesh->BaseIndexLocation - as if every material were alpha-tested, mirroring
+        // DrawWorldAround's GS-path equivalent.
+        bool usedPackedWorldMeshVS = false;
+        auto ensurePackedWorldMeshVS = [&]() {
+            if ( usedPackedWorldMeshVS ) return;
+            usedPackedWorldMeshVS = true;
+            SetActiveVertexShader( VShaderID::VS_ExPackedLayered );
+            SetupVS_ExMeshDrawCall();
+            SetupVS_ExConstantBuffer();
+            ActiveVS->UpdateBuffer( "Matrices_PerInstances", &identityMatrix, sizeof( identityMatrix ) );
+            BindWrappedWorldMeshPacked( Engine::GAPI->GetWrappedWorldMesh() );
+        };
+        auto drawFromWrappedMeshInstanced = [&]( MeshInfo* mesh ) {
+            ensurePackedWorldMeshVS();
+            const unsigned int count = GetShadowAwareIndexCount( mesh, true );
+            if ( !count ) return;
+            Context->DrawIndexedInstanced( count, 6, mesh->BaseIndexLocation, 0, 0 );
+            Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnTriangles += count / 3;
+        };
+
         // Only use cache if we haven't already collected the vobs
         // TODO: Collect vobs in a different way than using the drawn sections!
         //		 The current solution won't use the cache at all when there are
@@ -6285,12 +6316,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
                     }
                 }
 
-                // Draw from wrapped mesh
-                MeshInfo* mesh = meshInfoByKey->second;
-                DrawVertexBufferInstancedIndexed( mesh->GetMeshVertexBuffer(),
-                    GetShadowAwareIndexBuffer( mesh, isAlpha ),
-                    GetShadowAwareIndexCount( mesh, isAlpha ),
-                    6 );
+                drawFromWrappedMeshInstanced( meshInfoByKey->second );
             }
         } else {
             Frustum f;
@@ -6350,15 +6376,17 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
                             }
                         }
 
-                        // Draw from wrapped mesh
-                        MeshInfo* mesh = meshInfoByKey->second;
-                        DrawVertexBufferInstancedIndexed( mesh->GetMeshVertexBuffer(),
-                            GetShadowAwareIndexBuffer( mesh, isAlpha ),
-                            GetShadowAwareIndexCount( mesh, isAlpha ),
-                            6 );
+                        drawFromWrappedMeshInstanced( meshInfoByKey->second );
                     }
                 }
             }
+        }
+
+        if ( usedPackedWorldMeshVS ) {
+            // Restore VS_ExLayered (plain unpacked ExVertexStruct) for the VOB/mob draws below.
+            SetActiveVertexShader( VShaderID::VS_ExLayered );
+            SetupVS_ExMeshDrawCall();
+            SetupVS_ExConstantBuffer();
         }
     }
     

--- a/D3D11Engine/ShaderIDs.h
+++ b/D3D11Engine/ShaderIDs.h
@@ -36,6 +36,7 @@ enum class VShaderID : size_t {
     VS_ExDepth,
     VS_ExPacked,
     VS_ExPackedCube,
+    VS_ExPackedLayered,
     COUNT
 };
 

--- a/D3D11Engine/ShaderRegistry.cpp
+++ b/D3D11Engine/ShaderRegistry.cpp
@@ -343,6 +343,11 @@ void ShaderRegistry::Build() {
         Shaders.push_back( ShaderInfo::make<VShaderID::VS_ExLayered>( "VS_ExLayered.hlsl" )
             .with_layout( VERTEX_INPUT_LAYOUT_1 ) );
 
+        // Decodes the wrapped world mesh (Engine::GAPI->GetWrappedWorldMesh(), packed
+        // ExVertexStructGPU, 36 B) - VS_ExLayered's plain VS_INPUT can't read that stream.
+        Shaders.push_back( ShaderInfo::make<VShaderID::VS_ExPackedLayered>( "VS_ExPackedLayered.hlsl" )
+            .with_layout( VERTEX_INPUT_LAYOUT_PACKED_EX ) );
+
         Shaders.push_back( ShaderInfo::make<VShaderID::VS_ExNodeLayered>( "VS_ExNodeLayered.hlsl" )
             .with_layout( VERTEX_INPUT_LAYOUT_1 )  );
 

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -123,7 +123,8 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
 
             // Apply shadow if this light has a shadow cubemap and contribution is non-negligible
             if ( light.ShadowCubeIndex >= 0 && any( lighting > 0.001f ) ) {
-                float shadow = PLS_SampleShadowCubeArray( TX_ShadowCubeArray, TX_ShadowDynCubeArray, TX_ShadowStaticCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex );
+                bool taaActive = JitterOffset.x != 0.0f || JitterOffset.y != 0.0f;
+                float shadow = PLS_SampleShadowCubeArray( TX_ShadowCubeArray, TX_ShadowDynCubeArray, TX_ShadowStaticCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex, taaActive );
                 lighting *= shadow;
             }
 

--- a/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
@@ -97,7 +97,8 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float ndl = max(0, dot(lightDir, normal));
 	
 	// Apply dynamic shadow
-	float shadow = PLS_SampleShadowCube(TX_ShadowCube, SS_Comp, wsPosition, wsNormal, Pl_PositionWorld, PL_Range);
+	bool taaActive = PL_JitterOffset.x != 0.0f || PL_JitterOffset.y != 0.0f;
+	float shadow = PLS_SampleShadowCube(TX_ShadowCube, SS_Comp, wsPosition, wsNormal, Pl_PositionWorld, PL_Range, taaActive);
 	//return float4(ndl.rrr,1);
 	
 	// Get rid of lighting on the backfaces of normalmapped surfaces

--- a/D3D11Engine/Shaders/VS_ExPackedLayered.hlsl
+++ b/D3D11Engine/Shaders/VS_ExPackedLayered.hlsl
@@ -1,0 +1,71 @@
+//--------------------------------------------------------------------------------------
+// World-mesh vertex shader for the packed 36-byte vertex (ExVertexStructGPU), for the
+// VS-layered (SV_RenderTargetArrayIndex-from-VS) point-light cube shadow path. Mirrors
+// VS_ExLayered.hlsl but decodes the packed stream like VS_ExPacked.hlsl. See
+// D3D11ShadowMap::RenderShadowCube's layered branch / DrawWorldAround_Layered.
+//--------------------------------------------------------------------------------------
+#include "Globals_VS_ExConstants.h"
+#include "VertexPacking.h"
+
+cbuffer Matrices_PerFrame : register( b0 )
+{
+	VS_ExConstantBuffer_PerFrame frame;
+};
+
+cbuffer Matrices_PerInstances : register( b1 )
+{
+	matrix M_World;
+};
+
+cbuffer cbPerCubeRender : register( b3 )
+{
+    matrix PCR_View[6];
+    matrix PCR_ViewProj[6];
+};
+
+//--------------------------------------------------------------------------------------
+// Input / Output structures
+//--------------------------------------------------------------------------------------
+struct VS_INPUT
+{
+    uint instanceID : SV_InstanceID;
+	float3 vPosition	: POSITION;
+	float2 vNormalOct	: NORMAL;    // octahedral-encoded (R16G16_SNORM)
+	float4 vTangent		: TANGENT;   // R10G10B10A2 - not needed for depth-only shadow rendering
+	float2 vTex1		: TEXCOORD0;
+	float2 vTex2		: TEXCOORD1;
+	float4 vDiffuse		: DIFFUSE;
+};
+
+struct VS_OUTPUT
+{
+    float2 vTexcoord : TEXCOORD0;
+    float2 vTexcoord2 : TEXCOORD1;
+    float4 vDiffuse : TEXCOORD2;
+    float3 vNormalVS : TEXCOORD4;
+    float3 vViewPosition : TEXCOORD5;
+    float4 vPosition : SV_POSITION;
+    uint RTIndex : SV_RenderTargetArrayIndex;
+};
+
+//--------------------------------------------------------------------------------------
+// Vertex Shader
+//--------------------------------------------------------------------------------------
+VS_OUTPUT VSMain( VS_INPUT Input )
+{
+	VS_OUTPUT Output;
+
+	float3 vNormal = DecodeOctNormal( Input.vNormalOct );
+
+    float3 positionWorld = mul(float4(Input.vPosition, 1), M_World).xyz;
+
+    Output.RTIndex = Input.instanceID;
+    Output.vPosition = mul(float4(positionWorld, 1), PCR_ViewProj[Input.instanceID]);
+    Output.vTexcoord2 = Input.vTex2;
+    Output.vTexcoord = Input.vTex1;
+    Output.vDiffuse = Input.vDiffuse;
+    Output.vNormalVS = mul(vNormal, (float3x3)mul(M_World, PCR_View[Input.instanceID]));
+    Output.vViewPosition = mul(float4(positionWorld, 1), PCR_View[Input.instanceID]);
+
+	return Output;
+}

--- a/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
+++ b/D3D11Engine/Shaders/include/ForwardPlusLighting.hlsl
@@ -206,7 +206,11 @@ float3 FP_ComputePointLighting(
             // Don't fetch shadows if the light contribution is effectively zero.
             if ( light.ShadowCubeIndex >= 0 && any(lighting > 0.001f) )
             {
-                float shadow = PLS_SampleShadowCubeArray( FP_ShadowCubeArray, FP_ShadowDynCubeArray, FP_ShadowStaticCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex );
+                // SQ_FrameIndex is only ever incremented while camera jitter (TAA/FSR) is baked into the
+                // projection (see D3D11ShadowMap.cpp's FillSunCSMConstantBuffer) - same "is TAA active" signal
+                // GetPoissonRotationSCForCascade uses above for the sun CSM.
+                bool taaActive = SQ_FrameIndex != 0;
+                float shadow = PLS_SampleShadowCubeArray( FP_ShadowCubeArray, FP_ShadowDynCubeArray, FP_ShadowStaticCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.Range, light.ShadowCubeIndex, taaActive );
                 lighting *= shadow;
             }
 

--- a/D3D11Engine/Shaders/include/PointLightShadows.h
+++ b/D3D11Engine/Shaders/include/PointLightShadows.h
@@ -25,6 +25,32 @@ static const float2 PLS_SHADOW_BLUR_OFFSETS[PLS_SHADOW_BLUR_COUNT] = {
     float2(-0.258169f, -0.912648f)
 };
 
+// Extra ring used only for the low-res static-only tier (STATIC_SHADOW_CUBE_SIZE, 32^2 faces). At that
+// resolution each texel covers a large solid angle, so the caster silhouette itself is blocky - not just
+// its edge. PLS_SHADOW_BLUR_OFFSETS alone (8 taps in a tight ring) isn't enough support to average that
+// away; combined with PLS_SHADOW_BLUR_TIER_LOW_COUNT taps and a wider radius (see PLS_PrepareShadowSampling's
+// tierLow blur boost) this ring pushes the PCF footprint across several texels so the steps blend into a
+// smooth gradient instead of visible squares.
+static const int PLS_SHADOW_BLUR_TIER_LOW_COUNT = 16;
+static const float2 PLS_SHADOW_BLUR_OFFSETS_TIER_LOW[PLS_SHADOW_BLUR_TIER_LOW_COUNT] = {
+    float2( 0.076849f, -0.078216f),
+    float2(-0.165415f,  0.370808f),
+    float2(-0.551062f, -0.407284f),
+    float2( 0.449733f, -0.518174f),
+    float2( 0.347526f,  0.730303f),
+    float2(-0.840654f,  0.134261f),
+    float2( 0.896791f,  0.038446f),
+    float2(-0.258169f, -0.912648f),
+    float2( 0.573813f,  0.398287f),
+    float2(-0.398287f,  0.573813f),
+    float2( 0.184238f,  0.982878f),
+    float2(-0.982878f, -0.184238f),
+    float2( 0.712698f, -0.701456f),
+    float2(-0.701456f, -0.712698f),
+    float2( 0.994522f,  0.104528f),
+    float2(-0.104528f,  0.994522f)
+};
+
 float PLS_AggressiveNoise(float3 p)
 {
     float3 p3  = frac(p * 0.1031f);
@@ -129,6 +155,14 @@ void PLS_PrepareShadowSampling(
     fixedBias *= tierScale;
     baseBlur *= tierScale;
 
+    // Texel-matching alone (tierScale) keeps the SAME relative footprint as the full-res tier, but at 32^2
+    // only a handful of texels span the whole penumbra, so a texel-proportional blur still steps visibly.
+    // Widen the low tier further (blur only - not bias, to avoid light leaking through casters) so the PCF
+    // kernel spans several static-tier texels and the boundary reads as a soft gradient instead of blocks.
+    const float tierLowBlurBoost = 2.5f;
+    if ( tierLow )
+        baseBlur *= tierLowBlurBoost;
+
     float noise = PLS_AggressiveNoise(wsPosition * 50.0f);
     fixedBlurScale = baseBlur * lerp(0.5f, 1.5f, noise);
 
@@ -212,9 +246,17 @@ float PLS_SampleShadowCubeArray(
         right, up, sinA, cosA );
 
     float shd = 0;
-    [unroll] for ( int i = 0; i < PLS_SHADOW_BLUR_COUNT; i++ )
+    int tapCount = tierLow ? PLS_SHADOW_BLUR_TIER_LOW_COUNT : PLS_SHADOW_BLUR_COUNT;
+
+    [unroll] for ( int i = 0; i < PLS_SHADOW_BLUR_TIER_LOW_COUNT; i++ )
     {
-        float2 kernel = PLS_SHADOW_BLUR_OFFSETS[i];
+        if ( i >= tapCount )
+            break;
+
+        // '& 7' keeps this a valid compile-time-constant index into the 8-element array even though the
+        // [unroll] loop runs i up to 15 - the else branch is only ever taken (via tapCount/break above)
+        // for i < 8, so the wrap is never actually observed, just required for FXC to accept the index.
+        float2 kernel = tierLow ? PLS_SHADOW_BLUR_OFFSETS_TIER_LOW[i] : PLS_SHADOW_BLUR_OFFSETS[i & 7];
         float2 rotatedKernel = float2( kernel.x * cosA - kernel.y * sinA, kernel.x * sinA + kernel.y * cosA );
         float3 perturbedDir = normalize( dir + (right * rotatedKernel.x + up * rotatedKernel.y) * fixedBlurScale );
         float4 sampleCoord = float4( perturbedDir, (float)cubeIndex );
@@ -237,7 +279,7 @@ float PLS_SampleShadowCubeArray(
         shd += s;
     }
 
-    float finalShadow = shd / PLS_SHADOW_BLUR_COUNT;
+    float finalShadow = shd / (float)tapCount;
 
     // Shadow Distance Fading
     float distanceToLight = length(wsPosition - lightPosWorld);

--- a/D3D11Engine/Shaders/include/PointLightShadows.h
+++ b/D3D11Engine/Shaders/include/PointLightShadows.h
@@ -112,6 +112,7 @@ void PLS_PrepareShadowSampling(
     float3 lightPosWorld,
     float lightRange,
     bool tierLow,
+    bool taaActive,
     out float3 dir,
     out float compareDistance,
     out float fixedBias,
@@ -163,24 +164,41 @@ void PLS_PrepareShadowSampling(
     if ( tierLow )
         baseBlur *= tierLowBlurBoost;
 
-    float noise = PLS_AggressiveNoise(wsPosition * 50.0f);
-    fixedBlurScale = baseBlur * lerp(0.5f, 1.5f, noise);
+    // The rotation/blur-scale jitter below is a spatial hash of wsPosition, not a temporal one - it exists
+    // to break up the Poisson ring into dither that TAA/FSR resolves into smooth soft shadows over several
+    // frames. A hash is discontinuous: without TAA to average it out, the sub-pixel shift in reconstructed
+    // wsPosition from ordinary camera motion flips the hash output unpredictably frame to frame, which reads
+    // as flicker/sparkle rather than dither. Mirrors GetPoissonRotationSCForCascade's SQ_FrameIndex==0 guard
+    // in ShadowSampling.h - fall back to a fixed rotation/scale (still temporally stable, just static-banded)
+    // when the caller reports no camera jitter is active.
+    if ( taaActive )
+    {
+        float noise = PLS_AggressiveNoise(wsPosition * 50.0f);
+        fixedBlurScale = baseBlur * lerp(0.5f, 1.5f, noise);
+
+        float angle = noise * 6.2831853f;
+        sincos( angle, sinA, cosA );
+    }
+    else
+    {
+        fixedBlurScale = baseBlur;
+        sinA = 0.0f;
+        cosA = 1.0f;
+    }
 
     up = abs( dir.y ) < 0.999f ? float3( 0, 1, 0 ) : float3( 1, 0, 0 );
     right = normalize( cross( up, dir ) );
     up = cross( dir, right );
-
-    float angle = noise * 6.2831853f;
-    sincos( angle, sinA, cosA );
 }
 
 float PLS_SampleShadowCube(
     TextureCube shadowCube,
     SamplerComparisonState samplerState,
     float3 wsPosition,
-    float3 N, 
+    float3 N,
     float3 lightPosWorld,
-    float lightRange )
+    float lightRange,
+    bool taaActive )
 {
     float3 dir;
     float compareDistance;
@@ -192,7 +210,7 @@ float PLS_SampleShadowCube(
     float cosA;
 
     PLS_PrepareShadowSampling(
-        wsPosition, N, lightPosWorld, lightRange, false,
+        wsPosition, N, lightPosWorld, lightRange, false, taaActive,
         dir, compareDistance, fixedBias, fixedBlurScale,
         right, up, sinA, cosA );
 
@@ -225,7 +243,8 @@ float PLS_SampleShadowCubeArray(
     float3 N,
     float3 lightPosWorld,
     float lightRange,
-    int encodedIndex )
+    int encodedIndex,
+    bool taaActive )
 {
     int cubeIndex = encodedIndex & PLS_SHADOW_SLOT_MASK;
     bool tierLow = ( encodedIndex & PLS_SHADOW_TIER_LOW ) != 0;
@@ -241,7 +260,7 @@ float PLS_SampleShadowCubeArray(
     float cosA;
 
     PLS_PrepareShadowSampling(
-        wsPosition, N, lightPosWorld, lightRange, tierLow,
+        wsPosition, N, lightPosWorld, lightRange, tierLow, taaActive,
         dir, compareDistance, fixedBias, fixedBlurScale,
         right, up, sinA, cosA );
 


### PR DESCRIPTION
- static only (32x32) pointlight shadows now get more taps, a bigger blur radius and get TAA awareness. the additional taps should be totally ok, as static shadows arent updated frequently.