### PR TITLE
feat(dx11): load meshes for node attachments/particleFx/vobs in background. Dx12 introduce rendergraph

### DIFF
--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1125,6 +1125,11 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="D3D12Engine\D3D12EngineCommon.h" />
     <ClInclude Include="D3D12Engine\D3D12VertexBuffer.h" />
     <ClInclude Include="D3D12Engine\D3D12Texture.h" />
+    <ClInclude Include="D3D12Engine\D3D12PooledDescriptorHeap.h" />
+    <ClInclude Include="D3D12Engine\D3D12RenderTarget.h" />
+    <ClInclude Include="D3D12Engine\D3D12TexturePool.h" />
+    <ClInclude Include="D3D12Engine\D3D12RenderPass.h" />
+    <ClInclude Include="D3D12Engine\D3D12RenderGraph.h" />
     <ClInclude Include="D3D12Engine\D3D12LineRenderer.h" />
     <ClInclude Include="StringID.h" />
     <ClInclude Include="SMAA\D3D11SMAA.h" />
@@ -1410,6 +1415,66 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12Texture.cpp">
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_12f|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12PooledDescriptorHeap.cpp">
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_12f|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12RenderTarget.cpp">
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_12f|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12TexturePool.cpp">
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_12f|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12RenderGraph.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1130,6 +1130,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="D3D12Engine\D3D12TexturePool.h" />
     <ClInclude Include="D3D12Engine\D3D12RenderPass.h" />
     <ClInclude Include="D3D12Engine\D3D12RenderGraph.h" />
+    <ClInclude Include="D3D12Engine\D3D12AliasedTextureArena.h" />
     <ClInclude Include="D3D12Engine\D3D12LineRenderer.h" />
     <ClInclude Include="StringID.h" />
     <ClInclude Include="SMAA\D3D11SMAA.h" />
@@ -1475,6 +1476,21 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12RenderGraph.cpp">
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_12f|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12AliasedTextureArena.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -798,6 +798,21 @@
     <ClInclude Include="D3D12Engine\D3D12Texture.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
+    <ClInclude Include="D3D12Engine\D3D12PooledDescriptorHeap.h">
+      <Filter>Engine\D3D12</Filter>
+    </ClInclude>
+    <ClInclude Include="D3D12Engine\D3D12RenderTarget.h">
+      <Filter>Engine\D3D12</Filter>
+    </ClInclude>
+    <ClInclude Include="D3D12Engine\D3D12TexturePool.h">
+      <Filter>Engine\D3D12</Filter>
+    </ClInclude>
+    <ClInclude Include="D3D12Engine\D3D12RenderPass.h">
+      <Filter>Engine\D3D12</Filter>
+    </ClInclude>
+    <ClInclude Include="D3D12Engine\D3D12RenderGraph.h">
+      <Filter>Engine\D3D12</Filter>
+    </ClInclude>
     <ClInclude Include="D3D12Engine\D3D12LineRenderer.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
@@ -1020,6 +1035,18 @@
       <Filter>Engine\D3D12</Filter>
     </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12Texture.cpp">
+      <Filter>Engine\D3D12</Filter>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12PooledDescriptorHeap.cpp">
+      <Filter>Engine\D3D12</Filter>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12RenderTarget.cpp">
+      <Filter>Engine\D3D12</Filter>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12TexturePool.cpp">
+      <Filter>Engine\D3D12</Filter>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12RenderGraph.cpp">
       <Filter>Engine\D3D12</Filter>
     </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12AO.cpp">

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -813,6 +813,9 @@
     <ClInclude Include="D3D12Engine\D3D12RenderGraph.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
+    <ClInclude Include="D3D12Engine\D3D12AliasedTextureArena.h">
+      <Filter>Engine\D3D12</Filter>
+    </ClInclude>
     <ClInclude Include="D3D12Engine\D3D12LineRenderer.h">
       <Filter>Engine\D3D12</Filter>
     </ClInclude>
@@ -1047,6 +1050,9 @@
       <Filter>Engine\D3D12</Filter>
     </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12RenderGraph.cpp">
+      <Filter>Engine\D3D12</Filter>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12AliasedTextureArena.cpp">
       <Filter>Engine\D3D12</Filter>
     </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12AO.cpp">

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -3441,11 +3441,14 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
                 // Check if this is loaded
                 if ( node->NodeVisual && nodeAttachments.find( i ) == nodeAttachments.end() ) {
-                    WorldConverter::ExtractNodeVisual( i, node, nodeAttachments );
+                    WorldConverter::ExtractNodeVisualAsync( i, node, nodeAttachments );
                 }
 
-                // Check for changed visual
-                if ( nodeAttachments[i].size() && node->NodeVisual != nodeAttachments[i][0]->Visual ) {
+                // Check for changed visual. Gated on GetIsReady(): the worker thread writes Visual as
+                // it finishes extracting, so comparing against it any earlier races the extraction job
+                // (mirrors the D3D12 attachment path).
+                if ( nodeAttachments[i].size() && nodeAttachments[i][0]->GetIsReady()
+                    && node->NodeVisual != nodeAttachments[i][0]->Visual ) {
                     // Check for deleted attachment
                     if ( !node->NodeVisual ) {
                         // Remove attachment. Shared, so it goes back to the registry, not deleted here.
@@ -3455,7 +3458,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
                         continue; // Go to next attachment
                     }
-                    WorldConverter::ExtractNodeVisual( i, node, nodeAttachments );
+                    WorldConverter::ExtractNodeVisualAsync( i, node, nodeAttachments );
                 }
 
                 auto nodeAttachment = nodeAttachments.find( i );
@@ -3478,8 +3481,9 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
                 for ( MeshVisualInfo* mvi : nodeAttachment->second ) {
 
-                    if ( !mvi->Visual ) {
-                        LogWarn() << "Attachment without visual on model: " << model->GetVisualName();
+                    // Still being extracted on a worker thread — Meshes is being written to right now,
+                    // so skip this attachment entirely for this frame rather than race it (mirrors D3D12).
+                    if ( !mvi->GetIsReady() || !mvi->Visual ) {
                         continue;
                     }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -5847,37 +5847,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
     const bool drawAnimatedCasters = (casterMask & SHADOW_CASTER_ANIMATED) != 0;
 
     if ( drawWorldCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh ) {
-        // World-mesh sub-meshes don't own standalone GPU buffers - section->WorldMeshes /
-        // worldMeshCache only carry an index range (MeshInfo::BaseIndexLocation) into the single
-        // wrapped world mesh (Engine::GAPI->GetWrappedWorldMesh()), packed as ExVertexStructGPU -
-        // the same buffer ShadowPass_DrawWorldMesh/CSM draw from. VS_ExCube's plain VS_INPUT can't
-        // decode that stream, so switch to the packed-decoding cube variant and bind the wrapped
-        // mesh once for this block; VOBs afterward are unpacked ExVertexStruct and need VS_ExCube
-        // back. FullStaticMesh (the FastShadows branch below) is the one exception - it's built as
-        // plain ExVertexStruct with its own buffer, so it keeps using whatever VS is already active.
-        //
-        // First pass: always draw the full (non-welded) index range - GetShadowAwareIndexCount(mesh,
-        // true) / mesh->BaseIndexLocation, as if every material were alpha-tested - rather than
-        // picking the shadow-welded range per material. Simpler, and correctness comes first; the
-        // welded/reduced range can come back once this is confirmed working.
-        bool usedPackedWorldMeshVS = false;
-        auto ensurePackedWorldMeshVS = [&]() {
-            if ( usedPackedWorldMeshVS ) return;
-            usedPackedWorldMeshVS = true;
-            SetActiveVertexShader( VShaderID::VS_ExPackedCube );
-            SetupVS_ExMeshDrawCall();
-            SetupVS_ExConstantBuffer();
-            ActiveVS->UpdateBuffer( "Matrices_PerInstances", &identityMatrix, sizeof( identityMatrix ) );
-            BindWrappedWorldMeshPacked( Engine::GAPI->GetWrappedWorldMesh() );
-        };
-        auto drawFromWrappedMesh = [&]( MeshInfo* mesh ) {
-            ensurePackedWorldMeshVS();
-            const unsigned int count = GetShadowAwareIndexCount( mesh, true );
-            if ( !count ) return;
-            Context->DrawIndexed( count, mesh->BaseIndexLocation, 0 );
-            Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnTriangles += count / 3;
-        };
-
+        ActiveVS->UpdateBuffer( "Matrices_PerInstances", &identityMatrix, sizeof( identityMatrix ) );
         // Only use cache if we haven't already collected the vobs
         // TODO: Collect vobs in a different way than using the drawn sections!
         //		 The current solution won't use the cache at all when there are
@@ -5924,7 +5894,11 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                     }
                 }
 
-                drawFromWrappedMesh( meshInfoByKey->second );
+                // Draw from wrapped mesh
+                MeshInfo* mesh = meshInfoByKey->second;
+                DrawVertexBufferIndexed( mesh->GetMeshVertexBuffer(),
+                    GetShadowAwareIndexBuffer( mesh, isAlpha ),
+                    GetShadowAwareIndexCount( mesh, isAlpha ) );
             }
         } else {
             auto _ = RecordGraphicsEvent( GE_NAME( "DrawWorldAround::WorldMesh" ) );
@@ -5987,17 +5961,18 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                             }
                         }
 
-                        drawFromWrappedMesh( meshInfoByKey->second );
+                        // Draw from wrapped mesh
+                        MeshInfo* mesh = meshInfoByKey->second;
+                        DrawVertexBufferIndexed( mesh->GetMeshVertexBuffer(),
+                            GetShadowAwareIndexBuffer( mesh, isAlpha ),
+                            GetShadowAwareIndexCount( mesh, isAlpha ) );
+
+                        if ( worldMeshCache ) {
+                            worldMeshCache->push_back( *meshInfoByKey );
+                        }
                     }
                 }
             }
-        }
-
-        if ( usedPackedWorldMeshVS ) {
-            // Restore VS_ExCube (plain unpacked ExVertexStruct) for the VOB/mob draws below.
-            SetActiveVertexShader( VShaderID::VS_ExCube );
-            SetupVS_ExMeshDrawCall();
-            SetupVS_ExConstantBuffer();
         }
     }
 
@@ -6248,39 +6223,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
 
     void* lastTex = nullptr;
     if ( drawWorldCasters && Engine::GAPI->GetRendererState().RendererSettings.DrawWorldMesh ) {
+        ActiveVS->UpdateBuffer( "Matrices_PerInstances", &identityMatrix, sizeof( identityMatrix ) );
         auto _ = RecordGraphicsEvent( GE_NAME( "DrawWorldMesh::Layered" ) );
-
-        // World-mesh sub-meshes don't own standalone GPU buffers - section->WorldMeshes /
-        // worldMeshCache only carry an index range (MeshInfo::BaseIndexLocation) into the single
-        // wrapped world mesh (Engine::GAPI->GetWrappedWorldMesh()), packed as ExVertexStructGPU -
-        // the same buffer ShadowPass_DrawWorldMesh/CSM draw from. VS_ExLayered's plain VS_INPUT
-        // can't decode that stream, so switch to the packed-decoding layered variant and bind the
-        // wrapped mesh once for this block; VOBs drawn afterward are unpacked ExVertexStruct and
-        // need VS_ExLayered back. FullStaticMesh (the FastShadows branch below) is the one
-        // exception - it's built as plain ExVertexStruct with its own buffer, so it keeps using
-        // whatever VS is already active.
-        //
-        // First pass: always draw the full (non-welded) index range - GetShadowAwareIndexCount(mesh,
-        // true) / mesh->BaseIndexLocation - as if every material were alpha-tested, mirroring
-        // DrawWorldAround's GS-path equivalent.
-        bool usedPackedWorldMeshVS = false;
-        auto ensurePackedWorldMeshVS = [&]() {
-            if ( usedPackedWorldMeshVS ) return;
-            usedPackedWorldMeshVS = true;
-            SetActiveVertexShader( VShaderID::VS_ExPackedLayered );
-            SetupVS_ExMeshDrawCall();
-            SetupVS_ExConstantBuffer();
-            ActiveVS->UpdateBuffer( "Matrices_PerInstances", &identityMatrix, sizeof( identityMatrix ) );
-            BindWrappedWorldMeshPacked( Engine::GAPI->GetWrappedWorldMesh() );
-        };
-        auto drawFromWrappedMeshInstanced = [&]( MeshInfo* mesh ) {
-            ensurePackedWorldMeshVS();
-            const unsigned int count = GetShadowAwareIndexCount( mesh, true );
-            if ( !count ) return;
-            Context->DrawIndexedInstanced( count, 6, mesh->BaseIndexLocation, 0, 0 );
-            Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnTriangles += count / 3;
-        };
-
         // Only use cache if we haven't already collected the vobs
         // TODO: Collect vobs in a different way than using the drawn sections!
         //		 The current solution won't use the cache at all when there are
@@ -6324,7 +6268,12 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
                     }
                 }
 
-                drawFromWrappedMeshInstanced( meshInfoByKey->second );
+                // Draw from wrapped mesh
+                MeshInfo* mesh = meshInfoByKey->second;
+                DrawVertexBufferInstancedIndexed( mesh->GetMeshVertexBuffer(),
+                    GetShadowAwareIndexBuffer( mesh, isAlpha ),
+                    GetShadowAwareIndexCount( mesh, isAlpha ),
+                    6 );
             }
         } else {
             Frustum f;
@@ -6384,17 +6333,19 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
                             }
                         }
 
-                        drawFromWrappedMeshInstanced( meshInfoByKey->second );
+                        // Draw from wrapped mesh
+                        MeshInfo* mesh = meshInfoByKey->second;
+                        DrawVertexBufferInstancedIndexed( mesh->GetMeshVertexBuffer(),
+                            GetShadowAwareIndexBuffer( mesh, isAlpha ),
+                            GetShadowAwareIndexCount( mesh, isAlpha ),
+                            6 );
+
+                        if ( worldMeshCache ) {
+                            worldMeshCache->push_back( *meshInfoByKey );
+                        }
                     }
                 }
             }
-        }
-
-        if ( usedPackedWorldMeshVS ) {
-            // Restore VS_ExLayered (plain unpacked ExVertexStruct) for the VOB/mob draws below.
-            SetActiveVertexShader( VShaderID::VS_ExLayered );
-            SetupVS_ExMeshDrawCall();
-            SetupVS_ExConstantBuffer();
         }
     }
     

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -2932,7 +2932,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
 
             zCModel* model = static_cast<zCModel*>(vi->Vob->GetVisual());
             if ( !model || !vi->VisualInfo || !vi->Vob->GetShowVisual()
-                || !static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->Ready.load() ) {
+                || !static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->GetIsReady() ) {
                 continue;
             }
             vi->UpdateState();
@@ -3159,7 +3159,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
             model->SetIsVisible( true );
             if ( !vi->VisualInfo )
                 continue; // Gothic fortunately sets this to 0 when it throws the model out of the cache
-            if ( !static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->Ready.load() )
+            if ( !static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->GetIsReady() )
                 continue; // Still being built on a worker thread - don't touch its mesh data yet
             if ( !vi->Vob->GetShowVisual() )
                 continue;
@@ -3571,7 +3571,7 @@ void D3D11GraphicsEngine::DrawSkeletalMeshVobs(
                         // when it was last in range. Falls back to that copy until the rest mesh is built.
                         MeshVisualInfo* drawVis = mvi;
                         if ( isMMS && mvi->RestVisual
-                            && mvi->RestVisual->Ready.load( std::memory_order_acquire ) ) {
+                            && mvi->RestVisual->GetIsReady() ) {
                             drawVis = mvi->RestVisual;
                         }
 
@@ -6040,6 +6040,10 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
         VS_ExConstantBuffer_PerInstance cb;
 
         for ( auto const& vobInfo : rl ) {
+            // Still being filled in on a worker thread (GothicAPI::OnAddVob's async
+            // Extract3DSMeshFromVisual2Async) - skip until Meshes/MeshesByTexture are safe to iterate.
+            if ( !vobInfo->VisualInfo->GetIsReady() ) continue;
+
             // Bind per-instance buffer
             vobInfo->UpdateVobConstantBuffer( cb );
 
@@ -6437,6 +6441,10 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
 
         GfxTexture* lastBoundTexture = nullptr;
         for ( auto const& vobInfo : rl ) {
+            // Still being filled in on a worker thread (GothicAPI::OnAddVob's async
+            // Extract3DSMeshFromVisual2Async) - skip until Meshes/MeshesByTexture are safe to iterate.
+            if ( !vobInfo->VisualInfo->GetIsReady() ) continue;
+
             // Bind per-instance buffer
             vobInfo->UpdateVobConstantBuffer( cb );
             BindDynamicCBToVertexShader( 1, AllocateDynamicCB( &cb ) );
@@ -8777,6 +8785,10 @@ D3D11ENGINE_RENDER_STAGE D3D11GraphicsEngine::GetRenderingStage() {
 
 /** Draws a VOB (used for inventory) */
 void D3D11GraphicsEngine::DrawVobSingle( VobInfo* vob, zCCamera& camera ) {
+    // Still being filled in on a worker thread (GothicAPI::OnAddVob's async Extract3DSMeshFromVisual2Async)
+    // - skip until Meshes is safe to iterate. The item pops in a frame or two later instead.
+    if ( !vob->VisualInfo || !vob->VisualInfo->GetIsReady() ) return;
+
     Engine::GAPI->SetViewTransformXM( XMLoadFloat4x4( &camera.GetTransformDX( zCCamera::ETransformType::TT_VIEW ) ) );
 
     // Important: We NEED a swapchain-sized depth stencil buffer here, otherwise Advanced Inventory VOBs will be rendered without depth testing and thus look very bad.

--- a/D3D11Engine/D3D12Engine/D3D12AliasedTextureArena.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12AliasedTextureArena.cpp
@@ -45,10 +45,15 @@ bool D3D12AliasedTextureArena::Attach( D3D12GraphicsEngine& engine ) {
     return m_RtvHeap.Init( m_Device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, kMaxSlots, L"D3D12AliasedTextureArena_RTV" );
 }
 
-UINT64 D3D12AliasedTextureArena::ReserveBumpRange( UINT64 size, UINT64 alignment ) {
-    const UINT64 offset = alignment ? ( ( m_FrameBumpOffset + alignment - 1 ) / alignment ) * alignment : m_FrameBumpOffset;
+UINT64 D3D12AliasedTextureArena::ReserveNamedRange( const std::wstring& name, UINT64 size, UINT64 alignment ) {
+    auto it = m_NamedRanges.find( name );
+    if ( it != m_NamedRanges.end() ) return it->second;
+
+    const UINT64 offset = alignment ? ( ( m_BumpOffset + alignment - 1 ) / alignment ) * alignment : m_BumpOffset;
     if ( offset + size > kArenaCapacityBytes ) return UINT64_MAX;
-    m_FrameBumpOffset = offset + size;
+    m_BumpOffset = offset + size;
+
+    m_NamedRanges.emplace( name, offset );
     return offset;
 }
 
@@ -124,4 +129,6 @@ D3D12RenderTarget* D3D12AliasedTextureArena::Acquire( UINT64 slotOffset, UINT wi
 
 void D3D12AliasedTextureArena::Clear() {
     m_Slots.clear();
+    m_NamedRanges.clear();
+    m_BumpOffset = 0;
 }

--- a/D3D11Engine/D3D12Engine/D3D12AliasedTextureArena.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12AliasedTextureArena.cpp
@@ -1,0 +1,120 @@
+#include "../pch.h"
+#include "D3D12AliasedTextureArena.h"
+#include "D3D12GraphicsEngine.h"
+#include "D3D12StateCache.h"
+#include "../Logger.h"
+
+namespace {
+    D3D12_RESOURCE_DESC MakeDesc( UINT width, UINT height, DXGI_FORMAT format, bool needsUav ) {
+        D3D12_RESOURCE_DESC dd = {};
+        dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+        dd.Width = width;
+        dd.Height = height;
+        dd.DepthOrArraySize = 1;
+        dd.MipLevels = 1;
+        dd.Format = format;
+        dd.SampleDesc.Count = 1;
+        dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+        dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+        if ( needsUav ) dd.Flags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+        return dd;
+    }
+}
+
+bool D3D12AliasedTextureArena::Attach( D3D12GraphicsEngine& engine ) {
+    m_Engine = &engine;
+    m_Device = engine.GetD3DDevice();
+    if ( !m_Device ) return false;
+
+    D3D12_HEAP_DESC heapDesc = {};
+    heapDesc.SizeInBytes = kArenaCapacityBytes;
+    heapDesc.Properties.Type = D3D12_HEAP_TYPE_DEFAULT;
+    // RT/DS-category textures only: every transient graph texture carries ALLOW_RENDER_TARGET, so this
+    // is the correct (and, on a resource-heap-tier-1 device, the ONLY legal) category for a heap they
+    // get placed into — mixing it with buffers or non-RT/DS textures would need ALLOW_ALL_BUFFERS_AND_
+    // TEXTURES, which not every GPU this mod ships to supports.
+    heapDesc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES;
+    heapDesc.Alignment = D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT;
+
+    if ( FAILED( m_Device->CreateHeap( &heapDesc, IID_PPV_ARGS( m_Heap.ReleaseAndGetAddressOf() ) ) ) ) {
+        LogWarn() << "D3D12AliasedTextureArena: failed to create the " << ( kArenaCapacityBytes / ( 1024 * 1024 ) ) << " MB aliasing heap.";
+        return false;
+    }
+    m_Heap->SetName( L"D3D12RenderGraph_AliasArena" );
+
+    return m_RtvHeap.Init( m_Device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, kMaxSlots, L"D3D12AliasedTextureArena_RTV" );
+}
+
+void D3D12AliasedTextureArena::GetAllocationInfo( UINT width, UINT height, DXGI_FORMAT format, bool needsUav, UINT64& outSize, UINT64& outAlignment ) const {
+    outSize = 0;
+    outAlignment = 0;
+    if ( !m_Device ) return;
+    const D3D12_RESOURCE_DESC desc = MakeDesc( width, height, format, needsUav );
+    const D3D12_RESOURCE_ALLOCATION_INFO info = m_Device->GetResourceAllocationInfo( 0, 1, &desc );
+    outSize = info.SizeInBytes;
+    outAlignment = info.Alignment;
+}
+
+D3D12AliasedTextureArena::Slot* D3D12AliasedTextureArena::FindOrCreateSlot( UINT64 offset ) {
+    for ( auto& s : m_Slots ) {
+        if ( s->Offset == offset ) return s.get();
+    }
+    m_Slots.push_back( std::make_unique<Slot>() );
+    Slot* slot = m_Slots.back().get();
+    slot->Offset = offset;
+    return slot;
+}
+
+D3D12RenderTarget* D3D12AliasedTextureArena::Acquire( UINT64 slotOffset, UINT width, UINT height, DXGI_FORMAT format,
+    bool needsUav, D3D12CmdList& cmdList ) {
+    if ( !m_Device || !m_Heap ) return nullptr;
+
+    Slot* slot = FindOrCreateSlot( slotOffset );
+    const bool matches = slot->Texture && slot->Width == width && slot->Height == height
+        && slot->Format == format && slot->NeedsUav == needsUav;
+    if ( matches ) return slot->Texture.get();
+
+    const D3D12_RESOURCE_DESC desc = MakeDesc( width, height, format, needsUav );
+    D3D12_CLEAR_VALUE clear = {};
+    clear.Format = format;
+
+    Microsoft::WRL::ComPtr<ID3D12Resource> newResource;
+    // Legacy CreatePlacedResource (not CreatePlacedResource2/3) on purpose — matches AliasingBarrier
+    // staying on the legacy aliasing-barrier path; see this class' header comment.
+    if ( FAILED( m_Device->CreatePlacedResource( m_Heap.Get(), slotOffset, &desc, D3D12_RESOURCE_STATE_RENDER_TARGET,
+        &clear, IID_PPV_ARGS( newResource.ReleaseAndGetAddressOf() ) ) ) ) {
+        if ( !m_LoggedExhaustion ) {
+            LogWarn() << "D3D12AliasedTextureArena: failed to place a " << width << "x" << height << " transient texture at offset " << slotOffset << ".";
+            m_LoggedExhaustion = true;
+        }
+        return nullptr;
+    }
+    newResource->SetName( L"D3D12RenderGraph_Aliased" );
+
+    if ( !slot->Texture ) {
+        // First-ever resource at this offset: no aliasing barrier required before the first use of a
+        // placed resource in virgin heap memory (D3D12 spec).
+        slot->Texture = std::make_unique<D3D12RenderTarget>();
+        if ( !slot->Texture->InitPlaced( m_Device, newResource.Get(), m_Engine, &m_RtvHeap, width, height, format, needsUav, L"D3D12RenderGraph_Aliased" ) ) {
+            slot->Texture.reset();
+            return nullptr;
+        }
+    } else {
+        ID3D12Resource* oldResource = slot->Texture->GetResource();
+        if ( !slot->Texture->ReplaceResource( m_Device, newResource.Get(), width, height, format, needsUav ) )
+            return nullptr;   // old resource/views stay bound to what was there before — still valid, just stale
+        // oldResource is kept alive by ReplaceResource's deferred-release queue, so it is still a valid
+        // pointer here even though slot->Texture no longer holds its own reference to it.
+        cmdList.AliasingBarrier( oldResource, newResource.Get() );
+    }
+
+    slot->Width = width;
+    slot->Height = height;
+    slot->Format = format;
+    slot->NeedsUav = needsUav;
+    return slot->Texture.get();
+}
+
+void D3D12AliasedTextureArena::Clear() {
+    m_Slots.clear();
+}

--- a/D3D11Engine/D3D12Engine/D3D12AliasedTextureArena.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12AliasedTextureArena.cpp
@@ -45,6 +45,13 @@ bool D3D12AliasedTextureArena::Attach( D3D12GraphicsEngine& engine ) {
     return m_RtvHeap.Init( m_Device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, kMaxSlots, L"D3D12AliasedTextureArena_RTV" );
 }
 
+UINT64 D3D12AliasedTextureArena::ReserveBumpRange( UINT64 size, UINT64 alignment ) {
+    const UINT64 offset = alignment ? ( ( m_FrameBumpOffset + alignment - 1 ) / alignment ) * alignment : m_FrameBumpOffset;
+    if ( offset + size > kArenaCapacityBytes ) return UINT64_MAX;
+    m_FrameBumpOffset = offset + size;
+    return offset;
+}
+
 void D3D12AliasedTextureArena::GetAllocationInfo( UINT width, UINT height, DXGI_FORMAT format, bool needsUav, UINT64& outSize, UINT64& outAlignment ) const {
     outSize = 0;
     outAlignment = 0;

--- a/D3D11Engine/D3D12Engine/D3D12AliasedTextureArena.h
+++ b/D3D11Engine/D3D12Engine/D3D12AliasedTextureArena.h
@@ -43,9 +43,28 @@ public:
 
     bool Attach( D3D12GraphicsEngine& engine );
 
+    /** Resets the persistent bump-allocation cursor (see ReserveBumpRange) for a new frame. Call ONCE per
+        frame, before the first D3D12RenderGraph::Compile() call that might touch this arena — e.g.
+        D3D12GraphicsEngine::OnBeginFrame, which fires every frame in the menu and in-game alike. */
+    void BeginFrame() { m_FrameBumpOffset = 0; }
+
     /** {size, alignment} D3D12 would need for a texture matching this description, WITHOUT creating it
         — what D3D12RenderGraph's interval colorer sizes its packing against. */
     void GetAllocationInfo( UINT width, UINT height, DXGI_FORMAT format, bool needsUav, UINT64& outSize, UINT64& outAlignment ) const;
+
+    /** Bump-allocates `size` bytes (aligned to `alignment`) from a cursor that is PERSISTENT ACROSS EVERY
+        D3D12RenderGraph that touches this arena in the same frame — not reset per graph, only per
+        BeginFrame(). This is the reason multiple independent per-function local graphs (DoF's, the god-ray
+        pass's, ...) don't stomp on each other: if each graph's Compile() instead restarted its own bump
+        pointer at 0, the FIRST resource of every graph would collide at the same offset and every one of
+        them would see its occupant change EVERY SINGLE CALL — real GPU-correct (an aliasing barrier would
+        still fire) but real waste (a fresh CreatePlacedResource + view pair every frame for every one of
+        them, exactly the per-frame-allocation churn CLAUDE.md's central rule exists to avoid). Sharing one
+        monotonically-advancing cursor for the whole frame means each graph's resources land at STABLE,
+        non-overlapping offsets that repeat identically frame after frame (the post-fx call order is fixed),
+        so after the first frame every Acquire() is a same-desc cache hit — steady state, no churn. Returns
+        UINT64_MAX if the request would exceed kArenaCapacityBytes (caller logs and skips the resource). */
+    UINT64 ReserveBumpRange( UINT64 size, UINT64 alignment );
 
     /** Places (or reuses) a texture at the given byte offset for THIS pass, as decided by
         D3D12RenderGraph::Compile()'s interval coloring. If a different resource previously occupied
@@ -77,4 +96,5 @@ private:
 
     std::vector<std::unique_ptr<Slot>> m_Slots;
     bool m_LoggedExhaustion = false;
+    UINT64 m_FrameBumpOffset = 0;   // see ReserveBumpRange / BeginFrame
 };

--- a/D3D11Engine/D3D12Engine/D3D12AliasedTextureArena.h
+++ b/D3D11Engine/D3D12Engine/D3D12AliasedTextureArena.h
@@ -3,6 +3,8 @@
 #include <wrl/client.h>
 #include <cstdint>
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <vector>
 #include "D3D12RenderTarget.h"
 #include "D3D12PooledDescriptorHeap.h"
@@ -43,28 +45,34 @@ public:
 
     bool Attach( D3D12GraphicsEngine& engine );
 
-    /** Resets the persistent bump-allocation cursor (see ReserveBumpRange) for a new frame. Call ONCE per
-        frame, before the first D3D12RenderGraph::Compile() call that might touch this arena — e.g.
-        D3D12GraphicsEngine::OnBeginFrame, which fires every frame in the menu and in-game alike. */
-    void BeginFrame() { m_FrameBumpOffset = 0; }
-
     /** {size, alignment} D3D12 would need for a texture matching this description, WITHOUT creating it
         — what D3D12RenderGraph's interval colorer sizes its packing against. */
     void GetAllocationInfo( UINT width, UINT height, DXGI_FORMAT format, bool needsUav, UINT64& outSize, UINT64& outAlignment ) const;
 
-    /** Bump-allocates `size` bytes (aligned to `alignment`) from a cursor that is PERSISTENT ACROSS EVERY
-        D3D12RenderGraph that touches this arena in the same frame — not reset per graph, only per
-        BeginFrame(). This is the reason multiple independent per-function local graphs (DoF's, the god-ray
-        pass's, ...) don't stomp on each other: if each graph's Compile() instead restarted its own bump
-        pointer at 0, the FIRST resource of every graph would collide at the same offset and every one of
-        them would see its occupant change EVERY SINGLE CALL — real GPU-correct (an aliasing barrier would
-        still fire) but real waste (a fresh CreatePlacedResource + view pair every frame for every one of
-        them, exactly the per-frame-allocation churn CLAUDE.md's central rule exists to avoid). Sharing one
-        monotonically-advancing cursor for the whole frame means each graph's resources land at STABLE,
-        non-overlapping offsets that repeat identically frame after frame (the post-fx call order is fixed),
-        so after the first frame every Acquire() is a same-desc cache hit — steady state, no churn. Returns
-        UINT64_MAX if the request would exceed kArenaCapacityBytes (caller logs and skips the resource). */
-    UINT64 ReserveBumpRange( UINT64 size, UINT64 alignment );
+    /** Returns the byte offset permanently reserved for `name`, bump-allocating a fresh one on first sight.
+        STABLE for the life of the current epoch (until the next Clear()): a name's offset never moves once
+        assigned, regardless of which OTHER passes happen to run (or not) in any given frame.
+
+        This used to be a plain per-frame bump cursor (ReserveBumpRange, reset every frame in BeginFrame()),
+        which fixed the original cross-graph-collision bug (independent per-function local graphs — DoF's,
+        the god-ray pass's, SMAA's — all restarting their own cursor at 0 and stomping on each other) but
+        left a subtler one: several of these passes are CONDITIONALLY active (god rays only with the sun up
+        and outdoors, DoF only if EnableDoF, SMAA only in AA_SMAA, underwater only while submerged), so the
+        cumulative bump total at the point any given pass runs varies frame to frame — toggling ANY earlier
+        effect shifts every LATER one's offset, forcing a spurious aliasing barrier + resource recreation
+        for a pass whose own state didn't change at all.
+
+        Keying by name instead of "whatever the running total happens to be right now" removes that drift
+        entirely: each logical resource (RGTextureDesc::name, e.g. L"DoFHalf") permanently owns its own
+        range once first requested. The tradeoff is real: two DIFFERENT names never share memory this way
+        (no more cross-effect aliasing), only a given name's own steady-state reuse — but at the current
+        scale (a handful of few-MB scratch textures against a 256 MB arena) that memory saving was never
+        the point; proving the placed-resource + aliasing-barrier mechanism works was. Revisit if a much
+        larger transient set (e.g. a real Forward+ pass graph) makes actual cross-effect packing worth the
+        complexity of tracking "did this specific other name's lifetime end before this one's started" per
+        frame rather than once. Returns UINT64_MAX if the request would exceed kArenaCapacityBytes (caller
+        logs and skips the resource). */
+    UINT64 ReserveNamedRange( const std::wstring& name, UINT64 size, UINT64 alignment );
 
     /** Places (or reuses) a texture at the given byte offset for THIS pass, as decided by
         D3D12RenderGraph::Compile()'s interval coloring. If a different resource previously occupied
@@ -76,7 +84,10 @@ public:
         (arena exhausted, format+size rejected by the driver, ...). */
     D3D12RenderTarget* Acquire( UINT64 slotOffset, UINT width, UINT height, DXGI_FORMAT format, bool needsUav, D3D12CmdList& cmdList );
 
-    void Clear();   // drops every placed resource + their SRV/RTV slots (resize / level change); keeps the heap
+    /** Drops every placed resource + their SRV/RTV slots AND every name's reserved offset, starting a fresh
+        allocation epoch — call on resize (the only time a name's requested size legitimately changes, since
+        every one of these textures is sized off m_Resolution/m_BackbufferResolution). Keeps the heap itself. */
+    void Clear();
 
 private:
     struct Slot {
@@ -96,5 +107,6 @@ private:
 
     std::vector<std::unique_ptr<Slot>> m_Slots;
     bool m_LoggedExhaustion = false;
-    UINT64 m_FrameBumpOffset = 0;   // see ReserveBumpRange / BeginFrame
+    UINT64 m_BumpOffset = 0;                            // next never-yet-claimed byte, for a NEW name only
+    std::unordered_map<std::wstring, UINT64> m_NamedRanges;   // name -> permanently-reserved offset (this epoch)
 };

--- a/D3D11Engine/D3D12Engine/D3D12AliasedTextureArena.h
+++ b/D3D11Engine/D3D12Engine/D3D12AliasedTextureArena.h
@@ -1,0 +1,80 @@
+#pragma once
+#include <d3d12.h>
+#include <wrl/client.h>
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include "D3D12RenderTarget.h"
+#include "D3D12PooledDescriptorHeap.h"
+
+class D3D12GraphicsEngine;
+class D3D12CmdList;
+
+/** Backing store for D3D12RenderGraph's transient textures: ONE DEFAULT-heap ID3D12Heap that multiple,
+    non-overlapping-lifetime resources are placed into at different byte offsets via CreatePlacedResource
+    — the thing D3D11 fundamentally cannot do (D3D11 has no placed-resource / heap-aliasing API; every
+    texture in D3D11's TexturePool, and D3D12's own D3D12TexturePool, gets its own dedicated memory).
+
+    D3D12RenderGraph::Compile() runs a simple interval-coloring pass over the already-computed
+    firstPass/lastPass lifetimes (AssignSlots) to decide WHICH byte offset each transient resource is
+    given; this class only does the mechanical part — turning (offset, desc) into a live ID3D12Resource,
+    including the mandatory ALIASING BARRIER between whatever resource previously occupied that offset
+    (from earlier in the same frame, or held over from last frame) and the new one. Callers never need to
+    barrier manually; see Acquire().
+
+    Deliberately on the LEGACY D3D12_RESOURCE_BARRIER_TYPE_ALIASING path throughout (both here and in
+    D3D12CmdList::AliasingBarrier) rather than the enhanced-barrier UNDEFINED-layout model — see
+    AliasingBarrier's own comment for why. Resources are created via the plain (legacy-state)
+    CreatePlacedResource to match; D3D12CmdList::TransitionBarrier still transparently upgrades their
+    later transitions to enhanced barriers when the device supports them (see D3D12Barrier.cpp), so this
+    does not opt a resource out of enhanced-barrier tracking for anything except the aliasing hazard
+    itself. */
+class D3D12AliasedTextureArena {
+public:
+    // Arena capacity. Fixed rather than growable — see D3D12PooledDescriptorHeap for the same reasoning
+    // (CLAUDE.md's per-frame-allocation rule: size once, log+fail past the cap rather than reallocating
+    // a live heap mid-session). 256 MB comfortably covers a Forward+ scratch set (a handful of full-res
+    // R8/RG16F/RGBA16F targets, sized generously below the peak they'd need even WITHOUT aliasing) with
+    // headroom; overflow just means a slot's resource creation fails and that pass' output is skipped,
+    // exactly like today's DoF/Motion resource-creation-failure paths.
+    static constexpr UINT64 kArenaCapacityBytes = 256ull * 1024 * 1024;
+    // RTV heap sized like D3D12TexturePool's — a handful of transient targets per graph in practice.
+    static constexpr UINT kMaxSlots = 64;
+
+    bool Attach( D3D12GraphicsEngine& engine );
+
+    /** {size, alignment} D3D12 would need for a texture matching this description, WITHOUT creating it
+        — what D3D12RenderGraph's interval colorer sizes its packing against. */
+    void GetAllocationInfo( UINT width, UINT height, DXGI_FORMAT format, bool needsUav, UINT64& outSize, UINT64& outAlignment ) const;
+
+    /** Places (or reuses) a texture at the given byte offset for THIS pass, as decided by
+        D3D12RenderGraph::Compile()'s interval coloring. If a different resource previously occupied
+        this offset (a different Description at the same offset, either from earlier this exact frame
+        or held over from last frame) a fresh placed resource is created and an aliasing barrier against
+        the previous occupant is recorded on cmdList before returning. If the same Description already
+        occupies the offset, the existing resource is returned untouched — no barrier, no new views,
+        exactly like D3D12TexturePool's steady-state case. Returns nullptr (logged once) on failure
+        (arena exhausted, format+size rejected by the driver, ...). */
+    D3D12RenderTarget* Acquire( UINT64 slotOffset, UINT width, UINT height, DXGI_FORMAT format, bool needsUav, D3D12CmdList& cmdList );
+
+    void Clear();   // drops every placed resource + their SRV/RTV slots (resize / level change); keeps the heap
+
+private:
+    struct Slot {
+        UINT64 Offset = 0;
+        std::unique_ptr<D3D12RenderTarget> Texture;   // created once at first use; ReplaceResource() thereafter
+        UINT Width = 0, Height = 0;
+        DXGI_FORMAT Format = DXGI_FORMAT_UNKNOWN;
+        bool NeedsUav = false;
+    };
+
+    Slot* FindOrCreateSlot( UINT64 offset );
+
+    ID3D12Device* m_Device = nullptr;
+    D3D12GraphicsEngine* m_Engine = nullptr;
+    Microsoft::WRL::ComPtr<ID3D12Heap> m_Heap;
+    D3D12PooledDescriptorHeap m_RtvHeap;
+
+    std::vector<std::unique_ptr<Slot>> m_Slots;
+    bool m_LoggedExhaustion = false;
+};

--- a/D3D11Engine/D3D12Engine/D3D12DoF.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12DoF.cpp
@@ -7,14 +7,24 @@
 // FRAME SLOT. RenderDepthOfField runs on the LINEAR HDR scene colour, after the TAA resolve and before bloom.
 // That is D3D11's slot exactly: DoF is the first pass of its "Post-processing B" block, which sits after the
 // upscale/TAA stage and ahead of bloom and the tonemap. Blurring before bloom is what makes an out-of-focus
-// highlight bloom as the disc it has become rather than as the point it was, and it keeps DoF out of the
-// temporal accumulation — a blur inside TAA history smears as the focus point moves.
+// highlight bloom as the disc it has become rather than as the point it was; being after TAA keeps a moving
+// focus point from smearing through the temporal history.
 //
 // TRANSPARENCY TO THE REST OF THE CHAIN. Scene colour in, scene colour out (the composite goes to a scratch
 // texture and is copied back), so nothing downstream has to know the pass ran.
+//
+// RENDER-GRAPH USE (first live consumer of D3D12RenderGraph's actual resource system, not just its pass
+// structure — see D3D12RenderGraph.h / D3D12AliasedTextureArena.h). The half-res blur target and the full-res
+// composite scratch are PURELY transient within one call of RenderDepthOfField — written, read once, then
+// dead — so unlike the focus ping-pong (which must survive across frames for the temporal smoothing to mean
+// anything) they are acquired fresh from a local D3D12RenderGraph each call instead of being held as members.
+// They are NOT resized/recreated explicitly on a resolution change any more either: since they are asked for
+// at the CURRENT m_Resolution every call, a resize just makes next frame's CreateTexture() ask for a
+// different size, which the graph handles the same way it handles any other description change.
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
 #include "D3D12ResourceCreate.h"
+#include "D3D12RenderGraph.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 
@@ -27,15 +37,22 @@ namespace {
     // making the state identical to the one every other depth-reading pass parks it in.
     constexpr D3D12_RESOURCE_STATES kDoFDepthRead =
         D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
+    // D3D12RenderGraph's transient-texture flag convention (see RGTextureDesc::textureFlags / RGBuilder's
+    // consumer in D3D12RenderGraph.cpp): bit 0 requests a UAV alongside the SRV. Both DoF scratch targets are
+    // compute-written, so both need it.
+    constexpr uint32_t kRgNeedsUav = 1u;
 }
 
-/** (Re)creates the focus ping-pong pair, the half-res blur target and the full-res composite scratch.
+/** (Re)creates the temporally-persistent focus ping-pong pair only. The half-res blur target and the
+    full-res composite scratch used to live here too; they are now D3D12RenderGraph-managed transient
+    textures acquired inside RenderDepthOfField (see the file header) and need no explicit creation or
+    resize handling.
 
     Called LAZILY from RenderDepthOfField the first time DoF is actually switched on, and from the resize path
-    only if they already exist — see the header note on why these are not built unconditionally like the bloom
-    pyramid. Heap slots are allocated once and re-pointed at the fresh resources, the same pattern the bloom /
-    AO / TAA resources follow. Non-fatal: on failure m_DoFResourcesReady stays false and RenderDepthOfField
-    no-ops, leaving the scene in focus. */
+    only if it already ran once — see the header note on why this is not built unconditionally like the bloom
+    pyramid. Heap slots are allocated once and re-pointed at the fresh resources. Non-fatal: on failure
+    m_DoFResourcesReady stays false and RenderDepthOfField no-ops, leaving the scene in focus. */
 bool D3D12GraphicsEngine::CreateDoFResources( INT2 size ) {
     m_DoFResourcesReady = false;
     m_DoFCreateAttempted = true;
@@ -65,11 +82,11 @@ bool D3D12GraphicsEngine::CreateDoFResources( INT2 size ) {
         dd.SampleDesc.Count = 1;
         dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
         dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-        // Every one of these rests in UNORDERED_ACCESS between frames (see RenderDepthOfField), so create them
-        // in it — that makes the "before" state at the top of the pass deterministic on the very first frame.
+        // Rests in UNORDERED_ACCESS between frames (see RenderDepthOfField), so create it in it — that makes
+        // the "before" state at the top of the very first frame deterministic.
         if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             nullptr, outAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( out.ReleaseAndGetAddressOf() ) ) ) ) {
-            LogWarn() << "D3D12: failed to create a depth-of-field texture (" << w << "x" << h << ").";
+            LogWarn() << "D3D12: failed to create a depth-of-field focus texture (" << w << "x" << h << ").";
             return false;
         }
         out->SetName( name );
@@ -83,7 +100,7 @@ bool D3D12GraphicsEngine::CreateDoFResources( INT2 size ) {
     D3D12_UNORDERED_ACCESS_VIEW_DESC uav = {};
     uav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
 
-    // --- Focus pair: 1x1 R32_FLOAT, the auto-focus distance. Resolution-independent, but rebuilt with the rest
+    // Focus pair: 1x1 R32_FLOAT, the auto-focus distance. Resolution-independent, but rebuilt with the rest
     // so there is exactly one creation path; the history is worthless across a resolution change anyway.
     for ( UINT i = 0; i < 2; ++i ) {
         if ( !makeTex( 1, 1, DXGI_FORMAT_R32_FLOAT, m_DoFFocus[i], m_DoFFocusAlloc[i],
@@ -97,30 +114,13 @@ bool D3D12GraphicsEngine::CreateDoFResources( INT2 size ) {
     m_DoFFocusIndex = 0;
     m_DoFFocusValid = false;   // contents are undefined until the first resolve writes one of them
 
-    // --- Half-res bokeh target (rgb = blur, a = centre CoC). Integer-divided like D3D11's res.x / 2, and never
-    // below 1 texel so a tiny window can't produce a zero-sized resource.
-    m_DoFHalfSize = { std::max( 1, size.x / 2 ), std::max( 1, size.y / 2 ) };
-    if ( !makeTex( m_DoFHalfSize.x, m_DoFHalfSize.y, kSceneColorFormat, m_DoFHalf, m_DoFHalfAlloc, L"DoFHalfRes" ) )
-        return false;
-    if ( !ensureSlot( m_DoFHalfSrvSlot ) || !ensureSlot( m_DoFHalfUavSlot ) ) return false;
-    srv.Format = kSceneColorFormat;
-    uav.Format = kSceneColorFormat;
-    device->CreateShaderResourceView( m_DoFHalf.Get(), &srv, GetSrvCpuHandle( m_DoFHalfSrvSlot ) );
-    device->CreateUnorderedAccessView( m_DoFHalf.Get(), nullptr, &uav, GetSrvCpuHandle( m_DoFHalfUavSlot ) );
-
-    // --- Full-res composite scratch. Same format as the scene colour, which is what lets the result be handed
-    // back with a plain CopyResource instead of a full-screen blit (the TAA history does the same).
-    if ( !makeTex( size.x, size.y, kSceneColorFormat, m_DoFComposite, m_DoFCompositeAlloc, L"DoFComposite" ) )
-        return false;
-    if ( !ensureSlot( m_DoFCompositeUavSlot ) ) return false;
-    device->CreateUnorderedAccessView( m_DoFComposite.Get(), nullptr, &uav, GetSrvCpuHandle( m_DoFCompositeUavSlot ) );
-
     m_DoFResourcesReady = true;
     return true;
 }
 
 
-/** Focus resolve -> half-res blur -> full-res composite -> copy back over the scene colour. */
+/** Focus resolve -> half-res blur -> full-res composite -> copy back over the scene colour, the last three
+    steps issued through a local D3D12RenderGraph (see the file header). */
 void D3D12GraphicsEngine::RenderDepthOfField() {
     auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
     if ( !settings.EnableDoF ) return;
@@ -130,21 +130,16 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
     if ( !m_Pipelines.DoF.RootSig || !m_Pipelines.DoF.FocusPSO || !m_Pipelines.DoF.CompositePSO )
         return;
 
-    // Lazily build the textures the first time DoF is switched on (they are ~20 MB of VA at 1080p and DoF is off
-    // in a stock config — see the header). Creating a resource mid-frame is safe: nothing is destroyed here, so
-    // there is no in-flight resource to fence against. m_DoFCreateAttempted keeps a failure from retrying every
-    // frame; it is cleared on resize, which is the only thing that could change the outcome.
+    // Lazily build the focus ping-pong the first time DoF is switched on. Creating a resource mid-frame is
+    // safe: nothing is destroyed here, so there is no in-flight resource to fence against.
+    // m_DoFCreateAttempted keeps a failure from retrying every frame; cleared on resize.
     if ( !m_DoFResourcesReady ) {
         if ( m_DoFCreateAttempted ) return;
         if ( !CreateDoFResources( m_Resolution ) ) {
-            LogWarn() << "D3D12: depth of field is enabled but its textures could not be created — DoF disabled.";
+            LogWarn() << "D3D12: depth of field is enabled but its focus texture could not be created — DoF disabled.";
             return;
         }
     }
-    // Resolution changed without the resources following (the resize path only rebuilds them if they already
-    // exist, so this is a belt-and-braces check rather than an expected state).
-    if ( m_DoFHalfSize.x != std::max( 1, m_Resolution.x / 2 ) || m_DoFHalfSize.y != std::max( 1, m_Resolution.y / 2 ) )
-        return;
 
     ID3D12PipelineState* blurPso = settings.DoFGaussBlur
         ? m_Pipelines.DoF.GaussPSO.Get()
@@ -156,6 +151,7 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
 
     const UINT prevIdx = m_DoFFocusIndex;
     const UINT curIdx = 1 - m_DoFFocusIndex;
+    const INT2 halfSize = { std::max( 1, m_Resolution.x / 2 ), std::max( 1, m_Resolution.y / 2 ) };
 
     // b0 DoFCB — see Shaders/D3D12/DoF.hlsl. One block for all three passes; the per-pass fields (OutIndex and
     // the output resolution) are rewritten between dispatches, everything else is set once here.
@@ -191,14 +187,14 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
     cb.DepthIndex = m_DepthSrvSlot;
     cb.PrevFocusIndex = m_DoFFocusSrvSlot[prevIdx];
     cb.FocusIndex = m_DoFFocusSrvSlot[curIdx];
-    cb.BlurIndex = m_DoFHalfSrvSlot;
     cb.FocusUavIndex = m_DoFFocusUavSlot[curIdx];
     cb.FullResX = static_cast<float>( m_Resolution.x );
     cb.FullResY = static_cast<float>( m_Resolution.y );
 
     // Scene colour RENDER_TARGET -> compute-readable, depth out of DEPTH_WRITE, previous focus UAV -> readable.
     // The DSV/RTV must be unbound first: a resource cannot be bound as a render target while it is read through
-    // an SRV (same dance RenderTAA / RenderBloom / RenderFogAndGodRays do).
+    // an SRV (same dance RenderTAA / RenderBloom / RenderFogAndGodRays do). None of this touches the graph's
+    // resources, so it happens once, directly, before the graph runs.
     m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
     {
         D3D12ResourceTransition pre[3];
@@ -214,68 +210,125 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
         m_SceneColorInPixelState = true;
     }
 
-    m_CmdList->SetComputeRootSignature( m_Pipelines.DoF.RootSig.Get() );
+    D3D12RenderGraph dofGraph( &m_AliasArena );
+    RGResourceHandle halfHandle = RG_INVALID_HANDLE;
+    RGResourceHandle compositeHandle = RG_INVALID_HANDLE;
+    bool compositeCopied = false;   // did the composite pass below actually run the copy-back?
 
-    // --- Pass 0: focus resolve (1x1) ---
-    // This pass writes through FocusUavIndex, not OutIndex, and reads neither OutRes — it is the one pass whose
-    // output is a fixed 1x1 texel, so those three fields stay at their zero-init values here.
-    m_CmdList->SetPipelineState( m_Pipelines.DoF.FocusPSO.Get() );
-    m_CmdList->SetComputeRoot32BitConstants( 0, 16, &cb, 0 );
-    m_CmdList->Dispatch( 1, 1, 1 );
+    // --- Pass 0: focus resolve (1x1) --- Writes through FocusUavIndex, not OutIndex, and reads neither OutRes
+    // — it is the one pass whose output is a fixed 1x1 texel, so those three fields stay at zero-init here.
+    // Touches no graph resources (m_DoFFocus is a persistent member pair, not transient), but the curIdx/
+    // prevIdx UAV<->SRV handover it performs must happen before the blur pass below reads FocusIndex.
+    dofGraph.AddPass( RG_PASS_NAME( "DoF Focus Resolve" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+        pass.m_executeCallback = [this, prevIdx, curIdx, &cb]( const D3D12RenderGraph&, D3D12CmdList& cmdList ) {
+            cmdList.SetComputeRootSignature( m_Pipelines.DoF.RootSig.Get() );
+            cmdList.SetPipelineState( m_Pipelines.DoF.FocusPSO.Get() );
+            cmdList.SetComputeRoot32BitConstants( 0, 16, &cb, 0 );
+            cmdList.Dispatch( 1, 1, 1 );
 
-    // This frame's focus value becomes the read side for the two passes below; hand the previous one back to its
-    // resting UAV state. A UAV-write -> SRV-read handover needs a real state transition, not a UAV barrier: a
-    // UAV barrier only orders UAV access and performs no cache flush, so the SRV read would be undefined.
-    {
-        m_CmdList->TransitionBarriers( {
-        	{ m_DoFFocus[curIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE },
-        	{ m_DoFFocus[prevIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+            // This frame's focus value becomes the read side for the two passes below; hand the previous one
+            // back to its resting UAV state. A UAV-write -> SRV-read handover needs a real state transition,
+            // not a UAV barrier: a UAV barrier only orders UAV access and performs no cache flush, so the SRV
+            // read would be undefined.
+            cmdList.TransitionBarriers( {
+                { m_DoFFocus[curIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE },
+                { m_DoFFocus[prevIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+                } );
+            m_DoFFocusIndex = curIdx;
+            m_DoFFocusValid = true;
+            };
         } );
-    }
-    m_DoFFocusIndex = curIdx;
-    m_DoFFocusValid = true;
 
-    // --- Pass 1: half-res bokeh (or Gaussian) blur ---
-    m_CmdList->SetPipelineState( blurPso );
-    cb.OutIndex = m_DoFHalfUavSlot;
-    cb.OutResX = static_cast<float>( m_DoFHalfSize.x );
-    cb.OutResY = static_cast<float>( m_DoFHalfSize.y );
-    m_CmdList->SetComputeRoot32BitConstants( 0, 16, &cb, 0 );
-    m_CmdList->Dispatch( ( m_DoFHalfSize.x + 7 ) / 8, ( m_DoFHalfSize.y + 7 ) / 8, 1 );
+    // --- Pass 1: half-res bokeh (or Gaussian) blur --- The first CreateTexture() this backend has ever issued
+    // through D3D12RenderGraph: a real transient resource, acquired from m_AliasArena via interval coloring
+    // rather than held as a member. tex->State is caller-maintained (see D3D12RenderTarget.h) — check it
+    // rather than assuming, since a freshly (re)placed resource starts at RENDER_TARGET while a reused one
+    // already sits wherever last frame's DoF pass left it.
+    dofGraph.AddPass( RG_PASS_NAME( "DoF Half-Res Blur" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+        halfHandle = builder.CreateTexture( { static_cast<uint32_t>( halfSize.x ), static_cast<uint32_t>( halfSize.y ),
+            static_cast<int>( kSceneColorFormat ), L"DoFHalf", kRgNeedsUav } );
 
-    {
-        m_CmdList->TransitionBarrier( m_DoFHalf.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-    }
+        pass.m_executeCallback = [this, blurPso, halfSize, &cb, halfHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
+            D3D12RenderTarget* half = graph.GetPhysicalTexture( halfHandle );
+            if ( !half ) return;   // arena exhausted or creation failed (logged once by the arena) — skip the blur
 
-    // --- Pass 2: full-res composite into the scratch texture ---
-    m_CmdList->SetPipelineState( m_Pipelines.DoF.CompositePSO.Get() );
-    cb.OutIndex = m_DoFCompositeUavSlot;
-    cb.OutResX = static_cast<float>( m_Resolution.x );
-    cb.OutResY = static_cast<float>( m_Resolution.y );
-    m_CmdList->SetComputeRoot32BitConstants( 0, 16, &cb, 0 );
-    m_CmdList->Dispatch( ( m_Resolution.x + 7 ) / 8, ( m_Resolution.y + 7 ) / 8, 1 );
+            if ( half->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
+                cmdList.TransitionBarrier( half->GetResource(), half->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+                half->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+            }
 
-    // Hand the result back to the scene colour. Both are kSceneColorFormat, so this is a straight CopyResource.
-    {
-        m_CmdList->TransitionBarriers( {
-        	{ m_DoFComposite.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE },
-        	{ m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST },
+            cmdList.SetComputeRootSignature( m_Pipelines.DoF.RootSig.Get() );
+            cmdList.SetPipelineState( blurPso );
+            cb.OutIndex = half->GetUavSlot();
+            cb.OutResX = static_cast<float>( halfSize.x );
+            cb.OutResY = static_cast<float>( halfSize.y );
+            cmdList.SetComputeRoot32BitConstants( 0, 16, &cb, 0 );
+            cmdList.Dispatch( ( halfSize.x + 7 ) / 8, ( halfSize.y + 7 ) / 8, 1 );
+
+            // The composite pass below samples this through BlurIndex (its SRV slot).
+            cmdList.TransitionBarrier( half->GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+            half->State = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+            };
         } );
-        m_CmdList->CopyResource( m_SceneColor.Get(), m_DoFComposite.Get() );
-    }
 
-    // Resting states for the next frame: every DoF texture back to UNORDERED_ACCESS, depth back to DEPTH_WRITE,
-    // scene colour back to RENDER_TARGET for bloom / the tonemap.
-    {
-        m_CmdList->TransitionBarriers( {
-        	{ m_DoFComposite.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
-        	{ m_DoFHalf.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
-        	{ m_DoFFocus[curIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
-        	{ m_DepthBuffer.Get(), kDoFDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE },
-        	{ m_SceneColor.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_RENDER_TARGET },
+    // --- Pass 2: full-res composite into a graph-managed scratch texture, then copy back onto the scene colour ---
+    dofGraph.AddPass( RG_PASS_NAME( "DoF Composite" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+        builder.Read( halfHandle );
+        compositeHandle = builder.CreateTexture( { static_cast<uint32_t>( m_Resolution.x ), static_cast<uint32_t>( m_Resolution.y ),
+            static_cast<int>( kSceneColorFormat ), L"DoFComposite", kRgNeedsUav } );
+        // CreateTexture() already declares compositeHandle read (see D3D12RGBuilder::CreateTexture), so the
+        // resource itself is allocated. What's still missing is that its VISIBLE result leaves the graph
+        // entirely via the CopyResource onto m_SceneColor below — a plain member, not a resource the graph
+        // owns — so nothing the graph can see depends on this pass having run. Without MarkExternalEffect,
+        // Execute()'s dead-pass elimination would see a self-contained write/read pair with no visible
+        // external effect and skip the callback. See D3D12RenderPass::m_hasExternalSideEffect.
+        builder.MarkExternalEffect();
+
+        pass.m_executeCallback = [this, &cb, &compositeCopied, halfHandle, compositeHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
+            D3D12RenderTarget* half = graph.GetPhysicalTexture( halfHandle );
+            D3D12RenderTarget* composite = graph.GetPhysicalTexture( compositeHandle );
+            if ( !half || !composite ) return;   // scene colour / depth / focus are still restored below unconditionally
+
+            if ( composite->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
+                cmdList.TransitionBarrier( composite->GetResource(), composite->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+                composite->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+            }
+
+            cmdList.SetComputeRootSignature( m_Pipelines.DoF.RootSig.Get() );
+            cmdList.SetPipelineState( m_Pipelines.DoF.CompositePSO.Get() );
+            cb.BlurIndex = half->GetSrvSlot();
+            cb.OutIndex = composite->GetUavSlot();
+            cb.OutResX = static_cast<float>( m_Resolution.x );
+            cb.OutResY = static_cast<float>( m_Resolution.y );
+            cmdList.SetComputeRoot32BitConstants( 0, 16, &cb, 0 );
+            cmdList.Dispatch( ( m_Resolution.x + 7 ) / 8, ( m_Resolution.y + 7 ) / 8, 1 );
+
+            // Hand the result back to the scene colour. Both are kSceneColorFormat, so this is a straight copy.
+            cmdList.TransitionBarriers( {
+                { composite->GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE },
+                { m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST },
+                } );
+            cmdList.CopyResource( m_SceneColor.Get(), composite->GetResource() );
+            composite->State = D3D12_RESOURCE_STATE_COPY_SOURCE;
+            compositeCopied = true;
+            };
         } );
-        m_SceneColorInPixelState = false;
-    }
+
+    dofGraph.Compile();
+    dofGraph.Execute( m_CmdList );
+
+    // Resting states for the engine-owned resources DoF borrowed — NOT graph-managed, so nothing else restores
+    // them, and this must run regardless of whether the composite pass above actually found its textures (see
+    // its early-out). Depth back to DEPTH_WRITE, scene colour back to RENDER_TARGET (from COPY_DEST if the
+    // copy-back ran, otherwise from the plain shader-read state the pre-pass block put it in), this frame's
+    // focus texture back to its UAV resting state for whenever it becomes "prevIdx" again.
+    m_CmdList->TransitionBarriers( {
+        { m_DepthBuffer.Get(), kDoFDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE },
+        { m_SceneColor.Get(), compositeCopied ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+            D3D12_RESOURCE_STATE_RENDER_TARGET },
+        { m_DoFFocus[curIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+        } );
+    m_SceneColorInPixelState = false;
 
     // Rebind the scene colour + depth for whatever comes next in the frame (bloom re-transitions the scene
     // colour itself, but the render target must not be left unbound).

--- a/D3D11Engine/D3D12Engine/D3D12DoF.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12DoF.cpp
@@ -255,21 +255,18 @@ void D3D12GraphicsEngine::RenderDepthOfField( D3D12RenderGraph& graph ) {
             };
         } );
 
-    // --- Half-res bokeh (or Gaussian) blur --- tex->State is caller-maintained (see D3D12RenderTarget.h) —
-    // check it rather than assuming, since a freshly (re)placed resource starts at RENDER_TARGET while a
-    // reused one already sits wherever last frame's DoF pass left it.
+    // --- Half-res bokeh (or Gaussian) blur --- CreateTexture()'s state param gets this into UNORDERED_ACCESS
+    // automatically before the callback below runs (D3D12RenderGraph::Execute) — whether that means
+    // transitioning a freshly (re)placed resource from RENDER_TARGET or one reused from wherever last
+    // frame's DoF pass left it, and the composite pass's Read() below transitions it to shader-read
+    // afterward — neither needs a manual check/transition here any more.
     graph.AddPass( RG_PASS_NAME( "DoF Half-Res Blur" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
         halfHandle = builder.CreateTexture( { static_cast<uint32_t>( halfSize.x ), static_cast<uint32_t>( halfSize.y ),
-            static_cast<int>( kSceneColorFormat ), L"DoFHalf", kRgNeedsUav } );
+            static_cast<int>( kSceneColorFormat ), L"DoFHalf", kRgNeedsUav }, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
 
         pass.m_executeCallback = [this, blurPso, halfSize, cb, halfHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
             D3D12RenderTarget* half = g.GetPhysicalTexture( halfHandle );
             if ( !half ) return;   // arena exhausted or creation failed (logged once by the arena) — skip the blur
-
-            if ( half->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
-                cmdList.TransitionBarrier( half->GetResource(), half->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-                half->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-            }
 
             cmdList.SetComputeRootSignature( m_Pipelines.DoF.RootSig.Get() );
             cmdList.SetPipelineState( blurPso );
@@ -278,18 +275,14 @@ void D3D12GraphicsEngine::RenderDepthOfField( D3D12RenderGraph& graph ) {
             cb->OutResY = static_cast<float>( halfSize.y );
             cmdList.SetComputeRoot32BitConstants( 0, 16, cb.get(), 0 );
             cmdList.Dispatch( ( halfSize.x + 7 ) / 8, ( halfSize.y + 7 ) / 8, 1 );
-
-            // The composite pass below samples this through BlurIndex (its SRV slot).
-            cmdList.TransitionBarrier( half->GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-            half->State = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
             };
         } );
 
     // --- Full-res composite into a graph-managed scratch texture, then copy back onto the scene colour ---
     graph.AddPass( RG_PASS_NAME( "DoF Composite" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
-        builder.Read( halfHandle );
+        builder.Read( halfHandle, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
         compositeHandle = builder.CreateTexture( { static_cast<uint32_t>( m_Resolution.x ), static_cast<uint32_t>( m_Resolution.y ),
-            static_cast<int>( kSceneColorFormat ), L"DoFComposite", kRgNeedsUav } );
+            static_cast<int>( kSceneColorFormat ), L"DoFComposite", kRgNeedsUav }, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
         // CreateTexture() already declares compositeHandle read (see D3D12RGBuilder::CreateTexture), so the
         // resource itself is allocated. What's still missing is that its VISIBLE result leaves the graph
         // entirely via the CopyResource onto m_SceneColor below — a plain member, not a resource the graph
@@ -303,11 +296,8 @@ void D3D12GraphicsEngine::RenderDepthOfField( D3D12RenderGraph& graph ) {
             D3D12RenderTarget* composite = g.GetPhysicalTexture( compositeHandle );
             if ( !half || !composite ) return;   // scene colour / depth / focus are still restored below unconditionally
 
-            if ( composite->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
-                cmdList.TransitionBarrier( composite->GetResource(), composite->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-                composite->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-            }
-
+            // composite is already UNORDERED_ACCESS here (CreateTexture()'s declared state, applied
+            // automatically by Execute() before this callback runs).
             cmdList.SetComputeRootSignature( m_Pipelines.DoF.RootSig.Get() );
             cmdList.SetPipelineState( m_Pipelines.DoF.CompositePSO.Get() );
             cb->BlurIndex = half->GetSrvSlot();

--- a/D3D11Engine/D3D12Engine/D3D12DoF.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12DoF.cpp
@@ -27,6 +27,7 @@
 #include "D3D12RenderGraph.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
+#include <memory>
 
 using Microsoft::WRL::ComPtr;
 #include "D3D12EngineCommon.h"
@@ -119,9 +120,41 @@ bool D3D12GraphicsEngine::CreateDoFResources( INT2 size ) {
 }
 
 
-/** Focus resolve -> half-res blur -> full-res composite -> copy back over the scene colour, the last three
-    steps issued through a local D3D12RenderGraph (see the file header). */
-void D3D12GraphicsEngine::RenderDepthOfField() {
+// b0 DoFCB — see Shaders/D3D12/DoF.hlsl. One block shared by all three passes; the per-pass fields (OutIndex
+// and the output resolution) are rewritten between dispatches, everything else is set once. Lives on the heap
+// (not a RenderDepthOfField stack local) because it is written and read across MULTIPLE pass callbacks that
+// now run later, inside `graph`'s single deferred Execute() — a stack local captured by reference would be
+// dangling by the time that happens, since RenderDepthOfField itself returns right after registering its
+// passes. Every cross-pass mutable value in this file follows the same shared_ptr-capture-by-value pattern.
+namespace {
+    struct DoFConsts {
+        float    FocusRange;
+        float    BokehRadius;
+        float    MaxBlur;
+        uint32_t FocusValid;
+        uint32_t SceneIndex;
+        uint32_t DepthIndex;
+        uint32_t PrevFocusIndex;
+        uint32_t FocusIndex;
+        uint32_t BlurIndex;
+        uint32_t FocusUavIndex;
+        uint32_t OutIndex;
+        uint32_t Pad;
+        float    FullResX;
+        float    FullResY;
+        float    OutResX;
+        float    OutResY;
+    };
+    static_assert( sizeof( DoFConsts ) == 16 * sizeof( uint32_t ),
+        "DoFConsts must match DoF.hlsl's b0 DoFCB and the 16 root constants pushed below" );
+}
+
+/** Registers DoF's passes (prepare -> focus resolve -> half-res blur -> full-res composite -> copy back over
+    the scene colour -> restore) onto the SHARED per-frame graph — see D3D12RenderGraph.h and this file's
+    header comment. Called directly from the postFxGraph construction in D3D12Scene.cpp's
+    OnStartWorldRendering, NOT wrapped in its own opaque pass, so its own sub-passes are visible to (and
+    scheduled correctly among) every other post-FX pass. */
+void D3D12GraphicsEngine::RenderDepthOfField( D3D12RenderGraph& graph ) {
     auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
     if ( !settings.EnableDoF ) return;
     if ( !m_FrameOpen || !m_CmdList || !m_SceneColor || m_SceneColorSrvSlot == UINT_MAX
@@ -146,84 +179,67 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
         : m_Pipelines.DoF.BlurPSO.Get();
     if ( !blurPso ) return;
 
-    DX_ZONE( m_CmdList.Get(), "Depth of Field" );
-    TracyD3D12ZoneCGX( m_CmdList.Get(), "Depth of Field" );
-
     const UINT prevIdx = m_DoFFocusIndex;
     const UINT curIdx = 1 - m_DoFFocusIndex;
     const INT2 halfSize = { std::max( 1, m_Resolution.x / 2 ), std::max( 1, m_Resolution.y / 2 ) };
 
-    // b0 DoFCB — see Shaders/D3D12/DoF.hlsl. One block for all three passes; the per-pass fields (OutIndex and
-    // the output resolution) are rewritten between dispatches, everything else is set once here.
-    struct DoFConsts {
-        float    FocusRange;
-        float    BokehRadius;
-        float    MaxBlur;
-        uint32_t FocusValid;
-        uint32_t SceneIndex;
-        uint32_t DepthIndex;
-        uint32_t PrevFocusIndex;
-        uint32_t FocusIndex;
-        uint32_t BlurIndex;
-        uint32_t FocusUavIndex;
-        uint32_t OutIndex;
-        uint32_t Pad;
-        float    FullResX;
-        float    FullResY;
-        float    OutResX;
-        float    OutResY;
-    } cb = {};
-    static_assert( sizeof( DoFConsts ) == 16 * sizeof( uint32_t ),
-        "DoFConsts must match DoF.hlsl's b0 DoFCB and the 16 root constants pushed below" );
-
+    auto cb = std::make_shared<DoFConsts>();
     // The same three tuning values D3D11PFX_DepthOfField pushes, straight from the shared settings. D3D11 also
     // uploads DoF_ProjParams / near / far, which none of the three compute shaders read (depth linearization is
     // the parameter-free reversed-Z reciprocal) — so they are not carried over.
-    cb.FocusRange = settings.DoFFocusRange;
-    cb.BokehRadius = settings.DoFBokehRadius;
-    cb.MaxBlur = settings.DoFMaxBlur;
-    cb.FocusValid = m_DoFFocusValid ? 1u : 0u;
-    cb.SceneIndex = m_SceneColorSrvSlot;
-    cb.DepthIndex = m_DepthSrvSlot;
-    cb.PrevFocusIndex = m_DoFFocusSrvSlot[prevIdx];
-    cb.FocusIndex = m_DoFFocusSrvSlot[curIdx];
-    cb.FocusUavIndex = m_DoFFocusUavSlot[curIdx];
-    cb.FullResX = static_cast<float>( m_Resolution.x );
-    cb.FullResY = static_cast<float>( m_Resolution.y );
+    cb->FocusRange = settings.DoFFocusRange;
+    cb->BokehRadius = settings.DoFBokehRadius;
+    cb->MaxBlur = settings.DoFMaxBlur;
+    cb->FocusValid = m_DoFFocusValid ? 1u : 0u;
+    cb->SceneIndex = m_SceneColorSrvSlot;
+    cb->DepthIndex = m_DepthSrvSlot;
+    cb->PrevFocusIndex = m_DoFFocusSrvSlot[prevIdx];
+    cb->FocusIndex = m_DoFFocusSrvSlot[curIdx];
+    cb->FocusUavIndex = m_DoFFocusUavSlot[curIdx];
+    cb->FullResX = static_cast<float>( m_Resolution.x );
+    cb->FullResY = static_cast<float>( m_Resolution.y );
 
-    // Scene colour RENDER_TARGET -> compute-readable, depth out of DEPTH_WRITE, previous focus UAV -> readable.
-    // The DSV/RTV must be unbound first: a resource cannot be bound as a render target while it is read through
-    // an SRV (same dance RenderTAA / RenderBloom / RenderFogAndGodRays do). None of this touches the graph's
-    // resources, so it happens once, directly, before the graph runs.
-    m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
-    {
-        D3D12ResourceTransition pre[3];
-        UINT n = 0;
-        if ( !m_SceneColorInPixelState ) {
-            pre[n++] = { m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
-                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE };
-        }
-        pre[n++] = { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, kDoFDepthRead };
-        pre[n++] = { m_DoFFocus[prevIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE };
-        m_CmdList->TransitionBarriers( pre, n );
-        m_SceneColorInPixelState = true;
-    }
-
-    D3D12RenderGraph dofGraph( &m_AliasArena );
+    auto compositeCopied = std::make_shared<bool>( false );   // did the composite pass actually run the copy-back?
+    // Plain locals, NOT shared_ptr like cb/compositeCopied above: a handle is only ever written once,
+    // synchronously, inside a pass's own setup lambda (builder.CreateTexture) — never during the deferred
+    // Execute() — so by the time any lambda (this pass's own execute callback, or a LATER pass's setup/
+    // execute callback) captures it by value, the assignment has already happened. Nothing here crosses
+    // the "written at deferred-execution time, read at deferred-execution time" boundary the shared_ptr
+    // treatment exists for (see cb/compositeCopied, which genuinely are mutated across passes' callbacks).
     RGResourceHandle halfHandle = RG_INVALID_HANDLE;
     RGResourceHandle compositeHandle = RG_INVALID_HANDLE;
-    bool compositeCopied = false;   // did the composite pass below actually run the copy-back?
 
-    // --- Pass 0: focus resolve (1x1) --- Writes through FocusUavIndex, not OutIndex, and reads neither OutRes
-    // — it is the one pass whose output is a fixed 1x1 texel, so those three fields stay at zero-init here.
-    // Touches no graph resources (m_DoFFocus is a persistent member pair, not transient), but the curIdx/
-    // prevIdx UAV<->SRV handover it performs must happen before the blur pass below reads FocusIndex.
-    dofGraph.AddPass( RG_PASS_NAME( "DoF Focus Resolve" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
-        pass.m_executeCallback = [this, prevIdx, curIdx, &cb]( const D3D12RenderGraph&, D3D12CmdList& cmdList ) {
+    // --- Prepare: scene colour RENDER_TARGET -> compute-readable, depth out of DEPTH_WRITE, previous focus
+    // UAV -> readable. The DSV/RTV must be unbound first: a resource cannot be bound as a render target while
+    // read through an SRV (same dance RenderTAA / RenderBloom / RenderFogAndGodRays do). None of this touches
+    // graph resources, so it is its own tiny pass with no Read/Write, exactly like "Debug Lines"/"TAA".
+    graph.AddPass( RG_PASS_NAME( "DoF Prepare" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+        pass.m_executeCallback = [this, prevIdx]( const D3D12RenderGraph&, D3D12CmdList& cmdList ) {
+            DX_ZONE( cmdList.Get(), "Depth of Field" );
+            cmdList.OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
+            D3D12ResourceTransition pre[3];
+            UINT n = 0;
+            if ( !m_SceneColorInPixelState ) {
+                pre[n++] = { m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
+                    D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE };
+            }
+            pre[n++] = { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, kDoFDepthRead };
+            pre[n++] = { m_DoFFocus[prevIdx].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE };
+            cmdList.TransitionBarriers( pre, n );
+            m_SceneColorInPixelState = true;
+            };
+        } );
+
+    // --- Focus resolve (1x1) --- Writes through FocusUavIndex, not OutIndex, and reads neither OutRes — it is
+    // the one pass whose output is a fixed 1x1 texel, so those three fields stay at zero-init here. Touches no
+    // graph resources (m_DoFFocus is a persistent member pair, not transient), but the curIdx/prevIdx UAV<->SRV
+    // handover it performs must happen before the blur pass below reads FocusIndex.
+    graph.AddPass( RG_PASS_NAME( "DoF Focus Resolve" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+        pass.m_executeCallback = [this, prevIdx, curIdx, cb]( const D3D12RenderGraph&, D3D12CmdList& cmdList ) {
             cmdList.SetComputeRootSignature( m_Pipelines.DoF.RootSig.Get() );
             cmdList.SetPipelineState( m_Pipelines.DoF.FocusPSO.Get() );
-            cmdList.SetComputeRoot32BitConstants( 0, 16, &cb, 0 );
+            cmdList.SetComputeRoot32BitConstants( 0, 16, cb.get(), 0 );
             cmdList.Dispatch( 1, 1, 1 );
 
             // This frame's focus value becomes the read side for the two passes below; hand the previous one
@@ -239,17 +255,15 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
             };
         } );
 
-    // --- Pass 1: half-res bokeh (or Gaussian) blur --- The first CreateTexture() this backend has ever issued
-    // through D3D12RenderGraph: a real transient resource, acquired from m_AliasArena via interval coloring
-    // rather than held as a member. tex->State is caller-maintained (see D3D12RenderTarget.h) — check it
-    // rather than assuming, since a freshly (re)placed resource starts at RENDER_TARGET while a reused one
-    // already sits wherever last frame's DoF pass left it.
-    dofGraph.AddPass( RG_PASS_NAME( "DoF Half-Res Blur" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+    // --- Half-res bokeh (or Gaussian) blur --- tex->State is caller-maintained (see D3D12RenderTarget.h) —
+    // check it rather than assuming, since a freshly (re)placed resource starts at RENDER_TARGET while a
+    // reused one already sits wherever last frame's DoF pass left it.
+    graph.AddPass( RG_PASS_NAME( "DoF Half-Res Blur" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
         halfHandle = builder.CreateTexture( { static_cast<uint32_t>( halfSize.x ), static_cast<uint32_t>( halfSize.y ),
             static_cast<int>( kSceneColorFormat ), L"DoFHalf", kRgNeedsUav } );
 
-        pass.m_executeCallback = [this, blurPso, halfSize, &cb, halfHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
-            D3D12RenderTarget* half = graph.GetPhysicalTexture( halfHandle );
+        pass.m_executeCallback = [this, blurPso, halfSize, cb, halfHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
+            D3D12RenderTarget* half = g.GetPhysicalTexture( halfHandle );
             if ( !half ) return;   // arena exhausted or creation failed (logged once by the arena) — skip the blur
 
             if ( half->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
@@ -259,10 +273,10 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
 
             cmdList.SetComputeRootSignature( m_Pipelines.DoF.RootSig.Get() );
             cmdList.SetPipelineState( blurPso );
-            cb.OutIndex = half->GetUavSlot();
-            cb.OutResX = static_cast<float>( halfSize.x );
-            cb.OutResY = static_cast<float>( halfSize.y );
-            cmdList.SetComputeRoot32BitConstants( 0, 16, &cb, 0 );
+            cb->OutIndex = half->GetUavSlot();
+            cb->OutResX = static_cast<float>( halfSize.x );
+            cb->OutResY = static_cast<float>( halfSize.y );
+            cmdList.SetComputeRoot32BitConstants( 0, 16, cb.get(), 0 );
             cmdList.Dispatch( ( halfSize.x + 7 ) / 8, ( halfSize.y + 7 ) / 8, 1 );
 
             // The composite pass below samples this through BlurIndex (its SRV slot).
@@ -271,8 +285,8 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
             };
         } );
 
-    // --- Pass 2: full-res composite into a graph-managed scratch texture, then copy back onto the scene colour ---
-    dofGraph.AddPass( RG_PASS_NAME( "DoF Composite" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+    // --- Full-res composite into a graph-managed scratch texture, then copy back onto the scene colour ---
+    graph.AddPass( RG_PASS_NAME( "DoF Composite" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
         builder.Read( halfHandle );
         compositeHandle = builder.CreateTexture( { static_cast<uint32_t>( m_Resolution.x ), static_cast<uint32_t>( m_Resolution.y ),
             static_cast<int>( kSceneColorFormat ), L"DoFComposite", kRgNeedsUav } );
@@ -284,9 +298,9 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
         // external effect and skip the callback. See D3D12RenderPass::m_hasExternalSideEffect.
         builder.MarkExternalEffect();
 
-        pass.m_executeCallback = [this, &cb, &compositeCopied, halfHandle, compositeHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
-            D3D12RenderTarget* half = graph.GetPhysicalTexture( halfHandle );
-            D3D12RenderTarget* composite = graph.GetPhysicalTexture( compositeHandle );
+        pass.m_executeCallback = [this, cb, compositeCopied, halfHandle, compositeHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
+            D3D12RenderTarget* half = g.GetPhysicalTexture( halfHandle );
+            D3D12RenderTarget* composite = g.GetPhysicalTexture( compositeHandle );
             if ( !half || !composite ) return;   // scene colour / depth / focus are still restored below unconditionally
 
             if ( composite->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
@@ -296,11 +310,11 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
 
             cmdList.SetComputeRootSignature( m_Pipelines.DoF.RootSig.Get() );
             cmdList.SetPipelineState( m_Pipelines.DoF.CompositePSO.Get() );
-            cb.BlurIndex = half->GetSrvSlot();
-            cb.OutIndex = composite->GetUavSlot();
-            cb.OutResX = static_cast<float>( m_Resolution.x );
-            cb.OutResY = static_cast<float>( m_Resolution.y );
-            cmdList.SetComputeRoot32BitConstants( 0, 16, &cb, 0 );
+            cb->BlurIndex = half->GetSrvSlot();
+            cb->OutIndex = composite->GetUavSlot();
+            cb->OutResX = static_cast<float>( m_Resolution.x );
+            cb->OutResY = static_cast<float>( m_Resolution.y );
+            cmdList.SetComputeRoot32BitConstants( 0, 16, cb.get(), 0 );
             cmdList.Dispatch( ( m_Resolution.x + 7 ) / 8, ( m_Resolution.y + 7 ) / 8, 1 );
 
             // Hand the result back to the scene colour. Both are kSceneColorFormat, so this is a straight copy.
@@ -310,27 +324,28 @@ void D3D12GraphicsEngine::RenderDepthOfField() {
                 } );
             cmdList.CopyResource( m_SceneColor.Get(), composite->GetResource() );
             composite->State = D3D12_RESOURCE_STATE_COPY_SOURCE;
-            compositeCopied = true;
+            *compositeCopied = true;
             };
         } );
 
-    dofGraph.Compile();
-    dofGraph.Execute( m_CmdList );
+    // --- Restore: resting states for the engine-owned resources DoF borrowed — NOT graph-managed, so nothing
+    // else restores them, and this must run regardless of whether the composite pass above actually found its
+    // textures (see its early-out). Depth back to DEPTH_WRITE, scene colour back to RENDER_TARGET (from
+    // COPY_DEST if the copy-back ran, otherwise from the plain shader-read state Prepare put it in), this
+    // frame's focus texture back to its UAV resting state for whenever it becomes "prevIdx" again.
+    graph.AddPass( RG_PASS_NAME( "DoF Restore" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+        pass.m_executeCallback = [this, curIdx, compositeCopied]( const D3D12RenderGraph&, D3D12CmdList& cmdList ) {
+            cmdList.TransitionBarriers( {
+                { m_DepthBuffer.Get(), kDoFDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE },
+                { m_SceneColor.Get(), *compositeCopied ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                    D3D12_RESOURCE_STATE_RENDER_TARGET },
+                { m_DoFFocus[curIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+                } );
+            m_SceneColorInPixelState = false;
 
-    // Resting states for the engine-owned resources DoF borrowed — NOT graph-managed, so nothing else restores
-    // them, and this must run regardless of whether the composite pass above actually found its textures (see
-    // its early-out). Depth back to DEPTH_WRITE, scene colour back to RENDER_TARGET (from COPY_DEST if the
-    // copy-back ran, otherwise from the plain shader-read state the pre-pass block put it in), this frame's
-    // focus texture back to its UAV resting state for whenever it becomes "prevIdx" again.
-    m_CmdList->TransitionBarriers( {
-        { m_DepthBuffer.Get(), kDoFDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE },
-        { m_SceneColor.Get(), compositeCopied ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-            D3D12_RESOURCE_STATE_RENDER_TARGET },
-        { m_DoFFocus[curIdx].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+            // Rebind the scene colour + depth for whatever comes next in the frame (bloom re-transitions the
+            // scene colour itself, but the render target must not be left unbound).
+            BindSceneColorTarget();
+            };
         } );
-    m_SceneColorInPixelState = false;
-
-    // Rebind the scene colour + depth for whatever comes next in the frame (bloom re-transitions the scene
-    // colour itself, but the render target must not be left unbound).
-    BindSceneColorTarget();
 }

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -303,7 +303,6 @@ struct DXMarker {
             }
 
             UINT byteSize = static_cast<UINT>( (len + 1) * sizeof( wchar_t ) );
-            c->SetMarker( 0, text, byteSize );
             c->BeginEvent( 0, text, byteSize );
 
             // Increment tracking slot to match what DRED maps under the hood

--- a/D3D11Engine/D3D12Engine/D3D12Fog.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Fog.cpp
@@ -13,6 +13,7 @@
 #include "../pch.h"
 #include "D3D12GraphicsEngine.h"
 #include "D3D12ResourceCreate.h"
+#include "D3D12RenderGraph.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 #include "../GSky.h"
@@ -97,70 +98,10 @@ bool D3D12GraphicsEngine::CreateFogConstantBuffers() {
 }
 
 
-bool D3D12GraphicsEngine::CreateFogResources( INT2 size ) {
-    // Quarter-resolution god-ray chain (mask -> radial blur), the D3D12 equivalent of D3D11's
-    // GetTempBufferDS4() pool textures. HDR format so bright sky pixels keep their intensity through the
-    // 64-tap blur, exactly like D3D11 (which uses GetBackBufferFormat(), i.e. its HDR intermediate).
-    m_FogResourcesReady = false;
-    m_GodRaySize = { 0, 0 };
-    if ( size.x < 8 || size.y < 8 ) return false;
-    ID3D12Device* device = m_Device.GetDevice();
-    if ( !device ) return false;
-
-    const INT2 ds4 = { std::max( 1, size.x / 4 ), std::max( 1, size.y / 4 ) };
-
-    D3D12MA::ALLOCATION_DESC heapDefault = {};
-    heapDefault.HeapType = D3D12_HEAP_TYPE_DEFAULT;
-
-    auto makeTex = [&]( ComPtr<ID3D12Resource>& out, ComPtr<D3D12MA::Allocation>& outAlloc, const wchar_t* name ) -> bool {
-        D3D12_RESOURCE_DESC dd = {};
-        dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-        dd.Width = static_cast<UINT64>( ds4.x );
-        dd.Height = static_cast<UINT>( ds4.y );
-        dd.DepthOrArraySize = 1;
-        dd.MipLevels = 1;
-        dd.Format = kSceneColorFormat;
-        dd.SampleDesc.Count = 1;
-        dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
-        dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-        if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            nullptr, outAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( out.ReleaseAndGetAddressOf() ) ) ) ) {
-            LogWarn() << "D3D12: failed to create a god-ray texture (" << ds4.x << "x" << ds4.y << ").";
-            return false;
-        }
-        out->SetName( name );
-        return true;
-        };
-
-    if ( !makeTex( m_GodRayMask, m_GodRayMaskAlloc, L"GodRayMask" ) ) return false;
-    if ( !makeTex( m_GodRayZoom, m_GodRayZoomAlloc, L"GodRayZoom" ) ) return false;
-
-    auto ensureSlot = [&]( UINT& slot ) -> bool {
-        if ( slot == UINT_MAX ) slot = AllocateSrvSlot();
-        return slot != UINT_MAX;
-        };
-    if ( !ensureSlot( m_GodRayMaskSrvSlot ) || !ensureSlot( m_GodRayMaskUavSlot )
-        || !ensureSlot( m_GodRayZoomSrvSlot ) || !ensureSlot( m_GodRayZoomUavSlot ) )
-        return false;
-
-    D3D12_SHADER_RESOURCE_VIEW_DESC srv = {};
-    srv.Format = kSceneColorFormat;
-    srv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-    srv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-    srv.Texture2D.MipLevels = 1;
-    D3D12_UNORDERED_ACCESS_VIEW_DESC uav = {};
-    uav.Format = kSceneColorFormat;
-    uav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
-
-    device->CreateShaderResourceView( m_GodRayMask.Get(), &srv, GetSrvCpuHandle( m_GodRayMaskSrvSlot ) );
-    device->CreateUnorderedAccessView( m_GodRayMask.Get(), nullptr, &uav, GetSrvCpuHandle( m_GodRayMaskUavSlot ) );
-    device->CreateShaderResourceView( m_GodRayZoom.Get(), &srv, GetSrvCpuHandle( m_GodRayZoomSrvSlot ) );
-    device->CreateUnorderedAccessView( m_GodRayZoom.Get(), nullptr, &uav, GetSrvCpuHandle( m_GodRayZoomUavSlot ) );
-
-    m_GodRaySize = ds4;
-    m_FogResourcesReady = true;
-    return true;
-}
+// God-ray mask + zoom textures used to be built here as members (see CreateFogResources's former home) — both
+// are purely single-frame scratch (written then read once then dead, no cross-frame data dependency), so they
+// are now D3D12RenderGraph-managed transient textures acquired fresh every call inside RenderFogAndGodRays
+// instead. Same conversion DoF's scratch textures got — see D3D12DoF.cpp.
 
 
 bool D3D12GraphicsEngine::EvaluateHeightFogActive() const {
@@ -192,8 +133,9 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
 
     // God rays: `EnableGodRays && isOutdoor` (D3D11), plus this backend's resource/PSO guards. The outdoor
     // test is already folded into EvaluateHeightFogActive; redo the BSP check here so god rays can still run
-    // in the (settings-wise possible) DrawFog=off case.
-    bool godRays = settings.EnableGodRays && m_FogResourcesReady
+    // in the (settings-wise possible) DrawFog=off case. No resource-readiness check any more: the mask/zoom
+    // textures are graph-managed transients acquired on demand below, not built ahead of time.
+    bool godRays = settings.EnableGodRays
         && m_Pipelines.Fog.MaskPSO && m_Pipelines.Fog.ZoomPSO && m_Pipelines.Fog.GodRayRootSig
         && m_SceneColorSrvSlot != UINT_MAX;
     if ( godRays ) {
@@ -239,8 +181,8 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
                 if ( std::abs( zoomConsts.Center[1] - 0.5f ) > 0.5f )
                     zoomConsts.Weight *= std::max( 0.0f, 1.0f - ( std::abs( zoomConsts.Center[1] - 0.5f ) - 0.5f ) / 0.5f );
 
-                zoomConsts.MaskIndex = m_GodRayMaskSrvSlot;
-                zoomConsts.OutputIndex = m_GodRayZoomUavSlot;
+                // MaskIndex/OutputIndex are resolved once the graph actually places the two textures below
+                // (their SRV/UAV slots don't exist yet at this point).
             }
         }
     }
@@ -260,44 +202,90 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
     }
 
     // ---------------------------------------------------------------------------------------------------
-    // God rays: quarter-res mask -> quarter-res radial blur (both compute, both bindless).
+    // God rays: quarter-res mask -> quarter-res radial blur (both compute, both bindless), through a local
+    // D3D12RenderGraph — same conversion DoF's scratch textures got (see D3D12DoF.cpp), and for the same
+    // reason: both textures are written then read once then dead, with no cross-frame data dependency.
     // ---------------------------------------------------------------------------------------------------
+    UINT godRayZoomSrvSlot = UINT_MAX;   // resolved by the Zoom pass below; read by the composition further down
     if ( godRays ) {
-        // Scene color must be readable by the mask CS; compute can't run with it bound as an RTV.
+        // Scene color must be readable by the mask CS; compute can't run with it bound as an RTV. Not
+        // graph-managed (m_SceneColor is a plain member, not imported), so this happens before the graph runs.
         if ( !m_SceneColorInPixelState ) {
             m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
             m_SceneColorInPixelState = true;
         }
         m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
 
-        const UINT gx = ( static_cast<UINT>( m_GodRaySize.x ) + 7 ) / 8;
-        const UINT gy = ( static_cast<UINT>( m_GodRaySize.y ) + 7 ) / 8;
+        const INT2 godRaySize = { std::max( 1, m_Resolution.x / 4 ), std::max( 1, m_Resolution.y / 4 ) };
+        const UINT gx = ( static_cast<UINT>( godRaySize.x ) + 7 ) / 8;
+        const UINT gy = ( static_cast<UINT>( godRaySize.y ) + 7 ) / 8;
 
-        m_CmdList->SetComputeRootSignature( m_Pipelines.Fog.GodRayRootSig.Get() );
+        D3D12RenderGraph fogGraph( &m_AliasArena );
+        RGResourceHandle maskHandle = RG_INVALID_HANDLE;
+        RGResourceHandle zoomHandle = RG_INVALID_HANDLE;
 
-        // --- Pass 1: mask (scene color + depth -> m_GodRayMask) ---
-        GodRayMaskConsts maskConsts = { m_SceneColorSrvSlot, m_DepthSrvSlot, m_GodRayMaskUavSlot, 0 };
-        m_CmdList->SetPipelineState( m_Pipelines.Fog.MaskPSO.Get() );
-        m_CmdList->SetComputeRoot32BitConstants( 0, 4, &maskConsts, 0 );
-        m_CmdList->Dispatch( gx, gy, 1 );
+        // --- Pass 1: mask (scene color + depth -> mask) ---
+        fogGraph.AddPass( RG_PASS_NAME( "God Ray Mask" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+            maskHandle = builder.CreateTexture( { static_cast<uint32_t>( godRaySize.x ), static_cast<uint32_t>( godRaySize.y ),
+                static_cast<int>( kSceneColorFormat ), L"GodRayMask", 1u } );
 
-        // UAV write -> SRV read needs a real state transition, not just a UAV barrier (see RenderBloom).
-        {
-            m_CmdList->TransitionBarrier( m_GodRayMask.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-        }
+            pass.m_executeCallback = [this, gx, gy, maskHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
+                D3D12RenderTarget* mask = graph.GetPhysicalTexture( maskHandle );
+                if ( !mask ) return;
 
-        // --- Pass 2: radial blur (m_GodRayMask -> m_GodRayZoom) ---
-        m_CmdList->SetPipelineState( m_Pipelines.Fog.ZoomPSO.Get() );
-        m_CmdList->SetComputeRoot32BitConstants( 0, 12, &zoomConsts, 0 );
-        m_CmdList->Dispatch( gx, gy, 1 );
+                if ( mask->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
+                    cmdList.TransitionBarrier( mask->GetResource(), mask->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+                    mask->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+                }
 
-        // Result -> pixel-shader readable for the composition; mask back to its resting UNORDERED_ACCESS.
-        {
-            m_CmdList->TransitionBarriers( {
-            	{ m_GodRayZoom.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
-            	{ m_GodRayMask.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+                GodRayMaskConsts maskConsts = { m_SceneColorSrvSlot, m_DepthSrvSlot, mask->GetUavSlot(), 0 };
+                cmdList.SetComputeRootSignature( m_Pipelines.Fog.GodRayRootSig.Get() );
+                cmdList.SetPipelineState( m_Pipelines.Fog.MaskPSO.Get() );
+                cmdList.SetComputeRoot32BitConstants( 0, 4, &maskConsts, 0 );
+                cmdList.Dispatch( gx, gy, 1 );
+
+                // UAV write -> SRV read needs a real state transition, not just a UAV barrier (see RenderBloom).
+                cmdList.TransitionBarrier( mask->GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+                mask->State = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+                };
             } );
-        }
+
+        // --- Pass 2: radial blur (mask -> zoom) ---
+        fogGraph.AddPass( RG_PASS_NAME( "God Ray Zoom" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+            builder.Read( maskHandle );
+            zoomHandle = builder.CreateTexture( { static_cast<uint32_t>( godRaySize.x ), static_cast<uint32_t>( godRaySize.y ),
+                static_cast<int>( kSceneColorFormat ), L"GodRayZoom", 1u } );
+            // The composition draw further down reads this pass's result via godRayZoomSrvSlot, a plain
+            // local captured by reference — not a graph Read(), so mark the side effect explicitly (see
+            // D3D12RenderPass::m_hasExternalSideEffect).
+            builder.MarkExternalEffect();
+
+            pass.m_executeCallback = [this, gx, gy, &zoomConsts, &godRayZoomSrvSlot, maskHandle, zoomHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
+                D3D12RenderTarget* mask = graph.GetPhysicalTexture( maskHandle );
+                D3D12RenderTarget* zoom = graph.GetPhysicalTexture( zoomHandle );
+                if ( !mask || !zoom ) return;
+
+                if ( zoom->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
+                    cmdList.TransitionBarrier( zoom->GetResource(), zoom->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+                    zoom->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+                }
+
+                zoomConsts.MaskIndex = mask->GetSrvSlot();
+                zoomConsts.OutputIndex = zoom->GetUavSlot();
+                cmdList.SetComputeRootSignature( m_Pipelines.Fog.GodRayRootSig.Get() );
+                cmdList.SetPipelineState( m_Pipelines.Fog.ZoomPSO.Get() );
+                cmdList.SetComputeRoot32BitConstants( 0, 12, &zoomConsts, 0 );
+                cmdList.Dispatch( gx, gy, 1 );
+
+                // Result -> pixel-shader readable for the composition below.
+                cmdList.TransitionBarrier( zoom->GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
+                zoom->State = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+                godRayZoomSrvSlot = zoom->GetSrvSlot();
+                };
+            } );
+
+        fogGraph.Compile();
+        fogGraph.Execute( m_CmdList );
     }
 
     // ---------------------------------------------------------------------------------------------------
@@ -392,7 +380,7 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
 
     FogCompositeConsts consts = {};
     consts.DepthIndex = m_DepthSrvSlot;
-    consts.GodRaysIndex = godRays ? m_GodRayZoomSrvSlot : 0u;
+    consts.GodRaysIndex = godRays ? godRayZoomSrvSlot : 0u;
     consts.Flags = ( heightFog ? kFogFlagHeightFog : 0u ) | ( godRays ? kFogFlagGodRays : 0u );
 
     m_CmdList->SetPipelineState( m_Pipelines.Fog.CompositePSO.Get() );
@@ -402,17 +390,12 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
     m_CmdList->SetGraphicsRoot32BitConstants( 2, 4, &consts, 0 );
     m_CmdList->DrawInstanced( 3, 1, 0, 0 );
 
-    // Restore the resting states the rest of the frame (and the next one) expects: god-ray result back to
-    // UNORDERED_ACCESS, depth back to DEPTH_WRITE. The scene color stays bound as the RTV, which is exactly
-    // what RenderBloom (the next pass) assumes.
-    {
-        D3D12ResourceTransition b[2];
-        UINT n = 0;
-        if ( godRays )
-            b[n++] = { m_GodRayZoom.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS };
-        b[n++] = { m_DepthBuffer.Get(), kDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE };
-        m_CmdList->TransitionBarriers( b, n );
-    }
+    // Restore the resting state the rest of the frame (and the next one) expects: depth back to DEPTH_WRITE.
+    // The scene color stays bound as the RTV, which is exactly what RenderBloom (the next pass) assumes. The
+    // god-ray zoom texture needs no explicit reset any more — D3D12RenderTarget::State is caller-maintained
+    // and self-correcting: next frame's Zoom pass checks it and transitions from whatever it actually finds
+    // (see the pass callback above), the same way DoF's scratch textures work.
+    m_CmdList->TransitionBarrier( m_DepthBuffer.Get(), kDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE );
 
     m_ColorTargetIsHDR = true;
 }

--- a/D3D11Engine/D3D12Engine/D3D12Fog.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Fog.cpp
@@ -229,58 +229,48 @@ void D3D12GraphicsEngine::RenderFogAndGodRays( D3D12RenderGraph& graph ) {
         RGResourceHandle maskHandle = RG_INVALID_HANDLE;
         RGResourceHandle zoomHandle = RG_INVALID_HANDLE;
 
-        // --- Mask (scene color + depth -> mask) ---
+        // --- Mask (scene color + depth -> mask) --- CreateTexture()'s state param gets mask into
+        // UNORDERED_ACCESS automatically before this callback runs; the Zoom pass's Read() below
+        // transitions it to shader-read afterward — neither needs a manual check/transition here.
         graph.AddPass( RG_PASS_NAME( "God Ray Mask" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
             maskHandle = builder.CreateTexture( { static_cast<uint32_t>( godRaySize.x ), static_cast<uint32_t>( godRaySize.y ),
-                static_cast<int>( kSceneColorFormat ), L"GodRayMask", 1u } );
+                static_cast<int>( kSceneColorFormat ), L"GodRayMask", 1u }, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
 
             pass.m_executeCallback = [this, gx, gy, maskHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
                 D3D12RenderTarget* mask = g.GetPhysicalTexture( maskHandle );
                 if ( !mask ) return;
 
                 // Scene color must be readable by the mask CS; compute can't run with it bound as an RTV.
+                // Not graph-tracked (m_SceneColor is a plain member), so still transitioned manually.
                 if ( !m_SceneColorInPixelState ) {
                     cmdList.TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
                     m_SceneColorInPixelState = true;
                 }
                 cmdList.OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
 
-                if ( mask->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
-                    cmdList.TransitionBarrier( mask->GetResource(), mask->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-                    mask->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-                }
-
                 GodRayMaskConsts maskConsts = { m_SceneColorSrvSlot, m_DepthSrvSlot, mask->GetUavSlot(), 0 };
                 cmdList.SetComputeRootSignature( m_Pipelines.Fog.GodRayRootSig.Get() );
                 cmdList.SetPipelineState( m_Pipelines.Fog.MaskPSO.Get() );
                 cmdList.SetComputeRoot32BitConstants( 0, 4, &maskConsts, 0 );
                 cmdList.Dispatch( gx, gy, 1 );
-
-                // UAV write -> SRV read needs a real state transition, not just a UAV barrier (see RenderBloom).
-                cmdList.TransitionBarrier( mask->GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-                mask->State = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
                 };
             } );
 
         // --- Radial blur (mask -> zoom) ---
         graph.AddPass( RG_PASS_NAME( "God Ray Zoom" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
-            builder.Read( maskHandle );
+            builder.Read( maskHandle, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
             zoomHandle = builder.CreateTexture( { static_cast<uint32_t>( godRaySize.x ), static_cast<uint32_t>( godRaySize.y ),
-                static_cast<int>( kSceneColorFormat ), L"GodRayZoom", 1u } );
+                static_cast<int>( kSceneColorFormat ), L"GodRayZoom", 1u }, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
             // The composition pass further down reads this pass's result via godRayZoomSrvSlot, a plain
             // shared value — not a graph Read(), so mark the side effect explicitly (see
-            // D3D12RenderPass::m_hasExternalSideEffect).
+            // D3D12RenderPass::m_hasExternalSideEffect). Since nothing ever Read()s zoomHandle, its final
+            // transition to PIXEL_SHADER_RESOURCE below stays manual too — there's no Read() to hang it off.
             builder.MarkExternalEffect();
 
             pass.m_executeCallback = [this, gx, gy, zoomConsts, godRayZoomSrvSlot, maskHandle, zoomHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
                 D3D12RenderTarget* mask = g.GetPhysicalTexture( maskHandle );
                 D3D12RenderTarget* zoom = g.GetPhysicalTexture( zoomHandle );
                 if ( !mask || !zoom ) return;
-
-                if ( zoom->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
-                    cmdList.TransitionBarrier( zoom->GetResource(), zoom->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-                    zoom->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-                }
 
                 zoomConsts->MaskIndex = mask->GetSrvSlot();
                 zoomConsts->OutputIndex = zoom->GetUavSlot();

--- a/D3D11Engine/D3D12Engine/D3D12Fog.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Fog.cpp
@@ -20,6 +20,7 @@
 #include "../ConstantBufferStructs.h"
 #include "../Toolbox.h"
 #include "../zCBspTree.h"
+#include <memory>
 
 using Microsoft::WRL::ComPtr;
 #include "D3D12EngineCommon.h"
@@ -34,6 +35,13 @@ namespace {
     };
     constexpr UINT kFogFlagHeightFog = 1u;
     constexpr UINT kFogFlagGodRays = 2u;
+
+    // The depth buffer is still bound as the DSV from the geometry passes — dropped (color target only)
+    // before transitioning it to a shader-resource state. Combined NON_PIXEL|PIXEL because the god-ray mask
+    // reads it from a COMPUTE shader and the composition from a PIXEL shader, in the same frame. File-scope
+    // (not a RenderFogAndGodRays local) so every pass callback below can reference it without a capture.
+    constexpr D3D12_RESOURCE_STATES kDepthRead =
+        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 
     // b0 root constants of GodRays.hlsl's CSMask (padded out to the shared 12-DWORD root signature).
     struct GodRayMaskConsts {
@@ -119,7 +127,11 @@ bool D3D12GraphicsEngine::EvaluateHeightFogActive() const {
 }
 
 
-void D3D12GraphicsEngine::RenderFogAndGodRays() {
+/** Registers Fog/God-Ray's passes onto the SHARED per-frame graph — see D3D12DoF.cpp's file header for why
+    (RenderDepthOfField's doc comment there covers the general pattern this function, RenderSMAA and
+    DrawUnderwaterEffects all follow). Called directly from the postFxGraph construction in D3D12Scene.cpp's
+    OnStartWorldRendering. */
+void D3D12GraphicsEngine::RenderFogAndGodRays( D3D12RenderGraph& graph ) {
     // Called from OnStartWorldRendering after ALL scene content (opaque, water, decals, particles, rain,
     // ghosts) and before RenderBloom — the same slot D3D11's composition pass occupies (after "Draw ghosts"
     // / "Draw ParticleFX #2", before the post-upscale bloom+tonemap block).
@@ -143,7 +155,7 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
         godRays = worldInfo && worldInfo->BspTree && worldInfo->BspTree->GetBspTreeMode() == zBSP_MODE_OUTDOOR;
     }
 
-    GodRayZoomConsts zoomConsts = {};
+    auto zoomConsts = std::make_shared<GodRayZoomConsts>();
     if ( godRays ) {
         // --- Sun screen position + weight falloff: a verbatim port of D3D11PFX_GodRays::RenderToTextureCS ---
         GSky* sky = Engine::GAPI->GetSky();
@@ -166,20 +178,20 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
             if ( sunViewPosition.z < 0.0f ) {
                 godRays = false;   // sun behind the camera
             } else {
-                zoomConsts.Decay = settings.GodRayDecay;
-                zoomConsts.Weight = settings.GodRayWeight;
-                zoomConsts.Density = settings.GodRayDensity;
-                zoomConsts.Center[0] = sunPosition.x / 2.0f + 0.5f;
-                zoomConsts.Center[1] = sunPosition.y / -2.0f + 0.5f;
-                zoomConsts.ColorMod[0] = settings.GodRayColorMod.x;
-                zoomConsts.ColorMod[1] = settings.GodRayColorMod.y;
-                zoomConsts.ColorMod[2] = settings.GodRayColorMod.z;
+                zoomConsts->Decay = settings.GodRayDecay;
+                zoomConsts->Weight = settings.GodRayWeight;
+                zoomConsts->Density = settings.GodRayDensity;
+                zoomConsts->Center[0] = sunPosition.x / 2.0f + 0.5f;
+                zoomConsts->Center[1] = sunPosition.y / -2.0f + 0.5f;
+                zoomConsts->ColorMod[0] = settings.GodRayColorMod.x;
+                zoomConsts->ColorMod[1] = settings.GodRayColorMod.y;
+                zoomConsts->ColorMod[2] = settings.GodRayColorMod.z;
 
                 // Fade the rays out as the sun leaves the screen, so they don't pop at the viewport edge.
-                if ( std::abs( zoomConsts.Center[0] - 0.5f ) > 0.5f )
-                    zoomConsts.Weight *= std::max( 0.0f, 1.0f - ( std::abs( zoomConsts.Center[0] - 0.5f ) - 0.5f ) / 0.5f );
-                if ( std::abs( zoomConsts.Center[1] - 0.5f ) > 0.5f )
-                    zoomConsts.Weight *= std::max( 0.0f, 1.0f - ( std::abs( zoomConsts.Center[1] - 0.5f ) - 0.5f ) / 0.5f );
+                if ( std::abs( zoomConsts->Center[0] - 0.5f ) > 0.5f )
+                    zoomConsts->Weight *= std::max( 0.0f, 1.0f - ( std::abs( zoomConsts->Center[0] - 0.5f ) - 0.5f ) / 0.5f );
+                if ( std::abs( zoomConsts->Center[1] - 0.5f ) > 0.5f )
+                    zoomConsts->Weight *= std::max( 0.0f, 1.0f - ( std::abs( zoomConsts->Center[1] - 0.5f ) - 0.5f ) / 0.5f );
 
                 // MaskIndex/OutputIndex are resolved once the graph actually places the two textures below
                 // (their SRV/UAV slots don't exist yet at this point).
@@ -189,49 +201,49 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
 
     if ( !heightFog && !godRays ) return;
 
-    DX_ZONE( m_CmdList.Get(), "Height fog + god rays" );
-
-    // The depth buffer is still bound as the DSV from the geometry passes — drop it (color target only)
-    // before transitioning it to a shader-resource state. Combined NON_PIXEL|PIXEL because the god-ray mask
-    // reads it from a COMPUTE shader and the composition from a PIXEL shader, in the same block.
-    constexpr D3D12_RESOURCE_STATES kDepthRead =
-        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    {
-        m_CmdList->OMSetRenderTargets( 1, &m_SceneColorRtv, FALSE, nullptr );
-        m_CmdList->TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, kDepthRead );
-    }
+    graph.AddPass( RG_PASS_NAME( "Fog Setup" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+        pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& cmdList ) {
+            DX_ZONE( cmdList.Get(), "Height fog + god rays" );
+            cmdList.OMSetRenderTargets( 1, &m_SceneColorRtv, FALSE, nullptr );
+            cmdList.TransitionBarrier( m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, kDepthRead );
+            };
+        } );
 
     // ---------------------------------------------------------------------------------------------------
-    // God rays: quarter-res mask -> quarter-res radial blur (both compute, both bindless), through a local
-    // D3D12RenderGraph — same conversion DoF's scratch textures got (see D3D12DoF.cpp), and for the same
-    // reason: both textures are written then read once then dead, with no cross-frame data dependency.
+    // God rays: quarter-res mask -> quarter-res radial blur (both compute, both bindless). Both textures are
+    // written then read once then dead, with no cross-frame data dependency — same conversion DoF's scratch
+    // textures got (see D3D12DoF.cpp).
     // ---------------------------------------------------------------------------------------------------
-    UINT godRayZoomSrvSlot = UINT_MAX;   // resolved by the Zoom pass below; read by the composition further down
+    // Resolved by the Zoom pass below; read by the composition pass further down — shared_ptr because both
+    // passes' callbacks run later, deferred inside graph.Execute(), long after this function has returned
+    // (see D3D12DoF.cpp's file header for why a plain stack local can't be captured by reference here).
+    auto godRayZoomSrvSlot = std::make_shared<UINT>( UINT_MAX );
     if ( godRays ) {
-        // Scene color must be readable by the mask CS; compute can't run with it bound as an RTV. Not
-        // graph-managed (m_SceneColor is a plain member, not imported), so this happens before the graph runs.
-        if ( !m_SceneColorInPixelState ) {
-            m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-            m_SceneColorInPixelState = true;
-        }
-        m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
-
         const INT2 godRaySize = { std::max( 1, m_Resolution.x / 4 ), std::max( 1, m_Resolution.y / 4 ) };
         const UINT gx = ( static_cast<UINT>( godRaySize.x ) + 7 ) / 8;
         const UINT gy = ( static_cast<UINT>( godRaySize.y ) + 7 ) / 8;
 
-        D3D12RenderGraph fogGraph( &m_AliasArena );
+        // Plain locals (not shared_ptr): a handle is only ever written once, synchronously, inside a pass's
+        // own setup lambda — never during the deferred Execute() — so by-value capture in any later lambda
+        // already sees the final value. See D3D12DoF.cpp's file header for the full explanation.
         RGResourceHandle maskHandle = RG_INVALID_HANDLE;
         RGResourceHandle zoomHandle = RG_INVALID_HANDLE;
 
-        // --- Pass 1: mask (scene color + depth -> mask) ---
-        fogGraph.AddPass( RG_PASS_NAME( "God Ray Mask" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+        // --- Mask (scene color + depth -> mask) ---
+        graph.AddPass( RG_PASS_NAME( "God Ray Mask" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
             maskHandle = builder.CreateTexture( { static_cast<uint32_t>( godRaySize.x ), static_cast<uint32_t>( godRaySize.y ),
                 static_cast<int>( kSceneColorFormat ), L"GodRayMask", 1u } );
 
-            pass.m_executeCallback = [this, gx, gy, maskHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
-                D3D12RenderTarget* mask = graph.GetPhysicalTexture( maskHandle );
+            pass.m_executeCallback = [this, gx, gy, maskHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
+                D3D12RenderTarget* mask = g.GetPhysicalTexture( maskHandle );
                 if ( !mask ) return;
+
+                // Scene color must be readable by the mask CS; compute can't run with it bound as an RTV.
+                if ( !m_SceneColorInPixelState ) {
+                    cmdList.TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+                    m_SceneColorInPixelState = true;
+                }
+                cmdList.OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
 
                 if ( mask->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
                     cmdList.TransitionBarrier( mask->GetResource(), mask->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
@@ -250,19 +262,19 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
                 };
             } );
 
-        // --- Pass 2: radial blur (mask -> zoom) ---
-        fogGraph.AddPass( RG_PASS_NAME( "God Ray Zoom" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+        // --- Radial blur (mask -> zoom) ---
+        graph.AddPass( RG_PASS_NAME( "God Ray Zoom" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
             builder.Read( maskHandle );
             zoomHandle = builder.CreateTexture( { static_cast<uint32_t>( godRaySize.x ), static_cast<uint32_t>( godRaySize.y ),
                 static_cast<int>( kSceneColorFormat ), L"GodRayZoom", 1u } );
-            // The composition draw further down reads this pass's result via godRayZoomSrvSlot, a plain
-            // local captured by reference — not a graph Read(), so mark the side effect explicitly (see
+            // The composition pass further down reads this pass's result via godRayZoomSrvSlot, a plain
+            // shared value — not a graph Read(), so mark the side effect explicitly (see
             // D3D12RenderPass::m_hasExternalSideEffect).
             builder.MarkExternalEffect();
 
-            pass.m_executeCallback = [this, gx, gy, &zoomConsts, &godRayZoomSrvSlot, maskHandle, zoomHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
-                D3D12RenderTarget* mask = graph.GetPhysicalTexture( maskHandle );
-                D3D12RenderTarget* zoom = graph.GetPhysicalTexture( zoomHandle );
+            pass.m_executeCallback = [this, gx, gy, zoomConsts, godRayZoomSrvSlot, maskHandle, zoomHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
+                D3D12RenderTarget* mask = g.GetPhysicalTexture( maskHandle );
+                D3D12RenderTarget* zoom = g.GetPhysicalTexture( zoomHandle );
                 if ( !mask || !zoom ) return;
 
                 if ( zoom->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
@@ -270,26 +282,27 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
                     zoom->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
                 }
 
-                zoomConsts.MaskIndex = mask->GetSrvSlot();
-                zoomConsts.OutputIndex = zoom->GetUavSlot();
+                zoomConsts->MaskIndex = mask->GetSrvSlot();
+                zoomConsts->OutputIndex = zoom->GetUavSlot();
                 cmdList.SetComputeRootSignature( m_Pipelines.Fog.GodRayRootSig.Get() );
                 cmdList.SetPipelineState( m_Pipelines.Fog.ZoomPSO.Get() );
-                cmdList.SetComputeRoot32BitConstants( 0, 12, &zoomConsts, 0 );
+                cmdList.SetComputeRoot32BitConstants( 0, 12, zoomConsts.get(), 0 );
                 cmdList.Dispatch( gx, gy, 1 );
 
                 // Result -> pixel-shader readable for the composition below.
                 cmdList.TransitionBarrier( zoom->GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
                 zoom->State = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-                godRayZoomSrvSlot = zoom->GetSrvSlot();
+                *godRayZoomSrvSlot = zoom->GetSrvSlot();
                 };
             } );
-
-        fogGraph.Compile();
-        fogGraph.Execute( m_CmdList );
     }
 
     // ---------------------------------------------------------------------------------------------------
-    // Composition: premultiplied fog + additive rays, blended straight onto the HDR scene color.
+    // Composition: premultiplied fog + additive rays, blended straight onto the HDR scene color. The CB fill
+    // below is pure CPU work (a memcpy into a persistently-mapped upload buffer) with no m_CmdList calls, so
+    // — unlike everything else in this function — it is safe to run immediately here rather than deferred
+    // inside a pass callback: nothing needs it to happen in any particular order relative to recorded GPU
+    // commands, only before the GPU actually reads it, which is always true no matter when the CPU writes it.
     // ---------------------------------------------------------------------------------------------------
     if ( heightFog ) {
         // Constant setup below is a line-for-line port of D3D11PfxRenderer::RenderPostFXComposition's
@@ -364,38 +377,43 @@ void D3D12GraphicsEngine::RenderFogAndGodRays() {
         }
     }
 
-    // Scene color back to RENDER_TARGET (the god-ray mask pass may have flipped it to a read state).
-    if ( m_SceneColorInPixelState ) {
-        m_CmdList->TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
-        m_SceneColorInPixelState = false;
-    }
+    graph.AddPass( RG_PASS_NAME( "Fog Composition" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+        pass.m_executeCallback = [this, heightFog, godRays, godRayZoomSrvSlot]( const D3D12RenderGraph&, D3D12CmdList& cmdList ) {
+            // Scene color back to RENDER_TARGET (the god-ray mask pass may have flipped it to a read state).
+            if ( m_SceneColorInPixelState ) {
+                cmdList.TransitionBarrier( m_SceneColor.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET );
+                m_SceneColorInPixelState = false;
+            }
 
-    const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_Resolution.x ), static_cast<float>( m_Resolution.y ), 0.0f, 1.0f };
-    const D3D12_RECT     sc = { 0, 0, m_Resolution.x, m_Resolution.y };
-    m_CmdList->RSSetViewports( 1, &vp );
-    m_CmdList->RSSetScissorRects( 1, &sc );
-    m_CmdList->OMSetRenderTargets( 1, &m_SceneColorRtv, FALSE, nullptr );   // no DSV: depth is being read as an SRV
-    m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
-    m_CmdList->IASetVertexBuffers( 0, 0, nullptr );
+            const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_Resolution.x ), static_cast<float>( m_Resolution.y ), 0.0f, 1.0f };
+            const D3D12_RECT     sc = { 0, 0, m_Resolution.x, m_Resolution.y };
+            cmdList.RSSetViewports( 1, &vp );
+            cmdList.RSSetScissorRects( 1, &sc );
+            cmdList.OMSetRenderTargets( 1, &m_SceneColorRtv, FALSE, nullptr );   // no DSV: depth is being read as an SRV
+            cmdList.IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
+            cmdList.IASetVertexBuffers( 0, 0, nullptr );
 
-    FogCompositeConsts consts = {};
-    consts.DepthIndex = m_DepthSrvSlot;
-    consts.GodRaysIndex = godRays ? godRayZoomSrvSlot : 0u;
-    consts.Flags = ( heightFog ? kFogFlagHeightFog : 0u ) | ( godRays ? kFogFlagGodRays : 0u );
+            FogCompositeConsts consts = {};
+            consts.DepthIndex = m_DepthSrvSlot;
+            consts.GodRaysIndex = godRays ? *godRayZoomSrvSlot : 0u;
+            consts.Flags = ( heightFog ? kFogFlagHeightFog : 0u ) | ( godRays ? kFogFlagGodRays : 0u );
 
-    m_CmdList->SetPipelineState( m_Pipelines.Fog.CompositePSO.Get() );
-    m_CmdList->SetGraphicsRootSignature( m_Pipelines.Fog.CompositeRootSig.Get() );
-    m_CmdList->SetGraphicsRootConstantBufferView( 0, m_FogCBGpu[m_FrameIndex] );                            // b0 height fog
-    m_CmdList->SetGraphicsRootConstantBufferView( 1, m_FogCBGpu[m_FrameIndex] + kFogAtmosphereCbOffset );   // b1 atmosphere
-    m_CmdList->SetGraphicsRoot32BitConstants( 2, 4, &consts, 0 );
-    m_CmdList->DrawInstanced( 3, 1, 0, 0 );
+            cmdList.SetPipelineState( m_Pipelines.Fog.CompositePSO.Get() );
+            cmdList.SetGraphicsRootSignature( m_Pipelines.Fog.CompositeRootSig.Get() );
+            cmdList.SetGraphicsRootConstantBufferView( 0, m_FogCBGpu[m_FrameIndex] );                            // b0 height fog
+            cmdList.SetGraphicsRootConstantBufferView( 1, m_FogCBGpu[m_FrameIndex] + kFogAtmosphereCbOffset );   // b1 atmosphere
+            cmdList.SetGraphicsRoot32BitConstants( 2, 4, &consts, 0 );
+            cmdList.DrawInstanced( 3, 1, 0, 0 );
 
-    // Restore the resting state the rest of the frame (and the next one) expects: depth back to DEPTH_WRITE.
-    // The scene color stays bound as the RTV, which is exactly what RenderBloom (the next pass) assumes. The
-    // god-ray zoom texture needs no explicit reset any more — D3D12RenderTarget::State is caller-maintained
-    // and self-correcting: next frame's Zoom pass checks it and transitions from whatever it actually finds
-    // (see the pass callback above), the same way DoF's scratch textures work.
-    m_CmdList->TransitionBarrier( m_DepthBuffer.Get(), kDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE );
+            // Restore the resting state the rest of the frame (and the next one) expects: depth back to
+            // DEPTH_WRITE. The scene color stays bound as the RTV, which is exactly what RenderBloom (the
+            // next pass) assumes. The god-ray zoom texture needs no explicit reset any more —
+            // D3D12RenderTarget::State is caller-maintained and self-correcting: next frame's Zoom pass
+            // checks it and transitions from whatever it actually finds, the same way DoF's scratch
+            // textures work.
+            cmdList.TransitionBarrier( m_DepthBuffer.Get(), kDepthRead, D3D12_RESOURCE_STATE_DEPTH_WRITE );
 
-    m_ColorTargetIsHDR = true;
+            m_ColorTargetIsHDR = true;
+            };
+        } );
 }

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -1870,7 +1870,10 @@ XRESULT D3D12GraphicsEngine::OnBeginFrame() {
         FrameMark;
         WaitForFrameLatencyWaitable();
         FrameLimiterBeginFrame();
-    }
+    } else if ( Engine::GAPI->IsIngameMenuPaused()) {
+        FrameMark;
+	}
+
     PausedFrameLimiterBeginFrame();
 
     TracyD3D12BeginFrame;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -1698,6 +1698,13 @@ bool D3D12GraphicsEngine::RebakeMipLodBias( float newBias ) {
     resolve, which is where the up/downscale happens. Only depth + scene color are fatal; the rest follow
     the same non-fatal contract they have on the resize path (their passes guard on the resource existing). */
 bool D3D12GraphicsEngine::CreateRenderResolutionTargets( INT2 renderSize ) {
+    // Every D3D12RenderGraph-managed transient texture (DoF/god-ray/underwater/SMAA scratch) is sized off
+    // m_Resolution or m_BackbufferResolution, both of which are about to change — their names' reserved
+    // offsets (D3D12AliasedTextureArena::ReserveNamedRange) must NOT survive into the new resolution, or a
+    // name would keep its old, now too-small range and silently corrupt whatever got packed after it. This
+    // always runs before CreateDisplayResolutionTargets (every call site below), so one Clear() covers both.
+    m_AliasArena.Clear();
+
     // The FFX context is built for one specific (render, display) size pair and its internal resources are
     // freed immediately by ffxFsr3UpscalerContextDestroy — so it has to go here, on a path whose callers have
     // already idled the GPU, rather than lazily from the frame. EnsureFsr3Ready rebuilds it next frame.
@@ -1887,10 +1894,6 @@ XRESULT D3D12GraphicsEngine::OnBeginFrame() {
     PausedFrameLimiterBeginFrame();
 
     TracyD3D12BeginFrame;
-
-    // Reset the render-graph aliasing arena's persistent bump cursor for this frame — see
-    // D3D12AliasedTextureArena::ReserveBumpRange for why this must be a per-FRAME reset, not per-graph.
-    m_AliasArena.BeginFrame();
 
     // Apply a pending TriggerResize() request here — the command list from the previous frame is already
     // Closed+Executed+Presented at this point (no open recording to disrupt), so this is the one place in

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -1873,7 +1873,7 @@ XRESULT D3D12GraphicsEngine::OnBeginFrame() {
     }
     PausedFrameLimiterBeginFrame();
 
-    TracyD3D12BeginFrame
+    TracyD3D12BeginFrame;
 
     // Apply a pending TriggerResize() request here — the command list from the previous frame is already
     // Closed+Executed+Presented at this point (no open recording to disrupt), so this is the one place in

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -99,6 +99,11 @@ XRESULT D3D12GraphicsEngine::Init() {
         LogWarn() << "D3D12GraphicsEngine::Init: failed to create SRV heap.";
         return XR_FAILED;
     }
+    if ( !m_TexturePool.Attach( *this ) ) {
+        // Non-fatal: nothing consumes the pool yet (see D3D12RenderGraph.h), so a failure here just means
+        // that infrastructure stays unavailable until the next Init(). Nothing in today's frame depends on it.
+        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the pooled-render-target RTV heap.";
+    }
     if ( !m_Pipelines.Init( &m_Device, &m_ShaderBackend ) ) {
         LogWarn() << "D3D12GraphicsEngine::Init: failed to init the pipeline-state module.";
         return XR_FAILED;
@@ -2321,6 +2326,8 @@ void D3D12GraphicsEngine::MoveToNextFrame() {
     for ( auto& cleanupCallback : jobs ) {
         if ( cleanupCallback ) cleanupCallback(); // Calls FreeSrvSlot() and drops the captured ComPtrs
     }
+
+    m_TexturePool.GiveTick();
 }
 
 

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -104,6 +104,10 @@ XRESULT D3D12GraphicsEngine::Init() {
         // that infrastructure stays unavailable until the next Init(). Nothing in today's frame depends on it.
         LogWarn() << "D3D12GraphicsEngine::Init: failed to create the pooled-render-target RTV heap.";
     }
+    if ( !m_AliasArena.Attach( *this ) ) {
+        // Non-fatal for the same reason: no pass constructs a D3D12RenderGraph yet (see D3D12RenderGraph.h).
+        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the render-graph aliasing arena.";
+    }
     if ( !m_Pipelines.Init( &m_Device, &m_ShaderBackend ) ) {
         LogWarn() << "D3D12GraphicsEngine::Init: failed to init the pipeline-state module.";
         return XR_FAILED;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -1723,7 +1723,8 @@ bool D3D12GraphicsEngine::CreateRenderResolutionTargets( INT2 renderSize ) {
     CreateHiZResources( renderSize );    // without it the GPU VOB cull runs frustum-only (no occlusion)
     // Height-fog/god-ray textures no longer need a resize hook — they're D3D12RenderGraph-managed transients
     // acquired fresh at the current resolution every call (see D3D12Fog.cpp's RenderFogAndGodRays).
-    ReleaseWaterCopyResources();         // rebuilt at the new size by the next frame that renders water
+    // Water's scene/depth copies no longer need a resize hook — they're D3D12RenderGraph-managed transients
+    // acquired fresh at the current resolution every call (see D3D12Water.cpp's DrawWaterSurfaces).
     if ( !CreateLumPartialBuffer( renderSize ) ) {
         // Non-fatal: RenderLuminanceAdapt() guards on this and skips the update, leaving m_LumAdaptedBuffer
         // at its last valid value.

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -1714,7 +1714,8 @@ bool D3D12GraphicsEngine::CreateRenderResolutionTargets( INT2 renderSize ) {
     m_DoFCreateAttempted = false;
     if ( m_DoFResourcesReady ) CreateDoFResources( renderSize );
     CreateHiZResources( renderSize );    // without it the GPU VOB cull runs frustum-only (no occlusion)
-    CreateFogResources( renderSize );    // height fog/god rays are opt-in; RenderFogAndGodRays no-ops without them
+    // Height-fog/god-ray textures no longer need a resize hook — they're D3D12RenderGraph-managed transients
+    // acquired fresh at the current resolution every call (see D3D12Fog.cpp's RenderFogAndGodRays).
     ReleaseWaterCopyResources();         // rebuilt at the new size by the next frame that renders water
     if ( !CreateLumPartialBuffer( renderSize ) ) {
         // Non-fatal: RenderLuminanceAdapt() guards on this and skips the update, leaving m_LumAdaptedBuffer
@@ -1731,9 +1732,9 @@ bool D3D12GraphicsEngine::CreateRenderResolutionTargets( INT2 renderSize ) {
 void D3D12GraphicsEngine::CreateDisplayResolutionTargets( INT2 displaySize ) {
     ReleaseFsr3();                          // display size is half of the pair the FFX context is built for
     CreateLdrCopyResource( displaySize );   // shared LDR scratch for SMAA/sharpen; both no-op without it
-    CreateSmaaResources( displaySize );     // SMAA is opt-in (AntiAliasingMode == AA_SMAA)
-    m_UnderwaterCreateAttempted = false;
-    if ( m_UnderwaterResourcesReady ) CreateUnderwaterResources( displaySize );
+    // SMAA's edges/blend and the underwater blur pair no longer need a resize hook — both are
+    // D3D12RenderGraph-managed transients acquired fresh at the current resolution every call (see
+    // D3D12PostFX.cpp's RenderSMAA / D3D12Underwater.cpp's DrawUnderwaterEffects).
 }
 
 
@@ -1886,6 +1887,10 @@ XRESULT D3D12GraphicsEngine::OnBeginFrame() {
     PausedFrameLimiterBeginFrame();
 
     TracyD3D12BeginFrame;
+
+    // Reset the render-graph aliasing arena's persistent bump cursor for this frame — see
+    // D3D12AliasedTextureArena::ReserveBumpRange for why this must be a per-FRAME reset, not per-graph.
+    m_AliasArena.BeginFrame();
 
     // Apply a pending TriggerResize() request here — the command list from the previous frame is already
     // Closed+Executed+Presented at this point (no open recording to disrupt), so this is the one place in

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -23,6 +23,7 @@
 #include "D3D12VobArena.h"
 #include "D3D12PointShadows.h"
 #include "D3D12TexturePool.h"
+#include "D3D12AliasedTextureArena.h"
 
 struct RenderBucket;
 class D3D12LineRenderer;
@@ -639,11 +640,17 @@ private:
     // uncontended lock here is a few tens of ns, negligible next to a draw call.
     mutable std::mutex m_SrvHeapMutex;
 
-    // Pooled/transient render targets for D3D12RenderGraph (mirrors D3D11's TexturePool — see
-    // D3D12TexturePool.h). Not wired into a pass yet; see D3D12RenderGraph.h for why and for the
-    // intended first consumer. Declared after the SRV free-list above (and everything that manages it)
-    // so a pooled target's SRV slot is freed before that bookkeeping is torn down at shutdown.
+    // General-purpose pooled render targets (mirrors D3D11's TexturePool — see D3D12TexturePool.h).
+    // No longer used by D3D12RenderGraph (see D3D12AliasedTextureArena below), but kept as a standalone
+    // utility for non-graph pooled needs. Declared after the SRV free-list above (and everything that
+    // manages it) so a pooled target's SRV slot is freed before that bookkeeping is torn down at shutdown.
     D3D12TexturePool m_TexturePool;
+
+    // D3D12RenderGraph's transient-texture backing store (see D3D12AliasedTextureArena.h / D3D12RenderGraph.h)
+    // — aliases non-overlapping-lifetime transient textures into one shared heap via placed resources.
+    // Not wired into a live pass yet; see D3D12RenderGraph.h for why and for the intended first consumer.
+    // Same declaration-order reasoning as m_TexturePool above.
+    D3D12AliasedTextureArena m_AliasArena;
 
     // Loads + compiles the backend's HLSL from Shaders\D3D12\*.hlsl at runtime (DXC/SM6.6, zFILE_VDFS).
     D3D12ShaderBackend m_ShaderBackend;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -22,6 +22,7 @@
 #include "D3D12ShadowMap.h"
 #include "D3D12VobArena.h"
 #include "D3D12PointShadows.h"
+#include "D3D12TexturePool.h"
 
 struct RenderBucket;
 class D3D12LineRenderer;
@@ -637,6 +638,12 @@ private:
     // targets a private CPU-visible descriptor slot the render thread's own draws don't write to) — an
     // uncontended lock here is a few tens of ns, negligible next to a draw call.
     mutable std::mutex m_SrvHeapMutex;
+
+    // Pooled/transient render targets for D3D12RenderGraph (mirrors D3D11's TexturePool — see
+    // D3D12TexturePool.h). Not wired into a pass yet; see D3D12RenderGraph.h for why and for the
+    // intended first consumer. Declared after the SRV free-list above (and everything that manages it)
+    // so a pooled target's SRV slot is freed before that bookkeeping is torn down at shutdown.
+    D3D12TexturePool m_TexturePool;
 
     // Loads + compiles the backend's HLSL from Shaders\D3D12\*.hlsl at runtime (DXC/SM6.6, zFILE_VDFS).
     D3D12ShaderBackend m_ShaderBackend;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -1666,16 +1666,20 @@ private:
     // and CopyDepthStencil()s the depth before the water Z-prepass). Both copies must be taken BEFORE the
     // water Z-prepass writes the surface's own depth, or the refraction would read water-vs-water.
     //
-    // Allocated lazily on the first frame a world actually renders water (~24 MB of 32-bit VA at 1080p,
-    // which menus, indoor worlds and water-free maps should not pay) and released on resize, where the GPU
-    // is already idle; EnsureWaterCopyResources() then rebuilds them at the new size on the next water frame.
-    Microsoft::WRL::ComPtr<ID3D12Resource>      m_WaterSceneCopy;      // pre-water HDR scene (kSceneColorFormat)
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_WaterSceneCopyAlloc;
-    UINT m_WaterSceneCopySrvSlot = UINT_MAX;
-    Microsoft::WRL::ComPtr<ID3D12Resource>      m_WaterDepthCopy;      // pre-water depth (R32_TYPELESS -> R32_FLOAT SRV)
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_WaterDepthCopyAlloc;
-    UINT m_WaterDepthCopySrvSlot = UINT_MAX;
-    INT2 m_WaterCopySize = { 0, 0 };          // resolution the two copies were built for (0,0 = not allocated)
+    // USED to be allocated lazily as members the first frame a world actually rendered water (~24 MB of
+    // 32-bit VA at 1080p, which menus, indoor worlds and water-free maps should not pay). Both are purely
+    // single-frame scratch (copied from the opaque scene, read by the water shader, then dead — no
+    // cross-frame data dependency), so they are now D3D12RenderGraph-managed transient textures acquired
+    // fresh every call inside DrawWaterSurfaces instead — same conversion DoF's/the god-ray/the underwater/
+    // SMAA scratch textures got (see D3D12DoF.cpp for the pattern). DrawWaterSurfaces is a BaseGraphicsEngine
+    // override (fixed signature, no graph parameter), so — unlike the postFxGraph-fed functions — it builds
+    // its own small LOCAL D3D12RenderGraph; that is safe now that D3D12AliasedTextureArena::ReserveNamedRange
+    // dedups by name across the WHOLE arena, not per-graph-instance (see its comment).
+    //
+    // The depth copy is created as plain R32_FLOAT (not R32_TYPELESS + ALLOW_DEPTH_STENCIL like the old
+    // member): CopyResource only requires format-FAMILY compatibility (R32_TYPELESS and R32_FLOAT share one),
+    // not matching resource flags, and this copy is never bound as an actual depth target — only ever
+    // CopyResource's destination and an SRV source — so ALLOW_DEPTH_STENCIL was never actually required.
 
     // reflect_cube.dds as a real TextureCube — the static sky/environment reflection D3D11 binds at t3, and
     // the fallback whenever an SSR ray misses or leaves the screen. D3D12Texture is Texture2D-only, so this
@@ -1696,8 +1700,6 @@ private:
 
     bool LoadReflectionCube();                // one-time, non-fatal (mirrors LoadDistortionTexture)
     bool CreateWaterConstantBuffers();        // one-time: the per-frame-in-flight water/atmosphere CB ring
-    bool EnsureWaterCopyResources();          // lazy (re)build of the scene+depth copies at m_Resolution
-    void ReleaseWaterCopyResources();         // called on resize (GPU idle) so the next water frame rebuilds
 
     // Rain/snow particles (D3D12 rain parity, step 1: buffers + CS advance only — no draw yet). Mirrors
     // D3D11Effect's RainBufferStatic/RainBufferDrawFrom, but as plain StructuredBuffers bound via ROOT

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -1207,28 +1207,21 @@ private:
     // SMAA anti-aliasing (runtime toggle: RendererSettings.AntiAliasingMode == AA_SMAA). Mirrors the D3D11
     // 3-pass post-FX (D3D11SMAA::Render): run on the tonemapped LDR swapchain image right after
     // ResolveSceneToBackBuffer, before Gothic's 2D UI/HUD composites on top (so the HUD stays crisp).
-    //   1. Edge detection      color        -> m_SmaaEdges
-    //   2. Blend-weight calc    edges+LUTs   -> m_SmaaBlend
+    //   1. Edge detection      color        -> edges
+    //   2. Blend-weight calc    edges+LUTs   -> blend
     //   3. Neighborhood blend   color+blend  -> swapchain
     // m_LdrCopy (below) holds the copy of the tonemapped LDR image the color pass reads (the swapchain can't be
     // both the SMAA color SRV and the pass-3 RTV at once), so the effect costs one extra full-res copy per frame
-    // while enabled. The area/search LUTs are precomputed static textures loaded once; edges/blend are
-    // resolution-dependent (recreated on resize like the bloom pyramid). All are bound bindlessly (SRV heap
+    // while enabled. The area/search LUTs are precomputed static textures loaded once. Edges/blend USED to be
+    // resolution-dependent members (recreated on resize like the bloom pyramid); both are purely single-frame
+    // scratch (written then read once then dead, no cross-frame data dependency), so they are now
+    // D3D12RenderGraph-managed transient textures acquired fresh every call inside RenderSMAA instead — same
+    // conversion DoF's/the god-ray/the underwater scratch textures got. All are bound bindlessly (SRV heap
     // index -> b0 root const).
-    Microsoft::WRL::ComPtr<ID3D12Resource>      m_SmaaEdges;         // pass-1 output (R8G8B8A8)
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_SmaaEdgesAlloc;
-    Microsoft::WRL::ComPtr<ID3D12Resource>      m_SmaaBlend;         // pass-2 output (R8G8B8A8)
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_SmaaBlendAlloc;
-    UINT m_SmaaEdgesSrvSlot = UINT_MAX;
-    UINT m_SmaaBlendSrvSlot = UINT_MAX;
-    D3D12_CPU_DESCRIPTOR_HANDLE m_SmaaEdgesRtv = {};                 // RTV heap slot kBackBufferMax+1
-    D3D12_CPU_DESCRIPTOR_HANDLE m_SmaaBlendRtv = {};                 // RTV heap slot kBackBufferMax+2
     std::unique_ptr<D3D12Texture> m_SmaaAreaTex;                     // precomputed area LUT (160x560 R8G8), loaded once
     std::unique_ptr<D3D12Texture> m_SmaaSearchTex;                   // precomputed search LUT (66x33 R8), loaded once
     bool m_SmaaTexturesLoaded = false;
-    bool m_SmaaResourcesReady = false;                              // edges/blend created for the current resolution
     bool LoadSmaaTextures();                  // one-time: load the area + search LUTs from system\GD3D11\Textures
-    bool CreateSmaaResources( INT2 size );    // (re)builds the resolution-dependent edges/blend textures + views
     void RenderSMAA();                        // 3-pass SMAA on the swapchain LDR image (guards on the toggle + resources)
 
     // Shared scratch copy of the tonemapped LDR swapchain image, used by every post-tonemap pass that has to
@@ -1255,17 +1248,12 @@ private:
     // targets are compute-written, which is why they need no RTV heap slot; the composite has to be a graphics
     // pass because the display target has no UAV.
     //
-    // Built LAZILY the first time the player goes under water (same reasoning as the DoF textures — this is a
-    // rare state and the pair costs VA that 32-bit cannot spare for an effect most sessions never trigger).
-    // Both rest in UNORDERED_ACCESS between frames.
-    Microsoft::WRL::ComPtr<ID3D12Resource>      m_UnderwaterBlur[2];
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_UnderwaterBlurAlloc[2];
-    UINT m_UnderwaterBlurSrvSlot[2] = { UINT_MAX, UINT_MAX };
-    UINT m_UnderwaterBlurUavSlot[2] = { UINT_MAX, UINT_MAX };
-    INT2 m_UnderwaterBlurSize = { 0, 0 };       // quarter resolution the pair was built for
-    bool m_UnderwaterResourcesReady = false;
-    bool m_UnderwaterCreateAttempted = false;   // keeps a failed creation from retrying every frame; cleared on resize
-    bool CreateUnderwaterResources( INT2 size );   // (re)builds the quarter-res blur pair + its SRV/UAV slots
+    // USED to be built lazily as members the first time the player went under water (same reasoning as DoF's
+    // old members — rare state, 32-bit VA is scarce). Both were purely single-frame scratch (written then
+    // read once then dead, no cross-frame data dependency), so they are now D3D12RenderGraph-managed
+    // transient textures acquired fresh every call inside DrawUnderwaterEffects instead — same conversion
+    // DoF's and the god-ray mask/zoom textures got (see D3D12DoF.cpp / D3D12Fog.cpp). No lazy-creation flags
+    // or resize hook needed any more either.
     void DrawUnderwaterEffects();                  // no-op unless underwater; guards on the PSOs + m_LdrCopyReady
 
     // Simple screen-space AO (plan item #4, "SAO"): resolution-dependent R8_UNORM textures (m_AOMask holds the
@@ -1637,19 +1625,14 @@ private:
 
     // ---- Height fog + god rays (plan item #5) — D3D12 port of D3D11's PostFX composition pass. -------------
     // Two quarter-resolution HDR textures carry the god-ray chain (mask -> radial blur), mirroring D3D11's
-    // GetTempBufferDS4() pool textures; both rest in UNORDERED_ACCESS between frames like the bloom mips.
+    // GetTempBufferDS4() pool textures. USED to be members that rested in UNORDERED_ACCESS between frames
+    // like the bloom mips; both are purely single-frame scratch (written then read once then dead, no
+    // cross-frame data dependency — unlike bloom's pyramid or TAA's history), so they are now
+    // D3D12RenderGraph-managed transient textures acquired fresh every call from m_AliasArena inside
+    // RenderFogAndGodRays instead (see D3D12Fog.cpp — same conversion DoF's scratch textures got).
     // The composition itself needs no scene-color copy: it blends premultiplied straight onto m_SceneColor
     // (see Shaders/D3D12/HeightFog.hlsl's header for why that's equivalent to D3D11's copy-and-lerp).
-    Microsoft::WRL::ComPtr<ID3D12Resource>      m_GodRayMask;        // quarter-res, sky-only pixels of the scene
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_GodRayMaskAlloc;
-    Microsoft::WRL::ComPtr<ID3D12Resource>      m_GodRayZoom;        // quarter-res, radially blurred rays
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_GodRayZoomAlloc;
-    UINT m_GodRayMaskSrvSlot = UINT_MAX;
-    UINT m_GodRayMaskUavSlot = UINT_MAX;
-    UINT m_GodRayZoomSrvSlot = UINT_MAX;
-    UINT m_GodRayZoomUavSlot = UINT_MAX;
-    INT2 m_GodRaySize = { 0, 0 };             // quarter of the scene resolution (rounded up, min 1)
-    bool m_FogResourcesReady = false;
+    //
     // Per-frame-in-flight constant buffer for the composition pass: 512 B split into two 256-B-aligned
     // blocks — [0,256) the HeightfogConstantBuffer (b0), [256,512) the AtmosphereConstantBuffer (b1). Both
     // are filled once per frame in RenderFogAndGodRays from the exact same GAPI/GSky values D3D11 uses.
@@ -1665,7 +1648,6 @@ private:
     // Evaluated once per frame at the top of OnStartWorldRendering, before any geometry pass reads it.
     bool m_HeightFogActive = false;
     bool EvaluateHeightFogActive() const;     // DrawFog && outdoor && resources/PSOs present
-    bool CreateFogResources( INT2 size );     // (re)builds the quarter-res god-ray textures + their SRV/UAV slots
     bool CreateFogConstantBuffers();          // one-time: the per-frame-in-flight composition CB ring
     void RenderFogAndGodRays();               // god-ray mask+zoom compute, then the fullscreen composition blend
 

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -1533,14 +1533,14 @@ private:
     //
     //   m_DoFFocus[2]  1x1 R32_FLOAT ping-pong. The auto-focus distance, temporally smoothed against the
     //                  previous frame's value — pass 0 reads [m_DoFFocusIndex] and writes [1 - m_DoFFocusIndex].
-    //   m_DoFHalf      half-res kSceneColorFormat: rgb = bokeh blur, a = centre CoC (pass 1).
-    //   m_DoFComposite full-res kSceneColorFormat scratch. Compute cannot read and write the scene colour in one
-    //                  dispatch, so pass 2 writes here and the result is CopyResource'd back — same shape as the
-    //                  TAA resolve's history copy, and both are kSceneColorFormat so the copy is a straight one.
+    //                  Must persist across frames (that's the whole point of the smoothing), so it stays a
+    //                  member, built LAZILY (see CreateDoFResources): DoF is off in a stock config.
     //
-    // Unlike the bloom/AO/TAA resources these are built LAZILY (see CreateDoFResources): DoF is off in a stock
-    // config, and a full-res RGBA16F scratch plus a half-res one is ~20 MB of virtual address space at 1080p —
-    // real money in a 32-bit process. The resize path only rebuilds them if they already exist.
+    // The half-res bokeh-blur target and the full-res composite scratch USED to live here as members too; they
+    // are now D3D12RenderGraph-managed transient textures acquired fresh every call from m_AliasArena instead
+    // (see D3D12DoF.cpp's RenderDepthOfField) — first live consumer of the render graph's actual resource
+    // system. That also removes the need for the old "did the resolution change without us following" guard:
+    // asking the graph for the CURRENT resolution's size every call handles a resize for free.
     Microsoft::WRL::ComPtr<ID3D12Resource>      m_DoFFocus[2];
     Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_DoFFocusAlloc[2];
     UINT m_DoFFocusSrvSlot[2] = { UINT_MAX, UINT_MAX };
@@ -1549,20 +1549,12 @@ private:
     // The focus textures' initial contents are undefined, so the first resolve must SNAP to the measured depth
     // instead of blending against garbage (DoFCB::FocusValid). Cleared whenever the pair is (re)created.
     bool m_DoFFocusValid = false;
-    Microsoft::WRL::ComPtr<ID3D12Resource>      m_DoFHalf;
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_DoFHalfAlloc;
-    UINT m_DoFHalfSrvSlot = UINT_MAX;
-    UINT m_DoFHalfUavSlot = UINT_MAX;
-    INT2 m_DoFHalfSize = { 0, 0 };
-    Microsoft::WRL::ComPtr<ID3D12Resource>      m_DoFComposite;
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_DoFCompositeAlloc;
-    UINT m_DoFCompositeUavSlot = UINT_MAX;
     bool m_DoFResourcesReady = false;
     // Set once creation has been attempted at the current resolution, so a failure (out of heap slots, out of
     // memory) is logged once and not retried every frame while DoF stays enabled. Cleared on resize.
     bool m_DoFCreateAttempted = false;
 
-    bool CreateDoFResources( INT2 size );  // (re)builds the focus pair, the half-res blur target and the scratch
+    bool CreateDoFResources( INT2 size );  // (re)builds the persistent focus ping-pong only
     void RenderDepthOfField();             // focus resolve -> half-res blur -> composite -> copy back
 
     // ---- Sky image-based lighting (indirect light for the Forward+ PBR shaders) -----------------------------

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -1222,7 +1222,9 @@ private:
     std::unique_ptr<D3D12Texture> m_SmaaSearchTex;                   // precomputed search LUT (66x33 R8), loaded once
     bool m_SmaaTexturesLoaded = false;
     bool LoadSmaaTextures();                  // one-time: load the area + search LUTs from system\GD3D11\Textures
-    void RenderSMAA();                        // 3-pass SMAA on the swapchain LDR image (guards on the toggle + resources)
+    // Registers its passes onto the caller's SHARED per-frame D3D12RenderGraph — see D3D12DoF.cpp's file
+    // header / D3D12RenderDepthOfField's declaration above for why.
+    void RenderSMAA( class D3D12RenderGraph& graph );
 
     // Shared scratch copy of the tonemapped LDR swapchain image, used by every post-tonemap pass that has to
     // read the frame while writing it back (SMAA's color input, the sharpen source). Only one such pass reads
@@ -1254,7 +1256,9 @@ private:
     // transient textures acquired fresh every call inside DrawUnderwaterEffects instead — same conversion
     // DoF's and the god-ray mask/zoom textures got (see D3D12DoF.cpp / D3D12Fog.cpp). No lazy-creation flags
     // or resize hook needed any more either.
-    void DrawUnderwaterEffects();                  // no-op unless underwater; guards on the PSOs + m_LdrCopyReady
+    // Registers its passes onto the caller's SHARED per-frame D3D12RenderGraph — see D3D12DoF.cpp's file
+    // header / D3D12RenderDepthOfField's declaration above for why.
+    void DrawUnderwaterEffects( class D3D12RenderGraph& graph );   // no-op unless underwater; guards on the PSOs + m_LdrCopyReady
 
     // Simple screen-space AO (plan item #4, "SAO"): resolution-dependent R8_UNORM textures (m_AOMask holds the
     // final blurred result; m_AOBlurTemp is the horizontal-blur scratch target), recreated on resize like the
@@ -1543,7 +1547,10 @@ private:
     bool m_DoFCreateAttempted = false;
 
     bool CreateDoFResources( INT2 size );  // (re)builds the persistent focus ping-pong only
-    void RenderDepthOfField();             // focus resolve -> half-res blur -> composite -> copy back
+    // Registers its passes onto the caller's SHARED per-frame D3D12RenderGraph (postFxGraph, built in
+    // D3D12Scene.cpp's OnStartWorldRendering) instead of building its own — see D3D12RenderGraph.h and
+    // D3D12DoF.cpp's file header for why. Class forward-declared below; the .cpp includes D3D12RenderGraph.h.
+    void RenderDepthOfField( class D3D12RenderGraph& graph );
 
     // ---- Sky image-based lighting (indirect light for the Forward+ PBR shaders) -----------------------------
     // Replaces the flat greyscale ambient floor in PBRLighting.hlsl's ComputeSunLightingPBR
@@ -1649,7 +1656,9 @@ private:
     bool m_HeightFogActive = false;
     bool EvaluateHeightFogActive() const;     // DrawFog && outdoor && resources/PSOs present
     bool CreateFogConstantBuffers();          // one-time: the per-frame-in-flight composition CB ring
-    void RenderFogAndGodRays();               // god-ray mask+zoom compute, then the fullscreen composition blend
+    // Registers its passes onto the caller's SHARED per-frame D3D12RenderGraph — see D3D12DoF.cpp's file
+    // header / D3D12RenderDepthOfField's declaration above for why.
+    void RenderFogAndGodRays( class D3D12RenderGraph& graph );   // god-ray mask+zoom compute, then the fullscreen composition blend
 
     // ---- Water refraction / reflection (D3D12Water.cpp) — port of D3D11's DrawWaterSurfaces + PS_Water ----
     // Water is drawn OPAQUE and does its own see-through compositing from copies of the finished opaque

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -799,6 +799,9 @@ void D3D12PointShadows::Prepare() {
 				for ( const FrameVobUpload& up : g_FrameVobUploads ) {
 					MeshVisualInfo* visual = up.visual;
 					if ( !visual || visual->Instances.empty() ) continue;
+					// Still being filled in on a worker thread (GothicAPI::OnAddVob's async
+					// Extract3DSMeshFromVisual2Async) - skip until MeshesByTexture is safe to iterate.
+					if ( !visual->GetIsReady() ) continue;
 					const float cullR = ps.range + visual->MeshSize * 0.5f;   // sphere test allows for VOB extent
 					const float cullRSq = cullR * cullR;
 
@@ -954,6 +957,9 @@ void D3D12PointShadows::Prepare() {
 					if ( hasExclusions && std::find( excludeVobs.begin(), excludeVobs.end(), vi->Vob ) != excludeVobs.end() )
 						continue;
 					MeshVisualInfo* visual = static_cast<MeshVisualInfo*>( vi->VisualInfo );
+					// Still being filled in on a worker thread (GothicAPI::OnAddVob's async
+					// Extract3DSMeshFromVisual2Async) - skip until MeshesByTexture is safe to iterate.
+					if ( !visual->GetIsReady() ) continue;
 					const XMFLOAT3 pos = vi->Vob->GetPositionWorld();
 					const float cullR = ps.range + visual->MeshSize * 0.5f;
 					float dx = pos.x - ps.posWS.x, dy = pos.y - ps.posWS.y, dz = pos.z - ps.posWS.z;

--- a/D3D11Engine/D3D12Engine/D3D12PooledDescriptorHeap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PooledDescriptorHeap.cpp
@@ -1,0 +1,55 @@
+#include "../pch.h"
+#include "D3D12PooledDescriptorHeap.h"
+#include "../Logger.h"
+
+bool D3D12PooledDescriptorHeap::Init( ID3D12Device* device, D3D12_DESCRIPTOR_HEAP_TYPE type, UINT capacity, const wchar_t* debugName ) {
+    D3D12_DESCRIPTOR_HEAP_DESC desc = {};
+    desc.Type = type;
+    desc.NumDescriptors = capacity;
+    desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;   // CPU-only: RTV/DSV heaps are never shader-visible
+    if ( FAILED( device->CreateDescriptorHeap( &desc, IID_PPV_ARGS( m_Heap.ReleaseAndGetAddressOf() ) ) ) )
+        return false;
+    if ( debugName ) m_Heap->SetName( debugName );
+
+    m_DescriptorSize = device->GetDescriptorHandleIncrementSize( type );
+    m_Capacity = capacity;
+    m_NextFree = 0;
+    m_FreeList.clear();
+    m_LoggedExhaustion = false;
+    return true;
+}
+
+UINT D3D12PooledDescriptorHeap::Allocate() {
+    if ( !m_FreeList.empty() ) {
+        const UINT slot = m_FreeList.back();
+        m_FreeList.pop_back();
+        return slot;
+    }
+    if ( m_NextFree < m_Capacity ) return m_NextFree++;
+
+    if ( !m_LoggedExhaustion ) {
+        LogWarn() << "D3D12PooledDescriptorHeap: exhausted (" << m_Capacity << " descriptors) — further pooled targets will fail to allocate.";
+        m_LoggedExhaustion = true;
+    }
+    return kInvalidSlot;
+}
+
+void D3D12PooledDescriptorHeap::Free( UINT slot ) {
+    if ( slot == kInvalidSlot ) return;
+    m_FreeList.push_back( slot );
+}
+
+D3D12_CPU_DESCRIPTOR_HANDLE D3D12PooledDescriptorHeap::GetCpuHandle( UINT slot ) const {
+    D3D12_CPU_DESCRIPTOR_HANDLE handle = m_Heap->GetCPUDescriptorHandleForHeapStart();
+    handle.ptr += static_cast<SIZE_T>( slot ) * m_DescriptorSize;
+    return handle;
+}
+
+void D3D12PooledDescriptorHeap::Reset() {
+    m_Heap.Reset();
+    m_DescriptorSize = 0;
+    m_Capacity = 0;
+    m_NextFree = 0;
+    m_FreeList.clear();
+    m_LoggedExhaustion = false;
+}

--- a/D3D11Engine/D3D12Engine/D3D12PooledDescriptorHeap.h
+++ b/D3D11Engine/D3D12Engine/D3D12PooledDescriptorHeap.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <d3d12.h>
+#include <wrl/client.h>
+#include <vector>
+
+// Small free-list allocator over a single fixed-capacity, CPU-only (non-shader-visible) descriptor
+// heap. Used by D3D12TexturePool for its dedicated RTV heap.
+//
+// Deliberately fixed-capacity rather than growable: per CLAUDE.md's per-frame-allocation rule, a
+// generous cap sized once up front is simpler and cheaper than reallocating/CopyDescriptorsSimple-ing a
+// live heap, and pooled render targets are a few dozen at most even in the heaviest post-fx chain.
+// Exhaustion is logged once (not per call) and returns UINT_MAX rather than crashing or silently
+// dropping the caller's request without a trace.
+class D3D12PooledDescriptorHeap {
+public:
+    static constexpr UINT kInvalidSlot = 0xFFFFFFFFu;
+
+    bool Init( ID3D12Device* device, D3D12_DESCRIPTOR_HEAP_TYPE type, UINT capacity, const wchar_t* debugName );
+
+    UINT Allocate();
+    void Free( UINT slot );
+    D3D12_CPU_DESCRIPTOR_HANDLE GetCpuHandle( UINT slot ) const;
+
+    void Reset();   // drops the heap; pool Clear() calls this on resize/level change
+
+private:
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_Heap;
+    UINT m_DescriptorSize = 0;
+    UINT m_Capacity = 0;
+    UINT m_NextFree = 0;
+    std::vector<UINT> m_FreeList;
+    bool m_LoggedExhaustion = false;
+};

--- a/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
@@ -34,6 +34,7 @@
 #include "D3D12RenderQueue.h"
 #include "D3D12RenderGraph.h"
 #include "InstancingUtils.h"
+#include <memory>
 
 // CAS constant setup (ffxCasSetup) for RenderSharpen — the same CPU-side call D3D11PFX_CAS::Apply makes.
 // ConstantBufferStructs.h (pulled in above) already includes ffx_core.h with FFX_CPU defined.
@@ -522,9 +523,19 @@ bool D3D12GraphicsEngine::CreateLdrCopyResource( INT2 size ) {
 // both are purely single-frame scratch (written then read once then dead, no cross-frame data dependency),
 // so they are now D3D12RenderGraph-managed transient textures acquired fresh every call inside RenderSMAA
 // instead — same conversion DoF's/the god-ray/the underwater scratch textures got.
+namespace {
+    // Root constants b0: float4 RT_METRICS (1/w,1/h,w,h) + 5 bindless SRV heap indices. Lives on the heap
+    // (shared_ptr) because EdgesIdx/BlendIdx are filled in by two passes and read by a third, all of which
+    // run later, deferred inside the shared graph's Execute() — see D3D12DoF.cpp's file header for why a
+    // stack local captured by reference can't be used here any more.
+    struct SmaaConsts {
+        float RTMetrics[4];
+        UINT ColorIdx, EdgesIdx, BlendIdx, AreaIdx, SearchIdx;
+    };
+    constexpr float kSmaaClearZero[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+}
 
-
-void D3D12GraphicsEngine::RenderSMAA() {
+void D3D12GraphicsEngine::RenderSMAA( D3D12RenderGraph& graph ) {
 	// 3-pass SMAA on the tonemapped LDR swapchain image (mirrors D3D11SMAA::Render). Called from
 	// OnStartWorldRendering right after ResolveSceneToBackBuffer, while the swapchain backbuffer is bound as the
 	// RENDER_TARGET and holds the tonemapped frame — before Gothic's 2D UI/HUD draws on top (so the HUD stays
@@ -536,52 +547,40 @@ void D3D12GraphicsEngine::RenderSMAA() {
 		|| !m_Pipelines.Smaa.RootSig || !m_Pipelines.Smaa.EdgePSO || !m_Pipelines.Smaa.BlendPSO || !m_Pipelines.Smaa.NeighborPSO )
 		return;
 
-	DX_ZONE( m_CmdList.Get(), "SMAA" );
-
-	ID3D12Resource* backBuffer = GetDisplayTarget();
-	D3D12_CPU_DESCRIPTOR_HANDLE backRtv = GetDisplayRtv();
-
-	// --- Copy the tonemapped display image into m_LdrCopy (the SMAA color input). ---
-	// Display target: RENDER_TARGET -> COPY_SOURCE; m_LdrCopy rests in COPY_DEST. Not graph-managed (shared
-	// with Sharpen/Underwater — see the header comment), so this happens before the graph runs.
-	{
-		m_CmdList->TransitionBarrier( backBuffer, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
-	}
-	m_CmdList->CopyResource( m_LdrCopy.Get(), backBuffer );
-	{
-		m_CmdList->TransitionBarriers( {
-			{ m_LdrCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
-			{ backBuffer, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
-		} );
-	}
-
-	// Common state for all three fullscreen-triangle passes.
-	const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_BackbufferResolution.x ), static_cast<float>( m_BackbufferResolution.y ), 0.0f, 1.0f };
-	const D3D12_RECT     sc = { 0, 0, m_BackbufferResolution.x, m_BackbufferResolution.y };
-
-	// Root constants b0: float4 RT_METRICS (1/w,1/h,w,h) + 5 bindless SRV heap indices. EdgesIdx/BlendIdx are
-	// resolved once the graph places the two textures below.
-	struct SmaaConsts {
-		float RTMetrics[4];
-		UINT ColorIdx, EdgesIdx, BlendIdx, AreaIdx, SearchIdx;
-	} consts = {
+	auto consts = std::make_shared<SmaaConsts>( SmaaConsts{
 		{ 1.0f / m_BackbufferResolution.x, 1.0f / m_BackbufferResolution.y, static_cast<float>( m_BackbufferResolution.x ), static_cast<float>( m_BackbufferResolution.y ) },
 		m_LdrCopySrvSlot, 0, 0,
 		m_SmaaAreaTex->GetSrvSlot(), m_SmaaSearchTex->GetSrvSlot()
-	};
-	const float clearZero[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-
-	D3D12RenderGraph smaaGraph( &m_AliasArena );
+		} );
+	// Plain locals (not shared_ptr): a handle is only ever written once, synchronously, inside a pass's own
+	// setup lambda — never during the deferred Execute() — so by-value capture in any later lambda already
+	// sees the final value. See D3D12DoF.cpp's file header for the full explanation.
 	RGResourceHandle edgesHandle = RG_INVALID_HANDLE;
 	RGResourceHandle blendHandle = RG_INVALID_HANDLE;
 
-	// --- Pass 1: edge detection (color -> edges). ---
-	smaaGraph.AddPass( RG_PASS_NAME( "SMAA Edge Detection" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+	// --- Copy the tonemapped display image into m_LdrCopy (the SMAA color input). Display target:
+	// RENDER_TARGET -> COPY_SOURCE; m_LdrCopy rests in COPY_DEST. Not graph-managed (shared with Sharpen/
+	// Underwater — see the header comment). ---
+	graph.AddPass( RG_PASS_NAME( "SMAA Copy" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& cmdList ) {
+			DX_ZONE( cmdList.Get(), "SMAA" );
+			ID3D12Resource* backBuffer = GetDisplayTarget();
+			cmdList.TransitionBarrier( backBuffer, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
+			cmdList.CopyResource( m_LdrCopy.Get(), backBuffer );
+			cmdList.TransitionBarriers( {
+				{ m_LdrCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
+				{ backBuffer, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
+				} );
+			};
+		} );
+
+	// --- Edge detection (color -> edges). ---
+	graph.AddPass( RG_PASS_NAME( "SMAA Edge Detection" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
 		edgesHandle = builder.CreateTexture( { static_cast<uint32_t>( m_BackbufferResolution.x ), static_cast<uint32_t>( m_BackbufferResolution.y ),
 			static_cast<int>( DXGI_FORMAT_R8G8B8A8_UNORM ), L"SmaaEdges", 0u } );
 
-		pass.m_executeCallback = [this, vp, sc, &consts, &clearZero, edgesHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
-			D3D12RenderTarget* edges = graph.GetPhysicalTexture( edgesHandle );
+		pass.m_executeCallback = [this, consts, edgesHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
+			D3D12RenderTarget* edges = g.GetPhysicalTexture( edgesHandle );
 			if ( !edges ) return;
 
 			if ( edges->State != D3D12_RESOURCE_STATE_RENDER_TARGET ) {
@@ -589,17 +588,19 @@ void D3D12GraphicsEngine::RenderSMAA() {
 				edges->State = D3D12_RESOURCE_STATE_RENDER_TARGET;
 			}
 
-			consts.EdgesIdx = edges->GetSrvSlot();
+			consts->EdgesIdx = edges->GetSrvSlot();
+			const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_BackbufferResolution.x ), static_cast<float>( m_BackbufferResolution.y ), 0.0f, 1.0f };
+			const D3D12_RECT     sc = { 0, 0, m_BackbufferResolution.x, m_BackbufferResolution.y };
 			cmdList.RSSetViewports( 1, &vp );
 			cmdList.RSSetScissorRects( 1, &sc );
 			cmdList.IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 			cmdList.IASetVertexBuffers( 0, 0, nullptr );
 			cmdList.SetGraphicsRootSignature( m_Pipelines.Smaa.RootSig.Get() );
 			cmdList.SetPipelineState( m_Pipelines.Smaa.EdgePSO.Get() );
-			cmdList.SetGraphicsRoot32BitConstants( 0, 9, &consts, 0 );
+			cmdList.SetGraphicsRoot32BitConstants( 0, 9, consts.get(), 0 );
 			const D3D12_CPU_DESCRIPTOR_HANDLE rtv = edges->GetRTV();
 			cmdList.OMSetRenderTargets( 1, &rtv, FALSE, nullptr );
-			cmdList.ClearRenderTargetView( rtv, clearZero, 0, nullptr );
+			cmdList.ClearRenderTargetView( rtv, kSmaaClearZero, 0, nullptr );
 			cmdList.DrawInstanced( 3, 1, 0, 0 );
 
 			cmdList.TransitionBarrier( edges->GetResource(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
@@ -607,17 +608,17 @@ void D3D12GraphicsEngine::RenderSMAA() {
 			};
 		} );
 
-	// --- Pass 2: blend-weight calculation (edges + area + search -> blend). ---
-	smaaGraph.AddPass( RG_PASS_NAME( "SMAA Blend Weight" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+	// --- Blend-weight calculation (edges + area + search -> blend). ---
+	graph.AddPass( RG_PASS_NAME( "SMAA Blend Weight" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
 		builder.Read( edgesHandle );
 		blendHandle = builder.CreateTexture( { static_cast<uint32_t>( m_BackbufferResolution.x ), static_cast<uint32_t>( m_BackbufferResolution.y ),
 			static_cast<int>( DXGI_FORMAT_R8G8B8A8_UNORM ), L"SmaaBlend", 0u } );
-		// Pass 3 further down reads this pass's result via consts.BlendIdx, a plain local — not a graph
-		// Read(), so mark the side effect explicitly.
+		// The neighborhood-blend pass further down reads this pass's result via consts->BlendIdx, a plain
+		// shared value — not a graph Read(), so mark the side effect explicitly.
 		builder.MarkExternalEffect();
 
-		pass.m_executeCallback = [this, vp, sc, &consts, &clearZero, blendHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
-			D3D12RenderTarget* blend = graph.GetPhysicalTexture( blendHandle );
+		pass.m_executeCallback = [this, consts, blendHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
+			D3D12RenderTarget* blend = g.GetPhysicalTexture( blendHandle );
 			if ( !blend ) return;
 
 			if ( blend->State != D3D12_RESOURCE_STATE_RENDER_TARGET ) {
@@ -625,17 +626,19 @@ void D3D12GraphicsEngine::RenderSMAA() {
 				blend->State = D3D12_RESOURCE_STATE_RENDER_TARGET;
 			}
 
-			consts.BlendIdx = blend->GetSrvSlot();
+			consts->BlendIdx = blend->GetSrvSlot();
+			const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_BackbufferResolution.x ), static_cast<float>( m_BackbufferResolution.y ), 0.0f, 1.0f };
+			const D3D12_RECT     sc = { 0, 0, m_BackbufferResolution.x, m_BackbufferResolution.y };
 			cmdList.RSSetViewports( 1, &vp );
 			cmdList.RSSetScissorRects( 1, &sc );
 			cmdList.IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 			cmdList.IASetVertexBuffers( 0, 0, nullptr );
 			cmdList.SetGraphicsRootSignature( m_Pipelines.Smaa.RootSig.Get() );
 			cmdList.SetPipelineState( m_Pipelines.Smaa.BlendPSO.Get() );
-			cmdList.SetGraphicsRoot32BitConstants( 0, 9, &consts, 0 );
+			cmdList.SetGraphicsRoot32BitConstants( 0, 9, consts.get(), 0 );
 			const D3D12_CPU_DESCRIPTOR_HANDLE rtv = blend->GetRTV();
 			cmdList.OMSetRenderTargets( 1, &rtv, FALSE, nullptr );
-			cmdList.ClearRenderTargetView( rtv, clearZero, 0, nullptr );
+			cmdList.ClearRenderTargetView( rtv, kSmaaClearZero, 0, nullptr );
 			cmdList.DrawInstanced( 3, 1, 0, 0 );
 
 			cmdList.TransitionBarrier( blend->GetResource(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
@@ -643,24 +646,30 @@ void D3D12GraphicsEngine::RenderSMAA() {
 			};
 		} );
 
-	smaaGraph.Compile();
-	smaaGraph.Execute( m_CmdList );
+	// --- Neighborhood blending (color + blend -> swapchain). ---
+	graph.AddPass( RG_PASS_NAME( "SMAA Neighborhood Blend" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this, consts]( const D3D12RenderGraph&, D3D12CmdList& cmdList ) {
+			ID3D12Resource* backBuffer = GetDisplayTarget();
+			D3D12_CPU_DESCRIPTOR_HANDLE backRtv = GetDisplayRtv();
+			const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_BackbufferResolution.x ), static_cast<float>( m_BackbufferResolution.y ), 0.0f, 1.0f };
+			const D3D12_RECT     sc = { 0, 0, m_BackbufferResolution.x, m_BackbufferResolution.y };
+			cmdList.RSSetViewports( 1, &vp );
+			cmdList.RSSetScissorRects( 1, &sc );
+			cmdList.IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
+			cmdList.IASetVertexBuffers( 0, 0, nullptr );
+			cmdList.SetGraphicsRootSignature( m_Pipelines.Smaa.RootSig.Get() );
+			cmdList.SetPipelineState( m_Pipelines.Smaa.NeighborPSO.Get() );
+			cmdList.SetGraphicsRoot32BitConstants( 0, 9, consts.get(), 0 );
+			cmdList.OMSetRenderTargets( 1, &backRtv, FALSE, nullptr );
+			cmdList.DrawInstanced( 3, 1, 0, 0 );
 
-	// --- Pass 3: neighborhood blending (color + blend -> swapchain). ---
-	m_CmdList->RSSetViewports( 1, &vp );
-	m_CmdList->RSSetScissorRects( 1, &sc );
-	m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
-	m_CmdList->IASetVertexBuffers( 0, 0, nullptr );
-	m_CmdList->SetGraphicsRootSignature( m_Pipelines.Smaa.RootSig.Get() );
-	m_CmdList->SetPipelineState( m_Pipelines.Smaa.NeighborPSO.Get() );
-	m_CmdList->SetGraphicsRoot32BitConstants( 0, 9, &consts, 0 );
-	m_CmdList->OMSetRenderTargets( 1, &backRtv, FALSE, nullptr );
-	m_CmdList->DrawInstanced( 3, 1, 0, 0 );
-
-	// Resting state for next frame: color -> COPY_DEST. Swapchain stays RENDER_TARGET (bound above), ready for
-	// Gothic's 2D UI/HUD to composite on top. Edges/blend need no explicit reset — D3D12RenderTarget::State is
-	// caller-maintained and self-correcting, same as DoF's and the god-ray/underwater textures.
-	m_CmdList->TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST );
+			// Resting state for next frame: color -> COPY_DEST. Swapchain stays RENDER_TARGET (bound above),
+			// ready for Gothic's 2D UI/HUD to composite on top. Edges/blend need no explicit reset —
+			// D3D12RenderTarget::State is caller-maintained and self-correcting, same as DoF's and the
+			// god-ray/underwater textures.
+			cmdList.TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST );
+			};
+		} );
 }
 
 

--- a/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
@@ -574,19 +574,16 @@ void D3D12GraphicsEngine::RenderSMAA( D3D12RenderGraph& graph ) {
 			};
 		} );
 
-	// --- Edge detection (color -> edges). ---
+	// --- Edge detection (color -> edges). --- CreateTexture()'s state param gets edges into RENDER_TARGET
+	// automatically; the Blend Weight pass's Read() below transitions it to shader-read afterward — neither
+	// needs a manual check/transition here.
 	graph.AddPass( RG_PASS_NAME( "SMAA Edge Detection" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
 		edgesHandle = builder.CreateTexture( { static_cast<uint32_t>( m_BackbufferResolution.x ), static_cast<uint32_t>( m_BackbufferResolution.y ),
-			static_cast<int>( DXGI_FORMAT_R8G8B8A8_UNORM ), L"SmaaEdges", 0u } );
+			static_cast<int>( DXGI_FORMAT_R8G8B8A8_UNORM ), L"SmaaEdges", 0u }, D3D12_RESOURCE_STATE_RENDER_TARGET );
 
 		pass.m_executeCallback = [this, consts, edgesHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
 			D3D12RenderTarget* edges = g.GetPhysicalTexture( edgesHandle );
 			if ( !edges ) return;
-
-			if ( edges->State != D3D12_RESOURCE_STATE_RENDER_TARGET ) {
-				cmdList.TransitionBarrier( edges->GetResource(), edges->State, D3D12_RESOURCE_STATE_RENDER_TARGET );
-				edges->State = D3D12_RESOURCE_STATE_RENDER_TARGET;
-			}
 
 			consts->EdgesIdx = edges->GetSrvSlot();
 			const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_BackbufferResolution.x ), static_cast<float>( m_BackbufferResolution.y ), 0.0f, 1.0f };
@@ -602,17 +599,17 @@ void D3D12GraphicsEngine::RenderSMAA( D3D12RenderGraph& graph ) {
 			cmdList.OMSetRenderTargets( 1, &rtv, FALSE, nullptr );
 			cmdList.ClearRenderTargetView( rtv, kSmaaClearZero, 0, nullptr );
 			cmdList.DrawInstanced( 3, 1, 0, 0 );
-
-			cmdList.TransitionBarrier( edges->GetResource(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-			edges->State = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 			};
 		} );
 
-	// --- Blend-weight calculation (edges + area + search -> blend). ---
+	// --- Blend-weight calculation (edges + area + search -> blend). --- CreateTexture()'s state param gets
+	// blend into RENDER_TARGET automatically; nothing ever Read()s blendHandle (the neighborhood-blend pass
+	// consumes it via consts->BlendIdx, a side channel), so its final transition to PIXEL_SHADER_RESOURCE
+	// stays manual — there's no Read() to hang it off.
 	graph.AddPass( RG_PASS_NAME( "SMAA Blend Weight" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
-		builder.Read( edgesHandle );
+		builder.Read( edgesHandle, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
 		blendHandle = builder.CreateTexture( { static_cast<uint32_t>( m_BackbufferResolution.x ), static_cast<uint32_t>( m_BackbufferResolution.y ),
-			static_cast<int>( DXGI_FORMAT_R8G8B8A8_UNORM ), L"SmaaBlend", 0u } );
+			static_cast<int>( DXGI_FORMAT_R8G8B8A8_UNORM ), L"SmaaBlend", 0u }, D3D12_RESOURCE_STATE_RENDER_TARGET );
 		// The neighborhood-blend pass further down reads this pass's result via consts->BlendIdx, a plain
 		// shared value — not a graph Read(), so mark the side effect explicitly.
 		builder.MarkExternalEffect();
@@ -620,11 +617,6 @@ void D3D12GraphicsEngine::RenderSMAA( D3D12RenderGraph& graph ) {
 		pass.m_executeCallback = [this, consts, blendHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
 			D3D12RenderTarget* blend = g.GetPhysicalTexture( blendHandle );
 			if ( !blend ) return;
-
-			if ( blend->State != D3D12_RESOURCE_STATE_RENDER_TARGET ) {
-				cmdList.TransitionBarrier( blend->GetResource(), blend->State, D3D12_RESOURCE_STATE_RENDER_TARGET );
-				blend->State = D3D12_RESOURCE_STATE_RENDER_TARGET;
-			}
 
 			consts->BlendIdx = blend->GetSrvSlot();
 			const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_BackbufferResolution.x ), static_cast<float>( m_BackbufferResolution.y ), 0.0f, 1.0f };

--- a/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PostFX.cpp
@@ -32,6 +32,7 @@
 #include "../Toolbox.h"
 
 #include "D3D12RenderQueue.h"
+#include "D3D12RenderGraph.h"
 #include "InstancingUtils.h"
 
 // CAS constant setup (ffxCasSetup) for RenderSharpen — the same CPU-side call D3D11PFX_CAS::Apply makes.
@@ -517,79 +518,10 @@ bool D3D12GraphicsEngine::CreateLdrCopyResource( INT2 size ) {
 }
 
 
-bool D3D12GraphicsEngine::CreateSmaaResources( INT2 size ) {
-	// (Re)builds the resolution-dependent SMAA render targets: m_LdrCopy (LDR copy of the tonemapped
-	// swapchain), m_SmaaEdges, m_SmaaBlend. SRV heap slots + RTV heap slots are allocated ONCE and just
-	// re-pointed at the fresh resources on resize (like the bloom pyramid / m_SceneColor). Non-fatal — RenderSMAA
-	// guards on m_SmaaResourcesReady. Each resource is created in its RenderSMAA resting state (see RenderSMAA).
-	m_SmaaResourcesReady = false;
-	if ( size.x < 4 || size.y < 4 ) return false;
-	ID3D12Device* device = m_Device.GetDevice();
-	if ( !device || !m_RtvHeap ) return false;
-
-	D3D12MA::ALLOCATION_DESC heapDefault = {};
-	heapDefault.HeapType = D3D12_HEAP_TYPE_DEFAULT;
-
-	auto makeTex = [&]( DXGI_FORMAT fmt, D3D12_RESOURCE_FLAGS flags, D3D12_RESOURCE_STATES initState,
-		ComPtr<ID3D12Resource>& out, ComPtr<D3D12MA::Allocation>& outAlloc, const wchar_t* name ) -> bool {
-		D3D12_RESOURCE_DESC dd = {};
-		dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-		dd.Width = static_cast<UINT64>( size.x );
-		dd.Height = static_cast<UINT>( size.y );
-		dd.DepthOrArraySize = 1;
-		dd.MipLevels = 1;
-		dd.Format = fmt;
-		dd.SampleDesc.Count = 1;
-		dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
-		dd.Flags = flags;
-		if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, initState, nullptr,
-			outAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( out.ReleaseAndGetAddressOf() ) ) ) ) {
-			LogWarn() << "D3D12: failed to create an SMAA render target.";
-			return false;
-		}
-		out->SetName( name );
-		return true;
-		};
-
-	auto ensureSlot = [&]( UINT& slot ) -> bool {
-		if ( slot == UINT_MAX ) slot = AllocateSrvSlot();
-		return slot != UINT_MAX;
-		};
-
-	// Resting states mirror what RenderSMAA expects at entry (and restores at exit): edges/blend =
-	// RENDER_TARGET. The color input (m_LdrCopy, resting in COPY_DEST) is shared with the sharpen pass and is
-	// built separately by CreateLdrCopyResource, so a failure here can't cost sharpening its source.
-	if ( !makeTex( DXGI_FORMAT_R8G8B8A8_UNORM, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET, D3D12_RESOURCE_STATE_RENDER_TARGET,
-		m_SmaaEdges, m_SmaaEdgesAlloc, L"SmaaEdges" ) ) return false;
-	if ( !makeTex( DXGI_FORMAT_R8G8B8A8_UNORM, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET, D3D12_RESOURCE_STATE_RENDER_TARGET,
-		m_SmaaBlend, m_SmaaBlendAlloc, L"SmaaBlend" ) ) return false;
-
-	if ( !ensureSlot( m_SmaaEdgesSrvSlot ) || !ensureSlot( m_SmaaBlendSrvSlot ) )
-		return false;
-
-	D3D12_SHADER_RESOURCE_VIEW_DESC srv = {};
-	srv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-	srv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-	srv.Texture2D.MipLevels = 1;
-	srv.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-	device->CreateShaderResourceView( m_SmaaEdges.Get(), &srv, GetSrvCpuHandle( m_SmaaEdgesSrvSlot ) );
-	device->CreateShaderResourceView( m_SmaaBlend.Get(), &srv, GetSrvCpuHandle( m_SmaaBlendSrvSlot ) );
-
-	// RTVs for edges/blend at fixed RTV-heap slots kBackBufferMax+1 / +2 (slot kBackBufferMax is m_SceneColor).
-	D3D12_RENDER_TARGET_VIEW_DESC rtvDesc = {};
-	rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
-	rtvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-	m_SmaaEdgesRtv = m_RtvHeap->GetCPUDescriptorHandleForHeapStart();
-	m_SmaaEdgesRtv.ptr += static_cast<SIZE_T>( kBackBufferMax + 1 ) * m_RtvDescriptorSize;
-	device->CreateRenderTargetView( m_SmaaEdges.Get(), &rtvDesc, m_SmaaEdgesRtv );
-	m_SmaaBlendRtv = m_RtvHeap->GetCPUDescriptorHandleForHeapStart();
-	m_SmaaBlendRtv.ptr += static_cast<SIZE_T>( kBackBufferMax + 2 ) * m_RtvDescriptorSize;
-	device->CreateRenderTargetView( m_SmaaBlend.Get(), &rtvDesc, m_SmaaBlendRtv );
-	m_CmdList.InvalidateRenderTargets();   // descriptors rewritten in place — see D3D12StateCache.h
-
-	m_SmaaResourcesReady = true;
-	return true;
-}
+// Edges/blend USED to be built here as resolution-dependent members (see the header comment on RenderSMAA);
+// both are purely single-frame scratch (written then read once then dead, no cross-frame data dependency),
+// so they are now D3D12RenderGraph-managed transient textures acquired fresh every call inside RenderSMAA
+// instead — same conversion DoF's/the god-ray/the underwater scratch textures got.
 
 
 void D3D12GraphicsEngine::RenderSMAA() {
@@ -599,7 +531,7 @@ void D3D12GraphicsEngine::RenderSMAA() {
 	// crisp). Runtime toggle: only runs when AntiAliasingMode == AA_SMAA and every resource/PSO is present.
 	auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
 	if ( settings.AntiAliasingMode != GothicRendererSettings::AA_SMAA ) return;
-	if ( !m_CmdList || !m_SwapChainReady || !m_SmaaResourcesReady || !m_LdrCopyReady
+	if ( !m_CmdList || !m_SwapChainReady || !m_LdrCopyReady
 		|| !m_SmaaAreaTex || !m_SmaaAreaTex->HasSRV() || !m_SmaaSearchTex || !m_SmaaSearchTex->HasSRV()
 		|| !m_Pipelines.Smaa.RootSig || !m_Pipelines.Smaa.EdgePSO || !m_Pipelines.Smaa.BlendPSO || !m_Pipelines.Smaa.NeighborPSO )
 		return;
@@ -610,7 +542,8 @@ void D3D12GraphicsEngine::RenderSMAA() {
 	D3D12_CPU_DESCRIPTOR_HANDLE backRtv = GetDisplayRtv();
 
 	// --- Copy the tonemapped display image into m_LdrCopy (the SMAA color input). ---
-	// Display target: RENDER_TARGET -> COPY_SOURCE; m_LdrCopy rests in COPY_DEST.
+	// Display target: RENDER_TARGET -> COPY_SOURCE; m_LdrCopy rests in COPY_DEST. Not graph-managed (shared
+	// with Sharpen/Underwater — see the header comment), so this happens before the graph runs.
 	{
 		m_CmdList->TransitionBarrier( backBuffer, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
 	}
@@ -625,58 +558,109 @@ void D3D12GraphicsEngine::RenderSMAA() {
 	// Common state for all three fullscreen-triangle passes.
 	const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_BackbufferResolution.x ), static_cast<float>( m_BackbufferResolution.y ), 0.0f, 1.0f };
 	const D3D12_RECT     sc = { 0, 0, m_BackbufferResolution.x, m_BackbufferResolution.y };
-	m_CmdList->RSSetViewports( 1, &vp );
-	m_CmdList->RSSetScissorRects( 1, &sc );
-	m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
-	m_CmdList->IASetVertexBuffers( 0, 0, nullptr );
-	m_CmdList->SetGraphicsRootSignature( m_Pipelines.Smaa.RootSig.Get() );
 
-	// Root constants b0: float4 RT_METRICS (1/w,1/h,w,h) + 5 bindless SRV heap indices.
+	// Root constants b0: float4 RT_METRICS (1/w,1/h,w,h) + 5 bindless SRV heap indices. EdgesIdx/BlendIdx are
+	// resolved once the graph places the two textures below.
 	struct SmaaConsts {
 		float RTMetrics[4];
 		UINT ColorIdx, EdgesIdx, BlendIdx, AreaIdx, SearchIdx;
 	} consts = {
 		{ 1.0f / m_BackbufferResolution.x, 1.0f / m_BackbufferResolution.y, static_cast<float>( m_BackbufferResolution.x ), static_cast<float>( m_BackbufferResolution.y ) },
-		m_LdrCopySrvSlot, m_SmaaEdgesSrvSlot, m_SmaaBlendSrvSlot,
+		m_LdrCopySrvSlot, 0, 0,
 		m_SmaaAreaTex->GetSrvSlot(), m_SmaaSearchTex->GetSrvSlot()
 	};
 	const float clearZero[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
-	// --- Pass 1: edge detection (color -> edges). edges rests in RENDER_TARGET. ---
-	m_CmdList->SetPipelineState( m_Pipelines.Smaa.EdgePSO.Get() );
-	m_CmdList->SetGraphicsRoot32BitConstants( 0, 9, &consts, 0 );
-	m_CmdList->OMSetRenderTargets( 1, &m_SmaaEdgesRtv, FALSE, nullptr );
-	m_CmdList->ClearRenderTargetView( m_SmaaEdgesRtv, clearZero, 0, nullptr );
-	m_CmdList->DrawInstanced( 3, 1, 0, 0 );
-	{
-		m_CmdList->TransitionBarrier( m_SmaaEdges.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-	}
+	D3D12RenderGraph smaaGraph( &m_AliasArena );
+	RGResourceHandle edgesHandle = RG_INVALID_HANDLE;
+	RGResourceHandle blendHandle = RG_INVALID_HANDLE;
 
-	// --- Pass 2: blend-weight calculation (edges + area + search -> blend). blend rests in RENDER_TARGET. ---
-	m_CmdList->SetPipelineState( m_Pipelines.Smaa.BlendPSO.Get() );
-	m_CmdList->SetGraphicsRoot32BitConstants( 0, 9, &consts, 0 );
-	m_CmdList->OMSetRenderTargets( 1, &m_SmaaBlendRtv, FALSE, nullptr );
-	m_CmdList->ClearRenderTargetView( m_SmaaBlendRtv, clearZero, 0, nullptr );
-	m_CmdList->DrawInstanced( 3, 1, 0, 0 );
-	{
-		m_CmdList->TransitionBarrier( m_SmaaBlend.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-	}
+	// --- Pass 1: edge detection (color -> edges). ---
+	smaaGraph.AddPass( RG_PASS_NAME( "SMAA Edge Detection" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+		edgesHandle = builder.CreateTexture( { static_cast<uint32_t>( m_BackbufferResolution.x ), static_cast<uint32_t>( m_BackbufferResolution.y ),
+			static_cast<int>( DXGI_FORMAT_R8G8B8A8_UNORM ), L"SmaaEdges", 0u } );
+
+		pass.m_executeCallback = [this, vp, sc, &consts, &clearZero, edgesHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
+			D3D12RenderTarget* edges = graph.GetPhysicalTexture( edgesHandle );
+			if ( !edges ) return;
+
+			if ( edges->State != D3D12_RESOURCE_STATE_RENDER_TARGET ) {
+				cmdList.TransitionBarrier( edges->GetResource(), edges->State, D3D12_RESOURCE_STATE_RENDER_TARGET );
+				edges->State = D3D12_RESOURCE_STATE_RENDER_TARGET;
+			}
+
+			consts.EdgesIdx = edges->GetSrvSlot();
+			cmdList.RSSetViewports( 1, &vp );
+			cmdList.RSSetScissorRects( 1, &sc );
+			cmdList.IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
+			cmdList.IASetVertexBuffers( 0, 0, nullptr );
+			cmdList.SetGraphicsRootSignature( m_Pipelines.Smaa.RootSig.Get() );
+			cmdList.SetPipelineState( m_Pipelines.Smaa.EdgePSO.Get() );
+			cmdList.SetGraphicsRoot32BitConstants( 0, 9, &consts, 0 );
+			const D3D12_CPU_DESCRIPTOR_HANDLE rtv = edges->GetRTV();
+			cmdList.OMSetRenderTargets( 1, &rtv, FALSE, nullptr );
+			cmdList.ClearRenderTargetView( rtv, clearZero, 0, nullptr );
+			cmdList.DrawInstanced( 3, 1, 0, 0 );
+
+			cmdList.TransitionBarrier( edges->GetResource(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
+			edges->State = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+			};
+		} );
+
+	// --- Pass 2: blend-weight calculation (edges + area + search -> blend). ---
+	smaaGraph.AddPass( RG_PASS_NAME( "SMAA Blend Weight" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+		builder.Read( edgesHandle );
+		blendHandle = builder.CreateTexture( { static_cast<uint32_t>( m_BackbufferResolution.x ), static_cast<uint32_t>( m_BackbufferResolution.y ),
+			static_cast<int>( DXGI_FORMAT_R8G8B8A8_UNORM ), L"SmaaBlend", 0u } );
+		// Pass 3 further down reads this pass's result via consts.BlendIdx, a plain local — not a graph
+		// Read(), so mark the side effect explicitly.
+		builder.MarkExternalEffect();
+
+		pass.m_executeCallback = [this, vp, sc, &consts, &clearZero, blendHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
+			D3D12RenderTarget* blend = graph.GetPhysicalTexture( blendHandle );
+			if ( !blend ) return;
+
+			if ( blend->State != D3D12_RESOURCE_STATE_RENDER_TARGET ) {
+				cmdList.TransitionBarrier( blend->GetResource(), blend->State, D3D12_RESOURCE_STATE_RENDER_TARGET );
+				blend->State = D3D12_RESOURCE_STATE_RENDER_TARGET;
+			}
+
+			consts.BlendIdx = blend->GetSrvSlot();
+			cmdList.RSSetViewports( 1, &vp );
+			cmdList.RSSetScissorRects( 1, &sc );
+			cmdList.IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
+			cmdList.IASetVertexBuffers( 0, 0, nullptr );
+			cmdList.SetGraphicsRootSignature( m_Pipelines.Smaa.RootSig.Get() );
+			cmdList.SetPipelineState( m_Pipelines.Smaa.BlendPSO.Get() );
+			cmdList.SetGraphicsRoot32BitConstants( 0, 9, &consts, 0 );
+			const D3D12_CPU_DESCRIPTOR_HANDLE rtv = blend->GetRTV();
+			cmdList.OMSetRenderTargets( 1, &rtv, FALSE, nullptr );
+			cmdList.ClearRenderTargetView( rtv, clearZero, 0, nullptr );
+			cmdList.DrawInstanced( 3, 1, 0, 0 );
+
+			cmdList.TransitionBarrier( blend->GetResource(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
+			blend->State = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+			};
+		} );
+
+	smaaGraph.Compile();
+	smaaGraph.Execute( m_CmdList );
 
 	// --- Pass 3: neighborhood blending (color + blend -> swapchain). ---
+	m_CmdList->RSSetViewports( 1, &vp );
+	m_CmdList->RSSetScissorRects( 1, &sc );
+	m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
+	m_CmdList->IASetVertexBuffers( 0, 0, nullptr );
+	m_CmdList->SetGraphicsRootSignature( m_Pipelines.Smaa.RootSig.Get() );
 	m_CmdList->SetPipelineState( m_Pipelines.Smaa.NeighborPSO.Get() );
 	m_CmdList->SetGraphicsRoot32BitConstants( 0, 9, &consts, 0 );
 	m_CmdList->OMSetRenderTargets( 1, &backRtv, FALSE, nullptr );
 	m_CmdList->DrawInstanced( 3, 1, 0, 0 );
 
-	// Restore resting states for next frame: color -> COPY_DEST, edges/blend -> RENDER_TARGET. Swapchain stays
-	// RENDER_TARGET (bound above), ready for Gothic's 2D UI/HUD to composite on top.
-	{
-		m_CmdList->TransitionBarriers( {
-			{ m_LdrCopy.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST },
-			{ m_SmaaEdges.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
-			{ m_SmaaBlend.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
-		} );
-	}
+	// Resting state for next frame: color -> COPY_DEST. Swapchain stays RENDER_TARGET (bound above), ready for
+	// Gothic's 2D UI/HUD to composite on top. Edges/blend need no explicit reset — D3D12RenderTarget::State is
+	// caller-maintained and self-correcting, same as DoF's and the god-ray/underwater textures.
+	m_CmdList->TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST );
 }
 
 

--- a/D3D11Engine/D3D12Engine/D3D12RenderGraph.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12RenderGraph.cpp
@@ -7,17 +7,17 @@
 #include <algorithm>
 
 // Implement D3D12RGBuilder methods (must be done after D3D12RenderGraph is fully defined)
-RGResourceHandle D3D12RGBuilder::Read( RGResourceHandle handle ) {
-    m_pass.m_reads.push_back( handle );
+RGResourceHandle D3D12RGBuilder::Read( RGResourceHandle handle, D3D12_RESOURCE_STATES state ) {
+    m_pass.m_reads.push_back( { handle, state } );
     return handle;
 }
 
-RGResourceHandle D3D12RGBuilder::Write( RGResourceHandle handle ) {
-    m_pass.m_writes.push_back( handle );
+RGResourceHandle D3D12RGBuilder::Write( RGResourceHandle handle, D3D12_RESOURCE_STATES state ) {
+    m_pass.m_writes.push_back( { handle, state } );
     return handle;
 }
 
-RGResourceHandle D3D12RGBuilder::CreateTexture( const RGTextureDesc& desc ) {
+RGResourceHandle D3D12RGBuilder::CreateTexture( const RGTextureDesc& desc, D3D12_RESOURCE_STATES initialState ) {
     RGResourceHandle handle = m_graph.RegisterResource( desc );
     // Creating it implies both writing it (obviously) AND reading it: a resource nobody ever intends to
     // use isn't worth creating, so "created" is treated as sufficient demand on its own — the same way an
@@ -27,8 +27,11 @@ RGResourceHandle D3D12RGBuilder::CreateTexture( const RGTextureDesc& desc ) {
     // the same callback) has to remember an extra explicit Read() of its own Write() or the resource is
     // silently never allocated at all — isRead gates BOTH Compile()'s interval-coloring AND
     // AllocateResourcesForPass, so GetPhysicalTexture() quietly returns null with no error anywhere.
-    Read( handle );
-    return Write( handle );
+    // Both declarations carry the SAME initialState: the implicit Read isn't a second, different usage,
+    // it's just what makes the resource count as "wanted" — Execute()'s automatic transition only actually
+    // runs once for this pass (see TransitionPassResources' dedup-by-current-State check).
+    Read( handle, initialState );
+    return Write( handle, initialState );
 }
 
 void D3D12RGBuilder::MarkExternalEffect() {
@@ -71,8 +74,8 @@ void D3D12RenderGraph::Compile() {
         const auto& pass = m_passes[passIndex];
 
         // Track writes (creation/modification)
-        for ( RGResourceHandle writeHandle : pass->m_writes ) {
-            uint32_t index = D3D12GetHandleIndex( writeHandle );
+        for ( const RGResourceUsage& write : pass->m_writes ) {
+            uint32_t index = D3D12GetHandleIndex( write.Handle );
 
             if ( m_resourceLifetimes[index].firstPass == UINT32_MAX ) {
                 m_resourceLifetimes[index].firstPass = (uint32_t)passIndex;
@@ -81,8 +84,8 @@ void D3D12RenderGraph::Compile() {
         }
 
         // Track reads (usage)
-        for ( RGResourceHandle readHandle : pass->m_reads ) {
-            uint32_t index = D3D12GetHandleIndex( readHandle );
+        for ( const RGResourceUsage& read : pass->m_reads ) {
+            uint32_t index = D3D12GetHandleIndex( read.Handle );
 
             m_resourceLifetimes[index].lastPass = (uint32_t)passIndex;
             m_resourceLifetimes[index].isRead = true;
@@ -134,9 +137,9 @@ void D3D12RenderGraph::Execute( D3D12CmdList& cmdList ) {
         bool isPassDead = false;
         if ( !pass->m_hasExternalSideEffect && !pass->m_writes.empty() ) {
             isPassDead = true;
-            for ( RGResourceHandle writeHandle : pass->m_writes ) {
-                uint32_t index = D3D12GetHandleIndex( writeHandle );
-                if ( D3D12IsExternalHandle( writeHandle ) || m_resourceLifetimes[index].isRead ) {
+            for ( const RGResourceUsage& write : pass->m_writes ) {
+                uint32_t index = D3D12GetHandleIndex( write.Handle );
+                if ( D3D12IsExternalHandle( write.Handle ) || m_resourceLifetimes[index].isRead ) {
                     isPassDead = false;
                     break;
                 }
@@ -147,6 +150,7 @@ void D3D12RenderGraph::Execute( D3D12CmdList& cmdList ) {
             DXMarker marker( cmdList.Get(), pass->m_name.wide );
             ZoneScoped;
             ZoneName( pass->m_name.narrow, strlen( pass->m_name.narrow ) );
+            TransitionPassResources( *pass, cmdList );
             pass->m_executeCallback( *this, cmdList );
         }
     }
@@ -164,4 +168,30 @@ void D3D12RenderGraph::AllocateResourcesForPass( size_t passIndex, D3D12CmdList&
         m_activeTextures[i] = m_arena->Acquire( m_resourceOffsets[i], desc.width, desc.height,
             static_cast<DXGI_FORMAT>( desc.format ), needsUav, cmdList );
     }
+}
+
+void D3D12RenderGraph::TransitionPassResources( const D3D12RenderPass& pass, D3D12CmdList& cmdList ) {
+    // Generous per-pass cap: every pass converted so far touches at most a couple of graph resources.
+    // Passes with more just take an extra TransitionBarriers() call rather than losing a transition.
+    constexpr UINT kMaxPerPass = 16;
+    D3D12ResourceTransition transitions[kMaxPerPass];
+    UINT n = 0;
+
+    auto consider = [&]( const RGResourceUsage& usage ) {
+        if ( D3D12IsExternalHandle( usage.Handle ) ) return;   // not graph-tracked; caller manages state manually
+        D3D12RenderTarget* tex = GetPhysicalTexture( usage.Handle );
+        if ( !tex || tex->State == usage.State ) return;       // absent (skipped resource) or already there
+        if ( n < kMaxPerPass ) {
+            transitions[n++] = { tex->GetResource(), tex->State, usage.State };
+        } else {
+            // Fall back to an individual call past the batch cap rather than dropping the transition.
+            cmdList.TransitionBarrier( tex->GetResource(), tex->State, usage.State );
+        }
+        tex->State = usage.State;
+        };
+
+    for ( const RGResourceUsage& write : pass.m_writes ) consider( write );
+    for ( const RGResourceUsage& read : pass.m_reads ) consider( read );
+
+    if ( n > 0 ) cmdList.TransitionBarriers( transitions, n );
 }

--- a/D3D11Engine/D3D12Engine/D3D12RenderGraph.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12RenderGraph.cpp
@@ -19,7 +19,20 @@ RGResourceHandle D3D12RGBuilder::Write( RGResourceHandle handle ) {
 
 RGResourceHandle D3D12RGBuilder::CreateTexture( const RGTextureDesc& desc ) {
     RGResourceHandle handle = m_graph.RegisterResource( desc );
-    return Write( handle ); // Creating it implies we are writing to it
+    // Creating it implies both writing it (obviously) AND reading it: a resource nobody ever intends to
+    // use isn't worth creating, so "created" is treated as sufficient demand on its own — the same way an
+    // externally-imported resource's Write() is (see D3D12IsExternalHandle in Execute()'s dead-pass check).
+    // Without the implicit Read, a pass that creates AND consumes a resource purely within itself (see
+    // D3D12DoF.cpp's composite pass, which UAV-writes its scratch texture then CopyResource's it out in
+    // the same callback) has to remember an extra explicit Read() of its own Write() or the resource is
+    // silently never allocated at all — isRead gates BOTH Compile()'s interval-coloring AND
+    // AllocateResourcesForPass, so GetPhysicalTexture() quietly returns null with no error anywhere.
+    Read( handle );
+    return Write( handle );
+}
+
+void D3D12RGBuilder::MarkExternalEffect() {
+    m_pass.m_hasExternalSideEffect = true;
 }
 
 RGResourceHandle D3D12RenderGraph::ImportResource( const std::wstring& name, D3D12RenderTarget* externalTarget ) {
@@ -145,9 +158,10 @@ void D3D12RenderGraph::Execute( D3D12CmdList& cmdList ) {
 
         AllocateResourcesForPass( i, cmdList );
 
-        // Eliminate any passes whose writes are never read
+        // Eliminate any passes whose writes are never read — unless the pass told us (MarkExternalEffect)
+        // that it has a real effect the graph doesn't track as a Write in the first place.
         bool isPassDead = false;
-        if ( !pass->m_writes.empty() ) {
+        if ( !pass->m_hasExternalSideEffect && !pass->m_writes.empty() ) {
             isPassDead = true;
             for ( RGResourceHandle writeHandle : pass->m_writes ) {
                 uint32_t index = D3D12GetHandleIndex( writeHandle );

--- a/D3D11Engine/D3D12Engine/D3D12RenderGraph.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12RenderGraph.cpp
@@ -89,66 +89,35 @@ void D3D12RenderGraph::Compile() {
         }
     }
 
-    // --- Interval coloring: decide WHICH arena byte range each internal, actually-read resource gets. ---
-    // A simple best-fit "free list keyed by when its current occupant's lifetime ends" allocator. Resource
-    // counts here are a handful to a few dozen even in a heavy post-fx graph, so the O(n^2) scan below is
-    // negligible CPU cost run once per Compile() (i.e. once per graph rebuild, typically once per frame).
+    // --- Offset assignment: give each internal, actually-read resource its arena byte range. ---
+    // Delegated entirely to D3D12AliasedTextureArena::ReserveNamedRange, keyed by RGTextureDesc::name —
+    // see that method's comment for why identity (a stable name) rather than a bump-allocation position
+    // decides the offset: several real passes are conditionally active frame to frame (god rays only with
+    // the sun up, DoF only if enabled, ...), so "whatever the running total happens to be when this
+    // resource is first requested" drifts and forces spurious aliasing churn on unrelated passes. This
+    // also means two DIFFERENT names never share memory through this graph any more (no more within-
+    // Compile() best-fit reuse) — acceptable at the current scale; see ReserveNamedRange's comment.
     m_resourceOffsets.assign( m_nextHandle, 0 );
     m_resourceHasOffset.assign( m_nextHandle, false );
     if ( !m_arena ) return;
 
-    struct ArenaRange { UINT64 offset; UINT64 size; uint32_t occupantLastPass; };
-    static thread_local std::vector<ArenaRange> ranges;   // reused scratch, cleared below — not per-frame growth
-    ranges.clear();
-    // NOT reset to 0 here: fresh space is bump-allocated through the ARENA's own persistent, frame-scoped
-    // cursor (D3D12AliasedTextureArena::ReserveBumpRange), shared by every D3D12RenderGraph that runs this
-    // frame — see that method's comment for why a graph-local cursor starting at 0 every Compile() call
-    // would make independent per-function graphs (DoF's, the god-ray pass's, ...) collide and thrash.
-
-    // Process in firstPass order so "has this range's occupant already finished by the time I start"
-    // is a meaningful question — an index-order scan would let a later-starting resource steal a range
-    // out from under one that starts earlier but was registered with a higher handle index.
-    std::vector<uint32_t> order;
-    order.reserve( m_nextHandle );
     for ( uint32_t i = 0; i < m_nextHandle; ++i ) {
         if ( m_externalTextures[i] != nullptr ) continue;   // external resources are never arena-backed
-        if ( !m_resourceLifetimes[i].isRead ) continue;      // never allocated at all (RenderGraph::Execute kills the pass)
-        order.push_back( i );
-    }
-    std::sort( order.begin(), order.end(), [this]( uint32_t a, uint32_t b ) {
-        return m_resourceLifetimes[a].firstPass < m_resourceLifetimes[b].firstPass;
-        } );
+        if ( !m_resourceLifetimes[i].isRead ) continue;      // never allocated at all (Execute kills the pass)
 
-    for ( uint32_t i : order ) {
         const RGTextureDesc& desc = m_resourceDescs[i];
         const bool needsUav = ( desc.textureFlags & 1u ) != 0;
         UINT64 size = 0, alignment = 0;
         m_arena->GetAllocationInfo( desc.width, desc.height, static_cast<DXGI_FORMAT>( desc.format ), needsUav, size, alignment );
         if ( size == 0 ) continue;   // GetAllocationInfo failed (no device) — leave unassigned, Execute skips it
 
-        const uint32_t firstPass = m_resourceLifetimes[i].firstPass;
-        const uint32_t lastPass = m_resourceLifetimes[i].lastPass;
-
-        int best = -1;
-        for ( size_t r = 0; r < ranges.size(); ++r ) {
-            if ( ranges[r].occupantLastPass >= firstPass ) continue;   // still in use when this one needs to start
-            if ( ranges[r].size < size ) continue;
-            if ( best == -1 || ranges[r].size < ranges[(size_t)best].size ) best = (int)r;   // best fit
+        const UINT64 offset = m_arena->ReserveNamedRange( desc.name, size, alignment );
+        if ( offset == UINT64_MAX ) {
+            LogWarn() << "D3D12RenderGraph: aliasing arena exhausted (" << ( D3D12AliasedTextureArena::kArenaCapacityBytes / (1024*1024) )
+                << " MB) — a transient resource will be skipped this frame.";
+            continue;   // m_resourceHasOffset[i] stays false; AllocateResourcesForPass skips it
         }
-
-        if ( best != -1 ) {
-            ranges[(size_t)best].occupantLastPass = lastPass;
-            m_resourceOffsets[i] = ranges[(size_t)best].offset;
-        } else {
-            const UINT64 offset = m_arena->ReserveBumpRange( size, alignment );
-            if ( offset == UINT64_MAX ) {
-                LogWarn() << "D3D12RenderGraph: aliasing arena exhausted (" << ( D3D12AliasedTextureArena::kArenaCapacityBytes / (1024*1024) )
-                    << " MB) — a transient resource will be skipped this frame.";
-                continue;   // m_resourceHasOffset[i] stays false; AllocateResourcesForPass skips it
-            }
-            ranges.push_back( { offset, size, lastPass } );
-            m_resourceOffsets[i] = offset;
-        }
+        m_resourceOffsets[i] = offset;
         m_resourceHasOffset[i] = true;
     }
 }

--- a/D3D11Engine/D3D12Engine/D3D12RenderGraph.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12RenderGraph.cpp
@@ -100,7 +100,10 @@ void D3D12RenderGraph::Compile() {
     struct ArenaRange { UINT64 offset; UINT64 size; uint32_t occupantLastPass; };
     static thread_local std::vector<ArenaRange> ranges;   // reused scratch, cleared below — not per-frame growth
     ranges.clear();
-    UINT64 bumpOffset = 0;
+    // NOT reset to 0 here: fresh space is bump-allocated through the ARENA's own persistent, frame-scoped
+    // cursor (D3D12AliasedTextureArena::ReserveBumpRange), shared by every D3D12RenderGraph that runs this
+    // frame — see that method's comment for why a graph-local cursor starting at 0 every Compile() call
+    // would make independent per-function graphs (DoF's, the god-ray pass's, ...) collide and thrash.
 
     // Process in firstPass order so "has this range's occupant already finished by the time I start"
     // is a meaningful question — an index-order scan would let a later-starting resource steal a range
@@ -137,15 +140,14 @@ void D3D12RenderGraph::Compile() {
             ranges[(size_t)best].occupantLastPass = lastPass;
             m_resourceOffsets[i] = ranges[(size_t)best].offset;
         } else {
-            UINT64 offset = alignment ? ( ( bumpOffset + alignment - 1 ) / alignment ) * alignment : bumpOffset;
-            if ( offset + size > D3D12AliasedTextureArena::kArenaCapacityBytes ) {
+            const UINT64 offset = m_arena->ReserveBumpRange( size, alignment );
+            if ( offset == UINT64_MAX ) {
                 LogWarn() << "D3D12RenderGraph: aliasing arena exhausted (" << ( D3D12AliasedTextureArena::kArenaCapacityBytes / (1024*1024) )
                     << " MB) — a transient resource will be skipped this frame.";
                 continue;   // m_resourceHasOffset[i] stays false; AllocateResourcesForPass skips it
             }
             ranges.push_back( { offset, size, lastPass } );
             m_resourceOffsets[i] = offset;
-            bumpOffset = offset + size;
         }
         m_resourceHasOffset[i] = true;
     }

--- a/D3D11Engine/D3D12Engine/D3D12RenderGraph.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12RenderGraph.cpp
@@ -3,6 +3,8 @@
 #include "D3D12GraphicsEngine.h"
 #include "D3D12EngineCommon.h"   // DXMarker
 #include "D3D12StateCache.h"     // D3D12CmdList
+#include "../Logger.h"
+#include <algorithm>
 
 // Implement D3D12RGBuilder methods (must be done after D3D12RenderGraph is fully defined)
 RGResourceHandle D3D12RGBuilder::Read( RGResourceHandle handle ) {
@@ -24,8 +26,10 @@ RGResourceHandle D3D12RenderGraph::ImportResource( const std::wstring& name, D3D
     uint32_t index = m_nextHandle++;
 
     m_externalTextures.resize( m_nextHandle, nullptr );
-    m_activeTextures.resize( m_nextHandle );
+    m_activeTextures.resize( m_nextHandle, nullptr );
     m_resourceDescs.resize( m_nextHandle );
+    m_resourceOffsets.resize( m_nextHandle, 0 );
+    m_resourceHasOffset.resize( m_nextHandle, false );
 
     m_externalTextures[index] = externalTarget;
     m_resourceDescs[index] = { 0, 0, 0, name }; // Dummy desc for name tracking
@@ -37,8 +41,10 @@ RGResourceHandle D3D12RenderGraph::RegisterResource( const RGTextureDesc& desc )
     uint32_t index = m_nextHandle++;
 
     m_externalTextures.resize( m_nextHandle, nullptr );
-    m_activeTextures.resize( m_nextHandle );
+    m_activeTextures.resize( m_nextHandle, nullptr );
     m_resourceDescs.resize( m_nextHandle );
+    m_resourceOffsets.resize( m_nextHandle, 0 );
+    m_resourceHasOffset.resize( m_nextHandle, false );
 
     m_resourceDescs[index] = desc;
 
@@ -69,6 +75,67 @@ void D3D12RenderGraph::Compile() {
             m_resourceLifetimes[index].isRead = true;
         }
     }
+
+    // --- Interval coloring: decide WHICH arena byte range each internal, actually-read resource gets. ---
+    // A simple best-fit "free list keyed by when its current occupant's lifetime ends" allocator. Resource
+    // counts here are a handful to a few dozen even in a heavy post-fx graph, so the O(n^2) scan below is
+    // negligible CPU cost run once per Compile() (i.e. once per graph rebuild, typically once per frame).
+    m_resourceOffsets.assign( m_nextHandle, 0 );
+    m_resourceHasOffset.assign( m_nextHandle, false );
+    if ( !m_arena ) return;
+
+    struct ArenaRange { UINT64 offset; UINT64 size; uint32_t occupantLastPass; };
+    static thread_local std::vector<ArenaRange> ranges;   // reused scratch, cleared below — not per-frame growth
+    ranges.clear();
+    UINT64 bumpOffset = 0;
+
+    // Process in firstPass order so "has this range's occupant already finished by the time I start"
+    // is a meaningful question — an index-order scan would let a later-starting resource steal a range
+    // out from under one that starts earlier but was registered with a higher handle index.
+    std::vector<uint32_t> order;
+    order.reserve( m_nextHandle );
+    for ( uint32_t i = 0; i < m_nextHandle; ++i ) {
+        if ( m_externalTextures[i] != nullptr ) continue;   // external resources are never arena-backed
+        if ( !m_resourceLifetimes[i].isRead ) continue;      // never allocated at all (RenderGraph::Execute kills the pass)
+        order.push_back( i );
+    }
+    std::sort( order.begin(), order.end(), [this]( uint32_t a, uint32_t b ) {
+        return m_resourceLifetimes[a].firstPass < m_resourceLifetimes[b].firstPass;
+        } );
+
+    for ( uint32_t i : order ) {
+        const RGTextureDesc& desc = m_resourceDescs[i];
+        const bool needsUav = ( desc.textureFlags & 1u ) != 0;
+        UINT64 size = 0, alignment = 0;
+        m_arena->GetAllocationInfo( desc.width, desc.height, static_cast<DXGI_FORMAT>( desc.format ), needsUav, size, alignment );
+        if ( size == 0 ) continue;   // GetAllocationInfo failed (no device) — leave unassigned, Execute skips it
+
+        const uint32_t firstPass = m_resourceLifetimes[i].firstPass;
+        const uint32_t lastPass = m_resourceLifetimes[i].lastPass;
+
+        int best = -1;
+        for ( size_t r = 0; r < ranges.size(); ++r ) {
+            if ( ranges[r].occupantLastPass >= firstPass ) continue;   // still in use when this one needs to start
+            if ( ranges[r].size < size ) continue;
+            if ( best == -1 || ranges[r].size < ranges[(size_t)best].size ) best = (int)r;   // best fit
+        }
+
+        if ( best != -1 ) {
+            ranges[(size_t)best].occupantLastPass = lastPass;
+            m_resourceOffsets[i] = ranges[(size_t)best].offset;
+        } else {
+            UINT64 offset = alignment ? ( ( bumpOffset + alignment - 1 ) / alignment ) * alignment : bumpOffset;
+            if ( offset + size > D3D12AliasedTextureArena::kArenaCapacityBytes ) {
+                LogWarn() << "D3D12RenderGraph: aliasing arena exhausted (" << ( D3D12AliasedTextureArena::kArenaCapacityBytes / (1024*1024) )
+                    << " MB) — a transient resource will be skipped this frame.";
+                continue;   // m_resourceHasOffset[i] stays false; AllocateResourcesForPass skips it
+            }
+            ranges.push_back( { offset, size, lastPass } );
+            m_resourceOffsets[i] = offset;
+            bumpOffset = offset + size;
+        }
+        m_resourceHasOffset[i] = true;
+    }
 }
 
 void D3D12RenderGraph::Execute( D3D12CmdList& cmdList ) {
@@ -76,7 +143,7 @@ void D3D12RenderGraph::Execute( D3D12CmdList& cmdList ) {
     for ( size_t i = 0; i < m_passes.size(); ++i ) {
         const auto& pass = m_passes[i];
 
-        AllocateResourcesForPass( i );
+        AllocateResourcesForPass( i, cmdList );
 
         // Eliminate any passes whose writes are never read
         bool isPassDead = false;
@@ -97,35 +164,19 @@ void D3D12RenderGraph::Execute( D3D12CmdList& cmdList ) {
             ZoneName( pass->m_name.narrow, strlen( pass->m_name.narrow ) );
             pass->m_executeCallback( *this, cmdList );
         }
-
-        ReleaseResourcesForPass( i );
     }
 }
 
-void D3D12RenderGraph::AllocateResourcesForPass( size_t passIndex ) {
+void D3D12RenderGraph::AllocateResourcesForPass( size_t passIndex, D3D12CmdList& cmdList ) {
     for ( uint32_t i = 0; i < m_resourceLifetimes.size(); ++i ) {
-        if ( m_resourceLifetimes[i].firstPass == (uint32_t)passIndex ) {
-            if ( m_externalTextures[i] != nullptr ) continue;
-            if ( !m_resourceLifetimes[i].isRead ) continue;
+        if ( m_resourceLifetimes[i].firstPass != (uint32_t)passIndex ) continue;
+        if ( m_externalTextures[i] != nullptr ) continue;
+        if ( !m_resourceLifetimes[i].isRead ) continue;
+        if ( !m_resourceHasOffset[i] ) continue;   // Compile() couldn't fit it — leave m_activeTextures[i] null
 
-            const RGTextureDesc& desc = m_resourceDescs[i];
-            D3D12TexturePool::Description poolDesc{
-                desc.width, desc.height, static_cast<DXGI_FORMAT>( desc.format ),
-                ( desc.textureFlags & 1u ) != 0   // bit 0 == NeedsUav
-            };
-
-            m_activeTextures[i] = m_texturePool->Acquire( poolDesc );
-        }
-    }
-}
-
-void D3D12RenderGraph::ReleaseResourcesForPass( size_t passIndex ) {
-    for ( uint32_t i = 0; i < m_resourceLifetimes.size(); ++i ) {
-        if ( m_resourceLifetimes[i].lastPass == (uint32_t)passIndex ) {
-            if ( m_externalTextures[i] != nullptr ) continue;
-
-            // Resetting the handle triggers returning it to the D3D12TexturePool automatically.
-            m_activeTextures[i].reset();
-        }
+        const RGTextureDesc& desc = m_resourceDescs[i];
+        const bool needsUav = ( desc.textureFlags & 1u ) != 0;
+        m_activeTextures[i] = m_arena->Acquire( m_resourceOffsets[i], desc.width, desc.height,
+            static_cast<DXGI_FORMAT>( desc.format ), needsUav, cmdList );
     }
 }

--- a/D3D11Engine/D3D12Engine/D3D12RenderGraph.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12RenderGraph.cpp
@@ -1,0 +1,131 @@
+#include "../pch.h"
+#include "D3D12RenderGraph.h"
+#include "D3D12GraphicsEngine.h"
+#include "D3D12EngineCommon.h"   // DXMarker
+#include "D3D12StateCache.h"     // D3D12CmdList
+
+// Implement D3D12RGBuilder methods (must be done after D3D12RenderGraph is fully defined)
+RGResourceHandle D3D12RGBuilder::Read( RGResourceHandle handle ) {
+    m_pass.m_reads.push_back( handle );
+    return handle;
+}
+
+RGResourceHandle D3D12RGBuilder::Write( RGResourceHandle handle ) {
+    m_pass.m_writes.push_back( handle );
+    return handle;
+}
+
+RGResourceHandle D3D12RGBuilder::CreateTexture( const RGTextureDesc& desc ) {
+    RGResourceHandle handle = m_graph.RegisterResource( desc );
+    return Write( handle ); // Creating it implies we are writing to it
+}
+
+RGResourceHandle D3D12RenderGraph::ImportResource( const std::wstring& name, D3D12RenderTarget* externalTarget ) {
+    uint32_t index = m_nextHandle++;
+
+    m_externalTextures.resize( m_nextHandle, nullptr );
+    m_activeTextures.resize( m_nextHandle );
+    m_resourceDescs.resize( m_nextHandle );
+
+    m_externalTextures[index] = externalTarget;
+    m_resourceDescs[index] = { 0, 0, 0, name }; // Dummy desc for name tracking
+
+    return D3D12MakeHandle( index, true ); // Sets the first bit to 1
+}
+
+RGResourceHandle D3D12RenderGraph::RegisterResource( const RGTextureDesc& desc ) {
+    uint32_t index = m_nextHandle++;
+
+    m_externalTextures.resize( m_nextHandle, nullptr );
+    m_activeTextures.resize( m_nextHandle );
+    m_resourceDescs.resize( m_nextHandle );
+
+    m_resourceDescs[index] = desc;
+
+    return D3D12MakeHandle( index, false ); // First bit remains 0
+}
+
+void D3D12RenderGraph::Compile() {
+    m_resourceLifetimes.assign( m_nextHandle, { UINT32_MAX, 0, false } );
+
+    for ( size_t passIndex = 0; passIndex < m_passes.size(); ++passIndex ) {
+        const auto& pass = m_passes[passIndex];
+
+        // Track writes (creation/modification)
+        for ( RGResourceHandle writeHandle : pass->m_writes ) {
+            uint32_t index = D3D12GetHandleIndex( writeHandle );
+
+            if ( m_resourceLifetimes[index].firstPass == UINT32_MAX ) {
+                m_resourceLifetimes[index].firstPass = (uint32_t)passIndex;
+            }
+            m_resourceLifetimes[index].lastPass = (uint32_t)passIndex;
+        }
+
+        // Track reads (usage)
+        for ( RGResourceHandle readHandle : pass->m_reads ) {
+            uint32_t index = D3D12GetHandleIndex( readHandle );
+
+            m_resourceLifetimes[index].lastPass = (uint32_t)passIndex;
+            m_resourceLifetimes[index].isRead = true;
+        }
+    }
+}
+
+void D3D12RenderGraph::Execute( D3D12CmdList& cmdList ) {
+    ZoneScopedN( "D3D12RenderGraph::Execute" );
+    for ( size_t i = 0; i < m_passes.size(); ++i ) {
+        const auto& pass = m_passes[i];
+
+        AllocateResourcesForPass( i );
+
+        // Eliminate any passes whose writes are never read
+        bool isPassDead = false;
+        if ( !pass->m_writes.empty() ) {
+            isPassDead = true;
+            for ( RGResourceHandle writeHandle : pass->m_writes ) {
+                uint32_t index = D3D12GetHandleIndex( writeHandle );
+                if ( D3D12IsExternalHandle( writeHandle ) || m_resourceLifetimes[index].isRead ) {
+                    isPassDead = false;
+                    break;
+                }
+            }
+        }
+
+        if ( !isPassDead && pass->m_executeCallback ) {
+            DXMarker marker( cmdList.Get(), pass->m_name.wide );
+            ZoneScoped;
+            ZoneName( pass->m_name.narrow, strlen( pass->m_name.narrow ) );
+            pass->m_executeCallback( *this, cmdList );
+        }
+
+        ReleaseResourcesForPass( i );
+    }
+}
+
+void D3D12RenderGraph::AllocateResourcesForPass( size_t passIndex ) {
+    for ( uint32_t i = 0; i < m_resourceLifetimes.size(); ++i ) {
+        if ( m_resourceLifetimes[i].firstPass == (uint32_t)passIndex ) {
+            if ( m_externalTextures[i] != nullptr ) continue;
+            if ( !m_resourceLifetimes[i].isRead ) continue;
+
+            const RGTextureDesc& desc = m_resourceDescs[i];
+            D3D12TexturePool::Description poolDesc{
+                desc.width, desc.height, static_cast<DXGI_FORMAT>( desc.format ),
+                ( desc.textureFlags & 1u ) != 0   // bit 0 == NeedsUav
+            };
+
+            m_activeTextures[i] = m_texturePool->Acquire( poolDesc );
+        }
+    }
+}
+
+void D3D12RenderGraph::ReleaseResourcesForPass( size_t passIndex ) {
+    for ( uint32_t i = 0; i < m_resourceLifetimes.size(); ++i ) {
+        if ( m_resourceLifetimes[i].lastPass == (uint32_t)passIndex ) {
+            if ( m_externalTextures[i] != nullptr ) continue;
+
+            // Resetting the handle triggers returning it to the D3D12TexturePool automatically.
+            m_activeTextures[i].reset();
+        }
+    }
+}

--- a/D3D11Engine/D3D12Engine/D3D12RenderGraph.h
+++ b/D3D11Engine/D3D12Engine/D3D12RenderGraph.h
@@ -30,6 +30,12 @@ public:
     // Declare a brand new transient resource that lives only for this graph execution
     RGResourceHandle CreateTexture( const RGTextureDesc& desc );
 
+    // Declare that this pass has a real effect the graph doesn't track as a Write (see
+    // D3D12RenderPass::m_hasExternalSideEffect) — call this instead of inventing a fake Write handle when
+    // a pass's only externally-visible output is, say, a CopyResource onto a plain member the graph never
+    // imported. Exempts the pass from dead-pass elimination unconditionally.
+    void MarkExternalEffect();
+
 private:
     D3D12RenderGraph& m_graph;
     D3D12RenderPass& m_pass;

--- a/D3D11Engine/D3D12Engine/D3D12RenderGraph.h
+++ b/D3D11Engine/D3D12Engine/D3D12RenderGraph.h
@@ -49,20 +49,28 @@ private:
     textures with non-overlapping lifetimes onto the exact same GPU memory, via D3D12AliasedTextureArena
     — Compile() asks the arena for each internal, actually-read resource's byte range.
 
-    In active use today: RenderDepthOfField, RenderFogAndGodRays, DrawUnderwaterEffects and RenderSMAA
-    each build a small LOCAL D3D12RenderGraph (constructed fresh per call, same pattern D3D11's own
-    per-frame `RenderGraph graph(...)` uses) for their own private scratch textures. See D3D12DoF.cpp /
-    D3D12Fog.cpp / D3D12Underwater.cpp / D3D12PostFX.cpp.
+    In active use today: ONE shared instance, `postFxGraph`, built once per frame in D3D12Scene.cpp's
+    OnStartWorldRendering (same pattern D3D11's own per-frame `RenderGraph graph(...)` uses) and passed
+    BY REFERENCE into RenderFogAndGodRays / RenderDepthOfField / DrawUnderwaterEffects / RenderSMAA, each
+    of which registers its own passes directly onto it rather than building a private local graph. That
+    used to be per-function local graphs (each constructing its own D3D12RenderGraph); unifying them was
+    a deliberate correction once it became clear a single shared graph, not several independent ones, is
+    what actually matches D3D11's own structure — see the functions themselves (D3D12DoF.cpp /
+    D3D12Fog.cpp / D3D12Underwater.cpp / D3D12PostFX.cpp) for the pattern every one of them follows: any
+    per-function state that used to be a stack local captured by reference now has to be heap-allocated
+    (`std::make_shared`) and captured by value instead, because the function returns — and its stack
+    frame dies — long before postFxGraph.Execute() actually invokes the deferred callbacks.
 
-    Offset assignment is presently NAME-KEYED, not true interval-coloring: D3D12AliasedTextureArena::
+    Offset assignment is NAME-KEYED, not true interval-coloring: D3D12AliasedTextureArena::
     ReserveNamedRange gives each RGTextureDesc::name a byte range that is PERMANENT for the arena's
     current epoch (until the next resolution change), rather than recomputing packing per Compile() call.
-    This was a deliberate correction — see ReserveNamedRange's own comment for the two bugs pure
-    bump/interval packing hit in practice (independent per-function graphs colliding at offset 0, and
-    conditionally-active passes shifting everyone downstream of them). The tradeoff: two DIFFERENT names
-    no longer share memory through this graph, only a given name's own steady-state reuse across frames.
-    Real cross-effect aliasing (the more ambitious "even better than D3D11" case) is future work for when
-    the transient set is large enough that the packing actually matters — see ReserveNamedRange.
+    This was ALSO a deliberate correction, and it stays even under one shared graph — see
+    ReserveNamedRange's own comment: several real passes (god rays, DoF, SMAA, underwater) are
+    conditionally active per frame, so even within a single graph, pure position-based packing would
+    still shift every pass registered after a toggled one and force spurious churn. The tradeoff: two
+    DIFFERENT names no longer share memory through this graph, only a given name's own steady-state reuse
+    across frames. Real cross-effect aliasing (the more ambitious "even better than D3D11" case) is
+    future work for when the transient set is large enough that the packing actually matters.
 
     Resource STATE transitions (RENDER_TARGET <-> SHADER_RESOURCE etc) are still NOT automatic — each
     pass' execute callback remains responsible for transitioning whatever it binds, same as every other

--- a/D3D11Engine/D3D12Engine/D3D12RenderGraph.h
+++ b/D3D11Engine/D3D12Engine/D3D12RenderGraph.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include "../RGTextureDesc.h"
 #include "D3D12RenderPass.h"
-#include "D3D12TexturePool.h"
+#include "D3D12AliasedTextureArena.h"
 
 class D3D12CmdList;
 
@@ -35,28 +35,34 @@ private:
     D3D12RenderPass& m_pass;
 };
 
-/** D3D12 counterpart of D3D11's RenderGraph (RenderGraph.h) — same handle/lifetime API and the same
-    single-pass-over-a-list execution model, deliberately NOT reimplemented as something smarter so it
-    stays a drop-in mental model for anyone who already knows the D3D11 side. Backed by D3D12TexturePool
-    instead of TexturePool.
+/** D3D12 counterpart of D3D11's RenderGraph (RenderGraph.h) — same handle/lifetime declaration API
+    (Read/Write/CreateTexture, firstPass/lastPass from Compile()), so it stays a drop-in mental model
+    for anyone who already knows the D3D11 side. Where it goes further: D3D11 has no placed-resource
+    API, so its RenderGraph can only PACK transient textures into a free-list pool (one dedicated
+    allocation per distinct Description, reused across frames — see TexturePool.h). D3D12 can actually
+    ALIAS them — have two textures with non-overlapping lifetimes share the exact same GPU memory at
+    different points in the same frame — via D3D12AliasedTextureArena. Compile() below is what decides
+    the packing: a simple interval-coloring pass over the already-computed firstPass/lastPass lifetimes
+    (best-fit reuse of any arena byte range whose current occupant's lifetime has already ended,
+    bump-allocating a new range otherwise). See D3D12AliasedTextureArena::Acquire for the barrier this
+    packing requires when a range's occupant actually changes.
 
-    NOT YET WIRED INTO THE D3D12 FRAME LOOP. No pass constructs one today: the D3D12 backend's post-fx
-    resources (DoF, motion G-buffer, bloom, ...) are long-lived by design — allocated once, lazily, and
-    reused every frame (see D3D12DoF.cpp / D3D12Motion.cpp) — which is deliberately NOT what a render
-    graph is for. D3D12 also has no Forward+ pass-graph structure yet (D3D12Scene.cpp is still a
-    monolith of direct calls). This lands the infrastructure ahead of the first genuinely transient
-    per-frame scratch resource that needs it — the natural first consumer is a Forward+ screen-space
-    shadow-mask / AO-mask texture, mirroring D3D11ForwardPlusRenderer::AddGeometryPasses.
+    NOT YET WIRED INTO THE D3D12 FRAME LOOP. No pass constructs one today: D3D12 has no Forward+
+    pass-graph structure yet (D3D12Scene.cpp is still a monolith of direct calls) and its existing
+    post-fx resources (DoF, motion G-buffer, bloom, ...) are intentionally long-lived rather than
+    per-frame transient (see D3D12DoF.cpp / D3D12Motion.cpp) — not what this is for. This lands the
+    infrastructure ahead of the first genuinely transient per-frame scratch resource that needs it — the
+    natural first consumer is a Forward+ screen-space shadow-mask / AO-mask texture, mirroring
+    D3D11ForwardPlusRenderer::AddGeometryPasses.
 
-    UNLIKE D3D11, transitioning a physical resource's state is NOT automatic here. D3D12 needs explicit
-    barriers, and inferring them correctly from Read/Write declarations (and — the actual payoff of
-    doing this on D3D12 — aliasing non-overlapping-lifetime resources into shared heap memory) is real
-    design work, deferred to a follow-up increment. Until then, each pass' execute callback is
-    responsible for transitioning whatever it binds, exactly like every other D3D12 pass in this
-    backend (see D3D12RenderTarget::State). */
+    Resource STATE transitions (RENDER_TARGET <-> SHADER_RESOURCE etc) are still NOT automatic — each
+    pass' execute callback remains responsible for transitioning whatever it binds, same as every other
+    D3D12 pass in this backend (see D3D12RenderTarget::State). Only the ALIASING hazard (memory reuse
+    between two different logical resources) is handled by the graph; the ordinary read/write hazard
+    within one resource's own lifetime is not. */
 class D3D12RenderGraph {
 public:
-    D3D12RenderGraph( D3D12TexturePool* pool ) : m_texturePool( pool ) {}
+    D3D12RenderGraph( D3D12AliasedTextureArena* arena ) : m_arena( arena ) {}
 
     // Bring an existing engine resource (e.g. the scene-color target) into the graph
     RGResourceHandle ImportResource( const std::wstring& name, D3D12RenderTarget* externalTarget );
@@ -69,30 +75,39 @@ public:
     // Called by D3D12RGBuilder to register handles
     RGResourceHandle RegisterResource( const RGTextureDesc& desc );
 
+    /** Runs the reads/writes lifetime analysis (mirrors RenderGraph::Compile) AND, for every internal
+        resource that lifetime analysis says is actually read by something, the arena interval-coloring
+        pass described above. Must run before Execute(). */
     void Compile();
 
+    /** Records every live pass's draws, in order, onto cmdList. Aliasing barriers for any resource
+        whose arena byte range changes hands this call are inserted immediately before that resource's
+        first-writing pass — see D3D12AliasedTextureArena::Acquire. */
     void Execute( D3D12CmdList& cmdList );
 
     D3D12RenderTarget* GetPhysicalTexture( RGResourceHandle handle ) const {
         const uint32_t index = D3D12GetHandleIndex( handle );
-        return D3D12IsExternalHandle( handle ) ? m_externalTextures[index] : m_activeTextures[index].get();
+        return D3D12IsExternalHandle( handle ) ? m_externalTextures[index] : m_activeTextures[index];
     }
 
 private:
     struct Lifetime { uint32_t firstPass; uint32_t lastPass; bool isRead; };
 
-    D3D12TexturePool* m_texturePool;
+    D3D12AliasedTextureArena* m_arena;
     uint32_t m_nextHandle = 0;
     std::vector<std::unique_ptr<D3D12RenderPass>> m_passes;
     std::vector<RGTextureDesc> m_resourceDescs;
     std::vector<Lifetime> m_resourceLifetimes;
+    std::vector<UINT64> m_resourceOffsets;   // arena byte offset per internal resource, set by Compile()
+    std::vector<bool> m_resourceHasOffset;   // false if Compile() couldn't fit this resource (arena exhausted)
 
-    // Physical resource storage mapped by the Handle Index
-    std::vector<D3D12TextureHandle> m_activeTextures;
+    // Physical resource storage mapped by the Handle Index. Non-owning: internal textures live in the
+    // arena's own Slot list (see D3D12AliasedTextureArena), which persists across graph executions —
+    // there is nothing for this graph to release.
+    std::vector<D3D12RenderTarget*> m_activeTextures;
     std::vector<D3D12RenderTarget*> m_externalTextures;
 
-    void AllocateResourcesForPass( size_t passIndex );
-    void ReleaseResourcesForPass( size_t passIndex );
+    void AllocateResourcesForPass( size_t passIndex, D3D12CmdList& cmdList );
 };
 
 template<typename SetupFunc>

--- a/D3D11Engine/D3D12Engine/D3D12RenderGraph.h
+++ b/D3D11Engine/D3D12Engine/D3D12RenderGraph.h
@@ -21,14 +21,19 @@ public:
         : m_graph( graph ), m_pass( pass ) {
     }
 
-    // Declare that this pass READS from a resource (Source)
-    RGResourceHandle Read( RGResourceHandle handle );
+    // Declare that this pass READS from a resource (Source), in the given state — e.g.
+    // D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE for a compute SRV read, ..._PIXEL_SHADER_RESOURCE for
+    // a pixel-shader sample. Execute() transitions the resource into `state` automatically before this
+    // pass's callback runs (internal handles only — see D3D12RenderTarget::State and RGResourceUsage).
+    RGResourceHandle Read( RGResourceHandle handle, D3D12_RESOURCE_STATES state );
 
-    // Declare that this pass WRITES to a resource (Sink)
-    RGResourceHandle Write( RGResourceHandle handle );
+    // Declare that this pass WRITES to a resource (Sink), in the given state — e.g. RENDER_TARGET for a
+    // draw, UNORDERED_ACCESS for a compute dispatch. Same automatic-transition treatment as Read().
+    RGResourceHandle Write( RGResourceHandle handle, D3D12_RESOURCE_STATES state );
 
-    // Declare a brand new transient resource that lives only for this graph execution
-    RGResourceHandle CreateTexture( const RGTextureDesc& desc );
+    // Declare a brand new transient resource that lives only for this graph execution, and the state this
+    // pass needs it in for its first use (matches Write()'s automatic-transition contract).
+    RGResourceHandle CreateTexture( const RGTextureDesc& desc, D3D12_RESOURCE_STATES initialState );
 
     // Declare that this pass has a real effect the graph doesn't track as a Write (see
     // D3D12RenderPass::m_hasExternalSideEffect) — call this instead of inventing a fake Write handle when
@@ -72,11 +77,14 @@ private:
     across frames. Real cross-effect aliasing (the more ambitious "even better than D3D11" case) is
     future work for when the transient set is large enough that the packing actually matters.
 
-    Resource STATE transitions (RENDER_TARGET <-> SHADER_RESOURCE etc) are still NOT automatic — each
-    pass' execute callback remains responsible for transitioning whatever it binds, same as every other
-    D3D12 pass in this backend (see D3D12RenderTarget::State). Only the ALIASING hazard (memory reuse
-    between two different logical resources) is handled by the graph; the ordinary read/write hazard
-    within one resource's own lifetime is not. */
+    Resource STATE transitions (RENDER_TARGET <-> SHADER_RESOURCE etc) ARE now automatic for internal
+    (CreateTexture()'d) handles: every Read()/Write() carries the state that pass needs the resource in,
+    and Execute() transitions it there — batched into one D3D12CmdList::TransitionBarriers() call per pass
+    — immediately before that pass's callback runs, then updates D3D12RenderTarget::State. A callback only
+    needs to barrier manually for a state change IT makes mid-callback that no Read/Write models (DoF's
+    composite pass transitioning its scratch to COPY_SOURCE right before copying it out is exactly that —
+    nothing else in the graph ever reads it, so there is no Read() to hang that transition off of). External
+    (imported) handles are untouched by this — the graph has never tracked their state, and still doesn't. */
 class D3D12RenderGraph {
 public:
     D3D12RenderGraph( D3D12AliasedTextureArena* arena ) : m_arena( arena ) {}
@@ -125,6 +133,7 @@ private:
     std::vector<D3D12RenderTarget*> m_externalTextures;
 
     void AllocateResourcesForPass( size_t passIndex, D3D12CmdList& cmdList );
+    void TransitionPassResources( const D3D12RenderPass& pass, D3D12CmdList& cmdList );
 };
 
 template<typename SetupFunc>

--- a/D3D11Engine/D3D12Engine/D3D12RenderGraph.h
+++ b/D3D11Engine/D3D12Engine/D3D12RenderGraph.h
@@ -1,0 +1,108 @@
+#pragma once
+#include <memory>
+#include <string>
+#include <vector>
+#include "../RGTextureDesc.h"
+#include "D3D12RenderPass.h"
+#include "D3D12TexturePool.h"
+
+class D3D12CmdList;
+
+// Handle bit-packing, mirrors RenderGraph.h's free functions exactly (kept as a separate copy rather
+// than shared with the D3D11 side: RGResourceHandle is a plain uint32_t typedef with no backend
+// dependency, but duplicating four one-line helpers is cheaper than coupling this header to RenderGraph.h).
+inline bool D3D12IsExternalHandle( RGResourceHandle handle ) { return ( handle & 1 ) != 0; }
+inline uint32_t D3D12GetHandleIndex( RGResourceHandle handle ) { return handle >> 1; }
+inline RGResourceHandle D3D12MakeHandle( uint32_t index, bool isExternal ) { return ( index << 1 ) | ( isExternal ? 1 : 0 ); }
+
+class D3D12RGBuilder {
+public:
+    D3D12RGBuilder( class D3D12RenderGraph& graph, class D3D12RenderPass& pass )
+        : m_graph( graph ), m_pass( pass ) {
+    }
+
+    // Declare that this pass READS from a resource (Source)
+    RGResourceHandle Read( RGResourceHandle handle );
+
+    // Declare that this pass WRITES to a resource (Sink)
+    RGResourceHandle Write( RGResourceHandle handle );
+
+    // Declare a brand new transient resource that lives only for this graph execution
+    RGResourceHandle CreateTexture( const RGTextureDesc& desc );
+
+private:
+    D3D12RenderGraph& m_graph;
+    D3D12RenderPass& m_pass;
+};
+
+/** D3D12 counterpart of D3D11's RenderGraph (RenderGraph.h) — same handle/lifetime API and the same
+    single-pass-over-a-list execution model, deliberately NOT reimplemented as something smarter so it
+    stays a drop-in mental model for anyone who already knows the D3D11 side. Backed by D3D12TexturePool
+    instead of TexturePool.
+
+    NOT YET WIRED INTO THE D3D12 FRAME LOOP. No pass constructs one today: the D3D12 backend's post-fx
+    resources (DoF, motion G-buffer, bloom, ...) are long-lived by design — allocated once, lazily, and
+    reused every frame (see D3D12DoF.cpp / D3D12Motion.cpp) — which is deliberately NOT what a render
+    graph is for. D3D12 also has no Forward+ pass-graph structure yet (D3D12Scene.cpp is still a
+    monolith of direct calls). This lands the infrastructure ahead of the first genuinely transient
+    per-frame scratch resource that needs it — the natural first consumer is a Forward+ screen-space
+    shadow-mask / AO-mask texture, mirroring D3D11ForwardPlusRenderer::AddGeometryPasses.
+
+    UNLIKE D3D11, transitioning a physical resource's state is NOT automatic here. D3D12 needs explicit
+    barriers, and inferring them correctly from Read/Write declarations (and — the actual payoff of
+    doing this on D3D12 — aliasing non-overlapping-lifetime resources into shared heap memory) is real
+    design work, deferred to a follow-up increment. Until then, each pass' execute callback is
+    responsible for transitioning whatever it binds, exactly like every other D3D12 pass in this
+    backend (see D3D12RenderTarget::State). */
+class D3D12RenderGraph {
+public:
+    D3D12RenderGraph( D3D12TexturePool* pool ) : m_texturePool( pool ) {}
+
+    // Bring an existing engine resource (e.g. the scene-color target) into the graph
+    RGResourceHandle ImportResource( const std::wstring& name, D3D12RenderTarget* externalTarget );
+
+    // Add a pass using modern C++ lambdas
+    template<typename SetupFunc>
+        requires std::invocable<SetupFunc, D3D12RGBuilder&, D3D12RenderPass&>
+    void AddPass( RGPassName name, SetupFunc setupFunc );
+
+    // Called by D3D12RGBuilder to register handles
+    RGResourceHandle RegisterResource( const RGTextureDesc& desc );
+
+    void Compile();
+
+    void Execute( D3D12CmdList& cmdList );
+
+    D3D12RenderTarget* GetPhysicalTexture( RGResourceHandle handle ) const {
+        const uint32_t index = D3D12GetHandleIndex( handle );
+        return D3D12IsExternalHandle( handle ) ? m_externalTextures[index] : m_activeTextures[index].get();
+    }
+
+private:
+    struct Lifetime { uint32_t firstPass; uint32_t lastPass; bool isRead; };
+
+    D3D12TexturePool* m_texturePool;
+    uint32_t m_nextHandle = 0;
+    std::vector<std::unique_ptr<D3D12RenderPass>> m_passes;
+    std::vector<RGTextureDesc> m_resourceDescs;
+    std::vector<Lifetime> m_resourceLifetimes;
+
+    // Physical resource storage mapped by the Handle Index
+    std::vector<D3D12TextureHandle> m_activeTextures;
+    std::vector<D3D12RenderTarget*> m_externalTextures;
+
+    void AllocateResourcesForPass( size_t passIndex );
+    void ReleaseResourcesForPass( size_t passIndex );
+};
+
+template<typename SetupFunc>
+    requires std::invocable<SetupFunc, D3D12RGBuilder&, D3D12RenderPass&>
+inline void D3D12RenderGraph::AddPass( RGPassName name, SetupFunc setupFunc ) {
+    auto pass = std::make_unique<D3D12RenderPass>( name );
+    D3D12RGBuilder builder = D3D12RGBuilder( *this, *pass );
+
+    // 1. Run the setup function to declare reads/writes
+    setupFunc( builder, *pass );
+
+    m_passes.push_back( std::move( pass ) );
+}

--- a/D3D11Engine/D3D12Engine/D3D12RenderGraph.h
+++ b/D3D11Engine/D3D12Engine/D3D12RenderGraph.h
@@ -45,21 +45,24 @@ private:
     (Read/Write/CreateTexture, firstPass/lastPass from Compile()), so it stays a drop-in mental model
     for anyone who already knows the D3D11 side. Where it goes further: D3D11 has no placed-resource
     API, so its RenderGraph can only PACK transient textures into a free-list pool (one dedicated
-    allocation per distinct Description, reused across frames — see TexturePool.h). D3D12 can actually
-    ALIAS them — have two textures with non-overlapping lifetimes share the exact same GPU memory at
-    different points in the same frame — via D3D12AliasedTextureArena. Compile() below is what decides
-    the packing: a simple interval-coloring pass over the already-computed firstPass/lastPass lifetimes
-    (best-fit reuse of any arena byte range whose current occupant's lifetime has already ended,
-    bump-allocating a new range otherwise). See D3D12AliasedTextureArena::Acquire for the barrier this
-    packing requires when a range's occupant actually changes.
+    allocation per distinct Description, reused across frames — see TexturePool.h). D3D12 CAN alias two
+    textures with non-overlapping lifetimes onto the exact same GPU memory, via D3D12AliasedTextureArena
+    — Compile() asks the arena for each internal, actually-read resource's byte range.
 
-    NOT YET WIRED INTO THE D3D12 FRAME LOOP. No pass constructs one today: D3D12 has no Forward+
-    pass-graph structure yet (D3D12Scene.cpp is still a monolith of direct calls) and its existing
-    post-fx resources (DoF, motion G-buffer, bloom, ...) are intentionally long-lived rather than
-    per-frame transient (see D3D12DoF.cpp / D3D12Motion.cpp) — not what this is for. This lands the
-    infrastructure ahead of the first genuinely transient per-frame scratch resource that needs it — the
-    natural first consumer is a Forward+ screen-space shadow-mask / AO-mask texture, mirroring
-    D3D11ForwardPlusRenderer::AddGeometryPasses.
+    In active use today: RenderDepthOfField, RenderFogAndGodRays, DrawUnderwaterEffects and RenderSMAA
+    each build a small LOCAL D3D12RenderGraph (constructed fresh per call, same pattern D3D11's own
+    per-frame `RenderGraph graph(...)` uses) for their own private scratch textures. See D3D12DoF.cpp /
+    D3D12Fog.cpp / D3D12Underwater.cpp / D3D12PostFX.cpp.
+
+    Offset assignment is presently NAME-KEYED, not true interval-coloring: D3D12AliasedTextureArena::
+    ReserveNamedRange gives each RGTextureDesc::name a byte range that is PERMANENT for the arena's
+    current epoch (until the next resolution change), rather than recomputing packing per Compile() call.
+    This was a deliberate correction — see ReserveNamedRange's own comment for the two bugs pure
+    bump/interval packing hit in practice (independent per-function graphs colliding at offset 0, and
+    conditionally-active passes shifting everyone downstream of them). The tradeoff: two DIFFERENT names
+    no longer share memory through this graph, only a given name's own steady-state reuse across frames.
+    Real cross-effect aliasing (the more ambitious "even better than D3D11" case) is future work for when
+    the transient set is large enough that the packing actually matters — see ReserveNamedRange.
 
     Resource STATE transitions (RENDER_TARGET <-> SHADER_RESOURCE etc) are still NOT automatic — each
     pass' execute callback remains responsible for transitioning whatever it binds, same as every other

--- a/D3D11Engine/D3D12Engine/D3D12RenderPass.h
+++ b/D3D11Engine/D3D12Engine/D3D12RenderPass.h
@@ -20,5 +20,16 @@ public:
     std::vector<RGResourceHandle> m_reads;   // Sources
     std::vector<RGResourceHandle> m_writes;  // Sinks
 
+    // Set via D3D12RGBuilder::MarkExternalEffect() by a pass whose execute callback affects something the
+    // graph doesn't track as a Write — e.g. copying a graph-managed transient texture onto an externally-
+    // owned resource the graph never imported (D3D12DoF.cpp's composite pass does exactly this: it copies
+    // its CreateTexture()'d scratch onto m_SceneColor, a plain member, not a D3D12RenderTarget the graph
+    // could ImportResource()). Without this, a pass whose only declared Writes are internal handles that
+    // nothing else Reads looks like dead code to Execute()'s elimination and its callback never runs, even
+    // though real GPU work was expected of it — the resource it wrote still gets silently allocated by
+    // AllocateResourcesForPass (that runs unconditionally), so the failure mode is quiet: no error, no
+    // crash, just the pass's visible effect never happening.
+    bool m_hasExternalSideEffect = false;
+
     std::function<void( const D3D12RenderGraph& graph, D3D12CmdList& cmdList )> m_executeCallback;
 };

--- a/D3D11Engine/D3D12Engine/D3D12RenderPass.h
+++ b/D3D11Engine/D3D12Engine/D3D12RenderPass.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <d3d12.h>
 #include <functional>
 #include <vector>
 #include "../RenderPass.h"    // reuse RGPassName / RG_PASS_NAME — both fully backend-neutral
@@ -6,6 +7,21 @@
 
 class D3D12RenderGraph;
 class D3D12CmdList;
+
+/** One resource usage a pass declares (via D3D12RGBuilder::Read/Write) — the handle plus the resource
+    STATE the pass needs it in. D3D12RenderGraph::Execute() uses this to insert transition barriers
+    automatically for graph-owned (internal, CreateTexture()'d) resources: right before a pass's callback
+    runs, every one of its declared reads/writes whose current D3D12RenderTarget::State doesn't already
+    match gets transitioned, batched into one D3D12CmdList::TransitionBarriers() call. A pass's callback
+    therefore no longer needs to check/transition a graph resource into the state it declared for itself
+    — only for state changes it makes MID-callback that no other pass's declaration models (e.g. DoF's
+    composite pass transitioning its UAV-written scratch to COPY_SOURCE right before copying it out; see
+    D3D12DoF.cpp). External (imported) handles are skipped — the graph never tracks their state, exactly
+    as before. */
+struct RGResourceUsage {
+    RGResourceHandle Handle;
+    D3D12_RESOURCE_STATES State;
+};
 
 /** D3D12 counterpart of RenderPass (RenderPass.h) — same Reads/Writes declaration shape as the D3D11
     side. Differs in the execute callback: D3D12 has no implicit "current context" the way D3D11's
@@ -17,8 +33,8 @@ public:
     D3D12RenderPass( RGPassName name ) : m_name( std::move( name ) ) {}
 
     RGPassName m_name;
-    std::vector<RGResourceHandle> m_reads;   // Sources
-    std::vector<RGResourceHandle> m_writes;  // Sinks
+    std::vector<RGResourceUsage> m_reads;   // Sources
+    std::vector<RGResourceUsage> m_writes;  // Sinks
 
     // Set via D3D12RGBuilder::MarkExternalEffect() by a pass whose execute callback affects something the
     // graph doesn't track as a Write — e.g. copying a graph-managed transient texture onto an externally-

--- a/D3D11Engine/D3D12Engine/D3D12RenderPass.h
+++ b/D3D11Engine/D3D12Engine/D3D12RenderPass.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <functional>
+#include <vector>
+#include "../RenderPass.h"    // reuse RGPassName / RG_PASS_NAME — both fully backend-neutral
+#include "../RGTextureDesc.h"
+
+class D3D12RenderGraph;
+class D3D12CmdList;
+
+/** D3D12 counterpart of RenderPass (RenderPass.h) — same Reads/Writes declaration shape as the D3D11
+    side. Differs in the execute callback: D3D12 has no implicit "current context" the way D3D11's
+    ID3D11DeviceContext is, so the callback is handed the command list to record into explicitly. */
+class D3D12RenderPass {
+    friend class D3D12RenderGraph;
+
+public:
+    D3D12RenderPass( RGPassName name ) : m_name( std::move( name ) ) {}
+
+    RGPassName m_name;
+    std::vector<RGResourceHandle> m_reads;   // Sources
+    std::vector<RGResourceHandle> m_writes;  // Sinks
+
+    std::function<void( const D3D12RenderGraph& graph, D3D12CmdList& cmdList )> m_executeCallback;
+};

--- a/D3D11Engine/D3D12Engine/D3D12RenderTarget.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12RenderTarget.cpp
@@ -1,0 +1,75 @@
+#include "../pch.h"
+#include "D3D12RenderTarget.h"
+#include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
+#include "D3D12PooledDescriptorHeap.h"
+#include "../Logger.h"
+
+D3D12RenderTarget::~D3D12RenderTarget() {
+    if ( m_Engine ) {
+        if ( m_SrvSlot != 0xFFFFFFFFu ) m_Engine->FreeSrvSlot( m_SrvSlot );
+        if ( m_UavSlot != 0xFFFFFFFFu ) m_Engine->FreeSrvSlot( m_UavSlot );
+    }
+    if ( m_RtvHeap && m_RtvSlot != 0xFFFFFFFFu ) m_RtvHeap->Free( m_RtvSlot );
+}
+
+bool D3D12RenderTarget::Init( ID3D12Device* device, D3D12MA::Allocator* allocator, D3D12GraphicsEngine* engine,
+    D3D12PooledDescriptorHeap* rtvHeap, UINT width, UINT height, DXGI_FORMAT format, bool needsUav,
+    const wchar_t* debugName ) {
+    m_Engine = engine;
+    m_RtvHeap = rtvHeap;
+
+    D3D12_RESOURCE_DESC dd = {};
+    dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    dd.Width = width;
+    dd.Height = height;
+    dd.DepthOrArraySize = 1;
+    dd.MipLevels = 1;
+    dd.Format = format;
+    dd.SampleDesc.Count = 1;
+    dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+    dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+    if ( needsUav ) dd.Flags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+
+    D3D12_CLEAR_VALUE clear = {};
+    clear.Format = format;
+
+    D3D12MA::ALLOCATION_DESC allocDesc = {};
+    allocDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
+    if ( FAILED( D3D12ResourceCreate::CreateTexture( allocator, allocDesc, dd, D3D12_RESOURCE_STATE_RENDER_TARGET,
+        &clear, m_Allocation.ReleaseAndGetAddressOf(), IID_PPV_ARGS( m_Texture.ReleaseAndGetAddressOf() ) ) ) ) {
+        LogWarn() << "D3D12TexturePool: failed to create a pooled render target (" << width << "x" << height << ").";
+        return false;
+    }
+    if ( debugName ) m_Texture->SetName( debugName );
+
+    m_RtvSlot = rtvHeap->Allocate();
+    if ( m_RtvSlot == 0xFFFFFFFFu ) return false;
+    m_Rtv = rtvHeap->GetCpuHandle( m_RtvSlot );
+    device->CreateRenderTargetView( m_Texture.Get(), nullptr, m_Rtv );
+
+    m_SrvSlot = engine->AllocateSrvSlot();
+    if ( m_SrvSlot == 0xFFFFFFFFu ) return false;
+    D3D12_SHADER_RESOURCE_VIEW_DESC srv = {};
+    srv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    srv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    srv.Format = format;
+    srv.Texture2D.MipLevels = 1;
+    device->CreateShaderResourceView( m_Texture.Get(), &srv, engine->GetSrvCpuHandle( m_SrvSlot ) );
+
+    if ( needsUav ) {
+        m_UavSlot = engine->AllocateSrvSlot();
+        if ( m_UavSlot == 0xFFFFFFFFu ) return false;
+        D3D12_UNORDERED_ACCESS_VIEW_DESC uav = {};
+        uav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+        uav.Format = format;
+        device->CreateUnorderedAccessView( m_Texture.Get(), nullptr, &uav, engine->GetSrvCpuHandle( m_UavSlot ) );
+    }
+
+    m_Width = width;
+    m_Height = height;
+    m_Format = format;
+    State = D3D12_RESOURCE_STATE_RENDER_TARGET;
+    return true;
+}

--- a/D3D11Engine/D3D12Engine/D3D12RenderTarget.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12RenderTarget.cpp
@@ -13,6 +13,43 @@ D3D12RenderTarget::~D3D12RenderTarget() {
     if ( m_RtvHeap && m_RtvSlot != 0xFFFFFFFFu ) m_RtvHeap->Free( m_RtvSlot );
 }
 
+bool D3D12RenderTarget::CreateViews( ID3D12Device* device, UINT width, UINT height, DXGI_FORMAT format, bool needsUav ) {
+    if ( m_RtvSlot == 0xFFFFFFFFu ) {
+        m_RtvSlot = m_RtvHeap->Allocate();
+        if ( m_RtvSlot == 0xFFFFFFFFu ) return false;
+        m_Rtv = m_RtvHeap->GetCpuHandle( m_RtvSlot );
+    }
+    device->CreateRenderTargetView( m_Texture.Get(), nullptr, m_Rtv );
+
+    if ( m_SrvSlot == 0xFFFFFFFFu ) {
+        m_SrvSlot = m_Engine->AllocateSrvSlot();
+        if ( m_SrvSlot == 0xFFFFFFFFu ) return false;
+    }
+    D3D12_SHADER_RESOURCE_VIEW_DESC srv = {};
+    srv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    srv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    srv.Format = format;
+    srv.Texture2D.MipLevels = 1;
+    device->CreateShaderResourceView( m_Texture.Get(), &srv, m_Engine->GetSrvCpuHandle( m_SrvSlot ) );
+
+    if ( needsUav ) {
+        if ( m_UavSlot == 0xFFFFFFFFu ) {
+            m_UavSlot = m_Engine->AllocateSrvSlot();
+            if ( m_UavSlot == 0xFFFFFFFFu ) return false;
+        }
+        D3D12_UNORDERED_ACCESS_VIEW_DESC uav = {};
+        uav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+        uav.Format = format;
+        device->CreateUnorderedAccessView( m_Texture.Get(), nullptr, &uav, m_Engine->GetSrvCpuHandle( m_UavSlot ) );
+    }
+
+    m_Width = width;
+    m_Height = height;
+    m_Format = format;
+    State = D3D12_RESOURCE_STATE_RENDER_TARGET;
+    return true;
+}
+
 bool D3D12RenderTarget::Init( ID3D12Device* device, D3D12MA::Allocator* allocator, D3D12GraphicsEngine* engine,
     D3D12PooledDescriptorHeap* rtvHeap, UINT width, UINT height, DXGI_FORMAT format, bool needsUav,
     const wchar_t* debugName ) {
@@ -44,32 +81,39 @@ bool D3D12RenderTarget::Init( ID3D12Device* device, D3D12MA::Allocator* allocato
     }
     if ( debugName ) m_Texture->SetName( debugName );
 
-    m_RtvSlot = rtvHeap->Allocate();
-    if ( m_RtvSlot == 0xFFFFFFFFu ) return false;
-    m_Rtv = rtvHeap->GetCpuHandle( m_RtvSlot );
-    device->CreateRenderTargetView( m_Texture.Get(), nullptr, m_Rtv );
+    return CreateViews( device, width, height, format, needsUav );
+}
 
-    m_SrvSlot = engine->AllocateSrvSlot();
-    if ( m_SrvSlot == 0xFFFFFFFFu ) return false;
-    D3D12_SHADER_RESOURCE_VIEW_DESC srv = {};
-    srv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-    srv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-    srv.Format = format;
-    srv.Texture2D.MipLevels = 1;
-    device->CreateShaderResourceView( m_Texture.Get(), &srv, engine->GetSrvCpuHandle( m_SrvSlot ) );
+bool D3D12RenderTarget::InitPlaced( ID3D12Device* device, ID3D12Resource* resource, D3D12GraphicsEngine* engine,
+    D3D12PooledDescriptorHeap* rtvHeap, UINT width, UINT height, DXGI_FORMAT format, bool needsUav,
+    const wchar_t* debugName ) {
+    m_Engine = engine;
+    m_RtvHeap = rtvHeap;
+    m_Texture = resource;   // ComPtr::operator=(raw ptr) AddRefs; the arena's local ComPtr still owns its own ref
+    if ( debugName ) m_Texture->SetName( debugName );
 
-    if ( needsUav ) {
-        m_UavSlot = engine->AllocateSrvSlot();
-        if ( m_UavSlot == 0xFFFFFFFFu ) return false;
-        D3D12_UNORDERED_ACCESS_VIEW_DESC uav = {};
-        uav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
-        uav.Format = format;
-        device->CreateUnorderedAccessView( m_Texture.Get(), nullptr, &uav, engine->GetSrvCpuHandle( m_UavSlot ) );
+    return CreateViews( device, width, height, format, needsUav );
+}
+
+bool D3D12RenderTarget::ReplaceResource( ID3D12Device* device, ID3D12Resource* newResource, UINT width, UINT height,
+    DXGI_FORMAT format, bool needsUav ) {
+    // The RTV slot is reused in place (device->CreateRenderTargetView below overwrites its CPU-side
+    // descriptor content). That is safe unconditionally: an OM render-target bind snapshots the
+    // descriptor's CONTENTS into the command list at RECORD time (see D3D12StateCache.h's
+    // InvalidateRenderTargets comment), so an earlier, not-yet-executed pass that already recorded an
+    // OMSetRenderTargets against this handle is unaffected by us rewriting it now.
+    //
+    // The SRV/UAV slot(s) are the opposite: a bindless descriptor is read by the GPU at DRAW time, not
+    // snapshotted at record time, so the OLD resource + its SRV/UAV slot(s) must survive (and their
+    // slots stay unavailable for reuse) until the GPU has actually finished whatever earlier-recorded
+    // draws might still read them — QueueSrvResourceForRelease defers exactly that.
+    if ( m_Texture ) {
+        if ( m_SrvSlot != 0xFFFFFFFFu ) m_Engine->QueueSrvResourceForRelease( m_SrvSlot, m_Texture );
+        if ( m_UavSlot != 0xFFFFFFFFu ) m_Engine->QueueSrvResourceForRelease( m_UavSlot, m_Texture );
     }
+    m_SrvSlot = 0xFFFFFFFFu;
+    m_UavSlot = 0xFFFFFFFFu;
+    m_Texture = newResource;
 
-    m_Width = width;
-    m_Height = height;
-    m_Format = format;
-    State = D3D12_RESOURCE_STATE_RENDER_TARGET;
-    return true;
+    return CreateViews( device, width, height, format, needsUav );
 }

--- a/D3D11Engine/D3D12Engine/D3D12RenderTarget.h
+++ b/D3D11Engine/D3D12Engine/D3D12RenderTarget.h
@@ -6,14 +6,27 @@
 class D3D12GraphicsEngine;
 class D3D12PooledDescriptorHeap;
 
-/** Physical D3D12 color render target owned by D3D12TexturePool — the D3D12 counterpart of D3D11's
-    RenderToTextureBuffer. Owns a DEFAULT-heap 2D texture, an RTV in the pool's dedicated CPU-only
-    descriptor heap, and an SRV slot in the engine's shader-visible bindless heap (so a later pass can
-    sample what an earlier one rendered — the same "write here, read there" contract D3D11's RenderGraph
-    passes rely on). Optionally also gets a UAV slot for compute-written targets.
+/** Physical D3D12 color render target — the D3D12 counterpart of D3D11's RenderToTextureBuffer. Owns
+    an RTV (in a caller-supplied dedicated CPU-only descriptor heap) and an SRV slot in the engine's
+    shader-visible bindless heap (so a later pass can sample what an earlier one rendered — the same
+    "write here, read there" contract D3D11's RenderGraph passes rely on). Optionally also gets a UAV
+    slot for compute-written targets. Backing memory comes from one of two places:
 
-    Not resizable/reinitializable in place: a resolution or format change goes through the pool, which
-    simply stops matching this Description on Acquire() and lets the old entry age out (GiveTick). */
+      * Init()        — a dedicated DEFAULT-heap committed allocation. Used by D3D12TexturePool: one
+                         physical texture per pooled Description, reused across frames by matching
+                         Description on Acquire() (see TexturePool.h for the rationale).
+      * InitPlaced()   — a resource placed at a caller-owned offset inside an existing ID3D12Heap. Used
+                         by D3D12AliasedTextureArena, whose whole point is that TWO different
+                         Descriptions can share the same physical memory at different points in time
+                         (see D3D12RenderGraph.h's interval-coloring pass) — something Init()'s
+                         one-resource-per-Description model can't express.
+
+    ReplaceResource() swaps a placed instance's backing resource IN PLACE, keeping the RTV heap slot
+    (safe — see its own comment) while retiring the old resource + its SRV/UAV slot(s) through the
+    engine's DEFERRED release queue rather than freeing them immediately: a bindless SRV/UAV descriptor
+    is resolved by the GPU at DRAW time, not at CPU record time, so overwriting one while an earlier,
+    not-yet-executed command list still expects its old contents would corrupt that earlier pass's
+    read. Only D3D12AliasedTextureArena calls this — see its Acquire(). */
 class D3D12RenderTarget {
 public:
     D3D12RenderTarget() = default;
@@ -25,10 +38,17 @@ public:
         D3D12PooledDescriptorHeap* rtvHeap, UINT width, UINT height, DXGI_FORMAT format, bool needsUav,
         const wchar_t* debugName );
 
+    bool InitPlaced( ID3D12Device* device, ID3D12Resource* resource, D3D12GraphicsEngine* engine,
+        D3D12PooledDescriptorHeap* rtvHeap, UINT width, UINT height, DXGI_FORMAT format, bool needsUav,
+        const wchar_t* debugName );
+
+    bool ReplaceResource( ID3D12Device* device, ID3D12Resource* newResource, UINT width, UINT height,
+        DXGI_FORMAT format, bool needsUav );
+
     ID3D12Resource* GetResource() const { return m_Texture.Get(); }
     D3D12_CPU_DESCRIPTOR_HANDLE GetRTV() const { return m_Rtv; }
     UINT GetSrvSlot() const { return m_SrvSlot; }
-    UINT GetUavSlot() const { return m_UavSlot; }   // kInvalidSlot equivalent (0xFFFFFFFF) when not requested
+    UINT GetUavSlot() const { return m_UavSlot; }   // 0xFFFFFFFF when not requested
     UINT GetWidth() const { return m_Width; }
     UINT GetHeight() const { return m_Height; }
     DXGI_FORMAT GetFormat() const { return m_Format; }
@@ -37,15 +57,18 @@ public:
         needs explicit barriers, and this first cut leaves them to whoever records the pass (exactly
         like every other D3D12 pass in this backend). Defaults to the creation-time state. A pass that
         transitions this resource should update State so the next pass sharing it knows where it left
-        off; see D3D12RenderGraph.h for the follow-up that would automate this. */
+        off; see D3D12RenderGraph.h for the follow-up that would automate this. Reset to RENDER_TARGET
+        by ReplaceResource() too — CreatePlacedResource always creates at that state, same as Init(). */
     D3D12_RESOURCE_STATES State = D3D12_RESOURCE_STATE_RENDER_TARGET;
 
 private:
+    bool CreateViews( ID3D12Device* device, UINT width, UINT height, DXGI_FORMAT format, bool needsUav );
+
     D3D12GraphicsEngine* m_Engine = nullptr;
     D3D12PooledDescriptorHeap* m_RtvHeap = nullptr;
     UINT m_RtvSlot = 0xFFFFFFFFu;
 
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_Allocation;
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_Allocation;   // null for a placed instance (arena owns the heap)
     Microsoft::WRL::ComPtr<ID3D12Resource> m_Texture;
     D3D12_CPU_DESCRIPTOR_HANDLE m_Rtv{};
     UINT m_SrvSlot = 0xFFFFFFFFu;

--- a/D3D11Engine/D3D12Engine/D3D12RenderTarget.h
+++ b/D3D11Engine/D3D12Engine/D3D12RenderTarget.h
@@ -1,0 +1,55 @@
+#pragma once
+#include <d3d12.h>
+#include <D3D12MemAlloc.h>
+#include <wrl/client.h>
+
+class D3D12GraphicsEngine;
+class D3D12PooledDescriptorHeap;
+
+/** Physical D3D12 color render target owned by D3D12TexturePool — the D3D12 counterpart of D3D11's
+    RenderToTextureBuffer. Owns a DEFAULT-heap 2D texture, an RTV in the pool's dedicated CPU-only
+    descriptor heap, and an SRV slot in the engine's shader-visible bindless heap (so a later pass can
+    sample what an earlier one rendered — the same "write here, read there" contract D3D11's RenderGraph
+    passes rely on). Optionally also gets a UAV slot for compute-written targets.
+
+    Not resizable/reinitializable in place: a resolution or format change goes through the pool, which
+    simply stops matching this Description on Acquire() and lets the old entry age out (GiveTick). */
+class D3D12RenderTarget {
+public:
+    D3D12RenderTarget() = default;
+    ~D3D12RenderTarget();
+    D3D12RenderTarget( const D3D12RenderTarget& ) = delete;
+    D3D12RenderTarget& operator=( const D3D12RenderTarget& ) = delete;
+
+    bool Init( ID3D12Device* device, D3D12MA::Allocator* allocator, D3D12GraphicsEngine* engine,
+        D3D12PooledDescriptorHeap* rtvHeap, UINT width, UINT height, DXGI_FORMAT format, bool needsUav,
+        const wchar_t* debugName );
+
+    ID3D12Resource* GetResource() const { return m_Texture.Get(); }
+    D3D12_CPU_DESCRIPTOR_HANDLE GetRTV() const { return m_Rtv; }
+    UINT GetSrvSlot() const { return m_SrvSlot; }
+    UINT GetUavSlot() const { return m_UavSlot; }   // kInvalidSlot equivalent (0xFFFFFFFF) when not requested
+    UINT GetWidth() const { return m_Width; }
+    UINT GetHeight() const { return m_Height; }
+    DXGI_FORMAT GetFormat() const { return m_Format; }
+
+    /** Tracked resource state. NOT maintained automatically by the pool or the render graph — D3D12
+        needs explicit barriers, and this first cut leaves them to whoever records the pass (exactly
+        like every other D3D12 pass in this backend). Defaults to the creation-time state. A pass that
+        transitions this resource should update State so the next pass sharing it knows where it left
+        off; see D3D12RenderGraph.h for the follow-up that would automate this. */
+    D3D12_RESOURCE_STATES State = D3D12_RESOURCE_STATE_RENDER_TARGET;
+
+private:
+    D3D12GraphicsEngine* m_Engine = nullptr;
+    D3D12PooledDescriptorHeap* m_RtvHeap = nullptr;
+    UINT m_RtvSlot = 0xFFFFFFFFu;
+
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_Allocation;
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_Texture;
+    D3D12_CPU_DESCRIPTOR_HANDLE m_Rtv{};
+    UINT m_SrvSlot = 0xFFFFFFFFu;
+    UINT m_UavSlot = 0xFFFFFFFFu;
+    UINT m_Width = 0, m_Height = 0;
+    DXGI_FORMAT m_Format = DXGI_FORMAT_UNKNOWN;
+};

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2466,10 +2466,11 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 
 	// Height fog + god rays (parity item #5): the last thing to touch the scene before the post-FX chain, same
 	// slot D3D11's PostFX composition occupies (after the ghosts/particle passes, before bloom+tonemap). Both
-	// halves are outdoor-only and individually gated (DrawFog / EnableGodRays); no-ops otherwise.
-	postFxGraph.AddPass( RG_PASS_NAME( "Fog + God Rays" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
-		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderFogAndGodRays(); };
-		} );
+	// halves are outdoor-only and individually gated (DrawFog / EnableGodRays); no-ops otherwise. Registers its
+	// own passes directly onto postFxGraph (not wrapped in an opaque pass here) — see D3D12DoF.cpp's file
+	// header for why: its god-ray mask/zoom scratch textures need to be real graph resources, visible to
+	// (and correctly scheduled among) every other post-FX pass in this SAME shared graph.
+	RenderFogAndGodRays( postFxGraph );
 
 	// Debug/editor lines, INSIDE the scene rather than over the finished LDR image (D3D11's slot): drawing
 	// them at native size afterwards would need a native-res copy of the scene depth for the world-space list
@@ -2498,9 +2499,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// B" block, i.e. after the upscale/TAA stage and before bloom. Blurring before bloom is what makes an
 	// out-of-focus highlight bloom as the disc it has become rather than as the point it was; being after TAA
 	// keeps a moving focus point from smearing through the temporal history. No-op unless EnableDoF.
-	postFxGraph.AddPass( RG_PASS_NAME( "Depth Of Field" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
-		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderDepthOfField(); };
-		} );
+	RenderDepthOfField( postFxGraph );
 
 	postFxGraph.AddPass( RG_PASS_NAME( "Bloom" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
 		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderBloom(); };
@@ -2527,9 +2526,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// SMAA anti-aliasing (opt-in, RendererSettings.AntiAliasingMode == AA_SMAA): runs on the tonemapped LDR
 	// swapchain image, before Gothic's 2D UI/HUD composites on top so the HUD stays crisp. No-ops if disabled
 	// or resources unavailable. Mirrors D3D11's SMAA placement (post-tonemap, pre-sharpen/UI).
-	postFxGraph.AddPass( RG_PASS_NAME( "SMAA" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
-		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderSMAA(); };
-		} );
+	RenderSMAA( postFxGraph );
 
 	// Post-tonemap sharpening (SHARPEN_CAS by default — this one is ON for a stock config, unlike SMAA).
 	// D3D11's "Sharpen" pass sits in the same place: after AA, on the LDR backbuffer, before the 2D UI.
@@ -2540,9 +2537,7 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// Underwater screen effect (blue-tinted blur + animated UV distortion), only while the camera is below a
 	// water surface. D3D11 adds its "Draw UnderwaterFX" pass in exactly this slot: after the AA/sharpen passes,
 	// on the finished image, and before Gothic's own 2D UI/HUD phase — the HUD must stay sharp and untinted.
-	postFxGraph.AddPass( RG_PASS_NAME( "Underwater FX" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
-		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { DrawUnderwaterEffects(); };
-		} );
+	DrawUnderwaterEffects( postFxGraph );
 
 	// Developer view of the motion-vector / normal G-buffer, over the finished image (before Gothic's 2D UI and
 	// the ImGui overlay composite, so both stay readable on top of it). No-op unless one of the shared

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -404,6 +404,10 @@ void D3D12GraphicsEngine::DrawVobSingle( VobInfo* vob, zCCamera& camera ) {
         || !m_Pipelines.Preview.PSO || !m_Pipelines.Preview.RootSig || !m_DepthBuffer || !m_DsvHeap )
         return;
 
+    // Still being filled in on a worker thread (GothicAPI::OnAddVob's async Extract3DSMeshFromVisual2Async)
+    // - skip until Meshes is safe to iterate. The item pops in a frame or two later instead.
+    if ( !vob->VisualInfo->GetIsReady() ) return;
+
     Engine::GAPI->SetViewTransformXM( XMLoadFloat4x4( &camera.GetTransformDX( zCCamera::ETransformType::TT_VIEW ) ) );
 
     GothicRendererState& rs = Engine::GAPI->GetRendererState();
@@ -1747,7 +1751,7 @@ void D3D12GraphicsEngine::DrawGhostRun( std::span<const TransparentItem> items )
 						WorldConverter::ExtractNodeVisualAsync( n, node, skel->NodeAttachments );
 						it = skel->NodeAttachments.find( n );
 					} else if ( !it->second.empty() && it->second[0]
-						&& it->second[0]->Ready.load( std::memory_order_acquire )
+						&& it->second[0]->GetIsReady()
 						&& it->second[0]->Visual != node->NodeVisual ) {
 						WorldConverter::ExtractNodeVisualAsync( n, node, skel->NodeAttachments );  // visual changed
 						it = skel->NodeAttachments.find( n );
@@ -1760,7 +1764,7 @@ void D3D12GraphicsEngine::DrawGhostRun( std::span<const TransparentItem> items )
 					for ( MeshVisualInfo* mvi : it->second ) {
 						if ( !mvi ) continue;
 						// Still being extracted on a worker — Meshes is being written right now, don't race it.
-						if ( !mvi->Ready.load( std::memory_order_acquire ) || !mvi->Visual ) continue;
+						if ( !mvi->GetIsReady() || !mvi->Visual ) continue;
 
 						// Texture animation + facial/bow morphing, same calls the lit attachment path makes.
 						// A ghost NPC's head is exactly this case, so skipping it would freeze its face.
@@ -1813,6 +1817,10 @@ void D3D12GraphicsEngine::DrawGhostRun( std::span<const TransparentItem> items )
 		}
 
 		if ( !info.normalVob || !info.normalVob->VisualInfo || !m_Pipelines.Ghost.PSO || !m_Pipelines.Ghost.RootSig ) continue;
+
+		// Still being filled in on a worker thread (GothicAPI::OnAddVob's async
+		// Extract3DSMeshFromVisual2Async) - skip until Meshes is safe to iterate.
+		if ( !static_cast<MeshVisualInfo*>( info.normalVob->VisualInfo )->GetIsReady() ) continue;
 
 		VobInfo* vi = info.normalVob;
 		m_CmdList->SetPipelineState( m_Pipelines.Ghost.PSO.Get() );
@@ -3206,6 +3214,9 @@ UINT D3D12GraphicsEngine::BuildVobDrawCommands( const std::vector<FrameVobUpload
     for ( const FrameVobUpload& up : uploads ) {
         MeshVisualInfo* visual = up.visual;
         if ( !visual ) continue;
+        // Still being filled in on a worker thread (GothicAPI::OnAddVob's async
+        // Extract3DSMeshFromVisual2Async) - skip until MeshesByTexture is safe to iterate.
+        if ( !visual->GetIsReady() ) continue;
         const float minH = visual->BBox.Min.y;
         const float maxH = visual->BBox.Max.y;
         staged.clear();
@@ -4453,7 +4464,7 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
         zCModel* model = static_cast<zCModel*>( vi->Vob->GetVisual() );
         if ( !model ) continue;
 
-        if ( !visual->Ready.load() ) continue;   // still being built on a worker thread (GothicAPI::LoadzCModelData)
+        if ( !visual->GetIsReady() ) continue;   // still being built on a worker thread (GothicAPI::LoadzCModelData)
 
         // Some skeletal vobs arrive with their base mesh not yet extracted (SkeletalMeshes empty but the model
         // does carry soft-skin geometry) — build it lazily. Interactive MOBs whose ONLY renderable content is a
@@ -4662,7 +4673,7 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
                     WorldConverter::ExtractNodeVisualAsync( n, node, nodeAttachments );
                     it = nodeAttachments.find( n );
                 } else if ( !it->second.empty() && it->second[0]
-                    && it->second[0]->Ready.load( std::memory_order_acquire )
+                    && it->second[0]->GetIsReady()
                     && it->second[0]->Visual != node->NodeVisual ) {
                     WorldConverter::ExtractNodeVisualAsync( n, node, nodeAttachments );  // visual changed
                     it = nodeAttachments.find( n );
@@ -4687,7 +4698,7 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
                     if ( !mvi ) continue;
                     // Still being extracted on a worker thread — Meshes/MeshesByTexture are being written
                     // to right now, so skip this attachment entirely for this frame rather than race them.
-                    if ( !mvi->Ready.load( std::memory_order_acquire ) || !mvi->Visual ) continue;
+                    if ( !mvi->GetIsReady() || !mvi->Visual ) continue;
                     const bool isMMS = strcmp( mvi->Visual->GetFileExtension( 0 ), ".MMS" ) == 0;
                     // MMS attachments only MORPH within kMorphMeshMaxDistance; beyond it they render as their
                     // undeformed rest mesh and carry no Fatness/Scaling, mirroring D3D11's `isMMS &&
@@ -4723,7 +4734,7 @@ void D3D12GraphicsEngine::PrepareFrameSkeletals( std::vector<SkeletalVobInfo*>& 
                     // per head type, so they batch. Falls back while the rest mesh is still being built.
                     MeshVisualInfo* drawVis = mvi;
                     if ( isMMS && !morphActive && mvi->RestVisual
-                        && mvi->RestVisual->Ready.load( std::memory_order_acquire ) ) {
+                        && mvi->RestVisual->GetIsReady() ) {
                         drawVis = mvi->RestVisual;
                     }
                     const bool attBatchable = !isMMS || drawVis != mvi;

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -34,6 +34,7 @@
 #include "../Toolbox.h"
 
 #include "D3D12RenderQueue.h"
+#include "D3D12RenderGraph.h"
 #include "InstancingUtils.h"
 #include "../ThreadPool.h"   // Engine::RenderingThreadPool — MT shadow-cascade cull/record fan-out
 
@@ -2449,21 +2450,39 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// the clear sentinel, so the true per-object velocities the prepass wrote are left alone. See D3D12Motion.cpp.
 	FillCameraVelocity();
 
+	// --- Post-FX tail, issued through D3D12RenderGraph. --------------------------------------------------
+	// First live-frame use of the render-graph infrastructure (D3D12RenderGraph.h / D3D12AliasedTextureArena.h)
+	// — previously landed but never called. DELIBERATELY control-flow only for this increment: every pass
+	// below declares no Read/Write, so Compile()'s dead-pass elimination never triggers (a pass with no
+	// declared writes always executes) and every one of these still runs unconditionally, in the same
+	// order, exactly like the flat call sequence this replaces. Each function keeps managing its own
+	// resources and barriers internally, completely unchanged — see the per-function doc comments in
+	// D3D12Fog.cpp/D3D12Taa.cpp/D3D12DoF.cpp/D3D12PostFX.cpp/D3D12Fsr3.cpp/D3D12Underwater.cpp for what
+	// each one reads/writes. The payoff here is purely structural: named, GPU-marker-tagged (PIX/RenderDoc)
+	// and Tracy-zoned passes instead of a flat call list, ahead of a follow-up that teaches individual
+	// passes to expose their resources as graph handles — that is what would let Compile() actually
+	// alias/reorder them, the same way a Forward+ shadow-mask/AO-mask scratch texture eventually will.
+	D3D12RenderGraph postFxGraph( &m_AliasArena );
+
 	// Height fog + god rays (parity item #5): the last thing to touch the scene before the post-FX chain, same
 	// slot D3D11's PostFX composition occupies (after the ghosts/particle passes, before bloom+tonemap). Both
 	// halves are outdoor-only and individually gated (DrawFog / EnableGodRays); no-ops otherwise.
-	RenderFogAndGodRays();
+	postFxGraph.AddPass( RG_PASS_NAME( "Fog + God Rays" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderFogAndGodRays(); };
+		} );
 
 	// Debug/editor lines, INSIDE the scene rather than over the finished LDR image (D3D11's slot): drawing
 	// them at native size afterwards would need a native-res copy of the scene depth for the world-space list
 	// to test against. They end up as soft as the rest of the scene when downscaling — fine for a diagnostic
-	// overlay. Both calls also CLEAR their cache, which is what keeps the line lists from growing.
-	{
-		DX_ZONE( m_CmdList.Get(), "Draw debug lines" );
-		TracyD3D12ZoneCGX( m_CmdList.Get(), "Draw debug lines" );
-		m_LineRenderer->Flush();
-		m_LineRenderer->FlushScreenSpace();
-	}
+	// overlay. Both calls also CLEAR their cache, which is what keeps the line lists from growing. The pass's
+	// own DXMarker/Tracy zone (added by D3D12RenderGraph::Execute) replaces what used to be a manual DX_ZONE/
+	// TracyD3D12ZoneCGX pair here.
+	postFxGraph.AddPass( RG_PASS_NAME( "Debug Lines" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) {
+			m_LineRenderer->Flush();
+			m_LineRenderer->FlushScreenSpace();
+			};
+		} );
 
 	// Bloom (P2.11, opt-in via EnableBloom): must run before the tonemap resolve below, while the scene is still
 	// linear HDR — additively blending a mip pyramid of the scene's own bright pixels back onto itself.
@@ -2471,47 +2490,70 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 	// scene and belong inside the temporal accumulation) and BEFORE bloom + luminance adaptation (blooming or
 	// auto-exposing an aliased frame makes the flicker TAA exists to remove worse). The resolve writes the
 	// scene colour back in place, so nothing below needs to know it ran. No-op unless AA_TAA.
-	RenderTAA();
+	postFxGraph.AddPass( RG_PASS_NAME( "TAA" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderTAA(); };
+		} );
 
 	// Depth of field, on the resolved LINEAR HDR scene: D3D11 runs it as the first pass of its "Post-processing
 	// B" block, i.e. after the upscale/TAA stage and before bloom. Blurring before bloom is what makes an
 	// out-of-focus highlight bloom as the disc it has become rather than as the point it was; being after TAA
 	// keeps a moving focus point from smearing through the temporal history. No-op unless EnableDoF.
-	RenderDepthOfField();
+	postFxGraph.AddPass( RG_PASS_NAME( "Depth Of Field" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderDepthOfField(); };
+		} );
 
-	RenderBloom();
-	RenderLuminanceAdapt();
+	postFxGraph.AddPass( RG_PASS_NAME( "Bloom" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderBloom(); };
+		} );
+	postFxGraph.AddPass( RG_PASS_NAME( "Luminance Adapt" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderLuminanceAdapt(); };
+		} );
 
 	// FSR 3 temporal upscale (AA_FSR + the FSR 3 upscaler; mutually exclusive with RenderTAA above). Deliberately
 	// AFTER bloom/luminance and immediately before the tonemap resolve, i.e. on the linear HDR scene rather than
 	// on the finished LDR image D3D11 upscales — see D3D12Fsr3.cpp for the reasoning. It writes a DISPLAY-res
 	// target, which ResolveSceneToBackBuffer then samples in place of the render-res scene colour, so the
 	// resolve's implicit bilinear upscale becomes a 1:1 blit. No-op (and the resolve keeps upscaling) otherwise.
-	RenderFsr3Upscale();
+	postFxGraph.AddPass( RG_PASS_NAME( "FSR3 Upscale" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderFsr3Upscale(); };
+		} );
 
 	// Phase 3 HDR: the 3D scene is complete — tonemap the HDR target into the swapchain and rebind the backbuffer
 	// so Gothic's subsequent 2D UI/HUD draws (and the ImGui overlay in Present) composite on top in LDR.
-	ResolveSceneToBackBuffer();
+	postFxGraph.AddPass( RG_PASS_NAME( "Resolve Scene To BackBuffer" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { ResolveSceneToBackBuffer(); };
+		} );
 
 	// SMAA anti-aliasing (opt-in, RendererSettings.AntiAliasingMode == AA_SMAA): runs on the tonemapped LDR
 	// swapchain image, before Gothic's 2D UI/HUD composites on top so the HUD stays crisp. No-ops if disabled
 	// or resources unavailable. Mirrors D3D11's SMAA placement (post-tonemap, pre-sharpen/UI).
-	RenderSMAA();
+	postFxGraph.AddPass( RG_PASS_NAME( "SMAA" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderSMAA(); };
+		} );
 
 	// Post-tonemap sharpening (SHARPEN_CAS by default — this one is ON for a stock config, unlike SMAA).
 	// D3D11's "Sharpen" pass sits in the same place: after AA, on the LDR backbuffer, before the 2D UI.
-	RenderSharpen();
+	postFxGraph.AddPass( RG_PASS_NAME( "Sharpen" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderSharpen(); };
+		} );
 
 	// Underwater screen effect (blue-tinted blur + animated UV distortion), only while the camera is below a
 	// water surface. D3D11 adds its "Draw UnderwaterFX" pass in exactly this slot: after the AA/sharpen passes,
 	// on the finished image, and before Gothic's own 2D UI/HUD phase — the HUD must stay sharp and untinted.
-	DrawUnderwaterEffects();
+	postFxGraph.AddPass( RG_PASS_NAME( "Underwater FX" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { DrawUnderwaterEffects(); };
+		} );
 
 	// Developer view of the motion-vector / normal G-buffer, over the finished image (before Gothic's 2D UI and
 	// the ImGui overlay composite, so both stay readable on top of it). No-op unless one of the shared
 	// DebugSettings.TAA.Display* flags is on. This is currently the ONLY consumer of either target — TAA, FSR3
 	// and XeGTAO are still to come — and therefore the only way to verify this whole feature on the GPU.
-	RenderMotionDebugOverlay();
+	postFxGraph.AddPass( RG_PASS_NAME( "Motion Debug Overlay" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+		pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& ) { RenderMotionDebugOverlay(); };
+		} );
+
+	postFxGraph.Compile();
+	postFxGraph.Execute( m_CmdList );
 
 	// (Debug/editor lines used to be flushed here; see the call site above RenderTAA.)
 

--- a/D3D11Engine/D3D12Engine/D3D12TexturePool.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12TexturePool.cpp
@@ -1,0 +1,56 @@
+#include "../pch.h"
+#include "D3D12TexturePool.h"
+#include "D3D12GraphicsEngine.h"
+#include "../Logger.h"
+#include <algorithm>
+
+bool D3D12TexturePool::Attach( D3D12GraphicsEngine& engine ) {
+    m_Engine = &engine;
+    m_Device = engine.GetD3DDevice();
+    m_Allocator = engine.GetAllocator();
+    if ( !m_Device || !m_Allocator ) return false;
+    return m_RtvHeap.Init( m_Device, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, kMaxPooledTargets, L"D3D12TexturePool_RTV" );
+}
+
+D3D12TexturePool::Handle D3D12TexturePool::Acquire( const Description& desc ) {
+    PooledTexture* found = nullptr;
+    for ( auto& entry : m_Pool ) {
+        if ( !entry->InUse && entry->Desc == desc ) {
+            found = entry.get();
+            break;
+        }
+    }
+
+    if ( !found ) {
+        auto tex = std::make_unique<D3D12RenderTarget>();
+        wchar_t name[64];
+        swprintf_s( name, L"PooledRT_%zu", m_Pool.size() );
+        if ( !tex->Init( m_Device, m_Allocator, m_Engine, &m_RtvHeap, desc.Width, desc.Height, desc.Format, desc.NeedsUav, name ) ) {
+            LogWarn() << "D3D12TexturePool: could not create a pooled render target (" << desc.Width << "x" << desc.Height << ").";
+            return Handle( nullptr );
+        }
+        m_Pool.push_back( std::make_unique<PooledTexture>( PooledTexture{ std::move( tex ), desc, m_CurrentFrame, true } ) );
+        found = m_Pool.back().get();
+    }
+
+    found->InUse = true;
+    found->LastFrameUsed = m_CurrentFrame;
+    return Handle( found );
+}
+
+void D3D12TexturePool::GiveTick() {
+    m_CurrentFrame++;
+    m_Pool.erase( std::remove_if( m_Pool.begin(), m_Pool.end(), [this]( const auto& entry ) {
+        return !entry->InUse && ( m_CurrentFrame - entry->LastFrameUsed > kMaxUnusedFrames );
+        } ), m_Pool.end() );
+}
+
+void D3D12TexturePool::Clear() {
+    m_Pool.clear();
+}
+
+size_t D3D12TexturePool::GetActiveCount() const {
+    size_t count = 0;
+    for ( const auto& e : m_Pool ) if ( e->InUse ) count++;
+    return count;
+}

--- a/D3D11Engine/D3D12Engine/D3D12TexturePool.h
+++ b/D3D11Engine/D3D12Engine/D3D12TexturePool.h
@@ -1,0 +1,96 @@
+#pragma once
+#include <d3d12.h>
+#include <D3D12MemAlloc.h>
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include "D3D12RenderTarget.h"
+#include "D3D12PooledDescriptorHeap.h"
+
+class D3D12GraphicsEngine;
+
+/** Free-list pool of transient D3D12 render targets — the D3D12 counterpart of D3D11's TexturePool
+    (see TexturePool.h). Backs D3D12RenderGraph: a pass asks for a Description and gets back a texture
+    that may be a fresh allocation or one recycled from an earlier pass whose lifetime has already
+    ended (see D3D12RenderGraph::Compile/Execute). Owns one dedicated CPU-only RTV heap, fixed at
+    kMaxPooledTargets slots (see D3D12PooledDescriptorHeap for why fixed-capacity). */
+class D3D12TexturePool {
+public:
+    struct Description {
+        UINT Width = 0, Height = 0;
+        DXGI_FORMAT Format = DXGI_FORMAT_UNKNOWN;
+        bool NeedsUav = false;
+
+        bool operator==( const Description& other ) const {
+            return Width == other.Width && Height == other.Height
+                && Format == other.Format && NeedsUav == other.NeedsUav;
+        }
+    };
+
+    struct PooledTexture {
+        std::unique_ptr<D3D12RenderTarget> Texture;
+        Description Desc;
+        uint64_t LastFrameUsed;
+        bool InUse;
+    };
+
+    // RAII handle: releasing it just clears the pooled entry's InUse flag rather than destroying the
+    // resource, so "returning" a texture to the pool is O(1) and allocation-free. Mirrors TexturePool::Handle.
+    class Handle {
+    public:
+        Handle() noexcept = default;
+        Handle( std::nullptr_t ) noexcept {}
+        explicit Handle( PooledTexture* entry ) noexcept : m_entry( entry ) {}
+        Handle( const Handle& ) = delete;
+        Handle& operator=( const Handle& ) = delete;
+        Handle( Handle&& other ) noexcept : m_entry( other.m_entry ) { other.m_entry = nullptr; }
+        Handle& operator=( Handle&& other ) noexcept {
+            if ( this != &other ) {
+                Release();
+                m_entry = other.m_entry;
+                other.m_entry = nullptr;
+            }
+            return *this;
+        }
+        ~Handle() { Release(); }
+
+        D3D12RenderTarget* operator->() const { return m_entry->Texture.get(); }
+        D3D12RenderTarget& operator*() const { return *m_entry->Texture; }
+        D3D12RenderTarget* get() const { return m_entry ? m_entry->Texture.get() : nullptr; }
+        explicit operator bool() const { return m_entry != nullptr; }
+        friend bool operator==( const Handle& h, std::nullptr_t ) { return h.m_entry == nullptr; }
+        friend bool operator!=( const Handle& h, std::nullptr_t ) { return h.m_entry != nullptr; }
+        void reset() { Release(); m_entry = nullptr; }
+
+    private:
+        void Release() { if ( m_entry ) m_entry->InUse = false; }
+        PooledTexture* m_entry = nullptr;
+    };
+
+    // RTV heap is a plain CPU-only heap sized once in Attach() — see D3D12PooledDescriptorHeap for why
+    // this stays fixed-capacity rather than growable.
+    static constexpr UINT kMaxPooledTargets = 64;
+
+    /** One-time setup: grabs the device/allocator off the engine and creates the RTV heap. Safe to call
+        even though nothing consumes the pool yet (see D3D12RenderGraph.h) — this is pure infrastructure. */
+    bool Attach( D3D12GraphicsEngine& engine );
+
+    Handle Acquire( const Description& desc );
+
+    void GiveTick();   // call once per frame (ages out long-unused entries)
+    void Clear();      // drops every pooled texture (resize / level change)
+
+    size_t GetActiveCount() const;
+
+private:
+    ID3D12Device* m_Device = nullptr;
+    D3D12MA::Allocator* m_Allocator = nullptr;
+    D3D12GraphicsEngine* m_Engine = nullptr;
+    D3D12PooledDescriptorHeap m_RtvHeap;
+
+    std::vector<std::unique_ptr<PooledTexture>> m_Pool;
+    uint64_t m_CurrentFrame = 0;
+    static constexpr uint64_t kMaxUnusedFrames = 60;
+};
+
+using D3D12TextureHandle = D3D12TexturePool::Handle;

--- a/D3D11Engine/D3D12Engine/D3D12TracyDebug.h
+++ b/D3D11Engine/D3D12Engine/D3D12TracyDebug.h
@@ -2,6 +2,7 @@
 #include <tracy/public/tracy/TracyD3D12.hpp>
 
 inline TracyD3D12Ctx s_tracyD3D12Ctx = nullptr;
+#ifdef TRACY_ENABLE
 #define TracyD3D12ZoneNX( cmdList, name ) TracyD3D12Zone(s_tracyD3D12Ctx, cmdList, name);
 #define TracyD3D12ZoneCGX( cmdList, name ) TracyD3D12Zone(s_tracyD3D12Ctx, cmdList, name); ZoneScopedN( name );
 
@@ -9,3 +10,15 @@ inline TracyD3D12Ctx s_tracyD3D12Ctx = nullptr;
 #define TracyD3D12BeginFrame TracyD3D12NewFrame( s_tracyD3D12Ctx )
 
 #define ZoneTextStatic(text) ZoneText(text, std::size(text) - 1)
+
+#else
+
+#define TracyD3D12ZoneNX( cmdList, name ) (void)0;
+#define TracyD3D12ZoneCGX( cmdList, name ) (void)0;
+
+#define TracyD3D12CollectHere (void)0;
+#define TracyD3D12BeginFrame (void)0
+
+#define ZoneTextStatic(text) (void)0;
+
+#endif

--- a/D3D11Engine/D3D12Engine/D3D12Underwater.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Underwater.cpp
@@ -23,6 +23,7 @@
 #include "D3D12RenderGraph.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
+#include <memory>
 
 using Microsoft::WRL::ComPtr;
 #include "D3D12EngineCommon.h"
@@ -42,49 +43,11 @@ namespace {
     constexpr DXGI_FORMAT kUnderwaterBlurFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
 }
 
-/** Blur H -> blur V (both quarter-res, both tinted) -> distorted full-res composite over the display target.
-    The quarter-res blur pair USED to be built lazily as members the first time the camera went under water
-    (same reasoning DoF's old members had — rare state, 32-bit VA is scarce). Both are purely single-frame
-    scratch (written then read once then dead, no cross-frame data dependency), so they are now
-    D3D12RenderGraph-managed transient textures acquired fresh below instead — same conversion DoF's and the
-    god-ray mask/zoom textures got (see D3D12DoF.cpp / D3D12Fog.cpp). */
-void D3D12GraphicsEngine::DrawUnderwaterEffects() {
-    if ( !Engine::GAPI->IsUnderWater() ) return;
-    if ( !m_FrameOpen || !m_CmdList || !m_SwapChainReady || !m_LdrCopyReady ) return;
-    if ( !m_Pipelines.Underwater.BlurRootSig || !m_Pipelines.Underwater.BlurPSO
-        || !m_Pipelines.Underwater.CompositeRootSig || !m_Pipelines.Underwater.CompositePSO )
-        return;
-
-    // distortion2.dds drives both UV offsets. If it failed to load, fall back to the 1x1 white texture: that
-    // degrades the animated distortion to a constant sub-pixel shift instead of dropping the blue blur too.
-    const D3D12Texture* distortion = ( m_DistortionTexture && m_DistortionTexture->HasSRV() )
-        ? m_DistortionTexture.get()
-        : ( ( m_WhiteTexture && m_WhiteTexture->HasSRV() ) ? m_WhiteTexture.get() : nullptr );
-    if ( !distortion ) return;
-
-    DX_ZONE( m_CmdList.Get(), "Underwater FX" );
-    TracyD3D12ZoneCGX( m_CmdList.Get(), "Underwater FX" );
-
-    ID3D12Resource* displayTarget = GetDisplayTarget();
-    D3D12_CPU_DESCRIPTOR_HANDLE displayRtv = GetDisplayRtv();
-
-    // --- Copy the finished display image into m_LdrCopy (the blur's source). ---
-    // A texture cannot be its own SRV and RTV, and the composite below writes the display target — same
-    // copy-then-read shape RenderSMAA / RenderSharpen use. m_LdrCopy rests in COPY_DEST.
-    {
-        m_CmdList->TransitionBarrier( displayTarget, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
-    }
-    m_CmdList->CopyResource( m_LdrCopy.Get(), displayTarget );
-    {
-        // NON_PIXEL: the two blur passes read it from compute.
-        m_CmdList->TransitionBarriers( {
-            { m_LdrCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE },
-            { displayTarget, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
-        } );
-    }
-
-    // b0 UnderwaterBlurCB — see Shaders/D3D12/Underwater.hlsl. Only the source/destination and the step
-    // direction change between the two passes.
+// b0 UnderwaterBlurCB — see Shaders/D3D12/Underwater.hlsl. Only the source/destination and the step direction
+// change between the two blur passes. Lives on the heap (shared_ptr, not a stack local) because it is written
+// and read across MULTIPLE pass callbacks that run later, deferred inside the shared graph's Execute() — see
+// D3D12DoF.cpp's file header for why a plain stack local captured by reference can't be used here any more.
+namespace {
     struct BlurConsts {
         uint32_t SrcIndex;
         uint32_t OutIndex;
@@ -95,34 +58,76 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects() {
         float    OutResY;
         float    BlurSize;
         float    Pad;
-    } cb = {};
+    };
     static_assert( sizeof( BlurConsts ) == 12 * sizeof( uint32_t ),
         "BlurConsts must match Underwater.hlsl's b0 UnderwaterBlurCB and the 12 root constants pushed below" );
+}
+
+/** Registers the underwater FX passes (copy -> blur H -> blur V -> distorted composite) onto the SHARED
+    per-frame graph — see D3D12DoF.cpp's file header for the general pattern. Blur H -> blur V (both
+    quarter-res, both tinted) -> distorted full-res composite over the display target. The quarter-res blur
+    pair USED to be built lazily as members the first time the camera went under water (same reasoning DoF's
+    old members had — rare state, 32-bit VA is scarce). Both are purely single-frame scratch (written then
+    read once then dead, no cross-frame data dependency), so they are now D3D12RenderGraph-managed transient
+    textures acquired fresh every call instead — same conversion DoF's and the god-ray mask/zoom textures got
+    (see D3D12DoF.cpp / D3D12Fog.cpp). */
+void D3D12GraphicsEngine::DrawUnderwaterEffects( D3D12RenderGraph& graph ) {
+    if ( !Engine::GAPI->IsUnderWater() ) return;
+    if ( !m_FrameOpen || !m_CmdList || !m_SwapChainReady || !m_LdrCopyReady ) return;
+    if ( !m_Pipelines.Underwater.BlurRootSig || !m_Pipelines.Underwater.BlurPSO
+        || !m_Pipelines.Underwater.CompositeRootSig || !m_Pipelines.Underwater.CompositePSO )
+        return;
+
+    // distortion2.dds drives both UV offsets. If it failed to load, fall back to the 1x1 white texture: that
+    // degrades the animated distortion to a constant sub-pixel shift instead of dropping the blue blur too.
+    // A raw pointer is fine to capture by value below: both candidates are persistent engine members, not
+    // stack locals.
+    const D3D12Texture* distortion = ( m_DistortionTexture && m_DistortionTexture->HasSRV() )
+        ? m_DistortionTexture.get()
+        : ( ( m_WhiteTexture && m_WhiteTexture->HasSRV() ) ? m_WhiteTexture.get() : nullptr );
+    if ( !distortion ) return;
 
     const INT2 blurSize = { std::max( 1, m_BackbufferResolution.x / 4 ), std::max( 1, m_BackbufferResolution.y / 4 ) };
-    std::copy( std::begin( kUnderwaterColorMod ), std::end( kUnderwaterColorMod ), std::begin( cb.ColorMod ) );
-    cb.OutResX = static_cast<float>( blurSize.x );
-    cb.OutResY = static_cast<float>( blurSize.y );
-    cb.BlurSize = kUnderwaterBlurSize;
-
     const UINT groupsX = ( static_cast<UINT>( blurSize.x ) + 7 ) / 8;
     const UINT groupsY = ( static_cast<UINT>( blurSize.y ) + 7 ) / 8;
 
-    // Both blur textures are purely single-frame scratch (written then read once then dead, no cross-frame
-    // data dependency), so they go through a local D3D12RenderGraph — same conversion DoF's and the god-ray
-    // mask/zoom textures got (see D3D12DoF.cpp / D3D12Fog.cpp).
-    D3D12RenderGraph underwaterGraph( &m_AliasArena );
+    auto cb = std::make_shared<BlurConsts>();
+    std::copy( std::begin( kUnderwaterColorMod ), std::end( kUnderwaterColorMod ), std::begin( cb->ColorMod ) );
+    cb->OutResX = static_cast<float>( blurSize.x );
+    cb->OutResY = static_cast<float>( blurSize.y );
+    cb->BlurSize = kUnderwaterBlurSize;
+
+    // Plain locals (not shared_ptr): a handle is only ever written once, synchronously, inside a pass's own
+    // setup lambda — never during the deferred Execute() — so by-value capture in any later lambda already
+    // sees the final value. See D3D12DoF.cpp's file header for the full explanation.
     RGResourceHandle blurHHandle = RG_INVALID_HANDLE;
     RGResourceHandle blurVHandle = RG_INVALID_HANDLE;
-    UINT blurVSrvSlot = UINT_MAX;   // resolved by Pass 2; read by the composite draw further down
+    auto blurVSrvSlot = std::make_shared<UINT>( UINT_MAX );   // resolved by Blur V; read by Composite further down
 
-    // --- Pass 1: horizontal, full-res frame -> blurH (this is also the 4x downscale). ---
-    underwaterGraph.AddPass( RG_PASS_NAME( "Underwater Blur H" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+    // --- Copy the finished display image into m_LdrCopy (the blur's source). A texture cannot be its own
+    // SRV and RTV, and the composite pass writes the display target — same copy-then-read shape RenderSMAA /
+    // RenderSharpen use. m_LdrCopy rests in COPY_DEST. ---
+    graph.AddPass( RG_PASS_NAME( "Underwater Copy" ), [&]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+        pass.m_executeCallback = [this]( const D3D12RenderGraph&, D3D12CmdList& cmdList ) {
+            DX_ZONE( cmdList.Get(), "Underwater FX" );
+            ID3D12Resource* displayTarget = GetDisplayTarget();
+            cmdList.TransitionBarrier( displayTarget, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE );
+            cmdList.CopyResource( m_LdrCopy.Get(), displayTarget );
+            // NON_PIXEL: the two blur passes read it from compute.
+            cmdList.TransitionBarriers( {
+                { m_LdrCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE },
+                { displayTarget, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
+                } );
+            };
+        } );
+
+    // --- Horizontal, full-res frame -> blurH (this is also the 4x downscale). ---
+    graph.AddPass( RG_PASS_NAME( "Underwater Blur H" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
         blurHHandle = builder.CreateTexture( { static_cast<uint32_t>( blurSize.x ), static_cast<uint32_t>( blurSize.y ),
             static_cast<int>( kUnderwaterBlurFormat ), L"UnderwaterBlurH", 1u } );
 
-        pass.m_executeCallback = [this, &cb, groupsX, groupsY, blurHHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
-            D3D12RenderTarget* blurH = graph.GetPhysicalTexture( blurHHandle );
+        pass.m_executeCallback = [this, cb, groupsX, groupsY, blurHHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
+            D3D12RenderTarget* blurH = g.GetPhysicalTexture( blurHHandle );
             if ( !blurH ) return;
 
             if ( blurH->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
@@ -130,13 +135,13 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects() {
                 blurH->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
             }
 
-            cb.SrcIndex = m_LdrCopySrvSlot;
-            cb.OutIndex = blurH->GetUavSlot();
-            cb.TexelStepX = 1.0f / blurH->GetWidth();
-            cb.TexelStepY = 0.0f;
+            cb->SrcIndex = m_LdrCopySrvSlot;
+            cb->OutIndex = blurH->GetUavSlot();
+            cb->TexelStepX = 1.0f / blurH->GetWidth();
+            cb->TexelStepY = 0.0f;
             cmdList.SetComputeRootSignature( m_Pipelines.Underwater.BlurRootSig.Get() );
             cmdList.SetPipelineState( m_Pipelines.Underwater.BlurPSO.Get() );
-            cmdList.SetComputeRoot32BitConstants( 0, 12, &cb, 0 );
+            cmdList.SetComputeRoot32BitConstants( 0, 12, cb.get(), 0 );
             cmdList.Dispatch( groupsX, groupsY, 1 );
 
             // UAV-write -> SRV-read needs a real state transition, not a UAV barrier: a UAV barrier only
@@ -146,18 +151,18 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects() {
             };
         } );
 
-    // --- Pass 2: vertical, blurH -> blurV. ---
-    underwaterGraph.AddPass( RG_PASS_NAME( "Underwater Blur V" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+    // --- Vertical, blurH -> blurV. ---
+    graph.AddPass( RG_PASS_NAME( "Underwater Blur V" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
         builder.Read( blurHHandle );
         blurVHandle = builder.CreateTexture( { static_cast<uint32_t>( blurSize.x ), static_cast<uint32_t>( blurSize.y ),
             static_cast<int>( kUnderwaterBlurFormat ), L"UnderwaterBlurV", 1u } );
-        // The composite draw further down reads this pass's result via blurVSrvSlot, a plain local captured
-        // by reference — not a graph Read(), so mark the side effect explicitly.
+        // The composite pass further down reads this pass's result via blurVSrvSlot, a plain shared value —
+        // not a graph Read(), so mark the side effect explicitly.
         builder.MarkExternalEffect();
 
-        pass.m_executeCallback = [this, &cb, groupsX, groupsY, &blurVSrvSlot, blurHHandle, blurVHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
-            D3D12RenderTarget* blurH = graph.GetPhysicalTexture( blurHHandle );
-            D3D12RenderTarget* blurV = graph.GetPhysicalTexture( blurVHandle );
+        pass.m_executeCallback = [this, cb, groupsX, groupsY, blurVSrvSlot, blurHHandle, blurVHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
+            D3D12RenderTarget* blurH = g.GetPhysicalTexture( blurHHandle );
+            D3D12RenderTarget* blurV = g.GetPhysicalTexture( blurVHandle );
             if ( !blurH || !blurV ) return;
 
             if ( blurV->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
@@ -165,52 +170,55 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects() {
                 blurV->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
             }
 
-            cb.SrcIndex = blurH->GetSrvSlot();
-            cb.OutIndex = blurV->GetUavSlot();
-            cb.TexelStepX = 0.0f;
-            cb.TexelStepY = 1.0f / blurV->GetHeight();
+            cb->SrcIndex = blurH->GetSrvSlot();
+            cb->OutIndex = blurV->GetUavSlot();
+            cb->TexelStepX = 0.0f;
+            cb->TexelStepY = 1.0f / blurV->GetHeight();
             cmdList.SetComputeRootSignature( m_Pipelines.Underwater.BlurRootSig.Get() );
             cmdList.SetPipelineState( m_Pipelines.Underwater.BlurPSO.Get() );
-            cmdList.SetComputeRoot32BitConstants( 0, 12, &cb, 0 );
+            cmdList.SetComputeRoot32BitConstants( 0, 12, cb.get(), 0 );
             cmdList.Dispatch( groupsX, groupsY, 1 );
 
             cmdList.TransitionBarrier( blurV->GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
             blurV->State = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-            blurVSrvSlot = blurV->GetSrvSlot();
+            *blurVSrvSlot = blurV->GetSrvSlot();
             };
         } );
 
-    underwaterGraph.Compile();
-    underwaterGraph.Execute( m_CmdList );
+    // --- Full-res distorted composite back over the display target. ---
+    graph.AddPass( RG_PASS_NAME( "Underwater Composite" ), [&, distortion]( D3D12RGBuilder&, D3D12RenderPass& pass ) {
+        pass.m_executeCallback = [this, distortion, blurVSrvSlot]( const D3D12RenderGraph&, D3D12CmdList& cmdList ) {
+            struct CompositeConsts {
+                uint32_t BlurIndex;
+                uint32_t DistortionIndex;
+                float    Time;
+                float    Pad;
+            } comp = {};
+            static_assert( sizeof( CompositeConsts ) == 4 * sizeof( uint32_t ),
+                "CompositeConsts must match Underwater.hlsl's b0 UnderwaterCompositeCB and the 4 root constants below" );
+            comp.BlurIndex = *blurVSrvSlot;
+            comp.DistortionIndex = distortion->GetSrvSlot();
+            comp.Time = Engine::GAPI->GetTimeSeconds();   // D3D11's RI_Time
 
-    // --- Pass 3: full-res distorted composite back over the display target. ---
-    struct CompositeConsts {
-        uint32_t BlurIndex;
-        uint32_t DistortionIndex;
-        float    Time;
-        float    Pad;
-    } comp = {};
-    static_assert( sizeof( CompositeConsts ) == 4 * sizeof( uint32_t ),
-        "CompositeConsts must match Underwater.hlsl's b0 UnderwaterCompositeCB and the 4 root constants below" );
-    comp.BlurIndex = blurVSrvSlot;
-    comp.DistortionIndex = distortion->GetSrvSlot();
-    comp.Time = Engine::GAPI->GetTimeSeconds();   // D3D11's RI_Time
+            ID3D12Resource* displayTarget = GetDisplayTarget();
+            D3D12_CPU_DESCRIPTOR_HANDLE displayRtv = GetDisplayRtv();
+            const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_BackbufferResolution.x ), static_cast<float>( m_BackbufferResolution.y ), 0.0f, 1.0f };
+            const D3D12_RECT     sc = { 0, 0, m_BackbufferResolution.x, m_BackbufferResolution.y };
+            cmdList.RSSetViewports( 1, &vp );
+            cmdList.RSSetScissorRects( 1, &sc );
+            cmdList.IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
+            cmdList.IASetVertexBuffers( 0, 0, nullptr );
+            cmdList.SetGraphicsRootSignature( m_Pipelines.Underwater.CompositeRootSig.Get() );
+            cmdList.SetPipelineState( m_Pipelines.Underwater.CompositePSO.Get() );
+            cmdList.SetGraphicsRoot32BitConstants( 0, 4, &comp, 0 );
+            cmdList.OMSetRenderTargets( 1, &displayRtv, FALSE, nullptr );
+            cmdList.DrawInstanced( 3, 1, 0, 0 );
 
-    const D3D12_VIEWPORT vp = { 0.0f, 0.0f, static_cast<float>( m_BackbufferResolution.x ), static_cast<float>( m_BackbufferResolution.y ), 0.0f, 1.0f };
-    const D3D12_RECT     sc = { 0, 0, m_BackbufferResolution.x, m_BackbufferResolution.y };
-    m_CmdList->RSSetViewports( 1, &vp );
-    m_CmdList->RSSetScissorRects( 1, &sc );
-    m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
-    m_CmdList->IASetVertexBuffers( 0, 0, nullptr );
-    m_CmdList->SetGraphicsRootSignature( m_Pipelines.Underwater.CompositeRootSig.Get() );
-    m_CmdList->SetPipelineState( m_Pipelines.Underwater.CompositePSO.Get() );
-    m_CmdList->SetGraphicsRoot32BitConstants( 0, 4, &comp, 0 );
-    m_CmdList->OMSetRenderTargets( 1, &displayRtv, FALSE, nullptr );
-    m_CmdList->DrawInstanced( 3, 1, 0, 0 );
-
-    // Resting state for the next frame: the scratch copy back to COPY_DEST (SMAA/sharpen expect to find it
-    // there). The display target stays RENDER_TARGET and bound, ready for Gothic's 2D UI/HUD to composite on
-    // top. The blur pair needs no explicit reset — D3D12RenderTarget::State is caller-maintained and
-    // self-correcting, same as DoF's and the god-ray textures.
-    m_CmdList->TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST );
+            // Resting state for the next frame: the scratch copy back to COPY_DEST (SMAA/sharpen expect to
+            // find it there). The display target stays RENDER_TARGET and bound, ready for Gothic's 2D UI/HUD
+            // to composite on top. The blur pair needs no explicit reset — D3D12RenderTarget::State is
+            // caller-maintained and self-correcting, same as DoF's and the god-ray textures.
+            cmdList.TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST );
+            };
+        } );
 }

--- a/D3D11Engine/D3D12Engine/D3D12Underwater.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Underwater.cpp
@@ -121,19 +121,16 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects( D3D12RenderGraph& graph ) {
             };
         } );
 
-    // --- Horizontal, full-res frame -> blurH (this is also the 4x downscale). ---
+    // --- Horizontal, full-res frame -> blurH (this is also the 4x downscale). --- CreateTexture()'s state
+    // param gets blurH into UNORDERED_ACCESS automatically; Blur V's Read() below transitions it to
+    // shader-read afterward — neither needs a manual check/transition here.
     graph.AddPass( RG_PASS_NAME( "Underwater Blur H" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
         blurHHandle = builder.CreateTexture( { static_cast<uint32_t>( blurSize.x ), static_cast<uint32_t>( blurSize.y ),
-            static_cast<int>( kUnderwaterBlurFormat ), L"UnderwaterBlurH", 1u } );
+            static_cast<int>( kUnderwaterBlurFormat ), L"UnderwaterBlurH", 1u }, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
 
         pass.m_executeCallback = [this, cb, groupsX, groupsY, blurHHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
             D3D12RenderTarget* blurH = g.GetPhysicalTexture( blurHHandle );
             if ( !blurH ) return;
-
-            if ( blurH->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
-                cmdList.TransitionBarrier( blurH->GetResource(), blurH->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-                blurH->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-            }
 
             cb->SrcIndex = m_LdrCopySrvSlot;
             cb->OutIndex = blurH->GetUavSlot();
@@ -143,32 +140,23 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects( D3D12RenderGraph& graph ) {
             cmdList.SetPipelineState( m_Pipelines.Underwater.BlurPSO.Get() );
             cmdList.SetComputeRoot32BitConstants( 0, 12, cb.get(), 0 );
             cmdList.Dispatch( groupsX, groupsY, 1 );
-
-            // UAV-write -> SRV-read needs a real state transition, not a UAV barrier: a UAV barrier only
-            // orders access and performs no cache flush, so the SRV read would be undefined.
-            cmdList.TransitionBarrier( blurH->GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-            blurH->State = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
             };
         } );
 
     // --- Vertical, blurH -> blurV. ---
     graph.AddPass( RG_PASS_NAME( "Underwater Blur V" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
-        builder.Read( blurHHandle );
+        builder.Read( blurHHandle, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
         blurVHandle = builder.CreateTexture( { static_cast<uint32_t>( blurSize.x ), static_cast<uint32_t>( blurSize.y ),
-            static_cast<int>( kUnderwaterBlurFormat ), L"UnderwaterBlurV", 1u } );
+            static_cast<int>( kUnderwaterBlurFormat ), L"UnderwaterBlurV", 1u }, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
         // The composite pass further down reads this pass's result via blurVSrvSlot, a plain shared value —
-        // not a graph Read(), so mark the side effect explicitly.
+        // not a graph Read(), so mark the side effect explicitly. Since nothing ever Read()s blurVHandle, its
+        // final transition to PIXEL_SHADER_RESOURCE below stays manual too — there's no Read() to hang it off.
         builder.MarkExternalEffect();
 
         pass.m_executeCallback = [this, cb, groupsX, groupsY, blurVSrvSlot, blurHHandle, blurVHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
             D3D12RenderTarget* blurH = g.GetPhysicalTexture( blurHHandle );
             D3D12RenderTarget* blurV = g.GetPhysicalTexture( blurVHandle );
             if ( !blurH || !blurV ) return;
-
-            if ( blurV->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
-                cmdList.TransitionBarrier( blurV->GetResource(), blurV->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
-                blurV->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-            }
 
             cb->SrcIndex = blurH->GetSrvSlot();
             cb->OutIndex = blurV->GetUavSlot();

--- a/D3D11Engine/D3D12Engine/D3D12Underwater.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Underwater.cpp
@@ -20,6 +20,7 @@
 #include "D3D12GraphicsEngine.h"
 #include "D3D12Texture.h"
 #include "D3D12ResourceCreate.h"
+#include "D3D12RenderGraph.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 
@@ -41,95 +42,17 @@ namespace {
     constexpr DXGI_FORMAT kUnderwaterBlurFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
 }
 
-/** (Re)creates the quarter-res blur ping-pong pair.
-
-    Called LAZILY from DrawUnderwaterEffects the first time the camera actually goes under water, and from the
-    resize path only if the pair already exists — same policy as the DoF textures, and for the same reason:
-    most sessions never trigger this and 32-bit address space is the scarce resource (see CLAUDE.md). Heap
-    slots are allocated once and re-pointed at the fresh resources. Non-fatal: on failure
-    m_UnderwaterResourcesReady stays false and DrawUnderwaterEffects no-ops, leaving the frame untinted. */
-bool D3D12GraphicsEngine::CreateUnderwaterResources( INT2 size ) {
-    m_UnderwaterResourcesReady = false;
-    m_UnderwaterCreateAttempted = true;
-    if ( size.x < 4 || size.y < 4 ) return false;
-    ID3D12Device* device = m_Device.GetDevice();
-    if ( !device || !m_Allocator ) return false;
-    // Init runs before the first CreateSwapChain; don't build resources for a pipeline that failed there.
-    if ( !m_Pipelines.Underwater.BlurPSO || !m_Pipelines.Underwater.CompositePSO ) return false;
-
-    // Integer-divided like D3D11's fxbuffer->GetSizeX() / 4, and never below 1 texel so a tiny window cannot
-    // produce a zero-sized resource.
-    m_UnderwaterBlurSize = { std::max( 1, size.x / 4 ), std::max( 1, size.y / 4 ) };
-
-    D3D12MA::ALLOCATION_DESC heapDefault = {};
-    heapDefault.HeapType = D3D12_HEAP_TYPE_DEFAULT;
-
-    D3D12_SHADER_RESOURCE_VIEW_DESC srv = {};
-    srv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-    srv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-    srv.Texture2D.MipLevels = 1;
-    srv.Format = kUnderwaterBlurFormat;
-    D3D12_UNORDERED_ACCESS_VIEW_DESC uav = {};
-    uav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
-    uav.Format = kUnderwaterBlurFormat;
-
-    for ( UINT i = 0; i < 2; ++i ) {
-        D3D12_RESOURCE_DESC dd = {};
-        dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-        dd.Width = static_cast<UINT64>( m_UnderwaterBlurSize.x );
-        dd.Height = static_cast<UINT>( m_UnderwaterBlurSize.y );
-        dd.DepthOrArraySize = 1;
-        dd.MipLevels = 1;
-        dd.Format = kUnderwaterBlurFormat;
-        dd.SampleDesc.Count = 1;
-        dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
-        dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-        // Both rest in UNORDERED_ACCESS between frames (see DrawUnderwaterEffects), so create them in it —
-        // that makes the "before" state at the top of the pass deterministic on the very first frame.
-        if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-            nullptr, m_UnderwaterBlurAlloc[i].ReleaseAndGetAddressOf(),
-            IID_PPV_ARGS( m_UnderwaterBlur[i].ReleaseAndGetAddressOf() ) ) ) ) {
-            LogWarn() << "D3D12: failed to create an underwater blur texture ("
-                << m_UnderwaterBlurSize.x << "x" << m_UnderwaterBlurSize.y << ").";
-            return false;
-        }
-        m_UnderwaterBlur[i]->SetName( i == 0 ? L"UnderwaterBlurH" : L"UnderwaterBlurV" );
-
-        if ( m_UnderwaterBlurSrvSlot[i] == UINT_MAX ) m_UnderwaterBlurSrvSlot[i] = AllocateSrvSlot();
-        if ( m_UnderwaterBlurUavSlot[i] == UINT_MAX ) m_UnderwaterBlurUavSlot[i] = AllocateSrvSlot();
-        if ( m_UnderwaterBlurSrvSlot[i] == UINT_MAX || m_UnderwaterBlurUavSlot[i] == UINT_MAX ) return false;
-
-        device->CreateShaderResourceView( m_UnderwaterBlur[i].Get(), &srv, GetSrvCpuHandle( m_UnderwaterBlurSrvSlot[i] ) );
-        device->CreateUnorderedAccessView( m_UnderwaterBlur[i].Get(), nullptr, &uav, GetSrvCpuHandle( m_UnderwaterBlurUavSlot[i] ) );
-    }
-
-    m_UnderwaterResourcesReady = true;
-    return true;
-}
-
-
-/** Blur H -> blur V (both quarter-res, both tinted) -> distorted full-res composite over the display target. */
+/** Blur H -> blur V (both quarter-res, both tinted) -> distorted full-res composite over the display target.
+    The quarter-res blur pair USED to be built lazily as members the first time the camera went under water
+    (same reasoning DoF's old members had — rare state, 32-bit VA is scarce). Both are purely single-frame
+    scratch (written then read once then dead, no cross-frame data dependency), so they are now
+    D3D12RenderGraph-managed transient textures acquired fresh below instead — same conversion DoF's and the
+    god-ray mask/zoom textures got (see D3D12DoF.cpp / D3D12Fog.cpp). */
 void D3D12GraphicsEngine::DrawUnderwaterEffects() {
     if ( !Engine::GAPI->IsUnderWater() ) return;
     if ( !m_FrameOpen || !m_CmdList || !m_SwapChainReady || !m_LdrCopyReady ) return;
     if ( !m_Pipelines.Underwater.BlurRootSig || !m_Pipelines.Underwater.BlurPSO
         || !m_Pipelines.Underwater.CompositeRootSig || !m_Pipelines.Underwater.CompositePSO )
-        return;
-
-    // Lazily build the quarter-res pair the first time the player submerges. Creating a resource mid-frame is
-    // safe: nothing is destroyed here, so there is no in-flight resource to fence against.
-    if ( !m_UnderwaterResourcesReady ) {
-        if ( m_UnderwaterCreateAttempted ) return;
-        if ( !CreateUnderwaterResources( m_BackbufferResolution ) ) {
-            LogWarn() << "D3D12: the camera is under water but the underwater blur textures could not be "
-                         "created — the underwater effect is disabled.";
-            return;
-        }
-    }
-    // Resolution changed without the resources following (the resize path only rebuilds them if they already
-    // exist, so this is a belt-and-braces check rather than an expected state).
-    if ( m_UnderwaterBlurSize.x != std::max( 1, m_BackbufferResolution.x / 4 )
-        || m_UnderwaterBlurSize.y != std::max( 1, m_BackbufferResolution.y / 4 ) )
         return;
 
     // distortion2.dds drives both UV offsets. If it failed to load, fall back to the 1x1 white texture: that
@@ -176,45 +99,89 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects() {
     static_assert( sizeof( BlurConsts ) == 12 * sizeof( uint32_t ),
         "BlurConsts must match Underwater.hlsl's b0 UnderwaterBlurCB and the 12 root constants pushed below" );
 
+    const INT2 blurSize = { std::max( 1, m_BackbufferResolution.x / 4 ), std::max( 1, m_BackbufferResolution.y / 4 ) };
     std::copy( std::begin( kUnderwaterColorMod ), std::end( kUnderwaterColorMod ), std::begin( cb.ColorMod ) );
-    cb.OutResX = static_cast<float>( m_UnderwaterBlurSize.x );
-    cb.OutResY = static_cast<float>( m_UnderwaterBlurSize.y );
+    cb.OutResX = static_cast<float>( blurSize.x );
+    cb.OutResY = static_cast<float>( blurSize.y );
     cb.BlurSize = kUnderwaterBlurSize;
 
-    m_CmdList->SetComputeRootSignature( m_Pipelines.Underwater.BlurRootSig.Get() );
-    m_CmdList->SetPipelineState( m_Pipelines.Underwater.BlurPSO.Get() );
+    const UINT groupsX = ( static_cast<UINT>( blurSize.x ) + 7 ) / 8;
+    const UINT groupsY = ( static_cast<UINT>( blurSize.y ) + 7 ) / 8;
 
-    const UINT groupsX = ( static_cast<UINT>( m_UnderwaterBlurSize.x ) + 7 ) / 8;
-    const UINT groupsY = ( static_cast<UINT>( m_UnderwaterBlurSize.y ) + 7 ) / 8;
+    // Both blur textures are purely single-frame scratch (written then read once then dead, no cross-frame
+    // data dependency), so they go through a local D3D12RenderGraph — same conversion DoF's and the god-ray
+    // mask/zoom textures got (see D3D12DoF.cpp / D3D12Fog.cpp).
+    D3D12RenderGraph underwaterGraph( &m_AliasArena );
+    RGResourceHandle blurHHandle = RG_INVALID_HANDLE;
+    RGResourceHandle blurVHandle = RG_INVALID_HANDLE;
+    UINT blurVSrvSlot = UINT_MAX;   // resolved by Pass 2; read by the composite draw further down
 
-    // --- Pass 1: horizontal, full-res frame -> blur[0] (this is also the 4x downscale). ---
-    cb.SrcIndex = m_LdrCopySrvSlot;
-    cb.OutIndex = m_UnderwaterBlurUavSlot[0];
-    cb.TexelStepX = 1.0f / m_UnderwaterBlurSize.x;
-    cb.TexelStepY = 0.0f;
-    m_CmdList->SetComputeRoot32BitConstants( 0, 12, &cb, 0 );
-    m_CmdList->Dispatch( groupsX, groupsY, 1 );
+    // --- Pass 1: horizontal, full-res frame -> blurH (this is also the 4x downscale). ---
+    underwaterGraph.AddPass( RG_PASS_NAME( "Underwater Blur H" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+        blurHHandle = builder.CreateTexture( { static_cast<uint32_t>( blurSize.x ), static_cast<uint32_t>( blurSize.y ),
+            static_cast<int>( kUnderwaterBlurFormat ), L"UnderwaterBlurH", 1u } );
 
-    // UAV-write -> SRV-read needs a real state transition, not a UAV barrier: a UAV barrier only orders access
-    // and performs no cache flush, so the SRV read would be undefined.
-    {
-        m_CmdList->TransitionBarrier( m_UnderwaterBlur[0].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
-    }
+        pass.m_executeCallback = [this, &cb, groupsX, groupsY, blurHHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
+            D3D12RenderTarget* blurH = graph.GetPhysicalTexture( blurHHandle );
+            if ( !blurH ) return;
 
-    // --- Pass 2: vertical, blur[0] -> blur[1]. ---
-    cb.SrcIndex = m_UnderwaterBlurSrvSlot[0];
-    cb.OutIndex = m_UnderwaterBlurUavSlot[1];
-    cb.TexelStepX = 0.0f;
-    cb.TexelStepY = 1.0f / m_UnderwaterBlurSize.y;
-    m_CmdList->SetComputeRoot32BitConstants( 0, 12, &cb, 0 );
-    m_CmdList->Dispatch( groupsX, groupsY, 1 );
+            if ( blurH->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
+                cmdList.TransitionBarrier( blurH->GetResource(), blurH->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+                blurH->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+            }
 
-    {
-        m_CmdList->TransitionBarriers( {
-        	{ m_UnderwaterBlur[1].Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE },
-        	{ m_UnderwaterBlur[0].Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
+            cb.SrcIndex = m_LdrCopySrvSlot;
+            cb.OutIndex = blurH->GetUavSlot();
+            cb.TexelStepX = 1.0f / blurH->GetWidth();
+            cb.TexelStepY = 0.0f;
+            cmdList.SetComputeRootSignature( m_Pipelines.Underwater.BlurRootSig.Get() );
+            cmdList.SetPipelineState( m_Pipelines.Underwater.BlurPSO.Get() );
+            cmdList.SetComputeRoot32BitConstants( 0, 12, &cb, 0 );
+            cmdList.Dispatch( groupsX, groupsY, 1 );
+
+            // UAV-write -> SRV-read needs a real state transition, not a UAV barrier: a UAV barrier only
+            // orders access and performs no cache flush, so the SRV read would be undefined.
+            cmdList.TransitionBarrier( blurH->GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE );
+            blurH->State = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+            };
         } );
-    }
+
+    // --- Pass 2: vertical, blurH -> blurV. ---
+    underwaterGraph.AddPass( RG_PASS_NAME( "Underwater Blur V" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+        builder.Read( blurHHandle );
+        blurVHandle = builder.CreateTexture( { static_cast<uint32_t>( blurSize.x ), static_cast<uint32_t>( blurSize.y ),
+            static_cast<int>( kUnderwaterBlurFormat ), L"UnderwaterBlurV", 1u } );
+        // The composite draw further down reads this pass's result via blurVSrvSlot, a plain local captured
+        // by reference — not a graph Read(), so mark the side effect explicitly.
+        builder.MarkExternalEffect();
+
+        pass.m_executeCallback = [this, &cb, groupsX, groupsY, &blurVSrvSlot, blurHHandle, blurVHandle]( const D3D12RenderGraph& graph, D3D12CmdList& cmdList ) {
+            D3D12RenderTarget* blurH = graph.GetPhysicalTexture( blurHHandle );
+            D3D12RenderTarget* blurV = graph.GetPhysicalTexture( blurVHandle );
+            if ( !blurH || !blurV ) return;
+
+            if ( blurV->State != D3D12_RESOURCE_STATE_UNORDERED_ACCESS ) {
+                cmdList.TransitionBarrier( blurV->GetResource(), blurV->State, D3D12_RESOURCE_STATE_UNORDERED_ACCESS );
+                blurV->State = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+            }
+
+            cb.SrcIndex = blurH->GetSrvSlot();
+            cb.OutIndex = blurV->GetUavSlot();
+            cb.TexelStepX = 0.0f;
+            cb.TexelStepY = 1.0f / blurV->GetHeight();
+            cmdList.SetComputeRootSignature( m_Pipelines.Underwater.BlurRootSig.Get() );
+            cmdList.SetPipelineState( m_Pipelines.Underwater.BlurPSO.Get() );
+            cmdList.SetComputeRoot32BitConstants( 0, 12, &cb, 0 );
+            cmdList.Dispatch( groupsX, groupsY, 1 );
+
+            cmdList.TransitionBarrier( blurV->GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
+            blurV->State = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+            blurVSrvSlot = blurV->GetSrvSlot();
+            };
+        } );
+
+    underwaterGraph.Compile();
+    underwaterGraph.Execute( m_CmdList );
 
     // --- Pass 3: full-res distorted composite back over the display target. ---
     struct CompositeConsts {
@@ -225,7 +192,7 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects() {
     } comp = {};
     static_assert( sizeof( CompositeConsts ) == 4 * sizeof( uint32_t ),
         "CompositeConsts must match Underwater.hlsl's b0 UnderwaterCompositeCB and the 4 root constants below" );
-    comp.BlurIndex = m_UnderwaterBlurSrvSlot[1];
+    comp.BlurIndex = blurVSrvSlot;
     comp.DistortionIndex = distortion->GetSrvSlot();
     comp.Time = Engine::GAPI->GetTimeSeconds();   // D3D11's RI_Time
 
@@ -241,13 +208,9 @@ void D3D12GraphicsEngine::DrawUnderwaterEffects() {
     m_CmdList->OMSetRenderTargets( 1, &displayRtv, FALSE, nullptr );
     m_CmdList->DrawInstanced( 3, 1, 0, 0 );
 
-    // Resting states for the next frame: the scratch copy back to COPY_DEST (SMAA/sharpen expect to find it
-    // there), the blur pair back to UNORDERED_ACCESS. The display target stays RENDER_TARGET and bound, ready
-    // for Gothic's 2D UI/HUD to composite on top.
-    {
-        m_CmdList->TransitionBarriers( {
-        	{ m_LdrCopy.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST },
-        	{ m_UnderwaterBlur[1].Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS },
-        } );
-    }
+    // Resting state for the next frame: the scratch copy back to COPY_DEST (SMAA/sharpen expect to find it
+    // there). The display target stays RENDER_TARGET and bound, ready for Gothic's 2D UI/HUD to composite on
+    // top. The blur pair needs no explicit reset — D3D12RenderTarget::State is caller-maintained and
+    // self-correcting, same as DoF's and the god-ray textures.
+    m_CmdList->TransitionBarrier( m_LdrCopy.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST );
 }

--- a/D3D11Engine/D3D12Engine/D3D12VobArena.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12VobArena.cpp
@@ -34,6 +34,7 @@ namespace {
 void D3D12VobArena::Reset() {
     std::lock_guard<std::mutex> lock( m_PendingMutex );
     m_Pending.clear();
+    m_NotYetReady.clear();
     m_Ranges.clear();
     m_Resident.clear();
     m_Dynamic.clear();
@@ -46,10 +47,19 @@ void D3D12VobArena::Reset() {
 
 
 void D3D12VobArena::QueueVisual( MeshVisualInfo* visual ) {
-    // Ready() false means a worker thread is still filling MeshesByTexture in (async node-visual
-    // extraction). Skipping is safe: the visual gets queued again the next time a vob referencing it is
-    // added, and until then it simply isn't drawn by the arena path.
-    if ( !visual || !visual->Ready.load( std::memory_order_acquire ) ) return;
+    if ( !visual ) return;
+
+    // A worker thread is still filling MeshesByTexture in (GothicAPI::OnAddVob's async
+    // Extract3DSMeshFromVisual2Async). Remember it for RetryNotYetReady() instead of relying on another
+    // vob sharing this visual to queue it again - a uniquely-referenced mesh (common during world load,
+    // where OnAddVob fires once per vob while extraction is still in flight) would otherwise never make it
+    // into the arena.
+    if ( !visual->GetIsReady() ) {
+        std::lock_guard<std::mutex> lock( m_PendingMutex );
+        if ( std::find( m_NotYetReady.begin(), m_NotYetReady.end(), visual ) == m_NotYetReady.end() )
+            m_NotYetReady.push_back( visual );
+        return;
+    }
 
     // Animated static VOBs (.MMS): their vertices are rewritten every frame, so the arena copy is only the
     // conversion pose and has to be refreshed per frame — see DynamicMeshes(). Only the VISUAL knows this;
@@ -68,6 +78,20 @@ void D3D12VobArena::QueueVisual( MeshVisualInfo* visual ) {
             m_Pending.push_back( { mi, dynamic } );
         }
     }
+}
+
+
+void D3D12VobArena::RetryNotYetReady() {
+    std::vector<MeshVisualInfo*> retry;
+    {
+        std::lock_guard<std::mutex> lock( m_PendingMutex );
+        if ( m_NotYetReady.empty() ) return;
+        retry.swap( m_NotYetReady );
+    }
+    // QueueVisual re-adds anything still not ready, so this list only ever holds visuals that were pending
+    // as of the LAST retry - no risk of looping on the same entry within one call.
+    for ( MeshVisualInfo* visual : retry )
+        QueueVisual( visual );
 }
 
 
@@ -177,6 +201,8 @@ bool D3D12VobArena::Reallocate( D3D12GraphicsEngine* engine ) {
 
 bool D3D12VobArena::Flush( D3D12GraphicsEngine* engine ) {
     if ( !engine ) return false;
+
+    RetryNotYetReady();
 
     std::vector<PendingMesh> pending;
     {

--- a/D3D11Engine/D3D12Engine/D3D12VobArena.h
+++ b/D3D11Engine/D3D12Engine/D3D12VobArena.h
@@ -63,8 +63,18 @@ public:
 
     /** Register every drawable sub-mesh of a static VOB visual. Cheap and idempotent: already-resident and
         already-pending sub-meshes are skipped, so calling it once per vob (i.e. many times per visual) is
-        fine. Safe to call from any thread. */
+        fine. Safe to call from any thread.
+
+        If 'visual' is still being filled in by a background extraction (GothicAPI::OnAddVob's async
+        Extract3DSMeshFromVisual2Async), this only remembers it for RetryNotYetReady() and returns - a
+        visual with exactly one VOB instance in the world would otherwise never get queued again, since
+        OnAddVob calls this exactly once per VOB. */
     void QueueVisual( MeshVisualInfo* visual );
+
+    /** Re-attempts QueueVisual() for every visual it deferred for not being Ready yet. Called once per
+        frame from Flush(), before the pending list is drained, so a mesh that finishes extraction between
+        two frames is queued (and therefore uploaded) without needing another VOB to reference it. */
+    void RetryNotYetReady();
 
     /** Upload everything queued since the last call, growing the buffers if needed. Main thread, inside an
         open frame. Returns false if the arena is unusable this frame (allocation failure) — the caller
@@ -146,8 +156,12 @@ private:
         MeshInfo* Mesh;
         bool Dynamic;
     };
-    std::mutex m_PendingMutex;             // guards m_Pending only; the rest is main-thread/Flush-only
+    std::mutex m_PendingMutex;             // guards m_Pending and m_NotYetReady; the rest is main-thread/Flush-only
     std::vector<PendingMesh> m_Pending;
+
+    // Visuals QueueVisual() saw while their background extraction was still running. Retried once per
+    // frame - see RetryNotYetReady().
+    std::vector<MeshVisualInfo*> m_NotYetReady;
 
     bool m_AllocFailed = false;            // logged once; stops us retrying a doomed allocation every frame
 };

--- a/D3D11Engine/D3D12Engine/D3D12Water.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Water.cpp
@@ -25,6 +25,7 @@
 #include "D3D12Texture.h"
 #include "D3D12VertexBuffer.h"
 #include "D3D12PipelineState.h"
+#include "D3D12RenderGraph.h"
 #include "../Engine.h"
 #include "../GothicAPI.h"
 #include "../GSky.h"
@@ -124,102 +125,6 @@ bool D3D12GraphicsEngine::CreateWaterConstantBuffers() {
         m_WaterCBMapped[i] = static_cast<uint8_t*>( mapped );
         m_WaterCBGpu[i] = m_WaterCB[i]->GetGPUVirtualAddress();
     }
-    return true;
-}
-
-
-void D3D12GraphicsEngine::ReleaseWaterCopyResources() {
-    // Called from the resize path, where the GPU has already been waited idle — so dropping the resources
-    // outright is safe and there is no need to go through QueueSrvResourceForRelease. The heap slots are
-    // deliberately KEPT: EnsureWaterCopyResources re-points the same descriptors at the new textures, which
-    // avoids leaking a pair of slots on every resolution change.
-    m_WaterSceneCopy.Reset();
-    m_WaterSceneCopyAlloc.Reset();
-    m_WaterDepthCopy.Reset();
-    m_WaterDepthCopyAlloc.Reset();
-    m_WaterCopySize = { 0, 0 };
-}
-
-
-bool D3D12GraphicsEngine::EnsureWaterCopyResources() {
-    // Lazy: only worlds that actually render water pay the ~24 MB of 32-bit VA these two full-resolution
-    // surfaces cost at 1080p. Menus, indoor worlds and water-free maps never allocate them.
-    if ( m_WaterSceneCopy && m_WaterDepthCopy
-        && m_WaterCopySize.x == m_Resolution.x && m_WaterCopySize.y == m_Resolution.y )
-        return true;
-
-    ReleaseWaterCopyResources();
-    if ( m_Resolution.x < 4 || m_Resolution.y < 4 || !m_DepthBuffer || !m_SceneColor ) return false;
-    ID3D12Device* device = m_Device.GetDevice();
-    if ( !device ) return false;
-
-    D3D12MA::ALLOCATION_DESC heapDefault = {};
-    heapDefault.HeapType = D3D12_HEAP_TYPE_DEFAULT;
-
-    // Scene copy: same format as m_SceneColor so CopyResource is a straight blit.
-    {
-        D3D12_RESOURCE_DESC dd = {};
-        dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-        dd.Width = static_cast<UINT64>( m_Resolution.x );
-        dd.Height = static_cast<UINT>( m_Resolution.y );
-        dd.DepthOrArraySize = 1;
-        dd.MipLevels = 1;
-        dd.Format = kSceneColorFormat;
-        dd.SampleDesc.Count = 1;
-        dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
-        if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, kWaterCopyReadState, nullptr,
-            m_WaterSceneCopyAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( m_WaterSceneCopy.ReleaseAndGetAddressOf() ) ) ) ) {
-            LogWarn() << "D3D12: failed to create the water scene copy (" << m_Resolution.x << "x" << m_Resolution.y << ").";
-            ReleaseWaterCopyResources();
-            return false;
-        }
-        m_WaterSceneCopy->SetName( L"WaterSceneCopy" );
-    }
-
-    // Depth copy: SAME resource desc as m_DepthBuffer (R32_TYPELESS + ALLOW_DEPTH_STENCIL, see
-    // CreateDepthBuffer) so CopyResource is unambiguously legal — identical reasoning to m_TaaPrevDepth in
-    // CreateTaaResources.
-    {
-        D3D12_RESOURCE_DESC dd = {};
-        dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-        dd.Width = static_cast<UINT64>( m_Resolution.x );
-        dd.Height = static_cast<UINT>( m_Resolution.y );
-        dd.DepthOrArraySize = 1;
-        dd.MipLevels = 1;
-        dd.Format = DXGI_FORMAT_R32_TYPELESS;
-        dd.SampleDesc.Count = 1;
-        dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
-        dd.Flags = D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
-        D3D12_CLEAR_VALUE clear = {};
-        clear.Format = DXGI_FORMAT_D32_FLOAT;
-        clear.DepthStencil.Depth = 0.0f;   // reversed-Z, same optimized clear as the real depth buffer
-        if ( FAILED( m_Allocator->CreateResource( &heapDefault, &dd, kWaterCopyReadState, &clear,
-            m_WaterDepthCopyAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( m_WaterDepthCopy.ReleaseAndGetAddressOf() ) ) ) ) {
-            LogWarn() << "D3D12: failed to create the water depth copy (" << m_Resolution.x << "x" << m_Resolution.y << ").";
-            ReleaseWaterCopyResources();
-            return false;
-        }
-        m_WaterDepthCopy->SetName( L"WaterDepthCopy" );
-    }
-
-    if ( m_WaterSceneCopySrvSlot == UINT_MAX ) m_WaterSceneCopySrvSlot = AllocateSrvSlot();
-    if ( m_WaterDepthCopySrvSlot == UINT_MAX ) m_WaterDepthCopySrvSlot = AllocateSrvSlot();
-    if ( m_WaterSceneCopySrvSlot == UINT_MAX || m_WaterDepthCopySrvSlot == UINT_MAX ) {
-        LogWarn() << "D3D12: SRV heap exhausted allocating slots for the water copies.";
-        ReleaseWaterCopyResources();
-        return false;
-    }
-
-    D3D12_SHADER_RESOURCE_VIEW_DESC srv = {};
-    srv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-    srv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-    srv.Texture2D.MipLevels = 1;
-    srv.Format = kSceneColorFormat;
-    device->CreateShaderResourceView( m_WaterSceneCopy.Get(), &srv, GetSrvCpuHandle( m_WaterSceneCopySrvSlot ) );
-    srv.Format = DXGI_FORMAT_R32_FLOAT;   // typed view of the typeless depth copy
-    device->CreateShaderResourceView( m_WaterDepthCopy.Get(), &srv, GetSrvCpuHandle( m_WaterDepthCopySrvSlot ) );
-
-    m_WaterCopySize = m_Resolution;
     return true;
 }
 
@@ -377,33 +282,77 @@ void D3D12GraphicsEngine::DrawWaterSurfaces() {
     // ---------------------------------------------------------------------------------------------------
     // Steps 1+2: snapshot the finished opaque scene and its depth, BEFORE the Z-prepass below writes the
     // water surface's own depth. Getting the order wrong would have the refraction read water-vs-water
-    // (shallowDepth collapses to 0 everywhere and the surface goes flat/black).
+    // (shallowDepth collapses to 0 everywhere and the surface goes flat/black). Both copies are graph-managed
+    // transients (see the header comment on the old m_WaterSceneCopy/m_WaterDepthCopy members) — this
+    // function is a BaseGraphicsEngine override with a fixed signature, so it builds its own small LOCAL
+    // D3D12RenderGraph rather than taking a shared one (safe: D3D12AliasedTextureArena::ReserveNamedRange
+    // dedups by name across the whole arena, not per-graph-instance).
     // ---------------------------------------------------------------------------------------------------
-    const bool copiesReady = EnsureWaterCopyResources() && m_WaterCBMapped[m_FrameIndex];
-    if ( copiesReady ) {
-        DX_ZONE( m_CmdList.Get(), "Water scene+depth copy" );
-        // Both sources must leave their bound states, so drop the render targets first.
-        m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
+    UINT waterSceneSrvSlot = UINT_MAX;
+    UINT waterDepthSrvSlot = UINT_MAX;
+    bool copiesReady = false;
+    if ( m_WaterCBMapped[m_FrameIndex] ) {
+        D3D12RenderGraph waterGraph( &m_AliasArena );
+        RGResourceHandle sceneHandle = RG_INVALID_HANDLE;
+        RGResourceHandle depthHandle = RG_INVALID_HANDLE;
 
-        const D3D12_RESOURCE_STATES sceneFrom = m_SceneColorInPixelState
-            ? D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_RENDER_TARGET;
-        m_CmdList->TransitionBarriers( {
-        	{ m_SceneColor.Get(), sceneFrom, D3D12_RESOURCE_STATE_COPY_SOURCE },
-        	{ m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_COPY_SOURCE },
-        	{ m_WaterSceneCopy.Get(), kWaterCopyReadState, D3D12_RESOURCE_STATE_COPY_DEST },
-        	{ m_WaterDepthCopy.Get(), kWaterCopyReadState, D3D12_RESOURCE_STATE_COPY_DEST },
-        } );
+        waterGraph.AddPass( RG_PASS_NAME( "Water Copy" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+            sceneHandle = builder.CreateTexture( { static_cast<uint32_t>( m_Resolution.x ), static_cast<uint32_t>( m_Resolution.y ),
+                static_cast<int>( kSceneColorFormat ), L"WaterSceneCopy", 0u } );
+            // Plain R32_FLOAT, not R32_TYPELESS+ALLOW_DEPTH_STENCIL: CopyResource only needs format-FAMILY
+            // compatibility (R32_TYPELESS and R32_FLOAT share one) and this is never bound as a real depth
+            // target — see the header comment.
+            depthHandle = builder.CreateTexture( { static_cast<uint32_t>( m_Resolution.x ), static_cast<uint32_t>( m_Resolution.y ),
+                static_cast<int>( DXGI_FORMAT_R32_FLOAT ), L"WaterDepthCopy", 0u } );
 
-        m_CmdList->CopyResource( m_WaterSceneCopy.Get(), m_SceneColor.Get() );
-        m_CmdList->CopyResource( m_WaterDepthCopy.Get(), m_DepthBuffer.Get() );
+            pass.m_executeCallback = [this, sceneHandle, depthHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
+                D3D12RenderTarget* scene = g.GetPhysicalTexture( sceneHandle );
+                D3D12RenderTarget* depth = g.GetPhysicalTexture( depthHandle );
+                if ( !scene || !depth ) return;
 
-        m_CmdList->TransitionBarriers( {
-        	{ m_SceneColor.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
-        	{ m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE },
-        	{ m_WaterSceneCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, kWaterCopyReadState },
-        	{ m_WaterDepthCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, kWaterCopyReadState },
-        } );
-        m_SceneColorInPixelState = false;   // the scene target is back to RENDER_TARGET regardless of before
+                // Both sources must leave their bound states, so drop the render targets first.
+                cmdList.OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
+
+                const D3D12_RESOURCE_STATES sceneFrom = m_SceneColorInPixelState
+                    ? D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_RENDER_TARGET;
+                D3D12ResourceTransition pre[4] = {
+                    { m_SceneColor.Get(), sceneFrom, D3D12_RESOURCE_STATE_COPY_SOURCE },
+                    { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_COPY_SOURCE },
+                    { scene->GetResource(), scene->State, D3D12_RESOURCE_STATE_COPY_DEST },
+                    { depth->GetResource(), depth->State, D3D12_RESOURCE_STATE_COPY_DEST },
+                };
+                cmdList.TransitionBarriers( pre, 4 );
+                scene->State = D3D12_RESOURCE_STATE_COPY_DEST;
+                depth->State = D3D12_RESOURCE_STATE_COPY_DEST;
+
+                cmdList.CopyResource( scene->GetResource(), m_SceneColor.Get() );
+                cmdList.CopyResource( depth->GetResource(), m_DepthBuffer.Get() );
+
+                cmdList.TransitionBarriers( {
+                    { m_SceneColor.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
+                    { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE },
+                    { scene->GetResource(), D3D12_RESOURCE_STATE_COPY_DEST, kWaterCopyReadState },
+                    { depth->GetResource(), D3D12_RESOURCE_STATE_COPY_DEST, kWaterCopyReadState },
+                    } );
+                scene->State = kWaterCopyReadState;
+                depth->State = kWaterCopyReadState;
+                m_SceneColorInPixelState = false;   // the scene target is back to RENDER_TARGET regardless of before
+                };
+            } );
+
+        waterGraph.Compile();
+        waterGraph.Execute( m_CmdList );
+
+        // Execute() has already run by this point (this is a local, synchronous graph — see the header
+        // comment), so the physical textures it placed are valid to query immediately, unlike the deferred
+        // postFxGraph pattern DoF/SMAA/etc. use.
+        if ( D3D12RenderTarget* scene = waterGraph.GetPhysicalTexture( sceneHandle ) ) {
+            if ( D3D12RenderTarget* depth = waterGraph.GetPhysicalTexture( depthHandle ) ) {
+                waterSceneSrvSlot = scene->GetSrvSlot();
+                waterDepthSrvSlot = depth->GetSrvSlot();
+                copiesReady = true;
+            }
+        }
 
         // Re-bind what the geometry passes had: HDR scene RTV + the main DSV.
         m_CmdList->OMSetRenderTargets( 1, &m_SceneColorRtv, FALSE, &mainDsv );
@@ -425,8 +374,8 @@ void D3D12GraphicsEngine::DrawWaterSurfaces() {
         // matrix's _33/_34 — pass them explicitly rather than relying on that transposition being obvious.
         cb.ProjA = projM._33;
         cb.ProjB = projM._34;
-        cb.DepthIndex = m_WaterDepthCopySrvSlot;
-        cb.SceneIndex = m_WaterSceneCopySrvSlot;
+        cb.DepthIndex = waterDepthSrvSlot;
+        cb.SceneIndex = waterSceneSrvSlot;
         // The distortion texture drives every wave normal in the shader. If it failed to load, fall back to
         // the 1x1 black texture: the distortion decode (x*2-1) then yields a constant vector, so the water
         // renders with static (unanimated) waves instead of not at all.

--- a/D3D11Engine/D3D12Engine/D3D12Water.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Water.cpp
@@ -297,13 +297,19 @@ void D3D12GraphicsEngine::DrawWaterSurfaces() {
         RGResourceHandle depthHandle = RG_INVALID_HANDLE;
 
         waterGraph.AddPass( RG_PASS_NAME( "Water Copy" ), [&]( D3D12RGBuilder& builder, D3D12RenderPass& pass ) {
+            // CreateTexture()'s state param gets both into COPY_DEST automatically before this callback
+            // runs, so the callback itself never needs to check/transition scene->State or depth->State on
+            // entry — only m_SceneColor/m_DepthBuffer (not graph-tracked) still need a manual transition.
             sceneHandle = builder.CreateTexture( { static_cast<uint32_t>( m_Resolution.x ), static_cast<uint32_t>( m_Resolution.y ),
-                static_cast<int>( kSceneColorFormat ), L"WaterSceneCopy", 0u } );
+                static_cast<int>( kSceneColorFormat ), L"WaterSceneCopy", 0u }, D3D12_RESOURCE_STATE_COPY_DEST );
             // Plain R32_FLOAT, not R32_TYPELESS+ALLOW_DEPTH_STENCIL: CopyResource only needs format-FAMILY
             // compatibility (R32_TYPELESS and R32_FLOAT share one) and this is never bound as a real depth
             // target — see the header comment.
             depthHandle = builder.CreateTexture( { static_cast<uint32_t>( m_Resolution.x ), static_cast<uint32_t>( m_Resolution.y ),
-                static_cast<int>( DXGI_FORMAT_R32_FLOAT ), L"WaterDepthCopy", 0u } );
+                static_cast<int>( DXGI_FORMAT_R32_FLOAT ), L"WaterDepthCopy", 0u }, D3D12_RESOURCE_STATE_COPY_DEST );
+            // Nothing ever Read()s either handle (both leave the graph via waterSceneSrvSlot/
+            // waterDepthSrvSlot, plain locals read back further down) — mark the side effect explicitly.
+            builder.MarkExternalEffect();
 
             pass.m_executeCallback = [this, sceneHandle, depthHandle]( const D3D12RenderGraph& g, D3D12CmdList& cmdList ) {
                 D3D12RenderTarget* scene = g.GetPhysicalTexture( sceneHandle );
@@ -315,15 +321,10 @@ void D3D12GraphicsEngine::DrawWaterSurfaces() {
 
                 const D3D12_RESOURCE_STATES sceneFrom = m_SceneColorInPixelState
                     ? D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_RENDER_TARGET;
-                D3D12ResourceTransition pre[4] = {
+                cmdList.TransitionBarriers( {
                     { m_SceneColor.Get(), sceneFrom, D3D12_RESOURCE_STATE_COPY_SOURCE },
                     { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_COPY_SOURCE },
-                    { scene->GetResource(), scene->State, D3D12_RESOURCE_STATE_COPY_DEST },
-                    { depth->GetResource(), depth->State, D3D12_RESOURCE_STATE_COPY_DEST },
-                };
-                cmdList.TransitionBarriers( pre, 4 );
-                scene->State = D3D12_RESOURCE_STATE_COPY_DEST;
-                depth->State = D3D12_RESOURCE_STATE_COPY_DEST;
+                    } );
 
                 cmdList.CopyResource( scene->GetResource(), m_SceneColor.Get() );
                 cmdList.CopyResource( depth->GetResource(), m_DepthBuffer.Get() );

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -2942,11 +2942,14 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
         // Check if this is loaded
         if ( node->NodeVisual && nodeAttachments.find( i ) == nodeAttachments.end() ) {
             // It's not, extract it
-            WorldConverter::ExtractNodeVisual( i, node, nodeAttachments );
+            WorldConverter::ExtractNodeVisualAsync( i, node, nodeAttachments );
         }
 
-        // Check for changed visual
-        if ( nodeAttachments[i].size() && node->NodeVisual != nodeAttachments[i][0]->Visual ) {
+        // Check for changed visual. Gated on GetIsReady(): the worker thread writes Visual as it
+        // finishes extracting, so comparing against it any earlier races the extraction job (mirrors
+        // the D3D12 attachment path).
+        if ( nodeAttachments[i].size() && nodeAttachments[i][0]->GetIsReady()
+            && node->NodeVisual != nodeAttachments[i][0]->Visual ) {
             // Check for deleted attachment
             if ( !node->NodeVisual ) {
                 // Remove attachment. Shared, so it goes back to the registry, not deleted here.
@@ -2957,7 +2960,7 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
                 continue; // Go to next attachment
             }
             // Load the new one
-            WorldConverter::ExtractNodeVisual( i, node, nodeAttachments );
+            WorldConverter::ExtractNodeVisualAsync( i, node, nodeAttachments );
         }
 
         if ( model->GetDrawHandVisualsOnly() ) {
@@ -2982,8 +2985,9 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
                 XMMATRIX prevTransform = XMLoadFloat4x4( &prevBoneTransforms[i] );
                 auto prevWorldNode = prevWorldMatrix * prevTransform;
 
-                if ( !mvi->Visual ) {
-                    LogWarn() << "Attachment without visual on model: " << model->GetVisualName();
+                // Still being extracted on a worker thread — Meshes is being written to right now, so
+                // skip this attachment entirely for this frame rather than race it (mirrors D3D12).
+                if ( !mvi->GetIsReady() || !mvi->Visual ) {
                     continue;
                 }
 
@@ -3214,11 +3218,14 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
         // Check if this is loaded
         if ( node->NodeVisual && nodeAttachments.find( i ) == nodeAttachments.end() ) {
             // It's not, extract it
-            WorldConverter::ExtractNodeVisual( i, node, nodeAttachments );
+            WorldConverter::ExtractNodeVisualAsync( i, node, nodeAttachments );
         }
 
-        // Check for changed visual
-        if ( nodeAttachments[i].size() && node->NodeVisual != nodeAttachments[i][0]->Visual ) {
+        // Check for changed visual. Gated on GetIsReady(): the worker thread writes Visual as it
+        // finishes extracting, so comparing against it any earlier races the extraction job (mirrors
+        // the D3D12 attachment path).
+        if ( nodeAttachments[i].size() && nodeAttachments[i][0]->GetIsReady()
+            && node->NodeVisual != nodeAttachments[i][0]->Visual ) {
             // Check for deleted attachment
             if ( !node->NodeVisual ) {
                 // Remove attachment. Shared, so it goes back to the registry, not deleted here.
@@ -3229,7 +3236,7 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
                 continue; // Go to next attachment
             }
             // Load the new one
-            WorldConverter::ExtractNodeVisual( i, node, nodeAttachments );
+            WorldConverter::ExtractNodeVisualAsync( i, node, nodeAttachments );
         }
 
         if ( model->GetDrawHandVisualsOnly() ) {
@@ -3251,8 +3258,9 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
                 XMFLOAT4X4 finalWorld;
                 XMStoreFloat4x4( &finalWorld, xmWorld * curTransform );
 
-                if ( !mvi->Visual ) {
-                    LogWarn() << "Attachment without visual on model: " << model->GetVisualName();
+                // Still being extracted on a worker thread — Meshes is being written to right now, so
+                // skip this attachment entirely for this frame rather than race it (mirrors D3D12).
+                if ( !mvi->GetIsReady() || !mvi->Visual ) {
                     continue;
                 }
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1874,12 +1874,12 @@ void GothicAPI::OnMaterialDeleted( zCMaterial* mat ) {
     for ( auto&& it : SkeletalMeshVisuals ) {
         // Skip entries a background LoadzCModelData(...) job is still filling in - mutating
         // Meshes/SkeletalMeshes here would race with the worker thread writing to the same maps.
-        if ( !it.second->Ready.load() ) continue;
+        if ( !it.second->GetIsReady() ) continue;
         it.second->Meshes.erase(mat);
         it.second->SkeletalMeshes.erase(mat);
     }
     for ( auto&& it : SkeletalMeshNpcs ) {
-        if ( !it.second->Ready.load() ) continue;
+        if ( !it.second->GetIsReady() ) continue;
         it.second->Meshes.erase(mat);
         it.second->SkeletalMeshes.erase(mat);
     }
@@ -2418,7 +2418,11 @@ void GothicAPI::OnAddVob( zCVob* vob, zCWorld* world ) {
                     zCObject_AddRef( mi->MorphMeshVisual );
                 }
 
-                WorldConverter::Extract3DSMeshFromVisual2( pm, mi );
+                // Hand the expensive part (vertex unpacking + GPU buffer creation) to a worker thread -
+                // this fires once per distinct mesh during world load, and blocking here for every one of
+                // them is what makes loading (and mass-PFX-spawn) stutter. 'mi' is inserted below already
+                // Ready==false; draw sites must skip it until the job flips that back to true.
+                WorldConverter::Extract3DSMeshFromVisual2Async( vob->GetVisual(), pm, mi );
                 StaticMeshVisuals[pm] = mi;
             }
 
@@ -2585,7 +2589,7 @@ SkeletalMeshVisualInfo* GothicAPI::ResolveSkeletalVisualInfo( zCModel* model ) {
         }
     }
 
-    if ( !skeletalMesh || !skeletalMesh->Ready.load() )
+    if ( !skeletalMesh || !skeletalMesh->GetIsReady() )
         return nullptr; // Still being built on a worker thread - don't touch its mesh data yet
 
     // A model can reach OnAddVob before Gothic has built its soft-skin list (freshly spawned NPCs
@@ -2818,7 +2822,7 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
     if ( !model || !vi->VisualInfo )
         return; // Gothic fortunately sets this to 0 when it throws the model out of the cache
 
-    if ( !static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->Ready.load() )
+    if ( !static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->GetIsReady() )
         return; // Still being built on a worker thread - don't touch its mesh data yet
 
     model->SetIsVisible( true );
@@ -3102,7 +3106,7 @@ void GothicAPI::DrawSkeletalMeshVob_Layered( SkeletalVobInfo * vi, float distanc
     if ( !model || !vi->VisualInfo )
         return; // Gothic fortunately sets this to 0 when it throws the model out of the cache
 
-    if ( !static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->Ready.load() )
+    if ( !static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->GetIsReady() )
         return; // Still being built on a worker thread - don't touch its mesh data yet
 
     model->SetIsVisible( true );
@@ -3369,6 +3373,10 @@ void GothicAPI::DrawTransparencyVob( const TransparencyVobInfo& TransVobInfo ) {
             cbPool->BindPS(psBufGAI , cbPool->Allocate(&gacb, sizeof(gacb)));
             DrawSkeletalMeshVob( TransVobInfo.skeletalVob, TransVobInfo.distance, false );
         } else if ( TransVobInfo.normalVob ) {
+            // Still being filled in on a worker thread (GothicAPI::OnAddVob's async
+            // Extract3DSMeshFromVisual2Async) - skip until Meshes is safe to iterate.
+            if ( !TransVobInfo.normalVob->VisualInfo->GetIsReady() ) return;
+
             g->SetActiveVertexShader( VShaderID::VS_Ex );
             g->SetupVS_ExMeshDrawCall();
             
@@ -3442,7 +3450,7 @@ void GothicAPI::DrawSkeletalVN() {
 
         zCModel* model = static_cast<zCModel*>(vi->Vob->GetVisual());
 
-        if ( model && vi->VisualInfo && static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->Ready.load() ) {
+        if ( model && vi->VisualInfo && static_cast<SkeletalMeshVisualInfo*>(vi->VisualInfo)->GetIsReady() ) {
             XMMATRIX scale = XMMatrixScalingFromVector( model->GetModelScaleXM() );
 
             XMMATRIX xmWorld = vi->Vob->GetWorldMatrixXM() * scale;
@@ -3754,6 +3762,11 @@ VobInfo* GothicAPI::TraceStaticMeshVobsBB( const XMFLOAT3& origin, const XMFLOAT
     XMFLOAT3 max;
 
     for ( auto& [vob, vobInfo] : VobMap ) {
+        // Still being filled in on a worker thread (GothicAPI::OnAddVob's async
+        // Extract3DSMeshFromVisual2Async) - skip until BBox/Meshes are safe to read (this is the editor's
+        // mouse-picking ray, which later walks vobInfo->VisualInfo->Meshes via TraceVisualInfo).
+        if ( !vobInfo->VisualInfo || !vobInfo->VisualInfo->GetIsReady() ) continue;
+
         XMMATRIX world = XMMatrixTranspose( XMLoadFloat4x4( vob->GetWorldMatrixPtr() ) );
         XMStoreFloat3( &min, XMVector3TransformCoord( XMLoadFloat3( &vobInfo->VisualInfo->BBox.Min ), world ) );
         XMStoreFloat3( &max, XMVector3TransformCoord( XMLoadFloat3( &vobInfo->VisualInfo->BBox.Max ), world ) );
@@ -6453,7 +6466,9 @@ void GothicAPI::AddParticleEffect( zCVob* vob ) {
                     WorldConverter::ExtractProgMeshProtoFromModel( model, mi );
                 } else if ( zCProgMeshProto* progMesh = emitter->GetVisShpProgMesh() ) {
                     MeshVisualInfo* mi = ParticleEffectProgMeshes.emplace(vob, std::make_unique<MeshVisualInfo>()).first->second.get();
-                    WorldConverter::Extract3DSMeshFromVisual2( progMesh, mi );
+                    // Same rationale as GothicAPI::OnAddVob: spawning many PFX with a prog-mesh particle
+                    // shape at once (e.g. a fire/smoke burst) shouldn't hitch the frame it happens on.
+                    WorldConverter::Extract3DSMeshFromVisual2Async( progMesh, progMesh, mi );
                 } else if ( zCMesh* mesh = emitter->GetVisShpMesh() ) {
                     MeshVisualInfo* mi = ParticleEffectProgMeshes.emplace(vob, std::make_unique<MeshVisualInfo>()).first->second.get();
                     WorldConverter::ExtractProgMeshProtoFromMesh( mesh, mi );

--- a/D3D11Engine/RenderGraph.cpp
+++ b/D3D11Engine/RenderGraph.cpp
@@ -16,6 +16,7 @@ RGResourceHandle RGBuilder::Write( RGResourceHandle handle ) {
 
 RGResourceHandle RGBuilder::CreateTexture( const RGTextureDesc& desc ) {
     RGResourceHandle handle = m_graph.RegisterResource( desc );
+    Read( handle ); // otherwise the texture might never be created
     return Write( handle ); // Creating it implies we are writing to it
 }
 

--- a/D3D11Engine/SharedVisualRegistry.cpp
+++ b/D3D11Engine/SharedVisualRegistry.cpp
@@ -19,7 +19,7 @@ MeshVisualInfo* SharedVisualRegistry::Acquire( const void* key, bool& outNeedsFi
 
         // A cancelled extraction leaves a finished-but-empty entry. Hand it out for a refill, or it
         // stays empty forever - the "visual changed" check just lands back here on the same dead object.
-        outNeedsFill = mvi->Ready.load( std::memory_order_acquire ) && !mvi->Visual;
+        outNeedsFill = mvi->GetIsReady() && !mvi->Visual;
         if ( outNeedsFill ) {
             mvi->Ready.store( false, std::memory_order_release );
         }

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -2158,6 +2158,35 @@ void WorldConverter::ExtractNodeVisualAsync( int index, zCModelNodeInst* node, g
     s_PendingNodeVisuals.emplace_back( mi, nodeVisual, std::move( task ) );
 }
 
+void WorldConverter::Extract3DSMeshFromVisual2Async( zCVisual* holdVisual, zCProgMeshProto* pm, MeshVisualInfo* meshInfo ) {
+    ZoneScoped;
+
+    if ( !Engine::WorkerThreadPool ) {
+        Extract3DSMeshFromVisual2( pm, meshInfo );
+        return;
+    }
+
+    meshInfo->Ready.store( false, std::memory_order_relaxed );
+
+    zCObject_AddRef( holdVisual );
+
+    auto task = Engine::WorkerThreadPool->enqueue( [pm, meshInfo]( const std::stop_token& token ) {
+        if ( token.stop_requested() ) {
+            // World teardown / vob removed before a worker picked this up. 'meshInfo' is about to be
+            // deleted by the caller (which already waited for us via WaitForPendingNodeVisuals), so there
+            // is nothing left to fill in - just unblock that wait.
+            meshInfo->Ready.store( true, std::memory_order_release );
+            return;
+        }
+        Extract3DSMeshFromVisual2( pm, meshInfo );
+        meshInfo->Ready.store( true, std::memory_order_release );
+    } );
+
+    std::scoped_lock lock( s_PendingNodeVisualsMutex );
+    PruneFinishedNodeVisualsLocked();
+    s_PendingNodeVisuals.emplace_back( meshInfo, holdVisual, std::move( task ) );
+}
+
 /** Updates a Morph-Mesh visual */
 void WorldConverter::UpdateMorphMeshVisual( void* v, MeshVisualInfo* meshInfo ) {
     ZoneScoped;

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -117,8 +117,17 @@ public:
         which must not run while the game thread animates the same model. */
     static void ExtractNodeVisualAsync( int index, zCModelNodeInst* node, gtl::flat_hash_map<int, std::vector<MeshVisualInfo*>>& attachments );
 
-    /** Blocks until any in-flight ExtractNodeVisualAsync job reading from 'visual' has finished. Must be
-        called before ZENGIN frees a visual (GothicAPI::OnVisualDeleted). */
+    /** Same idea as ExtractNodeVisualAsync, but for a MeshVisualInfo that isn't SharedVisualRegistry-owned
+        (GothicAPI::StaticMeshVisuals / ParticleEffectProgMeshes): no shell-building or rest-pose handling,
+        just "run Extract3DSMeshFromVisual2 on a worker, hold a reference on 'holdVisual' for the job's
+        duration, flip Ready when done". 'holdVisual' is the object whose destruction the caller learns of
+        through GothicAPI::OnVisualDeleted - the outer zCMorphMesh for a .MMS, 'pm' itself otherwise - and
+        must be kept alive (zCObject-ref'd) by the caller until this call returns, since the job's own
+        reference is only taken here. Falls back to the synchronous call when there is no worker pool. */
+    static void Extract3DSMeshFromVisual2Async( zCVisual* holdVisual, zCProgMeshProto* pm, MeshVisualInfo* meshInfo );
+
+    /** Blocks until any in-flight ExtractNodeVisualAsync/Extract3DSMeshFromVisual2Async job reading from
+        'visual' has finished. Must be called before ZENGIN frees a visual (GothicAPI::OnVisualDeleted). */
     static void WaitForPendingNodeVisuals( zCVisual* visual );
 
     /** Blocks until every in-flight ExtractNodeVisualAsync job has finished. */

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -13,7 +13,7 @@
 MeshVisualInfo::~MeshVisualInfo() {
     // Node attachments may be extracted on a worker thread (WorldConverter::ExtractNodeVisualAsync).
     // Never free the target out from under a running job.
-    if ( !Ready.load( std::memory_order_acquire ) ) {
+    if ( !GetIsReady() ) {
         WaitForPendingNodeVisualExtraction( this );
     }
     // The rest mesh is shared with every other zCMorphMesh resolving to the same rest pose.

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -245,6 +245,17 @@ struct BaseVisualInfo {
 
     /** Name of this visual */
     std::string VisualName;
+
+    /** False while a worker thread is still filling Meshes (and, on MeshVisualInfo, MeshesByTexture) in -
+        WorldConverter::ExtractNodeVisualAsync/Extract3DSMeshFromVisual2Async, AsyncVisualExtractor. Draw/
+        update sites must skip a visual entirely until this flips back to true - reading the containers
+        before that races the extraction. Synchronously extracted visuals (every other path) leave it at
+        true throughout. Use GetIsReady() to read it - the direct field is for the extraction code that
+        sets it. */
+    std::atomic<bool> Ready{ true };
+
+    /** See Ready. */
+    bool GetIsReady() const { return Ready.load( std::memory_order_acquire ); }
 };
 
 /** Holds the converted mesh of a VOB */
@@ -293,12 +304,6 @@ struct MeshVisualInfo : public BaseVisualInfo {
     bool NeedsAlphaTesting;
     size_t LastAniUpdateFrame;
 
-    /** False while a worker thread is still filling Meshes/MeshesByTexture/FullMesh in
-        (WorldConverter::ExtractNodeVisualAsync). Draw/update sites must skip this visual entirely until
-        it flips to true - reading the containers before that races the extraction. Synchronously
-        extracted visuals (every other path) leave it at true. */
-    std::atomic<bool> Ready{ true };
-
     /** SharedVisualRegistry bookkeeping; 0/null on visuals owned outright by their holder. SharedKey is
         the lookup key - unlike Visual it is never rewritten by a background extraction. Destroyed when
         SharedRefs (the number of NodeAttachments slots pointing here) hits zero. */
@@ -339,11 +344,6 @@ struct SkeletalMeshVisualInfo : public BaseVisualInfo {
 
     /** Submeshes of this visual */
     std::map<zCMaterial*, std::vector<std::unique_ptr<SkeletalMeshInfo>>> SkeletalMeshes;
-
-    /** False while an AsyncVisualExtractor job is still filling SkeletalMeshes/Meshes. Draw/update
-     *  code must skip vobs pointing at a not-yet-ready visual instead of touching the (possibly
-     *  still empty) mesh lists. */
-    std::atomic<bool> Ready{true};
 };
 
 struct BaseVobInfo {

--- a/D3D11Engine/include/tracy/public/TracyClient.F90
+++ b/D3D11Engine/include/tracy/public/TracyClient.F90
@@ -861,43 +861,38 @@ module tracy
   end interface
 
   interface
-    subroutine impl_tracy_emit_memory_alloc_callstack(ptr, size, depth, secure) &
+    subroutine impl_tracy_emit_memory_alloc_callstack(ptr, size, depth) &
       bind(C, name="___tracy_emit_memory_alloc_callstack")
       import
       type(c_ptr), intent(in), value :: ptr
       integer(c_size_t), intent(in), value :: size
       integer(c_int32_t), intent(in), value :: depth
-      integer(c_int32_t), intent(in), value :: secure
     end subroutine impl_tracy_emit_memory_alloc_callstack
-    subroutine impl_tracy_emit_memory_alloc_callstack_named(ptr, size, depth, secure, name) &
+    subroutine impl_tracy_emit_memory_alloc_callstack_named(ptr, size, depth, name) &
       bind(C, name="___tracy_emit_memory_alloc_callstack_named")
       import
       type(c_ptr), intent(in), value :: ptr
       integer(c_size_t), intent(in), value :: size
       integer(c_int32_t), intent(in), value :: depth
-      integer(c_int32_t), intent(in), value :: secure
       type(c_ptr), intent(in), value :: name
     end subroutine impl_tracy_emit_memory_alloc_callstack_named
-    subroutine impl_tracy_emit_memory_free_callstack(ptr, depth, secure) &
+    subroutine impl_tracy_emit_memory_free_callstack(ptr, depth) &
       bind(C, name="___tracy_emit_memory_free_callstack")
       import
       type(c_ptr), intent(in), value :: ptr
       integer(c_int32_t), intent(in), value :: depth
-      integer(c_int32_t), intent(in), value :: secure
     end subroutine impl_tracy_emit_memory_free_callstack
-    subroutine impl_tracy_emit_memory_free_callstack_named(ptr, depth, secure, name) &
+    subroutine impl_tracy_emit_memory_free_callstack_named(ptr, depth, name) &
       bind(C, name="___tracy_emit_memory_free_callstack_named")
       import
       type(c_ptr), intent(in), value :: ptr
       integer(c_int32_t), intent(in), value :: depth
-      integer(c_int32_t), intent(in), value :: secure
       type(c_ptr), intent(in), value :: name
     end subroutine impl_tracy_emit_memory_free_callstack_named
-    subroutine impl_tracy_emit_memory_discard_callstack(name, secure, depth) &
+    subroutine impl_tracy_emit_memory_discard_callstack(name, depth) &
       bind(C, name="___tracy_emit_memory_discard_callstack")
       import
       type(c_ptr), intent(in), value :: name
-      integer(c_int32_t), intent(in), value :: secure
       integer(c_int32_t), intent(in), value :: depth
     end subroutine impl_tracy_emit_memory_discard_callstack
   end interface
@@ -1128,58 +1123,43 @@ contains
     tracy_connected = impl_tracy_connected() /= 0_c_int32_t
   end function tracy_connected
 
-  subroutine tracy_memory_alloc(ptr, size, name, depth, secure)
+  subroutine tracy_memory_alloc(ptr, size, name, depth)
     type(c_ptr), intent(in) :: ptr
     integer(c_size_t), intent(in) :: size
     character(kind=c_char, len=*), target, intent(in), optional :: name
     integer(c_int32_t), intent(in), optional :: depth
-    logical(1), intent(in), optional :: secure
     !
-    integer(c_int32_t) :: depth_, secure_
-    secure_ = 0_c_int32_t
+    integer(c_int32_t) :: depth_
     depth_ = 0_c_int32_t
-    if (present(secure)) then
-      if (secure) secure_ = 1_c_int32_t
-    end if
     if (present(depth)) depth_ = depth
     if (present(name)) then
-      call impl_tracy_emit_memory_alloc_callstack_named(ptr, size, depth_, secure_, c_loc(name))
+      call impl_tracy_emit_memory_alloc_callstack_named(ptr, size, depth_, c_loc(name))
     else
-      call impl_tracy_emit_memory_alloc_callstack(ptr, size, depth_, secure_)
+      call impl_tracy_emit_memory_alloc_callstack(ptr, size, depth_)
     end if
   end subroutine tracy_memory_alloc
-  subroutine tracy_memory_free(ptr, name, depth, secure)
+  subroutine tracy_memory_free(ptr, name, depth)
     type(c_ptr), intent(in) :: ptr
     character(kind=c_char, len=*), target, intent(in), optional :: name
     integer(c_int32_t), intent(in), optional :: depth
-    logical(1), intent(in), optional :: secure
     !
-    integer(c_int32_t) :: depth_, secure_
-    secure_ = 0_c_int32_t
+    integer(c_int32_t) :: depth_
     depth_ = 0_c_int32_t
-    if (present(secure)) then
-      if (secure) secure_ = 1_c_int32_t
-    end if
     if (present(depth)) depth_ = depth
     if (present(name)) then
-      call impl_tracy_emit_memory_free_callstack_named(ptr, depth_, secure_, c_loc(name))
+      call impl_tracy_emit_memory_free_callstack_named(ptr, depth_, c_loc(name))
     else
-      call impl_tracy_emit_memory_free_callstack(ptr, depth_, secure_)
+      call impl_tracy_emit_memory_free_callstack(ptr, depth_)
     end if
   end subroutine tracy_memory_free
-  subroutine tracy_memory_discard(name, depth, secure)
+  subroutine tracy_memory_discard(name, depth)
     character(kind=c_char, len=*), target, intent(in) :: name
     integer(c_int32_t), intent(in), optional :: depth
-    logical(1), intent(in), optional :: secure
     !
-    integer(c_int32_t) :: depth_, secure_
-    secure_ = 0_c_int32_t
+    integer(c_int32_t) :: depth_
     depth_ = 0_c_int32_t
-    if (present(secure)) then
-      if (secure) secure_ = 1_c_int32_t
-    end if
     if (present(depth)) depth_ = depth
-    call impl_tracy_emit_memory_discard_callstack(c_loc(name), depth_, secure_)
+    call impl_tracy_emit_memory_discard_callstack(c_loc(name), depth_)
   end subroutine tracy_memory_discard
 
   subroutine tracy_message(msg, color, depth)

--- a/D3D11Engine/include/tracy/public/TracyClient.cpp
+++ b/D3D11Engine/include/tracy/public/TracyClient.cpp
@@ -28,7 +28,9 @@
 #include "client/TracySysTime.cpp"
 #include "client/TracySysTrace.cpp"
 #include "common/TracySocket.cpp"
+#ifndef TRACY_HAS_CUSTOM_ALLOCATOR
 #include "client/tracy_rpmalloc.cpp"
+#endif
 #include "client/TracyDxt1.cpp"
 #include "client/TracyAlloc.cpp"
 #include "client/TracyOverride.cpp"

--- a/D3D11Engine/include/tracy/public/client/TracyAlloc.cpp
+++ b/D3D11Engine/include/tracy/public/client/TracyAlloc.cpp
@@ -1,6 +1,6 @@
 #include "../common/TracyAlloc.hpp"
 
-#ifdef TRACY_USE_RPMALLOC
+#if defined TRACY_USE_RPMALLOC || defined TRACY_HAS_CUSTOM_ALLOCATOR
 
 #include <atomic>
 
@@ -14,7 +14,7 @@ extern thread_local bool RpThreadInitDone;
 extern std::atomic<int> RpInitDone;
 extern std::atomic<int> RpInitLock;
 
-tracy_no_inline static void InitRpmallocPlumbing()
+tracy_no_inline static void InitAllocatorPlumbing()
 {
     const auto done = RpInitDone.load( std::memory_order_acquire );
     if( !done )
@@ -24,18 +24,26 @@ tracy_no_inline static void InitRpmallocPlumbing()
         const auto done = RpInitDone.load( std::memory_order_acquire );
         if( !done )
         {
+#if defined TRACY_HAS_CUSTOM_ALLOCATOR
+            PlatformAllocatorInit();
+#else
             rpmalloc_initialize();
+#endif
             RpInitDone.store( 1, std::memory_order_release );
         }
         RpInitLock.store( 0, std::memory_order_release );
     }
+#if defined TRACY_HAS_CUSTOM_ALLOCATOR
+    PlatformAllocatorThreadInit();
+#else
     rpmalloc_thread_initialize();
+#endif
     RpThreadInitDone = true;
 }
 
-TRACY_API void InitRpmalloc()
+TRACY_API void InitAllocator()
 {
-    if( !RpThreadInitDone ) InitRpmallocPlumbing();
+    if( !RpThreadInitDone ) InitAllocatorPlumbing();
 }
 
 }

--- a/D3D11Engine/include/tracy/public/client/TracyArmCpuTable.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracyArmCpuTable.hpp
@@ -26,6 +26,8 @@ static const char* DecodeArmImplementer( uint32_t v )
     case 0x66: return "Faraday";
     case 0x68: return "HXT";
     case 0x69: return "Intel";
+    case 0x6d: return "Microsoft";
+    case 0x70: return "Phytium";
     case 0xc0: return "Ampere Computing";
     default: break;
     }
@@ -90,20 +92,44 @@ static const char* DecodeArmPart( uint32_t impl, uint32_t part )
         case 0xd0e: return " Cortex-A76AE";
         case 0xd0f: return " AEMv8";
         case 0xd13: return " Cortex-R52";
+        case 0xd14: return " Cortex-R82AE";
+        case 0xd15: return " Cortex-R82";
+        case 0xd16: return " Cortex-R52+";
         case 0xd20: return " Cortex-M23";
         case 0xd21: return " Cortex-M33";
         case 0xd22: return " Cortex-M55";
+        case 0xd23: return " Cortex-M85";
+        case 0xd24: return " Cortex-M52";
         case 0xd40: return " Neoverse V1";
         case 0xd41: return " Cortex-A78";
         case 0xd42: return " Cortex-A78AE";
         case 0xd43: return " Cortex-A65AE";
         case 0xd44: return " Cortex-X1";
+        case 0xd46: return " Cortex-A510";
         case 0xd47: return " Cortex-A710";
         case 0xd48: return " Cortex-X2";
         case 0xd49: return " Neoverse N2";
         case 0xd4a: return " Neoverse E1";
         case 0xd4b: return " Cortex-A78C";
         case 0xd4c: return " Cortex-X1C";
+        case 0xd4d: return " Cortex-A715";
+        case 0xd4e: return " Cortex-X3";
+        case 0xd4f: return " Neoverse-V2";
+        case 0xd80: return " Cortex-A520";
+        case 0xd81: return " Cortex-A720";
+        case 0xd82: return " Cortex-X4";
+        case 0xd83: return " Neoverse-V3AE";
+        case 0xd84: return " Neoverse-V3";
+        case 0xd85: return " Cortex-X925";
+        case 0xd87: return " Cortex-A725";
+        case 0xd88: return " Cortex-A520AE";
+        case 0xd89: return " Cortex-A720AE";
+        case 0xd8a: return " C1-Nano";
+        case 0xd8b: return " C1-Pro";
+        case 0xd8c: return " C1-Ultra";
+        case 0xd8e: return " Neoverse-N3";
+        case 0xd8f: return " Cortex-A320";
+        case 0xd90: return " C1-Premium";
         default: break;
         }
     case 0x42:  // Broadcom
@@ -143,13 +169,17 @@ static const char* DecodeArmPart( uint32_t impl, uint32_t part )
         switch( part )
         {
         case 0x1: return " A64FX";
+        case 0x3: return " MONAKA";
         default: break;
         }
     case 0x48:  // HiSilicon
         switch( part )
         {
-        case 0xd01: return " TSV100";
-        case 0xd40: return " Kirin 980";
+        case 0xd01: return " TaiShan-v110";
+        case 0xd02: return " TaiShan-v120";
+        case 0xd06: return " hip12";
+        case 0xd40: return " Cortex-A76";
+        case 0xd41: return " Cortex-A77";
         default: break;
         }
     case 0x4e:  // Nvidia
@@ -158,6 +188,8 @@ static const char* DecodeArmPart( uint32_t impl, uint32_t part )
         case 0x0: return " Denver";
         case 0x3: return " Denver 2";
         case 0x4: return " Carmel";
+        case 0x10: return " Olympus";
+        case 0x11: return " Rigel";
         default: break;
         }
     case 0x50:  // Applied Micro
@@ -169,6 +201,7 @@ static const char* DecodeArmPart( uint32_t impl, uint32_t part )
     case 0x51:  // Qualcomm
         switch( part )
         {
+        case 0x1: return " Oryon";
         case 0xf: return " Scorpion";
         case 0x2d: return " Scorpion";
         case 0x4d: return " Krait";
@@ -213,6 +246,7 @@ static const char* DecodeArmPart( uint32_t impl, uint32_t part )
     case 0x61:  // Apple
         switch( part )
         {
+        case 0x0: return " Swift";
         case 0x1: return " Cyclone";
         case 0x2: return " Typhoon";
         case 0x3: return " Typhoon/Capri";
@@ -220,12 +254,52 @@ static const char* DecodeArmPart( uint32_t impl, uint32_t part )
         case 0x5: return " Twister/Elba/Malta";
         case 0x6: return " Hurricane";
         case 0x7: return " Hurricane/Myst";
+        case 0x8: return " Monsoon";
+        case 0x9: return " Mistral";
+        case 0xb: return " Vortex";
+        case 0xc: return " Tempest";
+        case 0xf: return " Tempest-M9";
+        case 0x10: return " Vortex/Aruba";
+        case 0x11: return " Tempest/Aruba";
+        case 0x12: return " Lightning";
+        case 0x13: return " Thunder";
+        case 0x20: return " A14 Icestorm";
+        case 0x21: return " A14 Firestorm";
         case 0x22: return " M1 Icestorm";
         case 0x23: return " M1 Firestorm";
         case 0x24: return " M1 Icestorm Pro";
         case 0x25: return " M1 Firestorm Pro";
+        case 0x26: return " M10 Thunder";
         case 0x28: return " M1 Icestorm Max";
         case 0x29: return " M1 Firestorm Max";
+        case 0x30: return " A15 Blizzard";
+        case 0x31: return " A15 Avalanche";
+        case 0x32: return " M2 Blizzard";
+        case 0x33: return " M2 Avalanche";
+        case 0x34: return " M2 Pro Blizzard";
+        case 0x35: return " M2 Pro Avalanche";
+        case 0x36: return " A16 Sawtooth";
+        case 0x37: return " A16 Everest";
+        case 0x38: return " M2 Max Blizzard";
+        case 0x39: return " M2 Max Avalanche";
+        case 0x42: return " M3";
+        case 0x43: return " M3";
+        case 0x44: return " M3";
+        case 0x45: return " M3";
+        case 0x48: return " M3";
+        case 0x49: return " M3";
+        case 0x52: return " M4";
+        case 0x53: return " M4";
+        case 0x54: return " M4";
+        case 0x55: return " M4";
+        case 0x58: return " M4";
+        case 0x59: return " M4";
+        case 0x62: return " M5";
+        case 0x63: return " M5";
+        case 0x64: return " M5";
+        case 0x65: return " M5";
+        case 0x68: return " M5";
+        case 0x69: return " M5";
         default: break;
         }
     case 0x66:  // Faraday
@@ -241,10 +315,55 @@ static const char* DecodeArmPart( uint32_t impl, uint32_t part )
         case 0x0: return " Phecda";
         default: break;
         }
+    case 0x69:  // Intel
+        switch( part )
+        {
+        case 0x200: return " i80200";
+        case 0x210: return " PXA250A";
+        case 0x212: return " PXA210A";
+        case 0x242: return " i80321-400";
+        case 0x243: return " i80321-600";
+        case 0x290: return " PXA250B/PXA26x";
+        case 0x292: return " PXA210B";
+        case 0x2c2: return " i80321-400-B0";
+        case 0x2c3: return " i80321-600-B0";
+        case 0x2d0: return " PXA250C/PXA255/PXA26x";
+        case 0x2d2: return " PXA210C";
+        case 0x411: return " PXA27x";
+        case 0x41c: return " IPX425-533";
+        case 0x41d: return " IPX425-400";
+        case 0x41f: return " IPX425-266";
+        case 0x682: return " PXA32x";
+        case 0x683: return " PXA930/PXA935";
+        case 0x688: return " PXA30x";
+        case 0x689: return " PXA31x";
+        case 0xb11: return " SA1110";
+        case 0xc12: return " IPX1200";
+        default: break;
+        }
+    case 0x6d:  // Microsoft
+        switch( part )
+        {
+        case 0xd49: return " Azure-Cobalt-100";
+        default: break;
+        }
+    case 0x70:  // Phytium
+        switch( part )
+        {
+        case 0x303: return " FTC310";
+        case 0x660: return " FTC660";
+        case 0x661: return " FTC661";
+        case 0x662: return " FTC662";
+        case 0x663: return " FTC663";
+        case 0x664: return " FTC664";
+        case 0x862: return " FTC862";
+        default: break;
+        }
     case 0xc0:  // Ampere Computing
         switch( part )
         {
-        case 0xac3: return " Ampere1";
+        case 0xac3: return " Ampere-1";
+        case 0xac4: return " Ampere-1a";
         default: break;
         }
     default: break;
@@ -313,6 +432,16 @@ static const char* DecodeIosDevice( const char* id )
         "iPhone15,5", "iPhone 15 Plus",
         "iPhone16,1", "iPhone 15 Pro",
         "iPhone16,2", "iPhone 15 Pro Max",
+        "iPhone17,1", "iPhone 16 Pro",
+        "iPhone17,2", "iPhone 16 Pro Max",
+        "iPhone17,3", "iPhone 16",
+        "iPhone17,4", "iPhone 16 Plus",
+        "iPhone17,5", "iPhone 16e",
+        "iPhone18,1", "iPhone 17 Pro",
+        "iPhone18,2", "iPhone 17 Pro Max",
+        "iPhone18,3", "iPhone 17",
+        "iPhone18,4", "iPhone Air",
+        "iPhone18,5", "iPhone 17e",
         "iPad1,1", "iPad (A1219/A1337)",
         "iPad2,1", "iPad 2 (A1395)",
         "iPad2,2", "iPad 2 (A1396)",
@@ -387,14 +516,34 @@ static const char* DecodeIosDevice( const char* id )
         "iPad13,11", "iPad Pro 12.9\" 5th gen",
         "iPad13,16", "iPad Air 5th Gen (WiFi)",
         "iPad13,17", "iPad Air 5th Gen (WiFi+Cellular)",
-        "iPad13,18", "iPad 10th Gen",
-        "iPad13,19", "iPad 10th Gen",
+        "iPad13,18", "iPad 10th Gen (WiFi)",
+        "iPad13,19", "iPad 10th Gen (WiFi+Cellular)",
         "iPad14,1", "iPad mini 6th Gen (WiFi)",
         "iPad14,2", "iPad mini 6th Gen (WiFi+Cellular)",
-        "iPad14,3", "iPad Pro 11\" 4th Gen",
-        "iPad14,4", "iPad Pro 11\" 4th Gen",
-        "iPad14,5", "iPad Pro 12.9\" 6th Gen",
-        "iPad14,6", "iPad Pro 12.9\" 6th Gen",
+        "iPad14,3", "iPad Pro 11\" 4th Gen (WiFi)",
+        "iPad14,4", "iPad Pro 11\" 4th Gen (WiFi+Cellular)",
+        "iPad14,5", "iPad Pro 12.9\" 6th Gen (WiFi)",
+        "iPad14,6", "iPad Pro 12.9\" 6th Gen (WiFi+Cellular)",
+        "iPad14,8", "iPad Air 11\" 6th Gen (WiFi)",
+        "iPad14,9", "iPad Air 11\" 6th Gen (WiFi+Cellular)",
+        "iPad14,10", "iPad Air 13\" 6th Gen (WiFi)",
+        "iPad14,11", "iPad Air 13\" 6th Gen (WiFi+Cellular)",
+        "iPad15,3", "iPad Air 11\" 7th Gen (WiFi)",
+        "iPad15,4", "iPad Air 11\" 7th Gen (WiFi+Cellular)",
+        "iPad15,5", "iPad Air 13\" 7th Gen (WiFi)",
+        "iPad15,6", "iPad Air 13\" 7th Gen (WiFi+Cellular)",
+        "iPad15,7", "iPad 11th Gen (WiFi)",
+        "iPad15,8", "iPad 11th Gen (WiFi+Cellular)",
+        "iPad16,1", "iPad mini 7th Gen (WiFi)",
+        "iPad16,2", "iPad mini 7th Gen (WiFi+Cellular)",
+        "iPad16,3", "iPad Pro 11\" 5th Gen (WiFi)",
+        "iPad16,4", "iPad Pro 11\" 5th Gen (WiFi+Cellular)",
+        "iPad16,5", "iPad Pro 12.9\" 7th Gen (WiFi)",
+        "iPad16,6", "iPad Pro 12.9\" 7th Gen (WiFi+Cellular)",
+        "iPad16,8", "iPad Air 11\" 8th Gen (WiFi)",
+        "iPad16,9", "iPad Air 11\" 8th Gen (WiFi+Cellular)",
+        "iPad16,10", "iPad Air 13\" 8th Gen (WiFi)",
+        "iPad16,11", "iPad Air 13\" 8th Gen (WiFi+Cellular)",
         "iPod1,1", "iPod Touch",
         "iPod2,1", "iPod Touch 2nd gen",
         "iPod3,1", "iPod Touch 3rd gen",

--- a/D3D11Engine/include/tracy/public/client/TracyCallstack.cpp
+++ b/D3D11Engine/include/tracy/public/client/TracyCallstack.cpp
@@ -2,11 +2,14 @@
 #include <new>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 #include "TracyCallstack.hpp"
 #include "TracyDebug.hpp"
 #include "TracyFastVector.hpp"
 #include "TracyStringHelpers.hpp"
 #include "../common/TracyAlloc.hpp"
+#include "../common/TracyAssert.hpp"
+#include "../common/TracyString.hpp"
 #include "../common/TracySystem.hpp"
 
 
@@ -35,6 +38,10 @@
 #  include <dlfcn.h>
 #  include <cxxabi.h>
 #  include <stdlib.h>
+
+#  ifdef __linux__
+#    include "TracyElf.hpp"
+#  endif
 
 // Implementation files
 #  include "../libbacktrace/alloc.cpp"
@@ -232,9 +239,18 @@ private:
         if( cache->ContainsImage( startAddress ) ) return 0;
 
         const uint32_t headerCount = info->dlpi_phnum;
-        assert( headerCount > 0);
-        const auto endAddress = static_cast<uint64_t>( info->dlpi_addr +
-            info->dlpi_phdr[info->dlpi_phnum - 1].p_vaddr + info->dlpi_phdr[info->dlpi_phnum - 1].p_memsz);
+        TRACY_ASSERT( headerCount > 0 );
+
+        // headers aren't guaranteed to be in address order; find the max
+        uint64_t endAddress = startAddress;
+        for( uint32_t i=0; i<headerCount; i++ )
+        {
+            const auto& phdr = info->dlpi_phdr[i];
+            if( phdr.p_type != PT_LOAD ) continue;
+
+            const auto phdrEnd = static_cast<uint64_t>( info->dlpi_addr + phdr.p_vaddr + phdr.p_memsz );
+            endAddress = std::max( phdrEnd, endAddress );
+        }
 
         ImageEntry image{};
         image.m_startAddress = startAddress;
@@ -279,9 +295,7 @@ private:
                 {
                     if( dlInfo.dli_fname )
                     {
-                        size_t sz = strlen( dlInfo.dli_fname ) + 1;
-                        entry.m_name = (char*)tracy_malloc( sz );
-                        memcpy( entry.m_name, dlInfo.dli_fname, sz );
+                        entry.m_name = CopyString( dlInfo.dli_fname );
                     }
                 }
 
@@ -308,7 +322,7 @@ static ImageCache* s_krnlCache;
 
 void CreateImageCaches()
 {
-    assert( s_imageCache == nullptr && s_krnlCache == nullptr );
+    TRACY_ASSERT( s_imageCache == nullptr && s_krnlCache == nullptr );
     s_imageCache = new ( tracy_malloc( sizeof( UserlandImageCache ) ) ) UserlandImageCache();
     s_krnlCache = new ( tracy_malloc( sizeof( ImageCache ) ) ) ImageCache();
 }
@@ -332,6 +346,241 @@ void DestroyImageCaches()
 }
 
 
+#ifdef __linux__
+
+static constexpr uint32_t ExtPT_LOAD = 1;
+
+struct ExternalImageEntry
+{
+    uint64_t startAddress;
+    uint64_t endAddress;
+    uint64_t loadBias;
+    char* path;
+    backtrace_state* btState;
+    bool btAttempted;
+};
+
+static FastVector<ExternalImageEntry>* s_extImages = nullptr;
+static pid_t s_externalPid = 0;
+static bool s_extImagesSorted = true;
+// Wall-clock second of the last /proc/<pid>/maps re-parse. Used to rate-limit
+// refreshes so addresses that never resolve (JIT, vDSO, stack) do not trigger
+// a full re-parse on every symbolization.
+static int64_t s_lastMapsRefresh = 0;
+
+static uint64_t ReadElfMinLoadVaddr( const char* path )
+{
+    int fd = open( path, O_RDONLY );
+    if( fd < 0 ) return UINT64_MAX;
+
+    elf_ehdr ehdr;
+    if( read( fd, &ehdr, sizeof( ehdr ) ) != sizeof( ehdr ) )
+    {
+        close( fd );
+        return UINT64_MAX;
+    }
+
+    if( ehdr.e_ident[0] != 0x7f || ehdr.e_ident[1] != 'E' ||
+        ehdr.e_ident[2] != 'L'  || ehdr.e_ident[3] != 'F' )
+    {
+        close( fd );
+        return UINT64_MAX;
+    }
+
+    if( ehdr.e_phoff == 0 || ehdr.e_phnum == 0 )
+    {
+        close( fd );
+        return UINT64_MAX;
+    }
+
+    if( lseek( fd, ehdr.e_phoff, SEEK_SET ) == (off_t)-1 )
+    {
+        close( fd );
+        return UINT64_MAX;
+    }
+
+    uint64_t minVaddr = UINT64_MAX;
+    for( uint16_t i = 0; i < ehdr.e_phnum; i++ )
+    {
+        elf_phdr phdr;
+        if( read( fd, &phdr, sizeof( phdr ) ) != sizeof( phdr ) ) break;
+        if( phdr.p_type == ExtPT_LOAD ) minVaddr = std::min( minVaddr, static_cast<uint64_t>(phdr.p_vaddr) );
+    }
+
+    close( fd );
+    return minVaddr;
+}
+
+static void ParseExternalProcMaps( pid_t pid )
+{
+    char mapPath[64];
+    snprintf( mapPath, sizeof( mapPath ), "/proc/%d/maps", (int)pid );
+    FILE* f = fopen( mapPath, "r" );
+    if( !f ) return;
+
+    char line[1024];
+    while( fgets( line, sizeof( line ), f ) )
+    {
+        uint64_t start, end, offset;
+        uint32_t devMaj, devMin;
+        uint64_t inode;
+        char perms[8];
+        int consumed = 0;
+
+        if( sscanf( line, "%lx-%lx %7s %lx %x:%x %lu %n", &start, &end, perms, &offset, &devMaj, &devMin, &inode, &consumed ) < 7 ) continue;
+        if( !strchr( perms, 'x' ) ) continue;
+
+        char* pathname = line + consumed;
+        while( *pathname == ' ' || *pathname == '\t' ) pathname++;
+        size_t plen = strlen( pathname );
+        while( plen > 0 && ( pathname[plen-1] == '\n' || pathname[plen-1] == '\r' ) ) plen--;
+        pathname[plen] = '\0';
+
+        if( plen == 0 || pathname[0] != '/' ) continue;
+        if( std::find_if( s_extImages->begin(), s_extImages->end(), [start]( const ExternalImageEntry& e ) { return e.startAddress == start; } ) != s_extImages->end() ) continue;
+
+        uint64_t minVaddr = ReadElfMinLoadVaddr( pathname );
+        uint64_t loadBias;
+        if( minVaddr == UINT64_MAX )
+        {
+            loadBias = start;
+        }
+        else
+        {
+            uint64_t pageSize = sysconf( _SC_PAGESIZE );
+            uint64_t alignedVaddr = minVaddr & ~(pageSize - 1);
+            loadBias = start - alignedVaddr - offset;
+        }
+
+        ExternalImageEntry entry = {
+            .startAddress = start,
+            .endAddress = end,
+            .loadBias = loadBias,
+            .path = (char*)tracy_malloc( plen + 1 ),
+            .btState = nullptr,
+            .btAttempted = false
+        };
+        memcpy( entry.path, pathname, plen + 1 );
+
+        s_extImagesSorted = false;
+        s_extImages->push_next()[0] = entry;
+    }
+
+    fclose( f );
+
+    if( !s_extImagesSorted )
+    {
+        std::sort( s_extImages->begin(), s_extImages->end(),
+            []( const ExternalImageEntry& a, const ExternalImageEntry& b ) { return a.startAddress > b.startAddress; } );
+        s_extImagesSorted = true;
+    }
+}
+
+static const ExternalImageEntry* FindExternalImage( uint64_t address )
+{
+    if( !s_extImages || s_extImages->empty() ) return nullptr;
+
+    auto it = std::lower_bound( s_extImages->begin(), s_extImages->end(), address,
+        []( const ExternalImageEntry& e, uint64_t a ) { return e.startAddress > a; } );
+
+    if( it != s_extImages->end() && address >= it->startAddress && address < it->endAddress )
+    {
+        return &*it;
+    }
+    return nullptr;
+}
+
+static const ExternalImageEntry* FindExternalImageRefresh( uint64_t address )
+{
+    auto entry = FindExternalImage( address );
+    if( entry ) return entry;
+
+    if( s_externalPid != 0 )
+    {
+        const int64_t now = (int64_t)time( nullptr );
+        if( now != s_lastMapsRefresh )
+        {
+            s_lastMapsRefresh = now;
+            ParseExternalProcMaps( s_externalPid );
+            return FindExternalImage( address );
+        }
+    }
+    return nullptr;
+}
+
+static void ExternalBacktraceErrorCb( void* data, const char* msg, int errnum )
+{
+}
+
+static backtrace_state* GetExternalBtState( const ExternalImageEntry* entry )
+{
+    auto* e = const_cast<ExternalImageEntry*>( entry );
+    if( e->btAttempted ) return e->btState;
+    e->btAttempted = true;
+    e->btState = backtrace_create_state_for_file( e->path, 0, ExternalBacktraceErrorCb, nullptr );
+    return e->btState;
+}
+
+struct ExternalResolveData
+{
+    const char* name;
+    const char* file;
+    uint32_t line;
+    int count;
+};
+
+static int ExternalPcInfoCb( void* data, uintptr_t pc, uintptr_t lowaddr, const char* filename, int lineno, const char* function )
+{
+    auto& rd = *(ExternalResolveData*)data;
+
+    if( rd.count > 0 ) return 1;
+    rd.count++;
+
+    if( function )
+    {
+        const char* demangled = ___tracy_demangle( function );
+        rd.name = demangled ? demangled : function;
+    }
+    else
+    {
+        rd.name = nullptr;
+    }
+
+    rd.file = filename;
+    rd.line = lineno;
+
+    return 0;
+}
+
+struct ExternalSymInfoData
+{
+    const char* symname;
+    uintptr_t symval;
+    uintptr_t symsize;
+};
+
+static void ExternalSymInfoCb( void* data, uintptr_t pc, const char* symname, uintptr_t symval, uintptr_t symsize )
+{
+    auto& sd = *(ExternalSymInfoData*)data;
+    sd.symname = symname;
+    sd.symval = symval;
+    sd.symsize = symsize;
+}
+
+void InitExternalImageCache( pid_t pid )
+{
+    s_externalPid = pid;
+    if( !s_extImages )
+    {
+        s_extImages = (FastVector<ExternalImageEntry>*)tracy_malloc( sizeof( FastVector<ExternalImageEntry> ) );
+        new (s_extImages) FastVector<ExternalImageEntry>( 64 );
+    }
+    ParseExternalProcMaps( pid );
+}
+
+#endif // __linux__
+
+
 // when "TRACY_SYMBOL_OFFLINE_RESOLVE" is set, instead of fully resolving symbols at runtime,
 // simply resolve the offset and image name (which will be enough the resolving to be done offline)
 #ifdef TRACY_SYMBOL_OFFLINE_RESOLVE
@@ -347,8 +596,8 @@ bool ShouldResolveSymbolsOffline()
 
 #if TRACY_HAS_CALLSTACK == 1
 
-enum { MaxCbTrace = 64 };
-enum { MaxNameSize = 8*1024 };
+constexpr size_t MaxCbTrace = 64;
+constexpr size_t MaxNameSize = 8*1024;
 
 int cb_num;
 CallstackEntry cb_data[MaxCbTrace];
@@ -378,6 +627,22 @@ void InitCallstackCritical()
     ___tracy_RtlWalkFrameChainPtr = (___tracy_t_RtlWalkFrameChain)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "RtlWalkFrameChain" );
 }
 
+static void SymError( const char* function, DWORD code ) {
+    char message[1024] = {};
+    int written = snprintf( message, sizeof( message ), "ERROR: %s FAILED with code %u (0x%x) | ", function, code, code );
+    written += FormatMessageA(
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        code,
+        MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US),
+        (LPSTR)&message[written],
+        sizeof(message) - written,
+        NULL
+    );
+    fprintf( stderr, "%s\n", message );
+    OutputDebugStringA( message );
+}
+
 void DbgHelpInit()
 {
     if( s_shouldResolveSymbolsOffline ) return;
@@ -392,8 +657,40 @@ void DbgHelpInit()
     DBGHELP_LOCK;
 #endif
 
-    SymInitialize( GetCurrentProcess(), nullptr, true );
-    SymSetOptions( SYMOPT_LOAD_LINES );
+    // append executable path to the _NT_SYMBOL_PATH environment variable
+    char buffer [32767];  // max env var length on Windows (including null-terminator)
+    DWORD length = GetEnvironmentVariableA( "_NT_SYMBOL_PATH", buffer, sizeof( buffer ) );
+    if( length > sizeof( buffer ) ) SymError( "GetEnvironmentVariableA", GetLastError() );
+    else if( length + 1 >= sizeof( buffer ) ) SymError( "_TracyAppendEnvironmentVariable", ERROR_INSUFFICIENT_BUFFER );
+    else
+    {
+        buffer[length] = ';';
+        buffer[++length] = '\0';
+        length += GetModuleFileNameA( NULL, &buffer[length], sizeof( buffer ) - length );
+        if( length >= sizeof( buffer ) && GetLastError() == ERROR_INSUFFICIENT_BUFFER )
+        {
+            SymError( "GetModuleFileNameA", GetLastError() );
+        }
+        else
+        {
+            while( length > 0 && buffer[--length] != '\\' )
+                buffer[length] = '\0';
+        }
+    }
+
+    TRACY_ASSERT( length < sizeof( buffer ) );
+    if( SetEnvironmentVariableA( "_NT_SYMBOL_PATH", buffer ) == FALSE ) SymError( "SetEnvironmentVariableA", GetLastError() );
+ 
+    SymSetOptions( SymGetOptions() | SYMOPT_LOAD_LINES );
+    if( SymInitialize( GetCurrentProcess(), NULL, TRUE ) == FALSE )
+    {
+        SymError( "SymInitialize", GetLastError() );
+    }
+    else if( GetModuleHandleA( "SymSrv.dll" ) == NULL )
+    {
+        TracyDebug( "SymSrv.dll was not loaded, it needs to be near a matching version of DbgHelp.dll. Symbol resolution may fail as symbol servers will not be used. See https://learn.microsoft.com/en-us/windows/win32/debug/calling-the-dbghelp-library" );
+    }
+
 
 #ifdef TRACY_DBGHELP_LOCK
     DBGHELP_UNLOCK;
@@ -532,7 +829,7 @@ void InitCallstack()
 #endif //#ifndef TRACY_SYMBOL_OFFLINE_RESOLVE
     if( s_shouldResolveSymbolsOffline )
     {
-        TracyDebug("TRACY: enabling offline symbol resolving!\n");
+        TracyDebug( "TRACY: enabling offline symbol resolving!" );
     }
 
     CreateImageCaches();
@@ -551,7 +848,7 @@ void InitCallstack()
     const bool initTimeModuleLoad = !( noInitLoadEnv && noInitLoadEnv[0] == '1' );
     if ( !initTimeModuleLoad )
     {
-        TracyDebug("TRACY: skipping init time dbghelper module load\n");
+        TracyDebug( "TRACY: skipping init time dbghelper module load" );
     }
     else
     {
@@ -601,7 +898,7 @@ const char* DecodeCallstackPtrFast( uint64_t ptr )
 
 const char* GetKernelModulePath( uint64_t addr )
 {
-    assert( IsKernelAddress( addr ) );
+    TRACY_ASSERT( IsKernelAddress( addr ) );
     if( !s_krnlCache ) return nullptr;
     const ImageEntry* imageEntry = s_krnlCache->GetImageForAddress( addr );
     if( imageEntry ) return imageEntry->m_path;
@@ -632,7 +929,7 @@ ModuleNameAndBaseAddress GetModuleNameAndPrepareSymbols( uint64_t addr )
     constexpr DWORD flag = GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
     HMODULE mod = NULL;
 
-    InitRpmalloc();
+    InitAllocator();
     if( GetModuleHandleExA( flag, (char*)addr, &mod ) != 0 )
     {
         MODULEINFO info;
@@ -693,13 +990,25 @@ CallstackSymbolData DecodeSymbolAddress( uint64_t ptr )
     return sym;
 }
 
+static CallstackEntryData MakeUnresolvedCallstackEntryData( uint64_t ptr, ModuleNameAndBaseAddress moduleNameAndBaseAddress )
+{
+    cb_data[0].symAddr = ptr - moduleNameAndBaseAddress.baseAddr;
+    cb_data[0].symLen = 0;
+
+    cb_data[0].name = CopyStringFast( "[unresolved]" );
+    cb_data[0].file = CopyStringFast( "[unknown]" );
+    cb_data[0].line = 0;
+
+    return { cb_data, 1, moduleNameAndBaseAddress.name };
+}
+
 CallstackEntryData DecodeCallstackPtr( uint64_t ptr )
 {
 #ifdef TRACY_DBGHELP_LOCK
     DBGHELP_LOCK;
 #endif
 
-    InitRpmalloc();
+    InitAllocator();
 
     const ModuleNameAndBaseAddress moduleNameAndAddress = GetModuleNameAndPrepareSymbols( ptr );
 
@@ -708,15 +1017,7 @@ CallstackEntryData DecodeCallstackPtr( uint64_t ptr )
 #ifdef TRACY_DBGHELP_LOCK
         DBGHELP_UNLOCK;
 #endif
-
-        cb_data[0].symAddr = ptr - moduleNameAndAddress.baseAddr;
-        cb_data[0].symLen = 0;
-
-        cb_data[0].name = CopyStringFast("[unresolved]");
-        cb_data[0].file = CopyStringFast("[unknown]");
-        cb_data[0].line = 0;
-
-        return { cb_data, 1, moduleNameAndAddress.name };
+        return MakeUnresolvedCallstackEntryData( ptr, moduleNameAndAddress );
     }
 
     int write;
@@ -829,7 +1130,7 @@ CallstackEntryData DecodeCallstackPtr( uint64_t ptr )
 
 #elif defined(TRACY_USE_LIBBACKTRACE)
 
-enum { MaxCbTrace = 64 };
+constexpr size_t MaxCbTrace = 64;
 
 struct backtrace_state* cb_bts = nullptr;
 
@@ -855,7 +1156,7 @@ static FastVector<DebugInfo>* s_di_known;
 struct KernelSymbol
 {
     uint64_t addr;
-    uint32_t size;
+    uint64_t endAddr;
     const char* name;
     const char* mod;
 };
@@ -895,9 +1196,9 @@ static void InitKernelSymbols()
             }
             else
             {
-                assert( false );
+                TRACY_ASSERT( false );
             }
-            assert( ( v & ~0xF ) == 0 );
+            TRACY_ASSERT( ( v & ~0xF ) == 0 );
             addr <<= 4;
             addr |= v;
             ptr++;
@@ -926,21 +1227,17 @@ static void InitKernelSymbols()
         {
             validCnt++;
 
-            strname = (char*)tracy_malloc_fast( nameend - namestart + 1 );
-            memcpy( strname, namestart, nameend - namestart );
-            strname[nameend-namestart] = '\0';
+            strname = CopyStringFast( namestart, nameend - namestart );
 
             if( modstart )
             {
-                strmod = (char*)tracy_malloc_fast( modend - modstart + 1 );
-                memcpy( strmod, modstart, modend - modstart );
-                strmod[modend-modstart] = '\0';
+                strmod = CopyStringFast( modstart, modend - modstart );
             }
         }
 
         auto sym = tmpSym.push_next();
         sym->addr = addr;
-        sym->size = 0;
+        sym->endAddr = addr;
         sym->name = strname;
         sym->mod = strmod;
     }
@@ -951,7 +1248,7 @@ static void InitKernelSymbols()
     std::sort( tmpSym.begin(), tmpSym.end(), []( const KernelSymbol& lhs, const KernelSymbol& rhs ) { return lhs.addr < rhs.addr; } );
     for( size_t i=0; i<tmpSym.size()-1; i++ )
     {
-        if( tmpSym[i].name ) tmpSym[i].size = tmpSym[i+1].addr - tmpSym[i].addr;
+        if( tmpSym[i].name ) tmpSym[i].endAddr = tmpSym[i+1].addr;
     }
 
     s_kernelSymCnt = validCnt;
@@ -961,9 +1258,9 @@ static void InitKernelSymbols()
     {
         if( v.name ) *dst++ = v;
     }
-    assert( dst == s_kernelSym + validCnt );
+    TRACY_ASSERT( dst == s_kernelSym + validCnt );
 
-    TracyDebug( "Loaded %zu kernel symbols (%zu code sections)\n", tmpSym.size(), validCnt );
+    TracyDebug( "Loaded %zu kernel symbols (%zu code sections)", tmpSym.size(), validCnt );
 }
 #endif
 
@@ -987,9 +1284,12 @@ char* NormalizePath( const char* path )
         case 2:
             if( memcmp( ptr, "..", 2 ) == 0 )
             {
-                const char* back = res + rsz - 1;
-                while( back > res && *back != '/' ) back--;
-                rsz = back - res;
+                if( rsz > 0 )
+                {
+                    const char* back = res + rsz - 1;
+                    while( back > res && *back != '/' ) back--;
+                    rsz = back - res;
+                }
                 ptr = next + 1;
                 continue;
             }
@@ -1028,7 +1328,7 @@ void InitCallstackCritical()
 
 void InitCallstack()
 {
-    InitRpmalloc();
+    InitAllocator();
 
 #ifdef TRACY_HAS_DL_ITERATE_PHDR_TO_REFRESH_IMAGE_CACHE
     CreateImageCaches();
@@ -1040,7 +1340,7 @@ void InitCallstack()
     if( s_shouldResolveSymbolsOffline )
     {
         cb_bts = nullptr; // disable use of libbacktrace calls
-        TracyDebug("TRACY: enabling offline symbol resolving!\n");
+        TracyDebug( "TRACY: enabling offline symbol resolving!" );
     }
     else
     {
@@ -1100,13 +1400,13 @@ int GetDebugInfoDescriptor( const char* buildid_data, size_t buildid_size, const
     it->filename = (char*)tracy_malloc( fnsz );
     memcpy( it->filename, filename, fnsz );
     it->fd = fd >= 0 ? fd : -1;
-    TracyDebug( "DebugInfo descriptor query: %i, fn: %s\n", fd, filename );
+    TracyDebug( "DebugInfo descriptor query: %i, fn: %s", fd, filename );
     return it->fd;
 }
 
 const uint8_t* GetBuildIdForImage( const char* image, size_t& size )
 {
-    assert( image );
+    TRACY_ASSERT( image );
     for( auto& v : *s_di_known )
     {
         if( strcmp( image, v.filename ) == 0 )
@@ -1141,11 +1441,52 @@ void EndCallstack()
 #endif
 }
 
-const char* DecodeCallstackPtrFast( uint64_t ptr )
+#ifdef __linux__
+static const char* DecodeCallstackPtrFastExternal( uint64_t ptr )
 {
     static char ret[1024];
     auto vptr = (void*)ptr;
     const char* symname = nullptr;
+
+    const auto* extImg = FindExternalImageRefresh( ptr );
+    if( extImg )
+    {
+        auto* bts = GetExternalBtState( extImg );
+        if( bts )
+        {
+            auto elfVaddr = (uintptr_t)( ptr - extImg->loadBias );
+            ExternalSymInfoData sid = {};
+            backtrace_syminfo( bts, elfVaddr, ExternalSymInfoCb, ExternalBacktraceErrorCb, &sid );
+            if( sid.symname )
+            {
+                const char* demangled = ___tracy_demangle( sid.symname );
+                symname = demangled ? demangled : sid.symname;
+            }
+        }
+    }
+    if( symname )
+    {
+        strzcpy( ret, symname, sizeof( ret ) );
+    }
+    else
+    {
+        *ret = '\0';
+    }
+    return ret;
+}
+#endif
+
+const char* DecodeCallstackPtrFast( uint64_t ptr )
+{
+    static char ret[1024];
+
+#ifdef __linux__
+    if( s_externalPid != 0 && s_extImages ) return DecodeCallstackPtrFastExternal( ptr );
+#endif
+
+    auto vptr = (void*)ptr;
+    const char* symname = nullptr;
+
     Dl_info dlinfo;
     if( dladdr( vptr, &dlinfo ) && dlinfo.dli_sname )
     {
@@ -1153,7 +1494,7 @@ const char* DecodeCallstackPtrFast( uint64_t ptr )
     }
     if( symname )
     {
-        strcpy( ret, symname );
+        strzcpy( ret, symname, sizeof( ret ) );
     }
     else
     {
@@ -1190,9 +1531,34 @@ static void SymbolAddressErrorCb( void* data, const char* /*msg*/, int /*errnum*
     sym.needFree = false;
 }
 
+#ifdef __linux__
+static CallstackSymbolData DecodeSymbolAddressExternal( uint64_t ptr )
+{
+    CallstackSymbolData sym;
+    const auto* extImg = FindExternalImageRefresh( ptr );
+    if( extImg )
+    {
+        auto* bts = GetExternalBtState( extImg );
+        if( bts )
+        {
+            auto elfVaddr = (uintptr_t)( ptr - extImg->loadBias );
+            backtrace_pcinfo( bts, elfVaddr, SymbolAddressDataCb, SymbolAddressErrorCb, &sym );
+            return sym;
+        }
+    }
+    SymbolAddressErrorCb( &sym, nullptr, 0 );
+    return sym;
+}
+#endif
+
 CallstackSymbolData DecodeSymbolAddress( uint64_t ptr )
 {
     CallstackSymbolData sym;
+
+#ifdef __linux__
+    if( s_externalPid != 0 && s_extImages ) return DecodeSymbolAddressExternal( ptr );
+#endif
+
     if( cb_bts )
     {
         backtrace_pcinfo( cb_bts, ptr, SymbolAddressDataCb, SymbolAddressErrorCb, &sym );
@@ -1315,11 +1681,125 @@ void GetSymbolForOfflineResolve(void* address, uint64_t imageBaseAddress, Callst
     cbEntry.line = 0;
 }
 
+#ifdef __linux__
+CallstackEntryData DecodeCallstackPtrExternal( uint64_t ptr )
+{
+    const auto* extImg = FindExternalImageRefresh( ptr );
+    if( extImg )
+    {
+        const char* imageName = extImg->path;
+
+        // Convert VMA (target process virtual address) to ELF virtual address.
+        // elf_vaddr = vma - load_bias
+        // libbacktrace indexes DWARF data by ELF virtual address when
+        // the backtrace_state is created from a file (base_address=0).
+        const auto elfVaddr = (uintptr_t)( ptr - extImg->loadBias );
+
+        auto* bts = GetExternalBtState( extImg );
+        if( bts )
+        {
+            // Try DWARF-based resolution
+            ExternalResolveData rd = {};
+            backtrace_pcinfo( bts, elfVaddr, ExternalPcInfoCb, ExternalBacktraceErrorCb, &rd );
+
+            if( rd.name || rd.file )
+            {
+                cb_num = 1;
+                if( rd.name )
+                {
+                    const auto len = std::min<size_t>( strlen( rd.name ), std::numeric_limits<uint16_t>::max() );
+                    cb_data[0].name = CopyStringFast( rd.name, len );
+                }
+                else
+                {
+                    cb_data[0].name = CopyStringFast( "[unknown]" );
+                }
+                if( rd.file )
+                {
+                    cb_data[0].file = NormalizePath( rd.file );
+                    if( !cb_data[0].file ) cb_data[0].file = CopyStringFast( rd.file );
+                }
+                else
+                {
+                    cb_data[0].file = CopyStringFast( "[unknown]" );
+                }
+                cb_data[0].line = rd.line;
+                cb_data[0].symLen = 0;
+                cb_data[0].symAddr = elfVaddr;
+
+                // Try to get symbol size info
+                ExternalSymInfoData sid = {};
+                backtrace_syminfo( bts, elfVaddr, ExternalSymInfoCb, ExternalBacktraceErrorCb, &sid );
+                if( sid.symsize > 0 )
+                {
+                    cb_data[0].symLen = (uint32_t)sid.symsize;
+                    cb_data[0].symAddr = (uint64_t)sid.symval;
+                }
+
+                // If DWARF gave us no function name, try the symbol table
+                if( !rd.name && sid.symname )
+                {
+                    tracy_free_fast( (void*)cb_data[0].name );
+                    const char* demangled = ___tracy_demangle( sid.symname );
+                    if( demangled )
+                    {
+                        cb_data[0].name = CopyStringFast( demangled );
+                    }
+                    else
+                    {
+                        cb_data[0].name = CopyStringFast( sid.symname );
+                    }
+                }
+
+                return { cb_data, 1, imageName ? imageName : "[unknown]" };
+            }
+
+            // DWARF resolution failed; try symtab-only fallback
+            ExternalSymInfoData sid = {};
+            backtrace_syminfo( bts, elfVaddr, ExternalSymInfoCb, ExternalBacktraceErrorCb, &sid );
+            if( sid.symname )
+            {
+                cb_num = 1;
+                const char* demangled = ___tracy_demangle( sid.symname );
+                cb_data[0].name = CopyStringFast( demangled ? demangled : sid.symname );
+                cb_data[0].file = CopyStringFast( imageName ? imageName : "[unknown]" );
+                cb_data[0].line = 0;
+                cb_data[0].symLen = (uint32_t)sid.symsize;
+                cb_data[0].symAddr = (uint64_t)sid.symval;
+                return { cb_data, 1, imageName ? imageName : "[unknown]" };
+            }
+        }
+
+        // Fallback: return unresolved with offset
+        cb_num = 1;
+        cb_data[0].name = CopyStringFast( "[unresolved]" );
+        cb_data[0].file = CopyStringFast( imageName ? imageName : "[unknown]" );
+        cb_data[0].line = 0;
+        cb_data[0].symLen = 0;
+        cb_data[0].symAddr = elfVaddr;
+        return { cb_data, 1, imageName ? imageName : "[unknown]" };
+    }
+
+    // Address doesn't belong to any known mapping
+    cb_num = 1;
+    cb_data[0].name = CopyStringFast( "[unknown]" );
+    cb_data[0].file = CopyStringFast( "[unknown]" );
+    cb_data[0].line = 0;
+    cb_data[0].symLen = 0;
+    cb_data[0].symAddr = ptr;
+    return { cb_data, 1, "[unknown]" };
+}
+#endif
+
 CallstackEntryData DecodeCallstackPtr( uint64_t ptr )
 {
-    InitRpmalloc();
-    if ( !IsKernelAddress( ptr ) )
+    InitAllocator();
+    if( !IsKernelAddress( ptr ) )
     {
+#ifdef __linux__
+        if( s_externalPid != 0 && s_extImages ) return DecodeCallstackPtrExternal( ptr );
+#endif
+
         const char* imageName = nullptr;
         uint64_t imageBaseAddress = 0x0;
 
@@ -1348,7 +1828,7 @@ CallstackEntryData DecodeCallstackPtr( uint64_t ptr )
         {
             cb_num = 0;
             backtrace_pcinfo( cb_bts, ptr, CallstackDataCb, CallstackErrorCb, nullptr );
-            assert( cb_num > 0 );
+            TRACY_ASSERT( cb_num > 0 );
 
             backtrace_syminfo( cb_bts, ptr, SymInfoCallback, SymInfoError, nullptr );
         }
@@ -1358,13 +1838,13 @@ CallstackEntryData DecodeCallstackPtr( uint64_t ptr )
 #ifdef __linux
     else if( s_kernelSym )
     {
-        auto it = std::lower_bound( s_kernelSym, s_kernelSym + s_kernelSymCnt, ptr, []( const KernelSymbol& lhs, const uint64_t& rhs ) { return lhs.addr + lhs.size < rhs; } );
+        auto it = std::lower_bound( s_kernelSym, s_kernelSym + s_kernelSymCnt, ptr, []( const KernelSymbol& lhs, const uint64_t& rhs ) { return lhs.endAddr < rhs; } );
         if( it != s_kernelSym + s_kernelSymCnt )
         {
             cb_data[0].name = CopyStringFast( it->name );
             cb_data[0].file = CopyStringFast( "<kernel>" );
             cb_data[0].line = 0;
-            cb_data[0].symLen = it->size;
+            cb_data[0].symLen = it->endAddr - it->addr;
             cb_data[0].symAddr = it->addr;
             return { cb_data, 1, it->mod ? it->mod : "<kernel>" };
         }
@@ -1407,7 +1887,7 @@ const char* DecodeCallstackPtrFast( uint64_t ptr )
     }
     if( symname )
     {
-        strcpy( ret, symname );
+        strzcpy( ret, symname, sizeof( ret ) );
     }
     else
     {

--- a/D3D11Engine/include/tracy/public/client/TracyCallstack.h
+++ b/D3D11Engine/include/tracy/public/client/TracyCallstack.h
@@ -3,10 +3,6 @@
 
 #ifndef TRACY_NO_CALLSTACK
 
-#  if !defined _WIN32
-#    include <sys/param.h>
-#  endif
-
 #  if defined _WIN32
 #    include "../common/TracyWinFamily.hpp"
 #    if !defined TRACY_WIN32_NO_DESKTOP
@@ -26,7 +22,7 @@
 #    endif
 #  elif defined __APPLE__
 #    define TRACY_HAS_CALLSTACK 4
-#  elif defined BSD
+#  elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
 #    define TRACY_HAS_CALLSTACK 6
 #  endif
 

--- a/D3D11Engine/include/tracy/public/client/TracyCallstack.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracyCallstack.hpp
@@ -46,10 +46,10 @@ static tracy_force_inline void* Callstack( int32_t /*depth*/ ) { return nullptr;
 #  include <elfutils/debuginfod.h>
 #endif
 
-#include <assert.h>
 #include <stdint.h>
 
 #include "../common/TracyAlloc.hpp"
+#include "../common/TracyAssert.hpp"
 
 namespace tracy
 {
@@ -88,6 +88,10 @@ void InitCallstackCritical();
 void EndCallstack();
 const char* GetKernelModulePath( uint64_t addr );
 
+#ifdef __linux__
+void InitExternalImageCache( pid_t pid );
+#endif
+
 #ifdef TRACY_DEBUGINFOD
 const uint8_t* GetBuildIdForImage( const char* image, size_t& size );
 debuginfod_client* GetDebuginfodClient();
@@ -102,7 +106,7 @@ extern "C"
 
 static tracy_force_inline void* Callstack( int32_t depth )
 {
-    assert( depth >= 1 && depth < 63 );
+    TRACY_ASSERT( depth >= 1 && depth < 63 );
     auto trace = (uintptr_t*)tracy_malloc( ( 1 + depth ) * sizeof( uintptr_t ) );
     const auto num = ___tracy_RtlWalkFrameChain( (void**)( trace + 1 ), depth, 0 );
     *trace = num;
@@ -131,7 +135,7 @@ static _Unwind_Reason_Code tracy_unwind_callback( struct _Unwind_Context* ctx, v
 
 static tracy_force_inline void* Callstack( int32_t depth )
 {
-    assert( depth >= 1 && depth < 63 );
+    TRACY_ASSERT( depth >= 1 && depth < 63 );
 
     auto trace = (uintptr_t*)tracy_malloc( ( 1 + depth ) * sizeof( uintptr_t ) );
     BacktraceState state = { (void**)(trace+1), (void**)(trace+1+depth) };
@@ -146,7 +150,7 @@ static tracy_force_inline void* Callstack( int32_t depth )
 
 static tracy_force_inline void* Callstack( int32_t depth )
 {
-    assert( depth >= 1 );
+    TRACY_ASSERT( depth >= 1 );
 
     auto trace = (uintptr_t*)tracy_malloc( ( 1 + (size_t)depth ) * sizeof( uintptr_t ) );
 

--- a/D3D11Engine/include/tracy/public/client/TracyDebug.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracyDebug.hpp
@@ -1,9 +1,34 @@
-#ifndef __TRACYPRINT_HPP__
-#define __TRACYPRINT_HPP__
+#ifndef __TRACYDEBUG_HPP__
+#define __TRACYDEBUG_HPP__
+
+#include "TracyMangle.hpp"
+
+#ifdef TRACY_ON_DEMAND
+#  define TRACY_VERBOSE_EARLY_OUT_COND if( !GetProfiler().IsConnected() ) break
+#else
+// Skip rather than assert: TracyDebug can fire during Profiler member
+// construction (e.g. SysPower ctor scanning intel-rapl), before s_instance is
+// set, so ProfilerAvailable() is legitimately false.
+#  define TRACY_VERBOSE_EARLY_OUT_COND if( !tracy::ProfilerAvailable() ) break
+#endif
+
+#define TracyInternalMessage( severity, ... )																				   \
+	do {																													   \
+        TRACY_VERBOSE_EARLY_OUT_COND;																						   \
+		char buffer[4096];																									   \
+		snprintf( buffer, sizeof(buffer), __VA_ARGS__ );																	   \
+		tracy::Profiler::LogString( tracy::MessageSourceType::Tracy, severity, 0, TRACY_CALLSTACK, strlen( buffer ), buffer ); \
+	} while( 0 )
 
 #ifdef TRACY_VERBOSE
 #  include <stdio.h>
-#  define TracyDebug(...) fprintf( stderr, __VA_ARGS__ );
+#  define TracyDebug(...) do { fprintf( stderr, __VA_ARGS__ ); fputc( '\n', stderr ); } while( 0 )
+// Note: We can't use LogString when using TRACY_DELAYED_INIT due to a deadlock in the init code.
+// This is caused by `GetProfilerData` triggering ProfileData ctor, which itself will call `GetProfilerData` and deadlock.
+// TRACY_MANUAL_LIFETIME does not have this issue since StartupProfiler sets s_profilerData before calling the constructor.
+// In general, this also means we can only call TracyDebug after and the first logging is after queue initialization and critical init (such as InitCallstackCritical).
+#elif !defined(TRACY_NO_INTERNAL_MESSAGE) && (!defined(TRACY_DELAYED_INIT) || defined(TRACY_MANUAL_LIFETIME))
+#  define TracyDebug(...) TracyInternalMessage( tracy::MessageSeverity::Debug, __VA_ARGS__ )
 #else
 #  define TracyDebug(...)
 #endif

--- a/D3D11Engine/include/tracy/public/client/TracyDxt1.cpp
+++ b/D3D11Engine/include/tracy/public/client/TracyDxt1.cpp
@@ -1,7 +1,7 @@
 #include "TracyDxt1.hpp"
+#include "../common/TracyAssert.hpp"
 #include "../common/TracyForceInline.hpp"
 
-#include <assert.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -584,7 +584,7 @@ static tracy_force_inline void ProcessRGB_AVX( const uint8_t* src, char*& dst )
 
 void CompressImageDxt1( const char* src, char* dst, int w, int h )
 {
-    assert( (w % 4) == 0 && (h % 4) == 0 );
+    TRACY_ASSERT( (w % 4) == 0 && (h % 4) == 0 );
 
 #ifdef __AVX2__
     if( w%8 == 0 )

--- a/D3D11Engine/include/tracy/public/client/TracyElf.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracyElf.hpp
@@ -1,0 +1,55 @@
+#ifndef __TRACYELF_HPP__
+#define __TRACYELF_HPP__
+
+#include <stdint.h>
+
+namespace tracy
+{
+
+using elf_half = uint16_t;
+using elf_word = uint32_t;
+using elf_sword = int32_t;
+
+#if __SIZEOF_POINTER__ == 8
+    using elf_addr = uint64_t;
+    using elf_off = uint64_t;
+    using elf_xword = uint64_t;
+#else
+    using elf_addr = uint32_t;
+    using elf_off = uint32_t;
+    using elf_xword = uint32_t;
+#endif
+
+struct elf_ehdr
+{
+    unsigned char e_ident[16];
+    elf_half e_type;
+    elf_half e_machine;
+    elf_word e_version;
+    elf_addr e_entry;
+    elf_off e_phoff;
+    elf_off e_shoff;
+    elf_word e_flags;
+    elf_half e_ehsize;
+    elf_half e_phentsize;
+    elf_half e_phnum;
+    elf_half e_shentsize;
+    elf_half e_shnum;
+    elf_half e_shstrndx;
+};
+
+struct elf_phdr
+{
+    elf_word p_type;
+    elf_word p_flags;
+    elf_off p_offset;
+    elf_addr p_vaddr;
+    elf_addr p_paddr;
+    elf_xword p_filesz;
+    elf_xword p_memsz;
+    uint64_t p_align;   // include 32-bit-only flags field for 32-bit compatibility
+};
+
+}
+
+#endif

--- a/D3D11Engine/include/tracy/public/client/TracyFastVector.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracyFastVector.hpp
@@ -1,10 +1,10 @@
 #ifndef __TRACYFASTVECTOR_HPP__
 #define __TRACYFASTVECTOR_HPP__
 
-#include <assert.h>
 #include <stddef.h>
 
 #include "../common/TracyAlloc.hpp"
+#include "../common/TracyAssert.hpp"
 #include "../common/TracyForceInline.hpp"
 
 namespace tracy
@@ -22,7 +22,7 @@ public:
         , m_write( m_ptr )
         , m_end( m_ptr + capacity )
     {
-        assert( capacity != 0 );
+        TRACY_ASSERT( capacity != 0 );
     }
 
     FastVector( const FastVector& ) = delete;
@@ -47,11 +47,11 @@ public:
     T* end() { return m_write; }
     const T* end() const { return m_write; }
 
-    T& front() { assert( !empty() ); return m_ptr[0]; }
-    const T& front() const { assert( !empty() ); return m_ptr[0]; }
+    T& front() { TRACY_ASSERT( !empty() ); return m_ptr[0]; }
+    const T& front() const { TRACY_ASSERT( !empty() ); return m_ptr[0]; }
 
-    T& back() { assert( !empty() ); return m_write[-1]; }
-    const T& back() const { assert( !empty() ); return m_write[-1]; }
+    T& back() { TRACY_ASSERT( !empty() ); return m_write[-1]; }
+    const T& back() const { TRACY_ASSERT( !empty() ); return m_write[-1]; }
 
     T& operator[]( size_t idx ) { return m_ptr[idx]; }
     const T& operator[]( size_t idx ) const { return m_ptr[idx]; }

--- a/D3D11Engine/include/tracy/public/client/TracyKCore.cpp
+++ b/D3D11Engine/include/tracy/public/client/TracyKCore.cpp
@@ -1,66 +1,19 @@
 #ifdef __linux__
 
 #include <algorithm>
-#include <assert.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <unistd.h>
 
 #include "TracyDebug.hpp"
+#include "TracyElf.hpp"
 #include "TracyKCore.hpp"
 #include "../common/TracyAlloc.hpp"
+#include "../common/TracyAssert.hpp"
 
-#if !defined(__GLIBC__) && !defined(__WORDSIZE)
-// include __WORDSIZE headers for musl
-#  include <bits/reg.h>
-#endif
 
 namespace tracy
 {
-
-using elf_half = uint16_t;
-using elf_word = uint32_t;
-using elf_sword = int32_t;
-
-#if __WORDSIZE == 32
-    using elf_addr = uint32_t;
-    using elf_off = uint32_t;
-    using elf_xword = uint32_t;
-#else
-    using elf_addr = uint64_t;
-    using elf_off = uint64_t;
-    using elf_xword = uint64_t;
-#endif
-
-struct elf_ehdr
-{
-    unsigned char e_ident[16];
-    elf_half e_type;
-    elf_half e_machine;
-    elf_word e_version;
-    elf_addr e_entry;
-    elf_off e_phoff;
-    elf_off e_shoff;
-    elf_word e_flags;
-    elf_half e_ehsize;
-    elf_half e_phentsize;
-    elf_half e_phnum;
-    elf_half e_shentsize;
-    elf_half e_shnum;
-    elf_half e_shstrndx;
-};
-
-struct elf_phdr
-{
-    elf_word p_type;
-    elf_word p_flags;
-    elf_off p_offset;
-    elf_addr p_vaddr;
-    elf_addr p_paddr;
-    elf_xword p_filesz;
-    elf_xword p_memsz;
-    uint64_t p_align;   // include 32-bit-only flags field for 32-bit compatibility
-};
 
 KCore::KCore()
     : m_offsets( 16 )
@@ -71,7 +24,7 @@ KCore::KCore()
     elf_ehdr ehdr;
     if( read( m_fd, &ehdr, sizeof( ehdr ) ) != sizeof( ehdr ) ) goto err;
 
-    assert( ehdr.e_phentsize == sizeof( elf_phdr ) );
+    TRACY_ASSERT( ehdr.e_phentsize == sizeof( elf_phdr ) );
 
     for( elf_half i=0; i<ehdr.e_phnum; i++ )
     {
@@ -87,7 +40,7 @@ KCore::KCore()
     }
 
     std::sort( m_offsets.begin(), m_offsets.end(), []( const Offset& lhs, const Offset& rhs ) { return lhs.start < rhs.start; } );
-    TracyDebug( "KCore: %zu segments found\n", m_offsets.size() );
+    TracyDebug( "KCore: %zu segments found", m_offsets.size() );
     return;
 
 err:

--- a/D3D11Engine/include/tracy/public/client/TracyLock.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracyLock.hpp
@@ -6,6 +6,7 @@
 
 #include "../common/TracySystem.hpp"
 #include "../common/TracyAlign.hpp"
+#include "../common/TracyAssert.hpp"
 #include "TracyProfiler.hpp"
 
 namespace tracy
@@ -21,7 +22,7 @@ public:
         , m_active( false )
 #endif
     {
-        assert( m_id != (std::numeric_limits<uint32_t>::max)() );
+        TRACY_ASSERT( m_id != (std::numeric_limits<uint32_t>::max)() );
 
         auto item = Profiler::QueueSerial();
         MemWrite( &item->hdr.type, QueueType::LockAnnounce );
@@ -154,7 +155,7 @@ public:
 
     tracy_force_inline void CustomName( const char* name, size_t size )
     {
-        assert( size < (std::numeric_limits<uint16_t>::max)() );
+        TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
         auto ptr = (char*)tracy_malloc( size );
         memcpy( ptr, name, size );
         auto item = Profiler::QueueSerial();
@@ -236,7 +237,7 @@ public:
         , m_active( false )
 #endif
     {
-        assert( m_id != (std::numeric_limits<uint32_t>::max)() );
+        TRACY_ASSERT( m_id != (std::numeric_limits<uint32_t>::max)() );
 
         auto item = Profiler::QueueSerial();
         MemWrite( &item->hdr.type, QueueType::LockAnnounce );
@@ -451,7 +452,7 @@ public:
 
     tracy_force_inline void CustomName( const char* name, size_t size )
     {
-        assert( size < (std::numeric_limits<uint16_t>::max)() );
+        TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
         auto ptr = (char*)tracy_malloc( size );
         memcpy( ptr, name, size );
         auto item = Profiler::QueueSerial();

--- a/D3D11Engine/include/tracy/public/client/TracyMangle.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracyMangle.hpp
@@ -1,0 +1,75 @@
+#ifndef __TRACYMANGLE_HPP__
+#define __TRACYMANGLE_HPP__
+
+// TRACY_DELAYED_INIT is an internal implementation switch, not a user-facing
+// option: Apple platforms require it, and TRACY_MANUAL_LIFETIME builds on top
+// of it. It is derived here so that every translation unit, and the client
+// implementation, see the same effective value before any config-dependent
+// symbol name is computed.
+#if defined(TRACY_MANUAL_LIFETIME) || defined(__APPLE__)
+#  ifndef TRACY_DELAYED_INIT
+#    define TRACY_DELAYED_INIT
+#  endif
+#endif
+
+#ifdef TRACY_ENABLE
+#define TRACY_ENABLE_MANGLE _E1
+#else
+#define TRACY_ENABLE_MANGLE _E0
+#endif
+
+#ifdef TRACY_ON_DEMAND
+#define TRACY_ON_DEMAND_MANGLE _OD1
+#else
+#define TRACY_ON_DEMAND_MANGLE _OD0
+#endif
+
+#ifdef TRACY_DELAYED_INIT
+#define TRACY_DELAYED_INIT_MANGLE _DI1
+#else
+#define TRACY_DELAYED_INIT_MANGLE _DI0
+#endif
+
+#ifdef TRACY_MANUAL_LIFETIME
+#define TRACY_MANUAL_LIFETIME_MANGLE _ML1
+#else
+#define TRACY_MANUAL_LIFETIME_MANGLE _ML0
+#endif
+
+#ifdef TRACY_FIBERS
+#define TRACY_FIBERS_MANGLE _F1
+#else
+#define TRACY_FIBERS_MANGLE _F0
+#endif
+
+#ifdef TRACY_DISALLOW_HW_TIMER
+#define TRACY_DISALLOW_HW_TIMER_MANGLE _DHT1
+#else
+#define TRACY_DISALLOW_HW_TIMER_MANGLE _DHT0
+#endif
+
+#ifdef TRACY_TIMER_FALLBACK
+#define TRACY_TIMER_FALLBACK_MANGLE _TF1
+#else
+#define TRACY_TIMER_FALLBACK_MANGLE _TF0
+#endif
+
+#ifdef TRACY_PLATFORM_HEADER
+#define TRACY_PLATFORM_HEADER_MANGLE _PH1
+#else
+#define TRACY_PLATFORM_HEADER_MANGLE _PH0
+#endif
+
+#define MANGLED_NAME_BASED_ON_CONFIG(base) \
+    TracyConcat(TracyConcat(TracyConcat(TracyConcat(TracyConcat(TracyConcat(TracyConcat(TracyConcat( \
+    base##_CFG, \
+    TRACY_ENABLE_MANGLE), \
+    TRACY_ON_DEMAND_MANGLE), \
+    TRACY_DELAYED_INIT_MANGLE), \
+    TRACY_MANUAL_LIFETIME_MANGLE), \
+    TRACY_FIBERS_MANGLE), \
+    TRACY_DISALLOW_HW_TIMER_MANGLE), \
+    TRACY_TIMER_FALLBACK_MANGLE), \
+    TRACY_PLATFORM_HEADER_MANGLE)
+
+#endif // __TRACYMANGLE_HPP__

--- a/D3D11Engine/include/tracy/public/client/TracyOverride.cpp
+++ b/D3D11Engine/include/tracy/public/client/TracyOverride.cpp
@@ -12,11 +12,11 @@ extern "C" int dlclose( void* hnd )
     struct link_map* lm;
     if( dlinfo( hnd, RTLD_DI_LINKMAP, &lm ) == 0 )
     {
-        TracyDebug( "Overriding dlclose for %s\n", lm->l_name );
+        TracyDebug( "Overriding dlclose for %s", lm->l_name );
     }
     else
     {
-        TracyDebug( "Overriding dlclose for unknown object (%s)\n", dlerror() );
+        TracyDebug( "Overriding dlclose for unknown object (%s)", dlerror() );
     }
 #endif
     return 0;

--- a/D3D11Engine/include/tracy/public/client/TracyProfiler.cpp
+++ b/D3D11Engine/include/tracy/public/client/TracyProfiler.cpp
@@ -10,12 +10,13 @@
 #  include <inttypes.h>
 #  include <intrin.h>
 #  include "../common/TracyWinFamily.hpp"
-#  ifndef _MSC_VER
+#  if defined(_MSC_VER) // https://devblogs.microsoft.com/oldnewthing/20200730-00/?p=104021/
+#    define fileno _fileno
+#  else
 #    include <excpt.h>
 #  endif
 #else
 #  include <sys/time.h>
-#  include <sys/param.h>
 #endif
 
 #ifdef _GNU_SOURCE
@@ -29,7 +30,7 @@
 #  include <sys/syscall.h>
 #endif
 
-#if defined __APPLE__ || defined BSD
+#if defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
 #  include <sys/types.h>
 #  include <sys/sysctl.h>
 #endif
@@ -43,13 +44,11 @@
 #  include <sys/mman.h>
 #  include <sys/system_properties.h>
 #  include <stdio.h>
-#  include <stdint.h>
 #  include <algorithm>
 #  include <vector>
 #endif
 
 #ifdef __QNX__
-#  include <stdint.h>
 #  include <stdio.h>
 #  include <string.h>
 #  include <sys/syspage.h>
@@ -57,11 +56,11 @@
 #endif
 
 #include <algorithm>
-#include <assert.h>
 #include <atomic>
 #include <chrono>
 #include <limits>
 #include <new>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -69,11 +68,11 @@
 
 #include "../common/TracyAlign.hpp"
 #include "../common/TracyAlloc.hpp"
+#include "../common/TracyAssert.hpp"
 #include "../common/TracySocket.hpp"
 #include "../common/TracySystem.hpp"
 #include "../common/TracyYield.hpp"
 #include "../common/tracy_lz4.hpp"
-#include "tracy_rpmalloc.hpp"
 #include "TracyCallstack.hpp"
 #include "TracyDebug.hpp"
 #include "TracyDxt1.hpp"
@@ -84,10 +83,6 @@
 #include "TracySysTrace.hpp"
 #include "../tracy/TracyC.h"
 
-#if defined TRACY_MANUAL_LIFETIME && !defined(TRACY_DELAYED_INIT)
-#  error "TRACY_MANUAL_LIFETIME requires enabled TRACY_DELAYED_INIT"
-#endif
-
 #ifdef TRACY_PORT
 #  ifndef TRACY_DATA_PORT
 #    define TRACY_DATA_PORT TRACY_PORT
@@ -97,11 +92,7 @@
 #  endif
 #endif
 
-#ifdef __APPLE__
-#  ifndef TRACY_DELAYED_INIT
-#    define TRACY_DELAYED_INIT
-#  endif
-#else
+#ifndef __APPLE__
 #  ifdef __GNUC__
 #    define init_order( val ) __attribute__ ((init_priority(val)))
 #  else
@@ -282,6 +273,9 @@ static bool EnsureReadable( uintptr_t address )
     return mapping && EnsureReadable( *mapping );
 }
 #elif defined WIN32
+#ifdef TRACY_HAS_CNTVCT
+static_assert( TRACY_WINARM64_CNTVCT_EL0 == ARM64_CNTVCT_EL0, "ARM64_CNTVCT_EL0 mismatch" );
+#endif
 static bool EnsureReadable( uintptr_t address )
 {
     MEMORY_BASIC_INFORMATION memInfo;
@@ -422,8 +416,13 @@ static int64_t SetupHwTimer()
 }
 #endif
 
+uint32_t ___tracy_magic_pid_override = 0;
+char ___tracy_magic_process_name[64] = {};
+
 static const char* GetProcessName()
 {
+    if( *___tracy_magic_process_name != 0 ) return ___tracy_magic_process_name;
+
     const char* processName = "unknown";
 #ifdef _WIN32
     static char buf[_MAX_PATH];
@@ -440,7 +439,7 @@ static const char* GetProcessName()
 #  endif
 #elif defined __linux__ && defined _GNU_SOURCE
     if( program_invocation_short_name ) processName = program_invocation_short_name;
-#elif defined __APPLE__ || defined BSD
+#elif defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
     auto buf = getprogname();
     if( buf ) processName = buf;
 #elif defined __QNX__
@@ -517,7 +516,7 @@ static const char* GetHostInfo()
     auto ptr = buf;
 #if defined _WIN32
 #  if defined TRACY_WIN32_NO_DESKTOP
-    auto GetVersion = &::GetVersionEx;
+    auto GetVersion = &::GetVersionExW;
 #  else
     auto GetVersion = (t_RtlGetVersion)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "RtlGetVersion" );
 #  endif
@@ -595,38 +594,20 @@ static const char* GetHostInfo()
 
 #if defined _WIN32
     InitWinSock();
-
-    char hostname[512];
-    gethostname( hostname, 512 );
-
-#  if defined TRACY_WIN32_NO_DESKTOP
-    const char* user = "";
-#  else
-    DWORD userSz = UNLEN+1;
-    char user[UNLEN+1];
-    GetUserNameA( user, &userSz );
-#  endif
-
-    ptr += sprintf( ptr, "User: %s@%s\n", user, hostname );
-#else
-    char hostname[_POSIX_HOST_NAME_MAX]{};
-    gethostname( hostname, _POSIX_HOST_NAME_MAX );
-#  if defined __ANDROID__
-    const auto login = getlogin();
-    if( login )
-    {
-        ptr += sprintf( ptr, "User: %s@%s\n", login, hostname );
-    }
-    else
-    {
-        ptr += sprintf( ptr, "User: (?)@%s\n", hostname );
-    }
-#  else
-    char user[_POSIX_LOGIN_NAME_MAX]{};
-    getlogin_r( user, _POSIX_LOGIN_NAME_MAX );
-    ptr += sprintf( ptr, "User: %s@%s\n", user, hostname );
-#  endif
 #endif
+
+    const char* user = GetUserLogin();
+    char hostname[512] = {};
+#if defined TRACY_HAS_CUSTOM_USER_INFO
+    PlatformGetHostname( hostname, sizeof( hostname ) );
+#else
+    gethostname( hostname, sizeof( hostname ) );
+#endif
+    ptr += sprintf( ptr, "User: %s@%s", user, hostname );
+
+    const char* fullName = GetUserFullName();
+    if( fullName ) ptr += sprintf( ptr, " (%s)", fullName );
+    ptr += sprintf( ptr, "\n" );
 
 #if defined __i386 || defined _M_IX86
     ptr += sprintf( ptr, "Arch: x86\n" );
@@ -656,7 +637,7 @@ static const char* GetHostInfo()
     FILE* fcpuinfo = fopen( "/proc/cpuinfo", "rb" );
     if( fcpuinfo )
     {
-        enum { BufSize = 4*1024 };
+        constexpr size_t BufSize = 4*1024;
         char buf[BufSize];
         const auto sz = fread( buf, 1, BufSize, fcpuinfo );
         fclose( fcpuinfo );
@@ -740,7 +721,7 @@ static const char* GetHostInfo()
     size_t sz = sizeof( memSize );
     sysctlbyname( "hw.memsize", &memSize, &sz, nullptr, 0 );
     ptr += sprintf( ptr, "RAM: %zu MB\n", memSize / 1024 / 1024 );
-#elif defined BSD
+#elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
     size_t memSize;
     size_t sz = sizeof( memSize );
     sysctlbyname( "hw.physmem", &memSize, &sz, nullptr, 0 );
@@ -769,6 +750,8 @@ static const char* GetHostInfo()
 
 static uint64_t GetPid()
 {
+    if( ___tracy_magic_pid_override != 0 ) return uint64_t( ___tracy_magic_pid_override );
+
 #if defined _WIN32
     return uint64_t( GetCurrentProcessId() );
 #else
@@ -867,7 +850,8 @@ LONG WINAPI CrashFilter( PEXCEPTION_POINTERS pExp )
     }
 
     {
-        GetProfiler().SendCallstack( 60, "KiUserExceptionDispatcher" );
+        const char* remove[] = { "KiUserExceptionDispatcher", nullptr };
+        GetProfiler().SendCallstack( 60, remove );
 
         TracyQueuePrepare( QueueType::CrashReport );
         item->crashReport.time = Profiler::GetTime();
@@ -933,7 +917,7 @@ static Thread* s_symbolThread;
 std::atomic<bool> s_symbolThreadGone { false };
 #endif
 #ifdef TRACY_HAS_SYSTEM_TRACING
-static std::atomic<Thread*> s_sysTraceThread = nullptr;
+static std::atomic<Thread*> s_sysTraceThread(nullptr);
 #endif
 
 #if defined __linux__ && !defined TRACY_NO_CRASH_HANDLER
@@ -977,7 +961,7 @@ static inline void HexPrint( char*& ptr, uint64_t val )
     while( bptr != buf );
 }
 
-static void CrashHandler( int signal, siginfo_t* info, void* /*ucontext*/ )
+TRACY_API void TracyCrashHandler( int signal, siginfo_t* info, void* /*ucontext*/ )
 {
     bool expected = false;
     if( !s_alreadyCrashed.compare_exchange_strong( expected, true ) ) ThreadFreezer( signal );
@@ -1129,7 +1113,12 @@ static void CrashHandler( int signal, siginfo_t* info, void* /*ucontext*/ )
     }
 
     {
-        GetProfiler().SendCallstack( 60, "__kernel_rt_sigreturn" );
+        const char* remove[] = {
+            "__kernel_rt_sigreturn",
+            "TracyCrashHandler",
+            nullptr
+        };
+        GetProfiler().SendCallstack( 60, remove );
 
         TracyQueuePrepare( QueueType::CrashReport );
         item->crashReport.time = Profiler::GetTime();
@@ -1172,7 +1161,7 @@ static void CrashHandler( int signal, siginfo_t* info, void* /*ucontext*/ )
 #ifdef TRACY_HAS_SYSTEM_TRACING
 static void StartSystemTracing( int64_t& samplingPeriod )
 {
-    assert( s_sysTraceThread == nullptr );
+    TRACY_ASSERT( s_sysTraceThread == nullptr );
 
     // use TRACY_NO_SYS_TRACE=1 to force disabling sys tracing (even if available in the underlying system)
     // as it can have significant impact on the size of the traces
@@ -1180,14 +1169,14 @@ static void StartSystemTracing( int64_t& samplingPeriod )
     const bool disableSystrace = ( noSysTrace && noSysTrace[0] == '1' );
     if( disableSystrace )
     {
-        TracyDebug( "TRACY: Sys Trace was disabled by 'TRACY_NO_SYS_TRACE=1'\n" );
+        TracyDebug( "TRACY: Sys Trace was disabled by 'TRACY_NO_SYS_TRACE=1'" );
     }
     else if( SysTraceStart( samplingPeriod ) )
     {
         Thread* sysTraceThread = (Thread*)tracy_malloc( sizeof( Thread ) );
         new( sysTraceThread ) Thread( SysTraceWorker, nullptr );
         Thread* prev = s_sysTraceThread.exchange( sysTraceThread );
-        assert( prev == nullptr );
+        TRACY_ASSERT( prev == nullptr );
         std::this_thread::sleep_for( std::chrono::milliseconds( 1 ) );
     }
 }
@@ -1220,7 +1209,7 @@ void Profiler::EndSamplingProfiling()
 #endif
 }
 
-enum { QueuePrealloc = 256 * 1024 };
+constexpr size_t QueuePrealloc = 256 * 1024;
 
 TRACY_API int64_t GetFrequencyQpc()
 {
@@ -1243,7 +1232,7 @@ struct ProfilerData
     moodycamel::ConcurrentQueue<QueueItem> queue;
     Profiler profiler;
     std::atomic<uint32_t> lockCounter { 0 };
-    std::atomic<uint8_t> gpuCtxCounter { 0 };
+    std::atomic<uint32_t> gpuCtxCounter { 0 };
     std::atomic<ThreadNameData*> threadNameData { nullptr };
 };
 
@@ -1283,7 +1272,7 @@ TRACY_API void StartupProfiler()
 }
 static ProfilerData& GetProfilerData()
 {
-    assert( s_profilerData );
+    TRACY_ASSERT( s_profilerData );
     return *s_profilerData;
 }
 TRACY_API void ShutdownProfiler()
@@ -1292,7 +1281,11 @@ TRACY_API void ShutdownProfiler()
     s_profilerData->~ProfilerData();
     tracy_free( s_profilerData );
     s_profilerData = nullptr;
+#if defined TRACY_HAS_CUSTOM_ALLOCATOR
+    PlatformAllocatorFinalize();
+#elif defined TRACY_USE_RPMALLOC
     rpmalloc_finalize();
+#endif
     RpThreadInitDone = false;
     RpInitDone.store( 0, std::memory_order_release );
 }
@@ -1337,13 +1330,13 @@ public:
     {
         int val = pthread_key_create(&m_key, sDestructor);
         static_cast<void>(val); // unused
-        assert(val == 0);
+        TRACY_ASSERT(val == 0);
     }
     ~ProfilerThreadDataKey()
     {
         int val = pthread_key_delete(m_key);
         static_cast<void>(val); // unused
-        assert(val == 0);
+        TRACY_ASSERT(val == 0);
     }
     ProfilerThreadData& get()
     {
@@ -1379,12 +1372,12 @@ static ProfilerThreadData& GetProfilerThreadData()
 }
 #endif
 
-TRACY_API moodycamel::ConcurrentQueue<QueueItem>::ExplicitProducer* GetToken() { return GetProfilerThreadData().token.ptr; }
-TRACY_API Profiler& GetProfiler() { return GetProfilerData().profiler; }
+TRACY_API moodycamel::ConcurrentQueue<QueueItem>::ExplicitProducer* MANGLED_NAME_BASED_ON_CONFIG(GetToken)() { return GetProfilerThreadData().token.ptr; }
+TRACY_API Profiler& MANGLED_NAME_BASED_ON_CONFIG(GetProfiler)() { return GetProfilerData().profiler; }
 TRACY_API moodycamel::ConcurrentQueue<QueueItem>& GetQueue() { return GetProfilerData().queue; }
 TRACY_API int64_t GetInitTime() { return GetProfilerData().initTime; }
 TRACY_API std::atomic<uint32_t>& GetLockCounter() { return GetProfilerData().lockCounter; }
-TRACY_API std::atomic<uint8_t>& GetGpuCtxCounter() { return GetProfilerData().gpuCtxCounter; }
+TRACY_API std::atomic<uint32_t>& GetGpuCtxCounter() { return GetProfilerData().gpuCtxCounter; }
 TRACY_API GpuCtxWrapper& GetGpuCtx() { return GetProfilerThreadData().gpuCtx; }
 TRACY_API uint32_t GetThreadHandle() { return detail::GetThreadHandleImpl(); }
 std::atomic<ThreadNameData*>& GetThreadNameData() { return GetProfilerData().threadNameData; }
@@ -1407,9 +1400,30 @@ namespace
 // 1a. But s_queue is needed for initialization of variables in point 2.
 extern moodycamel::ConcurrentQueue<QueueItem> s_queue;
 
+// A producer token may be created before s_initTime is constructed (the dynamic loader
+// runs shared object initializers before any of the executable's constructors, and such
+// an initializer may emit a zone). Remember the time of such an early token creation, so
+// that the init time can be backdated accordingly and no event timestamp precedes the
+// trace epoch.
+static std::atomic<int64_t> s_earlyTokenTime { 0 };
+static bool s_initTimeConstructed = false;
+
 // 2. If these variables would be in the .CRT$XCB section, they would be initialized only in main thread.
 thread_local moodycamel::ProducerToken init_order(107) s_token_detail( s_queue );
-thread_local ProducerWrapper init_order(108) s_token { s_queue.get_explicit_producer( s_token_detail ) };
+
+static moodycamel::ConcurrentQueue<QueueItem>::ExplicitProducer* CreateProducerToken()
+{
+    auto ptr = s_queue.get_explicit_producer( s_token_detail );
+    if( !s_initTimeConstructed )
+    {
+        const auto t = Profiler::GetTime();
+        auto e = s_earlyTokenTime.load( std::memory_order_relaxed );
+        while( ( e == 0 || t < e ) && !s_earlyTokenTime.compare_exchange_weak( e, t, std::memory_order_relaxed ) ) {}
+    }
+    return ptr;
+}
+
+thread_local ProducerWrapper init_order(108) s_token { CreateProducerToken() };
 thread_local ThreadHandleWrapper init_order(104) s_threadHandle { detail::GetThreadHandleImpl() };
 
 #  ifdef _MSC_VER
@@ -1418,14 +1432,38 @@ thread_local ThreadHandleWrapper init_order(104) s_threadHandle { detail::GetThr
 #    pragma init_seg( ".CRT$XCB" )
 #  endif
 
-static InitTimeWrapper init_order(101) s_initTime { SetupHwTimer() };
+static int64_t GetInitTimeImpl()
+{
+    auto t = SetupHwTimer();
+    const auto e = s_earlyTokenTime.load( std::memory_order_relaxed );
+    if( e != 0 && e < t ) t = e;
+    s_initTimeConstructed = true;
+    return t;
+}
+static InitTimeWrapper init_order(101) s_initTime { GetInitTimeImpl() };
 std::atomic<int> init_order(102) RpInitDone( 0 );
 std::atomic<int> init_order(102) RpInitLock( 0 );
 thread_local bool RpThreadInitDone = false;
 thread_local bool RpThreadShutdown = false;
 moodycamel::ConcurrentQueue<QueueItem> init_order(103) s_queue( QueuePrealloc );
+
+#  ifndef _MSC_VER
+// An instrumented shared object may emit zones from its static initializers, which the
+// dynamic loader runs before any of the executable's constructors, including the
+// priority-ordered constructor of s_queue above. The main thread producer token (s_token)
+// is then lazily created against the zero-initialized queue memory, and the queue
+// constructor subsequently orphans it, making all zones emitted on the main thread
+// invisible to the consumer. Re-adopt such a producer here. If no zones were emitted up
+// to this point, this only triggers construction of s_token, which is a no-op repair.
+struct EarlyMainThreadTokenRepair
+{
+    EarlyMainThreadTokenRepair() { if( s_token.ptr ) s_queue.readopt_orphaned_producer( s_token.ptr ); }
+};
+static EarlyMainThreadTokenRepair init_order(104) s_earlyMainThreadTokenRepair;
+#  endif
+
 std::atomic<uint32_t> init_order(104) s_lockCounter( 0 );
-std::atomic<uint8_t> init_order(104) s_gpuCtxCounter( 0 );
+std::atomic<uint32_t> init_order(104) s_gpuCtxCounter( 0 );
 
 thread_local GpuCtxWrapper init_order(104) s_gpuCtx { nullptr };
 
@@ -1439,12 +1477,12 @@ thread_local LuaZoneState init_order(104) s_luaZoneState { 0, false };
 
 static Profiler init_order(105) s_profiler;
 
-TRACY_API moodycamel::ConcurrentQueue<QueueItem>::ExplicitProducer* GetToken() { return s_token.ptr; }
-TRACY_API Profiler& GetProfiler() { return s_profiler; }
+TRACY_API moodycamel::ConcurrentQueue<QueueItem>::ExplicitProducer* MANGLED_NAME_BASED_ON_CONFIG(GetToken)() { return s_token.ptr; }
+TRACY_API Profiler& MANGLED_NAME_BASED_ON_CONFIG(GetProfiler)() { return s_profiler; }
 TRACY_API moodycamel::ConcurrentQueue<QueueItem>& GetQueue() { return s_queue; }
 TRACY_API int64_t GetInitTime() { return s_initTime.val; }
 TRACY_API std::atomic<uint32_t>& GetLockCounter() { return s_lockCounter; }
-TRACY_API std::atomic<uint8_t>& GetGpuCtxCounter() { return s_gpuCtxCounter; }
+TRACY_API std::atomic<uint32_t>& GetGpuCtxCounter() { return s_gpuCtxCounter; }
 TRACY_API GpuCtxWrapper& GetGpuCtx() { return s_gpuCtx; }
 TRACY_API uint32_t GetThreadHandle() { return s_threadHandle.val; }
 
@@ -1454,6 +1492,18 @@ std::atomic<ThreadNameData*>& GetThreadNameData() { return s_threadNameData; }
 TRACY_API LuaZoneState& GetLuaZoneState() { return s_luaZoneState; }
 #  endif
 #endif
+
+TRACY_API int32_t NextGpuContextId()
+{
+    const auto id = GetGpuCtxCounter().fetch_add( 1, std::memory_order_relaxed );
+    if( id > UINT8_MAX )
+    {
+        Profiler::LogString( MessageSourceType::Tracy, MessageSeverity::Error, 0, 0, "Tracy: more than 256 GPU contexts in this process; gpu context ids are 8-bit" );
+        TRACY_ASSERT( false );
+        return InvalidGpuContextId;
+    }
+    return int32_t( id );
+}
 
 TRACY_API bool ProfilerAvailable() { return s_instance != nullptr; }
 TRACY_API bool ProfilerAllocatorAvailable() { return !RpThreadShutdown; }
@@ -1475,6 +1525,7 @@ Profiler::Profiler()
     , m_noExit( false )
     , m_userPort( 0 )
     , m_zoneId( 1 )
+    , m_sectionId( 1 )
     , m_samplingPeriod( 0 )
     , m_stream( LZ4_createStream() )
     , m_buffer( (char*)tracy_malloc( TargetFrameSize*3 ) )
@@ -1502,7 +1553,7 @@ Profiler::Profiler()
     , m_crashHandlerInstalled( false )
     , m_programName( nullptr )
 {
-    assert( !s_instance );
+    TRACY_ASSERT( !s_instance );
     s_instance = this;
 
 #ifndef TRACY_DELAYED_INIT
@@ -1539,9 +1590,9 @@ Profiler::Profiler()
 
     m_safeSendBuffer = (char*)tracy_malloc( SafeSendBufferSize );
 
-#ifndef _WIN32
+#if !defined _WIN32 && !defined TRACY_HAS_CUSTOM_SAFE_COPY
     pipe(m_pipe);
-#  if defined __APPLE__ || defined BSD
+#  if defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
     // FreeBSD/XNU don't have F_SETPIPE_SZ, so use the default
     m_pipeBufSize = 16384;
 #  else
@@ -1566,7 +1617,7 @@ void Profiler::InstallCrashHandler()
     sigaction( TRACY_CRASH_SIGNAL, &threadFreezer, &m_prevSignal.pwr );
 
     struct sigaction crashHandler = {};
-    crashHandler.sa_sigaction = CrashHandler;
+    crashHandler.sa_sigaction = TracyCrashHandler;
     crashHandler.sa_flags = SA_SIGINFO;
     sigaction( SIGILL, &crashHandler, &m_prevSignal.ill );
     sigaction( SIGFPE, &crashHandler, &m_prevSignal.fpe );
@@ -1604,7 +1655,7 @@ void Profiler::RemoveCrashHandler()
         auto restore = []( int signum, struct sigaction* prev ) {
             struct sigaction old;
             sigaction( signum, prev, &old );
-            if( old.sa_sigaction != CrashHandler ) sigaction( signum, &old, nullptr ); // A different signal handler was installed over ours => put it back
+            if( old.sa_sigaction != TracyCrashHandler ) sigaction( signum, &old, nullptr ); // A different signal handler was installed over ours => put it back
         };
         restore( TRACY_CRASH_SIGNAL, &m_prevSignal.pwr );
         restore( SIGILL, &m_prevSignal.ill );
@@ -1683,7 +1734,7 @@ Profiler::~Profiler()
     tracy_free( m_kcore );
 #endif
 
-#ifndef _WIN32
+#if !defined _WIN32 && !defined TRACY_HAS_CUSTOM_SAFE_COPY
     close( m_pipe[0] );
     close( m_pipe[1] );
 #endif
@@ -1705,7 +1756,7 @@ Profiler::~Profiler()
         tracy_free( m_broadcast );
     }
 
-    assert( s_instance );
+    TRACY_ASSERT( s_instance );
     s_instance = nullptr;
 }
 
@@ -1931,7 +1982,7 @@ void Profiler::Worker()
                     lastBroadcast = t;
                     const auto ts = std::chrono::duration_cast<std::chrono::seconds>( std::chrono::system_clock::now().time_since_epoch() ).count();
                     broadcastMsg.activeTime = int32_t( ts - m_epoch );
-                    assert( broadcastMsg.activeTime >= 0 );
+                    TRACY_ASSERT( broadcastMsg.activeTime >= 0 );
                     m_broadcast->Send( broadcastPort, &broadcastMsg, broadcastLen );
                 }
             }
@@ -1978,8 +2029,12 @@ void Profiler::Worker()
         }
 
 #ifdef TRACY_ON_DEMAND
+#  ifdef TRACY_HAS_CALLSTACK
+        // Only wait on m_symbolsBusy if the symbol worker thread exists; otherwise nobody
+        // ever resets the flag and we'd spin forever on the second connection.
         while( m_symbolsBusy.load( std::memory_order_acquire ) ) { YieldThread(); }
         m_symbolsBusy.store( true, std::memory_order_release );
+#  endif
         const auto currentTime = GetTime();
         ClearQueues( token );
         m_connectionId.fetch_add( 1, std::memory_order_release );
@@ -2010,22 +2065,27 @@ void Profiler::Worker()
         {
             uint64_t ptr;
             uint16_t size;
-            const auto idx = MemRead<uint8_t>( &item.hdr.idx );
+            const auto idx = MemRead( &item.hdr.idx );
             switch( (QueueType)idx )
             {
             case QueueType::MessageAppInfo:
-                ptr = MemRead<uint64_t>( &item.messageFat.text );
-                size = MemRead<uint16_t>( &item.messageFat.size );
+                ptr = MemRead( &item.messageFat.textAndMetadata ).GetAddress();
+                size = MemRead( &item.messageFat.size );
                 SendSingleString( (const char*)ptr, size );
                 break;
             case QueueType::LockName:
-                ptr = MemRead<uint64_t>( &item.lockNameFat.name );
-                size = MemRead<uint16_t>( &item.lockNameFat.size );
+                ptr = MemRead( &item.lockNameFat.name );
+                size = MemRead( &item.lockNameFat.size );
                 SendSingleString( (const char*)ptr, size );
                 break;
             case QueueType::GpuContextName:
-                ptr = MemRead<uint64_t>( &item.gpuContextNameFat.ptr );
-                size = MemRead<uint16_t>( &item.gpuContextNameFat.size );
+                ptr = MemRead( &item.gpuContextNameFat.ptr );
+                size = MemRead( &item.gpuContextNameFat.size );
+                SendSingleString( (const char*)ptr, size );
+                break;
+            case QueueType::SectionSetup:
+                ptr = MemRead( &item.sectionSetupFat.text );
+                size = MemRead( &item.sectionSetupFat.size );
                 SendSingleString( (const char*)ptr, size );
                 break;
             default:
@@ -2082,6 +2142,7 @@ void Profiler::Worker()
                 connActive = HandleServerQuery();
                 if( !connActive ) break;
             }
+            if ( !m_symbolQueue.empty() ) m_symbolQueueSignal.notify_one();
             if( !connActive || ShouldExit() ) break;
         }
         if( ShouldExit() ) break;
@@ -2154,7 +2215,7 @@ void Profiler::Worker()
     // takes care of calling StopSystemTracing(). However, a client may decide to
     // manually RequestShutdown(), in which case ~Profile() may not execute before
     // this Worker() thread goes through its teardown stages and reaches this point.
-    // To ensure that system tracing does not keep pushing data to the worker queue 
+    // To ensure that system tracing does not keep pushing data to the worker queue
     // indefinitely (thus preventing this worker from terminating), we have to call
     // StopSystemTracing() here as well to be safe:
     StopSystemTracing();
@@ -2284,12 +2345,12 @@ void Profiler::CompressWorker()
                 const auto w = fi->w;
                 const auto h = fi->h;
                 const auto csz = size_t( w * h / 2 );
-                auto etc1buf = (char*)tracy_malloc( csz );
-                CompressImageDxt1( (const char*)fi->image, etc1buf, w, h );
+                auto texbuf = (char*)tracy_malloc( csz );
+                CompressImageDxt1( (const char*)fi->image, texbuf, w, h );
                 tracy_free( fi->image );
 
                 TracyLfqPrepare( QueueType::FrameImage );
-                MemWrite( &item->frameImageFat.image, (uint64_t)etc1buf );
+                MemWrite( &item->frameImageFat.image, (uint64_t)texbuf );
                 MemWrite( &item->frameImageFat.frame, fi->frame );
                 MemWrite( &item->frameImageFat.w, w );
                 MemWrite( &item->frameImageFat.h, h );
@@ -2323,12 +2384,12 @@ static void FreeAssociatedMemory( const QueueItem& item )
     {
     case QueueType::ZoneText:
     case QueueType::ZoneName:
-        ptr = MemRead<uint64_t>( &item.zoneTextFat.text );
+        ptr = MemRead( &item.zoneTextFat.text );
         tracy_free( (void*)ptr );
         break;
     case QueueType::MessageColor:
     case QueueType::MessageColorCallstack:
-        ptr = MemRead<uint64_t>( &item.messageColorFat.text );
+        ptr = MemRead( &item.messageColorFat.textAndMetadata ).GetAddress();
         tracy_free( (void*)ptr );
         break;
     case QueueType::Message:
@@ -2336,47 +2397,47 @@ static void FreeAssociatedMemory( const QueueItem& item )
 #ifndef TRACY_ON_DEMAND
     case QueueType::MessageAppInfo:
 #endif
-        ptr = MemRead<uint64_t>( &item.messageFat.text );
+        ptr = MemRead( &item.messageFat.textAndMetadata ).GetAddress();
         tracy_free( (void*)ptr );
         break;
     case QueueType::ZoneBeginAllocSrcLoc:
     case QueueType::ZoneBeginAllocSrcLocCallstack:
-        ptr = MemRead<uint64_t>( &item.zoneBegin.srcloc );
+        ptr = MemRead( &item.zoneBegin.srcloc );
         tracy_free( (void*)ptr );
         break;
     case QueueType::GpuZoneBeginAllocSrcLoc:
     case QueueType::GpuZoneBeginAllocSrcLocCallstack:
     case QueueType::GpuZoneBeginAllocSrcLocSerial:
     case QueueType::GpuZoneBeginAllocSrcLocCallstackSerial:
-        ptr = MemRead<uint64_t>( &item.gpuZoneBegin.srcloc );
+        ptr = MemRead( &item.gpuZoneBegin.srcloc );
         tracy_free( (void*)ptr );
         break;
     case QueueType::CallstackSerial:
     case QueueType::Callstack:
-        ptr = MemRead<uint64_t>( &item.callstackFat.ptr );
+        ptr = MemRead( &item.callstackFat.ptr );
         tracy_free( (void*)ptr );
         break;
     case QueueType::CallstackAlloc:
-        ptr = MemRead<uint64_t>( &item.callstackAllocFat.nativePtr );
+        ptr = MemRead( &item.callstackAllocFat.nativePtr );
         tracy_free( (void*)ptr );
-        ptr = MemRead<uint64_t>( &item.callstackAllocFat.ptr );
+        ptr = MemRead( &item.callstackAllocFat.ptr );
         tracy_free( (void*)ptr );
         break;
     case QueueType::CallstackSample:
     case QueueType::CallstackSampleContextSwitch:
-        ptr = MemRead<uint64_t>( &item.callstackSampleFat.ptr );
+        ptr = MemRead( &item.callstackSampleFat.ptr );
         tracy_free( (void*)ptr );
         break;
     case QueueType::FrameImage:
-        ptr = MemRead<uint64_t>( &item.frameImageFat.image );
+        ptr = MemRead( &item.frameImageFat.image );
         tracy_free( (void*)ptr );
         break;
 #ifdef TRACY_HAS_CALLSTACK
     case QueueType::CallstackFrameSize:
     {
-        InitRpmalloc();
-        auto size = MemRead<uint8_t>( &item.callstackFrameSizeFat.size );
-        auto data = (const CallstackEntry*)MemRead<uint64_t>( &item.callstackFrameSizeFat.data );
+        InitAllocator();
+        auto size = MemRead( &item.callstackFrameSizeFat.size );
+        auto data = (const CallstackEntry*)MemRead( &item.callstackFrameSizeFat.data );
         for( uint8_t i=0; i<size; i++ )
         {
             const auto& frame = data[i];
@@ -2388,51 +2449,62 @@ static void FreeAssociatedMemory( const QueueItem& item )
     }
     case QueueType::SymbolInformation:
     {
-        uint8_t needFree = MemRead<uint8_t>( &item.symbolInformationFat.needFree );
+        uint8_t needFree = MemRead( &item.symbolInformationFat.needFree );
         if( needFree )
         {
-            ptr = MemRead<uint64_t>( &item.symbolInformationFat.fileString );
+            ptr = MemRead( &item.symbolInformationFat.fileString );
             tracy_free( (void*)ptr );
         }
         break;
     }
     case QueueType::SymbolCodeMetadata:
-        ptr = MemRead<uint64_t>( &item.symbolCodeMetadata.ptr );
+        ptr = MemRead( &item.symbolCodeMetadata.ptr );
         tracy_free( (void*)ptr );
         break;
 #endif
 #ifndef TRACY_ON_DEMAND
     case QueueType::LockName:
-        ptr = MemRead<uint64_t>( &item.lockNameFat.name );
+        ptr = MemRead( &item.lockNameFat.name );
         tracy_free( (void*)ptr );
         break;
     case QueueType::GpuContextName:
-        ptr = MemRead<uint64_t>( &item.gpuContextNameFat.ptr );
+        ptr = MemRead( &item.gpuContextNameFat.ptr );
         tracy_free( (void*)ptr );
         break;
 #endif
     case QueueType::GpuAnnotationName:
-        ptr = MemRead<uint64_t>( &item.gpuAnnotationNameFat.ptr );
+        ptr = MemRead( &item.gpuAnnotationNameFat.ptr );
         tracy_free( (void*)ptr );
         break;
 #ifdef TRACY_ON_DEMAND
     case QueueType::MessageAppInfo:
     case QueueType::GpuContextName:
+    case QueueType::SectionSetup:
         // Don't free memory associated with deferred messages.
         break;
 #endif
 #ifdef TRACY_HAS_SYSTEM_TRACING
     case QueueType::ExternalNameMetadata:
-        ptr = MemRead<uint64_t>( &item.externalNameMetadata.name );
+        ptr = MemRead( &item.externalNameMetadata.name );
         tracy_free( (void*)ptr );
-        ptr = MemRead<uint64_t>( &item.externalNameMetadata.threadName );
+        ptr = MemRead( &item.externalNameMetadata.threadName );
         tracy_free_fast( (void*)ptr );
         break;
 #endif
     case QueueType::SourceCodeMetadata:
-        ptr = MemRead<uint64_t>( &item.sourceCodeMetadata.ptr );
+        ptr = MemRead( &item.sourceCodeMetadata.ptr );
         tracy_free( (void*)ptr );
         break;
+    case QueueType::SectionEnter:
+        ptr = MemRead( &item.sectionEnterFat.text );
+        tracy_free( (void*)ptr );
+        break;
+#ifndef TRACY_ON_DEMAND
+    case QueueType::SectionSetup:
+        ptr = MemRead( &item.sectionSetupFat.text );
+        tracy_free( (void*)ptr );
+        break;
+#endif
     default:
         break;
     }
@@ -2442,7 +2514,7 @@ void Profiler::ClearQueues( moodycamel::ConsumerToken& token )
 {
     for(;;)
     {
-        const auto sz = GetQueue().try_dequeue_bulk_single( token, [](const uint64_t&){}, []( QueueItem* item, size_t sz ) { assert( sz > 0 ); while( sz-- > 0 ) FreeAssociatedMemory( *item++ ); } );
+        const auto sz = GetQueue().try_dequeue_bulk_single( token, [](const uint64_t&){}, []( QueueItem* item, size_t sz ) { TRACY_ASSERT( sz > 0 ); while( sz-- > 0 ) FreeAssociatedMemory( *item++ ); } );
         if( sz == 0 ) break;
     }
 
@@ -2482,8 +2554,8 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
         [this, &connectionLost] ( QueueItem* item, size_t sz )
         {
             if( connectionLost ) return;
-            InitRpmalloc();
-            assert( sz > 0 );
+            InitAllocator();
+            TRACY_ASSERT( sz > 0 );
             int64_t refThread = m_refTimeThread;
             int64_t refCtx = m_refTimeCtx;
             int64_t refGpu = m_refTimeGpu;
@@ -2491,35 +2563,41 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
             {
                 uint64_t ptr;
                 uint16_t size;
-                auto idx = MemRead<uint8_t>( &item->hdr.idx );
+                auto idx = MemRead( &item->hdr.idx );
                 if( idx < (int)QueueType::Terminate )
                 {
                     switch( (QueueType)idx )
                     {
                     case QueueType::ZoneText:
                     case QueueType::ZoneName:
-                        ptr = MemRead<uint64_t>( &item->zoneTextFat.text );
-                        size = MemRead<uint16_t>( &item->zoneTextFat.size );
+                        ptr = MemRead( &item->zoneTextFat.text );
+                        size = MemRead( &item->zoneTextFat.size );
                         SendSingleString( (const char*)ptr, size );
                         tracy_free_fast( (void*)ptr );
                         break;
                     case QueueType::Message:
                     case QueueType::MessageCallstack:
-                        ptr = MemRead<uint64_t>( &item->messageFat.text );
-                        size = MemRead<uint16_t>( &item->messageFat.size );
+                    {
+                        TaggedUserlandAddress taggedPtr = MemRead( &item->messageFat.textAndMetadata );
+                        ptr = taggedPtr.GetAddress();
+                        size = MemRead( &item->messageFat.size );
                         SendSingleString( (const char*)ptr, size );
                         tracy_free_fast( (void*)ptr );
                         break;
+                    }
                     case QueueType::MessageColor:
                     case QueueType::MessageColorCallstack:
-                        ptr = MemRead<uint64_t>( &item->messageColorFat.text );
-                        size = MemRead<uint16_t>( &item->messageColorFat.size );
+                    {
+                        TaggedUserlandAddress taggedPtr = MemRead( &item->messageColorFat.textAndMetadata );
+                        ptr = taggedPtr.GetAddress();
+                        size = MemRead( &item->messageColorFat.size );
                         SendSingleString( (const char*)ptr, size );
                         tracy_free_fast( (void*)ptr );
                         break;
+                    }
                     case QueueType::MessageAppInfo:
-                        ptr = MemRead<uint64_t>( &item->messageFat.text );
-                        size = MemRead<uint16_t>( &item->messageFat.size );
+                        ptr = MemRead( &item->messageFat.textAndMetadata ).GetAddress();
+                        size = MemRead( &item->messageFat.size );
                         SendSingleString( (const char*)ptr, size );
 #ifndef TRACY_ON_DEMAND
                         tracy_free_fast( (void*)ptr );
@@ -2528,49 +2606,68 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
                     case QueueType::ZoneBeginAllocSrcLoc:
                     case QueueType::ZoneBeginAllocSrcLocCallstack:
                     {
-                        int64_t t = MemRead<int64_t>( &item->zoneBegin.time );
+                        int64_t t = MemRead( &item->zoneBegin.time );
                         int64_t dt = t - refThread;
                         refThread = t;
                         MemWrite( &item->zoneBegin.time, dt );
-                        ptr = MemRead<uint64_t>( &item->zoneBegin.srcloc );
+                        ptr = MemRead( &item->zoneBegin.srcloc );
                         SendSourceLocationPayload( ptr );
                         tracy_free_fast( (void*)ptr );
                         break;
                     }
                     case QueueType::Callstack:
-                        ptr = MemRead<uint64_t>( &item->callstackFat.ptr );
+                        ptr = MemRead( &item->callstackFat.ptr );
                         SendCallstackPayload( ptr );
                         tracy_free_fast( (void*)ptr );
                         break;
                     case QueueType::CallstackAlloc:
-                        ptr = MemRead<uint64_t>( &item->callstackAllocFat.nativePtr );
+                        ptr = MemRead( &item->callstackAllocFat.nativePtr );
                         if( ptr != 0 )
                         {
-                            CutCallstack( (void*)ptr, "lua_pcall" );
+                            const char* remove[] = { "lua_pcall", nullptr };
+                            CutCallstack( (void*)ptr, remove );
                             SendCallstackPayload( ptr );
                             tracy_free_fast( (void*)ptr );
                         }
-                        ptr = MemRead<uint64_t>( &item->callstackAllocFat.ptr );
+                        ptr = MemRead( &item->callstackAllocFat.ptr );
                         SendCallstackAlloc( ptr );
                         tracy_free_fast( (void*)ptr );
                         break;
                     case QueueType::CallstackSample:
                     case QueueType::CallstackSampleContextSwitch:
                     {
-                        ptr = MemRead<uint64_t>( &item->callstackSampleFat.ptr );
+                        ptr = MemRead( &item->callstackSampleFat.ptr );
                         SendCallstackPayload64( ptr );
                         tracy_free_fast( (void*)ptr );
-                        int64_t t = MemRead<int64_t>( &item->callstackSampleFat.time );
+                        int64_t t = MemRead( &item->callstackSampleFat.time );
                         int64_t dt = t - refCtx;
                         refCtx = t;
+                        if( dt >= 0 )
+                        {
+                            if( dt < ProtocolOffset16Bit )
+                            {
+                                idx = QueueType( idx ) == QueueType::CallstackSample ? (int)QueueType::CallstackSample16 : (int)QueueType::CallstackSampleContextSwitch16;
+                                MemWrite( &item->hdr.idx, idx );
+                            }
+                            else if( dt < ProtocolOffset32Bit )
+                            {
+                                dt -= ProtocolOffset16Bit;
+                                idx = QueueType( idx ) == QueueType::CallstackSample ? (int)QueueType::CallstackSample32 : (int)QueueType::CallstackSampleContextSwitch32;
+                                MemWrite( &item->hdr.idx, idx );
+                            }
+                            else
+                            {
+                                dt -= ProtocolOffset32Bit;
+                            }
+                        }
                         MemWrite( &item->callstackSampleFat.time, dt );
                         break;
                     }
                     case QueueType::FrameImage:
                     {
-                        ptr = MemRead<uint64_t>( &item->frameImageFat.image );
-                        const auto w = MemRead<uint16_t>( &item->frameImageFat.w );
-                        const auto h = MemRead<uint16_t>( &item->frameImageFat.h );
+                        ptr = MemRead( &item->frameImageFat.image );
+                        const auto w = MemRead( &item->frameImageFat.w );
+                        const auto h = MemRead( &item->frameImageFat.h );
                         const auto csz = size_t( w * h / 2 );
                         SendLongString( ptr, (const char*)ptr, csz, QueueType::FrameImageData );
                         tracy_free_fast( (void*)ptr );
@@ -2579,24 +2676,68 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
                     case QueueType::ZoneBegin:
                     case QueueType::ZoneBeginCallstack:
                     {
-                        int64_t t = MemRead<int64_t>( &item->zoneBegin.time );
+                        int64_t t = MemRead( &item->zoneBegin.time );
                         int64_t dt = t - refThread;
                         refThread = t;
+                        if( dt >= 0 )
+                        {
+                            if( dt < ProtocolOffset16Bit )
+                            {
+                                const uint64_t srcloc = MemRead( &item->zoneBegin.srcloc );
+                                idx = QueueType( idx ) == QueueType::ZoneBegin ? (int)QueueType::ZoneBegin16 : (int)QueueType::ZoneBeginCallstack16;
+                                MemWrite( &item->hdr.idx, idx );
+                                MemWrite( &item->zoneBegin16.time, uint16_t( dt ) );
+                                MemWrite( &item->zoneBegin16.srcloc, srcloc );
+                                break;
+                            }
+                            else if( dt < ProtocolOffset32Bit )
+                            {
+                                dt -= ProtocolOffset16Bit;
+                                const uint64_t srcloc = MemRead( &item->zoneBegin.srcloc );
+                                idx = QueueType( idx ) == QueueType::ZoneBegin ? (int)QueueType::ZoneBegin32 : (int)QueueType::ZoneBeginCallstack32;
+                                MemWrite( &item->hdr.idx, idx );
+                                MemWrite( &item->zoneBegin32.time, uint32_t( dt ) );
+                                MemWrite( &item->zoneBegin32.srcloc, srcloc );
+                                break;
+                            }
+                            else
+                            {
+                                dt -= ProtocolOffset32Bit;
+                            }
+                        }
                         MemWrite( &item->zoneBegin.time, dt );
                         break;
                     }
                     case QueueType::ZoneEnd:
                     {
-                        int64_t t = MemRead<int64_t>( &item->zoneEnd.time );
+                        int64_t t = MemRead( &item->zoneEnd.time );
                         int64_t dt = t - refThread;
                         refThread = t;
+                        if( dt >= 0 )
+                        {
+                            if( dt < ProtocolOffset16Bit )
+                            {
+                                idx = (int)QueueType::ZoneEnd16;
+                                MemWrite( &item->hdr.idx, idx );
+                            }
+                            else if( dt < ProtocolOffset32Bit )
+                            {
+                                dt -= ProtocolOffset16Bit;
+                                idx = (int)QueueType::ZoneEnd32;
+                                MemWrite( &item->hdr.idx, idx );
+                            }
+                            else
+                            {
+                                dt -= ProtocolOffset32Bit;
+                            }
+                        }
                         MemWrite( &item->zoneEnd.time, dt );
                         break;
                     }
                     case QueueType::GpuZoneBegin:
                     case QueueType::GpuZoneBeginCallstack:
                     {
-                        int64_t t = MemRead<int64_t>( &item->gpuZoneBegin.cpuTime );
+                        int64_t t = MemRead( &item->gpuZoneBegin.cpuTime );
                         int64_t dt = t - refThread;
                         refThread = t;
                         MemWrite( &item->gpuZoneBegin.cpuTime, dt );
@@ -2605,34 +2746,34 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
                     case QueueType::GpuZoneBeginAllocSrcLoc:
                     case QueueType::GpuZoneBeginAllocSrcLocCallstack:
                     {
-                        int64_t t = MemRead<int64_t>( &item->gpuZoneBegin.cpuTime );
+                        int64_t t = MemRead( &item->gpuZoneBegin.cpuTime );
                         int64_t dt = t - refThread;
                         refThread = t;
                         MemWrite( &item->gpuZoneBegin.cpuTime, dt );
-                        ptr = MemRead<uint64_t>( &item->gpuZoneBegin.srcloc );
+                        ptr = MemRead( &item->gpuZoneBegin.srcloc );
                         SendSourceLocationPayload( ptr );
                         tracy_free_fast( (void*)ptr );
                         break;
                     }
                     case QueueType::GpuZoneEnd:
                     {
-                        int64_t t = MemRead<int64_t>( &item->gpuZoneEnd.cpuTime );
+                        int64_t t = MemRead( &item->gpuZoneEnd.cpuTime );
                         int64_t dt = t - refThread;
                         refThread = t;
                         MemWrite( &item->gpuZoneEnd.cpuTime, dt );
                         break;
                     }
                     case QueueType::GpuContextName:
-                        ptr = MemRead<uint64_t>( &item->gpuContextNameFat.ptr );
-                        size = MemRead<uint16_t>( &item->gpuContextNameFat.size );
+                        ptr = MemRead( &item->gpuContextNameFat.ptr );
+                        size = MemRead( &item->gpuContextNameFat.size );
                         SendSingleString( (const char*)ptr, size );
 #ifndef TRACY_ON_DEMAND
                         tracy_free_fast( (void*)ptr );
 #endif
                         break;
                     case QueueType::GpuAnnotationName:
-                        ptr = MemRead<uint64_t>( &item->gpuAnnotationNameFat.ptr );
-                        size = MemRead<uint16_t>( &item->gpuAnnotationNameFat.size );
+                        ptr = MemRead( &item->gpuAnnotationNameFat.ptr );
+                        size = MemRead( &item->gpuAnnotationNameFat.size );
                         SendSingleString( (const char*)ptr, size );
                         tracy_free_fast( (void*)ptr );
                         break;
@@ -2640,7 +2781,7 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
                     case QueueType::PlotDataFloat:
                     case QueueType::PlotDataDouble:
                     {
-                        int64_t t = MemRead<int64_t>( &item->plotDataInt.time );
+                        int64_t t = MemRead( &item->plotDataInt.time );
                         int64_t dt = t - refThread;
                         refThread = t;
                         MemWrite( &item->plotDataInt.time, dt );
@@ -2648,7 +2789,7 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
                     }
                     case QueueType::ContextSwitch:
                     {
-                        int64_t t = MemRead<int64_t>( &item->contextSwitch.time );
+                        int64_t t = MemRead( &item->contextSwitch.time );
                         int64_t dt = t - refCtx;
                         refCtx = t;
                         MemWrite( &item->contextSwitch.time, dt );
@@ -2656,7 +2797,7 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
                     }
                     case QueueType::ThreadWakeup:
                     {
-                        int64_t t = MemRead<int64_t>( &item->threadWakeup.time );
+                        int64_t t = MemRead( &item->threadWakeup.time );
                         int64_t dt = t - refCtx;
                         refCtx = t;
                         MemWrite( &item->threadWakeup.time, dt );
@@ -2664,7 +2805,7 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
                     }
                     case QueueType::GpuTime:
                     {
-                        int64_t t = MemRead<int64_t>( &item->gpuTime.gpuTime );
+                        int64_t t = MemRead( &item->gpuTime.gpuTime );
                         int64_t dt = t - refGpu;
                         refGpu = t;
                         MemWrite( &item->gpuTime.gpuTime, dt );
@@ -2673,9 +2814,9 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
 #ifdef TRACY_HAS_CALLSTACK
                     case QueueType::CallstackFrameSize:
                     {
-                        auto data = (const CallstackEntry*)MemRead<uint64_t>( &item->callstackFrameSizeFat.data );
-                        auto datasz = MemRead<uint8_t>( &item->callstackFrameSizeFat.size );
-                        auto imageName = (const char*)MemRead<uint64_t>( &item->callstackFrameSizeFat.imageName );
+                        auto data = (const CallstackEntry*)MemRead( &item->callstackFrameSizeFat.data );
+                        auto datasz = MemRead( &item->callstackFrameSizeFat.size );
+                        auto imageName = (const char*)MemRead( &item->callstackFrameSizeFat.imageName );
                         SendSingleString( imageName );
                         AppendData( item++, QueueDataSize[idx] );
 
@@ -2702,17 +2843,17 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
                     }
                     case QueueType::SymbolInformation:
                     {
-                        auto fileString = (const char*)MemRead<uint64_t>( &item->symbolInformationFat.fileString );
-                        auto needFree = MemRead<uint8_t>( &item->symbolInformationFat.needFree );
+                        auto fileString = (const char*)MemRead( &item->symbolInformationFat.fileString );
+                        auto needFree = MemRead( &item->symbolInformationFat.needFree );
                         SendSingleString( fileString );
                         if( needFree ) tracy_free_fast( (void*)fileString );
                         break;
                     }
                     case QueueType::SymbolCodeMetadata:
                     {
-                        auto symbol = MemRead<uint64_t>( &item->symbolCodeMetadata.symbol );
-                        auto ptr = (const char*)MemRead<uint64_t>( &item->symbolCodeMetadata.ptr );
-                        auto size = MemRead<uint32_t>( &item->symbolCodeMetadata.size );
+                        auto symbol = MemRead( &item->symbolCodeMetadata.symbol );
+                        auto ptr = (const char*)MemRead( &item->symbolCodeMetadata.ptr );
+                        auto size = MemRead( &item->symbolCodeMetadata.size );
                         SendLongString( symbol, ptr, size, QueueType::SymbolCode );
                         tracy_free_fast( (void*)ptr );
                         ++item;
@@ -2722,9 +2863,9 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
 #ifdef TRACY_HAS_SYSTEM_TRACING
                     case QueueType::ExternalNameMetadata:
                     {
-                        auto thread = MemRead<uint64_t>( &item->externalNameMetadata.thread );
-                        auto name = (const char*)MemRead<uint64_t>( &item->externalNameMetadata.name );
-                        auto threadName = (const char*)MemRead<uint64_t>( &item->externalNameMetadata.threadName );
+                        auto thread = MemRead( &item->externalNameMetadata.thread );
+                        auto name = (const char*)MemRead( &item->externalNameMetadata.name );
+                        auto threadName = (const char*)MemRead( &item->externalNameMetadata.threadName );
                         SendString( thread, threadName, QueueType::ExternalThreadName );
                         SendString( thread, name, QueueType::ExternalName );
                         tracy_free_fast( (void*)threadName );
@@ -2735,16 +2876,44 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
 #endif
                     case QueueType::SourceCodeMetadata:
                     {
-                        auto ptr = (const char*)MemRead<uint64_t>( &item->sourceCodeMetadata.ptr );
-                        auto size = MemRead<uint32_t>( &item->sourceCodeMetadata.size );
-                        auto id = MemRead<uint32_t>( &item->sourceCodeMetadata.id );
+                        auto ptr = (const char*)MemRead( &item->sourceCodeMetadata.ptr );
+                        auto size = MemRead( &item->sourceCodeMetadata.size );
+                        auto id = MemRead( &item->sourceCodeMetadata.id );
                         SendLongString( (uint64_t)id, ptr, size, QueueType::SourceCode );
                         tracy_free_fast( (void*)ptr );
                         ++item;
                         continue;
                     }
+                    case QueueType::SectionEnter:
+                    {
+                        int64_t t = MemRead( &item->sectionEnter.time );
+                        int64_t dt = t - refThread;
+                        refThread = t;
+                        MemWrite( &item->sectionEnter.time, dt );
+                        ptr = MemRead( &item->sectionEnterFat.text );
+                        size = MemRead( &item->sectionEnterFat.size );
+                        SendSingleString( (const char*)ptr, size );
+                        tracy_free_fast( (void*)ptr );
+                        break;
+                    }
+                    case QueueType::SectionLeave:
+                    {
+                        int64_t t = MemRead( &item->sectionLeave.time );
+                        int64_t dt = t - refThread;
+                        refThread = t;
+                        MemWrite( &item->sectionLeave.time, dt );
+                        break;
+                    }
+                    case QueueType::SectionSetup:
+                        ptr = MemRead( &item->sectionSetupFat.text );
+                        size = MemRead( &item->sectionSetupFat.size );
+                        SendSingleString( (const char*)ptr, size );
+#ifndef TRACY_ON_DEMAND
+                        tracy_free_fast( (void*)ptr );
+#endif
+                        break;
                     default:
-                        assert( false );
+                        TRACY_ASSERT( false );
                         break;
                     }
                 }
@@ -2771,16 +2940,16 @@ Profiler::DequeueStatus Profiler::DequeueContextSwitches( tracy::moodycamel::Con
     const auto sz = GetQueue().try_dequeue_bulk_single( token, [] ( const uint64_t& ) {},
         [this, &timeStop] ( QueueItem* item, size_t sz )
         {
-            assert( sz > 0 );
+            TRACY_ASSERT( sz > 0 );
             int64_t refCtx = m_refTimeCtx;
             while( sz-- > 0 )
             {
                 FreeAssociatedMemory( *item );
                 if( timeStop < 0 ) return;
-                const auto idx = MemRead<uint8_t>( &item->hdr.idx );
+                const auto idx = MemRead( &item->hdr.idx );
                 if( idx == (uint8_t)QueueType::ContextSwitch )
                 {
-                    const auto csTime = MemRead<int64_t>( &item->contextSwitch.time );
+                    const auto csTime = MemRead( &item->contextSwitch.time );
                     if( csTime > timeStop )
                     {
                         timeStop = -1;
@@ -2799,7 +2968,7 @@ Profiler::DequeueStatus Profiler::DequeueContextSwitches( tracy::moodycamel::Con
                 }
                 else if( idx == (uint8_t)QueueType::ThreadWakeup )
                 {
-                    const auto csTime = MemRead<int64_t>( &item->threadWakeup.time );
+                    const auto csTime = MemRead( &item->threadWakeup.time );
                     if( csTime > timeStop )
                     {
                         timeStop = -1;
@@ -2827,13 +2996,13 @@ Profiler::DequeueStatus Profiler::DequeueContextSwitches( tracy::moodycamel::Con
 }
 
 #define ThreadCtxCheckSerial( _name ) \
-    uint32_t thread = MemRead<uint32_t>( &item->_name.thread ); \
+    uint32_t thread = MemRead( &item->_name.thread ); \
     switch( ThreadCtxCheck( thread ) ) \
     { \
     case ThreadCtxStatus::Same: break; \
-    case ThreadCtxStatus::Changed: assert( m_refTimeThread == 0 ); refThread = 0; break; \
+    case ThreadCtxStatus::Changed: TRACY_ASSERT( m_refTimeThread == 0 ); refThread = 0; break; \
     case ThreadCtxStatus::ConnectionLost: return DequeueStatus::ConnectionLost; \
-    default: assert( false ); break; \
+    default: TRACY_ASSERT( false ); break; \
     }
 
 Profiler::DequeueStatus Profiler::DequeueSerial()
@@ -2862,7 +3031,7 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
     {
         dequeueStatus = DequeueStatus::DataDequeued;
 
-        InitRpmalloc();
+        InitAllocator();
         int64_t refSerial = m_refTimeSerial;
         int64_t refGpu = m_refTimeGpu;
 #ifdef TRACY_FIBERS
@@ -2873,20 +3042,20 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
         while( item != end )
         {
             uint64_t ptr;
-            auto idx = MemRead<uint8_t>( &item->hdr.idx );
+            auto idx = MemRead( &item->hdr.idx );
             if( idx < (int)QueueType::Terminate )
             {
                 switch( (QueueType)idx )
                 {
                 case QueueType::CallstackSerial:
-                    ptr = MemRead<uint64_t>( &item->callstackFat.ptr );
+                    ptr = MemRead( &item->callstackFat.ptr );
                     SendCallstackPayload( ptr );
                     tracy_free_fast( (void*)ptr );
                     break;
                 case QueueType::LockWait:
                 case QueueType::LockSharedWait:
                 {
-                    int64_t t = MemRead<int64_t>( &item->lockWait.time );
+                    int64_t t = MemRead( &item->lockWait.time );
                     int64_t dt = t - refSerial;
                     refSerial = t;
                     MemWrite( &item->lockWait.time, dt );
@@ -2895,7 +3064,7 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::LockObtain:
                 case QueueType::LockSharedObtain:
                 {
-                    int64_t t = MemRead<int64_t>( &item->lockObtain.time );
+                    int64_t t = MemRead( &item->lockObtain.time );
                     int64_t dt = t - refSerial;
                     refSerial = t;
                     MemWrite( &item->lockObtain.time, dt );
@@ -2904,7 +3073,7 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::LockRelease:
                 case QueueType::LockSharedRelease:
                 {
-                    int64_t t = MemRead<int64_t>( &item->lockRelease.time );
+                    int64_t t = MemRead( &item->lockRelease.time );
                     int64_t dt = t - refSerial;
                     refSerial = t;
                     MemWrite( &item->lockRelease.time, dt );
@@ -2912,8 +3081,8 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 }
                 case QueueType::LockName:
                 {
-                    ptr = MemRead<uint64_t>( &item->lockNameFat.name );
-                    uint16_t size = MemRead<uint16_t>( &item->lockNameFat.size );
+                    ptr = MemRead( &item->lockNameFat.name );
+                    uint16_t size = MemRead( &item->lockNameFat.size );
                     SendSingleString( (const char*)ptr, size );
 #ifndef TRACY_ON_DEMAND
                     tracy_free_fast( (void*)ptr );
@@ -2925,7 +3094,7 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::MemAllocCallstack:
                 case QueueType::MemAllocCallstackNamed:
                 {
-                    int64_t t = MemRead<int64_t>( &item->memAlloc.time );
+                    int64_t t = MemRead( &item->memAlloc.time );
                     int64_t dt = t - refSerial;
                     refSerial = t;
                     MemWrite( &item->memAlloc.time, dt );
@@ -2936,7 +3105,7 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::MemFreeCallstack:
                 case QueueType::MemFreeCallstackNamed:
                 {
-                    int64_t t = MemRead<int64_t>( &item->memFree.time );
+                    int64_t t = MemRead( &item->memFree.time );
                     int64_t dt = t - refSerial;
                     refSerial = t;
                     MemWrite( &item->memFree.time, dt );
@@ -2945,7 +3114,7 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::MemDiscard:
                 case QueueType::MemDiscardCallstack:
                 {
-                    int64_t t = MemRead<int64_t>( &item->memDiscard.time );
+                    int64_t t = MemRead( &item->memDiscard.time );
                     int64_t dt = t - refSerial;
                     refSerial = t;
                     MemWrite( &item->memDiscard.time, dt );
@@ -2954,7 +3123,7 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::GpuZoneBeginSerial:
                 case QueueType::GpuZoneBeginCallstackSerial:
                 {
-                    int64_t t = MemRead<int64_t>( &item->gpuZoneBegin.cpuTime );
+                    int64_t t = MemRead( &item->gpuZoneBegin.cpuTime );
                     int64_t dt = t - refSerial;
                     refSerial = t;
                     MemWrite( &item->gpuZoneBegin.cpuTime, dt );
@@ -2963,18 +3132,18 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::GpuZoneBeginAllocSrcLocSerial:
                 case QueueType::GpuZoneBeginAllocSrcLocCallstackSerial:
                 {
-                    int64_t t = MemRead<int64_t>( &item->gpuZoneBegin.cpuTime );
+                    int64_t t = MemRead( &item->gpuZoneBegin.cpuTime );
                     int64_t dt = t - refSerial;
                     refSerial = t;
                     MemWrite( &item->gpuZoneBegin.cpuTime, dt );
-                    ptr = MemRead<uint64_t>( &item->gpuZoneBegin.srcloc );
+                    ptr = MemRead( &item->gpuZoneBegin.srcloc );
                     SendSourceLocationPayload( ptr );
                     tracy_free_fast( (void*)ptr );
                     break;
                 }
                 case QueueType::GpuZoneEndSerial:
                 {
-                    int64_t t = MemRead<int64_t>( &item->gpuZoneEnd.cpuTime );
+                    int64_t t = MemRead( &item->gpuZoneEnd.cpuTime );
                     int64_t dt = t - refSerial;
                     refSerial = t;
                     MemWrite( &item->gpuZoneEnd.cpuTime, dt );
@@ -2982,7 +3151,7 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 }
                 case QueueType::GpuTime:
                 {
-                    int64_t t = MemRead<int64_t>( &item->gpuTime.gpuTime );
+                    int64_t t = MemRead( &item->gpuTime.gpuTime );
                     int64_t dt = t - refGpu;
                     refGpu = t;
                     MemWrite( &item->gpuTime.gpuTime, dt );
@@ -2990,8 +3159,8 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 }
                 case QueueType::GpuContextName:
                 {
-                    ptr = MemRead<uint64_t>( &item->gpuContextNameFat.ptr );
-                    uint16_t size = MemRead<uint16_t>( &item->gpuContextNameFat.size );
+                    ptr = MemRead( &item->gpuContextNameFat.ptr );
+                    uint16_t size = MemRead( &item->gpuContextNameFat.size );
                     SendSingleString( (const char*)ptr, size );
 #ifndef TRACY_ON_DEMAND
                     tracy_free_fast( (void*)ptr );
@@ -3000,8 +3169,8 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 }
                 case QueueType::GpuAnnotationName:
                 {
-                    ptr = MemRead<uint64_t>( &item->gpuAnnotationNameFat.ptr );
-                    uint16_t size = MemRead<uint16_t>( &item->gpuAnnotationNameFat.size );
+                    ptr = MemRead( &item->gpuAnnotationNameFat.ptr );
+                    uint16_t size = MemRead( &item->gpuAnnotationNameFat.size );
                     SendSingleString( (const char*)ptr, size );
                     tracy_free_fast( (void*)ptr );
                     break;
@@ -3011,9 +3180,35 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::ZoneBeginCallstack:
                 {
                     ThreadCtxCheckSerial( zoneBeginThread );
-                    int64_t t = MemRead<int64_t>( &item->zoneBegin.time );
+                    int64_t t = MemRead( &item->zoneBegin.time );
                     int64_t dt = t - refThread;
                     refThread = t;
+                    if( dt >= 0 )
+                    {
+                        if( dt < ProtocolOffset16Bit )
+                        {
+                            const uint64_t srcloc = MemRead( &item->zoneBegin.srcloc );
+                            idx = QueueType( idx ) == QueueType::ZoneBegin ? (int)QueueType::ZoneBegin16 : (int)QueueType::ZoneBeginCallstack16;
+                            MemWrite( &item->hdr.idx, idx );
+                            MemWrite( &item->zoneBegin16.time, uint16_t( dt ) );
+                            MemWrite( &item->zoneBegin16.srcloc, srcloc );
+                            break;
+                        }
+                        else if( dt < ProtocolOffset32Bit )
+                        {
+                            dt -= ProtocolOffset16Bit;
+                            const uint64_t srcloc = MemRead( &item->zoneBegin.srcloc );
+                            idx = QueueType( idx ) == QueueType::ZoneBegin ? (int)QueueType::ZoneBegin32 : (int)QueueType::ZoneBeginCallstack32;
+                            MemWrite( &item->hdr.idx, idx );
+                            MemWrite( &item->zoneBegin32.time, uint32_t( dt ) );
+                            MemWrite( &item->zoneBegin32.srcloc, srcloc );
+                            break;
+                        }
+                        else
+                        {
+                            dt -= ProtocolOffset32Bit;
+                        }
+                    }
                     MemWrite( &item->zoneBegin.time, dt );
                     break;
                 }
@@ -3021,11 +3216,11 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::ZoneBeginAllocSrcLocCallstack:
                 {
                     ThreadCtxCheckSerial( zoneBeginThread );
-                    int64_t t = MemRead<int64_t>( &item->zoneBegin.time );
+                    int64_t t = MemRead( &item->zoneBegin.time );
                     int64_t dt = t - refThread;
                     refThread = t;
                     MemWrite( &item->zoneBegin.time, dt );
-                    ptr = MemRead<uint64_t>( &item->zoneBegin.srcloc );
+                    ptr = MemRead( &item->zoneBegin.srcloc );
                     SendSourceLocationPayload( ptr );
                     tracy_free_fast( (void*)ptr );
                     break;
@@ -3033,9 +3228,27 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::ZoneEnd:
                 {
                     ThreadCtxCheckSerial( zoneEndThread );
-                    int64_t t = MemRead<int64_t>( &item->zoneEnd.time );
+                    int64_t t = MemRead( &item->zoneEnd.time );
                     int64_t dt = t - refThread;
                     refThread = t;
+                    if( dt >= 0 )
+                    {
+                        if( dt < ProtocolOffset16Bit )
+                        {
+                            idx = (int)QueueType::ZoneEnd16;
+                            MemWrite( &item->hdr.idx, idx );
+                        }
+                        else if( dt < ProtocolOffset32Bit )
+                        {
+                            dt -= ProtocolOffset16Bit;
+                            idx = (int)QueueType::ZoneEnd32;
+                            MemWrite( &item->hdr.idx, idx );
+                        }
+                        else
+                        {
+                            dt -= ProtocolOffset32Bit;
+                        }
+                    }
                     MemWrite( &item->zoneEnd.time, dt );
                     break;
                 }
@@ -3043,8 +3256,8 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::ZoneName:
                 {
                     ThreadCtxCheckSerial( zoneTextFatThread );
-                    ptr = MemRead<uint64_t>( &item->zoneTextFat.text );
-                    uint16_t size = MemRead<uint16_t>( &item->zoneTextFat.size );
+                    ptr = MemRead( &item->zoneTextFat.text );
+                    uint16_t size = MemRead( &item->zoneTextFat.size );
                     SendSingleString( (const char*)ptr, size );
                     tracy_free_fast( (void*)ptr );
                     break;
@@ -3053,8 +3266,9 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::MessageCallstack:
                 {
                     ThreadCtxCheckSerial( messageFatThread );
-                    ptr = MemRead<uint64_t>( &item->messageFat.text );
-                    uint16_t size = MemRead<uint16_t>( &item->messageFat.size );
+                    TaggedUserlandAddress taggedPtr = MemRead( &item->messageFat.textAndMetadata );
+                    ptr = taggedPtr.GetAddress();
+                    uint16_t size = MemRead( &item->messageFat.size );
                     SendSingleString( (const char*)ptr, size );
                     tracy_free_fast( (void*)ptr );
                     break;
@@ -3063,8 +3277,9 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::MessageColorCallstack:
                 {
                     ThreadCtxCheckSerial( messageColorFatThread );
-                    ptr = MemRead<uint64_t>( &item->messageColorFat.text );
-                    uint16_t size = MemRead<uint16_t>( &item->messageColorFat.size );
+                    TaggedUserlandAddress taggedPtr = MemRead( &item->messageColorFat.textAndMetadata );
+                    ptr = taggedPtr.GetAddress();
+                    uint16_t size = MemRead( &item->messageColorFat.size );
                     SendSingleString( (const char*)ptr, size );
                     tracy_free_fast( (void*)ptr );
                     break;
@@ -3072,7 +3287,7 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::Callstack:
                 {
                     ThreadCtxCheckSerial( callstackFatThread );
-                    ptr = MemRead<uint64_t>( &item->callstackFat.ptr );
+                    ptr = MemRead( &item->callstackFat.ptr );
                     SendCallstackPayload( ptr );
                     tracy_free_fast( (void*)ptr );
                     break;
@@ -3080,14 +3295,15 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::CallstackAlloc:
                 {
                     ThreadCtxCheckSerial( callstackAllocFatThread );
-                    ptr = MemRead<uint64_t>( &item->callstackAllocFat.nativePtr );
+                    ptr = MemRead( &item->callstackAllocFat.nativePtr );
                     if( ptr != 0 )
                     {
-                        CutCallstack( (void*)ptr, "lua_pcall" );
+                        const char* remove[] = { "lua_pcall", nullptr };
+                        CutCallstack( (void*)ptr, remove );
                         SendCallstackPayload( ptr );
                         tracy_free_fast( (void*)ptr );
                     }
-                    ptr = MemRead<uint64_t>( &item->callstackAllocFat.ptr );
+                    ptr = MemRead( &item->callstackAllocFat.ptr );
                     SendCallstackAlloc( ptr );
                     tracy_free_fast( (void*)ptr );
                     break;
@@ -3095,7 +3311,7 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::FiberEnter:
                 {
                     ThreadCtxCheckSerial( fiberEnter );
-                    int64_t t = MemRead<int64_t>( &item->fiberEnter.time );
+                    int64_t t = MemRead( &item->fiberEnter.time );
                     int64_t dt = t - refThread;
                     refThread = t;
                     MemWrite( &item->fiberEnter.time, dt );
@@ -3104,7 +3320,7 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 case QueueType::FiberLeave:
                 {
                     ThreadCtxCheckSerial( fiberLeave );
-                    int64_t t = MemRead<int64_t>( &item->fiberLeave.time );
+                    int64_t t = MemRead( &item->fiberLeave.time );
                     int64_t dt = t - refThread;
                     refThread = t;
                     MemWrite( &item->fiberLeave.time, dt );
@@ -3112,7 +3328,7 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                 }
 #endif
                 default:
-                    assert( false );
+                    TRACY_ASSERT( false );
                     break;
                 }
             }
@@ -3199,12 +3415,14 @@ char* Profiler::SafeCopyProlog( const char* data, size_t size )
     bool success = true;
     char* buf = m_safeSendBuffer;
 #ifndef NDEBUG
-    assert( !m_inUse.exchange(true) );
+    TRACY_ASSERT( !m_inUse.exchange(true) );
 #endif
 
     if( size > SafeSendBufferSize ) buf = (char*)tracy_malloc( size );
 
-#ifdef _WIN32
+#if defined TRACY_HAS_CUSTOM_SAFE_COPY
+    success = PlatformSafeMemcpy( buf, data, size );
+#elif defined _WIN32
 #  ifdef _MSC_VER
     __try
     {
@@ -3263,7 +3481,7 @@ bool Profiler::SendData( const char* data, size_t len )
 
 void Profiler::SendString( uint64_t str, const char* ptr, size_t len, QueueType type )
 {
-    assert( type == QueueType::StringData ||
+    TRACY_ASSERT( type == QueueType::StringData ||
             type == QueueType::ThreadName ||
             type == QueueType::PlotName ||
             type == QueueType::FrameName ||
@@ -3275,7 +3493,7 @@ void Profiler::SendString( uint64_t str, const char* ptr, size_t len, QueueType 
     MemWrite( &item.hdr.type, type );
     MemWrite( &item.stringTransfer.ptr, str );
 
-    assert( len <= std::numeric_limits<uint16_t>::max() );
+    TRACY_ASSERT( len <= std::numeric_limits<uint16_t>::max() );
     auto l16 = uint16_t( len );
 
     NeedDataSize( QueueDataSize[(int)type] + sizeof( l16 ) + l16 );
@@ -3285,39 +3503,71 @@ void Profiler::SendString( uint64_t str, const char* ptr, size_t len, QueueType 
     AppendDataUnsafe( ptr, l16 );
 }
 
-void Profiler::SendSingleString( const char* ptr, size_t len )
+void Profiler::SendSingleString8( const char* ptr, size_t len )
+{
+    QueueItem item;
+    MemWrite( &item.hdr.type, QueueType::SingleStringData8 );
+
+    TRACY_ASSERT( len <= std::numeric_limits<uint8_t>::max() );
+    auto l8 = uint8_t( len );
+
+    NeedDataSize( QueueDataSize[(int)QueueType::SingleStringData8] + sizeof( l8 ) + len );
+
+    AppendDataUnsafe( &item, QueueDataSize[(int)QueueType::SingleStringData8] );
+    AppendDataUnsafe( &l8, sizeof( l8 ) );
+    AppendDataUnsafe( ptr, len );
+}
+
+void Profiler::SendSingleString16( const char* ptr, size_t len )
 {
     QueueItem item;
     MemWrite( &item.hdr.type, QueueType::SingleStringData );
 
-    assert( len <= std::numeric_limits<uint16_t>::max() );
-    auto l16 = uint16_t( len );
+    TRACY_ASSERT( len > std::numeric_limits<uint8_t>::max() );
+    TRACY_ASSERT( len <= ProtocolOffset8Bit + std::numeric_limits<uint16_t>::max() );
+    auto l16 = uint16_t( len - ProtocolOffset8Bit );
 
-    NeedDataSize( QueueDataSize[(int)QueueType::SingleStringData] + sizeof( l16 ) + l16 );
+    NeedDataSize( QueueDataSize[(int)QueueType::SingleStringData] + sizeof( l16 ) + len );
 
     AppendDataUnsafe( &item, QueueDataSize[(int)QueueType::SingleStringData] );
     AppendDataUnsafe( &l16, sizeof( l16 ) );
-    AppendDataUnsafe( ptr, l16 );
+    AppendDataUnsafe( ptr, len );
 }
 
-void Profiler::SendSecondString( const char* ptr, size_t len )
+void Profiler::SendSecondString8( const char* ptr, size_t len )
+{
+    QueueItem item;
+    MemWrite( &item.hdr.type, QueueType::SecondStringData8 );
+
+    TRACY_ASSERT( len <= std::numeric_limits<uint8_t>::max() );
+    auto l8 = uint8_t( len );
+
+    NeedDataSize( QueueDataSize[(int)QueueType::SecondStringData8] + sizeof( l8 ) + len );
+
+    AppendDataUnsafe( &item, QueueDataSize[(int)QueueType::SecondStringData8] );
+    AppendDataUnsafe( &l8, sizeof( l8 ) );
+    AppendDataUnsafe( ptr, len );
+}
+
+void Profiler::SendSecondString16( const char* ptr, size_t len )
 {
     QueueItem item;
     MemWrite( &item.hdr.type, QueueType::SecondStringData );
 
-    assert( len <= std::numeric_limits<uint16_t>::max() );
-    auto l16 = uint16_t( len );
+    TRACY_ASSERT( len > std::numeric_limits<uint8_t>::max() );
+    TRACY_ASSERT( len <= ProtocolOffset8Bit + std::numeric_limits<uint16_t>::max() );
+    auto l16 = uint16_t( len - ProtocolOffset8Bit );
 
-    NeedDataSize( QueueDataSize[(int)QueueType::SecondStringData] + sizeof( l16 ) + l16 );
+    NeedDataSize( QueueDataSize[(int)QueueType::SecondStringData] + sizeof( l16 ) + len );
 
     AppendDataUnsafe( &item, QueueDataSize[(int)QueueType::SecondStringData] );
     AppendDataUnsafe( &l16, sizeof( l16 ) );
-    AppendDataUnsafe( ptr, l16 );
+    AppendDataUnsafe( ptr, len );
 }
 
 void Profiler::SendLongString( uint64_t str, const char* ptr, size_t len, QueueType type )
 {
-    assert( type == QueueType::FrameImageData ||
+    TRACY_ASSERT( type == QueueType::FrameImageData ||
             type == QueueType::SymbolCode ||
             type == QueueType::SourceCode );
 
@@ -3325,8 +3575,8 @@ void Profiler::SendLongString( uint64_t str, const char* ptr, size_t len, QueueT
     MemWrite( &item.hdr.type, type );
     MemWrite( &item.stringTransfer.ptr, str );
 
-    assert( len <= std::numeric_limits<uint32_t>::max() );
-    assert( QueueDataSize[(int)type] + sizeof( uint32_t ) + len <= TargetFrameSize );
+    TRACY_ASSERT( len <= std::numeric_limits<uint32_t>::max() );
+    TRACY_ASSERT( QueueDataSize[(int)type] + sizeof( uint32_t ) + len <= TargetFrameSize );
     auto l32 = uint32_t( len );
 
     NeedDataSize( QueueDataSize[(int)type] + sizeof( l32 ) + l32 );
@@ -3361,7 +3611,7 @@ void Profiler::SendSourceLocationPayload( uint64_t _ptr )
 
     uint16_t len;
     memcpy( &len, ptr, sizeof( len ) );
-    assert( len > 2 );
+    TRACY_ASSERT( len > 2 );
     len -= 2;
     ptr += 2;
 
@@ -3459,7 +3709,7 @@ void Profiler::QueueSymbolQuery( uint64_t symbol )
         SendSingleString( "<kernel>" );
         QueueItem item;
         MemWrite( &item.hdr.type, QueueType::SymbolInformation );
-        MemWrite( &item.symbolInformation.line, 0 );
+        MemWrite( &item.symbolInformation.line, uint32_t( 0 ) );
         MemWrite( &item.symbolInformation.symAddr, symbol );
         AppendData( &item, QueueDataSize[(int)QueueType::SymbolInformation] );
     }
@@ -3481,7 +3731,7 @@ void Profiler::QueueExternalName( uint64_t ptr )
 
 void Profiler::QueueKernelCode( uint64_t symbol, uint32_t size )
 {
-    assert( symbol >> 63 != 0 );
+    TRACY_ASSERT( symbol >> 63 != 0 );
 #ifdef TRACY_HAS_CALLSTACK
     m_symbolQueue.emplace( SymbolQueueItem { SymbolQueueItemType::KernelCode, symbol, size } );
 #else
@@ -3491,8 +3741,8 @@ void Profiler::QueueKernelCode( uint64_t symbol, uint32_t size )
 
 void Profiler::QueueSourceCodeQuery( uint32_t id )
 {
-    assert( m_exectime != 0 );
-    assert( m_queryData );
+    TRACY_ASSERT( m_exectime != 0 );
+    TRACY_ASSERT( m_queryData );
     m_symbolQueue.emplace( SymbolQueueItem { SymbolQueueItemType::SourceCode, uint64_t( m_queryData ), uint64_t( m_queryImage ), id } );
     m_queryData = nullptr;
     m_queryImage = nullptr;
@@ -3600,7 +3850,7 @@ void Profiler::HandleSymbolQueueItem( const SymbolQueueItem& si )
         HandleSourceCodeQuery( (char*)si.ptr, (char*)si.extra, si.id );
         break;
     default:
-        assert( false );
+        TRACY_ASSERT( false );
         break;
     }
 }
@@ -3613,9 +3863,7 @@ void Profiler::SymbolWorker()
 
     ThreadExitHandler threadExitHandler;
     SetThreadName( "Tracy Symbol Worker" );
-#ifdef TRACY_USE_RPMALLOC
-    InitRpmalloc();
-#endif
+    InitAllocator();
     InitCallstack();
     while( m_timeBegin.load( std::memory_order_relaxed ) == 0 ) std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
 
@@ -3649,7 +3897,10 @@ void Profiler::SymbolWorker()
                 s_symbolThreadGone.store( true, std::memory_order_release );
                 return;
             }
-            std::this_thread::sleep_for( std::chrono::milliseconds( 20 ) );
+            // Symbol Worker is idle: wait for Profiler Worker to enqueue more symbol queries
+            // (having a timeout ensures progress even if notifications are missed)
+            std::unique_lock<std::mutex> lock( m_symbolQueueMutex );
+            m_symbolQueueSignal.wait_for( lock, std::chrono::milliseconds( 20 ), [this]() { return !m_symbolQueue.empty(); } );
         }
     }
 }
@@ -3734,7 +3985,7 @@ bool Profiler::HandleServerQuery()
     case ServerQueryDataTransfer:
         if( m_queryData )
         {
-            assert( !m_queryImage );
+            TRACY_ASSERT( !m_queryImage );
             m_queryImage = m_queryData;
         }
         m_queryDataPtr = m_queryData = (char*)tracy_malloc( ptr + 11 );
@@ -3752,7 +4003,7 @@ bool Profiler::HandleServerQuery()
         break;
 #endif
     default:
-        assert( false );
+        TRACY_ASSERT( false );
         break;
     }
 
@@ -3916,7 +4167,7 @@ void Profiler::ReportTopology()
     {
         packageInfo = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)tracy_malloc( psz );
         auto res = _GetLogicalProcessorInformationEx( RelationProcessorPackage, packageInfo, &psz );
-        assert( res );
+        TRACY_ASSERT( res );
     }
     else
     {
@@ -3929,7 +4180,7 @@ void Profiler::ReportTopology()
     {
         dieInfo = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)tracy_malloc( dsz );
         auto res = _GetLogicalProcessorInformationEx( RelationProcessorDie, dieInfo, &dsz );
-        assert( res );
+        TRACY_ASSERT( res );
     }
     else
     {
@@ -3942,7 +4193,7 @@ void Profiler::ReportTopology()
     {
         coreInfo = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)tracy_malloc( csz );
         auto res = _GetLogicalProcessorInformationEx( RelationProcessorCore, coreInfo, &csz );
-        assert( res );
+        TRACY_ASSERT( res );
     }
     else
     {
@@ -3961,7 +4212,7 @@ void Profiler::ReportTopology()
     auto ptr = packageInfo;
     while( (char*)ptr < ((char*)packageInfo) + psz )
     {
-        assert( ptr->Relationship == RelationProcessorPackage );
+        TRACY_ASSERT( ptr->Relationship == RelationProcessorPackage );
         // FIXME account for GroupCount
         auto mask = ptr->Processor.GroupMask[0].Mask;
         int core = 0;
@@ -3979,7 +4230,7 @@ void Profiler::ReportTopology()
     ptr = dieInfo;
     while( (char*)ptr < ((char*)dieInfo) + dsz )
     {
-        assert( ptr->Relationship == RelationProcessorDie );
+        TRACY_ASSERT( ptr->Relationship == RelationProcessorDie );
         // FIXME account for GroupCount
         auto mask = ptr->Processor.GroupMask[0].Mask;
         int core = 0;
@@ -3997,7 +4248,7 @@ void Profiler::ReportTopology()
     ptr = coreInfo;
     while( (char*)ptr < ((char*)coreInfo) + csz )
     {
-        assert( ptr->Relationship == RelationProcessorCore );
+        TRACY_ASSERT( ptr->Relationship == RelationProcessorCore );
         // FIXME account for GroupCount
         auto mask = ptr->Processor.GroupMask[0].Mask;
         int core = 0;
@@ -4097,7 +4348,7 @@ void Profiler::ReportTopology()
 #endif
 }
 
-void Profiler::SendCallstack( int32_t depth, const char* skipBefore )
+void Profiler::SendCallstack( int32_t depth, const char** skipBefore )
 {
 #ifdef TRACY_HAS_CALLSTACK
     auto ptr = Callstack( depth );
@@ -4109,23 +4360,29 @@ void Profiler::SendCallstack( int32_t depth, const char* skipBefore )
 #endif
 }
 
-void Profiler::CutCallstack( void* callstack, const char* skipBefore )
+void Profiler::CutCallstack( void* callstack, const char** skipBefore )
 {
 #ifdef TRACY_HAS_CALLSTACK
     auto data = (uintptr_t*)callstack;
     const auto sz = *data++;
     uintptr_t i;
-    for( i=0; i<sz; i++ )
+    while( *skipBefore )
     {
-        auto name = DecodeCallstackPtrFast( uint64_t( data[i] ) );
-        const bool found = strcmp( name, skipBefore ) == 0;
-        if( found )
+        for( i=0; i<sz; i++ )
         {
-            i++;
-            break;
+            auto name = DecodeCallstackPtrFast( uint64_t( data[i] ) );
+            const bool found = strstr( name, *skipBefore ) != nullptr;
+            if( found )
+            {
+                i++;
+                goto found;
+            }
         }
+        skipBefore++;
     }
+    return;
 
+found:
     if( i != sz )
     {
         memmove( data, data + i, ( sz - i ) * sizeof( uintptr_t* ) );
@@ -4157,7 +4414,7 @@ void Profiler::ProcessSysTime()
 
 void Profiler::HandleParameter( uint64_t payload )
 {
-    assert( m_paramCallback );
+    TRACY_ASSERT( m_paramCallback );
     const auto idx = uint32_t( payload >> 32 );
     const auto val = int32_t( payload & 0xFFFFFFFF );
     m_paramCallback( m_paramCallbackData, idx, val );
@@ -4166,6 +4423,16 @@ void Profiler::HandleParameter( uint64_t payload )
 
 void Profiler::HandleSymbolCodeQuery( uint64_t symbol, uint32_t size )
 {
+#ifdef __linux__
+    // When profiling an external process, symbol addresses are ELF virtual
+    // addresses, not pointers in the monitor's address space.  We cannot
+    // read code bytes directly.
+    if( ___tracy_magic_pid_override != 0 )
+    {
+        AckSymbolCodeNotAvailable();
+        return;
+    }
+#endif
     if( symbol >> 63 != 0 )
     {
         QueueKernelCode( symbol, size );
@@ -4184,6 +4451,7 @@ void Profiler::HandleSymbolCodeQuery( uint64_t symbol, uint32_t size )
 void Profiler::HandleSourceCodeQuery( char* data, char* image, uint32_t id )
 {
     bool ok = false;
+#ifndef TRACY_NO_CODE_TRANSFER
     FILE* f = fopen( data, "rb" );
     if( f )
     {
@@ -4209,7 +4477,7 @@ void Profiler::HandleSourceCodeQuery( char* data, char* image, uint32_t id )
         fclose( f );
     }
 
-#ifdef TRACY_DEBUGINFOD
+#  ifdef TRACY_DEBUGINFOD
     else if( image && data[0] == '/' )
     {
         size_t size;
@@ -4217,7 +4485,7 @@ void Profiler::HandleSourceCodeQuery( char* data, char* image, uint32_t id )
         if( buildid )
         {
             auto d = debuginfod_find_source( GetDebuginfodClient(), buildid, size, data, nullptr );
-            TracyDebug( "DebugInfo source query: %s, fn: %s, image: %s\n", d >= 0 ? " ok " : "fail", data, image );
+            TracyDebug( "DebugInfo source query: %s, fn: %s, image: %s", d >= 0 ? " ok " : "fail", data, image );
             if( d >= 0 )
             {
                 struct stat st;
@@ -4247,9 +4515,9 @@ void Profiler::HandleSourceCodeQuery( char* data, char* image, uint32_t id )
     }
     else
     {
-        TracyDebug( "DebugInfo invalid query fn: %s, image: %s\n", data, image );
+        TracyDebug( "DebugInfo invalid query fn: %s, image: %s", data, image );
     }
-#endif
+#  endif
 
     if( !ok && m_sourceCallback )
     {
@@ -4272,11 +4540,12 @@ void Profiler::HandleSourceCodeQuery( char* data, char* image, uint32_t id )
             }
         }
     }
+#endif
 
     if( !ok )
     {
         TracyLfqPrepare( QueueType::AckSourceCodeNotAvailable );
-        MemWrite( &item->sourceCodeNotAvailable, id );
+        MemWrite( &item->sourceCodeNotAvailable.id, id );
         TracyLfqCommit;
     }
 
@@ -4308,6 +4577,9 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_l
     ctx.active = active;
 #endif
     if( !ctx.active ) return ctx;
+#ifdef TRACY_ON_DEMAND
+    ctx.connectionId = tracy::GetProfiler().ConnectionId();
+#endif
     const auto id = tracy::GetProfiler().GetNextZoneId();
     ctx.id = id;
 
@@ -4336,6 +4608,9 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___trac
     ctx.active = active;
 #endif
     if( !ctx.active ) return ctx;
+#ifdef TRACY_ON_DEMAND
+    ctx.connectionId = tracy::GetProfiler().ConnectionId();
+#endif
     const auto id = tracy::GetProfiler().GetNextZoneId();
     ctx.id = id;
 
@@ -4373,6 +4648,9 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int32_t
         tracy::tracy_free( (void*)srcloc );
         return ctx;
     }
+#ifdef TRACY_ON_DEMAND
+    ctx.connectionId = tracy::GetProfiler().ConnectionId();
+#endif
     const auto id = tracy::GetProfiler().GetNextZoneId();
     ctx.id = id;
 
@@ -4405,6 +4683,9 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srclo
         tracy::tracy_free( (void*)srcloc );
         return ctx;
     }
+#ifdef TRACY_ON_DEMAND
+    ctx.connectionId = tracy::GetProfiler().ConnectionId();
+#endif
     const auto id = tracy::GetProfiler().GetNextZoneId();
     ctx.id = id;
 
@@ -4432,6 +4713,9 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srclo
 TRACY_API void ___tracy_emit_zone_end( TracyCZoneCtx ctx )
 {
     if( !ctx.active ) return;
+#ifdef TRACY_ON_DEMAND
+    if( tracy::GetProfiler().ConnectionId() != ctx.connectionId ) return;
+#endif
 #ifndef TRACY_NO_VERIFY
     {
         TracyQueuePrepareC( tracy::QueueType::ZoneValidation );
@@ -4448,8 +4732,11 @@ TRACY_API void ___tracy_emit_zone_end( TracyCZoneCtx ctx )
 
 TRACY_API void ___tracy_emit_zone_text( TracyCZoneCtx ctx, const char* txt, size_t size )
 {
-    assert( size < std::numeric_limits<uint16_t>::max() );
+    TRACY_ASSERT( size < std::numeric_limits<uint16_t>::max() );
     if( !ctx.active ) return;
+#ifdef TRACY_ON_DEMAND
+    if( tracy::GetProfiler().ConnectionId() != ctx.connectionId ) return;
+#endif
     auto ptr = (char*)tracy::tracy_malloc( size );
     memcpy( ptr, txt, size );
 #ifndef TRACY_NO_VERIFY
@@ -4467,10 +4754,44 @@ TRACY_API void ___tracy_emit_zone_text( TracyCZoneCtx ctx, const char* txt, size
     }
 }
 
+TRACY_API void ___tracy_emit_zone_text_fmt( TracyCZoneCtx ctx, const char* fmt, ... )
+{
+    if( !ctx.active ) return;
+#ifdef TRACY_ON_DEMAND
+    if( tracy::GetProfiler().ConnectionId() != ctx.connectionId ) return;
+#endif
+    va_list args;
+    va_start( args, fmt );
+    auto size = vsnprintf( nullptr, 0, fmt, args );
+    va_end( args );
+    if( size < 0 ) return;
+    TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
+
+    char* ptr = (char*)tracy::tracy_malloc( size_t( size ) + 1 );
+    va_start( args, fmt );
+    vsnprintf( ptr, size_t( size ) + 1, fmt, args );
+    va_end( args );
+
+#ifndef TRACY_NO_VERIFY
+    {
+        TracyQueuePrepareC( tracy::QueueType::ZoneValidation );
+        tracy::MemWrite( &item->zoneValidation.id, ctx.id );
+        TracyQueueCommitC( zoneValidationThread );
+    }
+#endif
+    TracyQueuePrepareC( tracy::QueueType::ZoneText );
+    tracy::MemWrite( &item->zoneTextFat.text, (uint64_t)ptr );
+    tracy::MemWrite( &item->zoneTextFat.size, (uint16_t)size );
+    TracyQueueCommitC( zoneTextFatThread );
+}
+
 TRACY_API void ___tracy_emit_zone_name( TracyCZoneCtx ctx, const char* txt, size_t size )
 {
-    assert( size < std::numeric_limits<uint16_t>::max() );
+    TRACY_ASSERT( size < std::numeric_limits<uint16_t>::max() );
     if( !ctx.active ) return;
+#ifdef TRACY_ON_DEMAND
+    if( tracy::GetProfiler().ConnectionId() != ctx.connectionId ) return;
+#endif
     auto ptr = (char*)tracy::tracy_malloc( size );
     memcpy( ptr, txt, size );
 #ifndef TRACY_NO_VERIFY
@@ -4488,8 +4809,42 @@ TRACY_API void ___tracy_emit_zone_name( TracyCZoneCtx ctx, const char* txt, size
     }
 }
 
+TRACY_API void ___tracy_emit_zone_name_fmt( TracyCZoneCtx ctx, const char* fmt, ... )
+{
+    if( !ctx.active ) return;
+#ifdef TRACY_ON_DEMAND
+    if( tracy::GetProfiler().ConnectionId() != ctx.connectionId ) return;
+#endif
+    va_list args;
+    va_start( args, fmt );
+    auto size = vsnprintf( nullptr, 0, fmt, args );
+    va_end( args );
+    if( size < 0 ) return;
+    TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
+
+    char* ptr = (char*)tracy::tracy_malloc( size_t( size ) + 1 );
+    va_start( args, fmt );
+    vsnprintf( ptr, size_t( size ) + 1, fmt, args );
+    va_end( args );
+
+#ifndef TRACY_NO_VERIFY
+    {
+        TracyQueuePrepareC( tracy::QueueType::ZoneValidation );
+        tracy::MemWrite( &item->zoneValidation.id, ctx.id );
+        TracyQueueCommitC( zoneValidationThread );
+    }
+#endif
+    TracyQueuePrepareC( tracy::QueueType::ZoneName );
+    tracy::MemWrite( &item->zoneTextFat.text, (uint64_t)ptr );
+    tracy::MemWrite( &item->zoneTextFat.size, (uint16_t)size );
+    TracyQueueCommitC( zoneTextFatThread );
+}
+
 TRACY_API void ___tracy_emit_zone_color( TracyCZoneCtx ctx, uint32_t color ) {
     if( !ctx.active ) return;
+#ifdef TRACY_ON_DEMAND
+    if( tracy::GetProfiler().ConnectionId() != ctx.connectionId ) return;
+#endif
 #ifndef TRACY_NO_VERIFY
     {
         TracyQueuePrepareC( tracy::QueueType::ZoneValidation );
@@ -4509,6 +4864,9 @@ TRACY_API void ___tracy_emit_zone_color( TracyCZoneCtx ctx, uint32_t color ) {
 TRACY_API void ___tracy_emit_zone_value( TracyCZoneCtx ctx, uint64_t value )
 {
     if( !ctx.active ) return;
+#ifdef TRACY_ON_DEMAND
+    if( tracy::GetProfiler().ConnectionId() != ctx.connectionId ) return;
+#endif
 #ifndef TRACY_NO_VERIFY
     {
         TracyQueuePrepareC( tracy::QueueType::ZoneValidation );
@@ -4523,64 +4881,64 @@ TRACY_API void ___tracy_emit_zone_value( TracyCZoneCtx ctx, uint64_t value )
     }
 }
 
-TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size, int32_t secure ) { tracy::Profiler::MemAlloc( ptr, size, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int32_t depth, int32_t secure )
+TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size ) { tracy::Profiler::MemAlloc( ptr, size ); }
+TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int32_t depth )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
-        tracy::Profiler::MemAllocCallstack( ptr, size, depth, secure != 0 );
+        tracy::Profiler::MemAllocCallstack( ptr, size, depth );
     }
     else
     {
-        tracy::Profiler::MemAlloc( ptr, size, secure != 0 );
+        tracy::Profiler::MemAlloc( ptr, size );
     }
 }
-TRACY_API void ___tracy_emit_memory_free( const void* ptr, int32_t secure ) { tracy::Profiler::MemFree( ptr, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int32_t depth, int32_t secure )
+TRACY_API void ___tracy_emit_memory_free( const void* ptr ) { tracy::Profiler::MemFree( ptr ); }
+TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int32_t depth )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
-        tracy::Profiler::MemFreeCallstack( ptr, depth, secure != 0 );
+        tracy::Profiler::MemFreeCallstack( ptr, depth );
     }
     else
     {
-        tracy::Profiler::MemFree( ptr, secure != 0 );
+        tracy::Profiler::MemFree( ptr );
     }
 }
-TRACY_API void ___tracy_emit_memory_discard( const char* name, int32_t secure ) { tracy::Profiler::MemDiscard( name, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t secure, int32_t depth )
+TRACY_API void ___tracy_emit_memory_discard( const char* name ) { tracy::Profiler::MemDiscard( name ); }
+TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t depth )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
-        tracy::Profiler::MemDiscardCallstack( name, secure != 0, depth );
+        tracy::Profiler::MemDiscardCallstack( name, depth );
     }
     else
     {
-        tracy::Profiler::MemDiscard( name, secure != 0 );
+        tracy::Profiler::MemDiscard( name );
     }
 }
-TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, int32_t secure, const char* name ) { tracy::Profiler::MemAllocNamed( ptr, size, secure != 0, name ); }
-TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int32_t depth, int32_t secure, const char* name )
+TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, const char* name ) { tracy::Profiler::MemAllocNamed( ptr, size, name ); }
+TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int32_t depth, const char* name )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
-        tracy::Profiler::MemAllocCallstackNamed( ptr, size, depth, secure != 0, name );
+        tracy::Profiler::MemAllocCallstackNamed( ptr, size, depth, name );
     }
     else
     {
-        tracy::Profiler::MemAllocNamed( ptr, size, secure != 0, name );
+        tracy::Profiler::MemAllocNamed( ptr, size, name );
     }
 }
-TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, int32_t secure, const char* name ) { tracy::Profiler::MemFreeNamed( ptr, secure != 0, name ); }
-TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int32_t depth, int32_t secure, const char* name )
+TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, const char* name ) { tracy::Profiler::MemFreeNamed( ptr, name ); }
+TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int32_t depth, const char* name )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
-        tracy::Profiler::MemFreeCallstackNamed( ptr, depth, secure != 0, name );
+        tracy::Profiler::MemFreeCallstackNamed( ptr, depth, name );
     }
     else
     {
-        tracy::Profiler::MemFreeNamed( ptr, secure != 0, name );
+        tracy::Profiler::MemFreeNamed( ptr, name );
     }
 }
 TRACY_API void ___tracy_emit_frame_mark( const char* name ) { tracy::Profiler::SendFrameMark( name ); }
@@ -4591,10 +4949,16 @@ TRACY_API void ___tracy_emit_plot( const char* name, double val ) { tracy::Profi
 TRACY_API void ___tracy_emit_plot_float( const char* name, float val ) { tracy::Profiler::PlotData( name, val ); }
 TRACY_API void ___tracy_emit_plot_int( const char* name, int64_t val ) { tracy::Profiler::PlotData( name, val ); }
 TRACY_API void ___tracy_emit_plot_config( const char* name, int32_t type, int32_t step, int32_t fill, uint32_t color ) { tracy::Profiler::ConfigurePlot( name, tracy::PlotFormatType(type), step != 0, fill != 0, color ); }
-TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int32_t callstack_depth ) { tracy::Profiler::Message( txt, size, callstack_depth ); }
-TRACY_API void ___tracy_emit_messageL( const char* txt, int32_t callstack_depth ) { tracy::Profiler::Message( txt, callstack_depth ); }
-TRACY_API void ___tracy_emit_messageC( const char* txt, size_t size, uint32_t color, int32_t callstack_depth ) { tracy::Profiler::MessageColor( txt, size, color, callstack_depth ); }
-TRACY_API void ___tracy_emit_messageLC( const char* txt, uint32_t color, int32_t callstack_depth ) { tracy::Profiler::MessageColor( txt, color, callstack_depth ); }
+
+static_assert( TracyMessageSeverityTrace == int(tracy::MessageSeverity::Trace), "Mismatch between C and C++ versions of message severity" );
+static_assert( TracyMessageSeverityDebug == int(tracy::MessageSeverity::Debug), "Mismatch between C and C++ versions of message severity" );
+static_assert( TracyMessageSeverityInfo == int(tracy::MessageSeverity::Info), "Mismatch between C and C++ versions of message severity" );
+static_assert( TracyMessageSeverityWarning == int(tracy::MessageSeverity::Warning), "Mismatch between C and C++ versions of message severity" );
+static_assert( TracyMessageSeverityError == int(tracy::MessageSeverity::Error), "Mismatch between C and C++ versions of message severity" );
+static_assert( TracyMessageSeverityFatal == int(tracy::MessageSeverity::Fatal), "Mismatch between C and C++ versions of message severity" );
+
+TRACY_API void ___tracy_emit_logString( int8_t severity, int32_t color, int32_t callstack_depth, size_t size, const char* txt ) { tracy::Profiler::LogString( tracy::MessageSourceType::User, tracy::MessageSeverity(severity), color, callstack_depth, size, txt ); }
+TRACY_API void ___tracy_emit_logStringL( int8_t severity, int32_t color, int32_t callstack_depth, const char* txt ) { tracy::Profiler::LogString( tracy::MessageSourceType::User, tracy::MessageSeverity(severity), color, callstack_depth, txt ); }
 TRACY_API void ___tracy_emit_message_appinfo( const char* txt, size_t size ) { tracy::Profiler::MessageAppInfo( txt, size ); }
 
 TRACY_API uint64_t ___tracy_alloc_srcloc( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, uint32_t color ) {
@@ -4607,6 +4971,9 @@ TRACY_API uint64_t ___tracy_alloc_srcloc_name( uint32_t line, const char* source
 
 TRACY_API void ___tracy_emit_gpu_zone_begin( const struct ___tracy_gpu_zone_begin_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() ) return;
+#endif
     TracyLfqPrepareC( tracy::QueueType::GpuZoneBegin );
     tracy::MemWrite( &item->gpuZoneBegin.cpuTime, tracy::Profiler::GetTime() );
     tracy::MemWrite( &item->gpuZoneBegin.thread, tracy::GetThreadHandle() );
@@ -4618,6 +4985,9 @@ TRACY_API void ___tracy_emit_gpu_zone_begin( const struct ___tracy_gpu_zone_begi
 
 TRACY_API void ___tracy_emit_gpu_zone_begin_callstack( const struct ___tracy_gpu_zone_begin_callstack_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() ) return;
+#endif
     tracy::GetProfiler().SendCallstack( data.depth );
     TracyLfqPrepareC( tracy::QueueType::GpuZoneBeginCallstack );
     tracy::MemWrite( &item->gpuZoneBegin.thread, tracy::GetThreadHandle() );
@@ -4630,6 +5000,13 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_callstack( const struct ___tracy_gpu
 
 TRACY_API void ___tracy_emit_gpu_zone_begin_alloc( const struct ___tracy_gpu_zone_begin_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() )
+    {
+        tracy::tracy_free( (void*)data.srcloc );
+        return;
+    }
+#endif
     TracyLfqPrepareC( tracy::QueueType::GpuZoneBeginAllocSrcLoc  );
     tracy::MemWrite( &item->gpuZoneBegin.cpuTime, tracy::Profiler::GetTime() );
     tracy::MemWrite( &item->gpuZoneBegin.thread, tracy::GetThreadHandle() );
@@ -4641,6 +5018,13 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_alloc( const struct ___tracy_gpu_zon
 
 TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_callstack( const struct ___tracy_gpu_zone_begin_callstack_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() )
+    {
+        tracy::tracy_free( (void*)data.srcloc );
+        return;
+    }
+#endif
     tracy::GetProfiler().SendCallstack( data.depth );
     TracyLfqPrepareC( tracy::QueueType::GpuZoneBeginAllocSrcLocCallstack  );
     tracy::MemWrite( &item->gpuZoneBegin.cpuTime, tracy::Profiler::GetTime() );
@@ -4653,6 +5037,9 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_callstack( const struct ___tra
 
 TRACY_API void ___tracy_emit_gpu_time( const struct ___tracy_gpu_time_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() ) return;
+#endif
     TracyLfqPrepareC( tracy::QueueType::GpuTime );
     tracy::MemWrite( &item->gpuTime.gpuTime, data.gpuTime );
     tracy::MemWrite( &item->gpuTime.queryId, data.queryId );
@@ -4662,6 +5049,9 @@ TRACY_API void ___tracy_emit_gpu_time( const struct ___tracy_gpu_time_data data 
 
 TRACY_API void ___tracy_emit_gpu_zone_end( const struct ___tracy_gpu_zone_end_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() ) return;
+#endif
     TracyLfqPrepareC( tracy::QueueType::GpuZoneEnd );
     tracy::MemWrite( &item->gpuZoneEnd.cpuTime, tracy::Profiler::GetTime() );
     memset( &item->gpuZoneEnd.thread, 0, sizeof( item->gpuZoneEnd.thread ) );
@@ -4678,8 +5068,8 @@ TRACY_API void ___tracy_emit_gpu_new_context( ___tracy_gpu_new_context_data data
     tracy::MemWrite( &item->gpuNewContext.gpuTime, data.gpuTime );
     tracy::MemWrite( &item->gpuNewContext.period, data.period );
     tracy::MemWrite( &item->gpuNewContext.context, data.context );
-    tracy::MemWrite( &item->gpuNewContext.flags, data.flags );
-    tracy::MemWrite( &item->gpuNewContext.type, data.type );
+    tracy::MemWrite( &item->gpuNewContext.flags, tracy::GpuContextFlags( data.flags ) );
+    tracy::MemWrite( &item->gpuNewContext.type, tracy::GpuContextType( data.type ) );
 
 #ifdef TRACY_ON_DEMAND
     tracy::GetProfiler().DeferItem( *item );
@@ -4707,6 +5097,9 @@ TRACY_API void ___tracy_emit_gpu_context_name( const struct ___tracy_gpu_context
 
 TRACY_API void ___tracy_emit_gpu_calibration( const struct ___tracy_gpu_calibration_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() ) return;
+#endif
     TracyLfqPrepareC( tracy::QueueType::GpuCalibration );
     tracy::MemWrite( &item->gpuCalibration.cpuTime, tracy::Profiler::GetTime() );
     tracy::MemWrite( &item->gpuCalibration.gpuTime, data.gpuTime );
@@ -4717,6 +5110,9 @@ TRACY_API void ___tracy_emit_gpu_calibration( const struct ___tracy_gpu_calibrat
 
 TRACY_API void ___tracy_emit_gpu_time_sync( const struct ___tracy_gpu_time_sync_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() ) return;
+#endif
     TracyLfqPrepareC( tracy::QueueType::GpuTimeSync );
     tracy::MemWrite( &item->gpuTimeSync.cpuTime, tracy::Profiler::GetTime() );
     tracy::MemWrite( &item->gpuTimeSync.gpuTime, data.gpuTime );
@@ -4726,6 +5122,9 @@ TRACY_API void ___tracy_emit_gpu_time_sync( const struct ___tracy_gpu_time_sync_
 
 TRACY_API void ___tracy_emit_gpu_zone_begin_serial( const struct ___tracy_gpu_zone_begin_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() ) return;
+#endif
     auto item = tracy::Profiler::QueueSerial();
     tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneBeginSerial );
     tracy::MemWrite( &item->gpuZoneBegin.cpuTime, tracy::Profiler::GetTime() );
@@ -4738,6 +5137,9 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_serial( const struct ___tracy_gpu_zo
 
 TRACY_API void ___tracy_emit_gpu_zone_begin_callstack_serial( const struct ___tracy_gpu_zone_begin_callstack_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() ) return;
+#endif
     auto item = tracy::Profiler::QueueSerialCallstack( tracy::Callstack( data.depth ) );
     tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneBeginCallstackSerial );
     tracy::MemWrite( &item->gpuZoneBegin.cpuTime, tracy::Profiler::GetTime() );
@@ -4750,6 +5152,13 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_callstack_serial( const struct ___tr
 
 TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_serial( const struct ___tracy_gpu_zone_begin_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() )
+    {
+        tracy::tracy_free( (void*)data.srcloc );
+        return;
+    }
+#endif
     auto item = tracy::Profiler::QueueSerial();
     tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneBeginAllocSrcLocSerial );
     tracy::MemWrite( &item->gpuZoneBegin.cpuTime, tracy::Profiler::GetTime() );
@@ -4762,6 +5171,13 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_serial( const struct ___tracy_
 
 TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_callstack_serial( const struct ___tracy_gpu_zone_begin_callstack_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() )
+    {
+        tracy::tracy_free( (void*)data.srcloc );
+        return;
+    }
+#endif
     auto item = tracy::Profiler::QueueSerialCallstack( tracy::Callstack( data.depth ) );
     tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneBeginAllocSrcLocCallstackSerial );
     tracy::MemWrite( &item->gpuZoneBegin.cpuTime, tracy::Profiler::GetTime() );
@@ -4774,6 +5190,9 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_callstack_serial( const struct
 
 TRACY_API void ___tracy_emit_gpu_time_serial( const struct ___tracy_gpu_time_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() ) return;
+#endif
     auto item = tracy::Profiler::QueueSerial();
     tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuTime );
     tracy::MemWrite( &item->gpuTime.gpuTime, data.gpuTime );
@@ -4784,6 +5203,9 @@ TRACY_API void ___tracy_emit_gpu_time_serial( const struct ___tracy_gpu_time_dat
 
 TRACY_API void ___tracy_emit_gpu_zone_end_serial( const struct ___tracy_gpu_zone_end_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() ) return;
+#endif
     auto item = tracy::Profiler::QueueSerial();
     tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneEndSerial );
     tracy::MemWrite( &item->gpuZoneEnd.cpuTime, tracy::Profiler::GetTime() );
@@ -4802,8 +5224,8 @@ TRACY_API void ___tracy_emit_gpu_new_context_serial( ___tracy_gpu_new_context_da
     tracy::MemWrite( &item->gpuNewContext.gpuTime, data.gpuTime );
     tracy::MemWrite( &item->gpuNewContext.period, data.period );
     tracy::MemWrite( &item->gpuNewContext.context, data.context );
-    tracy::MemWrite( &item->gpuNewContext.flags, data.flags );
-    tracy::MemWrite( &item->gpuNewContext.type, data.type );
+    tracy::MemWrite( &item->gpuNewContext.flags, tracy::GpuContextFlags( data.flags ) );
+    tracy::MemWrite( &item->gpuNewContext.type, tracy::GpuContextType( data.type ) );
 
 #ifdef TRACY_ON_DEMAND
     tracy::GetProfiler().DeferItem( *item );
@@ -4832,6 +5254,9 @@ TRACY_API void ___tracy_emit_gpu_context_name_serial( const struct ___tracy_gpu_
 
 TRACY_API void ___tracy_emit_gpu_calibration_serial( const struct ___tracy_gpu_calibration_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() ) return;
+#endif
     auto item = tracy::Profiler::QueueSerial();
     tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuCalibration );
     tracy::MemWrite( &item->gpuCalibration.cpuTime, tracy::Profiler::GetTime() );
@@ -4843,6 +5268,9 @@ TRACY_API void ___tracy_emit_gpu_calibration_serial( const struct ___tracy_gpu_c
 
 TRACY_API void ___tracy_emit_gpu_time_sync_serial( const struct ___tracy_gpu_time_sync_data data )
 {
+#ifdef TRACY_ON_DEMAND
+    if( !tracy::GetProfiler().IsConnected() ) return;
+#endif
     auto item = tracy::Profiler::QueueSerial();
     tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuTimeSync );
     tracy::MemWrite( &item->gpuTimeSync.cpuTime, tracy::Profiler::GetTime() );
@@ -4868,7 +5296,7 @@ TRACY_API struct __tracy_lockable_context_data* ___tracy_announce_lockable_ctx( 
     new(&lockdata->m_lockCount) std::atomic<uint32_t>( 0 );
     new(&lockdata->m_active) std::atomic<bool>( false );
 #endif
-    assert( lockdata->m_id != (std::numeric_limits<uint32_t>::max)() );
+    TRACY_ASSERT( lockdata->m_id != (std::numeric_limits<uint32_t>::max)() );
 
     auto item = tracy::Profiler::QueueSerial();
     tracy::MemWrite( &item->hdr.type, tracy::QueueType::LockAnnounce );
@@ -5006,7 +5434,7 @@ TRACY_API void ___tracy_mark_lockable_ctx( struct __tracy_lockable_context_data*
 
 TRACY_API void ___tracy_custom_name_lockable_ctx( struct __tracy_lockable_context_data* lockdata, const char* name, size_t nameSz )
 {
-    assert( nameSz < (std::numeric_limits<uint16_t>::max)() );
+    TRACY_ASSERT( nameSz < (std::numeric_limits<uint16_t>::max)() );
     auto ptr = (char*)tracy::tracy_malloc( nameSz );
     memcpy( ptr, name, nameSz );
     auto item = tracy::Profiler::QueueSerial();
@@ -5018,6 +5446,164 @@ TRACY_API void ___tracy_custom_name_lockable_ctx( struct __tracy_lockable_contex
     tracy::GetProfiler().DeferItem( *item );
 #endif
     tracy::Profiler::QueueSerialFinish();
+}
+
+struct __tracy_shared_lockable_context_data {
+    struct __tracy_lockable_context_data m_base;
+};
+
+TRACY_API struct __tracy_shared_lockable_context_data* ___tracy_announce_shared_lockable_ctx( const struct ___tracy_source_location_data* srcloc )
+{
+    struct __tracy_shared_lockable_context_data *lockdata = (__tracy_shared_lockable_context_data*)tracy::tracy_malloc( sizeof( __tracy_shared_lockable_context_data ) );
+    lockdata->m_base.m_id = tracy::GetLockCounter().fetch_add( 1, std::memory_order_relaxed );
+#ifdef TRACY_ON_DEMAND
+    new(&lockdata->m_base.m_lockCount) std::atomic<uint32_t>( 0 );
+    new(&lockdata->m_base.m_active) std::atomic<bool>( false );
+#endif
+    TRACY_ASSERT( lockdata->m_base.m_id != (std::numeric_limits<uint32_t>::max)() );
+
+    auto item = tracy::Profiler::QueueSerial();
+    tracy::MemWrite( &item->hdr.type, tracy::QueueType::LockAnnounce );
+    tracy::MemWrite( &item->lockAnnounce.id, lockdata->m_base.m_id );
+    tracy::MemWrite( &item->lockAnnounce.time, tracy::Profiler::GetTime() );
+    tracy::MemWrite( &item->lockAnnounce.lckloc, (uint64_t)srcloc );
+    tracy::MemWrite( &item->lockAnnounce.type, tracy::LockType::SharedLockable );
+#ifdef TRACY_ON_DEMAND
+    tracy::GetProfiler().DeferItem( *item );
+#endif
+    tracy::Profiler::QueueSerialFinish();
+
+    return lockdata;
+}
+
+TRACY_API void ___tracy_terminate_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata )
+{
+    auto item = tracy::Profiler::QueueSerial();
+    tracy::MemWrite( &item->hdr.type, tracy::QueueType::LockTerminate );
+    tracy::MemWrite( &item->lockTerminate.id, lockdata->m_base.m_id );
+    tracy::MemWrite( &item->lockTerminate.time, tracy::Profiler::GetTime() );
+#ifdef TRACY_ON_DEMAND
+    tracy::GetProfiler().DeferItem( *item );
+#endif
+    tracy::Profiler::QueueSerialFinish();
+
+#ifdef TRACY_ON_DEMAND
+    lockdata->m_base.m_lockCount.~atomic();
+    lockdata->m_base.m_active.~atomic();
+#endif
+    tracy::tracy_free((void*)lockdata);
+}
+
+TRACY_API int32_t ___tracy_before_lock_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata )
+{
+    return ___tracy_before_lock_lockable_ctx( &lockdata->m_base );
+}
+
+TRACY_API void ___tracy_after_lock_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata )
+{
+    ___tracy_after_lock_lockable_ctx( &lockdata->m_base );
+}
+
+TRACY_API void ___tracy_after_unlock_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata )
+{
+    ___tracy_after_unlock_lockable_ctx( &lockdata->m_base );
+}
+
+TRACY_API void ___tracy_after_try_lock_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata, int32_t acquired )
+{
+    ___tracy_after_try_lock_lockable_ctx( &lockdata->m_base, acquired );
+}
+
+TRACY_API int32_t ___tracy_before_lock_shared_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata )
+{
+#ifdef TRACY_ON_DEMAND
+    bool queue = false;
+    const auto locks = lockdata->m_base.m_lockCount.fetch_add( 1, std::memory_order_relaxed );
+    const auto active = lockdata->m_base.m_active.load( std::memory_order_relaxed );
+    if( locks == 0 || active )
+    {
+        const bool connected = tracy::GetProfiler().IsConnected();
+        if( active != connected ) lockdata->m_base.m_active.store( connected, std::memory_order_relaxed );
+        if( connected ) queue = true;
+    }
+    if( !queue ) return static_cast<int32_t>(false);
+#endif
+
+    auto item = tracy::Profiler::QueueSerial();
+    tracy::MemWrite( &item->hdr.type, tracy::QueueType::LockSharedWait );
+    tracy::MemWrite( &item->lockWait.thread, tracy::GetThreadHandle() );
+    tracy::MemWrite( &item->lockWait.id, lockdata->m_base.m_id );
+    tracy::MemWrite( &item->lockWait.time, tracy::Profiler::GetTime() );
+    tracy::Profiler::QueueSerialFinish();
+    return static_cast<int32_t>(true);
+}
+
+TRACY_API void ___tracy_after_lock_shared_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata )
+{
+    auto item = tracy::Profiler::QueueSerial();
+    tracy::MemWrite( &item->hdr.type, tracy::QueueType::LockSharedObtain );
+    tracy::MemWrite( &item->lockObtain.thread, tracy::GetThreadHandle() );
+    tracy::MemWrite( &item->lockObtain.id, lockdata->m_base.m_id );
+    tracy::MemWrite( &item->lockObtain.time, tracy::Profiler::GetTime() );
+    tracy::Profiler::QueueSerialFinish();
+}
+
+TRACY_API void ___tracy_after_unlock_shared_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata )
+{
+#ifdef TRACY_ON_DEMAND
+    lockdata->m_base.m_lockCount.fetch_sub( 1, std::memory_order_relaxed );
+    if( !lockdata->m_base.m_active.load( std::memory_order_relaxed ) ) return;
+    if( !tracy::GetProfiler().IsConnected() )
+    {
+        lockdata->m_base.m_active.store( false, std::memory_order_relaxed );
+        return;
+    }
+#endif
+
+    auto item = tracy::Profiler::QueueSerial();
+    tracy::MemWrite( &item->hdr.type, tracy::QueueType::LockSharedRelease );
+    tracy::MemWrite( &item->lockReleaseShared.thread, tracy::GetThreadHandle() );
+    tracy::MemWrite( &item->lockReleaseShared.id, lockdata->m_base.m_id );
+    tracy::MemWrite( &item->lockReleaseShared.time, tracy::Profiler::GetTime() );
+    tracy::Profiler::QueueSerialFinish();
+}
+
+TRACY_API void ___tracy_after_try_lock_shared_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata, int32_t acquired )
+{
+#ifdef TRACY_ON_DEMAND
+    if( !acquired ) return;
+
+    bool queue = false;
+    const auto locks = lockdata->m_base.m_lockCount.fetch_add( 1, std::memory_order_relaxed );
+    const auto active = lockdata->m_base.m_active.load( std::memory_order_relaxed );
+    if( locks == 0 || active )
+    {
+        const bool connected = tracy::GetProfiler().IsConnected();
+        if( active != connected ) lockdata->m_base.m_active.store( connected, std::memory_order_relaxed );
+        if( connected ) queue = true;
+    }
+    if( !queue ) return;
+#endif
+
+    if( acquired )
+    {
+        auto item = tracy::Profiler::QueueSerial();
+        tracy::MemWrite( &item->hdr.type, tracy::QueueType::LockObtain );
+        tracy::MemWrite( &item->lockObtain.thread, tracy::GetThreadHandle() );
+        tracy::MemWrite( &item->lockObtain.id, lockdata->m_base.m_id );
+        tracy::MemWrite( &item->lockObtain.time, tracy::Profiler::GetTime() );
+        tracy::Profiler::QueueSerialFinish();
+    }
+}
+
+TRACY_API void ___tracy_mark_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata, const struct ___tracy_source_location_data* srcloc )
+{
+    ___tracy_mark_lockable_ctx( &lockdata->m_base, srcloc );
+}
+
+TRACY_API void ___tracy_custom_name_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata, const char* name, size_t nameSz )
+{
+    ___tracy_custom_name_lockable_ctx( &lockdata->m_base, name, nameSz );
 }
 
 TRACY_API int32_t ___tracy_connected( void )
@@ -5053,6 +5639,11 @@ TRACY_API int ___tracy_begin_sampling_profiling( void ) {
 
 TRACY_API void ___tracy_end_sampling_profiling( void ) {
     tracy::EndSamplingProfiling();
+}
+
+TRACY_API int64_t ___tracy_get_time( void )
+{
+    return tracy::Profiler::GetTime();
 }
 
 #ifdef __cplusplus

--- a/D3D11Engine/include/tracy/public/client/TracyProfiler.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracyProfiler.hpp
@@ -1,8 +1,9 @@
 #ifndef __TRACYPROFILER_HPP__
 #define __TRACYPROFILER_HPP__
 
-#include <assert.h>
 #include <atomic>
+#include <condition_variable>
+#include <stdarg.h>
 #include <stdint.h>
 #include <string.h>
 #include <time.h>
@@ -11,14 +12,21 @@
 #include "tracy_SPSCQueue.h"
 #include "TracyCallstack.hpp"
 #include "TracyKCore.hpp"
+#include "TracyMangle.hpp"
 #include "TracySysPower.hpp"
 #include "TracySysTime.hpp"
 #include "TracyFastVector.hpp"
 #include "../common/TracyQueue.hpp"
 #include "../common/TracyAlign.hpp"
 #include "../common/TracyAlloc.hpp"
+#include "../common/TracyAssert.hpp"
+#include "../common/TracyFormat.h"
 #include "../common/TracyMutex.hpp"
 #include "../common/TracyProtocol.hpp"
+
+#ifdef TRACY_PLATFORM_HEADER
+#  include TRACY_PLATFORM_HEADER
+#endif
 
 #if defined _WIN32
 #  include <intrin.h>
@@ -28,8 +36,20 @@
 #  include <mach/mach_time.h>
 #endif
 
-#if ( (defined _WIN32 && !(defined _M_ARM64 || defined _M_ARM)) || ( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 ) || ( defined TARGET_OS_IOS && TARGET_OS_IOS == 1 ) )
-#  define TRACY_HW_TIMER
+#if ( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
+#  define TRACY_HAS_RDTSC
+#elif defined _WIN32 && defined _M_ARM64
+#  define TRACY_HAS_CNTVCT
+#elif defined __APPLE__ && defined __MACH__ && TARGET_CPU_ARM64 // For now only supported on Apple devices
+#  define TRACY_HAS_CNTVCT
+#endif
+
+#if !defined TRACY_DISALLOW_HW_TIMER
+#  if ( defined TRACY_HAS_RDTSC || defined TRACY_HAS_CNTVCT )
+#    define TRACY_HW_TIMER
+#  elif defined TARGET_OS_IOS && TARGET_OS_IOS == 1 // For now, !defined(TRACY_HW_TIMER) implies TRACY_TIMER_FALLBACK, so define TRACY_HW_TIMER to use mach_absolute_time() on iOS
+#    define TRACY_HW_TIMER
+#  endif
 #endif
 
 #ifdef __linux__
@@ -71,17 +91,20 @@ struct GpuCtxWrapper
     GpuCtx* ptr;
 };
 
-TRACY_API moodycamel::ConcurrentQueue<QueueItem>::ExplicitProducer* GetToken();
-TRACY_API Profiler& GetProfiler();
+TRACY_API moodycamel::ConcurrentQueue<QueueItem>::ExplicitProducer* MANGLED_NAME_BASED_ON_CONFIG(GetToken)();
+tracy_force_inline moodycamel::ConcurrentQueue<QueueItem>::ExplicitProducer* GetToken() { return MANGLED_NAME_BASED_ON_CONFIG(GetToken)(); }
+TRACY_API Profiler& MANGLED_NAME_BASED_ON_CONFIG(GetProfiler)();
+tracy_force_inline Profiler& GetProfiler() { return MANGLED_NAME_BASED_ON_CONFIG(GetProfiler)(); }
 TRACY_API std::atomic<uint32_t>& GetLockCounter();
-TRACY_API std::atomic<uint8_t>& GetGpuCtxCounter();
+TRACY_API std::atomic<uint32_t>& GetGpuCtxCounter();
+TRACY_API int32_t NextGpuContextId();
 TRACY_API GpuCtxWrapper& GetGpuCtx();
 TRACY_API uint32_t GetThreadHandle();
 TRACY_API bool ProfilerAvailable();
 TRACY_API bool ProfilerAllocatorAvailable();
 TRACY_API int64_t GetFrequencyQpc();
 
-#if defined TRACY_TIMER_FALLBACK && defined TRACY_HW_TIMER && ( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
+#if defined TRACY_TIMER_FALLBACK && defined TRACY_HW_TIMER && defined TRACY_HAS_RDTSC
 TRACY_API bool HardwareSupportsInvariantTSC();  // check, if we need fallback scenario
 #else
 #  if defined TRACY_HW_TIMER
@@ -161,6 +184,27 @@ struct LuaZoneState
 typedef void(*ParameterCallback)( void* data, uint32_t idx, int32_t val );
 typedef char*(*SourceContentsCallback)( void* data, const char* filename, size_t& size );
 
+#if defined _WIN32 && defined TRACY_HAS_CNTVCT
+// NOTE: implementing timestamp_win_arm64_cntvct_el0() requires ARM64_CNTVCT_EL0,
+// which in turn would require including "Windows.h" here... instead, just bring
+// what's needed from "winnt.h"
+#  ifdef ARM64_CNTVCT_EL0
+#    define TRACY_WINARM64_CNTVCT_EL0 ARM64_CNTVCT_EL0
+#  else
+#    define TRACY_WINARM64_SYSREG( op0, op1, crn, crm, op2 ) \
+        ( ( ( op0 & 1 ) << 14 ) |                            \
+          ( ( op1 & 7 ) << 11 ) |                            \
+          ( ( crn & 15 ) << 7 ) |                            \
+          ( ( crm & 15 ) << 3 ) |                            \
+          ( ( op2 & 7 ) << 0 ) )
+#    define TRACY_WINARM64_CNTVCT_EL0 TRACY_WINARM64_SYSREG( 3, 3, 14, 0, 2 )
+#  endif
+tracy_force_inline int64_t timestamp_win_arm64_cntvct_el0()
+{
+    return _ReadStatusReg( TRACY_WINARM64_CNTVCT_EL0 );
+}
+#endif
+
 class Profiler
 {
     struct FrameImageQueueItem
@@ -200,10 +244,25 @@ public:
 #ifdef TRACY_HW_TIMER
 #  if defined TARGET_OS_IOS && TARGET_OS_IOS == 1
         if( HardwareSupportsInvariantTSC() ) return mach_absolute_time();
+#  elif defined __APPLE__ && defined __MACH__ && TARGET_CPU_ARM64
+        if( HardwareSupportsInvariantTSC() )
+        {
+            uint64_t value;
+            __asm__ __volatile__(
+               //"isb \n"              // ommitting "Instruction Synchronization Barrier"
+                "mrs %0, CNTVCT_EL0"
+                : "=r" (value)          // Output: write 'register %0' to 'value'
+                :                       // No inputs
+                : "memory"              // Clobber list: memory (e.g., compiler barrier)
+            );
+            return value;
+        }
 #  elif defined _WIN32
 #    ifdef TRACY_TIMER_QPC
         return GetTimeQpc();
-#    else
+#    elif defined TRACY_HAS_CNTVCT
+        return timestamp_win_arm64_cntvct_el0();
+#    elif defined TRACY_HAS_RDTSC
         if( HardwareSupportsInvariantTSC() ) return int64_t( __rdtsc() );
 #    endif
 #  elif defined __i386 || defined _M_IX86
@@ -263,6 +322,11 @@ public:
         return m_zoneId.fetch_add( 1, std::memory_order_relaxed );
     }
 
+    tracy_force_inline uint32_t GetNextSectionId()
+    {
+        return m_sectionId.fetch_add( 1, std::memory_order_relaxed );
+    }
+
     static tracy_force_inline QueueItem* QueueSerial()
     {
         auto& p = GetProfiler();
@@ -300,7 +364,7 @@ public:
 
     static tracy_force_inline void SendFrameMark( const char* name, QueueType type )
     {
-        assert( type == QueueType::FrameMarkMsgStart || type == QueueType::FrameMarkMsgEnd );
+        TRACY_ASSERT( type == QueueType::FrameMarkMsgStart || type == QueueType::FrameMarkMsgEnd );
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() ) return;
 #endif
@@ -315,7 +379,7 @@ public:
     {
 #ifndef TRACY_NO_FRAME_IMAGE
         auto& profiler = GetProfiler();
-        assert( profiler.m_frameCount.load( std::memory_order_relaxed ) < (std::numeric_limits<uint32_t>::max)() );
+        TRACY_ASSERT( profiler.m_frameCount.load( std::memory_order_relaxed ) < (std::numeric_limits<uint32_t>::max)() );
 #  ifdef TRACY_ON_DEMAND
         if( !profiler.IsConnected() ) return;
 #  endif
@@ -393,9 +457,9 @@ public:
         TracyLfqCommit;
     }
 
-    static tracy_force_inline void Message( const char* txt, size_t size, int32_t callstack_depth )
+    static tracy_force_inline void LogString( MessageSourceType source, MessageSeverity severity, uint32_t color, int32_t callstack_depth, size_t txtLength, const char* txt )
     {
-        assert( size < (std::numeric_limits<uint16_t>::max)() );
+        TRACY_ASSERT( txtLength < (std::numeric_limits<uint16_t>::max)() );
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() ) return;
 #endif
@@ -404,57 +468,32 @@ public:
             tracy::GetProfiler().SendCallstack( callstack_depth );
         }
 
-        auto ptr = (char*)tracy_malloc( size );
-        memcpy( ptr, txt, size );
+        auto ptr = (char*)tracy_malloc( txtLength );
+        memcpy( ptr, txt, txtLength );
+        TaggedUserlandAddress taggedPtr{ (uint64_t)ptr, MakeMessageMetadata( source, severity ) };
 
-        TracyQueuePrepare( callstack_depth == 0 ? QueueType::Message : QueueType::MessageCallstack );
-        MemWrite( &item->messageFat.time, GetTime() );
-        MemWrite( &item->messageFat.text, (uint64_t)ptr );
-        MemWrite( &item->messageFat.size, (uint16_t)size );
-        TracyQueueCommit( messageFatThread );
-    }
-
-    static tracy_force_inline void Message( const char* txt, int32_t callstack_depth )
-    {
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
-        if( callstack_depth != 0 && has_callstack() )
+        if( color != 0 )
         {
-            tracy::GetProfiler().SendCallstack( callstack_depth );
+            TracyQueuePrepare( callstack_depth == 0 ? QueueType::MessageColor : QueueType::MessageColorCallstack );
+            MemWrite( &item->messageColorFat.time, GetTime() );
+            MemWrite( &item->messageColorFat.textAndMetadata, taggedPtr );
+            MemWrite( &item->messageColorFat.b, uint8_t( ( color       ) & 0xFF ) );
+            MemWrite( &item->messageColorFat.g, uint8_t( ( color >> 8  ) & 0xFF ) );
+            MemWrite( &item->messageColorFat.r, uint8_t( ( color >> 16 ) & 0xFF ) );
+            MemWrite( &item->messageColorFat.size, (uint16_t)txtLength );
+            TracyQueueCommit( messageColorFatThread );
         }
-
-        TracyQueuePrepare( callstack_depth == 0 ? QueueType::MessageLiteral : QueueType::MessageLiteralCallstack );
-        MemWrite( &item->messageLiteral.time, GetTime() );
-        MemWrite( &item->messageLiteral.text, (uint64_t)txt );
-        TracyQueueCommit( messageLiteralThread );
-    }
-
-    static tracy_force_inline void MessageColor( const char* txt, size_t size, uint32_t color, int32_t callstack_depth )
-    {
-        assert( size < (std::numeric_limits<uint16_t>::max)() );
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
-        if( callstack_depth != 0 && has_callstack() )
+        else
         {
-            tracy::GetProfiler().SendCallstack( callstack_depth );
+            TracyQueuePrepare( callstack_depth == 0 ? QueueType::Message : QueueType::MessageCallstack );
+            MemWrite( &item->messageFat.time, GetTime() );
+            MemWrite( &item->messageFat.textAndMetadata, taggedPtr );
+            MemWrite( &item->messageFat.size, (uint16_t)txtLength );
+            TracyQueueCommit( messageFatThread );
         }
-
-        auto ptr = (char*)tracy_malloc( size );
-        memcpy( ptr, txt, size );
-
-        TracyQueuePrepare( callstack_depth == 0 ? QueueType::MessageColor : QueueType::MessageColorCallstack );
-        MemWrite( &item->messageColorFat.time, GetTime() );
-        MemWrite( &item->messageColorFat.text, (uint64_t)ptr );
-        MemWrite( &item->messageColorFat.b, uint8_t( ( color       ) & 0xFF ) );
-        MemWrite( &item->messageColorFat.g, uint8_t( ( color >> 8  ) & 0xFF ) );
-        MemWrite( &item->messageColorFat.r, uint8_t( ( color >> 16 ) & 0xFF ) );
-        MemWrite( &item->messageColorFat.size, (uint16_t)size );
-        TracyQueueCommit( messageColorFatThread );
     }
 
-    static tracy_force_inline void MessageColor( const char* txt, uint32_t color, int32_t callstack_depth )
+    static tracy_force_inline void LogString( MessageSourceType source, MessageSeverity severity, uint32_t color, int32_t callstack_depth, const char* txt )
     {
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() ) return;
@@ -464,23 +503,38 @@ public:
             tracy::GetProfiler().SendCallstack( callstack_depth );
         }
 
-        TracyQueuePrepare( callstack_depth == 0 ? QueueType::MessageLiteralColor : QueueType::MessageLiteralColorCallstack );
-        MemWrite( &item->messageColorLiteral.time, GetTime() );
-        MemWrite( &item->messageColorLiteral.text, (uint64_t)txt );
-        MemWrite( &item->messageColorLiteral.b, uint8_t( ( color       ) & 0xFF ) );
-        MemWrite( &item->messageColorLiteral.g, uint8_t( ( color >> 8  ) & 0xFF ) );
-        MemWrite( &item->messageColorLiteral.r, uint8_t( ( color >> 16 ) & 0xFF ) );
-        TracyQueueCommit( messageColorLiteralThread );
+        TaggedUserlandAddress taggedPtr{ (uint64_t)txt, MakeMessageMetadata( source, severity ) };
+
+        if( color != 0 )
+        {
+            TracyQueuePrepare( callstack_depth == 0 ? QueueType::MessageLiteralColor : QueueType::MessageLiteralColorCallstack );
+            MemWrite( &item->messageColorLiteral.time, GetTime() );
+            MemWrite( &item->messageColorLiteral.textAndMetadata, taggedPtr );
+            MemWrite( &item->messageColorLiteral.b, uint8_t( ( color       ) & 0xFF ) );
+            MemWrite( &item->messageColorLiteral.g, uint8_t( ( color >> 8  ) & 0xFF ) );
+            MemWrite( &item->messageColorLiteral.r, uint8_t( ( color >> 16 ) & 0xFF ) );
+            TracyQueueCommit( messageColorLiteralThread );
+        }
+        else
+        {
+            TracyQueuePrepare( callstack_depth == 0 ? QueueType::MessageLiteral : QueueType::MessageLiteralCallstack );
+            MemWrite( &item->messageLiteral.time, GetTime() );
+            MemWrite( &item->messageLiteral.textAndMetadata, taggedPtr );
+            TracyQueueCommit( messageLiteralThread );
+        }
     }
+
 
     static tracy_force_inline void MessageAppInfo( const char* txt, size_t size )
     {
-        assert( size < (std::numeric_limits<uint16_t>::max)() );
+        TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
         auto ptr = (char*)tracy_malloc( size );
         memcpy( ptr, txt, size );
+        TaggedUserlandAddress taggedPtr{ (uint64_t)ptr, MakeMessageMetadata( MessageSourceType::User, MessageSeverity::Info ) };
+
         TracyLfqPrepare( QueueType::MessageAppInfo );
         MemWrite( &item->messageFat.time, GetTime() );
-        MemWrite( &item->messageFat.text, (uint64_t)ptr );
+        MemWrite( &item->messageFat.textAndMetadata, taggedPtr );
         MemWrite( &item->messageFat.size, (uint16_t)size );
 
 #ifdef TRACY_ON_DEMAND
@@ -490,9 +544,9 @@ public:
         TracyLfqCommit;
     }
 
-    static tracy_force_inline void MemAlloc( const void* ptr, size_t size, bool secure )
+    static tracy_force_inline void MemAlloc( const void* ptr, size_t size )
     {
-        if( secure && !ProfilerAvailable() ) return;
+        if( !ProfilerAvailable() ) return;
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() ) return;
 #endif
@@ -503,9 +557,9 @@ public:
         GetProfiler().m_serialLock.unlock();
     }
 
-    static tracy_force_inline void MemFree( const void* ptr, bool secure )
+    static tracy_force_inline void MemFree( const void* ptr )
     {
-        if( secure && !ProfilerAvailable() ) return;
+        if( !ProfilerAvailable() ) return;
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() ) return;
 #endif
@@ -516,9 +570,9 @@ public:
         GetProfiler().m_serialLock.unlock();
     }
 
-    static tracy_force_inline void MemAllocCallstack( const void* ptr, size_t size, int32_t depth, bool secure )
+    static tracy_force_inline void MemAllocCallstack( const void* ptr, size_t size, int32_t depth )
     {
-        if( secure && !ProfilerAvailable() ) return;
+        if( !ProfilerAvailable() ) return;
         if( depth > 0 && has_callstack() )
         {
             auto& profiler = GetProfiler();
@@ -536,16 +590,16 @@ public:
         }
         else
         {
-            MemAlloc( ptr, size, secure );
+            MemAlloc( ptr, size );
         }
     }
 
-    static tracy_force_inline void MemFreeCallstack( const void* ptr, int32_t depth, bool secure )
+    static tracy_force_inline void MemFreeCallstack( const void* ptr, int32_t depth )
     {
-        if( secure && !ProfilerAvailable() ) return;
+        if( !ProfilerAvailable() ) return;
         if( !ProfilerAllocatorAvailable() )
         {
-            MemFree( ptr, secure );
+            MemFree( ptr );
             return;
         }
         if( depth > 0 && has_callstack() )
@@ -565,13 +619,13 @@ public:
         }
         else
         {
-            MemFree( ptr, secure );
+            MemFree( ptr );
         }
     }
 
-    static tracy_force_inline void MemAllocNamed( const void* ptr, size_t size, bool secure, const char* name )
+    static tracy_force_inline void MemAllocNamed( const void* ptr, size_t size, const char* name )
     {
-        if( secure && !ProfilerAvailable() ) return;
+        if( !ProfilerAvailable() ) return;
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() ) return;
 #endif
@@ -583,9 +637,9 @@ public:
         GetProfiler().m_serialLock.unlock();
     }
 
-    static tracy_force_inline void MemFreeNamed( const void* ptr, bool secure, const char* name )
+    static tracy_force_inline void MemFreeNamed( const void* ptr, const char* name )
     {
-        if( secure && !ProfilerAvailable() ) return;
+        if( !ProfilerAvailable() ) return;
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() ) return;
 #endif
@@ -597,9 +651,9 @@ public:
         GetProfiler().m_serialLock.unlock();
     }
 
-    static tracy_force_inline void MemAllocCallstackNamed( const void* ptr, size_t size, int32_t depth, bool secure, const char* name )
+    static tracy_force_inline void MemAllocCallstackNamed( const void* ptr, size_t size, int32_t depth, const char* name )
     {
-        if( secure && !ProfilerAvailable() ) return;
+        if( !ProfilerAvailable() ) return;
         if( depth > 0 && has_callstack() )
         {
             auto& profiler = GetProfiler();
@@ -618,13 +672,13 @@ public:
         }
         else
         {
-            MemAllocNamed( ptr, size, secure, name );
+            MemAllocNamed( ptr, size, name );
         }
     }
 
-    static tracy_force_inline void MemFreeCallstackNamed( const void* ptr, int32_t depth, bool secure, const char* name )
+    static tracy_force_inline void MemFreeCallstackNamed( const void* ptr, int32_t depth, const char* name )
     {
-        if( secure && !ProfilerAvailable() ) return;
+        if( !ProfilerAvailable() ) return;
         if( depth > 0 && has_callstack() )
         {
             auto& profiler = GetProfiler();
@@ -643,13 +697,13 @@ public:
         }
         else
         {
-            MemFreeNamed( ptr, secure, name );
+            MemFreeNamed( ptr, name );
         }
     }
 
-    static tracy_force_inline void MemDiscard( const char* name, bool secure )
+    static tracy_force_inline void MemDiscard( const char* name )
     {
-        if( secure && !ProfilerAvailable() ) return;
+        if( !ProfilerAvailable() ) return;
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() ) return;
 #endif
@@ -660,9 +714,9 @@ public:
         GetProfiler().m_serialLock.unlock();
     }
 
-    static tracy_force_inline void MemDiscardCallstack( const char* name, bool secure, int32_t depth )
+    static tracy_force_inline void MemDiscardCallstack( const char* name, int32_t depth )
     {
-        if( secure && !ProfilerAvailable() ) return;
+        if( !ProfilerAvailable() ) return;
         if( depth > 0 && has_callstack() )
         {
 #  ifdef TRACY_ON_DEMAND
@@ -674,12 +728,12 @@ public:
 
             GetProfiler().m_serialLock.lock();
             SendCallstackSerial( callstack );
-            SendMemDiscard( QueueType::MemDiscard, thread, name );
+            SendMemDiscard( QueueType::MemDiscardCallstack, thread, name );
             GetProfiler().m_serialLock.unlock();
         }
         else
         {
-            MemDiscard( name, secure );
+            MemDiscard( name );
         }
     }
 
@@ -701,12 +755,13 @@ public:
         profiler.m_paramCallbackData = data;
     }
 
-    static tracy_force_inline void ParameterSetup( uint32_t idx, const char* name, bool isBool, int32_t val )
+    static tracy_force_inline void ParameterSetup( uint32_t idx, const char* name, uint8_t type, int32_t val )
     {
+        TRACY_ASSERT( type >= 0 && type <= 2 );
         TracyLfqPrepare( QueueType::ParamSetup );
         tracy::MemWrite( &item->paramSetup.idx, idx );
         tracy::MemWrite( &item->paramSetup.name, (uint64_t)name );
-        tracy::MemWrite( &item->paramSetup.isBool, (uint8_t)isBool );
+        tracy::MemWrite( &item->paramSetup.type, type );
         tracy::MemWrite( &item->paramSetup.val, val );
 
 #ifdef TRACY_ON_DEMAND
@@ -747,8 +802,75 @@ public:
     }
 #endif
 
-    void SendCallstack( int32_t depth, const char* skipBefore );
-    static void CutCallstack( void* callstack, const char* skipBefore );
+    static uint32_t SectionEnter( uint16_t category, const char* fmt, ... ) TRACY_ATTRIBUTE_FORMAT_PRINTF( 2, 3 )
+    {
+        auto& profiler = GetProfiler();
+#ifdef TRACY_ON_DEMAND
+        if( !profiler.IsConnected() ) return 0;
+#endif
+        va_list args;
+        va_start( args, fmt );
+        auto size = vsnprintf( nullptr, 0, fmt, args );
+        va_end( args );
+        if( size < 0 ) return 0;
+        TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
+
+        char* ptr = (char*)tracy_malloc( size_t( size ) + 1 );
+        va_start( args, fmt );
+        vsnprintf( ptr, size_t( size ) + 1, fmt, args );
+        va_end( args );
+
+        const auto id = profiler.GetNextSectionId();
+        TracyLfqPrepare( QueueType::SectionEnter );
+        MemWrite( &item->sectionEnterFat.time, GetTime() );
+        MemWrite( &item->sectionEnterFat.id, id );
+        MemWrite( &item->sectionEnterFat.category, category );
+        MemWrite( &item->sectionEnterFat.text, (uint64_t)ptr );
+        MemWrite( &item->sectionEnterFat.size, (uint16_t)size );
+        TracyLfqCommit;
+        return id;
+    }
+
+    static tracy_force_inline void SectionLeave( uint32_t id )
+    {
+        if( id == 0 ) return;
+#ifdef TRACY_ON_DEMAND
+        if( !GetProfiler().IsConnected() ) return;
+#endif
+        TracyLfqPrepare( QueueType::SectionLeave );
+        MemWrite( &item->sectionLeave.time, GetTime() );
+        MemWrite( &item->sectionLeave.id, id );
+        TracyLfqCommit;
+    }
+
+    static void SectionSetup( uint16_t category, const char* fmt, ... ) TRACY_ATTRIBUTE_FORMAT_PRINTF( 2, 3 )
+    {
+        va_list args;
+        va_start( args, fmt );
+        auto size = vsnprintf( nullptr, 0, fmt, args );
+        va_end( args );
+        if( size < 0 ) return;
+        TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
+
+        char* ptr = (char*)tracy_malloc( size_t( size ) + 1 );
+        va_start( args, fmt );
+        vsnprintf( ptr, size_t( size ) + 1, fmt, args );
+        va_end( args );
+
+        TracyLfqPrepare( QueueType::SectionSetup );
+        MemWrite( &item->sectionSetupFat.category, category );
+        MemWrite( &item->sectionSetupFat.text, (uint64_t)ptr );
+        MemWrite( &item->sectionSetupFat.size, (uint16_t)size );
+
+#ifdef TRACY_ON_DEMAND
+        GetProfiler().DeferItem( *item );
+#endif
+
+        TracyLfqCommit;
+    }
+
+    void SendCallstack( int32_t depth, const char** skipBefore );
+    static void CutCallstack( void* callstack, const char** skipBefore );
 
     static bool ShouldExit();
 
@@ -782,12 +904,12 @@ public:
     void RequestShutdown() { m_shutdown.store( true, std::memory_order_relaxed ); m_shutdownManual.store( true, std::memory_order_relaxed ); }
     bool HasShutdownFinished() const { return m_shutdownFinished.load( std::memory_order_relaxed ); }
 
-    void SendString( uint64_t str, const char* ptr, QueueType type ) { SendString( str, ptr, strlen( ptr ), type ); }
+    tracy_force_inline void SendString( uint64_t str, const char* ptr, QueueType type ) { SendString( str, ptr, strlen( ptr ), type ); }
     void SendString( uint64_t str, const char* ptr, size_t len, QueueType type );
-    void SendSingleString( const char* ptr ) { SendSingleString( ptr, strlen( ptr ) ); }
-    void SendSingleString( const char* ptr, size_t len );
-    void SendSecondString( const char* ptr ) { SendSecondString( ptr, strlen( ptr ) ); }
-    void SendSecondString( const char* ptr, size_t len );
+    tracy_force_inline void SendSingleString( const char* ptr ) { SendSingleString( ptr, strlen( ptr ) ); }
+    tracy_force_inline void SendSingleString( const char* ptr, size_t len ) { len <= 255 ? SendSingleString8( ptr, len ) : SendSingleString16( ptr, len ); }
+    tracy_force_inline void SendSecondString( const char* ptr ) { SendSecondString( ptr, strlen( ptr ) ); }
+    tracy_force_inline void SendSecondString( const char* ptr, size_t len ) { len <= 255 ? SendSecondString8( ptr, len ) : SendSecondString16( ptr, len ); }
 
 
     // Allocated source location data layout:
@@ -818,7 +940,7 @@ public:
     static tracy_force_inline uint64_t AllocSourceLocation( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, uint32_t color = 0 )
     {
         const auto sz32 = uint32_t( 2 + 4 + 4 + functionSz + 1 + sourceSz + 1 + nameSz );
-        assert( sz32 <= (std::numeric_limits<uint16_t>::max)() );
+        TRACY_ASSERT( sz32 <= (std::numeric_limits<uint16_t>::max)() );
         const auto sz = uint16_t( sz32 );
         auto ptr = (char*)tracy_malloc( sz );
         memcpy( ptr, &sz, 2 );
@@ -873,9 +995,9 @@ private:
 
     tracy_force_inline bool NeedDataSize( size_t len )
     {
-        assert( len <= TargetFrameSize );
+        TRACY_ASSERT( len <= TargetFrameSize );
         bool ret = true;
-        if( m_bufferOffset - m_bufferStart + (int)len > TargetFrameSize )
+        if( m_bufferOffset - m_bufferStart + (int)len > (int)TargetFrameSize )
         {
             ret = CommitData();
         }
@@ -930,6 +1052,11 @@ private:
     void CalibrateDelay();
     void ReportTopology();
 
+    void SendSingleString8( const char* ptr, size_t len );
+    void SendSingleString16( const char* ptr, size_t len );
+    void SendSecondString8( const char* ptr, size_t len );
+    void SendSecondString16( const char* ptr, size_t len );
+
     static tracy_force_inline void SendCallstackSerial( void* ptr )
     {
         if( has_callstack() )
@@ -943,7 +1070,7 @@ private:
 
     static tracy_force_inline void SendMemAlloc( QueueType type, const uint32_t thread, const void* ptr, size_t size )
     {
-        assert( type == QueueType::MemAlloc || type == QueueType::MemAllocCallstack || type == QueueType::MemAllocNamed || type == QueueType::MemAllocCallstackNamed );
+        TRACY_ASSERT( type == QueueType::MemAlloc || type == QueueType::MemAllocCallstack || type == QueueType::MemAllocNamed || type == QueueType::MemAllocCallstackNamed );
 
         auto item = GetProfiler().m_serialQueue.prepare_next();
         MemWrite( &item->hdr.type, type );
@@ -957,7 +1084,7 @@ private:
         }
         else
         {
-            assert( sizeof( size ) == 8 );
+            TRACY_ASSERT( sizeof( size ) == 8 );
             memcpy( &item->memAlloc.size, &size, 4 );
             memcpy( ((char*)&item->memAlloc.size)+4, ((char*)&size)+4, 2 );
         }
@@ -966,7 +1093,7 @@ private:
 
     static tracy_force_inline void SendMemFree( QueueType type, const uint32_t thread, const void* ptr )
     {
-        assert( type == QueueType::MemFree || type == QueueType::MemFreeCallstack || type == QueueType::MemFreeNamed || type == QueueType::MemFreeCallstackNamed );
+        TRACY_ASSERT( type == QueueType::MemFree || type == QueueType::MemFreeCallstack || type == QueueType::MemFreeNamed || type == QueueType::MemFreeCallstackNamed );
 
         auto item = GetProfiler().m_serialQueue.prepare_next();
         MemWrite( &item->hdr.type, type );
@@ -978,7 +1105,7 @@ private:
 
     static tracy_force_inline void SendMemDiscard( QueueType type, const uint32_t thread, const char* name )
     {
-        assert( type == QueueType::MemDiscard || type == QueueType::MemDiscardCallstack );
+        TRACY_ASSERT( type == QueueType::MemDiscard || type == QueueType::MemDiscardCallstack );
 
         auto item = GetProfiler().m_serialQueue.prepare_next();
         MemWrite( &item->hdr.type, type );
@@ -990,7 +1117,7 @@ private:
 
     static tracy_force_inline void SendMemName( const char* name )
     {
-        assert( name );
+        TRACY_ASSERT( name );
         auto item = GetProfiler().m_serialQueue.prepare_next();
         MemWrite( &item->hdr.type, QueueType::MemNamePayload );
         MemWrite( &item->memName.name, (uint64_t)name );
@@ -1014,6 +1141,7 @@ private:
     bool m_noExit;
     uint32_t m_userPort;
     std::atomic<uint32_t> m_zoneId;
+    std::atomic<uint32_t> m_sectionId;
     int64_t m_samplingPeriod;
 
     uint32_t m_threadCtx;
@@ -1038,6 +1166,8 @@ private:
 #endif
 
     SPSCQueue<SymbolQueueItem> m_symbolQueue;
+    std::condition_variable m_symbolQueueSignal;
+    std::mutex m_symbolQueueMutex;
 
     std::atomic<uint64_t> m_frameCount;
     std::atomic<bool> m_isConnected;
@@ -1079,7 +1209,7 @@ private:
 
 #if defined _WIN32
     void* m_prevHandler;
-#else
+#elif !defined TRACY_HAS_CUSTOM_SAFE_COPY
     int m_pipe[2];
     int m_pipeBufSize;
 #endif

--- a/D3D11Engine/include/tracy/public/client/TracyRingBuffer.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracyRingBuffer.hpp
@@ -1,5 +1,4 @@
 #include <atomic>
-#include <assert.h>
 #include <errno.h>
 #include <linux/perf_event.h>
 #include <stdint.h>
@@ -9,6 +8,8 @@
 #include <unistd.h>
 
 #include "TracyDebug.hpp"
+#include "../common/TracyAssert.hpp"
+#include "../common/TracyForceInline.hpp"
 
 namespace tracy
 {
@@ -18,25 +19,26 @@ class RingBuffer
 public:
     RingBuffer( unsigned int size, int fd, int id, int cpu = -1 )
         : m_size( size )
+        , m_mask( size - 1 )
         , m_id( id )
         , m_cpu( cpu )
         , m_fd( fd )
     {
         const auto pageSize = uint32_t( getpagesize() );
-        assert( size >= pageSize );
-        assert( __builtin_popcount( size ) == 1 );
+        TRACY_ASSERT( size >= pageSize );
+        TRACY_ASSERT( __builtin_popcount( size ) == 1 );
         m_mapSize = size + pageSize;
         auto mapAddr = mmap( nullptr, m_mapSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0 );
         if( mapAddr == MAP_FAILED )
         {
-            TracyDebug( "mmap failed: errno %i (%s)\n", errno, strerror( errno ) );
+            TracyDebug( "mmap failed: errno %i (%s)", errno, strerror( errno ) );
             m_fd = 0;
             m_metadata = nullptr;
             close( fd );
             return;
         }
         m_metadata = (perf_event_mmap_page*)mapAddr;
-        assert( m_metadata->data_offset == pageSize );
+        TRACY_ASSERT( m_metadata->data_offset == pageSize );
         m_buffer = ((char*)mapAddr) + pageSize;
         m_tail = m_metadata->data_tail;
     }
@@ -50,20 +52,8 @@ public:
     RingBuffer( const RingBuffer& ) = delete;
     RingBuffer& operator=( const RingBuffer& ) = delete;
 
-    RingBuffer( RingBuffer&& other )
-    {
-        memcpy( (char*)&other, (char*)this, sizeof( RingBuffer ) );
-        m_metadata = nullptr;
-        m_fd = 0;
-    }
-
-    RingBuffer& operator=( RingBuffer&& other )
-    {
-        memcpy( (char*)&other, (char*)this, sizeof( RingBuffer ) );
-        m_metadata = nullptr;
-        m_fd = 0;
-        return *this;
-    }
+    RingBuffer( RingBuffer&& other ) = delete;
+    RingBuffer& operator=( RingBuffer&& other ) = delete;
 
     bool IsValid() const { return m_metadata != nullptr; }
     int GetId() const { return m_id; }
@@ -74,10 +64,10 @@ public:
         ioctl( m_fd, PERF_EVENT_IOC_ENABLE, 0 );
     }
 
-    void Read( void* dst, uint64_t offset, uint64_t cnt )
+    tracy_force_inline void Read( void* dst, uint64_t offset, uint64_t cnt )
     {
         const auto size = m_size;
-        auto src = ( m_tail + offset ) % size;
+        auto src = ( m_tail + offset ) & m_mask;
         if( src + cnt <= size )
         {
             memcpy( dst, m_buffer + src, cnt );
@@ -128,6 +118,7 @@ private:
     }
 
     unsigned int m_size;
+    unsigned int m_mask;
     uint64_t m_tail;
     char* m_buffer;
     int m_id;

--- a/D3D11Engine/include/tracy/public/client/TracyRocprof.cpp
+++ b/D3D11Engine/include/tracy/public/client/TracyRocprof.cpp
@@ -1,3 +1,4 @@
+#include "../common/TracyAssert.hpp"
 #include "../server/tracy_robin_hood.h"
 #include "TracyProfiler.hpp"
 #include "TracyThread.hpp"
@@ -79,14 +80,9 @@ uint8_t gpu_context_allocate( ToolData* data )
     float timestamp_period = 1.0f;
     data->previous_cpu_time = cpu_timestamp;
 
-    // Allocate the process-unique GPU context ID. There's a max of 255 available;
-    // if we are recreating devices a lot we may exceed that. Don't do that, or
-    // wrap around and get weird (but probably still usable) numbers.
-    uint8_t context_id = tracy::GetGpuCtxCounter().fetch_add( 1, std::memory_order_relaxed );
-    if( context_id >= 255 )
-    {
-        context_id %= 255;
-    }
+    // Allocate the process-unique GPU context ID. There's a max of 256 available
+    // (ids are 8-bit); if we are recreating devices a lot we may exceed that.
+    uint8_t context_id = uint8_t( tracy::NextGpuContextId() );
 
     uint8_t context_flags = 0;
 #ifdef TRACY_ROCPROF_CALIBRATION
@@ -98,13 +94,16 @@ uint8_t gpu_context_allocate( ToolData* data )
     {
         auto* item = tracy::Profiler::QueueSerial();
         tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuNewContext );
-        tracy::MemWrite( &item->gpuNewContext.cpuTime, cpu_timestamp );
-        tracy::MemWrite( &item->gpuNewContext.gpuTime, gpu_timestamp );
+        tracy::MemWrite( &item->gpuNewContext.cpuTime, int64_t( cpu_timestamp ) );
+        tracy::MemWrite( &item->gpuNewContext.gpuTime, int64_t( gpu_timestamp ) );
         memset( &item->gpuNewContext.thread, 0, sizeof( item->gpuNewContext.thread ) );
         tracy::MemWrite( &item->gpuNewContext.period, timestamp_period );
         tracy::MemWrite( &item->gpuNewContext.context, context_id );
-        tracy::MemWrite( &item->gpuNewContext.flags, context_flags );
+        tracy::MemWrite( &item->gpuNewContext.flags, GpuContextFlags( context_flags ) );
         tracy::MemWrite( &item->gpuNewContext.type, tracy::GpuContextType::Rocprof );
+#ifdef TRACY_ON_DEMAND
+        GetProfiler().DeferItem( *item );
+#endif
         tracy::Profiler::QueueSerialFinish();
     }
 
@@ -119,8 +118,11 @@ uint8_t gpu_context_allocate( ToolData* data )
         auto* item = tracy::Profiler::QueueSerial();
         tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuContextName );
         tracy::MemWrite( &item->gpuContextNameFat.context, context_id );
-        tracy::MemWrite( &item->gpuContextNameFat.ptr, (uint64_t)cloned_name );
-        tracy::MemWrite( &item->gpuContextNameFat.size, name_length );
+        tracy::MemWrite( &item->gpuContextNameFat.ptr, uint64_t( cloned_name ) );
+        tracy::MemWrite( &item->gpuContextNameFat.size, uint16_t( name_length ) );
+#ifdef TRACY_ON_DEMAND
+        GetProfiler().DeferItem( *item );
+#endif
         tracy::Profiler::QueueSerialFinish();
     }
 
@@ -181,8 +183,8 @@ void record_interval( ToolData* data, rocprofiler_timestamp_t start_timestamp, r
         {
             auto* item = tracy::Profiler::QueueSerial();
             tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneBeginAllocSrcLocSerial );
-            tracy::MemWrite( &item->gpuZoneBegin.cpuTime, cpu_start_time );
-            tracy::MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)src_loc );
+            tracy::MemWrite( &item->gpuZoneBegin.cpuTime, int64_t( cpu_start_time ) );
+            tracy::MemWrite( &item->gpuZoneBegin.srcloc, src_loc );
             tracy::MemWrite( &item->gpuZoneBegin.thread, tracy::GetThreadHandle() );
             tracy::MemWrite( &item->gpuZoneBegin.queryId, query_id );
             tracy::MemWrite( &item->gpuZoneBegin.context, context_id );
@@ -195,7 +197,7 @@ void record_interval( ToolData* data, rocprofiler_timestamp_t start_timestamp, r
         {
             auto* item = tracy::Profiler::QueueSerial();
             tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneBeginSerial );
-            tracy::MemWrite( &item->gpuZoneBegin.cpuTime, cpu_start_time );
+            tracy::MemWrite( &item->gpuZoneBegin.cpuTime, int64_t( cpu_start_time ) );
             tracy::MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)&src_loc );
             tracy::MemWrite( &item->gpuZoneBegin.thread, tracy::GetThreadHandle() );
             tracy::MemWrite( &item->gpuZoneBegin.queryId, query_id );
@@ -207,7 +209,7 @@ void record_interval( ToolData* data, rocprofiler_timestamp_t start_timestamp, r
     {
         auto* item = tracy::Profiler::QueueSerial();
         tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuTime );
-        tracy::MemWrite( &item->gpuTime.gpuTime, start_timestamp );
+        tracy::MemWrite( &item->gpuTime.gpuTime, int64_t( start_timestamp ) );
         tracy::MemWrite( &item->gpuTime.queryId, query_id );
         tracy::MemWrite( &item->gpuTime.context, context_id );
         tracy::Profiler::QueueSerialFinish();
@@ -216,7 +218,7 @@ void record_interval( ToolData* data, rocprofiler_timestamp_t start_timestamp, r
     {
         auto* item = tracy::Profiler::QueueSerial();
         tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneEndSerial );
-        tracy::MemWrite( &item->gpuZoneEnd.cpuTime, cpu_end_time );
+        tracy::MemWrite( &item->gpuZoneEnd.cpuTime, int64_t( cpu_end_time ) );
         tracy::MemWrite( &item->gpuZoneEnd.thread, tracy::GetThreadHandle() );
         tracy::MemWrite( &item->gpuZoneEnd.queryId, query_id );
         tracy::MemWrite( &item->gpuZoneEnd.context, context_id );
@@ -226,7 +228,7 @@ void record_interval( ToolData* data, rocprofiler_timestamp_t start_timestamp, r
     {
         auto* item = tracy::Profiler::QueueSerial();
         tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuTime );
-        tracy::MemWrite( &item->gpuTime.gpuTime, end_timestamp );
+        tracy::MemWrite( &item->gpuTime.gpuTime, int64_t( end_timestamp ) );
         tracy::MemWrite( &item->gpuTime.queryId, query_id );
         tracy::MemWrite( &item->gpuTime.context, context_id );
         tracy::Profiler::QueueSerialFinish();
@@ -237,7 +239,7 @@ void record_callback( rocprofiler_dispatch_counting_service_data_t dispatch_data
                       rocprofiler_record_counter_t* record_data, size_t record_count,
                       rocprofiler_user_data_t /*user_data*/, void* callback_data )
 {
-    assert( callback_data != nullptr );
+    TRACY_ASSERT( callback_data != nullptr );
     ToolData* data = static_cast<ToolData*>( callback_data );
     if( !data->init ) return;
 
@@ -256,7 +258,7 @@ void record_callback( rocprofiler_dispatch_counting_service_data_t dispatch_data
         auto _lk = std::unique_lock{ data->mut };
         // An assumption is made here that the counter values are supplied after the dispatch
         // complete callback.
-        assert( data->dispatch_data.count( dispatch_data.dispatch_info.dispatch_id ) );
+        TRACY_ASSERT( data->dispatch_data.count( dispatch_data.dispatch_info.dispatch_id ) );
         DispatchData& ddata = data->dispatch_data[dispatch_data.dispatch_info.dispatch_id];
         query_id = ddata.query_id;
         thread_id = ddata.thread_id;
@@ -266,7 +268,7 @@ void record_callback( rocprofiler_dispatch_counting_service_data_t dispatch_data
     {
         auto* item = tracy::Profiler::QueueSerial();
         tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneAnnotation );
-        tracy::MemWrite( &item->zoneAnnotation.noteId, p.first );
+        tracy::MemWrite( &item->zoneAnnotation.noteId, int64_t( p.first ) );
         tracy::MemWrite( &item->zoneAnnotation.queryId, query_id );
         tracy::MemWrite( &item->zoneAnnotation.thread, thread_id );
         tracy::MemWrite( &item->zoneAnnotation.value, p.second );
@@ -284,7 +286,7 @@ void dispatch_callback( rocprofiler_dispatch_counting_service_data_t dispatch_da
                         rocprofiler_profile_config_id_t* config, rocprofiler_user_data_t* /*user_data*/,
                         void* callback_data )
 {
-    assert( callback_data != nullptr );
+    TRACY_ASSERT( callback_data != nullptr );
     ToolData* data = static_cast<ToolData*>( callback_data );
     if( !data->init ) return;
 
@@ -356,9 +358,9 @@ void dispatch_callback( rocprofiler_dispatch_counting_service_data_t dispatch_da
                 auto* item = tracy::Profiler::QueueSerial();
                 tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuAnnotationName );
                 tracy::MemWrite( &item->gpuAnnotationNameFat.context, data->context_id );
-                tracy::MemWrite( &item->gpuAnnotationNameFat.noteId, counter.handle );
-                tracy::MemWrite( &item->gpuAnnotationNameFat.ptr, (uint64_t)cloned_name );
-                tracy::MemWrite( &item->gpuAnnotationNameFat.size, name_length );
+                tracy::MemWrite( &item->gpuAnnotationNameFat.noteId, int64_t( counter.handle ) );
+                tracy::MemWrite( &item->gpuAnnotationNameFat.ptr, uint64_t( cloned_name ) );
+                tracy::MemWrite( &item->gpuAnnotationNameFat.size, uint16_t( name_length ) );
                 tracy::Profiler::QueueSerialFinish();
             }
         }
@@ -378,10 +380,12 @@ void dispatch_callback( rocprofiler_dispatch_counting_service_data_t dispatch_da
 void tool_callback_tracing_callback( rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data,
                                      void* callback_data )
 {
-    assert( callback_data != nullptr );
+    TRACY_ASSERT( callback_data != nullptr );
     ToolData* data = static_cast<ToolData*>( callback_data );
-    if( !data->init ) return;
 
+    // Kernel symbol registrations happen at HIP init time, before any Tracy
+    // client connects (and before data->init is set). Record them regardless
+    // of init state so that kernel names are available when profiling starts.
     if( record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
         record.operation == ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER )
     {
@@ -398,7 +402,13 @@ void tool_callback_tracing_callback( rocprofiler_callback_tracing_record_t recor
             data->client_kernels.erase( sym_data->kernel_id );
         }
     }
-    else if( record.kind == ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH )
+
+    // Gate dispatch and memory-copy recording on data->init, which is set
+    // once the GPU context is allocated (under TRACY_ON_DEMAND this waits
+    // for a client connection).
+    if( !data->init ) return;
+
+    if( record.kind == ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH )
     {
         auto* rdata = static_cast<rocprofiler_callback_tracing_kernel_dispatch_data_t*>( record.payload );
         if( record.operation == ROCPROFILER_KERNEL_DISPATCH_ENQUEUE )

--- a/D3D11Engine/include/tracy/public/client/TracyScoped.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracyScoped.hpp
@@ -9,15 +9,11 @@
 #include "../common/TracySystem.hpp"
 #include "../common/TracyAlign.hpp"
 #include "../common/TracyAlloc.hpp"
+#include "../common/TracyAssert.hpp"
+#include "../common/TracyFormat.h"
 #include "TracyProfiler.hpp"
 #include "TracyCallstack.hpp"
 
-#if (defined(__GNUC__) || defined(__clang__))
-#  define TRACY_ATTRIBUTE_FORMAT_PRINTF(fmt_idx, arg_idx) \
-     __attribute__((format(printf, fmt_idx, arg_idx)))
-#else
-#  define TRACY_ATTRIBUTE_FORMAT_PRINTF(fmt_idx, arg_idx)
-#endif
 namespace tracy
 {
 
@@ -92,7 +88,7 @@ public:
 
     tracy_force_inline void Text( const char* txt, size_t size )
     {
-        assert( size < (std::numeric_limits<uint16_t>::max)() );
+        TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
         if( !m_active ) return;
 #ifdef TRACY_ON_DEMAND
         if( GetProfiler().ConnectionId() != m_connectionId ) return;
@@ -116,7 +112,7 @@ public:
         auto size = vsnprintf( nullptr, 0, fmt, args );
         va_end( args );
         if( size < 0 ) return;
-        assert( size < (std::numeric_limits<uint16_t>::max)() );
+        TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
 
         char* ptr = (char*)tracy_malloc( size_t( size ) + 1 );
         va_start( args, fmt );
@@ -131,7 +127,7 @@ public:
 
     tracy_force_inline void Name( const char* txt, size_t size )
     {
-        assert( size < (std::numeric_limits<uint16_t>::max)() );
+        TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
         if( !m_active ) return;
 #ifdef TRACY_ON_DEMAND
         if( GetProfiler().ConnectionId() != m_connectionId ) return;
@@ -155,7 +151,7 @@ public:
         auto size = vsnprintf( nullptr, 0, fmt, args );
         va_end( args );
         if( size < 0 ) return;
-        assert( size < (std::numeric_limits<uint16_t>::max)() );
+        TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
 
         char* ptr = (char*)tracy_malloc( size_t( size ) + 1 );
         va_start( args, fmt );

--- a/D3D11Engine/include/tracy/public/client/TracySysPower.cpp
+++ b/D3D11Engine/include/tracy/public/client/TracySysPower.cpp
@@ -138,7 +138,7 @@ void SysPower::ScanDirectory( const char* path, int parent )
         domain->overflow = maxRange;
         domain->handle = handle;
         domain->name = name;
-        TracyDebug( "Power domain id %i, %s found at %s\n", parent, name, path );
+        TracyDebug( "Power domain id %i, %s found at %s", parent, name, path );
     }
     else
     {

--- a/D3D11Engine/include/tracy/public/client/TracySysTime.cpp
+++ b/D3D11Engine/include/tracy/public/client/TracySysTime.cpp
@@ -11,7 +11,7 @@
 #  elif defined __APPLE__
 #    include <mach/mach_host.h>
 #    include <mach/host_info.h>
-#  elif defined BSD
+#  elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
 #    include <sys/types.h>
 #    include <sys/sysctl.h>
 #  endif
@@ -79,7 +79,7 @@ void SysTime::ReadTimes()
     idle = info.cpu_ticks[CPU_STATE_IDLE];
 }
 
-#  elif defined BSD
+#  elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
 
 void SysTime::ReadTimes()
 {
@@ -109,7 +109,7 @@ float SysTime::Get()
 
 #if defined _WIN32
     return diffUsed == 0 ? -1 : ( diffUsed - diffIdle ) * 100.f / diffUsed;
-#elif defined __linux__ || defined __APPLE__ || defined BSD
+#elif defined __linux__ || defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
     const auto total = diffUsed + diffIdle;
     return total == 0 ? -1 : diffUsed * 100.f / total;
 #endif

--- a/D3D11Engine/include/tracy/public/client/TracySysTime.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracySysTime.hpp
@@ -1,13 +1,7 @@
 #ifndef __TRACYSYSTIME_HPP__
 #define __TRACYSYSTIME_HPP__
 
-#if defined _WIN32 || defined __linux__ || defined __APPLE__
-#  define TRACY_HAS_SYSTIME
-#else
-#  include <sys/param.h>
-#endif
-
-#ifdef BSD
+#if defined _WIN32 || defined __linux__ || defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
 #  define TRACY_HAS_SYSTIME
 #endif
 

--- a/D3D11Engine/include/tracy/public/client/TracySysTrace.cpp
+++ b/D3D11Engine/include/tracy/public/client/TracySysTrace.cpp
@@ -1,6 +1,7 @@
 #include "TracyDebug.hpp"
 #include "TracyStringHelpers.hpp"
 #include "TracySysTrace.hpp"
+#include "../common/TracyAssert.hpp"
 #include "../common/TracySystem.hpp"
 
 #ifdef TRACY_HAS_SYSTEM_TRACING
@@ -10,6 +11,8 @@
 #    define TRACY_SAMPLING_HZ 8000
 #  elif defined __linux__
 #    define TRACY_SAMPLING_HZ 10000
+#  elif defined __APPLE__
+#    define TRACY_SAMPLING_HZ 1000
 #  endif
 #endif
 
@@ -34,9 +37,9 @@ static int GetSamplingFrequency()
 #endif
 }
 
-static int GetSamplingPeriod()
+static int SamplingFrequencyToPeriodNs( int samplingHz )
 {
-    return 1000000000 / GetSamplingFrequency();
+    return 1000000000 / samplingHz;
 }
 
 }
@@ -48,12 +51,9 @@ static int GetSamplingPeriod()
 #    endif
 
 #    define INITGUID
-#    include <assert.h>
 #    include <string.h>
 #    include <windows.h>
 #    include <dbghelp.h>
-#    include <evntrace.h>
-#    include <evntcons.h>
 #    include <psapi.h>
 #    include <winternl.h>
 
@@ -61,84 +61,13 @@ static int GetSamplingPeriod()
 #    include "../common/TracySystem.hpp"
 #    include "TracyProfiler.hpp"
 #    include "TracyThread.hpp"
+#    include "windows/TracyETW_compat.h"
+#    include "windows/TracyETW.cpp"
 
 namespace tracy
 {
 
-static const GUID PerfInfoGuid = { 0xce1dbfb4, 0x137e, 0x4da6, { 0x87, 0xb0, 0x3f, 0x59, 0xaa, 0x10, 0x2c, 0xbc } };
-static const GUID DxgKrnlGuid  = { 0x802ec45a, 0x1e99, 0x4b83, { 0x99, 0x20, 0x87, 0xc9, 0x82, 0x77, 0xba, 0x9d } };
-static const GUID ThreadV2Guid = { 0x3d6fa8d1, 0xfe05, 0x11d0, { 0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c } };
-
-
-static TRACEHANDLE s_traceHandle;
-static TRACEHANDLE s_traceHandle2;
-static EVENT_TRACE_PROPERTIES* s_prop;
 static DWORD s_pid;
-
-static EVENT_TRACE_PROPERTIES* s_propVsync;
-static TRACEHANDLE s_traceHandleVsync;
-static TRACEHANDLE s_traceHandleVsync2;
-Thread* s_threadVsync = nullptr;
-
-struct CSwitch
-{
-    uint32_t    newThreadId;
-    uint32_t    oldThreadId;
-    int8_t      newThreadPriority;
-    int8_t      oldThreadPriority;
-    uint8_t     previousCState;
-    int8_t      spareByte;
-    int8_t      oldThreadWaitReason;
-    int8_t      oldThreadWaitMode;
-    int8_t      oldThreadState;
-    int8_t      oldThreadWaitIdealProcessor;
-    uint32_t    newThreadWaitTime;
-    uint32_t    reserved;
-};
-
-struct ReadyThread
-{
-    uint32_t    threadId;
-    int8_t      adjustReason;
-    int8_t      adjustIncrement;
-    int8_t      flag;
-    int8_t      reserverd;
-};
-
-struct ThreadTrace
-{
-    uint32_t processId;
-    uint32_t threadId;
-    uint32_t stackBase;
-    uint32_t stackLimit;
-    uint32_t userStackBase;
-    uint32_t userStackLimit;
-    uint32_t startAddr;
-    uint32_t win32StartAddr;
-    uint32_t tebBase;
-    uint32_t subProcessTag;
-};
-
-struct StackWalkEvent
-{
-    uint64_t eventTimeStamp;
-    uint32_t stackProcess;
-    uint32_t stackThread;
-    uint64_t stack[192];
-};
-
-struct VSyncInfo
-{
-    void*       dxgAdapter;
-    uint32_t    vidPnTargetId;
-    uint64_t    scannedPhysicalAddress;
-    uint32_t    vidPnSourceId;
-    uint32_t    frameNumber;
-    int64_t     frameQpcTime;
-    void*       hFlipDevice;
-    uint32_t    flipType;
-    uint64_t    flipFenceId;
-};
 
 extern "C" typedef NTSTATUS (WINAPI *t_NtQueryInformationThread)( HANDLE, THREADINFOCLASS, PVOID, ULONG, PULONG );
 extern "C" typedef BOOL (WINAPI *t_EnumProcessModules)( HANDLE, HMODULE*, DWORD, LPDWORD );
@@ -161,28 +90,32 @@ void WINAPI EventRecordCallback( PEVENT_RECORD record )
 #endif
 
     const auto& hdr = record->EventHeader;
+    // WARN: doing a fast switch-match below with the top 32 bits of the GUID
+    // (Data1 is the leading 32bit word of the 128bit GUID).
+    // Ideally, we should be using 'IsEqualGUID()' inside each case match to be
+    // inequivocally sure we are dealing the correct event provider.
     switch( hdr.ProviderId.Data1 )
     {
-    case 0x3d6fa8d1:    // Thread Guid
-        if( hdr.EventDescriptor.Opcode == 36 )
+    case etw::ThreadGuid.Data1:
+        if( hdr.EventDescriptor.Opcode == etw::CSwitch::Opcode )
         {
-            const auto cswitch = (const CSwitch*)record->UserData;
+            const auto cswitch = (const etw::CSwitch*)record->UserData;
 
             TracyLfqPrepare( QueueType::ContextSwitch );
             MemWrite( &item->contextSwitch.time, hdr.TimeStamp.QuadPart );
             MemWrite( &item->contextSwitch.oldThread, cswitch->oldThreadId );
             MemWrite( &item->contextSwitch.newThread, cswitch->newThreadId );
             MemWrite( &item->contextSwitch.cpu, record->BufferContext.ProcessorNumber );
-            MemWrite( &item->contextSwitch.oldThreadWaitReason, cswitch->oldThreadWaitReason );
-            MemWrite( &item->contextSwitch.oldThreadState, cswitch->oldThreadState );
+            MemWrite( &item->contextSwitch.oldThreadWaitReason, uint8_t( cswitch->oldThreadWaitReason ) );
+            MemWrite( &item->contextSwitch.oldThreadState, uint8_t( cswitch->oldThreadState ) );
             MemWrite( &item->contextSwitch.newThreadPriority, cswitch->newThreadPriority );
             MemWrite( &item->contextSwitch.oldThreadPriority, cswitch->oldThreadPriority );
             MemWrite( &item->contextSwitch.previousCState, cswitch->previousCState );
             TracyLfqCommit;
         }
-        else if( hdr.EventDescriptor.Opcode == 50 )
+        else if( hdr.EventDescriptor.Opcode == etw::ReadyThread::Opcode )
         {
-            const auto rt = (const ReadyThread*)record->UserData;
+            const auto rt = (const etw::ReadyThread*)record->UserData;
 
             TracyLfqPrepare( QueueType::ThreadWakeup );
             MemWrite( &item->threadWakeup.time, hdr.TimeStamp.QuadPart );
@@ -192,23 +125,23 @@ void WINAPI EventRecordCallback( PEVENT_RECORD record )
             MemWrite( &item->threadWakeup.adjustIncrement, rt->adjustIncrement );
             TracyLfqCommit;
         }
-        else if( hdr.EventDescriptor.Opcode == 1 || hdr.EventDescriptor.Opcode == 3 )
+        else if( hdr.EventDescriptor.Opcode == etw::ThreadStart::Opcode || hdr.EventDescriptor.Opcode == etw::ThreadDCStart::Opcode )
         {
-            const auto tt = (const ThreadTrace*)record->UserData;
+            const auto ti = (const etw::ThreadInfo*)record->UserData;
 
-            uint64_t tid = tt->threadId;
+            uint64_t tid = ti->threadId;
             if( tid == 0 ) return;
-            uint64_t pid = tt->processId;
+            uint64_t pid = ti->processId;
             TracyLfqPrepare( QueueType::TidToPid );
             MemWrite( &item->tidToPid.tid, tid );
             MemWrite( &item->tidToPid.pid, pid );
             TracyLfqCommit;
         }
         break;
-    case 0xdef2fe46:    // StackWalk Guid
-        if( hdr.EventDescriptor.Opcode == 32 )
+    case etw::StackWalkGuid.Data1:
+        if( hdr.EventDescriptor.Opcode == etw::StackWalkEvent::Opcode )
         {
-            const auto sw = (const StackWalkEvent*)record->UserData;
+            const auto sw = (const etw::StackWalkEvent*)record->UserData;
             if( sw->stackProcess == s_pid )
             {
                 const uint64_t sz = ( record->UserDataLength - 16 ) / 8;
@@ -218,12 +151,22 @@ void WINAPI EventRecordCallback( PEVENT_RECORD record )
                     memcpy( trace, &sz, sizeof( uint64_t ) );
                     memcpy( trace+1, sw->stack, sizeof( uint64_t ) * sz );
                     TracyLfqPrepare( QueueType::CallstackSample );
-                    MemWrite( &item->callstackSampleFat.time, sw->eventTimeStamp );
+                    MemWrite( &item->callstackSampleFat.time, int64_t( sw->eventTimeStamp ) );
                     MemWrite( &item->callstackSampleFat.thread, sw->stackThread );
-                    MemWrite( &item->callstackSampleFat.ptr, (uint64_t)trace );
+                    MemWrite( &item->callstackSampleFat.ptr, uint64_t( trace ) );
                     TracyLfqCommit;
                 }
             }
+        }
+        break;
+    case etw::DxgKrnlGuid.Data1:
+        TRACY_ASSERT( hdr.EventDescriptor.Id == etw::VSyncDPC::EventId );
+        {
+            const auto vs = (const etw::VSyncDPC*)record->UserData;
+            TracyLfqPrepare( QueueType::FrameVsync );
+            MemWrite( &item->frameVsync.time, hdr.TimeStamp.QuadPart );
+            MemWrite( &item->frameVsync.id, vs->vidPnTargetId );
+            TracyLfqCommit;
         }
         break;
     default:
@@ -231,119 +174,11 @@ void WINAPI EventRecordCallback( PEVENT_RECORD record )
     }
 }
 
-void WINAPI EventRecordCallbackVsync( PEVENT_RECORD record )
-{
-#ifdef TRACY_ON_DEMAND
-    if( !GetProfiler().IsConnected() ) return;
-#endif
-
-    const auto& hdr = record->EventHeader;
-
-    // Check for Lost_Event (6a399ae0-4bc6-4de9-870b-3657f8947e7e)
-    if( hdr.ProviderId.Data1 == 0x6A399AE0 ) return;
-
-    assert( hdr.ProviderId.Data1 == 0x802EC45A );
-    assert( hdr.EventDescriptor.Id == 0x0011 );
-
-    const auto vs = (const VSyncInfo*)record->UserData;
-
-    TracyLfqPrepare( QueueType::FrameVsync );
-    MemWrite( &item->frameVsync.time, hdr.TimeStamp.QuadPart );
-    MemWrite( &item->frameVsync.id, vs->vidPnTargetId );
-    TracyLfqCommit;
-}
-
-static void SetupVsync()
-{
-#if _WIN32_WINNT >= _WIN32_WINNT_WINBLUE && !defined(__MINGW32__)
-    const auto psz = sizeof( EVENT_TRACE_PROPERTIES ) + MAX_PATH;
-    s_propVsync = (EVENT_TRACE_PROPERTIES*)tracy_malloc( psz );
-    memset( s_propVsync, 0, sizeof( EVENT_TRACE_PROPERTIES ) );
-    s_propVsync->LogFileMode = EVENT_TRACE_REAL_TIME_MODE;
-    s_propVsync->Wnode.BufferSize = psz;
-#ifdef TRACY_TIMER_QPC
-    s_propVsync->Wnode.ClientContext = 1;
-#else
-    s_propVsync->Wnode.ClientContext = 3;
-#endif
-    s_propVsync->LoggerNameOffset = sizeof( EVENT_TRACE_PROPERTIES );
-    strcpy( ((char*)s_propVsync) + sizeof( EVENT_TRACE_PROPERTIES ), "TracyVsync" );
-
-    auto backup = tracy_malloc( psz );
-    memcpy( backup, s_propVsync, psz );
-
-    const auto controlStatus = ControlTraceA( 0, "TracyVsync", s_propVsync, EVENT_TRACE_CONTROL_STOP );
-    if( controlStatus != ERROR_SUCCESS && controlStatus != ERROR_WMI_INSTANCE_NOT_FOUND )
-    {
-        tracy_free( backup );
-        tracy_free( s_propVsync );
-        return;
-    }
-
-    memcpy( s_propVsync, backup, psz );
-    tracy_free( backup );
-
-    const auto startStatus = StartTraceA( &s_traceHandleVsync, "TracyVsync", s_propVsync );
-    if( startStatus != ERROR_SUCCESS )
-    {
-        tracy_free( s_propVsync );
-        return;
-    }
-
-    EVENT_FILTER_EVENT_ID fe = {};
-    fe.FilterIn = TRUE;
-    fe.Count = 1;
-    fe.Events[0] = 0x0011;  // VSyncDPC_Info
-
-    EVENT_FILTER_DESCRIPTOR desc = {};
-    desc.Ptr = (ULONGLONG)&fe;
-    desc.Size = sizeof( fe );
-    desc.Type = EVENT_FILTER_TYPE_EVENT_ID;
-
-    ENABLE_TRACE_PARAMETERS params = {};
-    params.Version = ENABLE_TRACE_PARAMETERS_VERSION_2;
-    params.EnableProperty = EVENT_ENABLE_PROPERTY_IGNORE_KEYWORD_0;
-    params.SourceId = s_propVsync->Wnode.Guid;
-    params.EnableFilterDesc = &desc;
-    params.FilterDescCount = 1;
-
-    uint64_t mask = 0x4000000000000001;   // Microsoft_Windows_DxgKrnl_Performance | Base
-    if( EnableTraceEx2( s_traceHandleVsync, &DxgKrnlGuid, EVENT_CONTROL_CODE_ENABLE_PROVIDER, TRACE_LEVEL_INFORMATION, mask, mask, 0, &params ) != ERROR_SUCCESS )
-    {
-        tracy_free( s_propVsync );
-        return;
-    }
-
-    char loggerName[MAX_PATH];
-    strcpy( loggerName, "TracyVsync" );
-
-    EVENT_TRACE_LOGFILEA log = {};
-    log.LoggerName = loggerName;
-    log.ProcessTraceMode = PROCESS_TRACE_MODE_REAL_TIME | PROCESS_TRACE_MODE_EVENT_RECORD | PROCESS_TRACE_MODE_RAW_TIMESTAMP;
-    log.EventRecordCallback = EventRecordCallbackVsync;
-
-    s_traceHandleVsync2 = OpenTraceA( &log );
-    if( s_traceHandleVsync2 == (TRACEHANDLE)INVALID_HANDLE_VALUE )
-    {
-        CloseTrace( s_traceHandleVsync );
-        tracy_free( s_propVsync );
-        return;
-    }
-
-    s_threadVsync = (Thread*)tracy_malloc( sizeof( Thread ) );
-    new(s_threadVsync) Thread( [] (void*) {
-        ThreadExitHandler threadExitHandler;
-        SetThreadPriority( GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL );
-        SetThreadName( "Tracy Vsync" );
-        ProcessTrace( &s_traceHandleVsync2, 1, nullptr, nullptr );
-    }, nullptr );
-#endif
-}
-
-static int GetSamplingInterval()
-{
-    return GetSamplingPeriod() / 100;
-}
+static etw::Session session_kernel = {};
+static etw::Session session_vsync = {};
+static PROCESSTRACE_HANDLE consumer_kernel = INVALID_PROCESSTRACE_HANDLE;
+static PROCESSTRACE_HANDLE consumer_vsync = INVALID_PROCESSTRACE_HANDLE;
+static Thread* s_threadVsync = nullptr;
 
 bool SysTraceStart( int64_t& samplingPeriod )
 {
@@ -351,121 +186,59 @@ bool SysTraceStart( int64_t& samplingPeriod )
 
     s_pid = GetCurrentProcessId();
 
-#if defined _WIN64
-    constexpr bool isOs64Bit = true;
-#else
-    BOOL _iswow64;
-    IsWow64Process( GetCurrentProcess(), &_iswow64 );
-    const bool isOs64Bit = _iswow64;
-#endif
+    if( !etw::CheckAdminPrivilege() )
+        return false;
 
-    TOKEN_PRIVILEGES priv = {};
-    priv.PrivilegeCount = 1;
-    priv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-    if( LookupPrivilegeValue( nullptr, SE_SYSTEM_PROFILE_NAME, &priv.Privileges[0].Luid ) == 0 ) return false;
+    session_kernel = etw::StartSingletonKernelLoggerSession( 0 );
+    if( session_kernel.handle == 0 )
+        return false;
 
-    HANDLE pt;
-    if( OpenProcessToken( GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &pt ) == 0 ) return false;
-    const auto adjust = AdjustTokenPrivileges( pt, FALSE, &priv, 0, nullptr, nullptr );
-    CloseHandle( pt );
-    if( adjust == 0 ) return false;
-    const auto status = GetLastError();
-    if( status != ERROR_SUCCESS ) return false;
-
-    if( isOs64Bit )
-    {
-        TRACE_PROFILE_INTERVAL interval = {};
-        interval.Interval = GetSamplingInterval();
-        const auto intervalStatus = TraceSetInformation( 0, TraceSampledProfileIntervalInfo, &interval, sizeof( interval ) );
-        if( intervalStatus != ERROR_SUCCESS ) return false;
-        samplingPeriod = GetSamplingPeriod();
-    }
-
-    const auto psz = sizeof( EVENT_TRACE_PROPERTIES ) + sizeof( KERNEL_LOGGER_NAME );
-    s_prop = (EVENT_TRACE_PROPERTIES*)tracy_malloc( psz );
-    memset( s_prop, 0, sizeof( EVENT_TRACE_PROPERTIES ) );
-    ULONG flags = 0;
 #ifndef TRACY_NO_CONTEXT_SWITCH
-    flags = EVENT_TRACE_FLAG_CSWITCH | EVENT_TRACE_FLAG_DISPATCHER | EVENT_TRACE_FLAG_THREAD;
-#endif
-#ifndef TRACY_NO_SAMPLING
-    if( isOs64Bit ) flags |= EVENT_TRACE_FLAG_PROFILE;
-#endif
-    s_prop->EnableFlags = flags;
-    s_prop->LogFileMode = EVENT_TRACE_REAL_TIME_MODE;
-    s_prop->Wnode.BufferSize = psz;
-    s_prop->Wnode.Flags = WNODE_FLAG_TRACED_GUID;
-#ifdef TRACY_TIMER_QPC
-    s_prop->Wnode.ClientContext = 1;
+#ifdef TRACY_NO_WAIT_STACKS
+    const bool noWaitStacks = true;
 #else
-    s_prop->Wnode.ClientContext = 3;
+    const char* noWaitStacksEnv = GetEnvVar( "TRACY_NO_WAIT_STACKS" );
+    const bool noWaitStacks = noWaitStacksEnv && noWaitStacksEnv[0] == '1';
 #endif
-    s_prop->Wnode.Guid = SystemTraceControlGuid;
-    s_prop->BufferSize = 1024;
-    s_prop->MinimumBuffers = std::thread::hardware_concurrency() * 4;
-    s_prop->MaximumBuffers = std::thread::hardware_concurrency() * 6;
-    s_prop->LoggerNameOffset = sizeof( EVENT_TRACE_PROPERTIES );
-    memcpy( ((char*)s_prop) + sizeof( EVENT_TRACE_PROPERTIES ), KERNEL_LOGGER_NAME, sizeof( KERNEL_LOGGER_NAME ) );
+    if( etw::EnableProcessAndThreadMonitoring( session_kernel ) != ERROR_SUCCESS )
+        return etw::StopSession( session_kernel ), false;
+    if( etw::EnableContextSwitchMonitoring( session_kernel, !noWaitStacks ) != ERROR_SUCCESS )
+        return etw::StopSession( session_kernel ), false;
+#endif
 
-    auto backup = tracy_malloc( psz );
-    memcpy( backup, s_prop, psz );
-
-    const auto controlStatus = ControlTrace( 0, KERNEL_LOGGER_NAME, s_prop, EVENT_TRACE_CONTROL_STOP );
-    if( controlStatus != ERROR_SUCCESS && controlStatus != ERROR_WMI_INSTANCE_NOT_FOUND )
-    {
-        tracy_free( backup );
-        tracy_free( s_prop );
-        return false;
-    }
-
-    memcpy( s_prop, backup, psz );
-    tracy_free( backup );
-
-    const auto startStatus = StartTrace( &s_traceHandle, KERNEL_LOGGER_NAME, s_prop );
-    if( startStatus != ERROR_SUCCESS )
-    {
-        tracy_free( s_prop );
-        return false;
-    }
 
 #ifndef TRACY_NO_SAMPLING
-    if( isOs64Bit )
-    {
-        CLASSIC_EVENT_ID stackId[2] = {};
-        stackId[0].EventGuid = PerfInfoGuid;
-        stackId[0].Type = 46;
-        stackId[1].EventGuid = ThreadV2Guid;
-        stackId[1].Type = 36;
-        const auto stackStatus = TraceSetInformation( s_traceHandle, TraceStackTracingInfo, &stackId, sizeof( stackId ) );
-        if( stackStatus != ERROR_SUCCESS )
-        {
-            tracy_free( s_prop );
-            return false;
-        }
-    }
+    samplingPeriod = SamplingFrequencyToPeriodNs( GetSamplingFrequency() );
+    const int microseconds = samplingPeriod / 1000;
+    if( etw::EnableCPUProfiling( session_kernel, microseconds ) != ERROR_SUCCESS )
+        return etw::StopSession( session_kernel ), false;
 #endif
 
-#ifdef UNICODE
-    WCHAR KernelLoggerName[sizeof( KERNEL_LOGGER_NAME )];
-#else
-    char KernelLoggerName[sizeof( KERNEL_LOGGER_NAME )];
-#endif
-    memcpy( KernelLoggerName, KERNEL_LOGGER_NAME, sizeof( KERNEL_LOGGER_NAME ) );
-    EVENT_TRACE_LOGFILE log = {};
-    log.LoggerName = KernelLoggerName;
-    log.ProcessTraceMode = PROCESS_TRACE_MODE_REAL_TIME | PROCESS_TRACE_MODE_EVENT_RECORD | PROCESS_TRACE_MODE_RAW_TIMESTAMP;
-    log.EventRecordCallback = EventRecordCallback;
-
-    s_traceHandle2 = OpenTrace( &log );
-    if( s_traceHandle2 == (TRACEHANDLE)INVALID_HANDLE_VALUE )
-    {
-        CloseTrace( s_traceHandle );
-        tracy_free( s_prop );
-        return false;
-    }
+    consumer_kernel = etw::SetupEventConsumer( session_kernel, EventRecordCallback );
+    if( consumer_kernel == INVALID_PROCESSTRACE_HANDLE )
+        return etw::StopSession( session_kernel ), false;
 
 #ifndef TRACY_NO_VSYNC_CAPTURE
-    SetupVsync();
+    session_vsync = etw::StartUserSession( "TracyVsync" );
+    if( session_vsync.handle != 0 )
+    {
+        if( etw::EnableVSyncMonitoring( session_vsync ) != ERROR_SUCCESS )
+            etw::StopSession( session_vsync );
+        else
+        {
+            consumer_vsync = etw::SetupEventConsumer( session_vsync, EventRecordCallback );
+            if( consumer_vsync != INVALID_PROCESSTRACE_HANDLE )
+            {
+                s_threadVsync = (Thread*)tracy_malloc( sizeof( Thread ) );
+                new(s_threadVsync) Thread( [] (void*) {
+                    ThreadExitHandler threadExitHandler;
+                    SetThreadPriority( GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL );
+                    SetThreadName( "Tracy Vsync (ETW)" );
+                    etw::EventConsumerLoop( consumer_vsync );
+                }, nullptr );
+            }
+        }
+    }
 #endif
 
     return true;
@@ -475,24 +248,21 @@ void SysTraceStop()
 {
     if( s_threadVsync )
     {
-        CloseTrace( s_traceHandleVsync2 );
-        CloseTrace( s_traceHandleVsync );
+        etw::StopEventConsumer( consumer_vsync );
+        etw::StopSession( session_vsync );
         s_threadVsync->~Thread();
         tracy_free( s_threadVsync );
     }
-
-    CloseTrace( s_traceHandle2 );
-    CloseTrace( s_traceHandle );
+    etw::StopEventConsumer( consumer_kernel );
+    etw::StopSession( session_kernel );
 }
 
 void SysTraceWorker( void* ptr )
 {
     ThreadExitHandler threadExitHandler;
     SetThreadPriority( GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL );
-    SetThreadName( "Tracy SysTrace" );
-    ProcessTrace( &s_traceHandle2, 1, 0, 0 );
-    ControlTrace( 0, KERNEL_LOGGER_NAME, s_prop, EVENT_TRACE_CONTROL_STOP );
-    tracy_free( s_prop );
+    SetThreadName( "Tracy SysTrace (ETW)" );
+    etw::EventConsumerLoop( consumer_kernel );
 }
 
 void SysTraceGetExternalName( uint64_t thread, const char*& threadName, const char*& name )
@@ -611,6 +381,7 @@ void SysTraceGetExternalName( uint64_t thread, const char*& threadName, const ch
 #    include <sys/types.h>
 #    include <sys/stat.h>
 #    include <sys/wait.h>
+#    include <dirent.h>
 #    include <fcntl.h>
 #    include <inttypes.h>
 #    include <limits>
@@ -643,8 +414,55 @@ static std::atomic<bool> traceActive { false };
 static int s_numCpus = 0;
 static int s_numBuffers = 0;
 static int s_ctxBufferIdx = 0;
+static bool s_ctxSwitchCallchain = false;
 
 static RingBuffer* s_ring = nullptr;
+
+extern uint32_t ___tracy_magic_pid_override;
+
+// (pid, cpu) pair for a per-task perf event open. In self-profiling mode we
+// iterate one entry per CPU with pid = our tgid. In monitor mode we iterate
+// one entry per existing thread of the target, with cpu = -1, so inherit=1
+// can cover all descendants without multiplying ring buffers by CPU count.
+struct PerfIterTarget
+{
+    pid_t pid;
+    int cpu;
+};
+
+// Read /proc/<pid>/task/ and return the list of tids. Caller owns the buffer
+// (tracy_free). Returns 0 and sets *out = nullptr on failure.
+static int EnumerateTaskTids( pid_t pid, uint32_t** out )
+{
+    char path[64];
+    snprintf( path, sizeof( path ), "/proc/%d/task", (int)pid );
+    DIR* dir = opendir( path );
+    if( !dir )
+    {
+        *out = nullptr;
+        return 0;
+    }
+    size_t capacity = 32;
+    uint32_t* tids = (uint32_t*)tracy_malloc( sizeof( uint32_t ) * capacity );
+    size_t count = 0;
+    struct dirent* entry;
+    while( ( entry = readdir( dir ) ) != nullptr )
+    {
+        if( entry->d_name[0] == '.' ) continue;
+        char* endp;
+        unsigned long tid = strtoul( entry->d_name, &endp, 10 );
+        if( *endp != '\0' || tid == 0 ) continue;
+        if( count >= capacity )
+        {
+            capacity *= 2;
+            tids = (uint32_t*)tracy_realloc( tids, sizeof( uint32_t ) * capacity );
+        }
+        tids[count++] = (uint32_t)tid;
+    }
+    closedir( dir );
+    *out = tids;
+    return (int)count;
+}
 
 static const int ThreadHashSize = 4 * 1024;
 static uint32_t s_threadHash[ThreadHashSize] = {};
@@ -657,7 +475,14 @@ static bool CurrentProcOwnsThread( uint32_t tid )
     if( hv == -tid ) return false;
 
     char path[256];
-    sprintf( path, "/proc/self/task/%d", tid );
+    if( ___tracy_magic_pid_override != 0 )
+    {
+        sprintf( path, "/proc/%d/task/%d", (int)___tracy_magic_pid_override, tid );
+    }
+    else
+    {
+        sprintf( path, "/proc/self/task/%d", tid );
+    }
     struct stat st;
     if( stat( path, &st ) == 0 )
     {
@@ -715,7 +540,7 @@ static void ProbePreciseIp( perf_event_attr& pe, unsigned long long config0, uns
         }
         pe.precise_ip--;
     }
-    TracyDebug( "  Probed precise_ip: %i\n", pe.precise_ip );
+    TracyDebug( "  Probed precise_ip: %i", pe.precise_ip );
 }
 
 static void ProbePreciseIp( perf_event_attr& pe, pid_t pid )
@@ -731,7 +556,7 @@ static void ProbePreciseIp( perf_event_attr& pe, pid_t pid )
         }
         pe.precise_ip--;
     }
-    TracyDebug( "  Probed precise_ip: %i\n", pe.precise_ip );
+    TracyDebug( "  Probed precise_ip: %i", pe.precise_ip );
 }
 
 static bool IsGenuineIntel()
@@ -785,13 +610,26 @@ static char* GetTraceFsPath()
     char* ret = nullptr;
     while( auto ent = getmntent( f ) )
     {
-        if( strcmp( ent->mnt_fsname, "tracefs" ) == 0 )
+        if( strcmp( ent->mnt_type, "tracefs" ) == 0 )
         {
             auto len = strlen( ent->mnt_dir );
-            ret = (char*)tracy_malloc( len + 1 );
+            // ret may be != nullptr if we already saw a debugfs entry
+            ret = (char*)tracy_realloc( ret, len + 1 );
             memcpy( ret, ent->mnt_dir, len );
             ret[len] = '\0';
             break;
+        }
+        else if( !ret && strcmp( ent->mnt_type, "debugfs" ) == 0 )
+        {
+            const char* tracingDirName = "tracing";
+            const size_t tracingDirNameLen = strlen( tracingDirName );
+            auto debugFsPathLen = strlen( ent->mnt_dir );
+            ret = (char*)tracy_malloc( debugFsPathLen + 1 + tracingDirNameLen + 1 );
+            memcpy( ret, ent->mnt_dir, debugFsPathLen );
+            ret[debugFsPathLen] = '/';
+            memcpy( ret + debugFsPathLen + 1, tracingDirName, tracingDirNameLen );
+            ret[debugFsPathLen + 1 + tracingDirNameLen] = '\0';
+            // Don't break to allow for tracefs to be found later as it is the preferred path
         }
     }
     endmntent( f );
@@ -805,16 +643,22 @@ bool SysTraceStart( int64_t& samplingPeriod )
 #endif
 
     const auto paranoidLevelStr = ReadFile( "/proc/sys/kernel/perf_event_paranoid" );
-    if( !paranoidLevelStr ) return false;
-#ifdef TRACY_VERBOSE
-    int paranoidLevel = 2;
-    paranoidLevel = atoi( paranoidLevelStr );
-    TracyDebug( "perf_event_paranoid: %i\n", paranoidLevel );
-#endif
+    if( !paranoidLevelStr )
+    {
+        TracyDebug( "Failed to read perf_event_paranoid, cannot setup system tracing." );
+        return false;
+    }
+
+    const int paranoidLevel = atoi( paranoidLevelStr );
+    TracyDebug( "perf_event_paranoid: %i", paranoidLevel );
 
     auto traceFsPath = GetTraceFsPath();
-    if( !traceFsPath ) return false;
-    TracyDebug( "tracefs path: %s\n", traceFsPath );
+    if( !traceFsPath )
+    {
+        TracyDebug( "Failed to get tracefs path, cannot setup system tracing." );
+        return false;
+    }
+    TracyDebug( "tracefs path: %s", traceFsPath );
 
     int switchId = -1, wakingId = -1, vsyncId = -1;
     const auto switchIdStr = ReadFile( traceFsPath, "/events/sched/sched_switch/id" );
@@ -826,9 +670,18 @@ bool SysTraceStart( int64_t& samplingPeriod )
 
     tracy_free( traceFsPath );
 
-    TracyDebug( "sched_switch id: %i\n", switchId );
-    TracyDebug( "sched_waking id: %i\n", wakingId );
-    TracyDebug( "drm_vblank_event id: %i\n", vsyncId );
+    TracyDebug( "sched_switch id: %i", switchId );
+    TracyDebug( "sched_waking id: %i", wakingId );
+    TracyDebug( "drm_vblank_event id: %i", vsyncId );
+
+    bool useMonotonicClockRaw = !HardwareSupportsInvariantTSC();
+#if !defined TRACY_HW_TIMER || !defined TRACY_HAS_RDTSC
+    useMonotonicClockRaw = true;
+#endif
+    if( useMonotonicClockRaw )
+    {
+        TracyDebug( "Using CLOCK_MONOTONIC_RAW for Linux perf events." );
+    }
 
 #ifdef TRACY_NO_SAMPLING
     const bool noSoftwareSampling = true;
@@ -872,16 +725,65 @@ bool SysTraceStart( int64_t& samplingPeriod )
     const bool noVsync = noVsyncEnv && noVsyncEnv[0] == '1';
 #endif
 
-    samplingPeriod = GetSamplingPeriod();
-    uint32_t currentPid = (uint32_t)getpid();
+#ifdef TRACY_NO_WAIT_STACKS
+    const bool noWaitStacks = true;
+#else
+    const char* noWaitStacksEnv = GetEnvVar( "TRACY_NO_WAIT_STACKS" );
+    const bool noWaitStacks = noWaitStacksEnv && noWaitStacksEnv[0] == '1';
+#endif
+
+    int samplingFrequency = GetSamplingFrequency();
+    if( samplingFrequency > 0 )
+    {
+        const auto maxSampleRateStr = ReadFile( "/proc/sys/kernel/perf_event_max_sample_rate" );
+        if( maxSampleRateStr )
+        {
+            const int sysMax = atoi( maxSampleRateStr );
+            if( sysMax > 0 && sysMax < samplingFrequency )
+            {
+                TracyDebug( "Requested sampling frequency %d Hz is higher than system maximum of %d Hz, reducing to system maximum.", samplingFrequency, sysMax );
+                samplingFrequency = sysMax;
+            }
+        }
+    }
+    samplingPeriod = SamplingFrequencyToPeriodNs( samplingFrequency );
+    uint32_t currentPid = ___tracy_magic_pid_override != 0 ? ___tracy_magic_pid_override : (uint32_t)getpid();
 
     s_numCpus = (int)std::thread::hardware_concurrency();
 
-    const auto maxNumBuffers = s_numCpus * (
+    // Build the per-task iteration list. In monitor mode this is all existing
+    // threads of the target (one event per thread, any CPU); in self-profiling
+    // it is per-CPU bound to our own tgid.
+    PerfIterTarget* iter = nullptr;
+    int numIter = 0;
+    if( ___tracy_magic_pid_override != 0 )
+    {
+        uint32_t* tids = nullptr;
+        const int numTids = EnumerateTaskTids( (pid_t)currentPid, &tids );
+        if( numTids == 0 )
+        {
+            TracyDebug( "Failed to enumerate threads of pid %u; target may have exited.", currentPid );
+            return false;
+        }
+        iter = (PerfIterTarget*)tracy_malloc( sizeof( PerfIterTarget ) * numTids );
+        for( int i=0; i<numTids; i++ ) iter[i] = { (pid_t)tids[i], -1 };
+        numIter = numTids;
+        tracy_free( tids );
+        TracyDebug( "Monitor mode: tracing %i existing threads of pid %u", numIter, currentPid );
+    }
+    else
+    {
+        iter = (PerfIterTarget*)tracy_malloc( sizeof( PerfIterTarget ) * s_numCpus );
+        for( int i=0; i<s_numCpus; i++ ) iter[i] = { (pid_t)currentPid, i };
+        numIter = s_numCpus;
+    }
+
+    const auto maxNumBuffers = numIter * (
         1 +     // software sampling
         2 +     // CPU cycles + instructions retired
         2 +     // cache reference + miss
-        2 +     // branch retired + miss
+        2       // branch retired + miss
+    ) + s_numCpus * (
         2 +     // context switches + waking ups
         1       // vsync
     );
@@ -893,7 +795,7 @@ bool SysTraceStart( int64_t& samplingPeriod )
     pe.type = PERF_TYPE_SOFTWARE;
     pe.size = sizeof( perf_event_attr );
     pe.config = PERF_COUNT_SW_CPU_CLOCK;
-    pe.sample_freq = GetSamplingFrequency();
+    pe.sample_freq = samplingFrequency;
     pe.sample_type = PERF_SAMPLE_TID | PERF_SAMPLE_TIME | PERF_SAMPLE_CALLCHAIN;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION( 4, 8, 0 )
     pe.sample_max_stack = 127;
@@ -901,35 +803,36 @@ bool SysTraceStart( int64_t& samplingPeriod )
     pe.disabled = 1;
     pe.freq = 1;
     pe.inherit = 1;
-#if !defined TRACY_HW_TIMER || !( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
-    pe.use_clockid = 1;
-    pe.clockid = CLOCK_MONOTONIC_RAW;
-#endif
+    if( useMonotonicClockRaw )
+    {
+        pe.use_clockid = 1;
+        pe.clockid = CLOCK_MONOTONIC_RAW;
+    }
 
     if( !noSoftwareSampling )
     {
-        TracyDebug( "Setup software sampling\n" );
+        TracyDebug( "Setup software sampling" );
         ProbePreciseIp( pe, currentPid );
-        for( int i=0; i<s_numCpus; i++ )
+        for( int i=0; i<numIter; i++ )
         {
-            int fd = perf_event_open( &pe, currentPid, i, -1, PERF_FLAG_FD_CLOEXEC );
+            int fd = perf_event_open( &pe, iter[i].pid, iter[i].cpu, -1, PERF_FLAG_FD_CLOEXEC );
             if( fd == -1 )
             {
                 pe.exclude_kernel = 1;
                 ProbePreciseIp( pe, currentPid );
-                fd = perf_event_open( &pe, currentPid, i, -1, PERF_FLAG_FD_CLOEXEC );
+                fd = perf_event_open( &pe, iter[i].pid, iter[i].cpu, -1, PERF_FLAG_FD_CLOEXEC );
                 if( fd == -1 )
                 {
-                    TracyDebug( "  Failed to setup!\n");
+                    TracyDebug( "  Failed to setup!");
                     break;
                 }
-                TracyDebug( "  No access to kernel samples\n" );
+                TracyDebug( "  No access to kernel samples" );
             }
             new( s_ring+s_numBuffers ) RingBuffer( 64*1024, fd, EventCallstack );
             if( s_ring[s_numBuffers].IsValid() )
             {
                 s_numBuffers++;
-                TracyDebug( "  Core %i ok\n", i );
+                TracyDebug( "  Target %i ok", i );
             }
         }
     }
@@ -946,40 +849,41 @@ bool SysTraceStart( int64_t& samplingPeriod )
     pe.exclude_hv = 1;
     pe.freq = 1;
     pe.inherit = 1;
-#if !defined TRACY_HW_TIMER || !( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
-    pe.use_clockid = 1;
-    pe.clockid = CLOCK_MONOTONIC_RAW;
-#endif
+    if( useMonotonicClockRaw )
+    {
+        pe.use_clockid = 1;
+        pe.clockid = CLOCK_MONOTONIC_RAW;
+    }
 
     if( !noRetirement )
     {
-        TracyDebug( "Setup sampling cycles + retirement\n" );
+        TracyDebug( "Setup sampling cycles + retirement" );
         ProbePreciseIp( pe, PERF_COUNT_HW_CPU_CYCLES, PERF_COUNT_HW_INSTRUCTIONS, currentPid );
-        for( int i=0; i<s_numCpus; i++ )
+        for( int i=0; i<numIter; i++ )
         {
-            const int fd = perf_event_open( &pe, currentPid, i, -1, PERF_FLAG_FD_CLOEXEC );
+            const int fd = perf_event_open( &pe, iter[i].pid, iter[i].cpu, -1, PERF_FLAG_FD_CLOEXEC );
             if( fd != -1 )
             {
                 new( s_ring+s_numBuffers ) RingBuffer( 64*1024, fd, EventCpuCycles );
                 if( s_ring[s_numBuffers].IsValid() )
                 {
                     s_numBuffers++;
-                    TracyDebug( "  Core %i ok\n", i );
+                    TracyDebug( "  Target %i ok", i );
                 }
             }
         }
 
         pe.config = PERF_COUNT_HW_INSTRUCTIONS;
-        for( int i=0; i<s_numCpus; i++ )
+        for( int i=0; i<numIter; i++ )
         {
-            const int fd = perf_event_open( &pe, currentPid, i, -1, PERF_FLAG_FD_CLOEXEC );
+            const int fd = perf_event_open( &pe, iter[i].pid, iter[i].cpu, -1, PERF_FLAG_FD_CLOEXEC );
             if( fd != -1 )
             {
                 new( s_ring+s_numBuffers ) RingBuffer( 64*1024, fd, EventInstructionsRetired );
                 if( s_ring[s_numBuffers].IsValid() )
                 {
                     s_numBuffers++;
-                    TracyDebug( "  Core %i ok\n", i );
+                    TracyDebug( "  Target %i ok", i );
                 }
             }
         }
@@ -988,38 +892,38 @@ bool SysTraceStart( int64_t& samplingPeriod )
     // cache reference + miss
     if( !noCache )
     {
-        TracyDebug( "Setup sampling CPU cache references + misses\n" );
+        TracyDebug( "Setup sampling CPU cache references + misses" );
         ProbePreciseIp( pe, PERF_COUNT_HW_CACHE_REFERENCES, PERF_COUNT_HW_CACHE_MISSES, currentPid );
         if( IsGenuineIntel() )
         {
             pe.precise_ip = 0;
-            TracyDebug( "  CPU is GenuineIntel, forcing precise_ip down to 0\n" );
+            TracyDebug( "  CPU is GenuineIntel, forcing precise_ip down to 0" );
         }
-        for( int i=0; i<s_numCpus; i++ )
+        for( int i=0; i<numIter; i++ )
         {
-            const int fd = perf_event_open( &pe, currentPid, i, -1, PERF_FLAG_FD_CLOEXEC );
+            const int fd = perf_event_open( &pe, iter[i].pid, iter[i].cpu, -1, PERF_FLAG_FD_CLOEXEC );
             if( fd != -1 )
             {
                 new( s_ring+s_numBuffers ) RingBuffer( 64*1024, fd, EventCacheReference );
                 if( s_ring[s_numBuffers].IsValid() )
                 {
                     s_numBuffers++;
-                    TracyDebug( "  Core %i ok\n", i );
+                    TracyDebug( "  Target %i ok", i );
                 }
             }
         }
 
         pe.config = PERF_COUNT_HW_CACHE_MISSES;
-        for( int i=0; i<s_numCpus; i++ )
+        for( int i=0; i<numIter; i++ )
         {
-            const int fd = perf_event_open( &pe, currentPid, i, -1, PERF_FLAG_FD_CLOEXEC );
+            const int fd = perf_event_open( &pe, iter[i].pid, iter[i].cpu, -1, PERF_FLAG_FD_CLOEXEC );
             if( fd != -1 )
             {
                 new( s_ring+s_numBuffers ) RingBuffer( 64*1024, fd, EventCacheMiss );
                 if( s_ring[s_numBuffers].IsValid() )
                 {
                     s_numBuffers++;
-                    TracyDebug( "  Core %i ok\n", i );
+                    TracyDebug( "  Target %i ok", i );
                 }
             }
         }
@@ -1028,33 +932,33 @@ bool SysTraceStart( int64_t& samplingPeriod )
     // branch retired + miss
     if( !noBranch )
     {
-        TracyDebug( "Setup sampling CPU branch retirements + misses\n" );
+        TracyDebug( "Setup sampling CPU branch retirements + misses" );
         ProbePreciseIp( pe, PERF_COUNT_HW_BRANCH_INSTRUCTIONS, PERF_COUNT_HW_BRANCH_MISSES, currentPid );
-        for( int i=0; i<s_numCpus; i++ )
+        for( int i=0; i<numIter; i++ )
         {
-            const int fd = perf_event_open( &pe, currentPid, i, -1, PERF_FLAG_FD_CLOEXEC );
+            const int fd = perf_event_open( &pe, iter[i].pid, iter[i].cpu, -1, PERF_FLAG_FD_CLOEXEC );
             if( fd != -1 )
             {
                 new( s_ring+s_numBuffers ) RingBuffer( 64*1024, fd, EventBranchRetired );
                 if( s_ring[s_numBuffers].IsValid() )
                 {
                     s_numBuffers++;
-                    TracyDebug( "  Core %i ok\n", i );
+                    TracyDebug( "  Target %i ok", i );
                 }
             }
         }
 
         pe.config = PERF_COUNT_HW_BRANCH_MISSES;
-        for( int i=0; i<s_numCpus; i++ )
+        for( int i=0; i<numIter; i++ )
         {
-            const int fd = perf_event_open( &pe, currentPid, i, -1, PERF_FLAG_FD_CLOEXEC );
+            const int fd = perf_event_open( &pe, iter[i].pid, iter[i].cpu, -1, PERF_FLAG_FD_CLOEXEC );
             if( fd != -1 )
             {
                 new( s_ring+s_numBuffers ) RingBuffer( 64*1024, fd, EventBranchMiss );
                 if( s_ring[s_numBuffers].IsValid() )
                 {
                     s_numBuffers++;
-                    TracyDebug( "  Core %i ok\n", i );
+                    TracyDebug( "  Target %i ok", i );
                 }
             }
         }
@@ -1072,12 +976,13 @@ bool SysTraceStart( int64_t& samplingPeriod )
         pe.sample_type = PERF_SAMPLE_TIME | PERF_SAMPLE_RAW;
         pe.disabled = 1;
         pe.config = vsyncId;
-#if !defined TRACY_HW_TIMER || !( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
-        pe.use_clockid = 1;
-        pe.clockid = CLOCK_MONOTONIC_RAW;
-#endif
+        if( useMonotonicClockRaw )
+        {
+            pe.use_clockid = 1;
+            pe.clockid = CLOCK_MONOTONIC_RAW;
+        }
 
-        TracyDebug( "Setup vsync capture\n" );
+        TracyDebug( "Setup vsync capture" );
         for( int i=0; i<s_numCpus; i++ )
         {
             const int fd = perf_event_open( &pe, -1, i, -1, PERF_FLAG_FD_CLOEXEC );
@@ -1087,7 +992,7 @@ bool SysTraceStart( int64_t& samplingPeriod )
                 if( s_ring[s_numBuffers].IsValid() )
                 {
                     s_numBuffers++;
-                    TracyDebug( "  Core %i ok\n", i );
+                    TracyDebug( "  Core %i ok", i );
                 }
             }
         }
@@ -1096,23 +1001,30 @@ bool SysTraceStart( int64_t& samplingPeriod )
     // context switches
     if( !noCtxSwitch && switchId != -1 )
     {
+        s_ctxSwitchCallchain = !noWaitStacks;
+
         pe = {};
         pe.type = PERF_TYPE_TRACEPOINT;
         pe.size = sizeof( perf_event_attr );
         pe.sample_period = 1;
-        pe.sample_type = PERF_SAMPLE_TIME | PERF_SAMPLE_RAW | PERF_SAMPLE_CALLCHAIN;
+        pe.sample_type = PERF_SAMPLE_TIME | PERF_SAMPLE_RAW;
+        if( s_ctxSwitchCallchain )
+        {
+            pe.sample_type |= PERF_SAMPLE_CALLCHAIN;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION( 4, 8, 0 )
-        pe.sample_max_stack = 127;
+            pe.sample_max_stack = 127;
 #endif
+        }
         pe.disabled = 1;
         pe.inherit = 1;
         pe.config = switchId;
-#if !defined TRACY_HW_TIMER || !( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
-        pe.use_clockid = 1;
-        pe.clockid = CLOCK_MONOTONIC_RAW;
-#endif
+        if( useMonotonicClockRaw )
+        {
+            pe.use_clockid = 1;
+            pe.clockid = CLOCK_MONOTONIC_RAW;
+        }
 
-        TracyDebug( "Setup context switch capture\n" );
+        TracyDebug( "Setup context switch capture" );
         for( int i=0; i<s_numCpus; i++ )
         {
             const int fd = perf_event_open( &pe, -1, i, -1, PERF_FLAG_FD_CLOEXEC );
@@ -1122,7 +1034,7 @@ bool SysTraceStart( int64_t& samplingPeriod )
                 if( s_ring[s_numBuffers].IsValid() )
                 {
                     s_numBuffers++;
-                    TracyDebug( "  Core %i ok\n", i );
+                    TracyDebug( "  Core %i ok", i );
                 }
             }
         }
@@ -1140,12 +1052,13 @@ bool SysTraceStart( int64_t& samplingPeriod )
             pe.inherit = 1;
             pe.config = wakingId;
             pe.read_format = 0;
-#if !defined TRACY_HW_TIMER || !( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
-            pe.use_clockid = 1;
-            pe.clockid = CLOCK_MONOTONIC_RAW;
-#endif
+            if( useMonotonicClockRaw )
+            {
+                pe.use_clockid = 1;
+                pe.clockid = CLOCK_MONOTONIC_RAW;
+            }
 
-            TracyDebug( "Setup waking up capture\n" );
+            TracyDebug( "Setup waking up capture" );
             for( int i=0; i<s_numCpus; i++ )
             {
                 const int fd = perf_event_open( &pe, -1, i, -1, PERF_FLAG_FD_CLOEXEC );
@@ -1155,14 +1068,16 @@ bool SysTraceStart( int64_t& samplingPeriod )
                     if( s_ring[s_numBuffers].IsValid() )
                     {
                         s_numBuffers++;
-                        TracyDebug( "  Core %i ok\n", i );
+                        TracyDebug( "  Core %i ok", i );
                     }
                 }
             }
         }
     }
 
-    TracyDebug( "Ringbuffers in use: %i\n", s_numBuffers );
+    TracyDebug( "Ringbuffers in use: %i", s_numBuffers );
+
+    tracy_free( iter );
 
     traceActive.store( true, std::memory_order_relaxed );
     return true;
@@ -1214,9 +1129,9 @@ void SysTraceWorker( void* ptr )
 {
     ThreadExitHandler threadExitHandler;
     SetThreadName( "Tracy Sampling" );
-    InitRpmalloc();
+    InitAllocator();
     sched_param sp = { 99 };
-    if( pthread_setschedparam( pthread_self(), SCHED_FIFO, &sp ) != 0 ) TracyDebug( "Failed to increase SysTraceWorker thread priority!\n" );
+    if( pthread_setschedparam( pthread_self(), SCHED_FIFO, &sp ) != 0 ) TracyDebug( "Failed to increase SysTraceWorker thread priority!" );
     auto ctxBufferIdx = s_ctxBufferIdx;
     auto ringArray = s_ring;
     auto numBuffers = s_numBuffers;
@@ -1252,11 +1167,11 @@ void SysTraceWorker( void* ptr )
             const auto head = ring.LoadHead();
             const auto tail = ring.GetTail();
             if( head == tail ) continue;
-            assert( head > tail );
+            TRACY_ASSERT( head > tail );
             hadData = true;
 
             const auto id = ring.GetId();
-            assert( id != EventContextSwitch );
+            TRACY_ASSERT( id != EventContextSwitch );
             const auto end = head - tail;
             uint64_t pos = 0;
             if( id == EventCallstack )
@@ -1275,29 +1190,30 @@ void SysTraceWorker( void* ptr )
                         //   u64 cnt
                         //   u64 ip[cnt]
 
-                        uint32_t tid;
-                        uint64_t t0;
-                        uint64_t cnt;
-
-                        offset += sizeof( uint32_t );
-                        ring.Read( &tid, offset, sizeof( uint32_t ) );
-                        offset += sizeof( uint32_t );
-                        ring.Read( &t0, offset, sizeof( uint64_t ) );
-                        offset += sizeof( uint64_t );
-                        ring.Read( &cnt, offset, sizeof( uint64_t ) );
-                        offset += sizeof( uint64_t );
-
-                        if( cnt > 0 )
+#pragma pack( push, 1 )
+                        struct
                         {
-#if defined TRACY_HW_TIMER && ( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
-                            t0 = ring.ConvertTimeToTsc( t0 );
+                            uint32_t tid;
+                            uint64_t t0;
+                            uint64_t cnt;
+                        } buf;
+#pragma pack( pop )
+
+                        offset += sizeof( uint32_t );
+                        ring.Read( &buf, offset, sizeof( buf ) );
+                        offset += sizeof( buf );
+
+                        if( buf.cnt > 0 )
+                        {
+#if defined TRACY_HW_TIMER && defined TRACY_HAS_RDTSC
+                            buf.t0 = ring.ConvertTimeToTsc( buf.t0 );
 #endif
-                            auto trace = GetCallstackBlock( cnt, ring, offset );
+                            auto trace = GetCallstackBlock( buf.cnt, ring, offset );
 
                             TracyLfqPrepare( QueueType::CallstackSample );
-                            MemWrite( &item->callstackSampleFat.time, t0 );
-                            MemWrite( &item->callstackSampleFat.thread, tid );
-                            MemWrite( &item->callstackSampleFat.ptr, (uint64_t)trace );
+                            MemWrite( &item->callstackSampleFat.time, int64_t( buf.t0 ) );
+                            MemWrite( &item->callstackSampleFat.thread, buf.tid );
+                            MemWrite( &item->callstackSampleFat.ptr, uint64_t( trace ) );
                             TracyLfqCommit;
                         }
                     }
@@ -1318,13 +1234,15 @@ void SysTraceWorker( void* ptr )
                         //   u64 ip
                         //   u64 time
 
-                        uint64_t ip, t0;
-                        ring.Read( &ip, offset, sizeof( uint64_t ) );
-                        offset += sizeof( uint64_t );
-                        ring.Read( &t0, offset, sizeof( uint64_t ) );
+                        struct
+                        {
+                            uint64_t ip, t0;
+                        } buf;
 
-#if defined TRACY_HW_TIMER && ( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
-                        t0 = ring.ConvertTimeToTsc( t0 );
+                        ring.Read( &buf, offset, sizeof( buf ) );
+
+#if defined TRACY_HW_TIMER && defined TRACY_HAS_RDTSC
+                        buf.t0 = ring.ConvertTimeToTsc( buf.t0 );
 #endif
                         QueueType type;
                         switch( id )
@@ -1352,14 +1270,14 @@ void SysTraceWorker( void* ptr )
                         }
 
                         TracyLfqPrepare( type );
-                        MemWrite( &item->hwSample.ip, ip );
-                        MemWrite( &item->hwSample.time, t0 );
+                        MemWrite( &item->hwSample.ip, buf.ip );
+                        MemWrite( &item->hwSample.time, int64_t( buf.t0 ) );
                         TracyLfqCommit;
                     }
                     pos += hdr.size;
                 }
             }
-            assert( pos == end );
+            TRACY_ASSERT( pos == end );
             ring.Advance( end );
         }
         if( !traceActive.load( std::memory_order_relaxed ) ) break;
@@ -1372,19 +1290,39 @@ void SysTraceWorker( void* ptr )
             uint16_t active[512];
             uint32_t end[512];
             uint32_t pos[512];
+            int64_t time[512];
+
+            auto PrimeNext = [&pos, &end, &time]( int idx, RingBuffer& ring ) {
+                while( pos[idx] < end[idx] )
+                {
+                    perf_event_header hdr;
+                    ring.Read( &hdr, pos[idx], sizeof( hdr ) );
+                    if( hdr.type == PERF_RECORD_SAMPLE )
+                    {
+                        ring.Read( time + idx, pos[idx] + sizeof( hdr ), sizeof( int64_t ) );
+                        return true;
+                    }
+                    TRACY_ASSERT( hdr.size > 0 );
+                    pos[idx] += hdr.size;
+                }
+                return false;
+            };
+
             for( int i=0; i<ctxBufNum; i++ )
             {
                 const auto rbIdx = ctxBufferIdx + i;
                 const auto rbHead = ringArray[rbIdx].LoadHead();
                 const auto rbTail = ringArray[rbIdx].GetTail();
-                const auto rbActive = rbHead != rbTail;
 
-                if( rbActive )
+                if( rbHead != rbTail )
                 {
-                    active[activeNum] = (uint16_t)i;
-                    activeNum++;
                     end[i] = rbHead - rbTail;
                     pos[i] = 0;
+                    if( PrimeNext( i, ringArray[rbIdx] ) )
+                    {
+                        active[activeNum] = (uint16_t)i;
+                        activeNum++;
+                    }
                 }
                 else
                 {
@@ -1403,47 +1341,25 @@ void SysTraceWorker( void* ptr )
                     for( int i=0; i<activeNum; i++ )
                     {
                         auto idx = active[i];
-                        auto rbPos = pos[idx];
-                        assert( rbPos < end[idx] );
-                        const auto rbIdx = ctxBufferIdx + idx;
-                        perf_event_header hdr;
-                        ringArray[rbIdx].Read( &hdr, rbPos, sizeof( perf_event_header ) );
-                        if( hdr.type == PERF_RECORD_SAMPLE )
+                        if( time[idx] < t0 )
                         {
-                            int64_t rbTime;
-                            ringArray[rbIdx].Read( &rbTime, rbPos + sizeof( perf_event_header ), sizeof( int64_t ) );
-                            if( rbTime < t0 )
-                            {
-                                t0 = rbTime;
-                                sel = idx;
-                                selPos = i;
-                            }
-                        }
-                        else
-                        {
-                            rbPos += hdr.size;
-                            if( rbPos == end[idx] )
-                            {
-                                memmove( active+i, active+i+1, sizeof(*active) * ( activeNum - i - 1 ) );
-                                activeNum--;
-                                i--;
-                            }
-                            else
-                            {
-                                pos[idx] = rbPos;
-                            }
+                            t0 = time[idx];
+                            sel = idx;
+                            selPos = i;
                         }
                     }
                     // Found any event
                     if( sel >= 0 )
                     {
+                        TRACY_ASSERT( pos[sel] < end[sel] );
+
                         auto& ring = ringArray[ctxBufferIdx + sel];
                         auto rbPos = pos[sel];
                         auto offset = rbPos;
                         perf_event_header hdr;
                         ring.Read( &hdr, offset, sizeof( perf_event_header ) );
 
-#if defined TRACY_HW_TIMER && ( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
+#if defined TRACY_HW_TIMER && defined TRACY_HAS_RDTSC
                         t0 = ring.ConvertTimeToTsc( t0 );
 #endif
 
@@ -1452,8 +1368,8 @@ void SysTraceWorker( void* ptr )
                         {
                             // Layout: See /sys/kernel/debug/tracing/events/sched/sched_switch/format
                             //   u64 time    // PERF_SAMPLE_TIME
-                            //   u64 cnt     // PERF_SAMPLE_CALLCHAIN
-                            //   u64 ip[cnt] // PERF_SAMPLE_CALLCHAIN
+                            //   u64 cnt     // PERF_SAMPLE_CALLCHAIN, if enabled
+                            //   u64 ip[cnt] // PERF_SAMPLE_CALLCHAIN, if enabled
                             //   u32 size
                             //   u8  data[size]
                             // Data (not ABI stable, but has not changed since it was added, in 2009):
@@ -1468,58 +1384,59 @@ void SysTraceWorker( void* ptr )
 
                             offset += sizeof( perf_event_header ) + sizeof( uint64_t );
 
-                            uint64_t cnt;
-                            ring.Read( &cnt, offset, sizeof( uint64_t ) );
-                            offset += sizeof( uint64_t );
-                            const auto traceOffset = offset;
-                            offset += sizeof( uint64_t ) * cnt + sizeof( uint32_t ) + 8 + 16;
+                            uint64_t cnt = 0;
+                            uint64_t traceOffset = 0;
+                            if( s_ctxSwitchCallchain )
+                            {
+                                ring.Read( &cnt, offset, sizeof( uint64_t ) );
+                                offset += sizeof( uint64_t );
+                                traceOffset = offset;
+                                offset += sizeof( uint64_t ) * cnt;
+                            }
+                            offset += sizeof( uint32_t ) + 8 + 16;
 
-                            uint32_t prev_pid, prev_prio;
-                            uint32_t next_pid, next_prio;
-                            long prev_state;
+                            struct
+                            {
+                                uint32_t prev_pid, prev_prio;
+                                long prev_state;
+                                char next_comm[16];
+                                uint32_t next_pid, next_prio;
+                            } buf;
 
-                            ring.Read( &prev_pid, offset, sizeof( uint32_t ) );
-                            offset += sizeof( uint32_t );
-                            ring.Read( &prev_prio, offset, sizeof( uint32_t ) );
-                            offset += sizeof( uint32_t );
-                            ring.Read( &prev_state, offset, sizeof( long ) );
-                            offset += sizeof( long ) + 16;
-                            ring.Read( &next_pid, offset, sizeof( uint32_t ) );
-                            offset += sizeof( uint32_t );
-                            ring.Read( &next_prio, offset, sizeof( uint32_t ) );
+                            ring.Read( &buf, offset, sizeof( buf ) );
 
                             uint8_t oldThreadWaitReason = 100;
                             uint8_t oldThreadState;
 
-                            if(      prev_state & 0x0001 ) oldThreadState = 104;
-                            else if( prev_state & 0x0002 ) oldThreadState = 101;
-                            else if( prev_state & 0x0004 ) oldThreadState = 105;
-                            else if( prev_state & 0x0008 ) oldThreadState = 106;
-                            else if( prev_state & 0x0010 ) oldThreadState = 108;
-                            else if( prev_state & 0x0020 ) oldThreadState = 109;
-                            else if( prev_state & 0x0040 ) oldThreadState = 110;
-                            else if( prev_state & 0x0080 ) oldThreadState = 102;
+                            if(      buf.prev_state & 0x0001 ) oldThreadState = 104;
+                            else if( buf.prev_state & 0x0002 ) oldThreadState = 101;
+                            else if( buf.prev_state & 0x0004 ) oldThreadState = 105;
+                            else if( buf.prev_state & 0x0008 ) oldThreadState = 106;
+                            else if( buf.prev_state & 0x0010 ) oldThreadState = 108;
+                            else if( buf.prev_state & 0x0020 ) oldThreadState = 109;
+                            else if( buf.prev_state & 0x0040 ) oldThreadState = 110;
+                            else if( buf.prev_state & 0x0080 ) oldThreadState = 102;
                             else                           oldThreadState = 103;
 
                             TracyLfqPrepare( QueueType::ContextSwitch );
                             MemWrite( &item->contextSwitch.time, t0 );
-                            MemWrite( &item->contextSwitch.oldThread, prev_pid );
-                            MemWrite( &item->contextSwitch.newThread, next_pid );
+                            MemWrite( &item->contextSwitch.oldThread, buf.prev_pid );
+                            MemWrite( &item->contextSwitch.newThread, buf.next_pid );
                             MemWrite( &item->contextSwitch.cpu, uint8_t( ring.GetCpu() ) );
                             MemWrite( &item->contextSwitch.oldThreadWaitReason, oldThreadWaitReason );
                             MemWrite( &item->contextSwitch.oldThreadState, oldThreadState );
                             MemWrite( &item->contextSwitch.previousCState, uint8_t( 0 ) );
-                            MemWrite( &item->contextSwitch.newThreadPriority, int8_t( next_prio ) );
-                            MemWrite( &item->contextSwitch.oldThreadPriority, int8_t( prev_prio ) );
+                            MemWrite( &item->contextSwitch.newThreadPriority, int8_t( buf.next_prio ) );
+                            MemWrite( &item->contextSwitch.oldThreadPriority, int8_t( buf.prev_prio ) );
                             TracyLfqCommit;
 
-                            if( cnt > 0 && prev_pid != 0 && CurrentProcOwnsThread( prev_pid ) )
+                            if( cnt > 0 && buf.prev_pid != 0 && CurrentProcOwnsThread( buf.prev_pid ) )
                             {
                                 auto trace = GetCallstackBlock( cnt, ring, traceOffset );
 
                                 TracyLfqPrepare( QueueType::CallstackSampleContextSwitch );
                                 MemWrite( &item->callstackSampleFat.time, t0 );
-                                MemWrite( &item->callstackSampleFat.thread, prev_pid );
+                                MemWrite( &item->callstackSampleFat.thread, buf.prev_pid );
                                 MemWrite( &item->callstackSampleFat.ptr, (uint64_t)trace );
                                 TracyLfqCommit;
                             }
@@ -1555,7 +1472,7 @@ void SysTraceWorker( void* ptr )
                         }
                         else
                         {
-                            assert( rid == EventVsync );
+                            TRACY_ASSERT( rid == EventVsync );
                             // Layout:
                             //   u64 time
                             //   u32 size
@@ -1583,20 +1500,17 @@ void SysTraceWorker( void* ptr )
 #endif
 
                             TracyLfqPrepare( QueueType::FrameVsync );
-                            MemWrite( &item->frameVsync.id, crtc );
+                            MemWrite( &item->frameVsync.id, uint32_t( crtc ) );
                             MemWrite( &item->frameVsync.time, t0 );
                             TracyLfqCommit;
                         }
 
                         rbPos += hdr.size;
-                        if( rbPos == end[sel] )
+                        pos[sel] = rbPos;
+                        if( !PrimeNext( sel, ring ) )
                         {
-                            memmove( active+selPos, active+selPos+1, sizeof(*active) * ( activeNum - selPos - 1 ) );
+                            active[selPos] = active[activeNum - 1];
                             activeNum--;
-                        }
-                        else
-                        {
-                            pos[sel] = rbPos;
                         }
                     }
                 }
@@ -1685,6 +1599,10 @@ void SysTraceGetExternalName( uint64_t thread, const char*& threadName, const ch
 }
 
 }
+
+#  elif defined __APPLE__
+
+#    include "apple/TracyMach.cpp"
 
 #  endif
 

--- a/D3D11Engine/include/tracy/public/client/TracySysTrace.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracySysTrace.hpp
@@ -1,9 +1,13 @@
 #ifndef __TRACYSYSTRACE_HPP__
 #define __TRACYSYSTRACE_HPP__
 
-#if !defined TRACY_NO_SYSTEM_TRACING && ( defined _WIN32 || defined __linux__ )
-#  include "../common/TracyWinFamily.hpp"
-#  if !defined TRACY_WIN32_NO_DESKTOP
+#if !defined TRACY_NO_SYSTEM_TRACING
+#  if defined _WIN32 || defined __linux__
+#    include "../common/TracyWinFamily.hpp"
+#    if !defined TRACY_WIN32_NO_DESKTOP
+#      define TRACY_HAS_SYSTEM_TRACING
+#    endif
+#  elif defined __APPLE__
 #    define TRACY_HAS_SYSTEM_TRACING
 #  endif
 #endif

--- a/D3D11Engine/include/tracy/public/client/TracyThread.hpp
+++ b/D3D11Engine/include/tracy/public/client/TracyThread.hpp
@@ -8,7 +8,7 @@
 #endif
 
 #ifdef TRACY_MANUAL_LIFETIME
-#  include "tracy_rpmalloc.hpp"
+#  include "../common/TracyAlloc.hpp"
 #endif
 
 namespace tracy
@@ -24,7 +24,11 @@ public:
     ~ThreadExitHandler()
     {
 #ifdef TRACY_MANUAL_LIFETIME
+#  if defined TRACY_HAS_CUSTOM_ALLOCATOR
+        PlatformAllocatorThreadFinalize();
+#  elif defined TRACY_USE_RPMALLOC
         rpmalloc_thread_finalize( 1 );
+#  endif
         RpThreadInitDone = false;
 #endif
     }

--- a/D3D11Engine/include/tracy/public/client/apple/TracyMach.cpp
+++ b/D3D11Engine/include/tracy/public/client/apple/TracyMach.cpp
@@ -1,0 +1,257 @@
+// (this file gets included by TracySysTrace.cpp)
+
+#ifndef __APPLE__
+#error this file can only be compiled for Apple targets
+#endif
+
+#include <atomic>
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#include <ptrauth.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <vector>
+
+#include "../TracyProfiler.hpp"
+#include "../TracyStringHelpers.hpp"
+#include "../TracyThread.hpp"
+
+namespace tracy
+{
+
+struct SysTraceApple
+{
+    std::atomic<bool> active { false };
+    int samplingHz = 1000;
+    static SysTraceApple& Get()
+    {
+        static SysTraceApple systrace = {};
+        return systrace;
+    }
+};
+
+static void SysTraceEmitCallstackSample( uint32_t threadId, int64_t timestamp, const uint64_t* frames, int depth )
+{
+#ifdef TRACY_ON_DEMAND
+    if( !GetProfiler().IsConnected() ) return;
+#endif
+
+    auto trace = (uint64_t*)tracy_malloc( ( 1 + depth ) * sizeof( uint64_t ) );
+    trace[0] = (uint64_t)depth;
+    memcpy( trace + 1, frames, depth * sizeof( uint64_t ) );
+
+    TracyLfqPrepare( QueueType::CallstackSample );
+    MemWrite( &item->callstackSampleFat.time, timestamp );
+    MemWrite( &item->callstackSampleFat.thread, threadId );
+    MemWrite( &item->callstackSampleFat.ptr, (uint64_t)trace );
+    TracyLfqCommit;
+}
+
+static int SysTraceBacktrace( uint64_t* frames, int maxDepth, uint64_t pc, uint64_t fp )
+{
+    int depth = 0;
+    frames[depth++] = pc;
+
+    // NOTE: frame-pointer walk for now... It should be fine since the ABI
+    // mandates it on ARM64 (and on x64 Apple clang preserves it by default)
+    auto framePtr = (const uint64_t*)fp;
+    while( framePtr && depth < maxDepth )
+    {
+        if( (uintptr_t)framePtr & (sizeof(uint64_t) - 1) ) break;  // misaligned — stop walk
+        // [framePtr + 0] = saved frame pointer (previous frame)
+        // [framePtr + 1] = return address, may be PAC-signed on ARM64
+        frames[depth++] = (uint64_t)ptrauth_strip( (void*)framePtr[1], ptrauth_key_return_address );
+        framePtr = (const uint64_t*)framePtr[0];
+    }
+
+    return depth;
+}
+
+static void SysTraceSampleThread( mach_port_t tid )
+{
+    const int64_t t0 = Profiler::GetTime();
+    if( thread_suspend( tid ) != KERN_SUCCESS ) return;
+    const int64_t t1 = Profiler::GetTime();
+    const int64_t timestamp = t0 + ( t1 - t0 ) / 2;
+
+#if defined(__aarch64__)
+    arm_thread_state64_t state;
+    mach_msg_type_number_t stateCount = ARM_THREAD_STATE64_COUNT;
+    const kern_return_t kr = thread_get_state( tid, ARM_THREAD_STATE64, (thread_state_t)&state, &stateCount );
+#elif defined(__x86_64__)
+    x86_thread_state64_t state;
+    mach_msg_type_number_t stateCount = x86_THREAD_STATE64_COUNT;
+    const kern_return_t kr = thread_get_state( tid, x86_THREAD_STATE64, (thread_state_t)&state, &stateCount );
+#else
+    #error "unsupported architecture"
+#endif
+
+    if( kr != KERN_SUCCESS )
+    {
+        thread_resume( tid );
+        return;
+    }
+
+    constexpr int MaxDepth = 192;
+    uint64_t frames [MaxDepth];
+
+#if defined(__aarch64__)
+    const int depth = SysTraceBacktrace( frames, MaxDepth, state.__pc, state.__fp );
+#elif defined(__x86_64__)
+    const int depth = SysTraceBacktrace( frames, MaxDepth, state.__rip, state.__rbp );
+#endif
+
+    thread_resume( tid );
+
+    SysTraceEmitCallstackSample( (uint32_t)tid, timestamp, frames, depth );
+}
+
+static void SysTraceWait( uint64_t deadline )
+{
+    mach_wait_until( deadline );
+}
+
+static uint64_t SysTraceRngInit()
+{
+    uint64_t seed = mach_absolute_time();
+    seed ^= (uint64_t)(uintptr_t)&seed;
+    return seed;
+}
+
+static uint32_t SysTraceRngNext( uint64_t& rng, uint32_t range )
+{
+    rng ^= rng << 13; rng ^= rng >> 7; rng ^= rng << 17;
+    return (uint32_t)( rng % range );
+}
+
+static void SysTraceWatch()
+{
+    auto& systrace = SysTraceApple::Get();
+
+    const mach_port_t selfThread = mach_thread_self();
+    mach_timebase_info_data_t timebase;
+    mach_timebase_info( &timebase );
+    const uint64_t samplingPeriodNs = 1000000000ULL / systrace.samplingHz;
+    const uint64_t periodMach = samplingPeriodNs * timebase.denom / timebase.numer;
+
+    std::vector<mach_port_t> runningThreads;
+    std::vector<mach_port_t> waitingThreads;
+
+    uint64_t rng = SysTraceRngInit();
+
+    uint64_t deadline = mach_absolute_time();
+    while( systrace.active.load( std::memory_order_relaxed ) )
+    {
+        SysTraceWait(deadline);
+        deadline = mach_absolute_time() + periodMach;
+
+#ifdef TRACY_ON_DEMAND
+        if( !GetProfiler().IsConnected() ) continue;
+#endif
+
+        thread_act_array_t threads;
+        mach_msg_type_number_t threadCount;
+        if( task_threads( mach_task_self(), &threads, &threadCount ) != KERN_SUCCESS ) continue;
+
+        runningThreads.clear();
+        waitingThreads.clear();
+
+        for( mach_msg_type_number_t i = 0; i < threadCount; i++ )
+        {
+            const mach_port_t tid = threads[i];
+            if( tid == selfThread ) continue;
+
+            thread_basic_info_data_t info;
+            mach_msg_type_number_t infoCount = THREAD_BASIC_INFO_COUNT;
+            if( thread_info( tid, THREAD_BASIC_INFO, (thread_info_t)&info, &infoCount ) != KERN_SUCCESS ) continue;
+            if( info.flags & TH_FLAGS_IDLE ) continue;  // kernel idle thread, not user code
+
+            if( info.run_state == TH_STATE_RUNNING )
+                runningThreads.push_back( tid );
+            else
+                waitingThreads.push_back( tid );
+        }
+
+        for( const mach_port_t tid : runningThreads )
+            SysTraceSampleThread( tid );
+
+        while( !waitingThreads.empty() )
+        {
+            if( mach_absolute_time() >= deadline ) break;
+            const uint32_t idx = SysTraceRngNext( rng, (uint32_t)waitingThreads.size() );
+            SysTraceSampleThread( waitingThreads[idx] );
+            std::swap( waitingThreads[idx], waitingThreads.back() );
+            waitingThreads.pop_back();
+        }
+
+        for( mach_msg_type_number_t i = 0; i < threadCount; i++ )
+            mach_port_deallocate( mach_task_self(), threads[i] );
+        vm_deallocate( mach_task_self(), (vm_address_t)threads, sizeof(thread_t) * threadCount );
+    }
+    mach_port_deallocate( mach_task_self(), selfThread );
+}
+
+void SysTraceWorker( void* )
+{
+    ThreadExitHandler threadExitHandler;
+    SetThreadName( "Tracy Mach Watchdog" );
+    InitAllocator();
+    SysTraceWatch();
+}
+
+bool SysTraceStart( int64_t& samplingPeriod )
+{
+    // check for elevated privileges
+    // (technically, since this is a software-based user-mode sampling, elevated
+    // privileges are unnecessary, but doing so keeps the behavior consistent with
+    // the system tracing in other platforms)
+    if( geteuid() != 0 ) return false;
+
+    auto& systrace = SysTraceApple::Get();
+
+    bool expected = false;
+    if( !systrace.active.compare_exchange_strong( expected, true, std::memory_order_relaxed ) )
+        return false;
+
+    systrace.samplingHz = GetSamplingFrequency();
+    samplingPeriod      = SamplingFrequencyToPeriodNs( systrace.samplingHz );
+    return true;
+}
+
+void SysTraceStop()
+{
+    auto& systrace = SysTraceApple::Get();
+    systrace.active.store( false, std::memory_order_relaxed );
+}
+
+void SysTraceGetExternalName( uint64_t thread, const char*& threadName, const char*& name )
+{
+    // Resolve pthread handle from the Mach port so we can query the thread name.
+    const mach_port_t mach_tid = (mach_port_t)thread;
+    thread_identifier_info_data_t idInfo;
+    mach_msg_type_number_t idInfoCount = THREAD_IDENTIFIER_INFO_COUNT;
+    if( thread_info( mach_tid, THREAD_IDENTIFIER_INFO, (thread_info_t)&idInfo, &idInfoCount ) == KERN_SUCCESS )
+    {
+        char buf[64] = {};
+        const pthread_t pt = (pthread_t)(uintptr_t)idInfo.thread_handle;
+        if( pt && pthread_getname_np( pt, buf, sizeof( buf ) ) == 0 && buf[0] != '\0' )
+            threadName = CopyString( buf );
+        else
+            threadName = CopyString( "???", 3 );
+
+        TracyLfqPrepare( QueueType::TidToPid );
+        MemWrite( &item->tidToPid.tid, thread );
+        MemWrite( &item->tidToPid.pid, (uint64_t)getpid() );
+        TracyLfqCommit;
+    }
+    else
+    {
+        threadName = CopyString( "???", 3 );
+    }
+
+    name = CopyStringFast( getprogname() );
+}
+
+} // namespace tracy

--- a/D3D11Engine/include/tracy/public/client/tracy_concurrentqueue.h
+++ b/D3D11Engine/include/tracy/public/client/tracy_concurrentqueue.h
@@ -171,8 +171,8 @@ struct ConcurrentQueueDefaultTraits
 #if defined(malloc) || defined(free)
 	// Gah, this is 2015, stop defining macros that break standard code already!
 	// Work around malloc/free being special macros:
-	static inline void* WORKAROUND_malloc(size_t size) { return malloc(size); }
-	static inline void WORKAROUND_free(void* ptr) { return free(ptr); }
+	static inline void* WORKAROUND_malloc(size_t size) { return tracy::tracy_malloc(size); }
+	static inline void WORKAROUND_free(void* ptr) { return tracy::tracy_free(ptr); }
 	static inline void* (malloc)(size_t size) { return WORKAROUND_malloc(size); }
 	static inline void (free)(void* ptr) { return WORKAROUND_free(ptr); }
 #else
@@ -975,7 +975,7 @@ private:
 				auto block = this->tailBlock;
 				do {
 					block = block->next;
-					if (block->ConcurrentQueue::Block::is_empty()) {
+					if (block->is_empty()) {
 						continue;
 					}
 
@@ -1020,10 +1020,10 @@ private:
         inline void enqueue_begin_alloc(index_t currentTailIndex)
         {
             // We reached the end of a block, start a new one
-            if (this->tailBlock != nullptr && this->tailBlock->next->ConcurrentQueue::Block::is_empty()) {
+            if (this->tailBlock != nullptr && this->tailBlock->next->is_empty()) {
                 // We can re-use the block ahead of us, it's empty!
                 this->tailBlock = this->tailBlock->next;
-                this->tailBlock->ConcurrentQueue::Block::reset_empty();
+                this->tailBlock->reset_empty();
 
                 // We'll put the block on the block index (guaranteed to be room since we're conceptually removing the
                 // last block from it first -- except instead of removing then adding, we can just overwrite).
@@ -1042,7 +1042,7 @@ private:
 
                 // Insert a new block in the circular linked list
                 auto newBlock = this->parent->ConcurrentQueue::requisition_block();
-                newBlock->ConcurrentQueue::Block::reset_empty();
+                newBlock->reset_empty();
                 if (this->tailBlock == nullptr) {
                     newBlock->next = newBlock;
                 }
@@ -1124,7 +1124,7 @@ private:
 						processData( (*block)[index], sz );
 						index += sz;
 
-						block->ConcurrentQueue::Block::set_many_empty(firstIndexInBlock, static_cast<size_t>(endIndex - firstIndexInBlock));
+						block->set_many_empty(firstIndexInBlock, static_cast<size_t>(endIndex - firstIndexInBlock));
 						indexIndex = (indexIndex + 1) & (localBlockIndex->size - 1);
 					} while (index != firstIndex + actualCount);
 
@@ -1208,6 +1208,21 @@ private:
     ExplicitProducer* get_explicit_producer(producer_token_t const& token)
     {
         return static_cast<ExplicitProducer*>(token.producer);
+    }
+
+    // If a producer token is created before the constructor of a statically allocated
+    // queue runs (which may happen due to the undefined order of static initialization
+    // across module boundaries), the constructor will orphan it by resetting the
+    // producer list. Such a producer is functional, as producer creation works on the
+    // zero-initialized queue memory, but the consumer is not able to see the data it
+    // enqueues. This method links the producer back into the list.
+    bool readopt_orphaned_producer(ExplicitProducer* producer)
+    {
+        for (auto ptr = producerListTail.load(std::memory_order_relaxed); ptr != nullptr; ptr = ptr->next_prod()) {
+            if (ptr == static_cast<ProducerBase*>(producer)) return false;
+        }
+        add_producer(static_cast<ProducerBase*>(producer));
+        return true;
     }
 
     private:

--- a/D3D11Engine/include/tracy/public/client/tracy_rpmalloc.cpp
+++ b/D3D11Engine/include/tracy/public/client/tracy_rpmalloc.cpp
@@ -743,7 +743,7 @@ get_thread_id(void) {
 	__asm__("movq %%fs:0, %0" : "=r" (tid) : : );
 #    endif
 #  elif defined(__arm__)
-	__asm__ volatile ("mrc p15, 0, %0, c13, c0, 3" : "=r" (tid));
+	tid = (uintptr_t)__builtin_thread_pointer();
 #  elif defined(__aarch64__)
 #    if defined(__MACH__)
 	// tpidr_el0 likely unused, always return 0 on iOS

--- a/D3D11Engine/include/tracy/public/client/windows/TracyETW.cpp
+++ b/D3D11Engine/include/tracy/public/client/windows/TracyETW.cpp
@@ -1,0 +1,608 @@
+#include <windows.h>
+#include <guiddef.h>
+#include <evntcons.h>
+#include <evntrace.h>
+
+#include <stdio.h>
+#include <thread>
+
+#include "../../common/TracyString.hpp"
+
+namespace tracy
+{
+namespace etw
+{
+
+constexpr GUID NullGuid      = {};
+constexpr GUID ThreadGuid    = { 0x3D6FA8D1, 0xFE05, 0x11D0, { 0x9D, 0xDA, 0x00, 0xC0, 0x4F, 0xD7, 0xBA, 0x7C } };
+constexpr GUID PerfInfoGuid  = { 0xCE1DBFB4, 0x137E, 0x4DA6, { 0x87, 0xB0, 0x3F, 0x59, 0xAA, 0x10, 0x2C, 0xBC } };
+constexpr GUID StackWalkGuid = { 0xDEF2FE46, 0x7BD6, 0x4B80, { 0xBD, 0x94, 0xF5, 0x7F, 0xE2, 0x0D, 0x0C, 0xE3 } };
+constexpr GUID DxgKrnlGuid   = { 0x802EC45A, 0x1E99, 0x4B83, { 0x99, 0x20, 0x87, 0xC9, 0x82, 0x77, 0xBA, 0x9D } };
+constexpr GUID LostEventGuid = { 0x6A399AE0, 0x4BC6, 0x4DE9, { 0x87, 0x0B, 0x36, 0x57, 0xF8, 0x94, 0x7E, 0x7E } };
+
+struct Session
+{
+    EVENT_TRACE_PROPERTIES properties = {};
+    CHAR name[64] = {};
+    CONTROLTRACE_ID handle = 0;
+    CLASSIC_EVENT_ID stackwalk[8] = {};
+};
+
+// ---- ETW Events ----------
+
+struct CSwitch
+{
+    // V2 fields:
+    static constexpr UCHAR Opcode = 36;
+    uint32_t    newThreadId;
+    uint32_t    oldThreadId;
+    int8_t      newThreadPriority;
+    int8_t      oldThreadPriority;
+    uint8_t     previousCState;
+    int8_t      spareByte;
+    int8_t      oldThreadWaitReason;
+    int8_t      oldThreadWaitMode;
+    int8_t      oldThreadState;
+    int8_t      oldThreadWaitIdealProcessor;
+    uint32_t    newThreadWaitTime;
+    uint32_t    reserved;
+};
+static_assert( sizeof( CSwitch ) == 24, "unexpected CSwitch struct size/alignment" );
+
+struct ReadyThread
+{
+    // V2 fields:
+    static constexpr UCHAR Opcode = 50;
+    uint32_t    threadId;
+    int8_t      adjustReason;
+    int8_t      adjustIncrement;
+    int8_t      flag;
+    int8_t      reserverd;
+};
+static_assert( sizeof( ReadyThread ) == 8, "unexpected ReadyThread struct size/alignment" );
+
+struct ThreadInfo
+{
+    // V0 (Thread_V0_TypeGroup1) fields:
+    uint32_t processId;
+    uint32_t threadId;
+    // NOTE: we only care about PID and TID for now, and these two are "invariant"
+    // across all revisions (versions) of this event. As such, let's omit the other
+    // fields since they vary based on the event version; their sizes also vary by
+    // target architecture (32bit or 64bit), and this is not even mentioned in the
+    // MSDN documentation, and worse, have not been updated in the official schemas
+    // either (which ETW Explorer uses), but can be introspected via the TDH API.
+};
+static_assert( sizeof( ThreadInfo ) == 8, "unexpected ThreadInfo struct size/alignment" );
+
+struct ThreadStart : public ThreadInfo
+{
+    static constexpr UCHAR Opcode = 1;
+};
+static_assert( sizeof( ThreadStart ) == 8, "unexpected ThreadStart struct size/alignment" );
+
+// DC: Data Collection (associated with the "rundown" phase)
+struct ThreadDCStart : public ThreadInfo
+{
+    static constexpr UCHAR Opcode = 3;
+};
+static_assert( sizeof( ThreadDCStart ) == 8, "unexpected ThreadDCStart struct size/alignment" );
+
+struct SampledProfile
+{
+    static constexpr UCHAR Opcode = 46;
+    // NOTE: we don't handle SampledProfile events directly; instead, we handle
+    // the StackWalk event associated with each SampledProfile event. Just like
+    // ThreadInfo, the data layout varies based on the target architecture, and
+    // the MSDN documentation and schemas are outdated.
+    //uint64_t instructionPointer;    // 32/64 bits
+    //uint32_t threadId;
+    //uint32_t count;                 // Not used.
+};
+static_assert( sizeof( SampledProfile ) == 1, "unexpected SampledProfile struct size/alignment" );
+
+struct StackWalkEvent
+{
+    // V2 fields:
+    static constexpr UCHAR Opcode = 32;
+    uint64_t eventTimeStamp;
+    uint32_t stackProcess;
+    uint32_t stackThread;
+    uint64_t stack[192];    // arbitrary upperbound limit; schema stops at [32]
+};
+static_assert( offsetof( StackWalkEvent, stackProcess ) == 8, "unexpected StackWalkEvent struct size/alignment" );
+static_assert( offsetof( StackWalkEvent, stackThread ) == 12, "unexpected StackWalkEvent struct size/alignment" );
+static_assert( offsetof( StackWalkEvent, stack ) == 16, "unexpected StackWalkEvent struct size/alignment" );
+
+struct VSyncDPC
+{
+    static constexpr USHORT EventId = 17; // 0x11
+    uint64_t    dxgAdapter;
+    uint32_t    vidPnTargetId;
+    uint64_t    scannedPhysicalAddress;
+    uint32_t    vidPnSourceId;
+    uint32_t    frameNumber;
+    int64_t     frameQpcTime;
+    uint64_t    hFlipDevice;
+    uint32_t    flipType;
+    uint64_t    flipFenceId;
+};
+static_assert( sizeof( VSyncDPC ) == 64, "unexpected VSyncDPC struct size/alignment" );
+
+// --------------------------
+
+constexpr uint32_t Color_Red4 = 0x8b0000;   // TracyColor.hpp
+
+static void ETWErrorAction( ULONG error_code, const char* message, int length )
+{
+#ifndef TRACY_NO_INTERNAL_MESSAGE
+#  ifdef TRACY_HAS_CALLSTACK
+    tracy::InitCallstackCritical();
+    tracy::Profiler::LogString( MessageSourceType::Tracy, MessageSeverity::Error, Color_Red4, 60, length, message );
+#  else
+    tracy::Profiler::LogString( MessageSourceType::Tracy, MessageSeverity::Error, Color_Red4, 0, length, message );
+#  endif
+#endif
+#ifdef __cpp_exceptions
+    // TODO: should we throw an exception?
+#endif
+}
+
+static ULONG ETWError( ULONG result )
+{
+    if( result == ERROR_SUCCESS )
+        return result;
+    static constexpr tracy::SourceLocationData srcLocHere{ nullptr, __FUNCTION__, __FILE__, __LINE__, Color_Red4 };
+    tracy::ScopedZone ___tracy_scoped_zone( &srcLocHere, 0, true );
+    char message[128] = {};
+    int written = snprintf( message, sizeof( message ), "ETW Error %u (0x%x): ", result, result );
+    written += FormatMessageA(
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        result,
+        MAKELANGID( LANG_ENGLISH, SUBLANG_ENGLISH_US ),
+        (LPSTR)&message[written],
+        sizeof( message ) - written,
+        NULL );
+    ETWErrorAction( result, message, written );
+    return result;
+}
+
+static bool CheckAdminPrivilege()
+{
+    HANDLE hToken = NULL;
+    if( OpenProcessToken( GetCurrentProcess(), TOKEN_QUERY, &hToken ) == FALSE )
+        return ETWError( GetLastError() ), false;
+    TOKEN_ELEVATION_TYPE elevationType = TokenElevationTypeDefault;
+    DWORD ReturnLength = 0;
+    if( GetTokenInformation( hToken, TokenElevationType, &elevationType, sizeof( elevationType ), &ReturnLength ) == FALSE )
+        ETWError( GetLastError() ), false;
+    CloseHandle( hToken );
+    return ( elevationType == TokenElevationTypeFull );
+}
+
+static DWORD ElevatePrivilege( LPCTSTR PrivilegeName )
+{
+    TOKEN_PRIVILEGES tp = {};
+    tp.PrivilegeCount = 1;
+    tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+    if( LookupPrivilegeValue( nullptr, PrivilegeName, &tp.Privileges[0].Luid ) == FALSE )
+        return ETWError( GetLastError() );
+    HANDLE hToken = {};
+    if( OpenProcessToken( GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &hToken ) == FALSE )
+        return ETWError( GetLastError() );
+    BOOL adjusted = AdjustTokenPrivileges( hToken, FALSE, &tp, 0, nullptr, nullptr );
+    DWORD status = GetLastError();
+    CloseHandle( hToken );    // NOTE: skipping error handling for CloseHandle()
+    return ETWError( status );
+}
+
+static bool IsOS64Bit()
+{
+#if defined _WIN64
+    constexpr bool isOs64Bit = true;
+#else
+    BOOL _iswow64;
+    IsWow64Process( GetCurrentProcess(), &_iswow64 );
+    const bool isOs64Bit = _iswow64;
+#endif
+    return isOs64Bit;
+}
+
+static ULONG StopSession( Session& session )
+{
+    // Use a copy of the session properties, because ControlTrace() will write stuff to it
+    Session temp = session;
+    ULONG status = ControlTraceA( temp.handle, temp.name, &temp.properties, EVENT_TRACE_CONTROL_STOP );
+    if( status != ERROR_SUCCESS )
+        return ETWError( status );
+    // once stopped, the session handle becomes invalid
+    session.handle = 0;
+    for( auto&& sw : session.stackwalk )
+        sw = {};
+    return ERROR_SUCCESS;
+}
+
+static ULONG StartSession( Session& session )
+{
+    ULONG status = StartTraceA( &session.handle, session.name, &session.properties );
+    if( status == ERROR_ALREADY_EXISTS )
+    {
+        // Session is already running (likely from a previous run that did not terminate
+        // gracefully). There are two options: take control of the existing session with
+        // ControlSession(UPDATE), or stop the session and start fresh again. The latter
+        // is better because it also resets the event providers.
+        status = StopSession( session );
+        if( status != ERROR_SUCCESS )
+            return status;
+        status = StartTraceA( &session.handle, session.name, &session.properties );
+    }
+    return ETWError( status );
+}
+
+static ULONG CheckProviderSessions( GUID provider, ULONGLONG MatchAnyKeyword )
+{
+    MatchAnyKeyword = ( MatchAnyKeyword != 0 ) ? MatchAnyKeyword : ~ULONGLONG( 0 );
+    char buffer[4096] = {};
+    auto Info = (PTRACE_GUID_INFO)buffer;
+    ULONG ActualSize = 0;
+    ULONG result = EnumerateTraceGuidsEx( TraceGuidQueryInfo, &provider, sizeof( provider ), Info, sizeof( buffer ), &ActualSize );
+    if( result != ERROR_SUCCESS )
+        return ETWError( result );
+    TRACE_ENABLE_INFO sessions[8] = {};
+    // Info->InstanceCount is typically 1, but can be more when the provider is registered from within a DLL
+    for( ULONG i = 0, offset = 0; i < Info->InstanceCount; ++i )
+    {
+        auto instance = (PTRACE_PROVIDER_INSTANCE_INFO)&buffer[sizeof( *Info ) + offset];
+        auto first = (PTRACE_ENABLE_INFO)&buffer[sizeof( *Info ) + offset + sizeof( *instance )];
+        for( ULONG j = 0; j < instance->EnableCount; ++j )
+        {
+            auto session = &first[j];
+            for( auto&& entry : sessions )
+            {
+                if( entry.LoggerId == session->LoggerId )
+                    continue;
+                if( entry.LoggerId != 0 )
+                    continue;
+                if( ( MatchAnyKeyword & session->MatchAnyKeyword ) != 0 )
+                    entry = *session;
+                break;
+            }
+        }
+        offset += instance->NextOffset;
+    }
+    if( sessions[0].LoggerId == 0 )
+        return ERROR_SUCCESS;
+    int length = snprintf( buffer, sizeof( buffer ), "ETW Warning: provider (0x%08X) already enabled by other session(s); Tracy may miss events.", provider.Data1 );
+    ETWErrorAction( 0, buffer, length );
+    return ERROR_SUCCESS;
+}
+
+static ULONG EnableProvider(
+    Session& session,
+    const GUID& ProviderId,
+    ULONG ControlCode = EVENT_CONTROL_CODE_ENABLE_PROVIDER,
+    UCHAR Level = TRACE_LEVEL_INFORMATION,
+    ULONGLONG MatchAnyKeyword = 0,  // NOTE: a MatchAnyKeyword of 0 actually means "all bits set", according to the EnableTraceEx2 docs
+    ULONGLONG MatchAllKeyword = 0,
+    ULONG Timeout = 0,
+    PENABLE_TRACE_PARAMETERS EnableParameters = NULL )
+{
+    ULONG status = EnableTraceEx2( session.handle, &ProviderId, ControlCode, Level, MatchAnyKeyword, MatchAllKeyword, Timeout, EnableParameters );
+    return ETWError( status );
+}
+
+static ULONG EnableStackWalk( Session& session, GUID EventGuid, UCHAR Opcode )
+{
+    if( !IsOS64Bit() )
+        return 0 /* ERROR_SUCCESS */;   // TODO: return error instead?
+    // TraceStackTracingInfo: Turns on stack trace collection for the specified kernel events
+    //                        for the specified logger. It also turns off stack tracing for
+    //                        all kernel events not on this list, regardless of prior status.
+    // NOTE: It'd be nice if we could rely on TraceQueryInformation(TraceStackTracingInfo)
+    // to retrieve the list of the active stack trace event ids, but even though MSDN says
+    // that it is possible, the query call returns ERROR_NOT_SUPPORTED...
+    // Instead, we keep our own array of active stack trace event ids in the session object.
+    for( auto&& sw : session.stackwalk )
+    {
+        if( !IsEqualGUID( sw.EventGuid, {} ) )
+            continue;
+        sw.EventGuid = EventGuid;
+        sw.Type = Opcode;
+        size_t count = ( &sw - session.stackwalk ) + 1;
+        ULONG status = TraceSetInformation( session.handle, TraceStackTracingInfo, session.stackwalk, count * sizeof( CLASSIC_EVENT_ID ) );
+        return ETWError( status );
+    }
+    return 0 /* ERROR_SUCCESS */;   // TODO: return error instead?
+}
+
+static ULONG SetCPUProfilingInterval( int microseconds )
+{
+    if( !IsOS64Bit() )
+        return 0 /* ERROR_SUCCESS */;   // TODO: fabricate SetLastError(ERROR_NOT_SUPPORTED) instead?
+    TRACE_PROFILE_INTERVAL interval = {};
+    interval.Source = 0; // 0: ProfileTime (from enum KPROFILE_SOURCE in wdm.h)
+    interval.Interval = ( microseconds * 1000 ) / 100; // in 100's of nanoseconds
+    CONTROLTRACE_ID TraceId = 0; // must be zero for TraceSampledProfileIntervalInfo
+    ULONG status = TraceSetInformation( TraceId, TraceSampledProfileIntervalInfo, &interval, sizeof( interval ) );
+    return ETWError( status );
+}
+
+static Session StartSingletonKernelLoggerSession( ULONGLONG EnableFlags )
+{
+    Session session = {};
+
+    strzcpy( session.name, KERNEL_LOGGER_NAMEA, sizeof( session.name ) );
+
+    auto& props = session.properties;
+    props.LoggerNameOffset = offsetof( Session, name );
+    props.Wnode.BufferSize = sizeof( Session );
+    props.Wnode.Guid = SystemTraceControlGuid;
+#ifdef TRACY_TIMER_QPC
+    props.Wnode.ClientContext = 1;  // 1: QueryPerformanceCounter
+#else
+    props.Wnode.ClientContext = 3;  // 3: CPU Ticks (e.g., rdtsc)
+#endif
+    props.Wnode.Flags = WNODE_FLAG_TRACED_GUID;
+    props.LogFileMode = EVENT_TRACE_REAL_TIME_MODE;
+
+    props.EnableFlags = EnableFlags;
+
+    // TODO: should we really be tweaking the buffering parameters?
+    props.BufferSize = 1024;    // in KB
+    props.MinimumBuffers = std::thread::hardware_concurrency() * 4;
+    props.MaximumBuffers = std::thread::hardware_concurrency() * 6;
+
+    ULONG status = StartSession( session );
+    if( status != ERROR_SUCCESS )
+        return {};
+
+    return session;
+}
+
+static Session StartPrivateKernelSession( const CHAR* name )
+{
+    Session session = {};
+
+    strzcpy( session.name, name, sizeof( session.name ) );
+
+    auto& props = session.properties;
+    props.LoggerNameOffset = offsetof( Session, name );
+    props.Wnode.BufferSize = sizeof( Session );
+    props.Wnode.Guid = NullGuid;
+#ifdef TRACY_TIMER_QPC
+    props.Wnode.ClientContext = 1;  // 1: QueryPerformanceCounter
+#else
+    props.Wnode.ClientContext = 3;  // 3: CPU Ticks (e.g., rdtsc)
+#endif
+    props.Wnode.Flags = WNODE_FLAG_TRACED_GUID;
+    props.LogFileMode = 0;
+    props.LogFileMode |= EVENT_TRACE_SYSTEM_LOGGER_MODE;
+    props.LogFileMode |= EVENT_TRACE_REAL_TIME_MODE;
+
+    // TODO: should we really be tweaking the buffering parameters?
+    props.BufferSize = 1024;    // in KB
+    props.MinimumBuffers = std::thread::hardware_concurrency() * 4;
+    props.MaximumBuffers = std::thread::hardware_concurrency() * 6;
+
+    ULONG status = StartSession( session );
+    if( status != ERROR_SUCCESS )
+        return {};
+
+    return session;
+}
+
+static Session StartUserSession( const CHAR* name )
+{
+    Session session = {};
+
+    strzcpy( session.name, name, sizeof( session.name ) );
+
+    auto& props = session.properties;
+    props.LoggerNameOffset = offsetof( Session, name );
+    props.Wnode.BufferSize = sizeof( Session );
+    props.Wnode.Guid = NullGuid;
+#ifdef TRACY_TIMER_QPC
+    props.Wnode.ClientContext = 1;  // 1: QueryPerformanceCounter
+#else
+    props.Wnode.ClientContext = 3;  // 3: CPU Ticks (e.g., rdtsc)
+#endif
+    //props.Wnode.Flags = WNODE_FLAG_TRACED_GUID; // unnecessary for user sessions, apparently
+    props.LogFileMode = EVENT_TRACE_REAL_TIME_MODE;
+
+    ULONG status = StartSession( session );
+    if( status != ERROR_SUCCESS )
+        return {};
+
+    return session;
+}
+
+bool IsSingletonKernelLoggerSession( Session& session )
+{
+    bool check = true;
+    check &= ( session.handle == 0xFFFF );
+    check &= ( strncmp( session.name, KERNEL_LOGGER_NAMEA, sizeof( session.name ) ) == 0 );
+    return check;
+}
+
+static ULONG UpdateSessionEnableFlags( Session& session, ULONGLONG EnableFlags )
+{
+    // Use a copy of the session properties, because ControlTrace(UPDATE) will modify
+    // LogFileNameOffset and "pad" the rest with zeros, overwriting the session.handle!
+    Session temp = session;
+    temp.properties.EnableFlags = EnableFlags;
+    ULONG status = ControlTraceA( temp.handle, temp.name, &temp.properties, EVENT_TRACE_CONTROL_UPDATE );
+    if( status != ERROR_SUCCESS )
+        return ETWError( status );
+    session.properties.EnableFlags = EnableFlags;
+    return status;
+}
+
+static ULONG EnableProcessAndThreadMonitoring( Session& session )
+{
+    if( IsSingletonKernelLoggerSession( session ) )
+    {
+        ULONGLONG EnableFlags = session.properties.EnableFlags;
+        EnableFlags |= EVENT_TRACE_FLAG_THREAD;
+        ULONG status = UpdateSessionEnableFlags( session, EnableFlags );
+        return status;
+    }
+
+    ULONGLONG MatchAnyKeyword = SYSTEM_PROCESS_KW_THREAD;   // ThreadStart and ThreadDCStart events
+    ULONG status = EnableProvider( session, SystemProcessProviderGuid,
+                                   EVENT_CONTROL_CODE_ENABLE_PROVIDER, TRACE_LEVEL_INFORMATION, MatchAnyKeyword );
+    return status;
+}
+
+static ULONG EnableCPUProfiling( Session& session, int microseconds = 125 /* 8KHz = 125us */ )
+{
+    if( !IsOS64Bit() )
+        return 0 /* ERROR_SUCCESS */;   // TODO: fabricate SetLastError(ERROR_NOT_SUPPORTED) instead?
+
+    // CPU Profiling requires special privileges on top of admin privileges
+    DWORD access = ElevatePrivilege( SE_SYSTEM_PROFILE_NAME );
+    if( access != ERROR_SUCCESS )
+        return access;
+
+    if( IsSingletonKernelLoggerSession( session ) )
+    {
+        ULONGLONG EnableFlags = session.properties.EnableFlags;
+        EnableFlags |= EVENT_TRACE_FLAG_PROFILE;
+        ULONG status = UpdateSessionEnableFlags( session, EnableFlags );
+        if( status != ERROR_SUCCESS )
+            return status;
+    }
+    else
+    {
+        CheckProviderSessions( SystemProfileProviderGuid, 0 );
+        ULONG status = EnableProvider( session, SystemProfileProviderGuid );
+        if( status != ERROR_SUCCESS )
+            return status;
+    }
+
+    ULONG status = SetCPUProfilingInterval( microseconds );
+    if( status != ERROR_SUCCESS )
+        return status;
+
+    status = EnableStackWalk( session, PerfInfoGuid, SampledProfile::Opcode );
+    return status;
+}
+
+static ULONG EnableContextSwitchMonitoring( Session& session, bool waitStacks )
+{
+    if( IsSingletonKernelLoggerSession( session ) )
+    {
+        ULONGLONG EnableFlags = session.properties.EnableFlags;
+        EnableFlags |= EVENT_TRACE_FLAG_CSWITCH;
+        EnableFlags |= EVENT_TRACE_FLAG_DISPATCHER;
+        ULONG status = UpdateSessionEnableFlags( session, EnableFlags );
+        if( status != ERROR_SUCCESS )
+            return status;
+    }
+    else
+    {
+        ULONGLONG MatchAnyKeyword = 0;
+        MatchAnyKeyword |= SYSTEM_SCHEDULER_KW_CONTEXT_SWITCH;  // CSwitch events
+        MatchAnyKeyword |= SYSTEM_SCHEDULER_KW_DISPATCHER;      // ReadyThread events
+        CheckProviderSessions( SystemSchedulerProviderGuid, MatchAnyKeyword );
+        ULONG status = EnableProvider( session, SystemSchedulerProviderGuid,
+                                       EVENT_CONTROL_CODE_ENABLE_PROVIDER, TRACE_LEVEL_INFORMATION, MatchAnyKeyword );
+        if( status != ERROR_SUCCESS )
+            return status;
+    }
+
+    if( !waitStacks )
+        return ERROR_SUCCESS;
+
+    ULONG status = EnableStackWalk( session, ThreadGuid, CSwitch::Opcode );
+    return status;
+}
+
+static ULONG EnableVSyncMonitoring( Session& session )
+{
+    if( !IsOS64Bit() )
+        return 0 /* ERROR_SUCCESS */;   // TODO: fabricate SetLastError(ERROR_NOT_SUPPORTED) instead?
+// TODO: is this correct?
+#if ( _WIN32_WINNT < _WIN32_WINNT_WINBLUE )
+    return ETWError( ERROR_NOT_SUPPORTED );
+#endif
+
+    enum Keyword : ULONGLONG
+    {
+        DxgKrnlBase    = 0x0000000000000001ULL, // Microsoft-Windows-DxgKrnl: Base
+        DxgKrnlPresent = 0x0000000008000000ULL, // Microsoft-Windows-DxgKrnl: Present
+        MSFTReserved62 = 0x4000000000000000ULL  // winmeta.h: WINEVENT_KEYWORD_RESERVED_62
+                                                // (Microsoft-Windows-DxgKrnl/Performance, according to logman)
+    };
+    // DxgKrnlPresent bit was added in Win11, but we do not want to break Win10, so do not put it in MatchAllKeyword
+    ULONGLONG MatchAnyKeyword = Keyword::MSFTReserved62 /*| Keyword::DxgKrnlPresent*/ | Keyword::DxgKrnlBase;
+    ULONGLONG MatchAllKeyword = MatchAnyKeyword;
+
+    EVENT_FILTER_EVENT_ID fe = {};
+    fe.FilterIn = TRUE;
+    fe.Count = 1;
+    fe.Events[0] = VSyncDPC::EventId;
+    EVENT_FILTER_DESCRIPTOR desc = {};
+    desc.Ptr = (ULONGLONG)&fe;
+    desc.Size = sizeof( fe );
+    desc.Type = EVENT_FILTER_TYPE_EVENT_ID;
+    ENABLE_TRACE_PARAMETERS EnableParameters = {};
+    EnableParameters.Version = ENABLE_TRACE_PARAMETERS_VERSION_2;
+    EnableParameters.EnableProperty = EVENT_ENABLE_PROPERTY_IGNORE_KEYWORD_0;
+    EnableParameters.SourceId = DxgKrnlGuid;    // or NullGuid? Does it even matter?
+    EnableParameters.EnableFilterDesc = &desc;
+    EnableParameters.FilterDescCount = 1;
+
+    CheckProviderSessions( DxgKrnlGuid, MatchAnyKeyword );
+    ULONG status = EnableProvider( session, DxgKrnlGuid,
+                                   EVENT_CONTROL_CODE_ENABLE_PROVIDER, TRACE_LEVEL_INFORMATION,
+                                   MatchAnyKeyword, MatchAllKeyword, 0, &EnableParameters );
+    return status;
+}
+
+static ULONG WINAPI OnBufferComplete( PEVENT_TRACE_LOGFILEA Buffer )
+{
+    if( Buffer->EventsLost > 0 )
+    {
+        char buffer[64] = {};
+        int length = snprintf( buffer, sizeof( buffer ), "ETW Warning: %u events have been lost.", Buffer->EventsLost );
+        ETWErrorAction( ERROR_BUFFER_OVERFLOW, buffer, length );
+    }
+    return TRUE;    // or FALSE to break out of ProcessTrace()
+}
+
+static PROCESSTRACE_HANDLE SetupEventConsumer( const Session& session, PEVENT_RECORD_CALLBACK callback )
+{
+    EVENT_TRACE_LOGFILEA trace = {};
+    trace.LoggerName = (LPSTR)session.name;
+    trace.ProcessTraceMode = PROCESS_TRACE_MODE_REAL_TIME;
+    trace.ProcessTraceMode |= PROCESS_TRACE_MODE_EVENT_RECORD;  // request EVENT_RECORD, not EVENT_TRACE (legacy)
+    trace.ProcessTraceMode |= PROCESS_TRACE_MODE_RAW_TIMESTAMP; // no timestamp conversions (use whatever the session is using)
+    trace.EventRecordCallback = callback;
+    trace.BufferCallback = OnBufferComplete;
+
+    PROCESSTRACE_HANDLE hConsumer = OpenTraceA( &trace );
+    if( hConsumer == INVALID_PROCESSTRACE_HANDLE )
+        ETWError( GetLastError() );
+
+    return hConsumer;
+}
+
+static ULONG StopEventConsumer( PROCESSTRACE_HANDLE hEventConsumer )
+{
+    ULONG status = CloseTrace( hEventConsumer );
+    if( ( status != ERROR_SUCCESS ) && ( status != ERROR_CTX_CLOSE_PENDING ) )
+        return ETWError( status );
+    return status;
+}
+
+static ULONG EventConsumerLoop( PROCESSTRACE_HANDLE hEventConsumer )
+{
+    ULONG status = ProcessTrace( &hEventConsumer, 1, NULL, NULL );
+    if( status != ERROR_SUCCESS && status != ERROR_CANCELLED )
+        return ETWError( status );
+    return status;
+}
+
+}
+}

--- a/D3D11Engine/include/tracy/public/client/windows/TracyETW_compat.h
+++ b/D3D11Engine/include/tracy/public/client/windows/TracyETW_compat.h
@@ -1,0 +1,57 @@
+#ifndef __TRACY_ETW_COMPAT_H__
+#define __TRACY_ETW_COMPAT_H__
+
+// Compatibility definitions for older Windows SDKs and MinGW-w64 which lacks some ETW types
+// present in Microsoft's Windows SDK
+
+#ifdef __MINGW32__
+
+// CONTROLTRACE_ID - ETW trace session handle type
+typedef ULONG64 CONTROLTRACE_ID;
+
+// PROCESSTRACE_HANDLE - ETW process trace handle type
+// MinGW defines INVALID_PROCESSTRACE_HANDLE but not the type itself
+#ifndef PROCESSTRACE_HANDLE
+#define PROCESSTRACE_HANDLE TRACEHANDLE
+#endif
+
+// EVENT_FILTER_EVENT_ID struct for event filtering
+typedef struct _EVENT_FILTER_EVENT_ID {
+    BOOLEAN FilterIn;
+    UCHAR Reserved;
+    USHORT Count;
+    USHORT Events[ANYSIZE_ARRAY];
+} EVENT_FILTER_EVENT_ID, *PEVENT_FILTER_EVENT_ID;
+
+// Event filter type constants
+#define EVENT_FILTER_TYPE_EVENT_ID (0x80000200) // Event IDs.
+
+// Enable property constants
+#define EVENT_ENABLE_PROPERTY_IGNORE_KEYWORD_0 (0x00000010)
+
+// System provider GUIDs
+// MinGW's DEFINE_GUID only declares the GUID, we need to define it with actual storage
+// Using GUID format: {l, w1, w2, d1, d2, d3, d4, d5, d6, d7, d8} where d1-d8 are bytes
+static const GUID SystemProcessProviderGuid = { 0x151f55dc, 0x467d, 0x471f, { 0x83, 0xb5, 0x5f, 0x88, 0x9d, 0x46, 0xff, 0x66 } };
+static const GUID SystemProfileProviderGuid = { 0xbfeb0324, 0x1cee, 0x496f, { 0xa4, 0x9, 0x2a, 0xc2, 0xb4, 0x8a, 0x63, 0x22 } };
+static const GUID SystemSchedulerProviderGuid = { 0x599a2a76, 0x4d91, 0x4910, { 0x9a, 0xc7, 0x7d, 0x33, 0xf2, 0xe9, 0x7a, 0x6c } };
+
+// System provider keyword constants
+#define SYSTEM_PROCESS_KW_THREAD (0x0000000000000800)
+#define SYSTEM_SCHEDULER_KW_DISPATCHER (0x0000000000000002)
+#define SYSTEM_SCHEDULER_KW_CONTEXT_SWITCH (0x0000000000000200)
+
+#else // __MINGW32__
+
+// Backcompat with older sdk versions
+// SDK 10.0.26100 introduced those two and marked TRACEHANDLE obsolete
+// SDK 10.0.26100 is the first one to define NTDDI_VERSION and WDK_NTDDI_VERSION to NTDDI_WIN11_GE, while older ones will have lower versions and NTDDI_WIN11_GE undefined.
+// Just in case we check both definition and value.
+#if !(defined NTDDI_WIN11_GE && WDK_NTDDI_VERSION >= NTDDI_WIN11_GE)
+typedef ULONG64 PROCESSTRACE_HANDLE;
+typedef ULONG64 CONTROLTRACE_ID;
+#endif
+
+#endif // __MINGW32__
+
+#endif // __TRACY_ETW_COMPAT_H__

--- a/D3D11Engine/include/tracy/public/common/TracyAlign.hpp
+++ b/D3D11Engine/include/tracy/public/common/TracyAlign.hpp
@@ -2,24 +2,32 @@
 #define __TRACYALIGN_HPP__
 
 #include <string.h>
+#include <type_traits>
 
 #include "TracyForceInline.hpp"
+
+#if defined _MSC_VER && !defined _M_IX86
+#  define TracyUnaligned __unaligned
+#else
+#  define TracyUnaligned
+#endif
 
 namespace tracy
 {
 
 template<typename T>
-tracy_force_inline T MemRead( const void* ptr )
+tracy_force_inline T MemRead( const TracyUnaligned T* ptr )
 {
     T val;
     memcpy( &val, ptr, sizeof( T ) );
     return val;
 }
 
-template<typename T>
-tracy_force_inline void MemWrite( void* ptr, T val )
+template<typename T, typename U>
+tracy_force_inline void MemWrite( TracyUnaligned T* ptr, U val )
 {
-    memcpy( ptr, &val, sizeof( T ) );
+    static_assert( std::is_same<T, U>::value, "MemWrite type mismatch" );
+    memcpy( (void*)ptr, &val, sizeof( T ) );
 }
 
 }

--- a/D3D11Engine/include/tracy/public/common/TracyAlloc.hpp
+++ b/D3D11Engine/include/tracy/public/common/TracyAlloc.hpp
@@ -3,26 +3,35 @@
 
 #include <stdlib.h>
 
+#ifdef TRACY_PLATFORM_HEADER
+#  include TRACY_PLATFORM_HEADER
+#endif
+
 #if defined TRACY_ENABLE && !defined __EMSCRIPTEN__
 #  include "TracyApi.h"
 #  include "TracyForceInline.hpp"
-#  include "../client/tracy_rpmalloc.hpp"
-#  define TRACY_USE_RPMALLOC
+#  if !defined TRACY_HAS_CUSTOM_ALLOCATOR
+#    include "../client/tracy_rpmalloc.hpp"
+#    define TRACY_USE_RPMALLOC
+#  endif
 #endif
 
 namespace tracy
 {
 
-#ifdef TRACY_USE_RPMALLOC
-TRACY_API void InitRpmalloc();
+#if defined TRACY_USE_RPMALLOC || defined TRACY_HAS_CUSTOM_ALLOCATOR
+TRACY_API void InitAllocator();
 #else
-static inline void InitRpmalloc() {}
+static inline void InitAllocator() {}
 #endif
 
 static inline void* tracy_malloc( size_t size )
 {
-#ifdef TRACY_USE_RPMALLOC
-    InitRpmalloc();
+#if defined TRACY_HAS_CUSTOM_ALLOCATOR
+    InitAllocator();
+    return PlatformMalloc( size );
+#elif defined TRACY_USE_RPMALLOC
+    InitAllocator();
     return rpmalloc( size );
 #else
     return malloc( size );
@@ -31,7 +40,9 @@ static inline void* tracy_malloc( size_t size )
 
 static inline void* tracy_malloc_fast( size_t size )
 {
-#ifdef TRACY_USE_RPMALLOC
+#if defined TRACY_HAS_CUSTOM_ALLOCATOR
+    return PlatformMalloc( size );
+#elif defined TRACY_USE_RPMALLOC
     return rpmalloc( size );
 #else
     return malloc( size );
@@ -40,8 +51,11 @@ static inline void* tracy_malloc_fast( size_t size )
 
 static inline void tracy_free( void* ptr )
 {
-#ifdef TRACY_USE_RPMALLOC
-    InitRpmalloc();
+#if defined TRACY_HAS_CUSTOM_ALLOCATOR
+    InitAllocator();
+    PlatformFree( ptr );
+#elif defined TRACY_USE_RPMALLOC
+    InitAllocator();
     rpfree( ptr );
 #else
     free( ptr );
@@ -50,7 +64,9 @@ static inline void tracy_free( void* ptr )
 
 static inline void tracy_free_fast( void* ptr )
 {
-#ifdef TRACY_USE_RPMALLOC
+#if defined TRACY_HAS_CUSTOM_ALLOCATOR
+    PlatformFree( ptr );
+#elif defined TRACY_USE_RPMALLOC
     rpfree( ptr );
 #else
     free( ptr );
@@ -59,8 +75,11 @@ static inline void tracy_free_fast( void* ptr )
 
 static inline void* tracy_realloc( void* ptr, size_t size )
 {
-#ifdef TRACY_USE_RPMALLOC
-    InitRpmalloc();
+#if defined TRACY_HAS_CUSTOM_ALLOCATOR
+    InitAllocator();
+    return PlatformRealloc( ptr, size );
+#elif defined TRACY_USE_RPMALLOC
+    InitAllocator();
     return rprealloc( ptr, size );
 #else
     return realloc( ptr, size );

--- a/D3D11Engine/include/tracy/public/common/TracyApi.h
+++ b/D3D11Engine/include/tracy/public/common/TracyApi.h
@@ -3,11 +3,23 @@
 
 #if defined _WIN32
 #  if defined TRACY_EXPORTS
-#    define TRACY_API __declspec(dllexport)
+#    if defined(__clang__)
+#      define TRACY_API __declspec(dllexport) __attribute__((visibility("default")))
+#    else
+#      define TRACY_API __declspec(dllexport)
+#    endif
 #  elif defined TRACY_IMPORTS
-#    define TRACY_API __declspec(dllimport)
+#    if defined(__clang__)
+#      define TRACY_API __declspec(dllimport) __attribute__((visibility("default")))
+#    else
+#      define TRACY_API __declspec(dllimport)
+#    endif
 #  else
-#    define TRACY_API
+#    if defined(__clang__)
+#      define TRACY_API __attribute__((visibility("default")))
+#    else
+#      define TRACY_API
+#    endif
 #  endif
 #else
 #  define TRACY_API __attribute__((visibility("default")))

--- a/D3D11Engine/include/tracy/public/common/TracyAssert.hpp
+++ b/D3D11Engine/include/tracy/public/common/TracyAssert.hpp
@@ -1,0 +1,12 @@
+#ifndef __TRACYASSERT_HPP__
+#define __TRACYASSERT_HPP__
+
+// Define TRACY_ASSERT(condition) before including any Tracy header to
+// route the internal checks through a custom assert implementation.
+// Falls back to the standard assert when not defined.
+#ifndef TRACY_ASSERT
+#  include <assert.h>
+#  define TRACY_ASSERT(x) assert(x)
+#endif
+
+#endif

--- a/D3D11Engine/include/tracy/public/common/TracyFormat.h
+++ b/D3D11Engine/include/tracy/public/common/TracyFormat.h
@@ -1,0 +1,11 @@
+#ifndef __TRACYFORMAT_H__
+#define __TRACYFORMAT_H__
+
+#if (defined(__GNUC__) || defined(__clang__))
+#  define TRACY_ATTRIBUTE_FORMAT_PRINTF(fmt_idx, arg_idx) \
+     __attribute__((format(printf, fmt_idx, arg_idx)))
+#else
+#  define TRACY_ATTRIBUTE_FORMAT_PRINTF(fmt_idx, arg_idx)
+#endif
+
+#endif

--- a/D3D11Engine/include/tracy/public/common/TracyProtocol.hpp
+++ b/D3D11Engine/include/tracy/public/common/TracyProtocol.hpp
@@ -2,6 +2,7 @@
 #define __TRACYPROTOCOL_HPP__
 
 #include <limits>
+#include <stddef.h>
 #include <stdint.h>
 
 namespace tracy
@@ -9,17 +10,17 @@ namespace tracy
 
 constexpr unsigned Lz4CompressBound( unsigned isize ) { return isize + ( isize / 255 ) + 16; }
 
-enum : uint32_t { ProtocolVersion = 76 };
-enum : uint16_t { BroadcastVersion = 3 };
+constexpr uint32_t ProtocolVersion = 82;
+constexpr uint16_t BroadcastVersion = 3;
 
 using lz4sz_t = uint32_t;
 
-enum { TargetFrameSize = 256 * 1024 };
-enum { LZ4Size = Lz4CompressBound( TargetFrameSize ) };
+constexpr unsigned TargetFrameSize = 256 * 1024;
+constexpr unsigned LZ4Size = Lz4CompressBound( TargetFrameSize );
 static_assert( LZ4Size <= (std::numeric_limits<lz4sz_t>::max)(), "LZ4Size greater than lz4sz_t" );
 static_assert( TargetFrameSize * 2 >= 64 * 1024, "Not enough space for LZ4 stream buffer" );
 
-enum { HandshakeShibbolethSize = 8 };
+constexpr size_t HandshakeShibbolethSize = 8;
 static const char HandshakeShibboleth[HandshakeShibbolethSize] = { 'T', 'r', 'a', 'c', 'y', 'P', 'r', 'f' };
 
 enum HandshakeStatus : uint8_t
@@ -31,8 +32,8 @@ enum HandshakeStatus : uint8_t
     HandshakeDropped
 };
 
-enum { WelcomeMessageProgramNameSize = 64 };
-enum { WelcomeMessageHostInfoSize = 1024 };
+constexpr size_t WelcomeMessageHostInfoSize = 1024;
+constexpr size_t WelcomeMessageProgramNameSize = 64;
 
 #pragma pack( push, 1 )
 
@@ -65,7 +66,7 @@ struct ServerQueryPacket
     uint32_t extra;
 };
 
-enum { ServerQueryPacketSize = sizeof( ServerQueryPacket ) };
+constexpr size_t ServerQueryPacketSize = sizeof( ServerQueryPacket );
 
 
 enum CpuArchitecture : uint8_t
@@ -108,16 +109,12 @@ struct WelcomeMessage
     char hostInfo[WelcomeMessageHostInfoSize];
 };
 
-enum { WelcomeMessageSize = sizeof( WelcomeMessage ) };
-
 
 struct OnDemandPayloadMessage
 {
     uint64_t frames;
     uint64_t currentTime;
 };
-
-enum { OnDemandPayloadMessageSize = sizeof( OnDemandPayloadMessage ) };
 
 
 struct BroadcastMessage
@@ -156,12 +153,11 @@ struct BroadcastMessage_v0
     char programName[WelcomeMessageProgramNameSize];
 };
 
-enum { BroadcastMessageSize = sizeof( BroadcastMessage ) };
-enum { BroadcastMessageSize_v2 = sizeof( BroadcastMessage_v2 ) };
-enum { BroadcastMessageSize_v1 = sizeof( BroadcastMessage_v1 ) };
-enum { BroadcastMessageSize_v0 = sizeof( BroadcastMessage_v0 ) };
-
 #pragma pack( pop )
+
+constexpr uint64_t ProtocolOffset8Bit  = (1ull << 8);
+constexpr uint64_t ProtocolOffset16Bit = (1ull << 16);
+constexpr uint64_t ProtocolOffset32Bit = (1ull << 16) + (1ull << 32);
 
 }
 

--- a/D3D11Engine/include/tracy/public/common/TracyQueue.hpp
+++ b/D3D11Engine/include/tracy/public/common/TracyQueue.hpp
@@ -3,6 +3,9 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "TracyAssert.hpp"
+#include "TracyTaggedUserlandAddress.hpp"
+#include "TracyForceInline.hpp"
 
 namespace tracy
 {
@@ -22,11 +25,21 @@ enum class QueueType : uint8_t
     Callstack,
     CallstackAlloc,
     CallstackSample,
+    CallstackSample32,
+    CallstackSample16,
     CallstackSampleContextSwitch,
+    CallstackSampleContextSwitch32,
+    CallstackSampleContextSwitch16,
     FrameImage,
     ZoneBegin,
+    ZoneBegin32,
+    ZoneBegin16,
     ZoneBeginCallstack,
+    ZoneBeginCallstack32,
+    ZoneBeginCallstack16,
     ZoneEnd,
+    ZoneEnd32,
+    ZoneEnd16,
     LockWait,
     LockObtain,
     LockRelease,
@@ -69,6 +82,9 @@ enum class QueueType : uint8_t
     SourceCodeMetadata,
     FiberEnter,
     FiberLeave,
+    SectionEnter,
+    SectionLeave,
+    SectionSetup,
     Terminate,
     KeepAlive,
     ThreadContext,
@@ -110,6 +126,8 @@ enum class QueueType : uint8_t
     CpuTopology,
     SingleStringData,
     SecondStringData,
+    SingleStringData8,
+    SecondStringData8,
     MemNamePayload,
     ThreadGroupHint,
     GpuZoneAnnotation,
@@ -151,9 +169,31 @@ struct QueueZoneBeginThread : public QueueZoneBegin
     uint32_t thread;
 };
 
+struct QueueZoneBegin32
+{
+    uint32_t time;
+    uint64_t srcloc;
+};
+
+struct QueueZoneBegin16
+{
+    uint16_t time;
+    uint64_t srcloc;
+};
+
 struct QueueZoneEnd
 {
     int64_t time;
+};
+
+struct QueueZoneEnd32
+{
+    uint32_t time;
+};
+
+struct QueueZoneEnd16
+{
+    uint16_t time;
 };
 
 struct QueueZoneEndThread : public QueueZoneEnd
@@ -273,6 +313,36 @@ struct QueueFiberLeave
     uint32_t thread;
 };
 
+struct QueueSectionEnter
+{
+    int64_t time;
+    uint32_t id;
+    uint16_t category;
+};
+
+struct QueueSectionEnterFat : public QueueSectionEnter
+{
+    uint64_t text;      // ptr
+    uint16_t size;
+};
+
+struct QueueSectionLeave
+{
+    int64_t time;
+    uint32_t id;
+};
+
+struct QueueSectionSetup
+{
+    uint16_t category;
+};
+
+struct QueueSectionSetupFat : public QueueSectionSetup
+{
+    uint64_t text;      // ptr
+    uint16_t size;
+};
+
 struct QueueLockTerminate
 {
     uint32_t id;
@@ -343,6 +413,45 @@ struct QueuePlotDataDouble : public QueuePlotDataBase
     double val;
 };
 
+enum class MessageSourceType : uint8_t
+{
+    User,
+    Tracy,
+    COUNT
+};
+
+enum class MessageSeverity : uint8_t
+{
+    Trace,   // Broadly track variable states and events in the software program.
+    Debug,   // Describes variable states and details about specific internal events in the software, that are useful for investigations.
+    Info,    // Describes normal events, which inform on the expected progress and state of your software.
+    Warning, // Describes potentially dangerous situations caused by unexpected events and states.
+    Error,   // Describes the occurrence of unexpected behavior. Does not interrupt the execution of the software.
+    Fatal,   // Describes a critical event that will lead to a software failure/crash.
+    COUNT
+};
+
+tracy_force_inline uint8_t MakeMessageMetadata(MessageSourceType source, MessageSeverity severity)
+{
+    static_assert( (uint8_t)MessageSourceType::COUNT < ( 1 << 4 ), "We use 4 bits for the messages source." );
+    static_assert( (uint8_t)MessageSeverity::COUNT < ( 1 << 4 ), "We use 4 bits for the messages severity." );
+    return ( (uint8_t)severity ) << 4 | (uint8_t)source;
+}
+
+tracy_force_inline MessageSourceType MessageSourceFromMetadata(uint8_t metadata)
+{
+    TRACY_ASSERT( ( metadata & 0x0F ) < (uint8_t)MessageSourceType::COUNT );
+    return (MessageSourceType)( metadata & 0x0F );
+}
+
+tracy_force_inline MessageSeverity MessageSeverityFromMetadata(uint8_t metadata)
+{
+    TRACY_ASSERT( ( ( metadata & 0xF0 ) >> 4 ) < (uint8_t)MessageSeverity::COUNT );
+    return (MessageSeverity)( ( metadata & 0xF0 ) >> 4 );
+}
+
+// QueueMessage*Metadata and QueMessageLiteral* are the only structures sent over the wire
+// All other variants are used only internally to dispatch from the thread to the profiler and interpreted by Profiler::Dequeue
 struct QueueMessage
 {
     int64_t time;
@@ -355,9 +464,19 @@ struct QueueMessageColor : public QueueMessage
     uint8_t r;
 };
 
+struct QueueMessageMetadata : public QueueMessage
+{
+    uint8_t metadata;
+};
+
+struct QueueMessageColorMetadata : public QueueMessageColor
+{
+    uint8_t metadata;
+};
+
 struct QueueMessageLiteral : public QueueMessage
 {
-    uint64_t text;      // ptr
+    TaggedUserlandAddress textAndMetadata;      // ptr + log level/channels
 };
 
 struct QueueMessageLiteralThread : public QueueMessageLiteral
@@ -367,7 +486,7 @@ struct QueueMessageLiteralThread : public QueueMessageLiteral
 
 struct QueueMessageColorLiteral : public QueueMessageColor
 {
-    uint64_t text;      // ptr
+    TaggedUserlandAddress textAndMetadata;      // ptr + log level/channels
 };
 
 struct QueueMessageColorLiteralThread : public QueueMessageColorLiteral
@@ -377,7 +496,7 @@ struct QueueMessageColorLiteralThread : public QueueMessageColorLiteral
 
 struct QueueMessageFat : public QueueMessage
 {
-    uint64_t text;      // ptr
+    TaggedUserlandAddress textAndMetadata;      // ptr + log level/channels
     uint16_t size;
 };
 
@@ -388,7 +507,7 @@ struct QueueMessageFatThread : public QueueMessageFat
 
 struct QueueMessageColorFat : public QueueMessageColor
 {
-    uint64_t text;      // ptr
+    TaggedUserlandAddress textAndMetadata;      // ptr + log level/channels
     uint16_t size;
 };
 
@@ -409,13 +528,16 @@ enum class GpuContextType : uint8_t
     Metal,
     Custom,
     CUDA,
-    Rocprof
+    Rocprof,
+    WebGPU
 };
 
 enum GpuContextFlags : uint8_t
 {
     GpuContextCalibration   = 1 << 0
 };
+
+constexpr int32_t InvalidGpuContextId = -1;
 
 struct QueueGpuNewContext
 {
@@ -559,13 +681,25 @@ struct QueueCallstackAllocFatThread : public QueueCallstackAllocFat
 
 struct QueueCallstackSample
 {
-    int64_t time;
     uint32_t thread;
+    int64_t time;
 };
 
 struct QueueCallstackSampleFat : public QueueCallstackSample
 {
     uint64_t ptr;
+};
+
+struct QueueCallstackSample32
+{
+    uint32_t thread;
+    uint32_t time;
+};
+
+struct QueueCallstackSample16
+{
+    uint32_t thread;
+    uint16_t time;
 };
 
 struct QueueCallstackFrameSize
@@ -677,7 +811,7 @@ struct QueueParamSetup
 {
     uint32_t idx;
     uint64_t name;      // ptr
-    uint8_t isBool;
+    uint8_t type;
     int32_t val;
 };
 
@@ -733,7 +867,11 @@ struct QueueItem
         QueueZoneBegin zoneBegin;
         QueueZoneBeginLean zoneBeginLean;
         QueueZoneBeginThread zoneBeginThread;
+        QueueZoneBegin32 zoneBegin32;
+        QueueZoneBegin16 zoneBegin16;
         QueueZoneEnd zoneEnd;
+        QueueZoneEnd32 zoneEnd32;
+        QueueZoneEnd16 zoneEnd16;
         QueueZoneEndThread zoneEndThread;
         QueueZoneValidation zoneValidation;
         QueueZoneValidationThread zoneValidationThread;
@@ -762,7 +900,9 @@ struct QueueItem
         QueuePlotDataFloat plotDataFloat;
         QueuePlotDataDouble plotDataDouble;
         QueueMessage message;
+        QueueMessageMetadata messageMetadata;
         QueueMessageColor messageColor;
+        QueueMessageColorMetadata messageColorMetadata;
         QueueMessageLiteral messageLiteral;
         QueueMessageLiteralThread messageLiteralThread;
         QueueMessageColorLiteral messageColorLiteral;
@@ -793,6 +933,8 @@ struct QueueItem
         QueueCallstackAllocFatThread callstackAllocFatThread;
         QueueCallstackSample callstackSample;
         QueueCallstackSampleFat callstackSampleFat;
+        QueueCallstackSample32 callstackSample32;
+        QueueCallstackSample16 callstackSample16;
         QueueCallstackFrameSize callstackFrameSize;
         QueueCallstackFrameSizeFat callstackFrameSizeFat;
         QueueCallstackFrame callstackFrame;
@@ -815,21 +957,26 @@ struct QueueItem
         QueueSourceCodeNotAvailable sourceCodeNotAvailable;
         QueueFiberEnter fiberEnter;
         QueueFiberLeave fiberLeave;
+        QueueSectionEnter sectionEnter;
+        QueueSectionEnterFat sectionEnterFat;
+        QueueSectionLeave sectionLeave;
+        QueueSectionSetup sectionSetup;
+        QueueSectionSetupFat sectionSetupFat;
         QueueGpuZoneAnnotation zoneAnnotation;
     };
 };
 #pragma pack( pop )
 
 
-enum { QueueItemSize = sizeof( QueueItem ) };
+constexpr size_t QueueItemSize = sizeof( QueueItem );
 
 static constexpr size_t QueueDataSize[] = {
     sizeof( QueueHeader ),                                  // zone text
     sizeof( QueueHeader ),                                  // zone name
-    sizeof( QueueHeader ) + sizeof( QueueMessage ),
-    sizeof( QueueHeader ) + sizeof( QueueMessageColor ),
-    sizeof( QueueHeader ) + sizeof( QueueMessage ),         // callstack
-    sizeof( QueueHeader ) + sizeof( QueueMessageColor ),    // callstack
+    sizeof( QueueHeader ) + sizeof( QueueMessageMetadata ),     // Message
+    sizeof( QueueHeader ) + sizeof( QueueMessageColorMetadata ),// MessageColor
+    sizeof( QueueHeader ) + sizeof( QueueMessageMetadata ),     // MessageCallstack
+    sizeof( QueueHeader ) + sizeof( QueueMessageColorMetadata ),// MessageColorCallstack
     sizeof( QueueHeader ) + sizeof( QueueMessage ),         // app info
     sizeof( QueueHeader ) + sizeof( QueueZoneBeginLean ),   // allocated source location
     sizeof( QueueHeader ) + sizeof( QueueZoneBeginLean ),   // allocated source location, callstack
@@ -837,11 +984,21 @@ static constexpr size_t QueueDataSize[] = {
     sizeof( QueueHeader ),                                  // callstack
     sizeof( QueueHeader ),                                  // callstack alloc
     sizeof( QueueHeader ) + sizeof( QueueCallstackSample ),
-    sizeof( QueueHeader ) + sizeof( QueueCallstackSample ), // context switch
+    sizeof( QueueHeader ) + sizeof( QueueCallstackSample32 ),
+    sizeof( QueueHeader ) + sizeof( QueueCallstackSample16 ),
+    sizeof( QueueHeader ) + sizeof( QueueCallstackSample ),   // context switch
+    sizeof( QueueHeader ) + sizeof( QueueCallstackSample32 ), // context switch
+    sizeof( QueueHeader ) + sizeof( QueueCallstackSample16 ), // context switch
     sizeof( QueueHeader ) + sizeof( QueueFrameImage ),
     sizeof( QueueHeader ) + sizeof( QueueZoneBegin ),
+    sizeof( QueueHeader ) + sizeof( QueueZoneBegin32 ),
+    sizeof( QueueHeader ) + sizeof( QueueZoneBegin16 ),
     sizeof( QueueHeader ) + sizeof( QueueZoneBegin ),       // callstack
+    sizeof( QueueHeader ) + sizeof( QueueZoneBegin32 ),     // callstack
+    sizeof( QueueHeader ) + sizeof( QueueZoneBegin16 ),     // callstack
     sizeof( QueueHeader ) + sizeof( QueueZoneEnd ),
+    sizeof( QueueHeader ) + sizeof( QueueZoneEnd32 ),
+    sizeof( QueueHeader ) + sizeof( QueueZoneEnd16 ),
     sizeof( QueueHeader ) + sizeof( QueueLockWait ),
     sizeof( QueueHeader ) + sizeof( QueueLockObtain ),
     sizeof( QueueHeader ) + sizeof( QueueLockRelease ),
@@ -884,6 +1041,9 @@ static constexpr size_t QueueDataSize[] = {
     sizeof( QueueHeader ),                                  // SourceCodeMetadata - not for wire transfer
     sizeof( QueueHeader ) + sizeof( QueueFiberEnter ),
     sizeof( QueueHeader ) + sizeof( QueueFiberLeave ),
+    sizeof( QueueHeader ) + sizeof( QueueSectionEnter ),
+    sizeof( QueueHeader ) + sizeof( QueueSectionLeave ),
+    sizeof( QueueHeader ) + sizeof( QueueSectionSetup ),
     // above items must be first
     sizeof( QueueHeader ),                                  // terminate
     sizeof( QueueHeader ),                                  // keep alive
@@ -926,6 +1086,8 @@ static constexpr size_t QueueDataSize[] = {
     sizeof( QueueHeader ) + sizeof( QueueCpuTopology ),
     sizeof( QueueHeader ),                                  // single string data
     sizeof( QueueHeader ),                                  // second string data
+    sizeof( QueueHeader ),                                  // single string data, 8 bit length
+    sizeof( QueueHeader ),                                  // second string data, 8 bit length
     sizeof( QueueHeader ) + sizeof( QueueMemNamePayload ),
     sizeof( QueueHeader ) + sizeof( QueueThreadGroupHint ),
     sizeof( QueueHeader ) + sizeof( QueueGpuZoneAnnotation ), // GPU zone annotation

--- a/D3D11Engine/include/tracy/public/common/TracySocket.cpp
+++ b/D3D11Engine/include/tracy/public/common/TracySocket.cpp
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include <inttypes.h>
 #include <new>
 #include <stdio.h>
@@ -7,6 +6,7 @@
 #include <sys/types.h>
 
 #include "TracyAlloc.hpp"
+#include "TracyAssert.hpp"
 #include "TracySocket.hpp"
 #include "TracySystem.hpp"
 
@@ -27,10 +27,10 @@
 #else
 #  include <arpa/inet.h>
 #  include <sys/socket.h>
-#  include <sys/param.h>
 #  include <errno.h>
 #  include <fcntl.h>
 #  include <netinet/in.h>
+#  include <netinet/tcp.h>
 #  include <netdb.h>
 #  include <unistd.h>
 #  include <poll.h>
@@ -70,7 +70,19 @@ void InitWinSock()
 #endif
 
 
-enum { BufSize = 128 * 1024 };
+static void SetNoDelay( int sock )
+{
+#ifdef _WIN32
+    unsigned long val = 1;
+    setsockopt( sock, IPPROTO_TCP, TCP_NODELAY, (const char*)&val, sizeof( val ) );
+#else
+    int val = 1;
+    setsockopt( sock, IPPROTO_TCP, TCP_NODELAY, &val, sizeof( val ) );
+#endif
+}
+
+
+constexpr size_t BufSize = 128 * 1024;
 
 Socket::Socket()
     : m_buf( (char*)tracy_malloc( BufSize ) )
@@ -113,7 +125,7 @@ Socket::~Socket()
 
 bool Socket::Connect( const char* addr, uint16_t port )
 {
-    assert( !IsValid() );
+    TRACY_ASSERT( !IsValid() );
 
     if( m_ptr )
     {
@@ -150,6 +162,7 @@ bool Socket::Connect( const char* addr, uint16_t port )
         int flags = fcntl( m_connSock, F_GETFL, 0 );
         fcntl( m_connSock, F_SETFL, flags & ~O_NONBLOCK );
 #endif
+        SetNoDelay( m_connSock );
         m_sock.store( m_connSock, std::memory_order_relaxed );
         freeaddrinfo( m_res );
         m_ptr = nullptr;
@@ -218,15 +231,15 @@ bool Socket::Connect( const char* addr, uint16_t port )
     int flags = fcntl( sock, F_GETFL, 0 );
     fcntl( sock, F_SETFL, flags & ~O_NONBLOCK );
 #endif
-
+    SetNoDelay( sock );
     m_sock.store( sock, std::memory_order_relaxed );
     return true;
 }
 
 bool Socket::ConnectBlocking( const char* addr, uint16_t port )
 {
-    assert( !IsValid() );
-    assert( !m_ptr );
+    TRACY_ASSERT( !IsValid() );
+    TRACY_ASSERT( !m_ptr );
 
     struct addrinfo hints;
     struct addrinfo *res, *ptr;
@@ -268,7 +281,7 @@ bool Socket::ConnectBlocking( const char* addr, uint16_t port )
 void Socket::Close()
 {
     const auto sock = m_sock.load( std::memory_order_relaxed );
-    assert( sock != -1 );
+    TRACY_ASSERT( sock != -1 );
 #ifdef _WIN32
     closesocket( sock );
 #else
@@ -281,7 +294,7 @@ int Socket::Send( const void* _buf, int len )
 {
     const auto sock = m_sock.load( std::memory_order_relaxed );
     auto buf = (const char*)_buf;
-    assert( sock != -1 );
+    TRACY_ASSERT( sock != -1 );
     auto start = buf;
     while( len > 0 )
     {
@@ -474,7 +487,7 @@ static int addrinfo_and_socket_for_family( uint16_t port, int ai_family, struct 
 
 bool ListenSocket::Listen( uint16_t port, int backlog )
 {
-    assert( m_sock == -1 );
+    TRACY_ASSERT( m_sock == -1 );
 
     struct addrinfo* res = nullptr;
 
@@ -495,7 +508,7 @@ bool ListenSocket::Listen( uint16_t port, int backlog )
 #if defined _WIN32
     unsigned long val = 0;
     setsockopt( m_sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&val, sizeof( val ) );
-#elif defined BSD
+#elif defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
     int val = 0;
     setsockopt( m_sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&val, sizeof( val ) );
     val = 1;
@@ -529,6 +542,8 @@ Socket* ListenSocket::Accept()
         setsockopt( sock, SOL_SOCKET, SO_NOSIGPIPE, &val, sizeof( val ) );
 #endif
 
+        SetNoDelay( sock );
+
         auto ptr = (Socket*)tracy_malloc( sizeof( Socket ) );
         new(ptr) Socket( sock );
         return ptr;
@@ -541,7 +556,7 @@ Socket* ListenSocket::Accept()
 
 void ListenSocket::Close()
 {
-    assert( m_sock != -1 );
+    TRACY_ASSERT( m_sock != -1 );
 #ifdef _WIN32
     closesocket( m_sock );
 #else
@@ -565,7 +580,7 @@ UdpBroadcast::~UdpBroadcast()
 
 bool UdpBroadcast::Open( const char* addr, uint16_t port )
 {
-    assert( m_sock == -1 );
+    TRACY_ASSERT( m_sock == -1 );
 
     struct addrinfo hints;
     struct addrinfo *res, *ptr;
@@ -613,7 +628,7 @@ bool UdpBroadcast::Open( const char* addr, uint16_t port )
 
 void UdpBroadcast::Close()
 {
-    assert( m_sock != -1 );
+    TRACY_ASSERT( m_sock != -1 );
 #ifdef _WIN32
     closesocket( m_sock );
 #else
@@ -624,7 +639,7 @@ void UdpBroadcast::Close()
 
 int UdpBroadcast::Send( uint16_t port, const void* data, int len )
 {
-    assert( m_sock != -1 );
+    TRACY_ASSERT( m_sock != -1 );
     struct sockaddr_in addr;
     addr.sin_family = AF_INET;
     addr.sin_port = htons( port );
@@ -670,7 +685,7 @@ UdpListen::~UdpListen()
 
 bool UdpListen::Listen( uint16_t port )
 {
-    assert( m_sock == -1 );
+    TRACY_ASSERT( m_sock == -1 );
 
     int sock;
     if( ( sock = socket( AF_INET, SOCK_DGRAM, 0 ) ) == -1 ) return false;
@@ -723,7 +738,7 @@ bool UdpListen::Listen( uint16_t port )
 
 void UdpListen::Close()
 {
-    assert( m_sock != -1 );
+    TRACY_ASSERT( m_sock != -1 );
 #ifdef _WIN32
     closesocket( m_sock );
 #else

--- a/D3D11Engine/include/tracy/public/common/TracyStackFrames.cpp
+++ b/D3D11Engine/include/tracy/public/common/TracyStackFrames.cpp
@@ -16,6 +16,7 @@ const char* s_tracyStackFrames_[] = {
     "tracy::Profiler::MemFreeCallstack(void const*, int)",
     "tracy::ScopedZone::{ctor}",
     "tracy::ScopedZone::ScopedZone(tracy::SourceLocationData const*, int, bool)",
+    "tracy::Profiler::LogString",
     "tracy::Profiler::Message",
     nullptr
 };

--- a/D3D11Engine/include/tracy/public/common/TracyString.hpp
+++ b/D3D11Engine/include/tracy/public/common/TracyString.hpp
@@ -1,0 +1,33 @@
+#ifndef __TRACYSTRING_HPP__
+#define __TRACYSTRING_HPP__
+
+#include <stddef.h>
+#include <string.h>
+
+#include "TracyAssert.hpp"
+
+namespace tracy
+{
+
+static inline size_t strzcpy( char* __restrict dst, const char* __restrict src, size_t dstSize )
+{
+    TRACY_ASSERT( dstSize > 0 );
+
+    const auto end = (const char*)memchr( src, '\0', dstSize );
+    if( end != nullptr )
+    {
+        const auto srcSz = end - src;
+        memcpy( dst, src, srcSz + 1 );
+        return srcSz;
+    }
+    else
+    {
+        memcpy( dst, src, dstSize - 1 );
+        dst[dstSize - 1] = '\0';
+        return dstSize - 1;
+    }
+}
+
+}
+
+#endif

--- a/D3D11Engine/include/tracy/public/common/TracySystem.cpp
+++ b/D3D11Engine/include/tracy/public/common/TracySystem.cpp
@@ -8,11 +8,18 @@
 #  ifndef NOMINMAX
 #    define NOMINMAX
 #  endif
+#  define SECURITY_WIN32
 #  include <windows.h>
 #  include <malloc.h>
+#  include <lmcons.h>
+#  include <security.h>
 #  include "TracyWinFamily.hpp"
+#  ifdef _MSC_VER
+#    pragma comment(lib, "secur32.lib")
+#  endif
 #else
 #  include <pthread.h>
+#  include <pwd.h>
 #  include <string.h>
 #  include <unistd.h>
 #endif
@@ -44,6 +51,10 @@
 
 #include "TracySystem.hpp"
 
+#ifdef TRACY_PLATFORM_HEADER
+#  include TRACY_PLATFORM_HEADER
+#endif
+
 #if defined _WIN32
 extern "C" typedef HRESULT (WINAPI *t_SetThreadDescription)( HANDLE, PCWSTR );
 extern "C" typedef HRESULT (WINAPI *t_GetThreadDescription)( HANDLE, PWSTR* );
@@ -62,7 +73,9 @@ namespace detail
 
 TRACY_API uint32_t GetThreadHandleImpl()
 {
-#if defined _WIN32
+#if defined TRACY_HAS_CUSTOM_THREAD_ID
+    return PlatformGetThreadId();
+#elif defined _WIN32
     static_assert( sizeof( decltype( GetCurrentThreadId() ) ) <= sizeof( uint32_t ), "Thread handle too big to fit in protocol" );
     return uint32_t( GetCurrentThreadId() );
 #elif defined __APPLE__
@@ -161,26 +174,22 @@ TRACY_API void SetThreadNameWithHint( const char* name, int32_t groupHint )
     }
 #elif defined _GNU_SOURCE && !defined __EMSCRIPTEN__
     {
+#if defined __APPLE__
+        pthread_setname_np( name );
+#else
         const auto sz = strlen( name );
         if( sz <= 15 )
         {
-#if defined __APPLE__
-            pthread_setname_np( name );
-#else
             pthread_setname_np( pthread_self(), name );
-#endif
         }
         else
         {
             char buf[16];
             memcpy( buf, name, 15 );
             buf[15] = '\0';
-#if defined __APPLE__
-            pthread_setname_np( buf );
-#else
             pthread_setname_np( pthread_self(), buf );
-#endif
         }
+#endif
     }
 #elif defined __QNX__
     {
@@ -333,6 +342,57 @@ TRACY_API const char* GetEnvVar( const char* name )
     return buffer;
 #else
     return getenv(name);
+#endif
+}
+
+TRACY_API const char* GetUserLogin()
+{
+#if defined TRACY_HAS_CUSTOM_USER_INFO
+    return PlatformGetUserLogin();
+#elif defined _WIN32
+#  if defined TRACY_WIN32_NO_DESKTOP
+    return "(?)";
+#  else
+    DWORD userSz = UNLEN+1;
+    static char user[UNLEN+1];
+    GetUserNameA( user, &userSz );
+    return user;
+#  endif
+#elif defined __ANDROID__
+    const auto user = getlogin();
+    if( user ) return user;
+    return "(?)";
+#else
+    static char user[1024] = {};
+    getlogin_r( user, sizeof( user ) );
+    return user;
+#endif
+}
+
+TRACY_API const char* GetUserFullName()
+{
+#if defined TRACY_HAS_CUSTOM_USER_INFO
+    return PlatformGetUserFullName();
+#elif defined _WIN32
+#  if !defined TRACY_WIN32_NO_DESKTOP
+    static char buf[1024];
+    ULONG size = sizeof( buf );
+    if( GetUserNameExA( NameDisplay, buf, &size ) ) return buf;
+#  endif
+    return nullptr;
+#elif defined __ANDROID__
+    const auto passwd = getpwuid( getuid() );
+    if( passwd && passwd->pw_gecos && *passwd->pw_gecos ) return passwd->pw_gecos;
+    return nullptr;
+#else
+    static char buf[4*1024];
+    struct passwd pwd;
+    struct passwd* ptr;
+    if( getpwuid_r( getuid(), &pwd, buf, sizeof( buf ), &ptr ) == 0 && ptr == &pwd && *pwd.pw_gecos )
+    {
+        return pwd.pw_gecos;
+    }
+    return nullptr;
 #endif
 }
 

--- a/D3D11Engine/include/tracy/public/common/TracySystem.hpp
+++ b/D3D11Engine/include/tracy/public/common/TracySystem.hpp
@@ -37,6 +37,8 @@ TRACY_API void SetThreadNameWithHint( const char* name, int32_t groupHint );
 TRACY_API const char* GetThreadName( uint32_t id );
 
 TRACY_API const char* GetEnvVar( const char* name );
+TRACY_API const char* GetUserLogin();
+TRACY_API const char* GetUserFullName();
 
 }
 

--- a/D3D11Engine/include/tracy/public/common/TracyTaggedUserlandAddress.hpp
+++ b/D3D11Engine/include/tracy/public/common/TracyTaggedUserlandAddress.hpp
@@ -1,0 +1,34 @@
+#ifndef __TRACYTAGGEDPTR_HPP__
+#define __TRACYTAGGEDPTR_HPP__
+
+#include <stdint.h>
+
+#include "TracyAssert.hpp"
+#include "TracyForceInline.hpp"
+
+namespace tracy
+{
+
+class TaggedUserlandAddress
+{
+    static constexpr uint64_t ptrShift = 8;
+    static constexpr uint64_t highBits = 0xFF00000000000000;
+
+public:
+    TaggedUserlandAddress() = default;
+    tracy_force_inline explicit TaggedUserlandAddress( uint64_t address, uint8_t tag = 0 )
+    {
+        TRACY_ASSERT( ( address & highBits ) == 0 );
+        m_storage = ( address << ptrShift ) | tag;
+    }
+
+    tracy_force_inline uint64_t GetAddress() const { return m_storage >> ptrShift; }
+    tracy_force_inline uint8_t GetTag() const { return uint8_t( m_storage & 0xFF ); }
+
+private:
+    uint64_t m_storage;
+};
+
+}
+
+#endif

--- a/D3D11Engine/include/tracy/public/common/TracyVersion.hpp
+++ b/D3D11Engine/include/tracy/public/common/TracyVersion.hpp
@@ -1,14 +1,11 @@
 #ifndef __TRACYVERSION_HPP__
 #define __TRACYVERSION_HPP__
 
-namespace tracy
+namespace tracy::Version
 {
-namespace Version
-{
-enum { Major = 0 };
-enum { Minor = 13 };
-enum { Patch = 1 };
-}
+constexpr int Major = 0;
+constexpr int Minor = 14;
+constexpr int Patch = 0;
 }
 
 #endif

--- a/D3D11Engine/include/tracy/public/libbacktrace/backtrace.hpp
+++ b/D3D11Engine/include/tracy/public/libbacktrace/backtrace.hpp
@@ -87,6 +87,19 @@ extern struct backtrace_state *backtrace_create_state (
     const char *filename, int threaded,
     backtrace_error_callback error_callback, void *data);
 
+/* Like backtrace_create_state, but marks the state as being for an
+   external file that is not loaded in the current process.  This
+   bypasses the ET_DYN deferral to dl_iterate_phdr that normally
+   happens for PIE executables and shared libraries, allowing DWARF
+   data to be loaded directly from the file with base_address=0.
+   The caller is responsible for converting runtime virtual addresses
+   to ELF virtual addresses before passing them to backtrace_pcinfo
+   or backtrace_syminfo.  */
+
+extern struct backtrace_state *backtrace_create_state_for_file (
+    const char *filename, int threaded,
+    backtrace_error_callback error_callback, void *data);
+
 /* The type of the callback argument to the backtrace_full function.
    DATA is the argument passed to backtrace_full.  PC is the program
    counter.  FILENAME is the name of the file containing PC, or NULL

--- a/D3D11Engine/include/tracy/public/libbacktrace/config.h
+++ b/D3D11Engine/include/tracy/public/libbacktrace/config.h
@@ -1,9 +1,4 @@
-#include <limits.h>
-#if defined(__linux__) && !defined(__GLIBC__) && !defined(__WORDSIZE)
-// include __WORDSIZE headers for musl
-#  include <bits/reg.h>
-#endif
-#if __WORDSIZE == 64
+#if __SIZEOF_POINTER__ == 8
 #  define BACKTRACE_ELF_SIZE 64
 #else
 #  define BACKTRACE_ELF_SIZE 32

--- a/D3D11Engine/include/tracy/public/libbacktrace/dwarf.cpp
+++ b/D3D11Engine/include/tracy/public/libbacktrace/dwarf.cpp
@@ -1613,6 +1613,194 @@ unit_addrs_search (const void *vkey, const void *ventry)
     return 0;
 }
 
+/* Fill in overlapping ranges as needed.  This is a subroutine of
+   resolve_unit_addrs_overlap.  */
+
+static int
+resolve_unit_addrs_overlap_walk (struct backtrace_state *state,
+				 size_t *pfrom, size_t *pto,
+				 struct unit_addrs *enclosing,
+				 struct unit_addrs_vector *old_vec,
+				 backtrace_error_callback error_callback,
+				 void *data,
+				 struct unit_addrs_vector *new_vec)
+{
+  struct unit_addrs *old_addrs;
+  size_t old_count;
+  struct unit_addrs *new_addrs;
+  size_t from;
+  size_t to;
+
+  old_addrs = (struct unit_addrs *) old_vec->vec.base;
+  old_count = old_vec->count;
+  new_addrs = (struct unit_addrs *) new_vec->vec.base;
+
+  for (from = *pfrom, to = *pto; from < old_count; from++, to++)
+    {
+      /* If we are in the scope of a larger range that can no longer
+	 cover any further ranges, return back to the caller.  */
+
+      if (enclosing != NULL
+	  && enclosing->high <= old_addrs[from].low)
+	{
+	  *pfrom = from;
+	  *pto = to;
+	  return 1;
+	}
+
+      new_addrs[to] = old_addrs[from];
+
+      /* If we are in scope of a larger range, fill in any gaps
+	 between this entry and the next one.
+
+	 There is an extra entry at the end of the vector, so it's
+	 always OK to refer to from + 1.  */
+
+      if (enclosing != NULL
+	  && enclosing->high > old_addrs[from].high
+	  && old_addrs[from].high < old_addrs[from + 1].low)
+	{
+	  void *grew;
+	  size_t new_high;
+
+	  grew = backtrace_vector_grow (state, sizeof (struct unit_addrs),
+					error_callback, data, &new_vec->vec);
+	  if (grew == NULL)
+	    return 0;
+	  new_addrs = (struct unit_addrs *) new_vec->vec.base;
+	  to++;
+	  new_addrs[to].low = old_addrs[from].high;
+	  new_high = old_addrs[from + 1].low;
+	  if (enclosing->high < new_high)
+	    new_high = enclosing->high;
+	  new_addrs[to].high = new_high;
+	  new_addrs[to].u = enclosing->u;
+	}
+
+      /* If this range has a larger scope than the next one, use it to
+	 fill in any gaps.  */
+
+      if (old_addrs[from].high > old_addrs[from + 1].high)
+	{
+	  *pfrom = from + 1;
+	  *pto = to + 1;
+	  if (!resolve_unit_addrs_overlap_walk (state, pfrom, pto,
+						&old_addrs[from], old_vec,
+						error_callback, data, new_vec))
+	    return 0;
+	  from = *pfrom;
+	  to = *pto;
+
+	  /* Undo the increment the loop is about to do.  */
+	  from--;
+	  to--;
+	}
+    }
+
+  if (enclosing == NULL)
+    {
+      struct unit_addrs *pa;
+
+      /* Add trailing entry.  */
+
+      pa = ((struct unit_addrs *)
+	    backtrace_vector_grow (state, sizeof (struct unit_addrs),
+				   error_callback, data, &new_vec->vec));
+      if (pa == NULL)
+	return 0;
+      pa->low = 0;
+      --pa->low;
+      pa->high = pa->low;
+      pa->u = NULL;
+
+      new_vec->count = to;
+    }
+
+  return 1;
+}
+
+/* It is possible for the unit_addrs list to contain overlaps, as in
+
+       10: low == 10, high == 20, unit 1
+       11: low == 12, high == 15, unit 2
+       12: low == 20, high == 30, unit 1
+
+   In such a case, for pc == 17, a search using units_addr_search will
+   return entry 11.  However, pc == 17 doesn't fit in that range.  We
+   actually want range 10.
+
+   It seems that in general we might have an arbitrary number of
+   ranges in between 10 and 12.
+
+   To handle this we look for cases where range R1 is followed by
+   range R2 such that R2 is a strict subset of R1.  In such cases we
+   insert a new range R3 following R2 that fills in the remainder of
+   the address space covered by R1.  That lets a relatively simple
+   search find the correct range.
+
+   These overlaps can occur because of the range merging we do in
+   add_unit_addr.  When the linker de-duplicates functions, it can
+   leave behind an address range that refers to the address range of
+   the retained duplicate.  If the retained duplicate address range is
+   merged with others, then after sorting we can see overlapping
+   address ranges.
+
+   See https://github.com/ianlancetaylor/libbacktrace/issues/137.  */
+
+static int
+resolve_unit_addrs_overlap (struct backtrace_state *state,
+			    backtrace_error_callback error_callback,
+			    void *data, struct unit_addrs_vector *addrs_vec)
+{
+  struct unit_addrs *addrs;
+  size_t count;
+  int found;
+  struct unit_addrs *entry;
+  size_t i;
+  struct unit_addrs_vector new_vec;
+  void *grew;
+  size_t from;
+  size_t to;
+
+  addrs = (struct unit_addrs *) addrs_vec->vec.base;
+  count = addrs_vec->count;
+
+  if (count == 0)
+    return 1;
+
+  /* Optimistically assume that overlaps are rare.  */
+  found = 0;
+  entry = addrs;
+  for (i = 0; i < count - 1; i++)
+    {
+      if (entry->low < (entry + 1)->low
+	  && entry->high > (entry + 1)->high)
+	{
+	  found = 1;
+	  break;
+	}
+      entry++;
+    }
+  if (!found)
+    return 1;
+
+  memset (&new_vec, 0, sizeof new_vec);
+  grew = backtrace_vector_grow (state,
+				count * sizeof (struct unit_addrs),
+				error_callback, data, &new_vec.vec);
+  if (grew == NULL)
+    return 0;
+
+  from = 0;
+  to = 0;
+  resolve_unit_addrs_overlap_walk (state, &from, &to, NULL, addrs_vec,
+				   error_callback, data, &new_vec);
+  backtrace_vector_free (state, &addrs_vec->vec, error_callback, data);
+  *addrs_vec = new_vec;
+
+  return 1;
+}
+
 /* Sort the line vector by PC.  We want a stable sort here to maintain
    the order of lines for the same PC values.  Since the sequence is
    being sorted in place, their addresses cannot be relied on to
@@ -3317,7 +3505,7 @@ read_line_info (struct backtrace_state *state, struct dwarf_data *ddata,
 
   if (vec.count == 0)
     {
-      /* This is not a failure in the sense of a generating an error,
+      /* This is not a failure in the sense of generating an error,
 	 but it is a failure in that sense that we have no useful
 	 information.  */
       goto fail;
@@ -3965,7 +4153,7 @@ report_inlined_functions (uintptr_t pc, struct function *function, const char* c
     return ret;
 
   /* Report this inlined call.  */
-  if (*filename[0] != '/' && comp_dir)
+  if (*filename && *filename[0] != '/' && comp_dir)
   {
     char buf[1024];
     snprintf (buf, 1024, "%s/%s", comp_dir, *filename);
@@ -4246,7 +4434,7 @@ dwarf_lookup_pc (struct backtrace_state *state, struct dwarf_data *ddata,
   if (ret != 0)
     return ret;
 
-  if (filename[0] != '/' && entry->u->comp_dir)
+  if (filename && filename[0] != '/' && entry->u->comp_dir)
   {
     char buf[1024];
     snprintf (buf, 1024, "%s/%s", entry->u->comp_dir, filename);
@@ -4344,11 +4532,7 @@ build_dwarf_data (struct backtrace_state *state,
 		  void *data)
 {
   struct unit_addrs_vector addrs_vec;
-  struct unit_addrs *addrs;
-  size_t addrs_count;
   struct unit_vector units_vec;
-  struct unit **units;
-  size_t units_count;
   struct dwarf_data *fdata;
 
   if (!build_address_map (state, base_address, dwarf_sections, is_bigendian,
@@ -4360,12 +4544,12 @@ build_dwarf_data (struct backtrace_state *state,
     return NULL;
   if (!backtrace_vector_release (state, &units_vec.vec, error_callback, data))
     return NULL;
-  addrs = (struct unit_addrs *) addrs_vec.vec.base;
-  units = (struct unit **) units_vec.vec.base;
-  addrs_count = addrs_vec.count;
-  units_count = units_vec.count;
-  backtrace_qsort (addrs, addrs_count, sizeof (struct unit_addrs),
-		   unit_addrs_compare);
+
+  backtrace_qsort ((struct unit_addrs *) addrs_vec.vec.base, addrs_vec.count,
+		   sizeof (struct unit_addrs), unit_addrs_compare);
+  if (!resolve_unit_addrs_overlap (state, error_callback, data, &addrs_vec))
+    return NULL;
+
   /* No qsort for units required, already sorted.  */
 
   fdata = ((struct dwarf_data *)
@@ -4377,10 +4561,10 @@ build_dwarf_data (struct backtrace_state *state,
   fdata->next = NULL;
   fdata->altlink = altlink;
   fdata->base_address = base_address;
-  fdata->addrs = addrs;
-  fdata->addrs_count = addrs_count;
-  fdata->units = units;
-  fdata->units_count = units_count;
+  fdata->addrs = (struct unit_addrs *) addrs_vec.vec.base;
+  fdata->addrs_count = addrs_vec.count;
+  fdata->units = (struct unit **) units_vec.vec.base;
+  fdata->units_count = units_vec.count;
   fdata->dwarf_sections = *dwarf_sections;
   fdata->is_bigendian = is_bigendian;
   memset (&fdata->fvec, 0, sizeof fdata->fvec);

--- a/D3D11Engine/include/tracy/public/libbacktrace/elf.cpp
+++ b/D3D11Engine/include/tracy/public/libbacktrace/elf.cpp
@@ -170,10 +170,10 @@ dl_iterate_phdr (int (*callback) (struct dl_phdr_info *,
 #undef EI_CLASS
 #undef EI_DATA
 #undef EI_VERSION
-#undef ELF_MAG0
-#undef ELF_MAG1
-#undef ELF_MAG2
-#undef ELF_MAG3
+#undef ELFMAG0
+#undef ELFMAG1
+#undef ELFMAG2
+#undef ELFMAG3
 #undef ELFCLASS32
 #undef ELFCLASS64
 #undef ELFDATA2LSB
@@ -1165,7 +1165,10 @@ elf_fetch_bits (const unsigned char **ppin, const unsigned char *pinend,
   next = __builtin_bswap32 (next);
 #endif
 #else
-  next = pin[0] | (pin[1] << 8) | (pin[2] << 16) | (pin[3] << 24);
+  next = ((uint32_t)pin[0]
+	  | ((uint32_t)pin[1] << 8)
+	  | ((uint32_t)pin[2] << 16)
+	  | ((uint32_t)pin[3] << 24));
 #endif
 
   val |= (uint64_t)next << bits;
@@ -1216,7 +1219,10 @@ elf_fetch_bits_backward (const unsigned char **ppin,
   next = __builtin_bswap32 (next);
 #endif
 #else
-  next = pin[0] | (pin[1] << 8) | (pin[2] << 16) | (pin[3] << 24);
+  next = ((uint32_t)pin[0]
+	  | ((uint32_t)pin[1] << 8)
+	  | ((uint32_t)pin[2] << 16)
+	  | ((uint32_t)pin[3] << 24));
 #endif
 
   val <<= 32;
@@ -4314,6 +4320,7 @@ elf_zstd_unpack_seq_decode (int mode,
 	decode->table_bits = 0;
 	if (!conv (&entry, 0, table))
 	  return 0;
+	decode->table = table;
       }
       break;
 
@@ -4350,15 +4357,17 @@ elf_zstd_unpack_seq_decode (int mode,
   return 1;
 }
 
-/* Decompress a zstd stream from PIN/SIN to POUT/SOUT.  Code based on RFC 8878.
+/* Decompress a single zstd frame from *PPIN, ending at PINEND, to *PPOUT/SOUT.
    Return 1 on success, 0 on error.  */
 
 static int
-elf_zstd_decompress (const unsigned char *pin, size_t sin,
-		     unsigned char *zdebug_table, unsigned char *pout,
-		     size_t sout)
+elf_zstd_decompress_frame (const unsigned char **ppin,
+			   const unsigned char *pinend,
+			   unsigned char *zdebug_table, unsigned char **ppout,
+			   size_t sout)
 {
-  const unsigned char *pinend;
+  const unsigned char *pin;
+  unsigned char *pout;
   unsigned char *poutstart;
   unsigned char *poutend;
   struct elf_zstd_seq_decode literal_decode;
@@ -4374,13 +4383,14 @@ elf_zstd_decompress (const unsigned char *pin, size_t sin,
   uint32_t repeated_offset3;
   uint16_t *scratch;
   unsigned char hdr;
+  int single_segment;
   int has_checksum;
   uint64_t content_size;
   int last_block;
 
-  pinend = pin + sin;
+  pin = *ppin;
+  pout = *ppout;
   poutstart = pout;
-  poutend = pout + sout;
 
   literal_decode.table = NULL;
   literal_decode.table_bits = -1;
@@ -4406,7 +4416,7 @@ elf_zstd_decompress (const unsigned char *pin, size_t sin,
   repeated_offset2 = 4;
   repeated_offset3 = 8;
 
-  if (unlikely (sin < 4))
+  if (unlikely (pinend - pin < 4))
     {
       elf_uncompress_failed ();
       return 0;
@@ -4432,12 +4442,18 @@ elf_zstd_decompress (const unsigned char *pin, size_t sin,
 
   hdr = *pin++;
 
-  /* We expect a single frame.  */
-  if (unlikely ((hdr & (1 << 5)) == 0))
+  single_segment = (hdr & (1 << 5)) != 0;
+  if (!single_segment)
     {
-      elf_uncompress_failed ();
-      return 0;
+      if (unlikely (pin >= pinend))
+        {
+          elf_uncompress_failed ();
+          return 0;
+        }
+      /* skip Window_Descriptor */
+      pin++;
     }
+
   /* Reserved bit must be zero.  */
   if (unlikely ((hdr & (1 << 3)) != 0))
     {
@@ -4454,13 +4470,22 @@ elf_zstd_decompress (const unsigned char *pin, size_t sin,
   switch (hdr >> 6)
     {
     case 0:
-      if (unlikely (pin >= pinend))
-	{
-	  elf_uncompress_failed ();
-	  return 0;
-	}
-      content_size = (uint64_t) *pin++;
-      break;
+      if (single_segment)
+        {
+          if (unlikely (pin >= pinend))
+	    {
+	      elf_uncompress_failed ();
+	      return 0;
+	    }
+          content_size = (uint64_t) *pin++;
+          break;
+        }
+      else
+        {
+          /* no Frame_Content_Size; use the remaining size as the upper bound */
+          content_size = (uint64_t) sout;
+          break;
+        }
     case 1:
       if (unlikely (pin + 1 >= pinend))
 	{
@@ -4504,11 +4529,13 @@ elf_zstd_decompress (const unsigned char *pin, size_t sin,
     }
 
   if (unlikely (content_size != (size_t) content_size
-		|| (size_t) content_size != sout))
+		|| (size_t) content_size > sout))
     {
       elf_uncompress_failed ();
       return 0;
     }
+
+  poutend = pout + content_size;
 
   last_block = 0;
   while (!last_block)
@@ -4628,6 +4655,11 @@ elf_zstd_decompress (const unsigned char *pin, size_t sin,
 		pin += 2;
 	      }
 
+	    pback = NULL;
+	    bits = 0;
+	    literal_state = 0;
+	    offset_state = 0;
+	    match_state = 0;
 	    if (seq_count > 0)
 	      {
 		int (*pfn)(const struct elf_zstd_fse_entry *,
@@ -4667,27 +4699,27 @@ elf_zstd_decompress (const unsigned char *pin, size_t sin,
 						 match_fse_table, 9, pfn,
 						 &match_decode))
 		  return 0;
+
+		pback = pblockend - 1;
+		if (!elf_fetch_backward_init (&pback, pin, &val, &bits))
+		  return 0;
+
+		bits -= literal_decode.table_bits;
+		literal_state = ((val >> bits)
+				 & ((1U << literal_decode.table_bits) - 1));
+
+		if (!elf_fetch_bits_backward (&pback, pin, &val, &bits))
+		  return 0;
+		bits -= offset_decode.table_bits;
+		offset_state = ((val >> bits)
+				& ((1U << offset_decode.table_bits) - 1));
+
+		if (!elf_fetch_bits_backward (&pback, pin, &val, &bits))
+		  return 0;
+		bits -= match_decode.table_bits;
+		match_state = ((val >> bits)
+			       & ((1U << match_decode.table_bits) - 1));
 	      }
-
-	    pback = pblockend - 1;
-	    if (!elf_fetch_backward_init (&pback, pin, &val, &bits))
-	      return 0;
-
-	    bits -= literal_decode.table_bits;
-	    literal_state = ((val >> bits)
-			     & ((1U << literal_decode.table_bits) - 1));
-
-	    if (!elf_fetch_bits_backward (&pback, pin, &val, &bits))
-	      return 0;
-	    bits -= offset_decode.table_bits;
-	    offset_state = ((val >> bits)
-			    & ((1U << offset_decode.table_bits) - 1));
-
-	    if (!elf_fetch_bits_backward (&pback, pin, &val, &bits))
-	      return 0;
-	    bits -= match_decode.table_bits;
-	    match_state = ((val >> bits)
-			   & ((1U << match_decode.table_bits) - 1));
 
 	    seq = 0;
 	    while (1)
@@ -4708,6 +4740,40 @@ elf_zstd_decompress (const unsigned char *pin, size_t sin,
 		uint32_t literal;
 		uint32_t need;
 		uint32_t add;
+
+		if (unlikely (seq >= seq_count))
+		  {
+		    /* Copy remaining literals.  */
+		    if (literal_count > 0 && plit != pout)
+		      {
+			if (unlikely ((size_t)(poutend - pout)
+				      < literal_count))
+			  {
+			    elf_uncompress_failed ();
+			    return 0;
+			  }
+
+			if ((size_t)(plit - pout) < literal_count)
+			  {
+			    uint32_t move;
+
+			    move = plit - pout;
+			    while (literal_count > move)
+			      {
+				memcpy (pout, plit, move);
+				pout += move;
+				plit += move;
+				literal_count -= move;
+			      }
+			  }
+
+			memcpy (pout, plit, literal_count);
+		      }
+
+		    pout += literal_count;
+
+		    break;
+		  }
 
 		pt = &offset_decode.table[offset_state];
 		offset_basebits = pt->basebits;
@@ -4946,40 +5012,6 @@ elf_zstd_decompress (const unsigned char *pin, size_t sin,
 			  }
 		      }
 		  }
-
-		if (unlikely (seq >= seq_count))
-		  {
-		    /* Copy remaining literals.  */
-		    if (literal_count > 0 && plit != pout)
-		      {
-			if (unlikely ((size_t)(poutend - pout)
-				      < literal_count))
-			  {
-			    elf_uncompress_failed ();
-			    return 0;
-			  }
-
-			if ((size_t)(plit - pout) < literal_count)
-			  {
-			    uint32_t move;
-
-			    move = plit - pout;
-			    while (literal_count > move)
-			      {
-				memcpy (pout, plit, move);
-				pout += move;
-				plit += move;
-				literal_count -= move;
-			      }
-			  }
-
-			memcpy (pout, plit, literal_count);
-		      }
-
-		    pout += literal_count;
-
-		    break;
-		  }
 	      }
 
 	    pin = pblockend;
@@ -5008,7 +5040,42 @@ elf_zstd_decompress (const unsigned char *pin, size_t sin,
       pin += 4;
     }
 
-  if (pin != pinend)
+  *ppin = pin;
+  *ppout = pout;
+
+  return 1;
+}
+
+/* Decompress a zstd stream from PIN/SIN to POUT/SOUT.  Code based on RFC 8878.
+   Return 1 on success, 0 on error.  */
+
+static int
+elf_zstd_decompress (const unsigned char *pin, size_t sin,
+		     unsigned char *zdebug_table, unsigned char *pout,
+		     size_t sout)
+{
+  const unsigned char *pinend;
+
+  pinend = pin + sin;
+
+  while (sin > 0)
+    {
+      const unsigned char *pin_frame;
+      unsigned char *pout_frame;
+
+      pin_frame = pin;
+      pout_frame = pout;
+      if (!elf_zstd_decompress_frame (&pin_frame, pinend, zdebug_table,
+				      &pout_frame, sout))
+	return 0;
+
+      sin -= pin_frame - pin;
+      pin = pin_frame;
+      sout -= pout_frame - pout;
+      pout = pout_frame;
+    }
+
+  if (sout > 0)
     {
       elf_uncompress_failed ();
       return 0;
@@ -5890,10 +5957,10 @@ elf_uncompress_lzma_block (const unsigned char *compressed,
 	  /* The byte at compressed[off] is ignored for some
 	     reason.  */
 
-	  code = ((compressed[off + 1] << 24)
-		  + (compressed[off + 2] << 16)
-		  + (compressed[off + 3] << 8)
-		  + compressed[off + 4]);
+	  code = (((uint32_t)compressed[off + 1] << 24)
+		  + ((uint32_t)compressed[off + 2] << 16)
+		  + ((uint32_t)compressed[off + 3] << 8)
+		  + (uint32_t)compressed[off + 4]);
 	  off += 5;
 
 	  /* This is the main LZMA decode loop.  */
@@ -6354,10 +6421,10 @@ elf_uncompress_lzma (struct backtrace_state *state,
 
   /* Before that is the size of the index field, which precedes the
      footer.  */
-  index_size = (compressed[offset - 4]
-		| (compressed[offset - 3] << 8)
-		| (compressed[offset - 2] << 16)
-		| (compressed[offset - 1] << 24));
+  index_size = ((size_t)compressed[offset - 4]
+		| ((size_t)compressed[offset - 3] << 8)
+		| ((size_t)compressed[offset - 2] << 16)
+		| ((size_t)compressed[offset - 1] << 24));
   index_size = (index_size + 1) * 4;
   offset -= 4;
 
@@ -7404,9 +7471,17 @@ phdr_callback_mock (struct dl_phdr_info *info, size_t size ATTRIBUTE_UNUSED,
   ptr->dlpi_addr = info->dlpi_addr;
 
   // calculate the end address as well, so we can quickly determine if a PC is within the range of this image
-  ptr->dlpi_end_addr = uintptr_t(info->dlpi_addr) + (info->dlpi_phnum ? uintptr_t(
-                            info->dlpi_phdr[info->dlpi_phnum - 1].p_vaddr + 
-                            info->dlpi_phdr[info->dlpi_phnum - 1].p_memsz) : 0);
+  // headers aren't guaranteed to be in address order; find the max
+  ptr->dlpi_end_addr = ElfW(Addr)(info->dlpi_addr);
+  for (uint32_t i = 0; i < info->dlpi_phnum; i++)
+    {
+      const auto &phdr = info->dlpi_phdr[i];
+      if (phdr.p_type != PT_LOAD)
+        continue;
+
+      const auto phdr_end = ElfW(Addr)(info->dlpi_addr + phdr.p_vaddr + phdr.p_memsz);
+      ptr->dlpi_end_addr = std::max(phdr_end, ptr->dlpi_end_addr);
+    }
 
   return 0;
 }
@@ -7550,23 +7625,38 @@ backtrace_initialize (struct backtrace_state *state, const char *filename,
       struct libbacktrace_base_address zero_base_address;
 
       memset (&zero_base_address, 0, sizeof zero_base_address);
+
+      /* For external files (not loaded in the current process), pass
+	 exe=0 so that elf_add does not bail out for ET_DYN files.
+	 This allows DWARF data and symbol tables to be loaded directly
+	 from PIE executables and shared libraries with base_address=0,
+	 letting the caller convert runtime addresses to ELF virtual
+	 addresses before lookup.  */
+      int exe = state->external_file ? 0 : 1;
+
       ret = elf_add (state, filename, descriptor, NULL, 0, zero_base_address,
 		     NULL, error_callback, data, &elf_fileline_fn, &found_sym,
-		     &found_dwarf, NULL, 1, 0, NULL, 0);
+		     &found_dwarf, NULL, exe, 0, NULL, 0);
       if (!ret)
 	return 0;
     }
 
-  pd.state = state;
-  pd.error_callback = error_callback;
-  pd.data = data;
-  pd.fileline_fn = &elf_fileline_fn;
-  pd.found_sym = &found_sym;
-  pd.found_dwarf = &found_dwarf;
-  pd.exe_filename = filename;
-  pd.exe_descriptor = ret < 0 ? descriptor : -1;
+  /* For external files, skip dl_iterate_phdr -- the file is not loaded
+     in the current process, so enumerating the current process's shared
+     libraries would only add noise.  */
+  if (!state->external_file)
+    {
+      pd.state = state;
+      pd.error_callback = error_callback;
+      pd.data = data;
+      pd.fileline_fn = &elf_fileline_fn;
+      pd.found_sym = &found_sym;
+      pd.found_dwarf = &found_dwarf;
+      pd.exe_filename = filename;
+      pd.exe_descriptor = ret < 0 ? descriptor : -1;
 
-  elf_iterate_phdr_and_add_new_files(&pd);
+      elf_iterate_phdr_and_add_new_files(&pd);
+    }
 
   if (!state->threaded)
     {

--- a/D3D11Engine/include/tracy/public/libbacktrace/internal.hpp
+++ b/D3D11Engine/include/tracy/public/libbacktrace/internal.hpp
@@ -166,6 +166,12 @@ struct backtrace_state
   struct backtrace_freelist_struct *freelist;
   /* Trigger an known address range refresh */
   request_known_address_ranges_refresh request_known_address_ranges_refresh_fn;
+  /* Non-zero if this state is for an external file, not the current
+     process.  When set, backtrace_initialize will not treat the file
+     as the main executable (bypassing the ET_DYN deferral to
+     dl_iterate_phdr) and will not enumerate the current process's
+     shared libraries.  */
+  int external_file;
 };
 
 /* Open a file for reading.  Returns -1 on error.  If DOES_NOT_EXIST

--- a/D3D11Engine/include/tracy/public/libbacktrace/state.cpp
+++ b/D3D11Engine/include/tracy/public/libbacktrace/state.cpp
@@ -73,4 +73,21 @@ backtrace_create_state (const char *filename, int threaded,
   return state;
 }
 
+/* Like backtrace_create_state, but marks the state as being for an
+   external file.  See backtrace.hpp for details.  */
+
+struct backtrace_state *
+backtrace_create_state_for_file (const char *filename, int threaded,
+				 backtrace_error_callback error_callback,
+				 void *data)
+{
+  struct backtrace_state *state;
+
+  state = backtrace_create_state (filename, threaded, error_callback, data);
+  if (state != NULL)
+    state->external_file = 1;
+
+  return state;
+}
+
 }

--- a/D3D11Engine/include/tracy/public/tracy/Tracy.hpp
+++ b/D3D11Engine/include/tracy/public/tracy/Tracy.hpp
@@ -16,6 +16,12 @@
 #  define TracyLine TracyConcat(__LINE__,U) // MSVC Edit and continue __LINE__ is non-constant. See https://developercommunity.visualstudio.com/t/-line-cannot-be-used-as-an-argument-for-constexpr/195665
 #endif
 
+
+#define TracyParamTypeInt       0
+#define TracyParamTypeBool      1
+#define TracyParamTypeTrigger   2
+
+
 #ifndef TRACY_ENABLE
 
 #define TracyNoop
@@ -76,14 +82,9 @@
 #define TracyAlloc(x,y)
 #define TracyFree(x)
 #define TracyMemoryDiscard(x)
-#define TracySecureAlloc(x,y)
-#define TracySecureFree(x)
-#define TracySecureMemoryDiscard(x)
 
 #define TracyAllocN(x,y,z)
 #define TracyFreeN(x,y)
-#define TracySecureAllocN(x,y,z)
-#define TracySecureFreeN(x,y)
 
 #define ZoneNamedS(x,y,z)
 #define ZoneNamedNS(x,y,z,w)
@@ -101,14 +102,9 @@
 #define TracyAllocS(x,y,z)
 #define TracyFreeS(x,y)
 #define TracyMemoryDiscardS(x,y)
-#define TracySecureAllocS(x,y,z)
-#define TracySecureFreeS(x,y)
-#define TracySecureMemoryDiscardS(x,y)
 
 #define TracyAllocNS(x,y,z,w)
 #define TracyFreeNS(x,y,z)
-#define TracySecureAllocNS(x,y,z,w)
-#define TracySecureFreeNS(x,y,z)
 
 #define TracyMessageS(x,y,z)
 #define TracyMessageLS(x,y)
@@ -121,6 +117,11 @@
 #define TracyIsConnected false
 #define TracyIsStarted false
 #define TracySetProgramName(x)
+
+#define TracySectionEnter(x, ...) 0
+#define TracySectionEnterCategory(x, y, ...) 0
+#define TracySectionLeave(x)
+#define TracySectionSetup(x, y, ...)
 
 #define TracyFiberEnter(x)
 #define TracyFiberEnterHint(x,y)
@@ -214,22 +215,19 @@
 
 #define TracyAppInfo( txt, size ) tracy::Profiler::MessageAppInfo( txt, size )
 
-#define TracyMessage( txt, size ) tracy::Profiler::Message( txt, size, TRACY_CALLSTACK )
-#define TracyMessageL( txt ) tracy::Profiler::Message( txt, TRACY_CALLSTACK )
-#define TracyMessageC( txt, size, color ) tracy::Profiler::MessageColor( txt, size, color, TRACY_CALLSTACK )
-#define TracyMessageLC( txt, color ) tracy::Profiler::MessageColor( txt, color, TRACY_CALLSTACK )
+#define TracyLogString( severity, color, depth, ... ) tracy::Profiler::LogString( tracy::MessageSourceType::User, severity, color, depth, __VA_ARGS__ )
 
-#define TracyAlloc( ptr, size ) tracy::Profiler::MemAllocCallstack( ptr, size, TRACY_CALLSTACK, false )
-#define TracyFree( ptr ) tracy::Profiler::MemFreeCallstack( ptr, TRACY_CALLSTACK, false )
-#define TracySecureAlloc( ptr, size ) tracy::Profiler::MemAllocCallstack( ptr, size, TRACY_CALLSTACK, true )
-#define TracySecureFree( ptr ) tracy::Profiler::MemFreeCallstack( ptr, TRACY_CALLSTACK, true )
+#define TracyMessage( txt, size ) tracy::Profiler::LogString( tracy::MessageSourceType::User, tracy::MessageSeverity::Info, 0, TRACY_CALLSTACK, size, txt )
+#define TracyMessageL( txt ) tracy::Profiler::LogString( tracy::MessageSourceType::User, tracy::MessageSeverity::Info, 0, TRACY_CALLSTACK, txt )
+#define TracyMessageC( txt, size, color ) tracy::Profiler::LogString( tracy::MessageSourceType::User, tracy::MessageSeverity::Info, color, TRACY_CALLSTACK, size, txt )
+#define TracyMessageLC( txt, color ) tracy::Profiler::LogString( tracy::MessageSourceType::User, tracy::MessageSeverity::Info, color, TRACY_CALLSTACK, txt )
 
-#define TracyAllocN( ptr, size, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, TRACY_CALLSTACK, false, name )
-#define TracyFreeN( ptr, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, TRACY_CALLSTACK, false, name )
-#define TracyMemoryDiscard( name ) tracy::Profiler::MemDiscardCallstack( name, false, TRACY_CALLSTACK )
-#define TracySecureAllocN( ptr, size, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, TRACY_CALLSTACK, true, name )
-#define TracySecureFreeN( ptr, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, TRACY_CALLSTACK, true, name )
-#define TracySecureMemoryDiscard( name ) tracy::Profiler::MemDiscardCallstack( name, true, TRACY_CALLSTACK )
+#define TracyAlloc( ptr, size ) tracy::Profiler::MemAllocCallstack( ptr, size, TRACY_CALLSTACK )
+#define TracyFree( ptr ) tracy::Profiler::MemFreeCallstack( ptr, TRACY_CALLSTACK )
+
+#define TracyAllocN( ptr, size, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, TRACY_CALLSTACK, name )
+#define TracyFreeN( ptr, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, TRACY_CALLSTACK, name )
+#define TracyMemoryDiscard( name ) tracy::Profiler::MemDiscardCallstack( name, TRACY_CALLSTACK )
 
 #define ZoneNamedS( varname, depth, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), depth, active )
 #define ZoneNamedNS( varname, name, depth, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), depth, active )
@@ -244,28 +242,28 @@
 #define ZoneScopedCS( color, depth ) ZoneNamedCS( ___tracy_scoped_zone, color, depth, true )
 #define ZoneScopedNCS( name, color, depth ) ZoneNamedNCS( ___tracy_scoped_zone, name, color, depth, true )
 
-#define TracyAllocS( ptr, size, depth ) tracy::Profiler::MemAllocCallstack( ptr, size, depth, false )
-#define TracyFreeS( ptr, depth ) tracy::Profiler::MemFreeCallstack( ptr, depth, false )
-#define TracySecureAllocS( ptr, size, depth ) tracy::Profiler::MemAllocCallstack( ptr, size, depth, true )
-#define TracySecureFreeS( ptr, depth ) tracy::Profiler::MemFreeCallstack( ptr, depth, true )
+#define TracyAllocS( ptr, size, depth ) tracy::Profiler::MemAllocCallstack( ptr, size, depth )
+#define TracyFreeS( ptr, depth ) tracy::Profiler::MemFreeCallstack( ptr, depth )
 
-#define TracyAllocNS( ptr, size, depth, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, depth, false, name )
-#define TracyFreeNS( ptr, depth, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, depth, false, name )
-#define TracyMemoryDiscardS( name, depth ) tracy::Profiler::MemDiscardCallstack( name, false, depth )
-#define TracySecureAllocNS( ptr, size, depth, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, depth, true, name )
-#define TracySecureFreeNS( ptr, depth, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, depth, true, name )
-#define TracySecureMemoryDiscardS( name, depth ) tracy::Profiler::MemDiscardCallstack( name, true, depth )
+#define TracyAllocNS( ptr, size, depth, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, depth, name )
+#define TracyFreeNS( ptr, depth, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, depth, name )
+#define TracyMemoryDiscardS( name, depth ) tracy::Profiler::MemDiscardCallstack( name, depth )
 
-#define TracyMessageS( txt, size, depth ) tracy::Profiler::Message( txt, size, depth )
-#define TracyMessageLS( txt, depth ) tracy::Profiler::Message( txt, depth )
-#define TracyMessageCS( txt, size, color, depth ) tracy::Profiler::MessageColor( txt, size, color, depth )
-#define TracyMessageLCS( txt, color, depth ) tracy::Profiler::MessageColor( txt, color, depth )
+#define TracyMessageS( txt, size, depth ) tracy::Profiler::LogString( tracy::MessageSourceType::User, tracy::MessageSeverity::Info, 0, depth, size, txt )
+#define TracyMessageLS( txt, depth ) tracy::Profiler::LogString( tracy::MessageSourceType::User, tracy::MessageSeverity::Info, 0, depth, txt )
+#define TracyMessageCS( txt, size, color, depth ) tracy::Profiler::LogString( tracy::MessageSourceType::User, tracy::MessageSeverity::Info, color, depth, size, txt )
+#define TracyMessageLCS( txt, color, depth ) tracy::Profiler::LogString( tracy::MessageSourceType::User, tracy::MessageSeverity::Info, color, depth, txt )
 
 #define TracySourceCallbackRegister( cb, data ) tracy::Profiler::SourceCallbackRegister( cb, data )
 #define TracyParameterRegister( cb, data ) tracy::Profiler::ParameterRegister( cb, data )
-#define TracyParameterSetup( idx, name, isBool, val ) tracy::Profiler::ParameterSetup( idx, name, isBool, val )
+#define TracyParameterSetup( idx, name, type, val ) tracy::Profiler::ParameterSetup( idx, name, type, val )
 #define TracyIsConnected tracy::GetProfiler().IsConnected()
-#define TracySetProgramName( name ) tracy::GetProfiler().SetProgramName( name );
+#define TracySetProgramName( name ) tracy::GetProfiler().SetProgramName( name )
+
+#define TracySectionEnter( fmt, ... ) tracy::Profiler::SectionEnter( 0, fmt, ##__VA_ARGS__ )
+#define TracySectionEnterCategory( category, fmt, ... ) tracy::Profiler::SectionEnter( category, fmt, ##__VA_ARGS__ )
+#define TracySectionLeave( id ) tracy::Profiler::SectionLeave( id )
+#define TracySectionSetup( category, fmt, ... ) tracy::Profiler::SectionSetup( category, fmt, ##__VA_ARGS__ )
 
 #ifdef TRACY_FIBERS
 #  define TracyFiberEnter( fiber ) tracy::Profiler::EnterFiber( fiber, 0 )

--- a/D3D11Engine/include/tracy/public/tracy/TracyC.h
+++ b/D3D11Engine/include/tracy/public/tracy/TracyC.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include "../common/TracyApi.h"
+#include "../common/TracyFormat.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,6 +17,16 @@ enum TracyPlotFormatEnum
     TracyPlotFormatMemory,
     TracyPlotFormatPercentage,
     TracyPlotFormatWatt
+};
+
+enum TracyMessageSeverity
+{
+    TracyMessageSeverityTrace,   // Broadly track variable states and events in the software program.
+    TracyMessageSeverityDebug,   // Describes variable states and details about specific internal events in the software, that are useful for investigations.
+    TracyMessageSeverityInfo,    // Describes normal events, which inform on the expected progress and state of your software.
+    TracyMessageSeverityWarning, // Describes potentially dangerous situations caused by unexpected events and states.
+    TracyMessageSeverityError,   // Describes the occurance of unexpected behavior. Does not interrupt the execution of the software.
+    TracyMessageSeverityFatal,   // Describes a critical event that will lead to a software failure/crash.
 };
 
 TRACY_API void ___tracy_set_thread_name( const char* name );
@@ -39,6 +50,7 @@ TRACY_API void ___tracy_set_thread_name( const char* name );
 typedef const void* TracyCZoneCtx;
 
 typedef const void* TracyCLockCtx;
+typedef const void* TracyCSharedLockCtx;
 
 #define TracyCZone(c,x)
 #define TracyCZoneN(c,x,y)
@@ -46,21 +58,18 @@ typedef const void* TracyCLockCtx;
 #define TracyCZoneNC(c,x,y,z)
 #define TracyCZoneEnd(c)
 #define TracyCZoneText(c,x,y)
+#define TracyCZoneTextF(c,x,...)
 #define TracyCZoneName(c,x,y)
+#define TracyCZoneNameF(c,x,...)
 #define TracyCZoneColor(c,x)
 #define TracyCZoneValue(c,x)
 
 #define TracyCAlloc(x,y)
 #define TracyCFree(x)
 #define TracyCMemoryDiscard(x)
-#define TracyCSecureAlloc(x,y)
-#define TracyCSecureFree(x)
-#define TracyCSecureMemoryDiscard(x)
 
 #define TracyCAllocN(x,y,z)
 #define TracyCFreeN(x,y)
-#define TracyCSecureAllocN(x,y,z)
-#define TracyCSecureFreeN(x,y)
 
 #define TracyCFrameMark
 #define TracyCFrameMarkNamed(x)
@@ -87,14 +96,9 @@ typedef const void* TracyCLockCtx;
 #define TracyCAllocS(x,y,z)
 #define TracyCFreeS(x,y)
 #define TracyCMemoryDiscardS(x,y)
-#define TracyCSecureAllocS(x,y,z)
-#define TracyCSecureFreeS(x,y)
-#define TracyCSecureMemoryDiscardS(x,y)
 
 #define TracyCAllocNS(x,y,z,w)
 #define TracyCFreeNS(x,y,z)
-#define TracyCSecureAllocNS(x,y,z,w)
-#define TracyCSecureFreeNS(x,y,z)
 
 #define TracyCMessageS(x,y,z)
 #define TracyCMessageLS(x,y)
@@ -110,6 +114,20 @@ typedef const void* TracyCLockCtx;
 #define TracyCLockAfterTryLock(l,x)
 #define TracyCLockMark(l)
 #define TracyCLockCustomName(l,x,y)
+
+#define TracyCSharedLockCtx(l)
+#define TracyCSharedLockAnnonce(l)
+#define TracyCSharedLockTerminate(l)
+#define TracyCSharedLockBeforeLock(l)
+#define TracyCSharedLockAfterLock(l)
+#define TracyCSharedLockAfterUnlock(l)
+#define TracyCSharedLockAfterTryLock(l,x)
+#define TracyCSharedLockBeforeSharedLock(l)
+#define TracyCSharedLockAfterSharedLock(l)
+#define TracyCSharedLockAfterSharedUnlock(l)
+#define TracyCSharedLockAfterTrySharedLock(l,x)
+#define TracyCSharedLockMark(l)
+#define TracyCSharedLockCustomName(l,x,y)
 
 #define TracyCIsConnected 0
 #define TracyCIsStarted 0
@@ -144,6 +162,9 @@ struct ___tracy_c_zone_context
 {
     uint32_t id;
     int32_t active;
+#ifdef TRACY_ON_DEMAND
+    uint64_t connectionId;
+#endif
 };
 
 struct ___tracy_gpu_time_data
@@ -197,12 +218,14 @@ struct ___tracy_gpu_time_sync_data {
 };
 
 struct __tracy_lockable_context_data;
+struct __tracy_shared_lockable_context_data;
 
 // Some containers don't support storing const types.
 // This struct, as visible to user, is immutable, so treat it as if const was declared here.
 typedef /*const*/ struct ___tracy_c_zone_context TracyCZoneCtx;
 
 typedef struct __tracy_lockable_context_data* TracyCLockCtx;
+typedef struct __tracy_shared_lockable_context_data* TracyCSharedLockCtx;
 
 #ifdef TRACY_MANUAL_LIFETIME
 TRACY_API void ___tracy_startup_profiler(void);
@@ -223,7 +246,9 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int32_t
 TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int32_t depth, int32_t active );
 TRACY_API void ___tracy_emit_zone_end( TracyCZoneCtx ctx );
 TRACY_API void ___tracy_emit_zone_text( TracyCZoneCtx ctx, const char* txt, size_t size );
+TRACY_API void ___tracy_emit_zone_text_fmt( TracyCZoneCtx ctx, const char* fmt, ... ) TRACY_ATTRIBUTE_FORMAT_PRINTF(2, 3);
 TRACY_API void ___tracy_emit_zone_name( TracyCZoneCtx ctx, const char* txt, size_t size );
+TRACY_API void ___tracy_emit_zone_name_fmt( TracyCZoneCtx ctx, const char* fmt, ... ) TRACY_ATTRIBUTE_FORMAT_PRINTF(2, 3);
 TRACY_API void ___tracy_emit_zone_color( TracyCZoneCtx ctx, uint32_t color );
 TRACY_API void ___tracy_emit_zone_value( TracyCZoneCtx ctx, uint64_t value );
 
@@ -263,43 +288,38 @@ TRACY_API int32_t ___tracy_connected(void);
 #define TracyCZoneEnd( ctx ) ___tracy_emit_zone_end( ctx );
 
 #define TracyCZoneText( ctx, txt, size ) ___tracy_emit_zone_text( ctx, txt, size );
+#define TracyCZoneTextF( ctx, fmt, ... ) ___tracy_emit_zone_text_fmt( ctx, fmt, ##__VA_ARGS__ );
 #define TracyCZoneName( ctx, txt, size ) ___tracy_emit_zone_name( ctx, txt, size );
+#define TracyCZoneNameF( ctx, fmt, ... ) ___tracy_emit_zone_name_fmt( ctx, fmt, ##__VA_ARGS__ );
 #define TracyCZoneColor( ctx, color ) ___tracy_emit_zone_color( ctx, color );
 #define TracyCZoneValue( ctx, value ) ___tracy_emit_zone_value( ctx, value );
 
 
-TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size, int32_t secure );
-TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int32_t depth, int32_t secure );
-TRACY_API void ___tracy_emit_memory_free( const void* ptr, int32_t secure );
-TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int32_t depth, int32_t secure );
-TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, int32_t secure, const char* name );
-TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int32_t depth, int32_t secure, const char* name );
-TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, int32_t secure, const char* name );
-TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int32_t depth, int32_t secure, const char* name );
-TRACY_API void ___tracy_emit_memory_discard( const char* name, int32_t secure );
-TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t secure, int32_t depth );
+TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size );
+TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int32_t depth );
+TRACY_API void ___tracy_emit_memory_free( const void* ptr );
+TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int32_t depth );
+TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, const char* name );
+TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int32_t depth, const char* name );
+TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, const char* name );
+TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int32_t depth, const char* name );
+TRACY_API void ___tracy_emit_memory_discard( const char* name );
+TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t depth );
 
-TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int32_t callstack_depth );
-TRACY_API void ___tracy_emit_messageL( const char* txt, int32_t callstack_depth );
-TRACY_API void ___tracy_emit_messageC( const char* txt, size_t size, uint32_t color, int32_t callstack_depth );
-TRACY_API void ___tracy_emit_messageLC( const char* txt, uint32_t color, int32_t callstack_depth );
+TRACY_API void ___tracy_emit_logString( int8_t severity, int32_t color, int32_t callstack_depth, size_t size, const char* txt );
+TRACY_API void ___tracy_emit_logStringL( int8_t severity, int32_t color, int32_t callstack_depth, const char* txt );
 
-#define TracyCAlloc( ptr, size ) ___tracy_emit_memory_alloc_callstack( ptr, size, TRACY_CALLSTACK, 0 )
-#define TracyCFree( ptr ) ___tracy_emit_memory_free_callstack( ptr, TRACY_CALLSTACK, 0 )
-#define TracyCMemoryDiscard( name ) ___tracy_emit_memory_discard_callstack( name, 0, TRACY_CALLSTACK );
-#define TracyCSecureAlloc( ptr, size ) ___tracy_emit_memory_alloc_callstack( ptr, size, TRACY_CALLSTACK, 1 )
-#define TracyCSecureFree( ptr ) ___tracy_emit_memory_free_callstack( ptr, TRACY_CALLSTACK, 1 )
-#define TracyCSecureMemoryDiscard( name ) ___tracy_emit_memory_discard_callstack( name, 1, TRACY_CALLSTACK );
+#define TracyCAlloc( ptr, size ) ___tracy_emit_memory_alloc_callstack( ptr, size, TRACY_CALLSTACK )
+#define TracyCFree( ptr ) ___tracy_emit_memory_free_callstack( ptr, TRACY_CALLSTACK )
+#define TracyCMemoryDiscard( name ) ___tracy_emit_memory_discard_callstack( name, TRACY_CALLSTACK );
 
-#define TracyCAllocN( ptr, size, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, TRACY_CALLSTACK, 0, name )
-#define TracyCFreeN( ptr, name ) ___tracy_emit_memory_free_callstack_named( ptr, TRACY_CALLSTACK, 0, name )
-#define TracyCSecureAllocN( ptr, size, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, TRACY_CALLSTACK, 1, name )
-#define TracyCSecureFreeN( ptr, name ) ___tracy_emit_memory_free_callstack_named( ptr, TRACY_CALLSTACK, 1, name )
+#define TracyCAllocN( ptr, size, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, TRACY_CALLSTACK, name )
+#define TracyCFreeN( ptr, name ) ___tracy_emit_memory_free_callstack_named( ptr, TRACY_CALLSTACK, name )
 
-#define TracyCMessage( txt, size ) ___tracy_emit_message( txt, size, TRACY_CALLSTACK );
-#define TracyCMessageL( txt ) ___tracy_emit_messageL( txt, TRACY_CALLSTACK );
-#define TracyCMessageC( txt, size, color ) ___tracy_emit_messageC( txt, size, color, TRACY_CALLSTACK );
-#define TracyCMessageLC( txt, color ) ___tracy_emit_messageLC( txt, color, TRACY_CALLSTACK );
+#define TracyCMessage( txt, size ) ___tracy_emit_logString( TracyMessageSeverityInfo, 0, TRACY_CALLSTACK, size, txt )
+#define TracyCMessageL( txt ) ___tracy_emit_logStringL( TracyMessageSeverityInfo, 0, TRACY_CALLSTACK, txt )
+#define TracyCMessageC( txt, size, color ) ___tracy_emit_logString( TracyMessageSeverityInfo, color, TRACY_CALLSTACK, size, txt )
+#define TracyCMessageLC( txt, color ) ___tracy_emit_logStringL( TracyMessageSeverityInfo, color, TRACY_CALLSTACK, txt )
 
 
 TRACY_API void ___tracy_emit_frame_mark( const char* name );
@@ -332,22 +352,17 @@ TRACY_API void ___tracy_emit_message_appinfo( const char* txt, size_t size );
 #define TracyCZoneCS( ctx, color, depth, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, color }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), depth, active );
 #define TracyCZoneNCS( ctx, name, color, depth, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { name, __func__,  TracyFile, (uint32_t)TracyLine, color }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), depth, active );
 
-#define TracyCAllocS( ptr, size, depth ) ___tracy_emit_memory_alloc_callstack( ptr, size, depth, 0 )
-#define TracyCFreeS( ptr, depth ) ___tracy_emit_memory_free_callstack( ptr, depth, 0 )
-#define TracyCMemoryDiscardS( name, depth ) ___tracy_emit_memory_discard_callstack( name, 0, depth )
-#define TracyCSecureAllocS( ptr, size, depth ) ___tracy_emit_memory_alloc_callstack( ptr, size, depth, 1 )
-#define TracyCSecureFreeS( ptr, depth ) ___tracy_emit_memory_free_callstack( ptr, depth, 1 )
-#define TracyCSecureMemoryDiscardS( name, depth ) ___tracy_emit_memory_discard_callstack( name, 1, depth )
+#define TracyCAllocS( ptr, size, depth ) ___tracy_emit_memory_alloc_callstack( ptr, size, depth )
+#define TracyCFreeS( ptr, depth ) ___tracy_emit_memory_free_callstack( ptr, depth )
+#define TracyCMemoryDiscardS( name, depth ) ___tracy_emit_memory_discard_callstack( name, depth )
 
-#define TracyCAllocNS( ptr, size, depth, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, depth, 0, name )
-#define TracyCFreeNS( ptr, depth, name ) ___tracy_emit_memory_free_callstack_named( ptr, depth, 0, name )
-#define TracyCSecureAllocNS( ptr, size, depth, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, depth, 1, name )
-#define TracyCSecureFreeNS( ptr, depth, name ) ___tracy_emit_memory_free_callstack_named( ptr, depth, 1, name )
+#define TracyCAllocNS( ptr, size, depth, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, depth, name )
+#define TracyCFreeNS( ptr, depth, name ) ___tracy_emit_memory_free_callstack_named( ptr, depth, name )
 
-#define TracyCMessageS( txt, size, depth ) ___tracy_emit_message( txt, size, depth );
-#define TracyCMessageLS( txt, depth ) ___tracy_emit_messageL( txt, depth );
-#define TracyCMessageCS( txt, size, color, depth ) ___tracy_emit_messageC( txt, size, color, depth );
-#define TracyCMessageLCS( txt, color, depth ) ___tracy_emit_messageLC( txt, color, depth );
+#define TracyCMessageS( txt, size, depth ) ___tracy_emit_logString( TracyMessageSeverityInfo, 0, depth, size, txt )
+#define TracyCMessageLS( txt, depth ) ___tracy_emit_logStringL( TracyMessageSeverityInfo, 0, depth, txt )
+#define TracyCMessageCS( txt, size, color, depth ) ___tracy_emit_logString( TracyMessageSeverityInfo, color, depth, size, txt )
+#define TracyCMessageLCS( txt, color, depth ) ___tracy_emit_logStringL( TracyMessageSeverityInfo, color, depth, txt )
 
 
 TRACY_API struct __tracy_lockable_context_data* ___tracy_announce_lockable_ctx( const struct ___tracy_source_location_data* srcloc );
@@ -359,6 +374,20 @@ TRACY_API void ___tracy_after_try_lock_lockable_ctx( struct __tracy_lockable_con
 TRACY_API void ___tracy_mark_lockable_ctx( struct __tracy_lockable_context_data* lockdata, const struct ___tracy_source_location_data* srcloc );
 TRACY_API void ___tracy_custom_name_lockable_ctx( struct __tracy_lockable_context_data* lockdata, const char* name, size_t nameSz );
 
+TRACY_API struct __tracy_shared_lockable_context_data* ___tracy_announce_shared_lockable_ctx( const struct ___tracy_source_location_data* srcloc );
+TRACY_API void ___tracy_terminate_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata );
+TRACY_API int32_t ___tracy_before_lock_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata );
+TRACY_API void ___tracy_after_lock_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata );
+TRACY_API void ___tracy_after_unlock_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata );
+TRACY_API void ___tracy_after_try_lock_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata, int32_t acquired );
+TRACY_API int32_t ___tracy_before_lock_shared_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata );
+TRACY_API void ___tracy_after_lock_shared_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata );
+TRACY_API void ___tracy_after_unlock_shared_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata );
+TRACY_API void ___tracy_after_try_lock_shared_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata, int32_t acquired );
+TRACY_API void ___tracy_mark_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata, const struct ___tracy_source_location_data* srcloc );
+TRACY_API void ___tracy_custom_name_shared_lockable_ctx( struct __tracy_shared_lockable_context_data* lockdata, const char* name, size_t nameSz );
+
+
 #define TracyCLockAnnounce( lock ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; lock = ___tracy_announce_lockable_ctx( &TracyConcat(__tracy_source_location,TracyLine) );
 #define TracyCLockTerminate( lock ) ___tracy_terminate_lockable_ctx( lock );
 #define TracyCLockBeforeLock( lock ) ___tracy_before_lock_lockable_ctx( lock );
@@ -368,10 +397,23 @@ TRACY_API void ___tracy_custom_name_lockable_ctx( struct __tracy_lockable_contex
 #define TracyCLockMark( lock ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; ___tracy_mark_lockable_ctx( lock, &TracyConcat(__tracy_source_location,TracyLine) );
 #define TracyCLockCustomName( lock, name, nameSz ) ___tracy_custom_name_lockable_ctx( lock, name, nameSz );
 
+#define TracyCSharedLockAnnounce( lock ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; lock = ___tracy_announce_shared_lockable_ctx( &TracyConcat(__tracy_source_location,TracyLine) );
+#define TracyCSharedLockTerminate( lock ) ___tracy_terminate_shared_lockable_ctx( lock );
+#define TracyCSharedLockBeforeLock( lock ) ___tracy_before_lock_shared_lockable_ctx( lock );
+#define TracyCSharedLockAfterLock( lock ) ___tracy_after_lock_shared_lockable_ctx( lock );
+#define TracyCSharedLockAfterUnlock( lock ) ___tracy_after_unlock_shared_lockable_ctx( lock );
+#define TracyCSharedLockAfterTryLock( lock, acquired ) ___tracy_after_try_lock_shared_lockable_ctx( lock, acquired );
+#define TracyCSharedLockBeforeSharedLock( lock ) ___tracy_before_lock_shared_shared_lockable_ctx( lock );
+#define TracyCSharedLockAfterSharedLock( lock ) ___tracy_after_lock_shared_shared_lockable_ctx( lock );
+#define TracyCSharedLockAfterSharedUnlock( lock ) ___tracy_after_unlock_shared_shared_lockable_ctx( lock );
+#define TracyCSharedLockAfterTrySharedLock( lock, acquired ) ___tracy_after_try_lock_shared_shared_lockable_ctx( lock, acquired );
+#define TracyCSharedLockMark( lock ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; ___tracy_mark_shared_lockable_ctx( lock, &TracyConcat(__tracy_source_location,TracyLine) );
+#define TracyCSharedLockCustomName( lock, name, nameSz ) ___tracy_custom_name_shared_lockable_ctx( lock, name, nameSz );
+
 #define TracyCIsConnected ___tracy_connected()
 
-TRACY_API int ___tracy_begin_sampling_profiler( void );
-TRACY_API void ___tracy_end_sampling_profiler( void );
+TRACY_API int ___tracy_begin_sampling_profiling( void );
+TRACY_API void ___tracy_end_sampling_profiling( void );
 
 #define TracyCBeginSamplingProfiling() ___tracy_begin_sampling_profiling()
 #define TracyCEndSamplingProfiling() ___tracy_end_sampling_profiling()
@@ -383,6 +425,8 @@ TRACY_API void ___tracy_fiber_leave( void );
 #  define TracyCFiberEnter( fiber ) ___tracy_fiber_enter( fiber );
 #  define TracyCFiberLeave ___tracy_fiber_leave();
 #endif
+
+TRACY_API int64_t ___tracy_get_time( void );
 
 #endif
 

--- a/D3D11Engine/include/tracy/public/tracy/TracyCUDA.hpp
+++ b/D3D11Engine/include/tracy/public/tracy/TracyCUDA.hpp
@@ -12,12 +12,20 @@
 
 #define TracyCUDACollect(ctx)
 
+namespace tracy{
+using CUDACtx = std::nullptr_t;
+} // namespace tracy
+
 #else
 #include <cupti.h>
 
-#include <cassert>
+#if CUDA_VERSION < 12040
+#error "CUDA v12.4 (or later) is required by TracyCUDA.hpp"
+#endif
+
 #include <cmath>
 #include <string>
+#include <string.h>
 #include <string_view>
 #include <atomic>
 #include <mutex>
@@ -31,7 +39,8 @@
 #include <cxxabi.h>
 #endif
 
-#include <tracy/Tracy.hpp>
+#include "../common/TracyAssert.hpp"
+#include "Tracy.hpp"
 
 #ifndef UNREFERENCED
 #define UNREFERENCED(x) (void)x
@@ -112,7 +121,7 @@ TracyTimestamp tracyFromCUpti(CUptiTimestamp cuptiTime) {
     auto [slope, intercept] = getCachedRegressionParameters();
     double y_hat = slope * cuptiTime + intercept;
     TracyTimestamp tracyTime = TracyTimestamp(y_hat);
-    assert(tracyTime >= 0);
+    TRACY_ASSERT(tracyTime >= 0);
     return tracyTime;
 }
 
@@ -201,7 +210,7 @@ void tracyEmitMemAlloc(const char* name, const void* ptr, size_t size, TracyTime
     }
     else
     {
-        assert(sizeof(size) == 8);
+        TRACY_ASSERT(sizeof(size) == 8);
         memcpy(&item->memAlloc.size, &size, 4);
         memcpy(((char *)&item->memAlloc.size) + 4, ((char *)&size) + 4, 2);
     }
@@ -285,7 +294,7 @@ CUptiResult CUptiCallChecked(CUptiResult result, const char* call, const char* f
     const char* resultMsg = "";
     CUPTI_API_CALL(cuptiGetResultString(result, &resultMsg));   // maybe not a good idea to recurse here...
     fprintf(stderr, "ERROR:\t%s:%d:\n\tfunction '%s' failed with error '%s'.\n", file, line, call, resultMsg);
-    //assert(result == CUPTI_SUCCESS);
+    //TRACY_ASSERT(result == CUPTI_SUCCESS);
     return result;
 }
 
@@ -295,7 +304,7 @@ CUresult cudaDriverCallChecked(CUresult result, const char* call, const char* fi
     const char* resultMsg = "";
     DRIVER_API_CALL(cuGetErrorString(result, &resultMsg));   // maybe not a good idea to recurse here...
     fprintf(stderr, "ERROR:\t%s:%d:\n\tfunction '%s' failed with error '%s'.\n", file, line, call, resultMsg);
-    //assert(result == CUDA_SUCCESS);
+    //TRACY_ASSERT(result == CUDA_SUCCESS);
     return result;
 }
 
@@ -333,6 +342,7 @@ struct ConcurrentHashMap {
     }
     auto fetch(TKey key, TValue& value) {
         ZoneNamed(fetch, instrument);
+        auto lock = acquire_read_lock();
         auto it = mapping.find(key);
         if (it != mapping.end()) {
             value = it->second;
@@ -355,6 +365,11 @@ struct ConcurrentHashMap {
         ZoneNamed(erase, instrument);
         auto lock = acquire_write_lock();
         return mapping.erase(key);
+    }
+    auto insert_or_assign(TKey key, TValue value) {
+        ZoneNamed(insert_or_assign, instrument);
+        auto lock = acquire_write_lock();
+        return mapping.insert_or_assign(std::move(key), std::move(value));
     }
 };
 
@@ -391,7 +406,7 @@ struct StringTable {
         if (!table.fetch(str, memoized)) {
             ZoneNamedN(lookup, "StringTable::insert", instrument);
             char* copy = (char*)tracyMalloc(str.size() + 1);
-            strncpy(copy, str.data(), str.size());
+            memcpy(copy, str.data(), str.size());
             copy[str.size()] = '\0';
             std::string_view value (copy, str.size());
             auto [it, inserted] = table.emplace(value, value);
@@ -401,7 +416,7 @@ struct StringTable {
             }
             memoized = it->second;
         }
-        assert(str == memoized);
+        TRACY_ASSERT(str == memoized);
         return memoized;
     }
 };
@@ -424,8 +439,8 @@ struct SourceLocationMap {
 
     tracy::SourceLocationData* add(std::string_view function, std::string_view file, int line, uint32_t color=0) {
         ZoneNamed(emplace, instrument);
-        assert(*function.end() == '\0');
-        assert(*file.end() == '\0');
+        TRACY_ASSERT(*function.end() == '\0');
+        TRACY_ASSERT(*file.end() == '\0');
         void* bytes = tracyMalloc(sizeof(tracy::SourceLocationData));
         auto pSrcLoc = new(bytes)tracy::SourceLocationData{ function.data(), TracyFunction, file.data(), (uint32_t)line, color };
         auto [it, inserted] = locations.emplace(function, pSrcLoc);
@@ -433,7 +448,7 @@ struct SourceLocationMap {
             // another thread inserted it while we were trying to: cleanup
             tracyFree(pSrcLoc); // POD: no destructor to call
         }
-        assert(it->second != nullptr);
+        TRACY_ASSERT(it->second != nullptr);
         return it->second;
     }
 };
@@ -476,8 +491,8 @@ struct SourceLocationLUT {
 uint32_t tracyTimelineId(uint32_t contextId, uint32_t streamId) {
     // 0xA7C5 = 42,949 => 42,949 * 100,000 = 4,294,900,000
     // 4,294,900,000 + 65,535  = 4,294,965,535 < 4,294,967,295 (max uint32)
-    assert(contextId <= 0xA7C5);
-    assert((streamId == CUPTI_INVALID_STREAM_ID) || (streamId < 0xFFFF));
+    TRACY_ASSERT(contextId <= 0xA7C5);
+    TRACY_ASSERT((streamId == CUPTI_INVALID_STREAM_ID) || (streamId < 0xFFFF));
     uint32_t packed = (contextId * 100'000) + (streamId & 0x0000'FFFF);
     return packed;
 }
@@ -493,7 +508,7 @@ namespace tracy
             auto& s = Singleton::Get();
             std::unique_lock<std::mutex> lock (s.m);
             if (s.ref_count == 0) {
-                assert(s.ctx == nullptr);
+                TRACY_ASSERT(s.ctx == nullptr);
                 s.ctx = new CUDACtx(s.ctx_id);
                 s.ref_count += 1;
                 s.ctx_id = s.ctx->m_tracyGpuContext;
@@ -504,7 +519,7 @@ namespace tracy
         static void Destroy(CUDACtx* ctx) {
             auto& s = Singleton::Get();
             std::unique_lock<std::mutex> lock(s.m);
-            assert(ctx == s.ctx);
+            TRACY_ASSERT(ctx == s.ctx);
             s.ref_count -= 1;
             if (s.ref_count == 0) {
                 delete s.ctx;
@@ -561,7 +576,7 @@ namespace tracy
 
             auto item = Profiler::QueueSerial();
             tracyMemWrite(item->hdr.type, QueueType::GpuContextName);
-            tracyMemWrite(item->gpuContextNameFat.context, m_tracyGpuContext);
+            tracyMemWrite(item->gpuContextNameFat.context, (uint8_t)m_tracyGpuContext);
             tracyMemWrite(item->gpuContextNameFat.ptr, (uint64_t)ptr);
             tracyMemWrite(item->gpuContextNameFat.size, len);
             SubmitQueueItem(item);
@@ -608,7 +623,7 @@ namespace tracy
                 tracyMemWrite(item->gpuCalibration.gpuTime, (int64_t)tCUpti);
                 tracyMemWrite(item->gpuCalibration.cpuTime, tTracy);
                 tracyMemWrite(item->gpuCalibration.cpuDelta, deltaTicksCUpti);
-                tracyMemWrite(item->gpuCalibration.context, m_tracyGpuContext);
+                tracyMemWrite(item->gpuCalibration.context, (uint8_t)m_tracyGpuContext);
                 Profiler::QueueSerialFinish();
             }
             #endif
@@ -629,8 +644,8 @@ namespace tracy
             //uint32_t timelineId = tracy::GetThreadHandle();
             uint32_t timelineId = tracyTimelineId(cudaContextId, cudaStreamId);
             uint16_t queryId = m_queryIdGen.fetch_add(2);
-            tracyAnnounceGpuTimestamp(apiStart, apiEnd, queryId, m_tracyGpuContext, pSrcLoc, timelineId);
-            tracySubmitGpuTimestamp(gpuStart, gpuEnd, queryId, m_tracyGpuContext);
+            tracyAnnounceGpuTimestamp(apiStart, apiEnd, queryId, (uint8_t)m_tracyGpuContext, pSrcLoc, timelineId);
+            tracySubmitGpuTimestamp(gpuStart, gpuEnd, queryId, (uint8_t)m_tracyGpuContext);
         }
 
         void OnEventsProcessed() {
@@ -638,6 +653,8 @@ namespace tracy
         }
 
         struct CUPTI {
+        using GraphID = uint32_t;
+
         static void CUPTIAPI OnBufferRequested(uint8_t **buffer, size_t *size, size_t *maxNumRecords)
         {
             ZoneScoped;
@@ -646,8 +663,23 @@ namespace tracy
             // should return as quickly as possible from these callbacks."
             *size = 1 * 1024*1024; // 1MB
             *buffer = (uint8_t*)tracyMalloc(*size);
-            assert(*buffer != nullptr);
+            TRACY_ASSERT(*buffer != nullptr);
             FlushActivityAsync();
+        }
+
+        // Returns the graphId field from activity record kinds that carry one,
+        // or 0 for records that are not graph-launched or don't have the field.
+        static GraphID getGraphIdFromRecord(const CUpti_Activity* record) {
+            switch (record->kind) {
+                case CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL:
+                    return reinterpret_cast<const CUpti_ActivityKernel9*>(record)->graphId;
+                case CUPTI_ACTIVITY_KIND_MEMCPY:
+                    return reinterpret_cast<const CUpti_ActivityMemcpy5*>(record)->graphId;
+                case CUPTI_ACTIVITY_KIND_MEMSET:
+                    return reinterpret_cast<const CUpti_ActivityMemset4*>(record)->graphId;
+                default:
+                    return 0;
+            }
         }
 
         static void CUPTIAPI OnBufferCompleted(CUcontext ctx, uint32_t streamId, uint8_t* buffer, size_t size, size_t validSize)
@@ -656,9 +688,19 @@ namespace tracy
             // (i.e. there is no context/stream specific buffer; ctx is always NULL)
             ZoneScoped;
             tracy::SetThreadName("NVIDIA CUPTI Worker");
+            // Check if any graph execs are pending retirement before entering
+            // the record loop — avoids the graphIdsSeenInBuffer heap allocation
+            // on the hot path when no execs have been destroyed.
+            // Uses an atomic flag so we skip the mutex entirely in the common case.
+            bool trackRetirement = PersistentState::Get().graphRetirePending.load(std::memory_order_acquire);
             CUptiResult status;
             CUpti_Activity* record = nullptr;
+            std::unordered_set<GraphID> graphIdsSeenInBuffer;
             while ((status = cuptiActivityGetNextRecord(buffer, validSize, &record)) == CUPTI_SUCCESS) {
+                if (trackRetirement) {
+                    GraphID gId = getGraphIdFromRecord(record);
+                    if (gId != 0) graphIdsSeenInBuffer.insert(gId);
+                }
                 DoProcessDeviceEvent(record);
             }
             if (status != CUPTI_ERROR_MAX_LIMIT_REACHED) {
@@ -666,8 +708,33 @@ namespace tracy
             }
             size_t dropped = 0;
             CUPTI_API_CALL(cuptiActivityGetNumDroppedRecords(ctx, streamId, &dropped));
-            assert(dropped == 0);
+            TRACY_ASSERT(dropped == 0);
             tracyFree(buffer);
+
+            // Retire cudaGraphCurrentLaunch entries for destroyed exec handles.
+            // We defer erasure until a buffer arrives that contains no records
+            // from the exec: if the graphId still appears here, more records may
+            // be in flight. Once a full buffer passes with no records for that
+            // graphId, all in-flight activity for that exec has been delivered.
+            // Note: holds graphRetireMutex then acquires cudaGraphCurrentLaunch's
+            // internal shared_mutex — lock order is always outer→inner, no deadlock.
+            if (trackRetirement) {
+                auto& state = PersistentState::Get();
+                std::lock_guard<std::mutex> lock(state.graphRetireMutex);
+                for (auto it = state.graphExecPendingRetire.begin();
+                     it != state.graphExecPendingRetire.end(); ) {
+                    if (graphIdsSeenInBuffer.count(*it) == 0) {
+                        state.cudaGraphCurrentLaunch.erase(*it);
+                        it = state.graphExecPendingRetire.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+                if (state.graphExecPendingRetire.empty()) {
+                    state.graphRetirePending.store(false, std::memory_order_release);
+                }
+            }
+
             PersistentState::Get().profilerHost->OnEventsProcessed();
         }
 
@@ -758,9 +825,10 @@ namespace tracy
                         { CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_ptsz_v7000,     GET_STREAM_FUNC(cudaLaunchKernel_ptsz_v7000_params, stream) },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,      GET_STREAM_FUNC(cudaLaunchKernelExC_v11060_params, config->stream) },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_ptsz_v11060, GET_STREAM_FUNC(cudaLaunchKernelExC_ptsz_v11060_params, config->stream) },
-                        // Runtime: Memory
-                        { CUPTI_RUNTIME_TRACE_CBID_cudaMalloc_v3020, NON_STREAM_FUNC() },
-                        { CUPTI_RUNTIME_TRACE_CBID_cudaFree_v3020,   NON_STREAM_FUNC() },
+                        // Runtime: Memory — NOT tracked here. The MEMORY2 handler
+                        // only needs address/size/timestamp from the activity record
+                        // and never calls EmitGpuZone, so there is no consumer for
+                        // the cudaCallSiteInfo entry. Tracking them would leak entries.
                         // Runtime: Memcpy
                         { CUPTI_RUNTIME_TRACE_CBID_cudaMemcpy_v3020,      NON_STREAM_FUNC() },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaMemcpyAsync_v3020, GET_STREAM_FUNC(cudaMemcpyAsync_v3020_params, stream) },
@@ -773,6 +841,10 @@ namespace tracy
                         { CUPTI_RUNTIME_TRACE_CBID_cudaEventQuery_v3020,        NON_STREAM_FUNC() },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaStreamWaitEvent_v3020,   NON_STREAM_FUNC() },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaDeviceSynchronize_v3020, NON_STREAM_FUNC() },
+                        // Graph launch: tracked so all CONCURRENT_KERNEL/MEMCPY/MEMSET activities
+                        // sharing the launch's correlationId can be correlated back to this call site.
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000,      GET_STREAM_FUNC(cudaGraphLaunch_v10000_params, stream) },
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_ptsz_v10000, GET_STREAM_FUNC(cudaGraphLaunch_v10000_params, stream) },
                     };
                     #undef NON_STREAM_FUNC
                     #undef GET_STREAM_FUNC
@@ -791,6 +863,44 @@ namespace tracy
                         { CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel_ptsz,   GET_STREAM_FUNC(cuLaunchKernel_ptsz_params, hStream)} ,
                         { CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx,      GET_STREAM_FUNC(cuLaunchKernelEx_params, config->hStream) },
                         { CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx_ptsz, GET_STREAM_FUNC(cuLaunchKernelEx_params, config->hStream) },
+                        // Driver: Memory — NOT tracked (see Runtime: Memory comment above).
+                        // Driver: Memcpy - Synchronous
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemcpy,              NON_STREAM_FUNC() },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoD_v2,       NON_STREAM_FUNC() },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoH_v2,       NON_STREAM_FUNC() },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoD_v2,       NON_STREAM_FUNC() },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemcpy2D_v2,         NON_STREAM_FUNC() },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemcpy3D_v2,         NON_STREAM_FUNC() },
+                        // Driver: Memcpy - Asynchronous
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemcpyAsync,         GET_STREAM_FUNC(cuMemcpyAsync_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoDAsync_v2,  GET_STREAM_FUNC(cuMemcpyHtoDAsync_v2_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoHAsync_v2,  GET_STREAM_FUNC(cuMemcpyDtoHAsync_v2_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoDAsync_v2,  GET_STREAM_FUNC(cuMemcpyDtoDAsync_v2_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemcpy2DAsync_v2,    GET_STREAM_FUNC(cuMemcpy2DAsync_v2_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DAsync_v2,    GET_STREAM_FUNC(cuMemcpy3DAsync_v2_params, hStream) },
+                        // Driver: Memset - Synchronous
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemsetD8_v2,         NON_STREAM_FUNC() },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemsetD16_v2,        NON_STREAM_FUNC() },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemsetD32_v2,        NON_STREAM_FUNC() },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D8_v2,       NON_STREAM_FUNC() },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D16_v2,      NON_STREAM_FUNC() },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D32_v2,      NON_STREAM_FUNC() },
+                        // Driver: Memset - Asynchronous
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemsetD8Async,       GET_STREAM_FUNC(cuMemsetD8Async_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemsetD16Async,      GET_STREAM_FUNC(cuMemsetD16Async_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemsetD32Async,      GET_STREAM_FUNC(cuMemsetD32Async_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D8Async,     GET_STREAM_FUNC(cuMemsetD2D8Async_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D16Async,    GET_STREAM_FUNC(cuMemsetD2D16Async_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D32Async,    GET_STREAM_FUNC(cuMemsetD2D32Async_params, hStream) },
+                        // Driver: Synchronization
+                        { CUPTI_DRIVER_TRACE_CBID_cuStreamSynchronize,   GET_STREAM_FUNC(cuStreamSynchronize_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuEventSynchronize,    NON_STREAM_FUNC() },
+                        { CUPTI_DRIVER_TRACE_CBID_cuCtxSynchronize,      NON_STREAM_FUNC() },
+                        { CUPTI_DRIVER_TRACE_CBID_cuStreamWaitEvent,     GET_STREAM_FUNC(cuStreamWaitEvent_params, hStream) },
+                        // Graph launch: tracked so all CONCURRENT_KERNEL/MEMCPY/MEMSET activities
+                        // sharing the launch's correlationId can be correlated back to this call site.
+                        { CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch,          GET_STREAM_FUNC(cuGraphLaunch_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch_ptsz,     GET_STREAM_FUNC(cuGraphLaunch_params, hStream) },
                     };
                     #undef NON_STREAM_FUNC
                     #undef GET_STREAM_FUNC
@@ -814,8 +924,33 @@ namespace tracy
                     cudaCallSiteInfo.emplace(apiInfo->correlationId, APICallInfo{ apiCallStartTime, apiCallStartTime, tgpu, profilerHost });
                 }
                 auto& entryFlags = *apiInfo->correlationData;
-                assert(entryFlags == 0);
+                TRACY_ASSERT(entryFlags == 0);
                 entryFlags |= trackDeviceActivity ? 0x8000 : 0;
+
+                // On graph exec destruction, record the graphId for deferred
+                // retirement of its cudaGraphCurrentLaunch cache entry.
+                // cuptiGetGraphExecId must be called here (ENTER), while the
+                // handle is still valid — at EXIT it has already been freed.
+                // Actual erasure is deferred to OnBufferCompleted so we don't
+                // race with CUPTI activity records that are still in-flight.
+                {
+                    GraphID retireGraphId = 0;
+                    if (domain == CUPTI_CB_DOMAIN_RUNTIME_API &&
+                        cbid == CUPTI_RUNTIME_TRACE_CBID_cudaGraphExecDestroy_v10000) {
+                        auto* p = (cudaGraphExecDestroy_v10000_params*)apiInfo->functionParams;
+                        CUPTI_API_CALL(cuptiGetGraphExecId((CUgraphExec)p->graphExec, &retireGraphId));
+                    } else if (domain == CUPTI_CB_DOMAIN_DRIVER_API &&
+                               cbid == CUPTI_DRIVER_TRACE_CBID_cuGraphExecDestroy) {
+                        auto* p = (cuGraphExecDestroy_params*)apiInfo->functionParams;
+                        CUPTI_API_CALL(cuptiGetGraphExecId(p->hGraphExec, &retireGraphId));
+                    }
+                    if (retireGraphId != 0) {
+                        auto& state = PersistentState::Get();
+                        std::lock_guard<std::mutex> lock(state.graphRetireMutex);
+                        state.graphExecPendingRetire.insert(retireGraphId);
+                        state.graphRetirePending.store(true, std::memory_order_release);
+                    }
+                }
             }
 
             if (apiInfo->callbackSite == CUPTI_API_EXIT) {
@@ -849,7 +984,24 @@ namespace tracy
                 return false;
             }
             cudaCallSiteInfo.erase(correlationId);
-            assert(apiCallInfo.host != nullptr);
+            TRACY_ASSERT(apiCallInfo.host != nullptr);
+            return true;
+        }
+
+        // Like matchActivityToAPICall, but also handles graph-launched activities.
+        // All activities in one cuGraphLaunch share the launch's correlationId, so
+        // the first activity consumes the cudaCallSiteInfo entry and caches it by
+        // graphId; subsequent activities from the same launch find it via graphId.
+        static bool matchGraphActivityToAPICall(uint32_t correlationId, GraphID graphId,
+                                                APICallInfo& apiCallInfo) {
+            auto& graphLaunchCache = PersistentState::Get().cudaGraphCurrentLaunch;
+            if (!matchActivityToAPICall(correlationId, apiCallInfo)) {
+                if (graphId == 0 || !graphLaunchCache.fetch(graphId, apiCallInfo)) {
+                    return false;
+                }
+            } else if (graphId != 0) {
+                graphLaunchCache.insert_or_assign(graphId, apiCallInfo);
+            }
             return true;
         }
 
@@ -955,7 +1107,7 @@ namespace tracy
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[kernel]", instrument);
                 CUpti_ActivityKernel9* kernel9 = (CUpti_ActivityKernel9*) record;
                 APICallInfo apiCall;
-                if (!matchActivityToAPICall(kernel9->correlationId, apiCall)) {
+                if (!matchGraphActivityToAPICall(kernel9->correlationId, kernel9->graphId, apiCall)) {
                     return matchError(kernel9->correlationId, "KERNEL");
                 }
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, kernel9->start, kernel9->end, getKernelSourceLocation(kernel9->name), kernel9->contextId, kernel9->streamId);
@@ -969,7 +1121,7 @@ namespace tracy
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[memcpy]", instrument);
                 CUpti_ActivityMemcpy5* memcpy5 = (CUpti_ActivityMemcpy5*) record;
                 APICallInfo apiCall;
-                if (!matchActivityToAPICall(memcpy5->correlationId, apiCall)) {
+                if (!matchGraphActivityToAPICall(memcpy5->correlationId, memcpy5->graphId, apiCall)) {
                     return matchError(memcpy5->correlationId, "MEMCPY");
                 }
                 static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemcpy { "CUDA::memcpy", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
@@ -985,7 +1137,7 @@ namespace tracy
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[memset]", instrument);
                 CUpti_ActivityMemset4* memset4 = (CUpti_ActivityMemset4*) record;
                 APICallInfo apiCall;
-                if (!matchActivityToAPICall(memset4->correlationId, apiCall)) {
+                if (!matchGraphActivityToAPICall(memset4->correlationId, memset4->graphId, apiCall)) {
                     return matchError(memset4->correlationId, "MEMSET");
                 }
                 static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemset { "CUDA::memset", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
@@ -1034,10 +1186,10 @@ namespace tracy
             {
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[malloc/free]", instrument);
                 CUpti_ActivityMemory3* memory3 = (CUpti_ActivityMemory3*)record;
-                APICallInfo apiCall;
-                if (!matchActivityToAPICall(memory3->correlationId, apiCall)) {
-                    return matchError(memory3->correlationId, "MEMORY");
-                }
+                // No API call correlation needed — this handler only uses address,
+                // size, and timestamp directly from the activity record. Memory
+                // API CBIDs are intentionally excluded from cbidRuntimeTrackers /
+                // cbidDriverTrackers so no cudaCallSiteInfo entry is created.
                 static constexpr const char* graph_name = "CUDA Memory Allocation";
                 if (memory3->memoryOperationType == CUPTI_ACTIVITY_MEMORY_OPERATION_TYPE_ALLOCATION){
                     auto& memAllocAddress = PersistentState::Get().memAllocAddress;
@@ -1064,8 +1216,15 @@ namespace tracy
             {
                 // NOTE(marcos): a byproduct of CUPTI_ACTIVITY_KIND_SYNCHRONIZATION
                 // (I think this is related to cudaEvent*() API calls)
+#if CUDA_VERSION < 12080
+                // prior to CUDA v12.8
+                CUpti_ActivityCudaEvent* event = (CUpti_ActivityCudaEvent*)record;
+                UNREFERENCED(event);
+#else
+                // starting from CUDA v12.8
                 CUpti_ActivityCudaEvent2* event = (CUpti_ActivityCudaEvent2*)record;
                 UNREFERENCED(event);
+#endif
                 break;
             }
             default:
@@ -1094,6 +1253,10 @@ namespace tracy
             CUPTI_ACTIVITY_KIND_MEMSET,
             CUPTI_ACTIVITY_KIND_SYNCHRONIZATION,
             CUPTI_ACTIVITY_KIND_MEMORY2,
+            // NOTE: CUPTI_ACTIVITY_KIND_GRAPH_TRACE must NOT be enabled alongside
+            // CONCURRENT_KERNEL — enabling it suppresses per-kernel activity records
+            // for graph-launched kernels, replacing them with graph-level summaries.
+            //CUPTI_ACTIVITY_KIND_GRAPH_TRACE,
             //CUPTI_ACTIVITY_KIND_MEMCPY2,
             //CUPTI_ACTIVITY_KIND_OVERHEAD,
             //CUPTI_ACTIVITY_KIND_INTERNAL_LAUNCH_API,
@@ -1222,7 +1385,18 @@ namespace tracy
             // NOTE(marcos): these objects do not need to persist, but their relative
             // footprint is trivial enough that we don't care if we let them leak
             ConcurrentHashMap<CorrelationID, APICallInfo> cudaCallSiteInfo;
+            // Graph launch cache: entries are retired via graphExecPendingRetire
+            // when the corresponding cudaGraphExec is destroyed.
+            ConcurrentHashMap<GraphID, APICallInfo> cudaGraphCurrentLaunch;
             ConcurrentHashMap<uintptr_t, int> memAllocAddress;
+            // Pending retirement: graphIds whose exec handles have been destroyed.
+            // Entries are erased from cudaGraphCurrentLaunch in OnBufferCompleted
+            // once no further activity records for the exec arrive in a buffer.
+            // graphRetirePending is an atomic dirty-flag so OnBufferCompleted can
+            // skip the mutex on the hot path when no execs have been destroyed.
+            std::atomic<bool> graphRetirePending{false};
+            std::mutex graphRetireMutex;
+            std::unordered_set<GraphID> graphExecPendingRetire;
             CUpti_SubscriberHandle subscriber = {};
             CUDACtx* profilerHost = nullptr;
 
@@ -1236,17 +1410,17 @@ namespace tracy
 
         };
 
-        CUDACtx(uint8_t gpuContextID = 255)
+        CUDACtx(int32_t gpuContextID = InvalidGpuContextId)
         {
             ZoneScoped;
 
-            if (gpuContextID != 255) {
+            if (gpuContextID != InvalidGpuContextId) {
                 m_tracyGpuContext = gpuContextID;
                 return;
             }
 
-            m_tracyGpuContext = GetGpuCtxCounter().fetch_add(1, std::memory_order_relaxed);
-            assert(m_tracyGpuContext != 255);
+            m_tracyGpuContext = NextGpuContextId();
+            TRACY_ASSERT(m_tracyGpuContext != InvalidGpuContextId);
 
             TracyTimestamp tTracy;
             CUptiTimestamp tCUpti;
@@ -1260,11 +1434,14 @@ namespace tracy
             tracyMemWrite(item->gpuNewContext.thread, (uint32_t)0);
             tracyMemWrite(item->gpuNewContext.period, 1.0f);
             tracyMemWrite(item->gpuNewContext.type, GpuContextType::CUDA);
-            tracyMemWrite(item->gpuNewContext.context, m_tracyGpuContext);
+            tracyMemWrite(item->gpuNewContext.context, (uint8_t)m_tracyGpuContext);
             #if TRACY_CUDA_CALIBRATED_CONTEXT
             tracyMemWrite(item->gpuNewContext.flags, GpuContextCalibration);
             #else
             tracyMemWrite(item->gpuNewContext.flags, tracy::GpuContextFlags(0));
+            #endif
+            #ifdef TRACY_ON_DEMAND
+            GetProfiler().DeferItem(*item);
             #endif
             Profiler::QueueSerialFinish();
 
@@ -1293,7 +1470,7 @@ namespace tracy
             CUDACtx* ctx = nullptr;
             std::mutex m;
             int ref_count = 0;
-            uint8_t ctx_id = 255;
+            int32_t ctx_id = InvalidGpuContextId;
             static Singleton& Get() {
                 static Singleton singleton;
                 return singleton;
@@ -1304,7 +1481,7 @@ namespace tracy
         ProfilerStats stats = {};
         #endif
 
-        uint8_t m_tracyGpuContext = 255;
+        int32_t m_tracyGpuContext = InvalidGpuContextId;
         static constexpr size_t cacheline = 64;
         alignas(cacheline) std::atomic<uint16_t> m_queryIdGen = 0;
     };

--- a/D3D11Engine/include/tracy/public/tracy/TracyD3D11.hpp
+++ b/D3D11Engine/include/tracy/public/tracy/TracyD3D11.hpp
@@ -33,17 +33,17 @@ using TracyD3D11Ctx = void*;
 #else
 
 #include <atomic>
-#include <assert.h>
 #include <stdlib.h>
 
 #include "Tracy.hpp"
 #include "../client/TracyProfiler.hpp"
 #include "../client/TracyCallstack.hpp"
+#include "../common/TracyAssert.hpp"
 #include "../common/TracyYield.hpp"
 
 #include <d3d11.h>
 
-#define TracyD3D11Panic(msg, ...) do { assert(false && "TracyD3D11: " msg); TracyMessageLC("TracyD3D11: " msg, tracy::Color::Red4); __VA_ARGS__; } while(false);
+#define TracyD3D11Panic(msg, ...) do { TRACY_ASSERT(false && "TracyD3D11: " msg); TracyMessageLC("TracyD3D11: " msg, tracy::Color::Red4); __VA_ARGS__; } while(false);
 
 namespace tracy
 {
@@ -108,7 +108,7 @@ public:
                 continue;
             }
 
-            if (disjoint.Disjoint)
+            if (disjoint.Disjoint || disjoint.Frequency == 0)
                 continue;
 
             UINT64 timestamp = 0;
@@ -121,7 +121,7 @@ public:
         }
 
         // ready to roll
-        m_contextId = GetGpuCtxCounter().fetch_add(1);
+        m_contextId = NextGpuContextId();
         m_immediateDevCtx->Begin(m_disjointQuery);
         m_previousCheckpoint = m_nextCheckpoint = 0;
 
@@ -131,8 +131,8 @@ public:
         MemWrite( &item->gpuNewContext.gpuTime, tgpu );
         MemWrite( &item->gpuNewContext.thread, uint32_t(0) );   // #TODO: why not GetThreadHandle()?
         MemWrite( &item->gpuNewContext.period, 1.0f );
-        MemWrite( &item->gpuNewContext.context, m_contextId);
-        MemWrite( &item->gpuNewContext.flags, uint8_t(0) );
+        MemWrite( &item->gpuNewContext.context, uint8_t(m_contextId));
+        MemWrite( &item->gpuNewContext.flags, GpuContextFlags(0) );
         MemWrite( &item->gpuNewContext.type, GpuContextType::Direct3D11 );
 
 #ifdef TRACY_ON_DEMAND
@@ -167,7 +167,7 @@ public:
 
         auto item = Profiler::QueueSerial();
         MemWrite( &item->hdr.type, QueueType::GpuContextName );
-        MemWrite( &item->gpuContextNameFat.context, m_contextId );
+        MemWrite( &item->gpuContextNameFat.context, uint8_t(m_contextId) );
         MemWrite( &item->gpuContextNameFat.ptr, (uint64_t)ptr );
         MemWrite( &item->gpuContextNameFat.size, len );
 #ifdef TRACY_ON_DEMAND
@@ -217,6 +217,13 @@ public:
             return;
         }
 
+        if (disjoint.Frequency == 0)
+        {
+            m_previousCheckpoint = m_nextCheckpoint;
+            TracyD3D11Panic("zero GPU timestamp frequency; dropping.");
+            return;
+        }
+
         auto begin = m_previousCheckpoint;
         auto end = m_nextCheckpoint;
         for (auto i = begin; i != end; ++i)
@@ -233,7 +240,7 @@ public:
             MemWrite(&item->hdr.type, QueueType::GpuTime);
             MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(timestamp));
             MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k));
-            MemWrite(&item->gpuTime.context, m_contextId);
+            MemWrite(&item->gpuTime.context, uint8_t(m_contextId));
             Profiler::QueueSerialFinish();
         }
 
@@ -280,7 +287,7 @@ private:
             YieldThread();  // busy-wait :-( attempt to reduce power usage with _mm_pause() & friends...
     }
 
-    tracy_force_inline uint8_t GetContextId() const
+    tracy_force_inline int32_t GetContextId() const
     {
         return m_contextId;
     }
@@ -291,7 +298,7 @@ private:
     ID3D11Query* m_queries[MaxQueries];
     ID3D11Query* m_disjointQuery = nullptr;
 
-    uint8_t m_contextId = 255;  // NOTE: apparently, 255 means invalid id; is this documented anywhere?
+    int32_t m_contextId = InvalidGpuContextId;
 
     uintptr_t m_queryCounter = 0;
 
@@ -365,12 +372,15 @@ public:
         const auto queryId = m_ctx->NextQueryId();
         m_ctx->m_immediateDevCtx->End(m_ctx->GetQueryObjectFromId(queryId));
 
+#ifdef TRACY_ON_DEMAND
+        if( GetProfiler().ConnectionId() != m_connectionId ) return;
+#endif
         auto* item = Profiler::QueueSerial();
         MemWrite( &item->hdr.type, QueueType::GpuZoneEndSerial );
         MemWrite( &item->gpuZoneEnd.cpuTime, Profiler::GetTime() );
         MemWrite( &item->gpuZoneEnd.thread, GetThreadHandle() );
         MemWrite( &item->gpuZoneEnd.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneEnd.context, m_ctx->GetContextId() );
+        MemWrite( &item->gpuZoneEnd.context, uint8_t(m_ctx->GetContextId()) );
         Profiler::QueueSerialFinish();
     }
 
@@ -378,6 +388,7 @@ private:
     tracy_force_inline D3D11ZoneScope( D3D11Ctx* ctx, bool active )
 #ifdef TRACY_ON_DEMAND
         : m_active( active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( active )
 #endif
@@ -396,11 +407,15 @@ private:
         MemWrite( &item->gpuZoneBegin.srcloc, sourceLocation );
         MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
         MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, m_ctx->GetContextId() );
+        MemWrite( &item->gpuZoneBegin.context, uint8_t(m_ctx->GetContextId()) );
         Profiler::QueueSerialFinish();
     }
 
     const bool m_active;
+
+#ifdef TRACY_ON_DEMAND
+    uint64_t m_connectionId = 0;
+#endif
 
     D3D11Ctx* m_ctx;
 };
@@ -418,7 +433,6 @@ static inline void DestroyD3D11Context( D3D11Ctx* ctx )
     tracy_free( ctx );
 }
 }
-
 #undef TracyD3D11Panic
 
 using TracyD3D11Ctx = tracy::D3D11Ctx*;

--- a/D3D11Engine/include/tracy/public/tracy/TracyD3D12.hpp
+++ b/D3D11Engine/include/tracy/public/tracy/TracyD3D12.hpp
@@ -33,45 +33,70 @@ using TracyD3D12Ctx = void*;
 #else
 
 #include "Tracy.hpp"
-#include "../client/TracyProfiler.hpp"
-#include "../client/TracyCallstack.hpp"
+#include "../client/TracyFastVector.hpp"
+#include "../common/TracyAssert.hpp"
 
+#include <atomic>
+#include <mutex>
 #include <cstdlib>
-#include <cassert>
+#include <cstring>
 #include <d3d12.h>
 #include <dxgi.h>
-#include <queue>
 
-#define TracyD3D12Panic(msg, ...) do { assert(false && "TracyD3D12: " msg); TracyMessageLC("TracyD3D12: " msg, tracy::Color::Red4); __VA_ARGS__; } while(false);
+#ifndef TRACY_D3D12_DEBUG_LEVEL
+#define TRACY_D3D12_DEBUG_LEVEL (0)
+#endif//TRACY_D3D12_DEBUG_LEVEL
+
+#ifndef TRACY_D3D12_PERSISTENT_TIMESTAMP_BUFFER
+#define TRACY_D3D12_PERSISTENT_TIMESTAMP_BUFFER (1)
+#endif//TRACY_D3D12_PERSISTENT_TIMESTAMP_BUFFER
+
+#if TRACY_D3D12_DEBUG_LEVEL
+#   define TracyD3D12Debug(...) __VA_ARGS__;
+#   ifdef _MSC_VER
+#       define TracyD3D12Break() if (IsDebuggerPresent()) __debugbreak()
+#   else
+#       define TracyD3D12Break() /* TODO */
+#   endif
+#   define TracyD3D12Assert(predicate, ...) if (predicate) {} else { __VA_ARGS__; TracyD3D12Break(); }
+#else
+#   define TracyD3D12Debug(...)
+#   define TracyD3D12Break()
+#   define TracyD3D12Assert(predicate, ...) TRACY_ASSERT(predicate);
+#endif
+
+#define TracyD3D12Log(severity, msg) tracy::Profiler::LogString( tracy::MessageSourceType::Tracy, tracy::MessageSeverity::severity, tracy::Color::Red4, 0, msg );
+#define TracyD3D12Panic(msg, ...) do { TracyD3D12Log(Error, msg); TracyD3D12Assert(false && "TracyD3D12: " msg); __VA_ARGS__; } while(false);
 
 namespace tracy
 {
-
-    struct D3D12QueryPayload
-    {
-        uint32_t m_queryIdStart = 0;
-        uint32_t m_queryCount = 0;
-    };
 
     // Command queue context.
     class D3D12QueueCtx
     {
         friend class D3D12ZoneScope;
 
+        int32_t m_contextId = InvalidGpuContextId;
+
+        std::mutex m_collectionMutex;
+
         ID3D12Device* m_device = nullptr;
         ID3D12CommandQueue* m_queue = nullptr;
-        uint8_t m_contextId = 255;  // TODO: apparently, 255 means "invalid id"; is this documented somewhere?
         ID3D12QueryHeap* m_queryHeap = nullptr;
         ID3D12Resource* m_readbackBuffer = nullptr;
 
-        // In-progress payload.
-        uint32_t m_queryLimit = 0;
-        std::atomic<uint32_t> m_queryCounter = 0;
-        uint32_t m_previousQueryCounter = 0;
+#if TRACY_D3D12_PERSISTENT_TIMESTAMP_BUFFER
+        UINT64* m_persistentTimestampBuffer = nullptr;
+#endif
 
-        uint32_t m_activePayload = 0;
-        ID3D12Fence* m_payloadFence = nullptr;
-        std::queue<D3D12QueryPayload> m_payloadQueue;
+        using atomic_counter = std::atomic<uint64_t>;
+        atomic_counter m_queryCounter = 0;
+        atomic_counter m_previousCheckpoint = 0;
+
+        uint32_t m_queryLimit = 64 * 1024;  // Must be even: each scope is a (begin, end) pair of queries
+
+        FastVector<UINT64> m_shadowBuffer;
+        UINT64 m_latestKnownGpuTimestamp = 0;
 
         UINT64 m_prevCalibrationTicksCPU = 0;
 
@@ -87,6 +112,10 @@ namespace tracy
             int64_t cpuDeltaTicks = cpuTimestamp - m_prevCalibrationTicksCPU;
             if (cpuDeltaTicks > 0)
             {
+                // WARNING: technically, we should not emit a GpuCalibration event if the GPU counter
+                // did not move, to prevent division by a gpuDelta of zero in later on (in the server).
+                // In practice, GetClockCalibration() should be advancing CPU and GPU together.
+
                 static const int64_t nanosecodsPerTick = int64_t(1000000000) / GetFrequencyQpc();
                 int64_t cpuDeltaNS = cpuDeltaTicks * nanosecodsPerTick;
                 // Save the device cpu timestamp, not the Tracy profiler timestamp:
@@ -96,10 +125,10 @@ namespace tracy
 
                 auto* item = Profiler::QueueSerial();
                 MemWrite(&item->hdr.type, QueueType::GpuCalibration);
-                MemWrite(&item->gpuCalibration.gpuTime, gpuTimestamp);
-                MemWrite(&item->gpuCalibration.cpuTime, cpuTimestamp);
+                MemWrite(&item->gpuCalibration.gpuTime, int64_t(gpuTimestamp));
+                MemWrite(&item->gpuCalibration.cpuTime, int64_t(cpuTimestamp));
                 MemWrite(&item->gpuCalibration.cpuDelta, cpuDeltaNS);
-                MemWrite(&item->gpuCalibration.context, GetId());
+                MemWrite(&item->gpuCalibration.context, static_cast<uint8_t>(GetId()));
                 SubmitQueueItem(item);
             }
         }
@@ -116,22 +145,22 @@ namespace tracy
         D3D12QueueCtx(ID3D12Device* device, ID3D12CommandQueue* queue)
             : m_device(device)
             , m_queue(queue)
+            , m_shadowBuffer(m_queryLimit)
         {
-            // Verify we support timestamp queries on this queue.
+            ZoneScopedC(Color::Red4);
 
+            m_queue->AddRef();
+
+            // Verify we support timestamp queries on this queue.
             if (queue->GetDesc().Type == D3D12_COMMAND_LIST_TYPE_COPY)
             {
                 D3D12_FEATURE_DATA_D3D12_OPTIONS3 featureData{};
-
                 HRESULT hr = device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS3, &featureData, sizeof(featureData));
                 if (FAILED(hr) || (featureData.CopyQueueTimestampQueriesSupported == FALSE))
                 {
                     TracyD3D12Panic("Platform does not support profiling of copy queues.", return);
                 }
             }
-
-            static constexpr uint32_t MaxQueries = 64 * 1024;  // Must be even, because queries are (begin, end) pairs
-            m_queryLimit = MaxQueries;
 
             D3D12_QUERY_HEAP_DESC heapDesc{};
             heapDesc.Type = queue->GetDesc().Type == D3D12_COMMAND_LIST_TYPE_COPY ? D3D12_QUERY_HEAP_TYPE_COPY_QUEUE_TIMESTAMP : D3D12_QUERY_HEAP_TYPE_TIMESTAMP;
@@ -171,10 +200,11 @@ namespace tracy
                 TracyD3D12Panic("Failed to create query readback buffer.", return);
             }
 
-            if (FAILED(device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_payloadFence))))
-            {
-                TracyD3D12Panic("Failed to create payload fence.", return);
-            }
+            UINT64* timestampBuffer = MapTimestampBuffer();
+            if (timestampBuffer == nullptr) return;
+            for (uint64_t i = 0; i < m_queryLimit; ++i)
+                timestampBuffer[i] = 0;
+            UnmapTimestampBuffer(timestampBuffer);
 
             float period = [queue]()
             {
@@ -198,21 +228,27 @@ namespace tracy
                 TracyD3D12Panic("Failed to get queue clock calibration.", return);
             }
 
+            // FastVector: clean/resize/init
+            for (size_t i = 0; i < m_queryLimit; ++i) *m_shadowBuffer.push_next() = gpuTimestamp;
+
+            m_latestKnownGpuTimestamp = gpuTimestamp;
+
             // Save the device cpu timestamp, not the profiler's timestamp.
             m_prevCalibrationTicksCPU = cpuTimestamp;
 
             cpuTimestamp = Profiler::GetTime();
 
-            // all checked: ready to roll
-            m_contextId = GetGpuCtxCounter().fetch_add(1);
+            // All setup/init checks completed: ready to create the context.
+            m_contextId = NextGpuContextId();
+            ZoneValue(m_contextId);
 
             auto* item = Profiler::QueueSerial();
             MemWrite(&item->hdr.type, QueueType::GpuNewContext);
-            MemWrite(&item->gpuNewContext.cpuTime, cpuTimestamp);
-            MemWrite(&item->gpuNewContext.gpuTime, gpuTimestamp);
-            MemWrite(&item->gpuNewContext.thread, decltype(item->gpuNewContext.thread)(0)); // #TODO: why 0 instead of GetThreadHandle()?
-            MemWrite(&item->gpuNewContext.period, period);
-            MemWrite(&item->gpuNewContext.context, GetId());
+            MemWrite(&item->gpuNewContext.cpuTime, static_cast<int64_t>(cpuTimestamp));
+            MemWrite(&item->gpuNewContext.gpuTime, static_cast<int64_t>(gpuTimestamp));
+            MemWrite(&item->gpuNewContext.thread, static_cast<uint32_t>(0)); // zero means the context is not associated with a specific thread
+            MemWrite(&item->gpuNewContext.period, static_cast<float>(period));
+            MemWrite(&item->gpuNewContext.context, static_cast<uint8_t>(GetId()));
             MemWrite(&item->gpuNewContext.flags, GpuContextCalibration);
             MemWrite(&item->gpuNewContext.type, GpuContextType::Direct3D12);
             SubmitQueueItem(item);
@@ -221,28 +257,40 @@ namespace tracy
         ~D3D12QueueCtx()
         {
             ZoneScopedC(Color::Red4);
-            // collect all pending timestamps
-            while (m_payloadFence->GetCompletedValue() != m_activePayload)
-                /* busy-wait ... */;
-            Collect();
-            m_payloadFence->Release();
-            m_readbackBuffer->Release();
-            m_queryHeap->Release();
+            ZoneValue(m_contextId);
+
+            // TODO: could use queue->Signal() to inject a progress point in the queue
+            // and the immediately wait for the signal, in order to avoid busy-waiting
+            // (need to create an ID3D12Fence and associate an Event object to it)
+            // NOTE: even with Signal(), there are no guarantees the queries were sent
+            // to the GPU for execution, so the Signal() does not give us much "signal"
+ 
+            // collect all pending queries up to the latest known query
+            uint64_t endTicket = m_queryCounter;
+            uint64_t lastIssuedTicket = endTicket - 2;
+            Drain(lastIssuedTicket, 200);
+
+            // if the client is still pushing queries past the latest checkpoint above,
+            // assume there's a bug in the client, and ignore them (don't collect)
+            if (Distance(endTicket, m_queryCounter) > 0)
+                TracyD3D12Panic("client is still pushing queries.");
+
+#if TRACY_D3D12_PERSISTENT_TIMESTAMP_BUFFER
+            if (m_readbackBuffer)
+            {
+                D3D12_RANGE fullRange { 0, m_queryLimit * sizeof(UINT64) };
+                m_readbackBuffer->Unmap(0, &fullRange);
+                m_persistentTimestampBuffer = nullptr;
+            }
+#endif
+            if (m_readbackBuffer) m_readbackBuffer->Release();
+            if (m_queryHeap) m_queryHeap->Release();
+            m_queue->Release();
         }
 
-
-        void NewFrame()
+        tracy_force_inline int32_t GetId() const
         {
-            uint32_t queryCounter = m_queryCounter.exchange(0);
-            m_payloadQueue.emplace(D3D12QueryPayload{ m_previousQueryCounter, queryCounter });
-            m_previousQueryCounter += queryCounter;
-
-            if (m_previousQueryCounter >= m_queryLimit)
-            {
-                m_previousQueryCounter -= m_queryLimit;
-            }
-
-            m_queue->Signal(m_payloadFence, ++m_activePayload);
+            return m_contextId;
         }
 
         void Name( const char* name, uint16_t len )
@@ -252,7 +300,7 @@ namespace tracy
 
             auto item = Profiler::QueueSerial();
             MemWrite( &item->hdr.type, QueueType::GpuContextName );
-            MemWrite( &item->gpuContextNameFat.context, GetId());
+            MemWrite( &item->gpuContextNameFat.context, static_cast<uint8_t>(GetId()));
             MemWrite( &item->gpuContextNameFat.ptr, (uint64_t)ptr );
             MemWrite( &item->gpuContextNameFat.size, len );
             SubmitQueueItem(item);
@@ -260,108 +308,314 @@ namespace tracy
 
         void Collect()
         {
-            ZoneScopedC(Color::Red4);
-
 #ifdef TRACY_ON_DEMAND
-            if (!GetProfiler().IsConnected())
-            {
-                m_queryCounter = 0;
-
-                return;
-            }
+            if (!GetProfiler().IsConnected()) return;
 #endif
-
-            // Find out what payloads are available.
-            const auto newestReadyPayload = m_payloadFence->GetCompletedValue();
-            const auto payloadCount = m_payloadQueue.size() - (m_activePayload - newestReadyPayload);
-
-            if (!payloadCount)
-            {
-                return;  // No payloads are available yet, exit out.
-            }
-
-            D3D12_RANGE mapRange{ 0, m_queryLimit * sizeof(uint64_t) };
-
-            // Map the readback buffer so we can fetch the query data from the GPU.
-            void* readbackBufferMapping = nullptr;
-
-            if (FAILED(m_readbackBuffer->Map(0, &mapRange, &readbackBufferMapping)))
-            {
-                TracyD3D12Panic("Failed to map readback buffer.", return);
-            }
-
-            auto* timestampData = static_cast<uint64_t*>(readbackBufferMapping);
-
-            for (uint32_t i = 0; i < payloadCount; ++i)
-            {
-                const auto& payload = m_payloadQueue.front();
-
-                for (uint32_t j = 0; j < payload.m_queryCount; ++j)
-                {
-                    const auto counter = (payload.m_queryIdStart + j) % m_queryLimit;
-                    const auto timestamp = timestampData[counter];
-                    const auto queryId = counter;
-
-                    auto* item = Profiler::QueueSerial();
-                    MemWrite(&item->hdr.type, QueueType::GpuTime);
-                    MemWrite(&item->gpuTime.gpuTime, timestamp);
-                    MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(queryId));
-                    MemWrite(&item->gpuTime.context, GetId());
-
-                    Profiler::QueueSerialFinish();
-                }
-
-                m_payloadQueue.pop();
-            }
-
-            m_readbackBuffer->Unmap(0, nullptr);
-
-            // Recalibrate to account for drift.
-            RecalibrateClocks();
+            // Only one thread is allowed to collect timestamps at any given time
+            // but there's no need to block contending threads
+            if (!m_collectionMutex.try_lock()) return;
+            std::unique_lock lock (m_collectionMutex, std::adopt_lock);
+            uint64_t targetTicket = m_queryCounter;
+            Collect(lock, m_queryCounter, false);
         }
 
     private:
-        tracy_force_inline uint32_t NextQueryId()
+        void Collect(std::unique_lock<std::mutex>& lock, uint64_t targetTicket, bool urgent)
         {
-            uint32_t queryCounter = m_queryCounter.fetch_add(2);
-            if (queryCounter >= m_queryLimit)
+            ZoneScopedC(Color::Red4);
+            TracyD3D12Assert( lock.owns_lock() );
+            TracyD3D12Debug( ZoneValue(m_contextId) );
+
+            uint64_t earliestTicket = m_previousCheckpoint.load(std::memory_order_relaxed);
+            uint64_t endTicket = m_queryCounter;
+            TracyD3D12Debug( ZoneValue(earliestTicket) );
+            TracyD3D12Debug( ZoneValue(endTicket) );
+            if (Distance(earliestTicket, endTicket) <= 0)
+                return;
+
+            UINT64* timestampBuffer = MapTimestampBuffer();
+            if (timestampBuffer == nullptr) return;
+
+            // Attempt to collect as many resolved queries as possible
+            uint64_t ticket = earliestTicket;
+            for (ticket = earliestTicket; ticket != endTicket; ticket += 2)
             {
-                TracyD3D12Panic("Submitted too many GPU queries! Consider increasing MaxQueries.");
-                // #TODO: consider returning an invalid id or sentinel value here
+                if (!ResolveTimestamp(ticket, timestampBuffer))
+                    // TODO: implement preemptive timeout policy
+                    break;
             }
 
-            const uint32_t id = (m_previousQueryCounter + queryCounter) % m_queryLimit;
+            // Urgent request: ensure 'targetTicket' is collected before returning
+            if (urgent)
+            {
+                TracyD3D12Assert( Distance(targetTicket, endTicket) > 0 );
+                while (Distance(ticket, targetTicket) >= 0)
+                {
+                    DropTimestamp(ticket, timestampBuffer);
+                    ticket += 2;
+                }
+            }
 
-            return id;
+            // Panic: overflow, start dropping queries to normalize the situation
+            while (Distance(ticket, endTicket) > RingCapacity())
+            {
+                DropTimestamp(ticket, timestampBuffer);
+                ticket += 2;
+            }
+
+            UnmapTimestampBuffer(timestampBuffer);
+
+            // TODO: check for device status (device lost).
+            // Technically speaking, values read from the timestamp buffer (readback heap)
+            // should only be trusted while the device is "fine". Ideally, queries should
+            // be "peeked" first, and those deemed "resolved" should only be "emitted" if
+            // the device is fine, or dropped otherwise. All that said, the collect code,
+            // as is, should not cause catastrophic issues.
+
+            RecalibrateClocks();
         }
 
-        tracy_force_inline uint8_t GetId() const
+        tracy_force_inline bool IsTicketPending(uint64_t queryTicket)
         {
-            return m_contextId;
+            auto checkpoint = m_previousCheckpoint.load(std::memory_order_acquire);
+            return (Distance(checkpoint, queryTicket) >= 0);
+        }
+
+        bool Wait(uint64_t queryTicket, uint64_t timeout_ms)
+        {
+            ZoneScopedC(Color::Red4);
+            TracyD3D12Debug( ZoneValue(m_contextId) );
+            TracyD3D12Debug( ZoneValue(queryTicket) );
+            TracyD3D12Debug( ZoneValue(RingIndex(queryTicket)) );
+            auto ini = GetTickCount64();
+            auto elapsed = 0;
+            // TODO: could use condition variable to avoid spurious lock + collect iterations
+            while (IsTicketPending(queryTicket))
+            {
+                if (elapsed >= timeout_ms)
+                    return false;
+                std::unique_lock lock (m_collectionMutex);
+                Collect(lock, queryTicket, false);
+                elapsed = GetTickCount64() - ini;
+            }
+            return true;
+        }
+
+        void Drain(uint64_t queryTicket, uint64_t gracePeriod_ms)
+        {
+            ZoneScopedC(Color::Red4);
+            TracyD3D12Debug( ZoneValue(m_contextId) );
+            TracyD3D12Debug( ZoneValue(queryTicket) );
+            TracyD3D12Debug( ZoneValue(RingIndex(queryTicket)) );
+            if (Wait(queryTicket, gracePeriod_ms))
+                return;
+            // can't wait anymore: urgent collect request
+            std::unique_lock lock (m_collectionMutex);
+            Collect(lock, queryTicket, true);
+        }
+
+        bool ResolveTimestamp(uint64_t queryTicket, UINT64* timestampBuffer)
+        {
+            uint32_t queryId = RingIndex(queryTicket);
+            UINT64 gpuZoneBeginTimestamp = timestampBuffer[queryId];
+            UINT64 gpuZoneEndTimestamp = timestampBuffer[queryId+1];
+            UINT64 baselineTimestamp = m_shadowBuffer[queryId+1];
+            int64_t baseline_diff = Distance(baselineTimestamp, gpuZoneEndTimestamp);
+            if (baseline_diff <= 0)
+                return false;
+            EmitGpuTime(gpuZoneBeginTimestamp, queryId);
+            EmitGpuTime(gpuZoneEndTimestamp, queryId+1);
+            RetireTicket(queryTicket);
+            if (Distance(m_latestKnownGpuTimestamp, gpuZoneEndTimestamp) > 0)
+                m_latestKnownGpuTimestamp = gpuZoneEndTimestamp;
+            return true;
+        }
+
+        void DropTimestamp(uint64_t queryTicket, UINT64* timestampBuffer)
+        {
+            // might as well attempt to resolve it before dropping it
+            if (ResolveTimestamp(queryTicket, timestampBuffer))
+                return;
+            // emit a "bogus" GpuTime to avoid problems with the internal
+            // zone tracking and matching logic in the server/profiler
+            uint32_t queryId = RingIndex(queryTicket);
+            TracyD3D12Debug( ZoneScopedC(Color::Red4) );
+            TracyD3D12Debug( ZoneValue(queryTicket) );
+            TracyD3D12Debug( ZoneValue(queryId) );
+            TracyD3D12Debug( TracyPlot("TracyD3D12|drop", int64_t(0)) );
+            TracyD3D12Debug( TracyPlot("TracyD3D12|drop", int64_t(1)) );
+            uint64_t latestGpuTimestamp = m_latestKnownGpuTimestamp;
+            EmitGpuTime(latestGpuTimestamp, queryId);
+            EmitGpuTime(latestGpuTimestamp, queryId+1);
+            RetireTicket(queryTicket);
+            TracyD3D12Debug( TracyPlot("TracyD3D12|drop", int64_t(1)) );
+            TracyD3D12Debug( TracyPlot("TracyD3D12|drop", int64_t(0)) );
+        }
+
+        void EmitGpuTime(UINT64 gpuTimestamp, uint32_t queryId)
+        {
+            auto* item = Profiler::QueueSerial();
+            MemWrite(&item->hdr.type, QueueType::GpuTime);
+            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(gpuTimestamp));
+            MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(queryId));
+            MemWrite(&item->gpuTime.context, static_cast<uint8_t>(GetId()));
+            Profiler::QueueSerialFinish();
+            m_shadowBuffer[queryId] = gpuTimestamp;
+            TracyD3D12Debug(
+                TracyFreeN(reinterpret_cast<void*>(uintptr_t(queryId)), "TracyD3D12|Query");
+            );
+        }
+
+        tracy_force_inline uint32_t RingCapacity() const
+        {
+            return m_queryLimit;
+        }
+
+        tracy_force_inline uint32_t RingIndex(uint64_t logicalSlot) const
+        {
+            return static_cast<uint32_t>(logicalSlot % RingCapacity());
+        }
+
+        tracy_force_inline static int64_t Distance(uint64_t begin, uint64_t end)
+        {
+            // difference accounting for unsigned wrap-around
+            return static_cast<int64_t>(end - begin);
+        }
+
+        void RetireTicket(uint64_t ticket)
+        {
+            TracyD3D12Assert( m_previousCheckpoint == ticket );
+            uint64_t nextTicket = ticket + 2;
+            m_previousCheckpoint.store(nextTicket, std::memory_order_release);
+        }
+
+        tracy_force_inline uint32_t NextQueryId()
+        {
+            // WARN: the moment m_queryCounter is incremented, Collect() will have instant
+            // visibility of the change and may therefore start attempting to collect them.
+            // Under most circumstances, this is fine. However, suppose Collect() ends up
+            // dropping a query due to timeout, but said query is indeed submitted to the
+            // GPU queue for execution later on. This "late" query will eventually become
+            // resolved by the GPU asynchronously writting to the corresponding query slot.
+            // The newly produced query below could have matching ids/slot with said query.
+            // From there, there's no bullet-proof way for Collect() to distinguish between
+            // the timestamp written to the query slot belonging to the old/late query, or
+            // to the query that has just been generated. The value of the "late" query may
+            // may end up being collected as if it belonged to the the new query.
+            const uint64_t ticket = m_queryCounter.fetch_add(2, std::memory_order_relaxed);
+            const uint64_t checkpoint = m_previousCheckpoint.load(std::memory_order_relaxed);
+            if (Distance(checkpoint, ticket) >= RingCapacity())
+            {
+                ZoneScopedC(Color::Red4);
+                TracyD3D12Log(Warning, "Too many pending GPU queries: stalling!");
+                uint64_t oldTicket = ticket - RingCapacity();
+                Drain(oldTicket, 0);
+            }
+
+            const uint32_t queryId = RingIndex(ticket);
+            TracyD3D12Debug(
+                TracyAllocN(reinterpret_cast<void*>(uintptr_t(queryId+0)), 1, "TracyD3D12|Query");
+                TracyAllocN(reinterpret_cast<void*>(uintptr_t(queryId+1)), 1, "TracyD3D12|Query");
+            );
+            return queryId;
+        }
+
+        UINT64* MapTimestampBuffer()
+        {
+#if TRACY_D3D12_PERSISTENT_TIMESTAMP_BUFFER
+            if (m_persistentTimestampBuffer != nullptr)
+                return m_persistentTimestampBuffer;
+#endif
+            D3D12_RANGE fullRange { 0, m_queryLimit * sizeof(UINT64) };
+            void* readbackBufferMapping = nullptr;
+            if (FAILED(m_readbackBuffer->Map(0, &fullRange, &readbackBufferMapping)))
+            {
+                TracyD3D12Panic("failed to map timestamp buffer.", return nullptr);
+            }
+            UINT64* timestampBuffer = static_cast<UINT64*>(readbackBufferMapping);
+#if TRACY_D3D12_PERSISTENT_TIMESTAMP_BUFFER
+            TracyD3D12Assert( m_persistentTimestampBuffer == nullptr );
+            m_persistentTimestampBuffer = timestampBuffer;
+#endif
+            return timestampBuffer;
+        }
+
+        void UnmapTimestampBuffer(UINT64*)
+        {
+#if !TRACY_D3D12_PERSISTENT_TIMESTAMP_BUFFER
+            D3D12_RANGE fullRange { 0, m_queryLimit * sizeof(UINT64) };
+            m_readbackBuffer->Unmap(0, &fullRange);
+#endif
+        }
+
+        bool DeviceLost()
+        {
+            HRESULT status = m_device->GetDeviceRemovedReason();
+            return (status != S_OK);
         }
     };
 
     class D3D12ZoneScope
     {
         const bool m_active;
+#ifdef TRACY_ON_DEMAND
+        uint64_t m_connectionId = 0;
+#endif
         D3D12QueueCtx* m_ctx = nullptr;
         ID3D12GraphicsCommandList* m_cmdList = nullptr;
-        uint32_t m_queryId = 0;  // Used for tracking in nested zones.
+        uint32_t m_queryId = 0;
 
-        tracy_force_inline void WriteQueueItem(QueueItem* item, QueueType type, uint64_t srcLocation)
+        tracy_force_inline void WriteQueueItem(const SourceLocationData* srcLocation, int32_t callstackDepth, uint32_t sourceLine, const char* sourceFile, size_t sourceFileLen, const char* functionName, size_t functionNameLen, const char* zoneName, size_t zoneNameLen)
         {
-            MemWrite(&item->hdr.type, type);
-            MemWrite(&item->gpuZoneBegin.cpuTime, Profiler::GetTime());
-            MemWrite(&item->gpuZoneBegin.srcloc, srcLocation);
-            MemWrite(&item->gpuZoneBegin.thread, GetThreadHandle());
-            MemWrite(&item->gpuZoneBegin.queryId, static_cast<uint16_t>(m_queryId));
-            MemWrite(&item->gpuZoneBegin.context, m_ctx->GetId());
+            if (!m_active) return;
+
+            const bool captureCallstack = callstackDepth > 0 && has_callstack();
+            const bool transientZone = srcLocation == nullptr;
+            uint64_t srcLocationAddr = reinterpret_cast<uint64_t>( srcLocation );
+
+            QueueItem* item = nullptr;
+            QueueType itemType;
+            if( transientZone )
+            {
+                srcLocationAddr = Profiler::AllocSourceLocation( sourceLine, sourceFile, sourceFileLen, functionName, functionNameLen, zoneName, zoneNameLen);
+                if( captureCallstack )
+                {
+                    item = Profiler::QueueSerialCallstack( Callstack( callstackDepth ) );
+                    itemType = QueueType::GpuZoneBeginAllocSrcLocCallstackSerial;
+                }
+                else
+                {
+                    item = Profiler::QueueSerial();
+                    itemType = QueueType::GpuZoneBeginAllocSrcLocSerial;
+                }
+            }
+            else
+            {
+                if( captureCallstack )
+                {
+                    item = Profiler::QueueSerialCallstack( Callstack( callstackDepth ) );
+                    itemType = QueueType::GpuZoneBeginCallstackSerial;
+                }
+                else
+                {
+                    item = Profiler::QueueSerial();
+                    itemType = QueueType::GpuZoneBeginSerial;
+                }
+            }
+
+            MemWrite( &item->hdr.type, itemType );
+            MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
+            MemWrite( &item->gpuZoneBegin.srcloc, srcLocationAddr );
+            MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
+            MemWrite( &item->gpuZoneBegin.queryId, static_cast<uint16_t>( m_queryId ) );
+            MemWrite( &item->gpuZoneBegin.context, static_cast<uint8_t>(m_ctx->GetId()) );
             Profiler::QueueSerialFinish();
         }
 
         tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, ID3D12GraphicsCommandList* cmdList, bool active)
 #ifdef TRACY_ON_DEMAND
             : m_active(active&& GetProfiler().IsConnected())
+            , m_connectionId(GetProfiler().ConnectionId())
 #else
             : m_active(active)
 #endif
@@ -379,41 +633,25 @@ namespace tracy
         tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, ID3D12GraphicsCommandList* cmdList, const SourceLocationData* srcLocation, bool active)
             : D3D12ZoneScope(ctx, cmdList, active)
         {
-            if (!m_active) return;
-
-            auto* item = Profiler::QueueSerial();
-            WriteQueueItem(item, QueueType::GpuZoneBeginSerial, reinterpret_cast<uint64_t>(srcLocation));
+            WriteQueueItem(srcLocation, 0, 0, nullptr, 0, nullptr, 0, nullptr, 0 );
         }
 
         tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, ID3D12GraphicsCommandList* cmdList, const SourceLocationData* srcLocation, int32_t depth, bool active)
             : D3D12ZoneScope(ctx, cmdList, active)
         {
-            if (!m_active) return;
-
-            auto* item = Profiler::QueueSerialCallstack(Callstack(depth));
-            WriteQueueItem(item, QueueType::GpuZoneBeginCallstackSerial, reinterpret_cast<uint64_t>(srcLocation));
+            WriteQueueItem(srcLocation, depth, 0, nullptr, 0, nullptr, 0, nullptr, 0 );
         }
 
         tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, ID3D12GraphicsCommandList* cmdList, bool active)
             : D3D12ZoneScope(ctx, cmdList, active)
         {
-            if (!m_active) return;
-
-            const auto sourceLocation = Profiler::AllocSourceLocation(line, source, sourceSz, function, functionSz, name, nameSz);
-
-            auto* item = Profiler::QueueSerial();
-            WriteQueueItem(item, QueueType::GpuZoneBeginAllocSrcLocSerial, sourceLocation);
+            WriteQueueItem(nullptr, 0, line, source, sourceSz, function, functionSz, name, nameSz);
         }
 
         tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, ID3D12GraphicsCommandList* cmdList, int32_t depth, bool active)
             : D3D12ZoneScope(ctx, cmdList, active)
         {
-            if (!m_active) return;
-
-            const auto sourceLocation = Profiler::AllocSourceLocation(line, source, sourceSz, function, functionSz, name, nameSz);
-
-            auto* item = Profiler::QueueSerialCallstack(Callstack(depth));
-            WriteQueueItem(item, QueueType::GpuZoneBeginAllocSrcLocCallstackSerial, sourceLocation);
+            WriteQueueItem(nullptr, depth, line, source, sourceSz, function, functionSz, name, nameSz);
         }
 
         tracy_force_inline ~D3D12ZoneScope()
@@ -421,37 +659,54 @@ namespace tracy
             if (!m_active) return;
 
             const auto queryId = m_queryId + 1;  // Our end query slot is immediately after the begin slot.
+
+#ifdef TRACY_ON_DEMAND
+            if (GetProfiler().ConnectionId() == m_connectionId)
+            {
+#endif
+                auto* item = Profiler::QueueSerial();
+                MemWrite(&item->hdr.type, QueueType::GpuZoneEndSerial);
+                MemWrite(&item->gpuZoneEnd.cpuTime, Profiler::GetTime());
+                MemWrite(&item->gpuZoneEnd.thread, GetThreadHandle());
+                MemWrite(&item->gpuZoneEnd.queryId, static_cast<uint16_t>(queryId));
+                MemWrite( &item->gpuZoneEnd.context, static_cast<uint8_t>(m_ctx->GetId()) );
+                Profiler::QueueSerialFinish();
+#ifdef TRACY_ON_DEMAND
+            }
+#endif
+
             m_cmdList->EndQuery(m_ctx->m_queryHeap, D3D12_QUERY_TYPE_TIMESTAMP, queryId);
-
-            auto* item = Profiler::QueueSerial();
-            MemWrite(&item->hdr.type, QueueType::GpuZoneEndSerial);
-            MemWrite(&item->gpuZoneEnd.cpuTime, Profiler::GetTime());
-            MemWrite(&item->gpuZoneEnd.thread, GetThreadHandle());
-            MemWrite(&item->gpuZoneEnd.queryId, static_cast<uint16_t>(queryId));
-            MemWrite(&item->gpuZoneEnd.context, m_ctx->GetId());
-            Profiler::QueueSerialFinish();
-
+            // NOTE: can't quite move this ResolveQueryData() call to Collect()...
+            // If a command is instrumented, but the command list is never submitted
+            // for execution, we should not ask the GPU to resolve the corresponding
+            // queries (we'll get stale/garbage data if we do so)
             m_cmdList->ResolveQueryData(m_ctx->m_queryHeap, D3D12_QUERY_TYPE_TIMESTAMP, m_queryId, 2, m_ctx->m_readbackBuffer, m_queryId * sizeof(uint64_t));
         }
     };
+
+    static inline void DestroyD3D12Context(D3D12QueueCtx* ctx)
+    {
+        TracyD3D12Assert(ctx);
+        ctx->~D3D12QueueCtx();
+        tracy_free(ctx);
+    }
 
     static inline D3D12QueueCtx* CreateD3D12Context(ID3D12Device* device, ID3D12CommandQueue* queue)
     {
         auto* ctx = static_cast<D3D12QueueCtx*>(tracy_malloc(sizeof(D3D12QueueCtx)));
         new (ctx) D3D12QueueCtx{ device, queue };
-
         return ctx;
-    }
-
-    static inline void DestroyD3D12Context(D3D12QueueCtx* ctx)
-    {
-        ctx->~D3D12QueueCtx();
-        tracy_free(ctx);
     }
 
 }
 
 #undef TracyD3D12Panic
+#undef TracyD3D12Log
+#undef TracyD3D12Assert
+#undef TracyD3D12Break
+#undef TracyD3D12Debug
+#undef TRACY_D3D12_PERSISTENT_TIMESTAMP_BUFFER
+#undef TRACY_D3D12_DEBUG_LEVEL
 
 using TracyD3D12Ctx = tracy::D3D12QueueCtx*;
 
@@ -459,7 +714,7 @@ using TracyD3D12Ctx = tracy::D3D12QueueCtx*;
 #define TracyD3D12Destroy(ctx) tracy::DestroyD3D12Context(ctx);
 #define TracyD3D12ContextName(ctx, name, size) ctx->Name(name, size);
 
-#define TracyD3D12NewFrame(ctx) ctx->NewFrame();
+#define TracyD3D12NewFrame(ctx) ((void)(ctx))
 
 #define TracyD3D12UnnamedZone ___tracy_gpu_d3d12_zone
 #define TracyD3D12SrcLocSymbol TracyConcat(__tracy_d3d12_source_location,TracyLine)

--- a/D3D11Engine/include/tracy/public/tracy/TracyLua.hpp
+++ b/D3D11Engine/include/tracy/public/tracy/TracyLua.hpp
@@ -13,6 +13,7 @@ namespace tracy
 namespace detail
 {
 static inline int noop( lua_State* L ) { return 0; }
+static inline int zero( lua_State* L ) { lua_pushinteger( L, 0 ); return 1; }
 }
 
 static inline void LuaRegister( lua_State* L )
@@ -34,6 +35,10 @@ static inline void LuaRegister( lua_State* L )
     lua_setfield( L, -2, "ZoneName" );
     lua_pushcfunction( L, detail::noop );
     lua_setfield( L, -2, "Message" );
+    lua_pushcfunction( L, detail::zero );
+    lua_setfield( L, -2, "SectionEnter" );
+    lua_pushcfunction( L, detail::noop );
+    lua_setfield( L, -2, "SectionLeave" );
     lua_setglobal( L, "tracy" );
 }
 
@@ -108,6 +113,19 @@ static inline void LuaRemove( char* script )
                 memset( script, ' ', end - script );
                 script = end;
             }
+            else if( strncmp( script + 6, "SectionEnter(", 13 ) == 0 )
+            {
+                auto end = FindEnd( script + 19 );
+                *script = '0';
+                memset( script + 1, ' ', end - script - 1 );
+                script = end;
+            }
+            else if( strncmp( script + 6, "SectionLeave(", 13 ) == 0 )
+            {
+                auto end = FindEnd( script + 19 );
+                memset( script, ' ', end - script );
+                script = end;
+            }
             else
             {
                 script += 6;
@@ -126,9 +144,9 @@ static inline void LuaHook( lua_State* L, lua_Debug* ar ) {}
 
 #else
 
-#include <assert.h>
 #include <limits>
 
+#include "../common/TracyAssert.hpp"
 #include "../common/TracyColor.hpp"
 #include "../common/TracyAlign.hpp"
 #include "../common/TracyForceInline.hpp"
@@ -148,14 +166,18 @@ namespace detail
 static inline void LuaShortenSrc( char* dst, const char* src )
 {
     size_t l = std::min( (size_t)255, strlen( src ) );
-    memcpy( dst, src, l );
+    for( size_t i=0; i<l; i++ )
+    {
+        if( src[i] == '\n' ) dst[i] = ' ';
+        else dst[i] = src[i];
+    }
     dst[l] = 0;
 }
 
 #ifdef TRACY_HAS_CALLSTACK
 static tracy_force_inline void SendLuaCallstack( lua_State* L, uint32_t depth )
 {
-    assert( depth <= 64 );
+    TRACY_ASSERT( depth <= 64 );
     lua_Debug dbg[64];
     const char* func[64];
     uint32_t fsz[64];
@@ -182,14 +204,14 @@ static tracy_force_inline void SendLuaCallstack( lua_State* L, uint32_t depth )
     {
         const uint32_t line = dbg[i].currentline;
         memcpy( dst, &line, 4 ); dst += 4;
-        assert( fsz[i] <= (std::numeric_limits<uint16_t>::max)() );
+        TRACY_ASSERT( fsz[i] <= (std::numeric_limits<uint16_t>::max)() );
         memcpy( dst, fsz+i, 2 ); dst += 2;
         memcpy( dst, func[i], fsz[i] ); dst += fsz[i];
-        assert( ssz[i] <= (std::numeric_limits<uint16_t>::max)() );
+        TRACY_ASSERT( ssz[i] <= (std::numeric_limits<uint16_t>::max)() );
         memcpy( dst, ssz+i, 2 ); dst += 2;
         memcpy( dst, dbg[i].source, ssz[i] ), dst += ssz[i];
     }
-    assert( dst - ptr == spaceNeeded + 2 );
+    TRACY_ASSERT( dst - ptr == spaceNeeded + 2 );
 
     TracyQueuePrepare( QueueType::CallstackAlloc );
     MemWrite( &item->callstackAllocFat.ptr, (uint64_t)ptr );
@@ -206,11 +228,12 @@ static inline int LuaZoneBeginS( lua_State* L )
     if( !GetLuaZoneState().active ) return 0;
 #endif
 
-#ifdef TRACY_CALLSTACK
+#if defined TRACY_CALLSTACK && TRACY_CALLSTACK > 0
     const uint32_t depth = TRACY_CALLSTACK;
 #else
     const auto depth = uint32_t( lua_tointeger( L, 1 ) );
 #endif
+    TRACY_ASSERT( depth > 0 ); // Would crash later anyway, this is not allowed
     SendLuaCallstack( L, depth );
 
     lua_Debug dbg;
@@ -237,11 +260,12 @@ static inline int LuaZoneBeginNS( lua_State* L )
     if( !GetLuaZoneState().active ) return 0;
 #endif
 
-#ifdef TRACY_CALLSTACK
+#if defined TRACY_CALLSTACK && TRACY_CALLSTACK > 0
     const uint32_t depth = TRACY_CALLSTACK;
 #else
     const auto depth = uint32_t( lua_tointeger( L, 2 ) );
 #endif
+    TRACY_ASSERT( depth > 0 ); // Would crash later anyway, this is not allowed
     SendLuaCallstack( L, depth );
 
     lua_Debug dbg;
@@ -264,7 +288,7 @@ static inline int LuaZoneBeginNS( lua_State* L )
 
 static inline int LuaZoneBegin( lua_State* L )
 {
-#if defined TRACY_HAS_CALLSTACK && defined TRACY_CALLSTACK
+#if defined TRACY_HAS_CALLSTACK && defined TRACY_CALLSTACK && TRACY_CALLSTACK > 0
     return LuaZoneBeginS( L );
 #else
 #ifdef TRACY_ON_DEMAND
@@ -291,7 +315,7 @@ static inline int LuaZoneBegin( lua_State* L )
 
 static inline int LuaZoneBeginN( lua_State* L )
 {
-#if defined TRACY_HAS_CALLSTACK && defined TRACY_CALLSTACK
+#if defined TRACY_HAS_CALLSTACK && defined TRACY_CALLSTACK && TRACY_CALLSTACK > 0
     return LuaZoneBeginNS( L );
 #else
 #ifdef TRACY_ON_DEMAND
@@ -321,7 +345,7 @@ static inline int LuaZoneBeginN( lua_State* L )
 static inline int LuaZoneEnd( lua_State* L )
 {
 #ifdef TRACY_ON_DEMAND
-    assert( GetLuaZoneState().counter != 0 );
+    TRACY_ASSERT( GetLuaZoneState().counter != 0 );
     GetLuaZoneState().counter--;
     if( !GetLuaZoneState().active ) return 0;
     if( !GetProfiler().IsConnected() )
@@ -350,7 +374,7 @@ static inline int LuaZoneText( lua_State* L )
 
     auto txt = lua_tostring( L, 1 );
     const auto size = strlen( txt );
-    assert( size < (std::numeric_limits<uint16_t>::max)() );
+    TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
 
     auto ptr = (char*)tracy_malloc( size );
     memcpy( ptr, txt, size );
@@ -375,7 +399,7 @@ static inline int LuaZoneName( lua_State* L )
 
     auto txt = lua_tostring( L, 1 );
     const auto size = strlen( txt );
-    assert( size < (std::numeric_limits<uint16_t>::max)() );
+    TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
 
     auto ptr = (char*)tracy_malloc( size );
     memcpy( ptr, txt, size );
@@ -395,16 +419,67 @@ static inline int LuaMessage( lua_State* L )
 
     auto txt = lua_tostring( L, 1 );
     const auto size = strlen( txt );
-    assert( size < (std::numeric_limits<uint16_t>::max)() );
+    TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
 
     auto ptr = (char*)tracy_malloc( size );
     memcpy( ptr, txt, size );
 
+    TaggedUserlandAddress taggedPtr{ (uint64_t)ptr, MakeMessageMetadata( MessageSourceType::User, MessageSeverity::Info ) };
+
     TracyQueuePrepare( QueueType::Message );
     MemWrite( &item->messageFat.time, Profiler::GetTime() );
-    MemWrite( &item->messageFat.text, (uint64_t)ptr );
+    MemWrite( &item->messageFat.textAndMetadata, taggedPtr );
     MemWrite( &item->messageFat.size, (uint16_t)size );
     TracyQueueCommit( messageFatThread );
+    return 0;
+}
+
+static inline int LuaSectionEnter( lua_State* L )
+{
+    auto& profiler = GetProfiler();
+#ifdef TRACY_ON_DEMAND
+    if( !profiler.IsConnected() )
+    {
+        lua_pushinteger( L, 0 );
+        return 1;
+    }
+#endif
+
+    auto txt = lua_tostring( L, 1 );
+    const auto size = strlen( txt );
+    TRACY_ASSERT( size < (std::numeric_limits<uint16_t>::max)() );
+
+    uint16_t category = lua_isnumber( L, 2 ) ? lua_tointeger( L, 2 ) : 0;
+
+    auto ptr = (char*)tracy_malloc( size );
+    memcpy( ptr, txt, size );
+
+    const auto id = profiler.GetNextSectionId();
+    TracyLfqPrepare( QueueType::SectionEnter );
+    MemWrite( &item->sectionEnterFat.time, Profiler::GetTime() );
+    MemWrite( &item->sectionEnterFat.id, id );
+    MemWrite( &item->sectionEnterFat.category, category );
+    MemWrite( &item->sectionEnterFat.text, (uint64_t)ptr );
+    MemWrite( &item->sectionEnterFat.size, (uint16_t)size );
+    TracyLfqCommit;
+
+    lua_pushinteger( L, id );
+    return 1;
+}
+
+static inline int LuaSectionLeave( lua_State* L )
+{
+#ifdef TRACY_ON_DEMAND
+    if( !GetProfiler().IsConnected() ) return 0;
+#endif
+
+    const auto id = uint32_t( lua_tointeger( L, 1 ) );
+    if( id == 0 ) return 0;
+
+    TracyLfqPrepare( QueueType::SectionLeave );
+    MemWrite( &item->sectionLeave.time, Profiler::GetTime() );
+    MemWrite( &item->sectionLeave.id, id );
+    TracyLfqCommit;
     return 0;
 }
 
@@ -436,6 +511,10 @@ static inline void LuaRegister( lua_State* L )
     lua_setfield( L, -2, "ZoneName" );
     lua_pushcfunction( L, detail::LuaMessage );
     lua_setfield( L, -2, "Message" );
+    lua_pushcfunction( L, detail::LuaSectionEnter );
+    lua_setfield( L, -2, "SectionEnter" );
+    lua_pushcfunction( L, detail::LuaSectionLeave );
+    lua_setfield( L, -2, "SectionLeave" );
     lua_setglobal( L, "tracy" );
 }
 
@@ -464,7 +543,7 @@ static inline void LuaHook( lua_State* L, lua_Debug* ar )
     }
     else if (ar->event == LUA_HOOKRET) {
 #ifdef TRACY_ON_DEMAND
-        assert( GetLuaZoneState().counter != 0 );
+        TRACY_ASSERT( GetLuaZoneState().counter != 0 );
         GetLuaZoneState().counter--;
         if ( !GetLuaZoneState().active ) return;
         if ( !GetProfiler().IsConnected() )

--- a/D3D11Engine/include/tracy/public/tracy/TracyMetal.hmm
+++ b/D3D11Engine/include/tracy/public/tracy/TracyMetal.hmm
@@ -58,7 +58,6 @@ using TracyMetalCtx = void;
 #endif
 
 #include <atomic>
-#include <cassert>
 #include <cstdlib>
 
 #include "Tracy.hpp"
@@ -66,6 +65,7 @@ using TracyMetalCtx = void;
 #include "../client/TracyCallstack.hpp"
 #include "../common/TracyAlign.hpp"
 #include "../common/TracyAlloc.hpp"
+#include "../common/TracyAssert.hpp"
 
 // ok to import if in obj-c code
 #import <Metal/Metal.h>
@@ -125,11 +125,6 @@ public:
         ZoneScopedNC("tracy::MetalCtx::Create", Color::Red4);
         auto ctx = static_cast<MetalCtx*>(tracy_malloc(sizeof(MetalCtx)));
         new (ctx) MetalCtx(device);
-        if (ctx->m_contextId == 255)
-        {
-            TracyMetalPanic({assert(false);} return nullptr, "ERROR: unable to create context.");
-            Destroy(ctx);
-        }
         return ctx;
     }
 
@@ -147,7 +142,7 @@ public:
 
         auto* item = Profiler::QueueSerial();
         MemWrite( &item->hdr.type, QueueType::GpuContextName );
-        MemWrite( &item->gpuContextNameFat.context, m_contextId );
+        MemWrite( &item->gpuContextNameFat.context, static_cast<uint8_t>(m_contextId) );
         MemWrite( &item->gpuContextNameFat.ptr, (uint64_t)ptr );
         MemWrite( &item->gpuContextNameFat.size, len );
         SubmitQueueItem(item);
@@ -259,7 +254,7 @@ public:
             MemWrite(&item->hdr.type, QueueType::GpuTime);
             MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_start));
             MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k));
-            MemWrite(&item->gpuTime.context, m_contextId);
+            MemWrite(&item->gpuTime.context, static_cast<uint8_t>(m_contextId));
             Profiler::QueueSerialFinish();
             }
             {
@@ -267,7 +262,7 @@ public:
             MemWrite(&item->hdr.type, QueueType::GpuTime);
             MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_end));
             MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k+1));
-            MemWrite(&item->gpuTime.context, m_contextId);
+            MemWrite(&item->gpuTime.context, static_cast<uint8_t>(m_contextId));
             Profiler::QueueSerialFinish();
             }
             m_mostRecentTimestamp = (t_end > m_mostRecentTimestamp) ? t_end : m_mostRecentTimestamp;
@@ -302,11 +297,11 @@ private:
         
         if (m_device == nil)
         {
-            TracyMetalPanic({assert(false);} return, "device is nil.");
+            TracyMetalPanic({TRACY_ASSERT(false);} return, "device is nil.");
         }
         if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtStageBoundary])
         {
-            TracyMetalPanic({assert(false);} return, "ERROR: timestamp sampling at pipeline stage boundary is not supported.");
+            TracyMetalPanic({TRACY_ASSERT(false);} return, "ERROR: timestamp sampling at pipeline stage boundary is not supported.");
         }
         if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtDrawBoundary])
         {
@@ -342,7 +337,7 @@ private:
 
         float period = 1.0f;
         
-        m_contextId = GetGpuCtxCounter().fetch_add(1);
+        m_contextId = NextGpuContextId();
         
         auto* item = Profiler::QueueSerial();
         MemWrite(&item->hdr.type, QueueType::GpuNewContext);
@@ -350,7 +345,7 @@ private:
         MemWrite(&item->gpuNewContext.gpuTime, int64_t(gpuTimestamp));
         MemWrite(&item->gpuNewContext.thread, uint32_t(0)); // TODO: why not GetThreadHandle()?
         MemWrite(&item->gpuNewContext.period, period);
-        MemWrite(&item->gpuNewContext.context, m_contextId);
+        MemWrite(&item->gpuNewContext.context, static_cast<uint8_t>(m_contextId));
         //MemWrite(&item->gpuNewContext.flags, GpuContextCalibration);
         MemWrite(&item->gpuNewContext.flags, GpuContextFlags(0));
         MemWrite(&item->gpuNewContext.type, GpuContextType::Metal);
@@ -421,7 +416,7 @@ private:
         return Query{ buffer, idx };
     }
 
-    tracy_force_inline uint8_t GetContextId() const
+    tracy_force_inline int32_t GetContextId() const
     {
         return m_contextId;
     }
@@ -441,7 +436,7 @@ private:
         }
         if (timestampCounterSet == nil)
         {
-            TracyMetalPanic({assert(false);} return nil, "ERROR: timestamp counters are not supported on the platform.");
+            TracyMetalPanic({TRACY_ASSERT(false);} return nil, "ERROR: timestamp counters are not supported on the platform.");
         }
 
         MTLCounterSampleBufferDescriptor* sampleDescriptor = [[MTLCounterSampleBufferDescriptor alloc] init];
@@ -455,7 +450,7 @@ private:
         if (error != nil)
         {
             //NSLog(@"%@ | %@", error.localizedDescription, error.localizedFailureReason);
-            TracyMetalPanic({assert(false);} return nil,
+            TracyMetalPanic({TRACY_ASSERT(false);} return nil,
                 "ERROR: unable to create sample buffer for timestamp counters : %s | %s",
                 [error.localizedDescription cString], [error.localizedFailureReason cString]);
         }
@@ -463,7 +458,7 @@ private:
         return counterSampleBuffer;
     }
 
-    uint8_t m_contextId = 255;
+    int32_t m_contextId = InvalidGpuContextId;
 
     id<MTLDevice> m_device = nil;
     id<MTLCounterSampleBuffer> m_counterSampleBuffers [2] = {};
@@ -486,12 +481,13 @@ public:
     tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLComputePassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( is_active )
 #endif
     {
         if ( !m_active ) return;
-        if (desc == nil) TracyMetalPanic({assert(false);} return, "compute pass descriptor is nil.");
+        if (desc == nil) TracyMetalPanic({TRACY_ASSERT(false);} return, "compute pass descriptor is nil.");
         m_ctx = ctx;
 
         auto& query = m_query = ctx->NextQuery();
@@ -506,12 +502,13 @@ public:
     tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLBlitPassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( is_active )
 #endif
     {
         if ( !m_active ) return;
-        if (desc == nil) TracyMetalPanic({assert(false); }return, "blit pass descriptor is nil.");
+        if (desc == nil) TracyMetalPanic({TRACY_ASSERT(false); }return, "blit pass descriptor is nil.");
         m_ctx = ctx;
 
         auto& query = m_query = ctx->NextQuery();
@@ -526,12 +523,13 @@ public:
     tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLRenderPassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( is_active )
 #endif
     {
         if ( !m_active ) return;
-        if (desc == nil) TracyMetalPanic({assert(false);} return, "render pass descriptor is nil.");
+        if (desc == nil) TracyMetalPanic({TRACY_ASSERT(false);} return, "render pass descriptor is nil.");
         m_ctx = ctx;
 
         auto& query = m_query = ctx->NextQuery();
@@ -549,6 +547,7 @@ public:
     tracy_force_inline MetalZoneScope( MetalCtx* ctx, id<MTLComputeCommandEncoder> cmdEncoder, const SourceLocationData* srcloc, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( is_active )
 #endif
@@ -569,6 +568,9 @@ public:
     {
         if( !m_active ) return;
 
+#ifdef TRACY_ON_DEMAND
+        if( GetProfiler().ConnectionId() != m_connectionId ) return;
+#endif
         SubmitZoneEndGpu(m_ctx, m_query.idx + 1);
     }
     
@@ -576,6 +578,10 @@ public:
 
 private:
     const bool m_active;
+
+#ifdef TRACY_ON_DEMAND
+    uint64_t m_connectionId = 0;
+#endif
 
     MetalCtx* m_ctx;
 
@@ -591,7 +597,7 @@ private:
         MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
         MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
         MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
+        MemWrite( &item->gpuZoneBegin.context, static_cast<uint8_t>(ctx->GetContextId()) );
         Profiler::QueueSerialFinish();
         
         TracyMetalDebugMasked(1<<2, TracyAllocN((void*)(uintptr_t)queryId, 1, "TracyMetalGpuZone"));
@@ -604,7 +610,7 @@ private:
         MemWrite( &item->gpuZoneEnd.cpuTime, Profiler::GetTime() );
         MemWrite( &item->gpuZoneEnd.thread, GetThreadHandle() );
         MemWrite( &item->gpuZoneEnd.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneEnd.context, ctx->GetContextId() );
+        MemWrite( &item->gpuZoneEnd.context, static_cast<uint8_t>(ctx->GetContextId()) );
         Profiler::QueueSerialFinish();
         
         TracyMetalDebugMasked(1<<2, TracyAllocN((void*)(uintptr_t)queryId, 1, "TracyMetalGpuZone"));

--- a/D3D11Engine/include/tracy/public/tracy/TracyOpenCL.hpp
+++ b/D3D11Engine/include/tracy/public/tracy/TracyOpenCL.hpp
@@ -36,19 +36,19 @@ using TracyCLCtx = void*;
 #include <CL/cl.h>
 
 #include <atomic>
-#include <cassert>
 #include <sstream>
 
 #include "Tracy.hpp"
 #include "../client/TracyCallstack.hpp"
 #include "../client/TracyProfiler.hpp"
 #include "../common/TracyAlloc.hpp"
+#include "../common/TracyAssert.hpp"
 
 #define TRACY_CL_TO_STRING_INDIRECT(T) #T
 #define TRACY_CL_TO_STRING(T) TRACY_CL_TO_STRING_INDIRECT(T)
 #define TRACY_CL_ASSERT(p) if(!(p)) {                                                         \
     TracyMessageL( "TRACY_CL_ASSERT failed on " TracyFile ":" TRACY_CL_TO_STRING(TracyLine) );  \
-    assert(false && "TRACY_CL_ASSERT failed");                                                \
+    TRACY_ASSERT(false && "TRACY_CL_ASSERT failed");                                                \
 }
 #define TRACY_CL_CHECK_ERROR(err) if(err != CL_SUCCESS) {                    \
     std::ostringstream oss;                                                  \
@@ -56,7 +56,7 @@ using TracyCLCtx = void*;
         << ": error code " << err;                                           \
     auto msg = oss.str();                                                    \
     TracyMessage(msg.data(), msg.size());                                    \
-    assert(false && "TRACY_CL_CHECK_ERROR failed");                          \
+    TRACY_ASSERT(false && "TRACY_CL_CHECK_ERROR failed");                          \
 }
 
 namespace tracy {
@@ -76,15 +76,15 @@ namespace tracy {
     class OpenCLCtx
     {
     public:
-        enum { QueryCount = 64 * 1024 };
+        static constexpr size_t QueryCount = 64 * 1024;
 
         OpenCLCtx(cl_context context, cl_device_id device)
-            : m_contextId(GetGpuCtxCounter().fetch_add(1, std::memory_order_relaxed))
+            : m_contextId(NextGpuContextId())
             , m_head(0)
             , m_tail(0)
         {
             int64_t tcpu, tgpu;
-            TRACY_CL_ASSERT(m_contextId != 255);
+            TRACY_CL_ASSERT(m_contextId != InvalidGpuContextId);
 
             cl_int err = CL_SUCCESS;
             cl_command_queue queue = clCreateCommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &err);
@@ -113,8 +113,8 @@ namespace tracy {
             memset(&item->gpuNewContext.thread, 0, sizeof(item->gpuNewContext.thread));
             MemWrite(&item->gpuNewContext.period, 1.0f);
             MemWrite(&item->gpuNewContext.type, GpuContextType::OpenCL);
-            MemWrite(&item->gpuNewContext.context, (uint8_t) m_contextId);
-            MemWrite(&item->gpuNewContext.flags, (uint8_t)0);
+            MemWrite(&item->gpuNewContext.context, uint8_t(m_contextId));
+            MemWrite(&item->gpuNewContext.flags, GpuContextFlags(0));
 #ifdef TRACY_ON_DEMAND
             GetProfiler().DeferItem(*item);
 #endif
@@ -164,7 +164,7 @@ namespace tracy {
                     if (eventInfo.event == nullptr) {
                         TracyMessageL("A TracyCLZone must be paird with a TracyCLZoneSetEvent, check your code!");
                     }
-                    assert(false && "clGetEventInfo failed, maybe a TracyCLZone is not paired with TracyCLZoneSetEvent");
+                    TRACY_ASSERT(false && "clGetEventInfo failed, maybe a TracyCLZone is not paired with TracyCLZoneSetEvent");
                     continue;
                 }
                 if (eventStatus != CL_COMPLETE) return;
@@ -178,7 +178,7 @@ namespace tracy {
                 if (err == CL_PROFILING_INFO_NOT_AVAILABLE)
                 {
                     TracyMessageL("command queue is not created with CL_QUEUE_PROFILING_ENABLE flag, check your code!");
-                    assert(false && "command queue is not created with CL_QUEUE_PROFILING_ENABLE flag");
+                    TRACY_ASSERT(false && "command queue is not created with CL_QUEUE_PROFILING_ENABLE flag");
                 }
                 else
                     TRACY_CL_CHECK_ERROR(err);
@@ -187,9 +187,9 @@ namespace tracy {
 
                 auto item = Profiler::QueueSerial();
                 MemWrite(&item->hdr.type, QueueType::GpuTime);
-                MemWrite(&item->gpuTime.gpuTime, (int64_t)eventTimeStamp);
-                MemWrite(&item->gpuTime.queryId, (uint16_t)m_tail);
-                MemWrite(&item->gpuTime.context, m_contextId);
+                MemWrite(&item->gpuTime.gpuTime, int64_t(eventTimeStamp));
+                MemWrite(&item->gpuTime.queryId, uint16_t(m_tail));
+                MemWrite(&item->gpuTime.context, uint8_t(m_contextId));
                 Profiler::QueueSerialFinish();
 
                 if (eventInfo.phase == EventPhase::End)
@@ -200,7 +200,7 @@ namespace tracy {
             }
         }
 
-        tracy_force_inline uint8_t GetId() const
+        tracy_force_inline int32_t GetId() const
         {
             return m_contextId;
         }
@@ -222,7 +222,7 @@ namespace tracy {
 
     private:
 
-        unsigned int m_contextId;
+        int32_t m_contextId;
 
         EventInfo m_query[QueryCount];
         unsigned int m_head; // index at which a new event should be inserted
@@ -251,7 +251,7 @@ namespace tracy {
             MemWrite(&item->gpuZoneBegin.srcloc, (uint64_t)srcLoc);
             MemWrite(&item->gpuZoneBegin.thread, GetThreadHandle());
             MemWrite(&item->gpuZoneBegin.queryId, (uint16_t)m_beginQueryId);
-            MemWrite(&item->gpuZoneBegin.context, ctx->GetId());
+            MemWrite(&item->gpuZoneBegin.context, uint8_t(ctx->GetId()));
             Profiler::QueueSerialFinish();
         }
 
@@ -276,7 +276,7 @@ namespace tracy {
             MemWrite(&item->gpuZoneBegin.srcloc, (uint64_t)srcLoc);
             MemWrite(&item->gpuZoneBegin.thread, GetThreadHandle());
             MemWrite(&item->gpuZoneBegin.queryId, (uint16_t)m_beginQueryId);
-            MemWrite(&item->gpuZoneBegin.context, ctx->GetId());
+            MemWrite(&item->gpuZoneBegin.context, uint8_t(ctx->GetId()));
             Profiler::QueueSerialFinish();
         }
 
@@ -300,7 +300,7 @@ namespace tracy {
             MemWrite(&item->gpuZoneBegin.srcloc, srcloc);
             MemWrite(&item->gpuZoneBegin.thread, GetThreadHandle());
             MemWrite(&item->gpuZoneBegin.queryId, (uint16_t)m_beginQueryId);
-            MemWrite(&item->gpuZoneBegin.context, ctx->GetId());
+            MemWrite(&item->gpuZoneBegin.context, uint8_t(ctx->GetId()));
             Profiler::QueueSerialFinish();
         }
 
@@ -324,7 +324,7 @@ namespace tracy {
             MemWrite(&item->gpuZoneBegin.srcloc, srcloc);
             MemWrite(&item->gpuZoneBegin.thread, GetThreadHandle());
             MemWrite(&item->gpuZoneBegin.queryId, (uint16_t)m_beginQueryId);
-            MemWrite(&item->gpuZoneBegin.context, ctx->GetId());
+            MemWrite(&item->gpuZoneBegin.context, uint8_t(ctx->GetId()));
             Profiler::QueueSerialFinish();
         }
 
@@ -346,7 +346,7 @@ namespace tracy {
             MemWrite(&item->gpuZoneEnd.cpuTime, Profiler::GetTime());
             MemWrite(&item->gpuZoneEnd.thread, GetThreadHandle());
             MemWrite(&item->gpuZoneEnd.queryId, (uint16_t)queryId);
-            MemWrite(&item->gpuZoneEnd.context, m_ctx->GetId());
+            MemWrite(&item->gpuZoneEnd.context, uint8_t(m_ctx->GetId()));
             Profiler::QueueSerialFinish();
         }
 

--- a/D3D11Engine/include/tracy/public/tracy/TracyOpenGL.hpp
+++ b/D3D11Engine/include/tracy/public/tracy/TracyOpenGL.hpp
@@ -1,7 +1,12 @@
 #ifndef __TRACYOPENGL_HPP__
 #define __TRACYOPENGL_HPP__
 
-#if !defined TRACY_ENABLE || defined __APPLE__
+#ifdef __APPLE__
+#define TRACY_OPENGL_DISABLE
+#warning "OpenGL timestamps are unreliable on Apple devices that still run OpenGL."
+#endif
+
+#if !defined TRACY_ENABLE || defined TRACY_OPENGL_DISABLE
 
 #define TracyGpuContext
 #define TracyGpuContextName(x,y)
@@ -32,21 +37,39 @@ public:
 #else
 
 #include <atomic>
-#include <assert.h>
 #include <stdlib.h>
+#ifdef TRACY_OPENGL_AUTO_CALIBRATION
+#  include <chrono>
+#endif
 
 #include "Tracy.hpp"
 #include "../client/TracyProfiler.hpp"
 #include "../client/TracyCallstack.hpp"
 #include "../common/TracyAlign.hpp"
 #include "../common/TracyAlloc.hpp"
+#include "../common/TracyAssert.hpp"
 
 #if !defined GL_TIMESTAMP && defined GL_TIMESTAMP_EXT
 #  define GL_TIMESTAMP GL_TIMESTAMP_EXT
 #  define GL_QUERY_COUNTER_BITS GL_QUERY_COUNTER_BITS_EXT
+#  define GL_QUERY_RESULT GL_QUERY_RESULT_EXT
+#  define GL_QUERY_RESULT_AVAILABLE GL_QUERY_RESULT_AVAILABLE_EXT
+#  define glGenQueries glGenQueriesEXT
+#  define glGetQueryiv glGetQueryivEXT
 #  define glGetQueryObjectiv glGetQueryObjectivEXT
 #  define glGetQueryObjectui64v glGetQueryObjectui64vEXT
+#  define glGetInteger64v glGetInteger64vEXT
 #  define glQueryCounter glQueryCounterEXT
+#endif
+
+#ifndef GL_MAJOR_VERSION
+#  define GL_MAJOR_VERSION 0x821B
+#endif
+#ifndef GL_NUM_EXTENSIONS
+#  define GL_NUM_EXTENSIONS 0x821D
+#endif
+#ifndef GL_QUERY_RESULT_NO_WAIT
+#  define GL_QUERY_RESULT_NO_WAIT 0x9194
 #endif
 
 #define TracyGpuContext tracy::GetGpuCtx().ptr = (tracy::GpuCtx*)tracy::tracy_malloc( sizeof( tracy::GpuCtx ) ); new(tracy::GetGpuCtx().ptr) tracy::GpuCtx;
@@ -87,24 +110,57 @@ class GpuCtx
 {
     friend class GpuCtxScope;
 
-    enum { QueryCount = 64 * 1024 };
+    static constexpr size_t QueryCount = 64 * 1024;
 
 public:
     GpuCtx()
-        : m_context( GetGpuCtxCounter().fetch_add( 1, std::memory_order_relaxed ) )
+        : m_context( NextGpuContextId() )
         , m_head( 0 )
         , m_tail( 0 )
+        , m_supportsQueryBufferObject( false )
     {
-        assert( m_context != 255 );
+        ZoneScopedC( Color::Red4 );
 
-        glGenQueries( QueryCount, m_query );
+        TRACY_ASSERT( m_context != InvalidGpuContextId );
+
+        if( !CheckFeature( "GL_ARB_timer_query" ) && !CheckFeature( "GL_EXT_disjoint_timer_query" ) )
+        {
+            Profiler::LogString( MessageSourceType::Tracy, MessageSeverity::Warning, Color::Tomato, 0,
+                    "OpenGL context does not support timer queries." );
+        }
+
+        // check for GL_QUERY_RESULT_NO_WAIT support
+        m_supportsQueryBufferObject = CheckFeature( "GL_ARB_query_buffer_object" );
+        if( !m_supportsQueryBufferObject )
+        {
+            Profiler::LogString( MessageSourceType::Tracy, MessageSeverity::Info, 0, 0,
+                    "OpenGL context does not support GL_ARB_query_buffer_object." );
+        }
+
+        GLint bits;
+        glGetQueryiv( GL_TIMESTAMP, GL_QUERY_COUNTER_BITS, &bits );
+        if( bits == 0 )
+        {
+            // all timestamp queries would resolve to 0 (and produce 0ns GPU zones).
+            // (this is the case for many TBDR GPUs, including Apple Silicon)
+            Profiler::LogString( MessageSourceType::Tracy, MessageSeverity::Warning, Color::Tomato, 0,
+                "OpenGL driver does not implement GL_TIMESTAMP precision." );
+        }
+        TRACY_ASSERT( bits > 0 );
 
         int64_t tgpu;
         glGetInteger64v( GL_TIMESTAMP, &tgpu );
         int64_t tcpu = Profiler::GetTime();
 
-        GLint bits;
-        glGetQueryiv( GL_TIMESTAMP, GL_QUERY_COUNTER_BITS, &bits );
+#ifdef TRACY_OPENGL_AUTO_CALIBRATION
+        // The anchor above is never refreshed; advertise calibration and emit periodic
+        // GpuCalibration events to correct CPU/GPU drift (see Recalibrate). Opt-in,
+        // because Recalibrate() calls glGetInteger64v( GL_TIMESTAMP ), which forces a
+        // CPU/GPU sync.
+        m_prevCalibration = GetHostTimeNs();
+#endif
+
+        glGenQueries( QueryCount, m_query );
 
         const float period = 1.f;
         const auto thread = GetThreadHandle();
@@ -113,8 +169,12 @@ public:
         MemWrite( &item->gpuNewContext.gpuTime, tgpu );
         MemWrite( &item->gpuNewContext.thread, thread );
         MemWrite( &item->gpuNewContext.period, period );
-        MemWrite( &item->gpuNewContext.context, m_context );
-        MemWrite( &item->gpuNewContext.flags, uint8_t( 0 ) );
+        MemWrite( &item->gpuNewContext.context, uint8_t( m_context ) );
+#ifdef TRACY_OPENGL_AUTO_CALIBRATION
+        MemWrite( &item->gpuNewContext.flags, GpuContextFlags( GpuContextCalibration ) );
+#else
+        MemWrite( &item->gpuNewContext.flags, GpuContextFlags( 0 ) );
+#endif
         MemWrite( &item->gpuNewContext.type, GpuContextType::OpenGl );
 
 #ifdef TRACY_ON_DEMAND
@@ -130,7 +190,7 @@ public:
         memcpy( ptr, name, len );
 
         TracyLfqPrepare( QueueType::GpuContextName );
-        MemWrite( &item->gpuContextNameFat.context, m_context );
+        MemWrite( &item->gpuContextNameFat.context, uint8_t( m_context ) );
         MemWrite( &item->gpuContextNameFat.ptr, (uint64_t)ptr );
         MemWrite( &item->gpuContextNameFat.size, len );
 #ifdef TRACY_ON_DEMAND
@@ -143,8 +203,6 @@ public:
     {
         ZoneScopedC( Color::Red4 );
 
-        if( m_tail == m_head ) return;
-
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() )
         {
@@ -153,19 +211,23 @@ public:
         }
 #endif
 
+#ifdef TRACY_OPENGL_AUTO_CALIBRATION
+        // Before the drain's early-returns, so it runs even on frames with no
+        // completed queries.
+        Recalibrate();
+#endif
+
+        if( m_tail == m_head ) return;
+
         while( m_tail != m_head )
         {
-            GLint available;
-            glGetQueryObjectiv( m_query[m_tail], GL_QUERY_RESULT_AVAILABLE, &available );
-            if( !available ) return;
-
             uint64_t time;
-            glGetQueryObjectui64v( m_query[m_tail], GL_QUERY_RESULT, &time );
+            if( !GetTimestamp(time, m_tail) ) return;
 
             TracyLfqPrepare( QueueType::GpuTime );
             MemWrite( &item->gpuTime.gpuTime, (int64_t)time );
             MemWrite( &item->gpuTime.queryId, (uint16_t)m_tail );
-            MemWrite( &item->gpuTime.context, m_context );
+            MemWrite( &item->gpuTime.context, uint8_t( m_context ) );
             TracyLfqCommit;
 
             m_tail = ( m_tail + 1 ) % QueryCount;
@@ -173,11 +235,92 @@ public:
     }
 
 private:
+    // Returns whether the driver advertises a single extension (full GL_-prefixed token).
+    static bool CheckFeature( const char* feature )
+    {
+        GLint major = 0;
+        glGetIntegerv( GL_MAJOR_VERSION, &major );
+        if( glGetError() != GL_NO_ERROR ) major = 0;   // pre-3.0: enum not supported
+
+#if defined(GL_VERSION_3_0) || defined(GL_ES_VERSION_3_0)
+        // GL 3 onwards: glGetStringi
+        if( major >= 3 )
+        {
+            GLint numExt = 0;
+            glGetIntegerv( GL_NUM_EXTENSIONS, &numExt );
+            for( GLint i = 0; i < numExt; i++ )
+            {
+                auto ext = (const char*)glGetStringi( GL_EXTENSIONS, i );
+                if( ext && strcmp( ext, feature ) == 0 ) return true;
+            }
+            return false;
+        }
+#endif
+
+        // pre GL3 fallback:
+        auto exts = (const char*)glGetString( GL_EXTENSIONS );
+        return exts && strstr( exts, feature ) != nullptr;
+    }
+
+    tracy_force_inline bool GetTimestamp( uint64_t& timestamp, unsigned int queryId )
+    {
+        if( m_supportsQueryBufferObject )
+        {
+            constexpr uint64_t sentinel = ~uint64_t(0);
+            uint64_t time = sentinel;
+            glGetQueryObjectui64v( m_query[queryId], GL_QUERY_RESULT_NO_WAIT, &time );
+            if ( time == sentinel ) return false;
+            timestamp = time;
+        }
+        else
+        {
+            GLint available;
+            glGetQueryObjectiv( m_query[queryId], GL_QUERY_RESULT_AVAILABLE, &available );
+            if( available == GL_FALSE ) return false;
+            uint64_t time;
+            glGetQueryObjectui64v( m_query[queryId], GL_QUERY_RESULT, &time );
+            timestamp = time;
+        }
+        return true;
+    }
+
+#ifdef TRACY_OPENGL_AUTO_CALIBRATION
+    // Monotonic host ns for the inter-calibration interval (cpuDelta), kept
+    // separate from Profiler::GetTime() as in the D3D12/Vulkan backends.
+    static tracy_force_inline int64_t GetHostTimeNs()
+    {
+        return std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch() ).count();
+    }
+
+    // OpenGL has no atomic CPU+GPU timestamp query, so sample back-to-back; the
+    // gap is negligible against the recalibration interval below. Note this forces
+    // a CPU/GPU sync, which is why the whole path is opt-in (TRACY_OPENGL_AUTO_CALIBRATION).
+    tracy_force_inline void Recalibrate()
+    {
+        const int64_t hostNow = GetHostTimeNs();
+        const int64_t delta = hostNow - m_prevCalibration;
+        if( delta < 1000ll * 1000 * 1000 ) return; // throttle: ~once per second
+
+        int64_t tgpu;
+        glGetInteger64v( GL_TIMESTAMP, &tgpu );
+        const int64_t refCpu = Profiler::GetTime();
+        m_prevCalibration = hostNow;
+
+        TracyLfqPrepare( QueueType::GpuCalibration );
+        MemWrite( &item->gpuCalibration.gpuTime, tgpu );
+        MemWrite( &item->gpuCalibration.cpuTime, refCpu );
+        MemWrite( &item->gpuCalibration.cpuDelta, delta );
+        MemWrite( &item->gpuCalibration.context, uint8_t( m_context ) );
+        TracyLfqCommit;
+    }
+#endif
+
     tracy_force_inline unsigned int NextQueryId()
     {
         const auto id = m_head;
         m_head = ( m_head + 1 ) % QueryCount;
-        assert( m_head != m_tail );
+        TRACY_ASSERT( m_head != m_tail );
         return id;
     }
 
@@ -186,16 +329,22 @@ private:
         return m_query[id];
     }
 
-    tracy_force_inline uint8_t GetId() const
+    tracy_force_inline int32_t GetId() const
     {
         return m_context;
     }
 
     unsigned int m_query[QueryCount];
-    uint8_t m_context;
+    int32_t m_context;
 
     unsigned int m_head;
     unsigned int m_tail;
+
+#ifdef TRACY_OPENGL_AUTO_CALIBRATION
+    int64_t m_prevCalibration; // host-ns timestamp of the last emitted calibration
+#endif
+
+    bool m_supportsQueryBufferObject;
 };
 
 class GpuCtxScope
@@ -204,6 +353,7 @@ public:
     tracy_force_inline GpuCtxScope( const SourceLocationData* srcloc, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( is_active )
 #endif
@@ -217,7 +367,7 @@ public:
         MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
         memset( &item->gpuZoneBegin.thread, 0, sizeof( item->gpuZoneBegin.thread ) );
         MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, GetGpuCtx().ptr->GetId() );
+        MemWrite( &item->gpuZoneBegin.context, uint8_t( GetGpuCtx().ptr->GetId() ) );
         MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
         TracyLfqCommit;
     }
@@ -225,6 +375,7 @@ public:
     tracy_force_inline GpuCtxScope( const SourceLocationData* srcloc, int32_t depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( is_active )
 #endif
@@ -244,7 +395,7 @@ public:
 #endif
         MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
         MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, GetGpuCtx().ptr->GetId() );
+        MemWrite( &item->gpuZoneBegin.context, uint8_t( GetGpuCtx().ptr->GetId() ) );
         MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
         TracyLfqCommit;
     }
@@ -252,6 +403,7 @@ public:
     tracy_force_inline GpuCtxScope( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( is_active )
 #endif
@@ -266,7 +418,7 @@ public:
         MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
         memset( &item->gpuZoneBegin.thread, 0, sizeof( item->gpuZoneBegin.thread ) );
         MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, GetGpuCtx().ptr->GetId() );
+        MemWrite( &item->gpuZoneBegin.context, uint8_t( GetGpuCtx().ptr->GetId() ) );
         MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
         TracyLfqCommit;
     }
@@ -274,6 +426,7 @@ public:
     tracy_force_inline GpuCtxScope( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int32_t depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( is_active )
 #endif
@@ -294,7 +447,7 @@ public:
         const auto srcloc = Profiler::AllocSourceLocation( line, source, sourceSz, function, functionSz, name, nameSz );
         MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
         MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, GetGpuCtx().ptr->GetId() );
+        MemWrite( &item->gpuZoneBegin.context, uint8_t( GetGpuCtx().ptr->GetId() ) );
         MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
         TracyLfqCommit;
     }
@@ -306,16 +459,23 @@ public:
         const auto queryId = GetGpuCtx().ptr->NextQueryId();
         glQueryCounter( GetGpuCtx().ptr->TranslateOpenGlQueryId( queryId ), GL_TIMESTAMP );
 
+#ifdef TRACY_ON_DEMAND
+        if( GetProfiler().ConnectionId() != m_connectionId ) return;
+#endif
         TracyLfqPrepare( QueueType::GpuZoneEnd );
         MemWrite( &item->gpuZoneEnd.cpuTime, Profiler::GetTime() );
         memset( &item->gpuZoneEnd.thread, 0, sizeof( item->gpuZoneEnd.thread ) );
         MemWrite( &item->gpuZoneEnd.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneEnd.context, GetGpuCtx().ptr->GetId() );
+        MemWrite( &item->gpuZoneEnd.context, uint8_t( GetGpuCtx().ptr->GetId() ) );
         TracyLfqCommit;
     }
 
 private:
     const bool m_active;
+
+#ifdef TRACY_ON_DEMAND
+    uint64_t m_connectionId = 0;
+#endif
 };
 
 }

--- a/D3D11Engine/include/tracy/public/tracy/TracyVulkan.hpp
+++ b/D3D11Engine/include/tracy/public/tracy/TracyVulkan.hpp
@@ -37,11 +37,11 @@ using TracyVkCtx = void*;
 #  error "You must include Vulkan headers before including TracyVulkan.hpp"
 #endif
 
-#include <assert.h>
 #include <stdlib.h>
 #include "Tracy.hpp"
 #include "../client/TracyProfiler.hpp"
 #include "../client/TracyCallstack.hpp"
+#include "../common/TracyAssert.hpp"
 
 #include <atomic>
 
@@ -91,7 +91,11 @@ class VkCtx
 {
     friend class VkCtxScope;
 
-    enum { QueryCount = 64 * 1024 };
+#if !defined __APPLE__
+    static constexpr size_t QueryCount = 64 * 1024;
+#else
+    static constexpr size_t QueryCount = 4 * 1024;
+#endif
 
 public:
 #if defined TRACY_VK_USE_SYMBOL_TABLE
@@ -101,7 +105,7 @@ public:
 #endif
         : m_device( device )
         , m_timeDomain( VK_TIME_DOMAIN_DEVICE_EXT )
-        , m_context( GetGpuCtxCounter().fetch_add( 1, std::memory_order_relaxed ) )
+        , m_context( NextGpuContextId() )
         , m_head( 0 )
         , m_tail( 0 )
         , m_oldCnt( 0 )
@@ -110,7 +114,7 @@ public:
         , m_vkGetCalibratedTimestampsEXT( vkGetCalibratedTimestampsEXT )
 #endif
     {
-        assert( m_context != 255 );
+        TRACY_ASSERT( m_context != InvalidGpuContextId );
 
 #if defined TRACY_VK_USE_SYMBOL_TABLE
         PopulateSymbolTable(instance, instanceProcAddr, deviceProcAddr);
@@ -164,7 +168,7 @@ public:
         else
         {
             FindCalibratedTimestampDeviation();
-            Calibrate( device, m_prevCalibration, tgpu );
+            Calibrate( m_prevCalibration, tgpu );
             tcpu = Profiler::GetTime();
         }
 
@@ -186,7 +190,7 @@ public:
 #endif
         : m_device( device )
         , m_timeDomain( VK_TIME_DOMAIN_DEVICE_EXT )
-        , m_context( GetGpuCtxCounter().fetch_add(1, std::memory_order_relaxed) )
+        , m_context( NextGpuContextId() )
         , m_head( 0 )
         , m_tail( 0 )
         , m_oldCnt( 0 )
@@ -195,23 +199,23 @@ public:
         , m_vkGetCalibratedTimestampsEXT( vkGetCalibratedTimestampsEXT )
 #endif
     {
-        assert( m_context != 255);
+        TRACY_ASSERT( m_context != InvalidGpuContextId);
 
 #if defined TRACY_VK_USE_SYMBOL_TABLE
         PopulateSymbolTable(instance, instanceProcAddr, deviceProcAddr);
         m_vkGetCalibratedTimestampsEXT = m_symbols.vkGetCalibratedTimestampsEXT;
 #endif
 
-        assert( VK_FUNCTION_WRAPPER( vkResetQueryPool ) != nullptr );
-        assert( VK_FUNCTION_WRAPPER( vkGetPhysicalDeviceCalibrateableTimeDomainsEXT ) != nullptr );
-        assert( VK_FUNCTION_WRAPPER( vkGetCalibratedTimestampsEXT ) != nullptr );
+        TRACY_ASSERT( VK_FUNCTION_WRAPPER( vkResetQueryPool ) != nullptr );
+        TRACY_ASSERT( VK_FUNCTION_WRAPPER( vkGetPhysicalDeviceCalibrateableTimeDomainsEXT ) != nullptr );
+        TRACY_ASSERT( VK_FUNCTION_WRAPPER( vkGetCalibratedTimestampsEXT ) != nullptr );
 
         FindAvailableTimeDomains( physdev, VK_FUNCTION_WRAPPER( vkGetPhysicalDeviceCalibrateableTimeDomainsEXT ) );
 
         // We require a host time domain to be available to properly calibrate.
         FindCalibratedTimestampDeviation();
         int64_t tgpu;
-        Calibrate( device, m_prevCalibration, tgpu );
+        Calibrate( m_prevCalibration, tgpu );
         int64_t tcpu = Profiler::GetTime();
 
         CreateQueryPool();
@@ -238,7 +242,7 @@ public:
 
         auto item = Profiler::QueueSerial();
         MemWrite( &item->hdr.type, QueueType::GpuContextName );
-        MemWrite( &item->gpuContextNameFat.context, m_context );
+        MemWrite( &item->gpuContextNameFat.context, uint8_t( m_context ) );
         MemWrite( &item->gpuContextNameFat.ptr, (uint64_t)ptr );
         MemWrite( &item->gpuContextNameFat.size, len );
 #ifdef TRACY_ON_DEMAND
@@ -263,11 +267,11 @@ public:
             m_tail = head;
             m_oldCnt = 0;
             int64_t tgpu;
-            if( m_timeDomain != VK_TIME_DOMAIN_DEVICE_EXT ) Calibrate( m_device, m_prevCalibration, tgpu );
+            if( m_timeDomain != VK_TIME_DOMAIN_DEVICE_EXT ) Calibrate( m_prevCalibration, tgpu, 10 );
             return;
         }
 #endif
-        assert( head > m_tail );
+        TRACY_ASSERT( head > m_tail );
 
         const unsigned int wrappedTail = (unsigned int)( m_tail % m_queryCount );
 
@@ -280,7 +284,7 @@ public:
         else
         {
             cnt = (unsigned int)( head - m_tail );
-            assert( cnt <= m_queryCount );
+            TRACY_ASSERT( cnt <= m_queryCount );
             if( wrappedTail + cnt > m_queryCount )
             {
                 cnt = m_queryCount - wrappedTail;
@@ -305,14 +309,14 @@ public:
             MemWrite( &item->hdr.type, QueueType::GpuTime );
             MemWrite( &item->gpuTime.gpuTime, m_res[idx * 2] );
             MemWrite( &item->gpuTime.queryId, uint16_t( wrappedTail + idx ) );
-            MemWrite( &item->gpuTime.context, m_context );
+            MemWrite( &item->gpuTime.context, uint8_t( m_context ) );
             Profiler::QueueSerialFinish();
         }
 
         if( m_timeDomain != VK_TIME_DOMAIN_DEVICE_EXT )
         {
-            int64_t tgpu, tcpu;
-            Calibrate( m_device, tcpu, tgpu );
+            int64_t tgpu, tcpu = m_prevCalibration;
+            Calibrate( tcpu, tgpu, 10 );
             const auto refCpu = Profiler::GetTime();
             const auto delta = tcpu - m_prevCalibration;
             if( delta > 0 )
@@ -323,7 +327,7 @@ public:
                 MemWrite( &item->gpuCalibration.gpuTime, tgpu );
                 MemWrite( &item->gpuCalibration.cpuTime, refCpu );
                 MemWrite( &item->gpuCalibration.cpuDelta, delta );
-                MemWrite( &item->gpuCalibration.context, m_context );
+                MemWrite( &item->gpuCalibration.context, uint8_t( m_context ) );
                 Profiler::QueueSerialFinish();
             }
         }
@@ -341,7 +345,7 @@ public:
         return id % m_queryCount;
     }
 
-    tracy_force_inline uint8_t GetId() const
+    tracy_force_inline int32_t GetId() const
     {
         return m_context;
     }
@@ -352,30 +356,49 @@ public:
     }
 
 private:
-    tracy_force_inline void Calibrate( VkDevice device, int64_t& tCpu, int64_t& tGpu )
+    tracy_force_inline int64_t VulkanTimeToPlatformTime(uint64_t tCpu)
     {
-        assert( m_timeDomain != VK_TIME_DOMAIN_DEVICE_EXT );
+#if defined _WIN32
+        return tCpu * m_qpcToNs;
+#elif defined __linux__ && defined CLOCK_MONOTONIC_RAW
+        return tCpu;
+#else
+        TRACY_ASSERT( false );
+        return 0;
+#endif
+    }
+
+    tracy_force_inline bool GetCalibratedTimestamps( int64_t& tCpu, int64_t& tGpu, uint64_t& tDeviation )
+    {
+        TRACY_ASSERT( m_device );
+        TRACY_ASSERT( m_timeDomain != VK_TIME_DOMAIN_DEVICE_EXT );
         VkCalibratedTimestampInfoEXT spec[2] = {
             { VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT, nullptr, VK_TIME_DOMAIN_DEVICE_EXT },
             { VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT, nullptr, m_timeDomain },
         };
         uint64_t ts[2];
         uint64_t deviation;
-        do
-        {
-            m_vkGetCalibratedTimestampsEXT( device, 2, spec, ts, &deviation );
-        }
-        while( deviation > m_deviation );
+        VkResult result = m_vkGetCalibratedTimestampsEXT( m_device, 2, spec, ts, &deviation );
+        if ( result != VK_SUCCESS ) return false;
+        tGpu = ts[0];
+        tCpu = VulkanTimeToPlatformTime(ts[1]);
+        tDeviation = deviation;
+        return true;
+    }
 
-#if defined _WIN32
-        tGpu = ts[0];
-        tCpu = ts[1] * m_qpcToNs;
-#elif defined __linux__ && defined CLOCK_MONOTONIC_RAW
-        tGpu = ts[0];
-        tCpu = ts[1];
-#else
-        assert( false );
-#endif
+    tracy_force_inline bool Calibrate( int64_t& tCpu, int64_t& tGpu, uint64_t maxSamples = ~uint64_t(0) )
+    {
+        for ( uint64_t i = 0; i < maxSamples; ++i )
+        {
+            int64_t cpu, gpu;
+            uint64_t deviation;
+            if( !GetCalibratedTimestamps( cpu, gpu, deviation ) ) continue;
+            if( deviation > m_deviation ) continue;
+            tCpu = cpu;
+            tGpu = gpu;
+            return true;
+        }
+        return false;
     }
 
     tracy_force_inline void CreateQueryPool()
@@ -414,28 +437,25 @@ private:
 
     tracy_force_inline void FindCalibratedTimestampDeviation()
     {
-        assert( m_timeDomain != VK_TIME_DOMAIN_DEVICE_EXT );
+#if defined _WIN32
+        m_qpcToNs = int64_t( 1000000000. / GetFrequencyQpc() );
+#endif
+
         constexpr size_t NumProbes = 32;
-        VkCalibratedTimestampInfoEXT spec[2] = {
-            { VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT, nullptr, VK_TIME_DOMAIN_DEVICE_EXT },
-            { VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT, nullptr, m_timeDomain },
-        };
-        uint64_t ts[2];
         uint64_t deviation[NumProbes];
         for( size_t i=0; i<NumProbes; i++ ) {
-            m_vkGetCalibratedTimestampsEXT( m_device, 2, spec, ts, deviation + i );
+            int64_t cpu, gpu;
+            deviation[i] = ~uint64_t(0);
+            GetCalibratedTimestamps( cpu, gpu, deviation[i] );
         }
+
         uint64_t minDeviation = deviation[0];
         for( size_t i=1; i<NumProbes; i++ ) {
             if ( minDeviation > deviation[i] ) {
                 minDeviation = deviation[i];
             }
         }
-        m_deviation = minDeviation * 3 / 2;
-
-#if defined _WIN32
-        m_qpcToNs = int64_t( 1000000000. / GetFrequencyQpc() );
-#endif
+        m_deviation = minDeviation * 3 / 2; // i.e., 1.5x minDeviation
     }
 
     tracy_force_inline void WriteInitialItem( VkPhysicalDevice physdev, int64_t tcpu, int64_t tgpu )
@@ -453,8 +473,8 @@ private:
         MemWrite( &item->gpuNewContext.gpuTime, tgpu );
         memset( &item->gpuNewContext.thread, 0, sizeof( item->gpuNewContext.thread ) );
         MemWrite( &item->gpuNewContext.period, period );
-        MemWrite( &item->gpuNewContext.context, m_context );
-        MemWrite( &item->gpuNewContext.flags, flags );
+        MemWrite( &item->gpuNewContext.context, uint8_t( m_context ) );
+        MemWrite( &item->gpuNewContext.flags, GpuContextFlags( flags ) );
         MemWrite( &item->gpuNewContext.type, GpuContextType::Vulkan );
 
 #ifdef TRACY_ON_DEMAND
@@ -497,7 +517,7 @@ private:
     int64_t m_qpcToNs;
 #endif
     int64_t m_prevCalibration;
-    uint8_t m_context;
+    int32_t m_context;
 
     std::atomic<uint64_t> m_head;
     uint64_t m_tail;
@@ -515,6 +535,7 @@ public:
     tracy_force_inline VkCtxScope( VkCtx* ctx, const SourceLocationData* srcloc, VkCommandBuffer cmdbuf, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( is_active )
 #endif
@@ -532,13 +553,14 @@ public:
         MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
         MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
         MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, ctx->GetId() );
+        MemWrite( &item->gpuZoneBegin.context, uint8_t( ctx->GetId() ) );
         Profiler::QueueSerialFinish();
     }
 
     tracy_force_inline VkCtxScope( VkCtx* ctx, const SourceLocationData* srcloc, VkCommandBuffer cmdbuf, int32_t depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( is_active )
 #endif
@@ -565,13 +587,14 @@ public:
         MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
         MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
         MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, ctx->GetId() );
+        MemWrite( &item->gpuZoneBegin.context, uint8_t( ctx->GetId() ) );
         Profiler::QueueSerialFinish();
     }
 
     tracy_force_inline VkCtxScope( VkCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, VkCommandBuffer cmdbuf, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( is_active )
 #endif
@@ -590,13 +613,14 @@ public:
         MemWrite( &item->gpuZoneBegin.srcloc, srcloc );
         MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
         MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, ctx->GetId() );
+        MemWrite( &item->gpuZoneBegin.context, uint8_t( ctx->GetId() ) );
         Profiler::QueueSerialFinish();
     }
 
     tracy_force_inline VkCtxScope( VkCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, VkCommandBuffer cmdbuf, int32_t depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
+        , m_connectionId( GetProfiler().ConnectionId() )
 #else
         : m_active( is_active )
 #endif
@@ -624,7 +648,7 @@ public:
         MemWrite( &item->gpuZoneBegin.srcloc, srcloc );
         MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
         MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, ctx->GetId() );
+        MemWrite( &item->gpuZoneBegin.context, uint8_t( ctx->GetId() ) );
         Profiler::QueueSerialFinish();
     }
 
@@ -635,17 +659,24 @@ public:
         const auto queryId = m_ctx->NextQueryId();
         CONTEXT_VK_FUNCTION_WRAPPER( vkCmdWriteTimestamp( m_cmdbuf, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, m_ctx->m_query, queryId ) );
 
+#ifdef TRACY_ON_DEMAND
+        if( GetProfiler().ConnectionId() != m_connectionId ) return;
+#endif
         auto item = Profiler::QueueSerial();
         MemWrite( &item->hdr.type, QueueType::GpuZoneEndSerial );
         MemWrite( &item->gpuZoneEnd.cpuTime, Profiler::GetTime() );
         MemWrite( &item->gpuZoneEnd.thread, GetThreadHandle() );
         MemWrite( &item->gpuZoneEnd.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneEnd.context, m_ctx->GetId() );
+        MemWrite( &item->gpuZoneEnd.context, uint8_t( m_ctx->GetId() ) );
         Profiler::QueueSerialFinish();
     }
 
 private:
     const bool m_active;
+
+#ifdef TRACY_ON_DEMAND
+    uint64_t m_connectionId = 0;
+#endif
 
     VkCommandBuffer m_cmdbuf;
     VkCtx* m_ctx;

--- a/D3D11Engine/include/tracy/public/tracy/TracyWebGPU.hpp
+++ b/D3D11Engine/include/tracy/public/tracy/TracyWebGPU.hpp
@@ -1,0 +1,982 @@
+#ifndef __TRACYWEBGPU_HPP__
+#define __TRACYWEBGPU_HPP__
+
+// WebGPU, unlike other graphics APIs, has many annoying restrictions that complicate
+// the design of the Tracy WebGPU back-end:
+// - there's no CPU/GPU clock calibration API
+// - submitting GPU commands that touch a buffer that the host is mapping is not permitted
+// - resolving timestamps require destination offsets aligned to 256 bytes
+// - timestamps are only available at pass granularity (implementations may need to emulate this)
+// - spec mandates timestamps to be in nanoseconds (implementationw may need to emulate this)
+
+#ifndef TRACY_ENABLE
+
+#define TracyWebGPUSetupDeviceDescriptor(deviceDescriptor)
+
+#define TracyWebGPUContext(instance, device, queue) nullptr
+#define TracyWebGPUDestroy(ctx)
+#define TracyWebGPUContextName(ctx, name, size)
+
+#define TracyWebGPUZone(ctx, encoder, passDesc, name)
+#define TracyWebGPUZoneC(ctx, encoder, passDesc, name, color)
+#define TracyWebGPUNamedZone(ctx, varname, encoder, passDesc, name, active)
+#define TracyWebGPUNamedZoneC(ctx, varname, encoder, passDesc, name, color, active)
+#define TracyWebGPUZoneTransient(ctx, varname, encoder, passDesc, name, active)
+
+#define TracyWebGPUZoneS(ctx, encoder, passDesc, name, depth)
+#define TracyWebGPUZoneCS(ctx, encoder, passDesc, name, color, depth)
+#define TracyWebGPUNamedZoneS(ctx, varname, encoder, passDesc, name, depth, active)
+#define TracyWebGPUNamedZoneCS(ctx, varname, encoder, passDesc, name, color, depth, active)
+#define TracyWebGPUZoneTransientS(ctx, varname, encoder, passDesc, name, depth, active)
+
+#define TracyWebGPUCollect(ctx)
+
+namespace tracy
+{
+    class WebGPUZoneScope {};
+}
+
+using TracyWebGPUCtx = void*;
+
+#else
+
+#include "Tracy.hpp"
+#include "../client/TracyProfiler.hpp"
+#include "../client/TracyCallstack.hpp"
+#include "../common/TracyAlign.hpp"
+#include "../common/TracyAlloc.hpp"
+#include "../common/TracyAssert.hpp"
+
+#include <atomic>
+#include <mutex>
+#include <vector>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <chrono>
+#include <thread>
+
+#include <webgpu/webgpu.h>
+
+// piggy-back on WGPU_DAWN_TOGGLES_DESCRIPTOR_INIT to detect Dawn header
+#ifdef WGPU_DAWN_TOGGLES_DESCRIPTOR_INIT
+#define TRACY_WEBGPU_DAWN_NATIVE (1)
+#include <dawn/native/DawnNative.h>
+#else
+#define TRACY_WEBGPU_WGPU_NATIVE (1)
+#include <webgpu/wgpu.h>
+#endif
+
+#ifndef TRACY_WEBGPU_DEBUG_LEVEL
+#define TRACY_WEBGPU_DEBUG_LEVEL (0)
+#endif//TRACY_WEBGPU_DEBUG_LEVEL
+
+#if TRACY_WEBGPU_DEBUG_LEVEL
+#define TracyWebGPUDebug(...) __VA_ARGS__;
+#if defined(_MSC_VER)
+extern "C" int32_t IsDebuggerPresent(void);
+#define TracyWebGPUBreak() if (IsDebuggerPresent()) __debugbreak()
+#else
+#define TracyWebGPUBreak() ((void)0)
+#endif
+#define TracyWebGPUAssert(predicate, ...) if (predicate) {} else { __VA_ARGS__; TracyWebGPUBreak(); }
+#else
+#define TracyWebGPUDebug(...)
+#define TracyWebGPUBreak()
+#define TracyWebGPUAssert(predicate, ...) TRACY_ASSERT(predicate);
+#endif
+
+#define TracyWebGPULog(severity, msg) do { char buffer [1024]; int len = snprintf(buffer, sizeof(buffer), "TracyWebGPU: %s", msg); tracy::Profiler::LogString( tracy::MessageSourceType::Tracy, tracy::MessageSeverity::severity, tracy::Color::Red4, 0, len, buffer ); } while(false)
+#define TracyWebGPUPanic(msg, ...) do { TracyWebGPULog(Error, msg); TracyWebGPUAssert(false && "TracyWebGPU: " msg); __VA_ARGS__; } while(false)
+
+namespace tracy
+{
+
+    class WebGPUQueueCtx
+    {
+        friend class WebGPUZoneScope;
+
+        int32_t m_contextId = InvalidGpuContextId;
+
+        std::mutex m_collectionMutex;
+
+        WGPUInstance m_instance = nullptr;
+        WGPUDevice m_device = nullptr;
+        WGPUQueue m_queue = nullptr;
+
+        struct ReadbackStage
+        {
+            WGPUBuffer buffer = nullptr;
+            std::atomic<uint64_t> copiedUpto {0};
+            std::atomic<WGPUMapAsyncStatus> mapStatus = {};
+            WGPUFuture pendingFuture = {};
+        };
+        static_assert(std::atomic<WGPUMapAsyncStatus>::is_always_lock_free, "WGPUMapAsyncStatus must be lock-free atomic");
+
+        WGPUQuerySet  m_querySet = nullptr;
+        WGPUBuffer    m_resolveBuffer = nullptr;
+        ReadbackStage m_readbackReel [3];
+        std::atomic<int> m_writeIdx {0};
+
+        using atomic_counter = std::atomic<uint64_t>;
+        atomic_counter m_queryCounter = 0;
+        atomic_counter m_previousCheckpoint = 0;
+
+        uint32_t m_queryLimit = 0;
+
+        std::vector<uint64_t> m_shadowBuffer;
+
+        using WallTime = std::chrono::steady_clock::time_point;
+        static tracy_force_inline auto GetWallTime() { return WallTime::clock::now(); }
+        static tracy_force_inline auto Milliseconds(int value) { return std::chrono::milliseconds(value); }
+
+        static bool WaitQueueIdle(WGPUQueue queue, WGPUInstance instance)
+        {
+            bool gpuDone = false;
+            WGPUQueueWorkDoneCallbackInfo doneCB = {};
+            doneCB.mode = WGPUCallbackMode_AllowProcessEvents;
+            doneCB.callback = [](WGPUQueueWorkDoneStatus, WGPUStringView, void* userData, void*) {
+                *static_cast<bool*>(userData) = true;
+            };
+            doneCB.userdata1 = &gpuDone;
+            wgpuQueueOnSubmittedWorkDone(queue, doneCB);
+
+            const auto deadline = GetWallTime() + Milliseconds(2000);
+            while (!gpuDone && GetWallTime() < deadline)
+                wgpuInstanceProcessEvents(instance);
+            return gpuDone;
+        }
+
+        static const uint64_t* MapBufferSync(WGPUBuffer buffer, WGPUInstance instance)
+        {
+            struct MapCtx { WGPUMapAsyncStatus status = {}; } ctx;
+            WGPUBufferMapCallbackInfo cbInfo = {};
+            cbInfo.mode      = WGPUCallbackMode_AllowProcessEvents;
+            cbInfo.callback  = [](WGPUMapAsyncStatus status, WGPUStringView, void* userData, void*) {
+                auto* ctx = static_cast<MapCtx*>(userData);
+                ctx->status = status;
+            };
+            cbInfo.userdata1 = &ctx;
+            size_t offset = 0;
+            size_t size = 2 * sizeof(uint64_t);
+            wgpuBufferMapAsync(buffer, WGPUMapMode_Read, offset, size, cbInfo);
+
+            const auto deadline = GetWallTime() + Milliseconds(2000);
+            while (ctx.status == 0 && GetWallTime() < deadline)
+                wgpuInstanceProcessEvents(instance);
+
+            if (ctx.status != WGPUMapAsyncStatus_Success) return nullptr;
+            auto data = wgpuBufferGetConstMappedRange(buffer, offset, size);
+            return static_cast<const uint64_t*>(data);
+        }
+
+        struct Calibration {
+            int64_t minCpuRange = ~uint64_t(0) >> 1;
+            struct Regression
+            {
+                int64_t n = 0;
+                int64_t mean_x = 0;
+                int64_t mean_y = 0;
+                int64_t S_xx = 0;
+                int64_t S_xy = 0;
+                void Update(int64_t x, int64_t y)
+                {
+                    n += 1;
+                    int64_t dx = x - mean_x;
+                    int64_t dy = y - mean_y;
+                    mean_x += dx / n;
+                    mean_y += dy / n;
+                    S_xx += dx * (x - mean_x);
+                    S_xy += dx * (y - mean_y);
+                }
+                double Slope() const { return double(S_xy) / S_xx; }
+                double Intercept() const { return mean_y - Slope() * mean_x; }
+            };
+            Regression cpuToGpuModel;   // cpu-ticks to gpu-ticks
+            Regression cpuRangeModel;   // cpu-tick interval uncertainty
+            Regression wallToGpuModel;  // nanoseconds to gpu-ticks
+            void GetReferenceTime(uint64_t& cpuTime, uint64_t& gpuTime) const
+            {
+                // the mean belongs to the regression line
+                cpuTime = cpuToGpuModel.mean_x;
+                gpuTime = cpuToGpuModel.mean_y;
+            }
+            double Period() const { return 1.0 / wallToGpuModel.Slope(); }    // ns/tick
+            bool AcceptX(const Regression& r, int64_t x, double threshold = 3.0) const {
+                if (r.n < 2) return true;
+                auto dx = x - r.mean_x;
+                if (dx <= 0) return true; // always accept "tighter" outliers
+                double variance = double(r.S_xx) / (r.n - 1);
+                if (variance == 0.0) return true;
+                // WARN: dx*dx "could" overflow, but very unlikely in practice
+                double zz = (double)(dx*dx) / variance;
+                return zz <= (threshold*threshold);
+            }
+            bool Update(WallTime twall0, WallTime twall1, uint64_t tcpu0, uint64_t tcpu1, uint64_t tgpu)
+            {
+                using namespace std::chrono;
+                int64_t cpuRange = tcpu1 - tcpu0;
+                cpuRangeModel.Update(cpuRange, 0);
+                if (!AcceptX(cpuRangeModel, cpuRange, 1.0)) return false;
+                // Process sample:
+                int64_t tcpu = tcpu0 + (tcpu1 - tcpu0) / 2; // mid-point
+                int64_t twall = duration_cast<nanoseconds>(
+                    (twall0 + (twall1 - twall0) / 2)        // mid-point
+                    .time_since_epoch()
+                ).count();
+                // incremental regression:
+                cpuToGpuModel.Update(tcpu, tgpu);
+                wallToGpuModel.Update(twall, tgpu);
+                TracyWebGPUDebug( fprintf(stderr, "----- (sample accepted! wall = %lld | cpu = %lld | gpu = %lld | period = %f)\n", twall, tcpu, tgpu, Period()) );
+                return true;
+            }
+        } m_calibration;
+
+        tracy_force_inline void SubmitQueueItem(tracy::QueueItem* item)
+        {
+#ifdef TRACY_ON_DEMAND
+            GetProfiler().DeferItem(*item);
+#endif
+            Profiler::QueueSerialFinish();
+        }
+
+        bool CalibrateClocks(uint64_t& outCpuTime, uint64_t& outGpuTime, double& period)
+        {
+            // WebGPU does not have any clock calibration API.
+            // This routine attempts to estimates a reasonable (cpuTime, gpuTime) correlation
+            // by sampling CPU and GPU timestamps around a "synchronous" draw call.
+            // Several samples are taken to tighten the estimation.
+
+            ZoneScoped;
+
+            WGPUShaderSourceWGSL wgslSrc = {};
+            wgslSrc.chain.sType = WGPUSType_ShaderSourceWGSL;
+            wgslSrc.code =
+            {
+                R"(
+                @vertex fn vs(@builtin(vertex_index) i: u32) -> @builtin(position) vec4f {
+                    var p = array(vec4f(-1,-1,.5,1), vec4f(3,-1,.5,1), vec4f(-1,3,.5,1));
+                    return p[i];
+                }
+                @fragment fn fs() -> @location(0) vec4f { return vec4f(0.0); }
+                )",
+                WGPU_STRLEN
+            };
+            WGPUShaderModuleDescriptor smDesc = {};
+            smDesc.nextInChain  = reinterpret_cast<WGPUChainedStruct*>(&wgslSrc);
+            WGPUShaderModule calibShader = wgpuDeviceCreateShaderModule(m_device, &smDesc);
+            if (!calibShader) { TracyWebGPUPanic("Failed to create calibration shader.", return false); }
+
+            WGPUTextureDescriptor texDesc = {};
+            texDesc.usage         = WGPUTextureUsage_RenderAttachment;
+            texDesc.dimension     = WGPUTextureDimension_2D;
+            texDesc.size          = { 1, 1, 1 };
+            texDesc.format        = WGPUTextureFormat_BGRA8Unorm;
+            texDesc.mipLevelCount = 1;
+            texDesc.sampleCount   = 1;
+            WGPUTexture tex = wgpuDeviceCreateTexture(m_device, &texDesc);
+            if (!tex) { wgpuShaderModuleRelease(calibShader); TracyWebGPUPanic("Failed to create calibration scratch texture.", return false); }
+            WGPUTextureView texView = wgpuTextureCreateView(tex, nullptr);
+            if (!texView) { wgpuTextureRelease(tex); wgpuShaderModuleRelease(calibShader); TracyWebGPUPanic("Failed to create calibration scratch texture view.", return false); }
+
+            WGPUColorTargetState colorTarget = {};
+            colorTarget.format    = WGPUTextureFormat_BGRA8Unorm;
+            colorTarget.writeMask = WGPUColorWriteMask_All;
+            WGPUFragmentState fragState = {};
+            fragState.module      = calibShader;
+            fragState.entryPoint  = { "fs", WGPU_STRLEN };
+            fragState.targetCount = 1;
+            fragState.targets     = &colorTarget;
+            WGPURenderPipelineDescriptor pipeDesc = {};
+            pipeDesc.vertex.module        = calibShader;
+            pipeDesc.vertex.entryPoint    = { "vs", WGPU_STRLEN };
+            pipeDesc.primitive.topology   = WGPUPrimitiveTopology_TriangleList;
+            pipeDesc.multisample.count    = 1;
+            pipeDesc.fragment             = &fragState;
+            WGPURenderPipeline calibPipeline = wgpuDeviceCreateRenderPipeline(m_device, &pipeDesc);
+            if (!calibPipeline) { wgpuTextureViewRelease(texView); wgpuTextureRelease(tex); wgpuShaderModuleRelease(calibShader); TracyWebGPUPanic("Failed to create calibration pipeline.", return false); }
+
+            uint32_t queryId = 0;
+            WGPUPassTimestampWrites anchorTs = {};
+            anchorTs.querySet                  = m_querySet;
+            anchorTs.beginningOfPassWriteIndex = queryId;
+            anchorTs.endOfPassWriteIndex       = queryId+1;
+
+            WGPURenderPassColorAttachment att = {};
+            att.view       = texView;
+            att.loadOp     = WGPULoadOp_Clear;
+            att.storeOp    = WGPUStoreOp_Store;
+            att.depthSlice = WGPU_DEPTH_SLICE_UNDEFINED;
+
+            WGPURenderPassDescriptor passDesc = {};
+            passDesc.colorAttachmentCount = 1;
+            passDesc.colorAttachments     = &att;
+            passDesc.timestampWrites      = &anchorTs;
+
+            // calibration loop
+            const auto deadline = GetWallTime() + Milliseconds(100);
+            for (int i = 0; i < 1000; ++i)
+            {
+                // loop until time budget (100ms) allows, but ensure at least 5 iterations
+                if ((GetWallTime() >= deadline) && (i > 5))
+                    break;
+
+                WGPUCommandEncoder enc = wgpuDeviceCreateCommandEncoder(m_device, nullptr);
+                if (!enc) { TracyWebGPUPanic("Failed to create command encoder for time calibration.", return false); }
+
+                WGPURenderPassEncoder pass = wgpuCommandEncoderBeginRenderPass(enc, &passDesc);
+                wgpuRenderPassEncoderSetPipeline(pass, calibPipeline);
+                wgpuRenderPassEncoderDraw(pass, 3, 1, 0, 0);
+                wgpuRenderPassEncoderEnd(pass);
+                wgpuRenderPassEncoderRelease(pass);
+
+                WGPUBuffer readBackBuffer = m_readbackReel[0].buffer;
+                uint32_t byteOffset = queryId * sizeof(uint64_t);
+                uint32_t sizeInBytes = 2 * sizeof(uint64_t);
+                wgpuCommandEncoderResolveQuerySet(enc, m_querySet, queryId, 2, m_resolveBuffer, byteOffset);
+                wgpuCommandEncoderCopyBufferToBuffer(enc, m_resolveBuffer, byteOffset, readBackBuffer, byteOffset, sizeInBytes);
+
+                WGPUCommandBuffer cmd = wgpuCommandEncoderFinish(enc, nullptr);
+                wgpuCommandEncoderRelease(enc);
+                if (!cmd) { TracyWebGPUPanic("Failed to finish calibration command encoder.", return false); }
+
+                WaitQueueIdle(m_queue, m_instance);
+                int64_t cpu [2] = {};
+                int64_t gpu [2] = {};
+                WallTime wall [2] = {};
+                cpu[0] = Profiler::GetTime();
+                wall[0] = GetWallTime();
+                wgpuQueueSubmit(m_queue, 1, &cmd);
+                wgpuCommandBufferRelease(cmd);
+                WaitQueueIdle(m_queue, m_instance);
+                wall[1] = GetWallTime();
+                cpu[1] = Profiler::GetTime();
+                auto gpuTimestamps = MapBufferSync(readBackBuffer, m_instance);
+                TracyWebGPUAssert(gpuTimestamps != nullptr);
+                gpu[0] = gpuTimestamps[0];
+                gpu[1] = gpuTimestamps[1];
+                wgpuBufferUnmap(readBackBuffer);
+                TracyWebGPUDebug(
+                    fprintf(stdout, "[%03d] CalibrateClocks() [CPU] %16lld | %16lld | /// %lld\n", i, cpu[0], cpu[1], cpu[1]-cpu[0]);
+                    fprintf(stdout,  "----------------------- [GPU] %16llu | %16llu | /// %lld\n",    gpu[0], gpu[1], gpu[1]-gpu[0]);
+                    uint64_t cpuTimeRef, gpuTimeRef;
+                    m_calibration.GetReferenceTime(cpuTimeRef, gpuTimeRef);
+                    if (gpu[0] < gpuTimeRef)
+                        fprintf(stdout, "!!!!! CalibrateClocks() -> WARNING!!! going backwards!\n%llu\n%llu\n%lld\n", gpuTimeRef, gpu[0], gpu[0] - gpuTimeRef);
+                );
+
+                // skip first sample since it is quite jittery (lazy intialization of WebGPU objects)
+                if (i == 0)
+                    continue;
+
+                m_calibration.Update(wall[0], wall[1], cpu[0], cpu[1], gpu[0]);
+            };
+
+            TracyWebGPUDebug(
+                fprintf(stdout, "##### CalibrateClocks() WALL = %lld | CPU = %lld | GPU = %lld | period = %f\n",
+                    m_calibration.wallToGpuModel.mean_x,
+                    m_calibration.cpuToGpuModel.mean_x,
+                    m_calibration.cpuToGpuModel.mean_y,
+                    m_calibration.Period());
+            );
+
+            wgpuRenderPipelineRelease(calibPipeline);
+            wgpuShaderModuleRelease(calibShader);
+            wgpuTextureViewRelease(texView);
+            wgpuTextureRelease(tex);
+
+            m_calibration.GetReferenceTime(outCpuTime, outGpuTime);
+            period = m_calibration.Period();
+            // assume 1 ns/tick if the period estimation is close enough to 1
+            if (std::abs(period - 1.0) < 0.001)
+                period = 1.0;
+
+            return true;
+        }
+
+    public:
+        class Requirements
+        {
+            private:
+#           if (TRACY_WEBGPU_DAWN_NATIVE)
+                WGPUDawnTogglesDescriptor dawnTogglesDesc = {};
+                static constexpr int NumExtras = 0;
+#           elif (TRACY_WEBGPU_WGPU_NATIVE)
+                static constexpr int NumExtras = 1;
+#           endif
+
+            public:
+            static constexpr int NumFeatures = 1 + NumExtras;
+            WGPUFeatureName  features [NumFeatures] = {};
+            WGPUChainedStruct* togglesDesc = nullptr;
+
+            Requirements()
+            {
+                this->features[0] = WGPUFeatureName_TimestampQuery;
+#               if (TRACY_WEBGPU_WGPU_NATIVE)
+                    this->features[1] = (WGPUFeatureName)WGPUNativeFeature_TimestampQueryInsideEncoders;
+#               endif
+#               if (TRACY_WEBGPU_DAWN_NATIVE)
+                    static const char* dawnDisabledToggles[] = { "timestamp_quantization" };
+                    static const char* dawnEnabledToggles[]  = { "disable_timestamp_query_conversion" };
+                    this->dawnTogglesDesc.chain.sType = WGPUSType_DawnTogglesDescriptor;
+                    this->dawnTogglesDesc.disabledToggles = dawnDisabledToggles;
+                    this->dawnTogglesDesc.disabledToggleCount = 1;
+                    this->dawnTogglesDesc.enabledToggles = dawnEnabledToggles;
+                    this->dawnTogglesDesc.enabledToggleCount  = 1;
+                    this->togglesDesc = reinterpret_cast<WGPUChainedStruct*>(&this->dawnTogglesDesc);
+#               endif
+            }
+
+            static bool VerifyDevice(WGPUDevice device)
+            {
+                if (device == nullptr)
+                    TracyWebGPUPanic("Invalid WGPUDevice.", return false);
+                if (wgpuDeviceHasFeature(device, WGPUFeatureName_TimestampQuery) == WGPU_FALSE)
+                    TracyWebGPUPanic("Device is missing feature WGPUFeatureName_TimestampQuery.", return false);
+#               if (TRACY_WEBGPU_DAWN_NATIVE)
+                    bool hasDisableConversion = false, hasQuantization = false;
+                    for (const char* t : ::dawn::native::GetTogglesUsed(device))
+                    {
+                        if (strcmp(t, "disable_timestamp_query_conversion") == 0)
+                            hasDisableConversion = true;
+                        if (strcmp(t, "timestamp_quantization") == 0)
+                            hasQuantization = true;
+                    }
+                    if (!hasDisableConversion)
+                        TracyWebGPUPanic("Device must toggle disable_timestamp_query_conversion (Dawn).", return false);
+                    if (hasQuantization)
+                        TracyWebGPUPanic("Device must disable timestamp_quantization (Dawn).", return false);
+#               elif (TRACY_WEBGPU_WGPU_NATIVE)
+                    if (wgpuDeviceHasFeature(device, (WGPUFeatureName)WGPUNativeFeature_TimestampQueryInsideEncoders) == WGPU_FALSE)
+                        TracyWebGPUPanic("Device is missing feature WGPUNativeFeature_TimestampQueryInsideEncoders (wgpu-native).", return false);
+#               endif
+                return true;
+            }
+
+            void ApplyToDeviceDescriptor(WGPUDeviceDescriptor& deviceDescriptor)
+            {
+                size_t userCount  = deviceDescriptor.requiredFeatureCount;
+                size_t totalCount = userCount + NumFeatures;
+                // NOTE: this allocation will leak...
+                auto* mergedFeatures = static_cast<WGPUFeatureName*>(tracy_malloc(totalCount * sizeof(WGPUFeatureName)));
+                if (userCount > 0 && deviceDescriptor.requiredFeatures)
+                    memcpy(mergedFeatures, deviceDescriptor.requiredFeatures, userCount * sizeof(WGPUFeatureName));
+                memcpy(mergedFeatures + userCount, features, NumFeatures * sizeof(WGPUFeatureName));
+                deviceDescriptor.requiredFeatures     = mergedFeatures;
+                deviceDescriptor.requiredFeatureCount = totalCount;
+
+                if (togglesDesc)
+                {
+                    togglesDesc->next            = deviceDescriptor.nextInChain;
+                    deviceDescriptor.nextInChain = togglesDesc;
+                }
+            }
+        };
+
+        WebGPUQueueCtx(WGPUInstance instance, WGPUDevice device, WGPUQueue queue)
+        {
+            ZoneScopedC(Color::Red4);
+
+            if (!Requirements::VerifyDevice(device))
+                TracyWebGPUPanic("GPU profiling disabled: the device did not set the required features.", return);
+
+            TracyWebGPUAssert(instance); wgpuInstanceAddRef(instance); m_instance = instance;
+            TracyWebGPUAssert(device);   wgpuDeviceAddRef(device);     m_device   = device;
+            TracyWebGPUAssert(queue);    wgpuQueueAddRef(queue);       m_queue    = queue;
+
+            // Setup Query Set: must have even size since queries are issued in pairs.
+            // (The WebGPU spec mandates 4096, with no way to query the device limit.)
+            WGPUQuerySetDescriptor qsDesc = {};
+            qsDesc.type = WGPUQueryType_Timestamp;
+            qsDesc.count = 4096;
+            for (;;)
+            {
+                m_querySet = wgpuDeviceCreateQuerySet(m_device, &qsDesc);
+                if (m_querySet) break;
+                qsDesc.count /= 2;
+                if (qsDesc.count < 128) break;
+            }
+            if (m_querySet == nullptr)
+                TracyWebGPUPanic("Failed to create timestamp query set.", return);
+            m_queryLimit = qsDesc.count;
+
+            WGPUBufferDescriptor resolveDesc = {};
+            resolveDesc.usage = WGPUBufferUsage_QueryResolve | WGPUBufferUsage_CopySrc;
+            resolveDesc.size  = static_cast<uint64_t>(m_queryLimit) * sizeof(uint64_t);
+            m_resolveBuffer = wgpuDeviceCreateBuffer(m_device, &resolveDesc);
+            if (!m_resolveBuffer)
+                TracyWebGPUPanic("Failed to create timestamp resolve buffer.", return);
+
+            WGPUBufferDescriptor readbackDesc = {};
+            readbackDesc.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_MapRead;
+            readbackDesc.size  = static_cast<uint64_t>(m_queryLimit) * sizeof(uint64_t);
+            for (auto& stage : m_readbackReel)
+            {
+                stage.buffer = wgpuDeviceCreateBuffer(m_device, &readbackDesc);
+                stage.copiedUpto = 0;
+                if (!stage.buffer) { TracyWebGPUPanic("Failed to create timestamp readback buffer.", return); }
+            }
+
+            uint64_t cpuTimestamp = 0;
+            uint64_t gpuTimestamp = 0;
+            double period = 0.0;  // in nanoseconds per gpu-tick
+            if (!CalibrateClocks(cpuTimestamp, gpuTimestamp, period))
+                TracyWebGPUPanic("Failed to calibrate CPU/GPU clocks.", return);
+
+            TracyWebGPUDebug( fprintf(stdout, "[WebGPUQueueCtx] cpuTimestamp: %llu | gpuTimestamp: %llu | period: %f\n", cpuTimestamp, gpuTimestamp, period) );
+            m_shadowBuffer.resize(m_queryLimit, gpuTimestamp);
+
+            // All setup completed: register the context.
+            m_contextId = NextGpuContextId();
+            ZoneValue(m_contextId);
+
+            auto* item = Profiler::QueueSerial();
+            MemWrite(&item->hdr.type, QueueType::GpuNewContext);
+            MemWrite(&item->gpuNewContext.cpuTime, static_cast<int64_t>(cpuTimestamp));
+            MemWrite(&item->gpuNewContext.gpuTime, static_cast<int64_t>(gpuTimestamp));
+            MemWrite(&item->gpuNewContext.thread, static_cast<uint32_t>(0));
+            MemWrite(&item->gpuNewContext.period, static_cast<float>(period));
+            MemWrite(&item->gpuNewContext.context, static_cast<uint8_t>(GetId()));
+            MemWrite(&item->gpuNewContext.flags, GpuContextFlags(0));  // no calibration available
+            MemWrite(&item->gpuNewContext.type, GpuContextType::WebGPU);
+            SubmitQueueItem(item);
+        }
+
+        ~WebGPUQueueCtx()
+        {
+            // TODO: a few problems to address later during this final Collect():
+            // 1. ensure "partial" query batches are collected
+            // 2. ensure all readback stages are collected and empty
+            // 3. ensure readback buffers are not mapped before deleting them
+            Collect();
+
+            for (auto& stage : m_readbackReel)
+                if (stage.buffer) { wgpuBufferRelease(stage.buffer);     stage.buffer     = nullptr; }
+            if (m_resolveBuffer)  { wgpuBufferRelease(m_resolveBuffer);  m_resolveBuffer  = nullptr; }
+            if (m_querySet)       { wgpuQuerySetRelease(m_querySet);     m_querySet       = nullptr; }
+            if (m_queue)          { wgpuQueueRelease(m_queue);           m_queue          = nullptr; }
+            if (m_device)         { wgpuDeviceRelease(m_device);         m_device         = nullptr; }
+            if (m_instance)       { wgpuInstanceRelease(m_instance);     m_instance       = nullptr; }
+        }
+
+        tracy_force_inline int32_t GetId() const
+        {
+            return m_contextId;
+        }
+
+        void Name(const char* name, uint16_t len)
+        {
+            auto ptr = (char*)tracy_malloc(len);
+            memcpy(ptr, name, len);
+
+            auto item = Profiler::QueueSerial();
+            MemWrite(&item->hdr.type, QueueType::GpuContextName);
+            MemWrite(&item->gpuContextNameFat.context, static_cast<uint8_t>(GetId()));
+            MemWrite(&item->gpuContextNameFat.ptr, (uint64_t)ptr);
+            MemWrite(&item->gpuContextNameFat.size, len);
+            SubmitQueueItem(item);
+        }
+
+        void Collect(bool webgpuProcessEvents=false)
+        {
+#ifdef TRACY_ON_DEMAND
+            if (!GetProfiler().IsConnected()) return;
+#endif
+            if (!m_collectionMutex.try_lock()) return;
+            std::unique_lock<std::mutex> lock(m_collectionMutex, std::adopt_lock);
+
+            ZoneScopedC(Color::Red4);
+
+            if (Distance(m_previousCheckpoint, m_queryCounter) <= 0)
+                return;
+
+            // Current Readback "Reel" Stages:
+            const int state = m_writeIdx;
+            const int fillingIdx = (state + 0) % 3; // this is where instrumentation is pushing new queries
+            const int pendingIdx = (state + 1) % 3; // instrumentation is done here; ready to be collected
+            const int collectIdx = (state + 2) % 3; // this is where queries are being collected right now
+
+            // Ensure readback buffer has been mapped to the host
+            auto& collectStage = m_readbackReel[collectIdx];
+            if (collectStage.pendingFuture.id != 0)
+            {
+                if (webgpuProcessEvents)
+                    wgpuInstanceProcessEvents(m_instance);
+                if (collectStage.mapStatus == WGPUMapAsyncStatus{})
+                    return;  // callback hasn't fired yet
+                collectStage.pendingFuture = {};
+                if (collectStage.mapStatus != WGPUMapAsyncStatus_Success)
+                    TracyWebGPUPanic("Colect(): unable to map readback buffer.", return);
+            }
+
+            if (collectStage.mapStatus == WGPUMapAsyncStatus_Success)
+            {
+                const uint64_t* ts = static_cast<const uint64_t*>(
+                    wgpuBufferGetConstMappedRange(collectStage.buffer, 0,
+                        static_cast<uint64_t>(m_queryLimit) * sizeof(uint64_t)));
+                if (ts)
+                {
+                    uint64_t ticket = m_previousCheckpoint;
+                    const uint64_t end = collectStage.copiedUpto;
+                    TracyWebGPUDebug( fprintf(stdout, "[TWG] Collect [%d] (%llu, %llu)\n", collectIdx, ticket, end) );
+                    for (; Distance(ticket, end) > 0; ticket += 2)
+                    {
+                        const uint32_t slotB = RingIndex(ticket);
+                        const uint32_t slotE = slotB + 1;
+                        TracyWebGPUDebug(
+                            fprintf(stderr,
+                                "[TWG] slot B=%4u E=%4u ts[B]=%llu ts[E]=%llu shadow[E]=%llu ts-diff=%lld shadow-diff=%lld\n",
+                                slotB, slotE,
+                                ts[slotB], ts[slotE], m_shadowBuffer[slotE],
+                                Distance(ts[slotB], ts[slotE]),
+                                Distance(m_shadowBuffer[slotE], ts[slotE]));
+                        );
+                        if (Distance(m_shadowBuffer[slotE], ts[slotE]) <= 0)
+                            break; // GPU hasn't written this timestamp yet; retry next Collect()
+                        EmitGpuTime(ts[slotB], slotB);
+                        EmitGpuTime(ts[slotE], slotE);
+                    }
+                    m_previousCheckpoint = ticket;
+
+                    if (Distance(ticket, end) > 0)
+                        return; // still unresolved queries in this buffer; come back next Collect()
+                }
+
+                // All queries resolved (or getMappedRange failed): unmap and fall through to rotate.
+                wgpuBufferUnmap(collectStage.buffer);
+                collectStage.mapStatus = {};
+            }
+
+            // At this point, all queries in the collect buffer have been processed.
+            // (it's now tie to "rotate" the buffers around...)
+
+            // Has any ResolveQueryBatch call landed in this reel stage since it was last recycled?
+            // (Are there any queries to resolve and collect at all?)
+            if (m_readbackReel[fillingIdx].copiedUpto <= m_previousCheckpoint)
+                return;
+
+            // Rotate/Cycle the Readback Pipeline State:
+            // the buffer that was just collected shall now be used for instrumentation
+            collectStage.copiedUpto = m_previousCheckpoint.load();
+            m_writeIdx = collectIdx;    // atomically commit the pipeline rotation
+
+            auto& nextToCollect = m_readbackReel[pendingIdx];
+            WGPUBufferMapCallbackInfo cbInfo = {};
+            cbInfo.mode = WGPUCallbackMode_AllowProcessEvents;
+            cbInfo.callback = [](WGPUMapAsyncStatus status, WGPUStringView, void* userData, void*)
+            {
+                auto* stage = static_cast<ReadbackStage*>(userData);
+                stage->mapStatus = status;
+            };
+            cbInfo.userdata1 = &nextToCollect;
+            nextToCollect.pendingFuture = wgpuBufferMapAsync(
+                nextToCollect.buffer, WGPUMapMode_Read, 0,
+                static_cast<uint64_t>(m_queryLimit) * sizeof(uint64_t), cbInfo);
+        }
+
+    private:
+        void EmitGpuTime(uint64_t gpuTimestamp, uint32_t queryId)
+        {
+            auto* item = Profiler::QueueSerial();
+            MemWrite(&item->hdr.type, QueueType::GpuTime);
+            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(gpuTimestamp));
+            MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(queryId));
+            MemWrite(&item->gpuTime.context, static_cast<uint8_t>(GetId()));
+            Profiler::QueueSerialFinish();
+            m_shadowBuffer[queryId] = gpuTimestamp;
+        }
+
+        tracy_force_inline uint32_t RingCapacity() const { return m_queryLimit; }
+
+        tracy_force_inline uint32_t RingIndex(uint64_t t) const
+        {
+            return static_cast<uint32_t>(t % RingCapacity());
+        }
+
+        tracy_force_inline static int64_t Distance(uint64_t begin, uint64_t end)
+        {
+            return static_cast<int64_t>(end - begin);
+        }
+
+        tracy_force_inline uint64_t NextQueryId()
+        {
+            const uint64_t ticket = m_queryCounter.fetch_add(2, std::memory_order_relaxed);
+            if (Distance(m_previousCheckpoint, ticket)
+                >= static_cast<int64_t>(RingCapacity()))
+            {
+                TracyWebGPULog(Warning, "Too many pending GPU queries: stalling!");
+                Collect();
+            }
+            return ticket;
+        }
+    };
+
+    class WebGPUZoneScope
+    {
+        const bool m_active;
+#ifdef TRACY_ON_DEMAND
+        uint64_t m_connectionId = 0;
+#endif
+        WebGPUQueueCtx* m_ctx = nullptr;
+        WGPUCommandEncoder m_encoder = nullptr;
+        uint64_t m_rawTicket = 0;
+        uint32_t m_queryId = 0;
+
+        WGPUPassTimestampWrites m_timestampWrites = {};
+
+        void ResolveQueryBatch(uint32_t queryBatchStartId)
+        {
+            // Ensure there are pending queries to resolve in the batch
+            auto& stage = m_ctx->m_readbackReel[m_ctx->m_writeIdx];
+            if (WebGPUQueueCtx::Distance(stage.copiedUpto, m_rawTicket) <= 0) return;
+
+            // 32 queries = 32 * 8 bytes = 256 bytes
+            TracyWebGPUAssert(queryBatchStartId % 32 == 0, return);
+            queryBatchStartId = m_ctx->RingIndex(queryBatchStartId);
+
+            const uint64_t blockOffset = static_cast<uint64_t>(queryBatchStartId) * sizeof(uint64_t);
+            wgpuCommandEncoderResolveQuerySet(
+                m_encoder,
+                m_ctx->m_querySet,
+                queryBatchStartId, 32,
+                m_ctx->m_resolveBuffer,
+                blockOffset // MUST be a multiple of (aligned to) 256...
+            );
+
+            auto readbackBuffer = stage.buffer;
+            wgpuCommandEncoderCopyBufferToBuffer(
+                m_encoder,
+                m_ctx->m_resolveBuffer,
+                blockOffset,
+                readbackBuffer,
+                blockOffset,
+                32 * sizeof(uint64_t)
+            );
+
+            // Advance this stage's high-water mark to cover the block just encoded.
+            // TODO: maybe we can use fetch_add to increment the atomic and not need
+            // to keep track of the raw ticket; Collect would need to derive the raw
+            // end ticket number.
+            const uint64_t blockEnd = m_rawTicket;
+            uint64_t prev = stage.copiedUpto;
+            while ((WebGPUQueueCtx::Distance(prev, blockEnd) > 0) &&
+                   !stage.copiedUpto.compare_exchange_weak(prev, blockEnd)) {}
+            TracyWebGPUDebug( fprintf(stdout, "[TWG] WebGPUZoneScope [%d] (%d,%d)\n", (int)m_ctx->m_writeIdx, queryBatchStartId, queryBatchStartId+32) );
+        }
+
+        tracy_force_inline void WriteQueueItem(const SourceLocationData* srcLocation, int32_t callstackDepth, uint32_t sourceLine, const char* sourceFile, size_t sourceFileLen, const char* functionName, size_t functionNameLen, const char* zoneName, size_t zoneNameLen)
+        {
+            if (!m_active) return;
+
+            const bool captureCallstack = callstackDepth > 0 && has_callstack();
+            const bool transientZone = srcLocation == nullptr;
+            uint64_t srcLocationAddr = reinterpret_cast<uint64_t>(srcLocation);
+
+            QueueItem* item = nullptr;
+            QueueType itemType;
+            if (transientZone)
+            {
+                srcLocationAddr = Profiler::AllocSourceLocation(sourceLine, sourceFile, sourceFileLen, functionName, functionNameLen, zoneName, zoneNameLen);
+                if (captureCallstack)
+                {
+                    item = Profiler::QueueSerialCallstack(Callstack(callstackDepth));
+                    itemType = QueueType::GpuZoneBeginAllocSrcLocCallstackSerial;
+                }
+                else
+                {
+                    item = Profiler::QueueSerial();
+                    itemType = QueueType::GpuZoneBeginAllocSrcLocSerial;
+                }
+            }
+            else
+            {
+                if (captureCallstack)
+                {
+                    item = Profiler::QueueSerialCallstack(Callstack(callstackDepth));
+                    itemType = QueueType::GpuZoneBeginCallstackSerial;
+                }
+                else
+                {
+                    item = Profiler::QueueSerial();
+                    itemType = QueueType::GpuZoneBeginSerial;
+                }
+            }
+
+            MemWrite(&item->hdr.type, itemType);
+            MemWrite(&item->gpuZoneBegin.cpuTime, Profiler::GetTime());
+            MemWrite(&item->gpuZoneBegin.srcloc, srcLocationAddr);
+            MemWrite(&item->gpuZoneBegin.thread, GetThreadHandle());
+            MemWrite(&item->gpuZoneBegin.queryId, static_cast<uint16_t>(m_queryId));
+            MemWrite(&item->gpuZoneBegin.context, static_cast<uint8_t>(m_ctx->GetId()));
+            Profiler::QueueSerialFinish();
+        }
+
+        // Fills in m_timestampWrites and assigns its address to passDesc.timestampWrites.
+        // Works with both WGPURenderPassDescriptor and WGPUComputePassDescriptor.
+        template<typename PassDescriptor>
+        tracy_force_inline void InitBase(WebGPUQueueCtx* ctx, WGPUCommandEncoder encoder, PassDescriptor& passDesc)
+        {
+            m_ctx     = ctx;
+            m_encoder = encoder;
+
+            m_rawTicket = m_ctx->NextQueryId();
+            m_queryId   = m_ctx->RingIndex(m_rawTicket);
+
+            m_timestampWrites.querySet                  = m_ctx->m_querySet;
+            m_timestampWrites.beginningOfPassWriteIndex = m_queryId;
+            m_timestampWrites.endOfPassWriteIndex       = m_queryId + 1;
+            passDesc.timestampWrites                    = &m_timestampWrites;
+        }
+
+    public:
+        template<typename PassDescriptor>
+        tracy_force_inline WebGPUZoneScope(WebGPUQueueCtx* ctx, WGPUCommandEncoder encoder, PassDescriptor& passDesc, const SourceLocationData* srcLocation, bool active)
+#ifdef TRACY_ON_DEMAND
+            : m_active(active && GetProfiler().IsConnected())
+            , m_connectionId(GetProfiler().ConnectionId())
+#else
+            : m_active(active)
+#endif
+        {
+            if (!m_active || !ctx) return;
+            InitBase(ctx, encoder, passDesc);
+            WriteQueueItem(srcLocation, 0, 0, nullptr, 0, nullptr, 0, nullptr, 0);
+        }
+
+        template<typename PassDescriptor>
+        tracy_force_inline WebGPUZoneScope(WebGPUQueueCtx* ctx, WGPUCommandEncoder encoder, PassDescriptor& passDesc, const SourceLocationData* srcLocation, int32_t depth, bool active)
+#ifdef TRACY_ON_DEMAND
+            : m_active(active && GetProfiler().IsConnected())
+            , m_connectionId(GetProfiler().ConnectionId())
+#else
+            : m_active(active)
+#endif
+        {
+            if (!m_active || !ctx) return;
+            InitBase(ctx, encoder, passDesc);
+            WriteQueueItem(srcLocation, depth, 0, nullptr, 0, nullptr, 0, nullptr, 0);
+        }
+
+        template<typename PassDescriptor>
+        tracy_force_inline WebGPUZoneScope(WebGPUQueueCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, WGPUCommandEncoder encoder, PassDescriptor& passDesc, bool active)
+#ifdef TRACY_ON_DEMAND
+            : m_active(active && GetProfiler().IsConnected())
+            , m_connectionId(GetProfiler().ConnectionId())
+#else
+            : m_active(active)
+#endif
+        {
+            if (!m_active || !ctx) return;
+            InitBase(ctx, encoder, passDesc);
+            WriteQueueItem(nullptr, 0, line, source, sourceSz, function, functionSz, name, nameSz);
+        }
+
+        template<typename PassDescriptor>
+        tracy_force_inline WebGPUZoneScope(WebGPUQueueCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, WGPUCommandEncoder encoder, PassDescriptor& passDesc, int32_t depth, bool active)
+#ifdef TRACY_ON_DEMAND
+            : m_active(active && GetProfiler().IsConnected())
+            , m_connectionId(GetProfiler().ConnectionId())
+#else
+            : m_active(active)
+#endif
+        {
+            if (!m_active || !ctx) return;
+            InitBase(ctx, encoder, passDesc);
+            WriteQueueItem(nullptr, depth, line, source, sourceSz, function, functionSz, name, nameSz);
+        }
+
+        tracy_force_inline ~WebGPUZoneScope()
+        {
+            if (!m_active || !m_ctx) return;
+
+            const auto queryId = m_queryId + 1;
+
+#ifdef TRACY_ON_DEMAND
+            if (GetProfiler().ConnectionId() == m_connectionId)
+            {
+#endif
+                auto* item = Profiler::QueueSerial();
+                MemWrite(&item->hdr.type, QueueType::GpuZoneEndSerial);
+                MemWrite(&item->gpuZoneEnd.cpuTime, Profiler::GetTime());
+                MemWrite(&item->gpuZoneEnd.thread, GetThreadHandle());
+                MemWrite(&item->gpuZoneEnd.queryId, static_cast<uint16_t>(queryId));
+                MemWrite(&item->gpuZoneEnd.context, static_cast<uint8_t>(m_ctx->GetId()));
+                Profiler::QueueSerialFinish();
+#ifdef TRACY_ON_DEMAND
+            }
+#endif
+
+            if (m_queryId % 32 == 0)
+                ResolveQueryBatch(m_queryId-32);
+        }
+    };
+
+    static inline void DestroyWebGPUContext(WebGPUQueueCtx* ctx)
+    {
+        if (!ctx) return;
+        ctx->~WebGPUQueueCtx();
+        tracy_free(ctx);
+    }
+
+    static inline WebGPUQueueCtx* CreateWebGPUContext(WGPUInstance instance, WGPUDevice device, WGPUQueue queue)
+    {
+        auto* ctx = static_cast<WebGPUQueueCtx*>(tracy_malloc(sizeof(WebGPUQueueCtx)));
+        new (ctx) WebGPUQueueCtx{ instance, device, queue };
+        return ctx;
+    }
+
+}
+
+#undef TracyWebGPUPanic
+#undef TracyWebGPULog
+#undef TracyWebGPUAssert
+#undef TracyWebGPUBreak
+#undef TracyWebGPUDebug
+#undef TRACY_WEBGPU_DEBUG_LEVEL
+
+using TracyWebGPUCtx = tracy::WebGPUQueueCtx*;
+
+#define TracyWebGPUSetupDeviceDescriptor(deviceDescriptor) tracy::WebGPUQueueCtx::Requirements TracyConcat(__tracy_wgpu_setup_, TracyLine); TracyConcat(__tracy_wgpu_setup_, TracyLine).ApplyToDeviceDescriptor(deviceDescriptor)
+
+#define TracyWebGPUContext(instance, device, queue) tracy::CreateWebGPUContext(instance, device, queue);
+#define TracyWebGPUDestroy(ctx) tracy::DestroyWebGPUContext(ctx);
+#define TracyWebGPUContextName(ctx, name, size) if (ctx) ctx->Name(name, size);
+
+#define TracyWebGPUUnnamedZone ___tracy_gpu_webgpu_zone
+#define TracyWebGPUSrcLocSymbol TracyConcat(__tracy_webgpu_source_location,TracyLine)
+#define TracyWebGPUSrcLocObject(name, color) static constexpr tracy::SourceLocationData TracyWebGPUSrcLocSymbol { name, TracyFunction, TracyFile, (uint32_t)TracyLine, color };
+
+#if defined TRACY_HAS_CALLSTACK && defined TRACY_CALLSTACK
+#  define TracyWebGPUZone(ctx, encoder, passDesc, name) TracyWebGPUNamedZoneS(ctx, TracyWebGPUUnnamedZone, encoder, passDesc, name, TRACY_CALLSTACK, true)
+#  define TracyWebGPUZoneC(ctx, encoder, passDesc, name, color) TracyWebGPUNamedZoneCS(ctx, TracyWebGPUUnnamedZone, encoder, passDesc, name, color, TRACY_CALLSTACK, true)
+#  define TracyWebGPUNamedZone(ctx, varname, encoder, passDesc, name, active) TracyWebGPUSrcLocObject(name, 0); tracy::WebGPUZoneScope varname{ ctx, encoder, passDesc, &TracyWebGPUSrcLocSymbol, TRACY_CALLSTACK, active };
+#  define TracyWebGPUNamedZoneC(ctx, varname, encoder, passDesc, name, color, active) TracyWebGPUSrcLocObject(name, color); tracy::WebGPUZoneScope varname{ ctx, encoder, passDesc, &TracyWebGPUSrcLocSymbol, TRACY_CALLSTACK, active };
+#  define TracyWebGPUZoneTransient(ctx, varname, encoder, passDesc, name, active) TracyWebGPUZoneTransientS(ctx, varname, encoder, passDesc, name, TRACY_CALLSTACK, active)
+#else
+#  define TracyWebGPUZone(ctx, encoder, passDesc, name) TracyWebGPUNamedZone(ctx, TracyWebGPUUnnamedZone, encoder, passDesc, name, true)
+#  define TracyWebGPUZoneC(ctx, encoder, passDesc, name, color) TracyWebGPUNamedZoneC(ctx, TracyWebGPUUnnamedZone, encoder, passDesc, name, color, true)
+#  define TracyWebGPUNamedZone(ctx, varname, encoder, passDesc, name, active) TracyWebGPUSrcLocObject(name, 0); tracy::WebGPUZoneScope varname{ ctx, encoder, passDesc, &TracyWebGPUSrcLocSymbol, active };
+#  define TracyWebGPUNamedZoneC(ctx, varname, encoder, passDesc, name, color, active) TracyWebGPUSrcLocObject(name, color); tracy::WebGPUZoneScope varname{ ctx, encoder, passDesc, &TracyWebGPUSrcLocSymbol, active };
+#  define TracyWebGPUZoneTransient(ctx, varname, encoder, passDesc, name, active) tracy::WebGPUZoneScope varname{ ctx, TracyLine, TracyFile, strlen(TracyFile), TracyFunction, strlen(TracyFunction), name, strlen(name), encoder, passDesc, active };
+#endif
+
+#ifdef TRACY_HAS_CALLSTACK
+#  define TracyWebGPUZoneS(ctx, encoder, passDesc, name, depth) TracyWebGPUNamedZoneS(ctx, TracyWebGPUUnnamedZone, encoder, passDesc, name, depth, true)
+#  define TracyWebGPUZoneCS(ctx, encoder, passDesc, name, color, depth) TracyWebGPUNamedZoneCS(ctx, TracyWebGPUUnnamedZone, encoder, passDesc, name, color, depth, true)
+#  define TracyWebGPUNamedZoneS(ctx, varname, encoder, passDesc, name, depth, active) TracyWebGPUSrcLocObject(name, 0); tracy::WebGPUZoneScope varname{ ctx, encoder, passDesc, &TracyWebGPUSrcLocSymbol, depth, active };
+#  define TracyWebGPUNamedZoneCS(ctx, varname, encoder, passDesc, name, color, depth, active) TracyWebGPUSrcLocObject(name, color); tracy::WebGPUZoneScope varname{ ctx, encoder, passDesc, &TracyWebGPUSrcLocSymbol, depth, active };
+#  define TracyWebGPUZoneTransientS(ctx, varname, encoder, passDesc, name, depth, active) tracy::WebGPUZoneScope varname{ ctx, TracyLine, TracyFile, strlen(TracyFile), TracyFunction, strlen(TracyFunction), name, strlen(name), encoder, passDesc, depth, active };
+#else
+#  define TracyWebGPUZoneS(ctx, encoder, passDesc, name, depth) TracyWebGPUZone(ctx, encoder, passDesc, name)
+#  define TracyWebGPUZoneCS(ctx, encoder, passDesc, name, color, depth) TracyWebGPUZoneC(ctx, encoder, passDesc, name, color)
+#  define TracyWebGPUNamedZoneS(ctx, varname, encoder, passDesc, name, depth, active) TracyWebGPUNamedZone(ctx, varname, encoder, passDesc, name, active)
+#  define TracyWebGPUNamedZoneCS(ctx, varname, encoder, passDesc, name, color, depth, active) TracyWebGPUNamedZoneC(ctx, varname, encoder, passDesc, name, color, active)
+#  define TracyWebGPUZoneTransientS(ctx, varname, encoder, passDesc, name, depth, active) TracyWebGPUZoneTransient(ctx, varname, encoder, passDesc, name, active)
+#endif
+
+#define TracyWebGPUCollect(ctx) if (ctx) ctx->Collect();
+
+#endif
+
+#endif


### PR DESCRIPTION
general:
  - WorldConverter now prepares vob mesh data in background workers.
  - update Tracy to 0.14

dx11:
 - on-the-fly extraction of meshes now uses async variant. code now uses info->GetIsReady() before using the meshes.
 - fix broken world mesh rendering for pointlight shadow cubemaps. They don't like the wrapped world mesh, eh?

dx12:
 - introduce rendergraph for resource management.
   - removes a lot of otherwise "static" resources, and replace them by pooled rendergraph resources.
   - Less overall VRAM and cpu-memory usage for dx12