### PR TITLE
fix: backport pointlight distance preference to dx11. Load ProgMesh in background threads. Disable layered rendering on Nvidia. Cache rework. ...

### DIFF
--- a/D3D11Engine/BaseShadowedPointLight.h
+++ b/D3D11Engine/BaseShadowedPointLight.h
@@ -8,5 +8,12 @@ public:
 
     /** Called when a vob got removed from the world */
     virtual void OnVobRemovedFromWorld( BaseVobInfo* vob ) {};
+
+    /** True once this light has a valid, up-to-date baked static shadow it can just keep reusing (no
+        camera-proximity nudge needed). Backend-neutral so callers outside the D3D11-specific classes (e.g.
+        GothicAPI's per-frame light collection) can ask "does this still need a bake" without downcasting.
+        Default false so a backend that never overrides this (nothing to bake, or not implemented yet) is
+        conservatively treated as always needing one. */
+    virtual bool IsShadowReady() const { return false; }
 };
 

--- a/D3D11Engine/ByteCursor.h
+++ b/D3D11Engine/ByteCursor.h
@@ -1,0 +1,66 @@
+#pragma once
+
+/** Tiny in-memory binary serialization helpers shared by the SqliteBlobStore-backed caches
+    (MeshOptimizeCache.h, D3D11ShaderManager.cpp, D3D12ShaderBackend.cpp). Each of those owns its own
+    record layout (magic + format version + key + payload) and validity rules - this only factors out the
+    byte-level Append/Read plumbing so it isn't hand-rolled three times. */
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace ByteCursor {
+
+    template<typename T> void AppendPod( std::vector<uint8_t>& buf, const T& value ) {
+        const uint8_t* p = reinterpret_cast<const uint8_t*>( &value );
+        buf.insert( buf.end(), p, p + sizeof( T ) );
+    }
+    inline void AppendBytes( std::vector<uint8_t>& buf, const void* data, size_t size ) {
+        const uint8_t* p = static_cast<const uint8_t*>( data );
+        buf.insert( buf.end(), p, p + size );
+    }
+    template<typename T> void AppendVector( std::vector<uint8_t>& buf, const std::vector<T>& v ) {
+        if ( !v.empty() ) {
+            AppendBytes( buf, v.data(), v.size() * sizeof( T ) );
+        }
+    }
+    inline void AppendString( std::vector<uint8_t>& buf, const std::string& s ) {
+        AppendBytes( buf, s.data(), s.size() );
+    }
+
+    /** Bounds-checked read cursor over an in-memory buffer (e.g. what SqliteBlobStore::TryGet hands
+        back). Every Read* returns false and leaves the buffer(s) it was reading into unspecified on
+        underflow, so a truncated or corrupted blob is just a miss - never a read past the end. */
+    struct Reader {
+        const uint8_t* p;
+        const uint8_t* end;
+
+        Reader( const uint8_t* data, size_t size ) : p( data ), end( data + size ) {}
+
+        size_t Remaining() const { return static_cast<size_t>( end - p ); }
+
+        template<typename T> bool ReadPod( T& out ) {
+            if ( Remaining() < sizeof( T ) ) return false;
+            memcpy( &out, p, sizeof( T ) );
+            p += sizeof( T );
+            return true;
+        }
+        bool ReadBytes( void* dst, size_t size ) {
+            if ( Remaining() < size ) return false;
+            if ( size ) memcpy( dst, p, size );
+            p += size;
+            return true;
+        }
+        template<typename T> bool ReadVector( std::vector<T>& out, uint32_t count, uint32_t maxCount ) {
+            if ( count > maxCount ) return false;
+            out.resize( count );
+            return ReadBytes( out.data(), static_cast<size_t>( count ) * sizeof( T ) );
+        }
+        bool ReadString( std::string& out, uint32_t len ) {
+            out.resize( len );
+            return ReadBytes( out.data(), len );
+        }
+    };
+
+}   // namespace ByteCursor

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1101,6 +1101,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="Logger.h" />
     <ClInclude Include="MemoryTracker.h" />
     <ClInclude Include="MeshManager.h" />
+    <ClInclude Include="MeshOptimizeCache.h" />
     <ClInclude Include="MeshShadowIndexBuilder.h" />
     <ClInclude Include="MorphBlend.h" />
     <ClInclude Include="MorphGpu.h" />

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1103,6 +1103,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="MeshManager.h" />
     <ClInclude Include="MeshOptimizeCache.h" />
     <ClInclude Include="MeshShadowIndexBuilder.h" />
+    <ClInclude Include="SqliteBlobStore.h" />
     <ClInclude Include="MorphBlend.h" />
     <ClInclude Include="MorphGpu.h" />
     <ClInclude Include="AsyncVisualExtractor.h" />
@@ -1856,6 +1857,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="MorphGpu.cpp" />
     <ClCompile Include="AsyncVisualExtractor.cpp" />
     <ClCompile Include="SharedVisualRegistry.cpp" />
+    <ClCompile Include="SqliteBlobStore.cpp" />
     <ClCompile Include="MeshModifier.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -967,6 +967,7 @@
     <ClInclude Include="zCPathSearch.h" />
     <ClInclude Include="MeshShadowIndexBuilder.h" />
     <ClInclude Include="MeshOptimizeCache.h" />
+    <ClInclude Include="SqliteBlobStore.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -1396,6 +1397,7 @@
     <ClCompile Include="MorphBlend.cpp" />
     <ClCompile Include="AsyncVisualExtractor.cpp" />
     <ClCompile Include="SharedVisualRegistry.cpp" />
+    <ClCompile Include="SqliteBlobStore.cpp" />
     <ClCompile Include="D3D12Engine\D3D12MorphFold.cpp" />
     <ClCompile Include="D3D12Engine\D3D12VobArena.cpp" />
     <ClCompile Include="include\meshoptimizer\src\simplifier.cpp" />

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -966,6 +966,7 @@
     <ClInclude Include="MorphGpu.h" />
     <ClInclude Include="zCPathSearch.h" />
     <ClInclude Include="MeshShadowIndexBuilder.h" />
+    <ClInclude Include="MeshOptimizeCache.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -709,11 +709,18 @@ XRESULT D3D11GraphicsEngine::Init() {
     hr = Device->CheckFeatureSupport(D3D11_FEATURE_D3D11_OPTIONS3, &options3, sizeof( options3 ) );
     if ( SUCCEEDED( hr ) ) {
         FeatureRTArrayIndexFromAnyShader = options3.VPAndRTArrayIndexFromAnyShaderFeedingRasterizer;
-        Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.FeatureSet.UseLayeredRendering = FeatureRTArrayIndexFromAnyShader;
         LogInfo() << "D3D11_FEATURE_D3D11_OPTIONS3: VPAndRTArrayIndexFromAnyShaderFeedingRasterizer = " << (FeatureRTArrayIndexFromAnyShader ? "Supported" : "Unsupported");
     } else {
         LogInfo() << "D3D11_FEATURE_D3D11_OPTIONS3: CheckFeatureSupport failed, assuming Unsupported";
     }
+
+    // NVIDIA's D3D11 driver reports this cap bit as supported but doesn't actually honor
+    // SV_RenderTargetArrayIndex written from a VS (no GS in the pipeline): only cube face 0 gets
+    // drawn and the rest of the depth-array slices are left stale/garbage, corrupting point-light
+    // cube shadows. AMD and Intel implement it correctly. Distrust the cap bit on NVIDIA and always
+    // fall back to the geometry-shader cubemap path (GS_Cubemap.hlsl) there.
+    Engine::GAPI->GetRendererState().RendererSettings.DebugSettings.FeatureSet.UseLayeredRendering =
+        FeatureRTArrayIndexFromAnyShader && adpDesc.VendorId != 0x10DE;
 
     LogInfo() << "Creating ShaderManager";
     ShaderManager = std::make_unique<D3D11ShaderManager>();

--- a/D3D11Engine/D3D11LegacyDeferredShading.cpp
+++ b/D3D11Engine/D3D11LegacyDeferredShading.cpp
@@ -67,16 +67,32 @@ XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
     specular.BindToPixelShader( context.Get(), 7 );
     depthCopy.BindToPixelShader( context.Get(), 2 );
 
+    // Mirrors D3D12 BuildFrameLightBuffer's post-selection range clamp (D3D12Scene.cpp): a light that
+    // ends up with no shadow cube shades unshadowed and bleeds through walls. Clamping its range to a
+    // small fraction keeps it lighting its own alcove instead of the next room - or, worse, the
+    // outside of the building it's sealed inside when the camera is outdoors and nothing can occlude
+    // it. Gated on IsStatic() OR IsIndoorVob, not IsStatic() alone: zCVobLight's "static" bit is
+    // Gothic's own IsStatic() (colour-animated fine, never repositioned), so a candle or brazier with
+    // a colour animation reads as non-static and would otherwise bleed through walls completely
+    // unshadowed - same failure mode as an atmospheric fill light. Outdoor dynamic lights (the
+    // player's torch, spell effects) are still exempt: open air has no walls to bleed through.
+    constexpr float kUnshadowedStaticScale = 0.35f;      // still lights its own alcove
+    constexpr float kIndoorSeenFromOutsideScale = 0.15f; // worst bleed case - clamp it much harder
+    const zCVob* playerVob = Engine::GAPI->GetPlayerVob();
+    const bool cameraIndoors = playerVob && playerVob->IsIndoorVob();
+
     auto cbPool = graphicsEngine->GetConstantBufferPool();
     for ( auto const& light : lights ) {
         zCVobLight* vob = light->Vob;
 
         if ( !vob->IsEnabled() ) continue;
 
+        bool hasShadow = false;
         if ( settings.EnablePointlightShadows > 0 ) {
             D3D11PointLight* pl = light->LightShadowBuffers ? static_cast<D3D11PointLight*>(light->LightShadowBuffers.get()) : nullptr;
 
-            if ( pl && pl->IsInited() && pl->HasShadowMap( 0 ) ) {
+            hasShadow = pl && pl->IsInited() && pl->HasShadowMap( 0 );
+            if ( hasShadow ) {
                 if ( graphicsEngine->GetActivePS() != psPointLightDynShadow ) {
                     graphicsEngine->SetActivePS( psPointLightDynShadow )->Apply();
                 }
@@ -90,6 +106,10 @@ XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
         plcb.PL_Color = float4( vob->GetLightColor() );
         plcb.PL_Color.w = settings.PointLightSpecularScale( vob->IsStatic() );
         plcb.PL_Range = vob->GetLightRange();
+        if ( !hasShadow && ( vob->IsStatic() || light->IsIndoorVob ) ) {
+            const bool leakingOutdoors = light->IsIndoorVob && !cameraIndoors;
+            plcb.PL_Range *= leakingOutdoors ? kIndoorSeenFromOutsideScale : kUnshadowedStaticScale;
+        }
         plcb.Pl_PositionWorld = vob->GetPositionWorld();
         plcb.PL_Outdoor = light->IsIndoorVob ? 0.0f : 1.0f;
 

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -49,7 +49,7 @@ static void SetupVobsToExclude(const VobLightInfo* LightInfo)
     CollectVobTreeToExclude(LightInfo->Vob);
 }
 
-static bool GetHasOriginVob( VobLightInfo* info ) {
+static bool GetHasOriginVob( VobLightInfo* info ) {    
     if ( !info->IsPFXVobLight ) {
         zCVob* vob = info->Vob;
         while ( auto parent = vob->GetVobParent() ) {
@@ -172,7 +172,7 @@ void D3D11PointLight::ClearTiledSlot() {
 int D3D11PointLight::GetCurrentShadowMode() const {
     auto mode = static_cast<int>(Engine::GAPI->GetRendererState().RendererSettings.EnablePointlightShadows);
     if ( mode > 1 ) {
-        if ( LightInfo->Vob->GetLightInfoFlags().isStatic ) {
+        if ( LightInfo->IsStaticVobLight ) {
             return GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY;
         }
     }
@@ -268,7 +268,15 @@ void D3D11PointLight::RenderStaticShadowPass( RenderToDepthStencilBuffer& target
         wc = nullptr;
     }
 
-    const unsigned int staticCasterMask = LightInfo->Vob->GetLightInfoFlags().isStatic
+    // PFX-driven lights (candles/torches/campfires - oCVisualFX-owned rather than a static level light) can
+    // be parented anywhere in the vob tree, including onto NPCs/the player. GetHasOriginVob's self-exclusion
+    // below only walks the oCItem-origin chain, so a PFX light whose origin ISN'T an item has no reliable way
+    // to exclude its own carrier from the caster set - that's what used to make e.g. a belt-mounted light
+    // draw a huge shadow from the player all around (see SetupVobsToExclude's comment). Restricting these to
+    // world-mesh-only casters sidesteps that class of bug entirely instead of needing a more general fix, at
+    // the cost of PFX lights never getting VOB/NPC shadows.
+    const unsigned int staticCasterMask = LightInfo->IsPFXVobLight ? SHADOW_CASTER_WORLD
+        : LightInfo->IsStaticVobLight
         ? SHADOW_CASTER_WORLD // static light? only draw world mesh.
         : SHADOW_CASTER_WORLD | SHADOW_CASTER_VOBS | SHADOW_CASTER_MOBS;
 
@@ -466,6 +474,8 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate ) {
     // Create the projection matrix
     float zNear = 15.0f;
     float zFar = LightInfo->Vob->GetLightRange()*2.0f;
+    m_DebugLastZNear = zNear;
+    m_DebugLastZFar = zFar;
 
     XMMATRIX proj = XMMatrixPerspectiveFovLH( XM_PIDIV2, 1.0f, zNear, zFar );
     proj = XMMatrixTranspose( proj );
@@ -539,9 +549,15 @@ void D3D11PointLight::RenderFullCubemap() {
                     m_StaticShadowReady = true;
                 }
 
-                // Clear: the overlay must hold ONLY this update's movers, never the previous one's.
-                RenderAnimatedShadowPass( *dynTarget, true );
-                m_HasDynamicOverlay = true;
+                // PFX lights are restricted to world-mesh casters only (see RenderStaticShadowPass) - there
+                // is nothing animated to put in the overlay, and this shared array slot may still hold a
+                // DIFFERENT light's stale movers from whichever light last held it. Leave m_HasDynamicOverlay
+                // false so the shader never composites against that leftover data.
+                if ( !LightInfo->IsPFXVobLight ) {
+                    // Clear: the overlay must hold ONLY this update's movers, never the previous one's.
+                    RenderAnimatedShadowPass( *dynTarget, true );
+                    m_HasDynamicOverlay = true;
+                }
                 return;
             }
             // Overlay array unavailable - fall through to the composited single-cube path below.
@@ -564,26 +580,32 @@ void D3D11PointLight::RenderFullCubemap() {
             CopyStaticAsideToActiveTarget();
         }
 
-        RenderAnimatedShadowPass( *activeTarget, false );
+        // See the PLS_UPDATE_DYNAMIC/tiled branch above: PFX lights have no animated casters to add.
+        if ( !LightInfo->IsPFXVobLight ) {
+            RenderAnimatedShadowPass( *activeTarget, false );
+        }
         return;
     }
-    
+
     if ( shadowMode == GothicRendererSettings::PLS_FULL ) {
         auto wc = &WorldMeshCache;
         if ( WorldCacheInvalid ) {
             wc = nullptr;
         }
 
+        // See RenderStaticShadowPass: PFX lights are restricted to world-mesh casters only.
+        const unsigned int casterMask = LightInfo->IsPFXVobLight ? SHADOW_CASTER_WORLD : SHADOW_CASTER_ALL;
+
         if ( GetHasOriginVob( LightInfo ) ) {
             SetupVobsToExclude(LightInfo);
 
             engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), LightInfo->Vob->GetLightRange(), *activeTarget,
-                nullptr, nullptr, false, LightInfo->IsIndoorVob, false, &VobCache, &SkeletalVobCache, wc, true, SHADOW_CASTER_ALL,
+                nullptr, nullptr, false, LightInfo->IsIndoorVob, false, &VobCache, &SkeletalVobCache, wc, true, casterMask,
                 excludeVobsToExclude);
             vobsToExclude.clear();
         } else {
             engine->RenderShadowCube( LightInfo->Vob->GetPositionWorldXM(), LightInfo->Vob->GetLightRange(), *activeTarget,
-                nullptr, nullptr, false, LightInfo->IsIndoorVob, false, &VobCache, &SkeletalVobCache, wc, true, SHADOW_CASTER_ALL );
+                nullptr, nullptr, false, LightInfo->IsIndoorVob, false, &VobCache, &SkeletalVobCache, wc, true, casterMask );
         }
     }
 }

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -507,6 +507,9 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate ) {
 
     LastUpdateColor = LightInfo->Vob->GetLightColor();
     LastUpdatePosition = vobPos;
+    // Was declared but never actually assigned anywhere in the codebase - always read back (0,0,0)
+    // regardless of whether a render actually happened, so it was not trustworthy debug signal.
+    LightInfo->LastRenderedPosition = vobPos;
     DrawnOnce = true;
 }
 

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -81,6 +81,25 @@ public:
     void AcquireShadowMap( DepthStencilPool* pool, int resolution );
     void ReleaseShadowMap();
 
+    /** Called once per frame from DrawPointlightShadows for every light that currently owns shadow
+        resources. Tracks consecutive absent frames (light disabled, or dropped out of VisibleInFrame) and
+        returns true only once that streak exceeds retentionFrames - the caller should release the slot/
+        shadow map then, not on the very first absent frame. A light that merely blinks (zCVobLight
+        IsEnabled toggling for a flicker effect, or a one-frame frustum/visibility edge case) never crosses
+        the threshold and keeps its slot and baked depth. Without this, a PLS_STATIC_ONLY light that blinks
+        even occasionally can never finish a bake that STICKS: it gets evicted the instant it goes briefly
+        absent, so by the time it wins a slot again the next blink has already wiped the previous progress -
+        it lights unshadowed (bleeding through walls) forever. Mirrors D3D12PointShadows' Slot::missingFrames
+        retention in SelectShadowedLights. */
+    bool NoteAbsence( bool visibleThisFrame, int retentionFrames ) {
+        if ( visibleThisFrame ) {
+            m_MissingFrames = 0;
+            return false;
+        }
+        return ++m_MissingFrames > retentionFrames;
+    }
+    int GetMissingFrames() const { return m_MissingFrames; }
+
     // Debug-visualization accessors (see ImGuiShim::RenderPointLightShadowDebugWindow).
     VobLightInfo* GetLightInfo() const { return LightInfo; }
     ID3D11Texture2D* GetTiledShadowCubeTexture() const { return m_TiledDepthTarget ? m_TiledDepthTarget->GetTexture().Get() : nullptr; }
@@ -139,6 +158,8 @@ protected:
     int m_LastShadowMode = -1;
     float m_DebugLastZNear = 0.0f;
     float m_DebugLastZFar = 0.0f;
+    // Consecutive frames this light has been absent (disabled/out of VisibleInFrame) - see NoteAbsence().
+    int m_MissingFrames = 0;
 
     // Tiled deferred slot (non-owning, owned by D3D11TiledDeferredShading)
     int m_TiledSlotIndex = -1;

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -52,6 +52,10 @@ public:
         return m_StaticShadowReady;
     }
 
+    bool IsShadowReady() const override {
+        return m_StaticShadowReady;
+    }
+
     /** True when this light's tiled slot in the dynamic-overlay cube array holds a valid, already-rendered set
         of moving casters. Drives SHADOW_CUBE_HAS_DYNAMIC, i.e. whether the shader takes the second sample.
         Only PLS_UPDATE_DYNAMIC ever refreshes that overlay, so the mode is re-checked here rather than trusted
@@ -76,6 +80,13 @@ public:
 
     void AcquireShadowMap( DepthStencilPool* pool, int resolution );
     void ReleaseShadowMap();
+
+    // Debug-visualization accessors (see ImGuiShim::RenderPointLightShadowDebugWindow).
+    VobLightInfo* GetLightInfo() const { return LightInfo; }
+    ID3D11Texture2D* GetTiledShadowCubeTexture() const { return m_TiledDepthTarget ? m_TiledDepthTarget->GetTexture().Get() : nullptr; }
+    int GetTiledFaceBaseSlice() const { return m_TiledSlotIndex >= 0 ? m_TiledSlotIndex * 6 : -1; }
+    float GetDebugZNear() const { return m_DebugLastZNear; }
+    float GetDebugZFar() const { return m_DebugLastZFar; }
 
     // Tiled deferred slot management (renders directly into a shared TextureCubeArray). `lowRes` selects
     // which of the two independent slot pools this came from - see WantsStaticOnlySlot().
@@ -126,6 +137,8 @@ protected:
         overlay that still holds another light's (or a stale) depth. */
     bool m_HasDynamicOverlay = false;
     int m_LastShadowMode = -1;
+    float m_DebugLastZNear = 0.0f;
+    float m_DebugLastZFar = 0.0f;
 
     // Tiled deferred slot (non-owning, owned by D3D11TiledDeferredShading)
     int m_TiledSlotIndex = -1;

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -16,6 +16,8 @@
 #include "D3D11PFX_TAA.h"
 #include "D3D11FileRelativeInclude.h"
 #include "ShaderCacheHash.h"
+#include "SqliteBlobStore.h"
+#include "ByteCursor.h"
 
 #pragma comment(lib, "d3d11.lib")
 #pragma comment(lib, "d3dcompiler.lib")
@@ -48,7 +50,6 @@ namespace {
     // Bump when the D3DCOMPILE_* flags below change in a way that alters codegen.
     constexpr uint32_t kDxbcCacheArgsRevision = 1;
     constexpr uint32_t kDxbcCacheFormatVersion = 1;
-    const char* kDxbcCacheDirRel = "\\system\\GD3D11\\shadercache\\D3D11\\";
 
     int g_CacheHits = 0;
     int g_CacheMisses = 0;
@@ -101,51 +102,34 @@ namespace {
         return ShaderCacheHash::HashBytes( &fxc, sizeof( fxc ), h );
     }
 
-    std::string CacheFilePath( uint64_t key, bool createDir ) {
-        const std::string dir = Engine::GAPI->GetStartDirectory() + kDxbcCacheDirRel;
-        if ( createDir ) {
-            // CreateDirectory has no "create parents" flag; both levels may be missing.
-            const std::string parent = Engine::GAPI->GetStartDirectory() + "\\system\\GD3D11\\shadercache";
-            CreateDirectoryA( parent.c_str(), nullptr );
-            if ( !CreateDirectoryA( dir.c_str(), nullptr ) && GetLastError() != ERROR_ALREADY_EXISTS )
-                return "";
-        }
-        char name[32] = {};
-        sprintf_s( name, "%016llx.dxbc", static_cast<unsigned long long>( key ) );
-        return dir + name;
-    }
-
-    template<typename T> bool ReadPod( std::ifstream& in, T& out ) {
-        return static_cast<bool>( in.read( reinterpret_cast<char*>( &out ), sizeof( T ) ) );
-    }
-    template<typename T> void WritePod( std::ofstream& out, const T& value ) {
-        out.write( reinterpret_cast<const char*>( &value ), sizeof( T ) );
+    SqliteBlobStore& GetCacheStore() {
+        // Magic-static: constructed once, on whichever thread compiles the first shader.
+        static SqliteBlobStore s_store( Engine::GAPI->GetStartDirectory() + R"(\system\GD3D11\cache\d3d11_shaders.db)");
+        return s_store;
     }
 
     // Deps are stored relative to the start directory so the cache is portable across installs.
     bool TryLoadCachedBlob( uint64_t key, ID3DBlob** ppCode ) {
-        const std::string path = CacheFilePath( key, false );
-        if ( path.empty() ) return false;
-        std::ifstream in( path, std::ios::binary );
-        if ( !in ) return false;
+        std::vector<uint8_t> blob;
+        if ( !GetCacheStore().TryGet( key, blob ) || blob.size() < 4 ) return false;
+        if ( memcmp( blob.data(), "GDBC", 4 ) != 0 ) return false;
 
-        char magic[4] = {};
+        ByteCursor::Reader in( blob.data() + 4, blob.size() - 4 );
         uint32_t version = 0;
         uint64_t storedKey = 0;
         uint32_t depCount = 0;
-        if ( !in.read( magic, 4 ) || memcmp( magic, "GDBC", 4 ) != 0 ) return false;
-        if ( !ReadPod( in, version ) || version != kDxbcCacheFormatVersion ) return false;
-        if ( !ReadPod( in, storedKey ) || storedKey != key ) return false;
-        if ( !ReadPod( in, depCount ) || depCount > 256 ) return false;
+        if ( !in.ReadPod( version ) || version != kDxbcCacheFormatVersion ) return false;
+        if ( !in.ReadPod( storedKey ) || storedKey != key ) return false;
+        if ( !in.ReadPod( depCount ) || depCount > 256 ) return false;
 
         const std::string startDir = Engine::GAPI->GetStartDirectory();
         for ( uint32_t i = 0; i < depCount; ++i ) {
             uint32_t nameLen = 0;
             uint64_t storedHash = 0;
-            if ( !ReadPod( in, nameLen ) || nameLen == 0 || nameLen > 512 ) return false;
-            std::string relName( nameLen, '\0' );
-            if ( !in.read( relName.data(), nameLen ) ) return false;
-            if ( !ReadPod( in, storedHash ) ) return false;
+            if ( !in.ReadPod( nameLen ) || nameLen == 0 || nameLen > 512 ) return false;
+            std::string relName;
+            if ( !in.ReadString( relName, nameLen ) ) return false;
+            if ( !in.ReadPod( storedHash ) ) return false;
 
             std::ifstream depIn( startDir + "\\" + relName, std::ios::binary );
             if ( !depIn ) return false;   // include vanished
@@ -155,45 +139,37 @@ namespace {
         }
 
         uint32_t blobSize = 0;
-        if ( !ReadPod( in, blobSize ) || blobSize == 0 || blobSize > ( 64u << 20 ) ) return false;
+        if ( !in.ReadPod( blobSize ) || blobSize == 0 || blobSize > ( 64u << 20 ) || blobSize > in.Remaining() ) return false;
 
-        Microsoft::WRL::ComPtr<ID3DBlob> blob;
-        if ( FAILED( D3DCreateBlob( blobSize, blob.GetAddressOf() ) ) ) return false;
-        if ( !in.read( static_cast<char*>( blob->GetBufferPointer() ), blobSize ) ) return false;
-        *ppCode = blob.Detach();
+        Microsoft::WRL::ComPtr<ID3DBlob> code;
+        if ( FAILED( D3DCreateBlob( blobSize, code.GetAddressOf() ) ) ) return false;
+        if ( !in.ReadBytes( code->GetBufferPointer(), blobSize ) ) return false;
+        *ppCode = code.Detach();
         return true;
     }
 
-    // Writes to a temp file and renames, so a crash mid-write can't leave a torn entry.
     void StoreCachedBlob( uint64_t key, const ShaderDeps& deps, ID3DBlob* code ) {
         if ( !code || code->GetBufferSize() == 0 || deps.size() > 256 ) return;
-        const std::string path = CacheFilePath( key, true );
-        if ( path.empty() ) return;
-        const std::string tmp = path + ".tmp";
 
         const std::string startDir = Engine::GAPI->GetStartDirectory();
-        {
-            std::ofstream out( tmp, std::ios::binary | std::ios::trunc );
-            if ( !out ) return;
-            out.write( "GDBC", 4 );
-            WritePod( out, kDxbcCacheFormatVersion );
-            WritePod( out, key );
-            WritePod( out, static_cast<uint32_t>( deps.size() ) );
-            for ( const auto& [absPath, hash] : deps ) {
-                std::error_code ec;
-                std::string relStr = std::filesystem::relative( absPath, startDir, ec ).string();
-                if ( ec || relStr.empty() ) relStr = absPath;   // fallback: dep lives outside StartDirectory
-                WritePod( out, static_cast<uint32_t>( relStr.size() ) );
-                out.write( relStr.data(), static_cast<std::streamsize>( relStr.size() ) );
-                WritePod( out, hash );
-            }
-            WritePod( out, static_cast<uint32_t>( code->GetBufferSize() ) );
-            out.write( static_cast<const char*>( code->GetBufferPointer() ),
-                static_cast<std::streamsize>( code->GetBufferSize() ) );
-            if ( !out ) { out.close(); DeleteFileA( tmp.c_str() ); return; }
+        std::vector<uint8_t> blob;
+        blob.reserve( 32 + code->GetBufferSize() );
+        ByteCursor::AppendBytes( blob, "GDBC", 4 );
+        ByteCursor::AppendPod( blob, kDxbcCacheFormatVersion );
+        ByteCursor::AppendPod( blob, key );
+        ByteCursor::AppendPod( blob, static_cast<uint32_t>( deps.size() ) );
+        for ( const auto& [absPath, hash] : deps ) {
+            std::error_code ec;
+            std::string relStr = std::filesystem::relative( absPath, startDir, ec ).string();
+            if ( ec || relStr.empty() ) relStr = absPath;   // fallback: dep lives outside StartDirectory
+            ByteCursor::AppendPod( blob, static_cast<uint32_t>( relStr.size() ) );
+            ByteCursor::AppendString( blob, relStr );
+            ByteCursor::AppendPod( blob, hash );
         }
-        if ( !MoveFileExA( tmp.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING ) )
-            DeleteFileA( tmp.c_str() );
+        ByteCursor::AppendPod( blob, static_cast<uint32_t>( code->GetBufferSize() ) );
+        ByteCursor::AppendBytes( blob, code->GetBufferPointer(), code->GetBufferSize() );
+
+        GetCacheStore().Put( key, blob.data(), blob.size() );
     }
 }
 

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -911,11 +911,20 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
 
     auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
 
-    // Release any resources of not visible lights
+    // Release resources of lights that have been out of view for a while now - NOT on the very first
+    // missing frame. A light that only blinks (zCVobLight::IsEnabled toggling for a flicker effect, or a
+    // one-frame frustum/visibility edge case) must keep its slot and baked depth across that blink: a
+    // PLS_STATIC_ONLY light's bake is meant to happen once and stick, but if every absent frame evicted it
+    // outright, a light that blinks even occasionally could never finish a bake that survives - it gets
+    // evicted mid-wait, wins a slot again on the next visible frame, and gets evicted again before that
+    // bake completes, so it lights unshadowed (bleeding through walls) forever instead of self-healing.
+    // Mirrors D3D12PointShadows' Slot::missingFrames retention in SelectShadowedLights.
+    constexpr int kPointLightSlotRetentionFrames = 120;
     for ( auto& it : Engine::GAPI->VobLightMap ) {
-        if ( it.second->LightShadowBuffers
-            && (!it.second->Vob->IsEnabled() || !it.second->VisibleInFrame) ) {
-            if ( D3D11PointLight* pl = dynamic_cast<D3D11PointLight*>(it.second->LightShadowBuffers.get()) ) {
+        if ( !it.second->LightShadowBuffers ) continue;
+        if ( D3D11PointLight* pl = dynamic_cast<D3D11PointLight*>(it.second->LightShadowBuffers.get()) ) {
+            const bool visible = it.second->Vob->IsEnabled() && it.second->VisibleInFrame;
+            if ( pl->NoteAbsence( visible, kPointLightSlotRetentionFrames ) ) {
                 pl->ClearTiledSlot();
                 pl->ReleaseShadowMap();
             }

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -443,6 +443,22 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
 
     const auto camPos = Engine::GAPI->GetCameraPositionXM();
 
+    // Mirrors D3D12 BuildFrameLightBuffer's post-selection range clamp (D3D12Scene.cpp): a light that
+    // ends up with no shadow cube shades unshadowed and bleeds through walls. Clamping its range to a
+    // small fraction keeps it lighting its own alcove instead of the next room - or, worse, the
+    // outside of the building it's sealed inside when the camera is outdoors and nothing can occlude
+    // it. Gated on IsStatic() OR IsIndoorVob, not IsStatic() alone: zCVobLight's "static" bit is
+    // Gothic's own IsStatic() (colour-animated fine, never repositioned), so a candle or brazier with
+    // a colour animation reads as non-static and would otherwise bleed through walls completely
+    // unshadowed - same failure mode as an atmospheric fill light. Outdoor dynamic lights (the
+    // player's torch, spell effects) are still exempt: open air has no walls to bleed through.
+    // Shrinking Range here (not just Color) also keeps the cluster cull from assigning the light to
+    // distant tiles it can no longer reach.
+    constexpr float kUnshadowedStaticScale = 0.35f;      // still lights its own alcove
+    constexpr float kIndoorSeenFromOutsideScale = 0.15f; // worst bleed case - clamp it much harder
+    const zCVob* playerVob = Engine::GAPI->GetPlayerVob();
+    const bool cameraIndoors = playerVob && playerVob->IsIndoorVob();
+
     for ( auto const& light : lights ) {
         zCVobLight* vob = light->Vob;
 
@@ -470,6 +486,10 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
 
         float4 lightColor = float4( vob->GetLightColor() );
         float lightRange = vob->GetLightRange();
+        if ( !hasShadow && ( vob->IsStatic() || light->IsIndoorVob ) ) {
+            const bool leakingOutdoors = light->IsIndoorVob && !cameraIndoors;
+            lightRange *= leakingOutdoors ? kIndoorSeenFromOutsideScale : kUnshadowedStaticScale;
+        }
         float3 posWorld = vob->GetPositionWorld();
 
         // Distance fade

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -1092,17 +1092,21 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 	// each winner's ShadowCubeIndex back into the GPU light struct. See D3D12PointShadows.h.
 	m_PointShadows.SelectShadowedLights( dst, count, s_lightKeys );
 
-	// ---- Range clamp for static lights that ended up WITHOUT a cube --------------------------------------
+	// ---- Range clamp for lights that ended up WITHOUT a cube ----------------------------------------------
 	// Runs after selection because only now is "did this light get a cube" known. Shrinking Range shrinks the
 	// light's whole sphere, so the tiled cull stops assigning it to distant tiles too — the bleed and its
-	// culling cost go away together. Dynamic lights are never clamped: they are few, they get the full-res
-	// tier, and a moving light that suddenly changed radius would be far more noticeable than a static one.
+	// culling cost go away together. Outdoor dynamic lights are never clamped: they are few, get the full-res
+	// tier, and open air has no walls to bleed through. INDOOR lights DO get clamped even when isStatic() is
+	// false: zCVobLight's "static" bit is Gothic's own IsStatic() (color-animated fine, never repositioned),
+	// so a candle or brazier with a colour animation reads as non-static and would otherwise bleed through
+	// walls completely unshadowed for as long as it never wins a cube - same failure mode as an atmospheric
+	// fill light, just reached through a different flag.
 	// s_cands is parallel to dst[] for i < count (the fill loop walks it in order and only ever breaks).
 	constexpr float kUnshadowedStaticScale = 0.35f;        // still lights its own alcove; can't reach the next room
 	constexpr float kIndoorSeenFromOutsideScale = 0.15f;   // the worst bleed case — clamp it much harder
 	for ( UINT i = 0; i < count; ++i ) {
 		if ( dst[i].ShadowCubeIndex >= 0 ) continue;   // shadowed: correctly occluded, leave it alone
-		if ( !s_cands[i].isStatic ) continue;
+		if ( !s_cands[i].isStatic && !s_cands[i].isIndoor ) continue;
 		// An INDOOR light with no cube, seen from outdoors, looks worst: it washes over the outside of the
 		// building it is sealed inside, and nothing can occlude it. Cut it to almost nothing.
 		const bool leakingOutdoors = s_cands[i].isIndoor && !cameraIndoors;

--- a/D3D11Engine/D3D12Engine/D3D12ShaderBackend.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShaderBackend.cpp
@@ -16,6 +16,8 @@
 #include "../GothicAPI.h"
 #include "../zFILE_VDFS.h"
 #include "../ShaderCacheHash.h"
+#include "../SqliteBlobStore.h"
+#include "../ByteCursor.h"
 
 using Microsoft::WRL::ComPtr;
 
@@ -92,7 +94,6 @@ namespace {
     // Bump when the DXC argument list in CompileSource changes in a way that alters codegen.
     constexpr uint32_t kDxilCacheArgsRevision = 1;
     constexpr uint32_t kDxilCacheFormatVersion = 1;
-    const char* kDxilCacheDirRel = "\\system\\GD3D11\\shadercache\\D3D12\\";
 
     int g_CacheHits = 0;
     int g_CacheMisses = 0;
@@ -161,53 +162,34 @@ namespace {
         return HashBytes( &dxc, sizeof( dxc ), h );
     }
 
-    /** Absolute path of the cache file for `key`. Empty when the directory can't be made (read-only
-        install) — the caller then skips the cache entirely. */
-    std::string CacheFilePath( uint64_t key, bool createDir ) {
-        const std::string dir = Engine::GAPI->GetStartDirectory() + kDxilCacheDirRel;
-        if ( createDir ) {
-            // One level at a time; CreateDirectory has no "create parents" flag and both may be missing.
-            const std::string parent = Engine::GAPI->GetStartDirectory() + "\\system\\GD3D11\\shadercache";
-            CreateDirectoryA( parent.c_str(), nullptr );
-            if ( !CreateDirectoryA( dir.c_str(), nullptr ) && GetLastError() != ERROR_ALREADY_EXISTS )
-                return "";
-        }
-        char name[32] = {};
-        sprintf_s( name, "%016llx.dxil", static_cast<unsigned long long>( key ) );
-        return dir + name;
-    }
-
-    template<typename T> bool ReadPod( std::ifstream& in, T& out ) {
-        return static_cast<bool>( in.read( reinterpret_cast<char*>( &out ), sizeof( T ) ) );
-    }
-    template<typename T> void WritePod( std::ofstream& out, const T& value ) {
-        out.write( reinterpret_cast<const char*>( &value ), sizeof( T ) );
+    SqliteBlobStore& GetCacheStore() {
+        // Magic-static: constructed once, on whichever thread compiles the first shader.
+        static SqliteBlobStore s_store( Engine::GAPI->GetStartDirectory() + R"(\system\GD3D11\cache\d3d12_shaders.db)" );
+        return s_store;
     }
 
     /** Reads the entry, re-hashes every recorded #include and, if they all still match, hands back the
-        stored DXIL. Any inconsistency (including a truncated/corrupt file) is just a miss. */
+        stored DXIL. Any inconsistency (including a truncated/corrupt record) is just a miss. */
     bool TryLoadCachedBlob( uint64_t key, ID3DBlob** ppCode ) {
-        const std::string path = CacheFilePath( key, false );
-        if ( path.empty() ) return false;
-        std::ifstream in( path, std::ios::binary );
-        if ( !in ) return false;
+        std::vector<uint8_t> blob;
+        if ( !GetCacheStore().TryGet( key, blob ) || blob.size() < 4 ) return false;
+        if ( memcmp( blob.data(), "GDXC", 4 ) != 0 ) return false;
 
-        char magic[4] = {};
+        ByteCursor::Reader in( blob.data() + 4, blob.size() - 4 );
         uint32_t version = 0;
         uint64_t storedKey = 0;
         uint32_t depCount = 0;
-        if ( !in.read( magic, 4 ) || memcmp( magic, "GDXC", 4 ) != 0 ) return false;
-        if ( !ReadPod( in, version ) || version != kDxilCacheFormatVersion ) return false;
-        if ( !ReadPod( in, storedKey ) || storedKey != key ) return false;
-        if ( !ReadPod( in, depCount ) || depCount > 256 ) return false;
+        if ( !in.ReadPod( version ) || version != kDxilCacheFormatVersion ) return false;
+        if ( !in.ReadPod( storedKey ) || storedKey != key ) return false;
+        if ( !in.ReadPod( depCount ) || depCount > 256 ) return false;
 
         for ( uint32_t i = 0; i < depCount; ++i ) {
             uint32_t nameLen = 0;
             uint64_t storedHash = 0;
-            if ( !ReadPod( in, nameLen ) || nameLen == 0 || nameLen > 512 ) return false;
-            std::string name( nameLen, '\0' );
-            if ( !in.read( name.data(), nameLen ) ) return false;
-            if ( !ReadPod( in, storedHash ) ) return false;
+            if ( !in.ReadPod( nameLen ) || nameLen == 0 || nameLen > 512 ) return false;
+            std::string name;
+            if ( !in.ReadString( name, nameLen ) ) return false;
+            if ( !in.ReadPod( storedHash ) ) return false;
 
             std::string depSource;
             if ( !D3D12ShaderBackend::LoadShaderSource( name, depSource ) ) return false;   // include vanished
@@ -215,42 +197,34 @@ namespace {
         }
 
         uint32_t blobSize = 0;
-        if ( !ReadPod( in, blobSize ) || blobSize == 0 || blobSize > ( 64u << 20 ) ) return false;
+        if ( !in.ReadPod( blobSize ) || blobSize == 0 || blobSize > ( 64u << 20 ) || blobSize > in.Remaining() ) return false;
 
-        ComPtr<ID3DBlob> blob;
-        if ( FAILED( D3DCreateBlob( blobSize, blob.GetAddressOf() ) ) ) return false;
-        if ( !in.read( static_cast<char*>( blob->GetBufferPointer() ), blobSize ) ) return false;
-        *ppCode = blob.Detach();
+        ComPtr<ID3DBlob> code;
+        if ( FAILED( D3DCreateBlob( blobSize, code.GetAddressOf() ) ) ) return false;
+        if ( !in.ReadBytes( code->GetBufferPointer(), blobSize ) ) return false;
+        *ppCode = code.Detach();
         return true;
     }
 
-    /** Best-effort store (a missing cache only costs time). Writes to a temp file and renames, so a crash
-        mid-write can't leave a torn entry that later reads as valid. */
+    /** Best-effort store (a missing cache only costs time). */
     void StoreCachedBlob( uint64_t key, const ShaderDeps& deps, ID3DBlob* code ) {
         if ( !code || code->GetBufferSize() == 0 || deps.size() > 256 ) return;
-        const std::string path = CacheFilePath( key, true );
-        if ( path.empty() ) return;
-        const std::string tmp = path + ".tmp";
 
-        {
-            std::ofstream out( tmp, std::ios::binary | std::ios::trunc );
-            if ( !out ) return;
-            out.write( "GDXC", 4 );
-            WritePod( out, kDxilCacheFormatVersion );
-            WritePod( out, key );
-            WritePod( out, static_cast<uint32_t>( deps.size() ) );
-            for ( const auto& [name, hash] : deps ) {
-                WritePod( out, static_cast<uint32_t>( name.size() ) );
-                out.write( name.data(), static_cast<std::streamsize>( name.size() ) );
-                WritePod( out, hash );
-            }
-            WritePod( out, static_cast<uint32_t>( code->GetBufferSize() ) );
-            out.write( static_cast<const char*>( code->GetBufferPointer() ),
-                static_cast<std::streamsize>( code->GetBufferSize() ) );
-            if ( !out ) { out.close(); DeleteFileA( tmp.c_str() ); return; }
+        std::vector<uint8_t> blob;
+        blob.reserve( 32 + code->GetBufferSize() );
+        ByteCursor::AppendBytes( blob, "GDXC", 4 );
+        ByteCursor::AppendPod( blob, kDxilCacheFormatVersion );
+        ByteCursor::AppendPod( blob, key );
+        ByteCursor::AppendPod( blob, static_cast<uint32_t>( deps.size() ) );
+        for ( const auto& [name, hash] : deps ) {
+            ByteCursor::AppendPod( blob, static_cast<uint32_t>( name.size() ) );
+            ByteCursor::AppendString( blob, name );
+            ByteCursor::AppendPod( blob, hash );
         }
-        if ( !MoveFileExA( tmp.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING ) )
-            DeleteFileA( tmp.c_str() );
+        ByteCursor::AppendPod( blob, static_cast<uint32_t>( code->GetBufferSize() ) );
+        ByteCursor::AppendBytes( blob, code->GetBufferPointer(), code->GetBufferSize() );
+
+        GetCacheStore().Put( key, blob.data(), blob.size() );
     }
 
     // Resolves #include directives inside D3D12 HLSL sources through the same VDFS+physical-fallback

--- a/D3D11Engine/Engine.cpp
+++ b/D3D11Engine/Engine.cpp
@@ -7,6 +7,7 @@
 #include "ImGuiShim.h"
 #include "D3D12Engine/D3D12Device.h"
 #include "D3D12Engine/D3D12GraphicsEngine.h"
+#include "SqliteBlobStore.h"
 
 #include <algorithm>
 
@@ -115,6 +116,12 @@ namespace Engine {
     /** Called when the game is about to close */
     void OnShutDown() {
         LogInfo() << "Shutting down...";
+
+        // Explicit and ordered, ahead of the exit(0) below: closing the LAST connection to a WAL-mode
+        // SQLite database is what makes it checkpoint and delete its -wal/-shm files, and this is called
+        // from DllMain(DLL_PROCESS_DETACH) under the loader lock - not a place to bet that outcome on
+        // function-local statics' destructors still running cleanly. See SqliteBlobStore::CloseAll().
+        SqliteBlobStore::CloseAll();
 
         // TODO: remove this hack in the future, just a temporary workaround to fix crash on shutdown with the need to kill process via TaskManager
         // Just killing before GraphicsEngine is not enough.

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -3526,7 +3526,7 @@ void GothicAPI::DrawParticleFX( zCVob* source, zCParticleFX* fx, ParticleFrameDa
         // Get texture
         zCTexture* texture = nullptr;
         if ( zCParticleEmitter* emitter = fx->GetEmitter() ) {
-            if ( emitter->GetVisShpType() == 5 && ParticleEffectProgMeshes.find(source) == ParticleEffectProgMeshes.end() ) {
+            if ( emitter->GetVisShpType() == 5 && !ParticleEffectProgMeshes.contains(source) ) {
                 AddParticleEffect( source );
             }
             if ( (texture = emitter->GetVisTexture( pfx )) != nullptr ) {

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -6492,7 +6492,9 @@ void GothicAPI::AddParticleEffect( zCVob* vob ) {
             if ( emitter->GetVisShpType() == 5 ) {
                 if ( zCModel* model = emitter->GetVisShpModel() ) {
                     MeshVisualInfo* mi = ParticleEffectProgMeshes.emplace(vob, std::make_unique<MeshVisualInfo>()).first->second.get();
-                    WorldConverter::ExtractProgMeshProtoFromModel( model, mi );
+                    // Same rationale as the prog-mesh branch below: don't hitch the frame a model-shaped
+                    // PFX burst spawns on.
+                    WorldConverter::ExtractProgMeshProtoFromModelAsync( model, mi );
                 } else if ( zCProgMeshProto* progMesh = emitter->GetVisShpProgMesh() ) {
                     MeshVisualInfo* mi = ParticleEffectProgMeshes.emplace(vob, std::make_unique<MeshVisualInfo>()).first->second.get();
                     // Same rationale as GothicAPI::OnAddVob: spawning many PFX with a prog-mesh particle

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -3051,14 +3051,18 @@ void GothicAPI::DrawSkeletalMeshVob( SkeletalVobInfo* vi, float distance, bool u
 
                     for ( auto const& itm : mvi->Meshes ) {
                         // no texture binding for shadowmap
+                        zCTexture* aniTex = nullptr;
+                        if ( !itm.first || !(aniTex = itm.first->GetAniTexture()) ) {
+                            continue;
+                        }
 
-                        if ( lastTex != itm.first->GetAniTexture() ) {
-                            if ( itm.first->GetAniTexture()->GetCacheState() != zRES_CACHED_IN ) {
+                        if ( lastTex != aniTex ) {
+                            if ( aniTex->GetCacheState() != zRES_CACHED_IN ) {
                                 continue;
                             }
-                            if ( itm.first->HasAlphaTest() || itm.first->GetAniTexture()->HasAlphaChannel() ) {
-                                itm.first->GetAniTexture()->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
-                                lastTex = itm.first->GetAniTexture();
+                            if ( itm.first->HasAlphaTest() || aniTex->HasAlphaChannel() ) {
+                                aniTex->GetSurface()->GetEngineTexture()->BindToPixelShader( 0 );
+                                lastTex = aniTex;
                             } else if ( isCube ) {
                                 g->GetWhiteTexture()->BindToPixelShader( 0 );
                                 lastTex = g->GetWhiteTexture()->GetShaderResourceView().Get();

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -6986,10 +6986,19 @@ static void CollectLeafVobs(
 
         const bool dropStaticLights = Engine::GAPI->GetRendererState().RendererSettings.DisableStaticPointlights;
 
+        // Portal culling for ambient lights: IsStatic() (== IsStaticVobLight) marks ZenGin's
+        // pre-placed atmospheric fills - they never move, so a room no chain of active portals
+        // reaches this frame is safe to skip outright; it picks back up the instant a door opens.
+        // Dynamic/PFX lights (torches, spell effects, the player's own light) are NOT gated here:
+        // they can be carried across sectors and their range test below already bounds the cost.
+        const bool leafPortalVisible = !ctx.portalCuller || ctx.portalCuller->IsLeafVisible( *base );
+
         for ( int i = 0; i < numLights; i++ ) {
             zCVobLight* vob = leaf->LightVobList.Array[i];
 
             if ( dropStaticLights && vob->IsStatic() ) continue;
+
+            if ( !leafPortalVisible && vob->IsStatic() ) continue;
 
             // Range test first - it needs nothing but the zCVobLight, and keeping it ahead of the
             // resolve below preserves the original rule that an out-of-range light never causes a

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4623,16 +4623,18 @@ void GothicAPI::CollectVisibleVobs(
             renderQueue.lights.push_back( vi );
             vi->VisibleInFrame = true;
 
-            // Update the lights shadows if: Light is dynamic or full shadow-updates are set
-            if ( !vi->IsPFXVobLight ) {
-                // TODO: should things like "light-spell" also cast shadows?
-                // i mean, we make torches cast them, why not also spells?
-                if ( lightUpdateEnabled && !vi->Vob->IsStatic() ) {
-                    const float lightRange = vi->Vob->GetLightRange();
-                    if ( lightRange > minDynamicUpdateLightRange && distSq < (lightRange * lightRange) )
-                        vi->UpdateShadows = true;
-                }
+            if ( lightUpdateEnabled ) {
+                // things like candles MUST also draw shadow cubes, otherwise they shine through walls.
+                const float lightRange = vi->Vob->GetLightRange();
+
+                // force light update for static/pfx lights, well anyone who hasent managed to get its shadow at least once
+                // otherwise we get ugly light bleeding from stuff like torches or spellFx
+                if ( distSq < (lightRange * lightRange) )
+                    vi->UpdateShadows = true;
             }
+            const bool pfxNeedsBake = vi->IsStaticVobLight && (!vi->LightShadowBuffers || !vi->LightShadowBuffers->IsShadowReady());
+            if ( pfxNeedsBake )
+                vi->UpdateShadows = true;
         }
     }
 }
@@ -5224,6 +5226,22 @@ void GothicAPI::BuildBspVobMapCacheHelper( zCBspBase* base ) {
                 VobLightInfo* vi = new VobLightInfo;
                 vi->Vob = vob;
                 VobLightMap[vob] = vi;
+                if ( vob->IsIndoorVob() ) {
+                    vi->IsIndoorVob = true;
+                }
+
+                if ( zCVob* parent = vob->GetVobParent(); parent ) {
+                    if ( auto visFx = parent->As<oCVisualFX>() ) {
+                        bool isPfx = true;
+                        if (auto origin = visFx->GetOrigin()) {
+                            // any PFX that stems from an ITEM should be counted as simple light.
+                            isPfx = !origin->As<oCItem>();
+                        }
+                        vi->IsPFXVobLight = isPfx;
+                    }
+                }
+                
+                vi->IsStaticVobLight = vob->GetLightInfoFlags().isStatic;
 
                 float minDynamicUpdateLightRange = Engine::GAPI->GetRendererState().RendererSettings.MinLightShadowUpdateRange;
                 if ( RendererState.RendererSettings.EnablePointlightShadows >= GothicRendererSettings::PLS_STATIC_ONLY
@@ -5234,9 +5252,6 @@ void GothicAPI::BuildBspVobMapCacheHelper( zCBspBase* base ) {
                     vi->LightShadowBuffers.reset(bpl);
                 }
 
-                if ( vob->IsIndoorVob() ) {
-                    vi->IsIndoorVob = true;
-                }
 
                 bvi.Lights.push_back( vi );
             } else {
@@ -7012,11 +7027,18 @@ static void CollectLeafVobs(
                     }
 
                     nvi->IsPFXVobLight = PFXVobLight;
-                    nvi->UpdateShadows = !PFXVobLight;
+                    nvi->UpdateShadows = true;
                     vit = VobLightMap.emplace( vob, nvi ).first;
 
-                    // Create shadow-buffers for these lights since it was dynamically added to the world
-                    if ( !nvi->IsPFXVobLight && rendererSettings.EnablePointlightShadows >= GothicRendererSettings::PLS_STATIC_ONLY ) {
+                    // Create shadow-buffers for these lights since it was dynamically added to the world.
+                    // PFX lights (candles/torches/campfires) get one too - they used to be excluded here
+                    // outright because their origin can be anywhere in the vob tree (including NPCs/the
+                    // player) with no reliable way to self-exclude it, which caused huge phantom shadows.
+                    // D3D11PointLight now sidesteps that by restricting PFX casters to world mesh only (see
+                    // RenderStaticShadowPass), so they can safely get shadows instead of none at all - the
+                    // previous exclusion meant candles/torches never cast any shadow and their light bled
+                    // straight through walls.
+                    if ( rendererSettings.EnablePointlightShadows >= GothicRendererSettings::PLS_STATIC_ONLY ) {
                         BaseShadowedPointLight* bpl = nullptr;
                         Engine::GraphicsEngine->CreateShadowedPointLight( &bpl, nvi, true ); // Also flag as dynamic
                         nvi->LightShadowBuffers.reset(bpl);
@@ -7036,13 +7058,14 @@ static void CollectLeafVobs(
             // it skips could not have rejected the light either.
             if ( !visitor->Visit( vi ) ) continue;
 
-            BoundingSphere lightSphere;
-            lightSphere.Center = vob->GetPositionWorld();
-            lightSphere.Radius = lightRange;
 
             // Cull any lights that are not visible even though they are in range
-            if ( clipResult != ContainmentType::CONTAINS && !ctx.frustum.Intersects( lightSphere ) )
-                continue;
+            if ( clipResult != ContainmentType::CONTAINS) {
+                BoundingSphere lightSphere;
+                lightSphere.Center = vob->GetPositionWorld();
+                lightSphere.Radius = lightRange;
+                if ( !ctx.frustum.Intersects( lightSphere ) ) continue;
+            }
 
             ctx.queue->PushLightVob( vi );
         }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -48,6 +48,8 @@
 #include "zCView.h"
 
 // TODO: REMOVE THIS!
+#include <ranges>
+
 #include "D3D11GraphicsEngine.h"
 #include "D3D11PipelineStateCache.h"
 #include "MeshManager.h"
@@ -1967,9 +1969,7 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
     }
 
     // Check every extension
-    for ( unsigned int i = 0; i < extv.size(); i++ ) {
-        std::string& ext = extv[i];
-
+    for (auto& ext : extv) {
         // Delete according to the type
         if ( ext == ".3DS" ) {
             // Clear the visual from all vobs (TODO: This may be slow!)
@@ -2397,9 +2397,7 @@ void GothicAPI::OnAddVob( zCVob* vob, zCWorld* world ) {
         PolyStripVisuals.insert( reinterpret_cast<zCPolyStrip*>(vob->GetVisual()) );
     }
 
-    for ( unsigned int i = 0; i < extv.size(); i++ ) {
-        std::string ext = extv[i];
-
+    for (auto ext : extv) {
         if ( ext == ".3DS" || ext == ".MMS" ) {
             zCProgMeshProto* pm;
             if ( ext == ".3DS" )
@@ -3679,10 +3677,10 @@ void GothicAPI::DrawTriangle( float3 pos = { 0.0f,0.0f,0.0f } ) {
     vx[5].Color = vx[1].Color;
     vx[4].Color = vx[2].Color;
 
-    for ( int i = 0; i < 6; i++ ) {
-        vx[i].Position.x += pos.x;
-        vx[i].Position.y += pos.y;
-        vx[i].Position.z += pos.z;
+    for (auto& i : vx) {
+        i.Position.x += pos.x;
+        i.Position.y += pos.y;
+        i.Position.z += pos.z;
     }
 
     vxb->UpdateBuffer( vx );
@@ -3900,39 +3898,39 @@ bool GothicAPI::TraceWorldMesh( const XMFLOAT3& origin, const XMFLOAT3& dir, XMF
 
     int numProcessed = 0;
     for ( auto const& bit : hitSections ) {
-        for ( auto it = bit.first->WorldMeshes.begin(); it != bit.first->WorldMeshes.end(); ++it ) {
+        for (auto& worldMesh : bit.first->WorldMeshes) {
             float u, v, t;
 
             // Positions come from the slim CPU copy the world mesh keeps instead of the full vertices.
-            const std::vector<WorldVertexCPU>& verts = it->second->CpuVertices;
+            const std::vector<WorldVertexCPU>& verts = worldMesh.second->CpuVertices;
             if ( verts.empty() ) {
                 continue;
             }
 
-            for ( unsigned int i = 0; i < it->second->Indices.size(); i += 3 ) {
-                if ( Toolbox::IntersectTri( verts[it->second->Indices[i]].Position,
-                    verts[it->second->Indices[i + 1]].Position,
-                    verts[it->second->Indices[i + 2]].Position,
+            for ( unsigned int i = 0; i < worldMesh.second->Indices.size(); i += 3 ) {
+                if ( Toolbox::IntersectTri( verts[worldMesh.second->Indices[i]].Position,
+                    verts[worldMesh.second->Indices[i + 1]].Position,
+                    verts[worldMesh.second->Indices[i + 2]].Position,
                     origin, dir, u, v, t ) ) {
                     if ( t > 0 && t < closest ) {
                         closest = t;
 
                         if ( hitTriangle ) {
-                            hitTriangle[0] = verts[it->second->Indices[i]].Position;
-                            hitTriangle[1] = verts[it->second->Indices[i + 1]].Position;
-                            hitTriangle[2] = verts[it->second->Indices[i + 2]].Position;
+                            hitTriangle[0] = verts[worldMesh.second->Indices[i]].Position;
+                            hitTriangle[1] = verts[worldMesh.second->Indices[i + 1]].Position;
+                            hitTriangle[2] = verts[worldMesh.second->Indices[i + 2]].Position;
                         }
 
                         if ( hitMesh ) {
-                            *hitMesh = it->second;
+                            *hitMesh = worldMesh.second;
                         }
 
                         if ( hitMaterial ) {
-                            *hitMaterial = it->first.Material;
+                            *hitMaterial = worldMesh.first.Material;
                         }
 
-                        if ( hitTextureName && it->first.Material && it->first.Material->GetTextureSingle() )
-                            *hitTextureName = it->first.Material->GetTextureSingle()->GetNameWithoutExt();
+                        if ( hitTextureName && worldMesh.first.Material && worldMesh.first.Material->GetTextureSingle() )
+                            *hitTextureName = worldMesh.first.Material->GetTextureSingle()->GetNameWithoutExt();
                     }
                 }
             }
@@ -5629,9 +5627,9 @@ void GothicAPI::ApplySuppressedSectionTextures() {
             if (auto mat = mit->first.Material ) {
                 if ( auto tx = mat->GetTextureSingle()) {
                     auto txName = tx->GetNameWithoutExtView();
-                    for ( unsigned int i = 0; i < it.second.size(); i++ ) {
+                    for (const auto& i : it.second) {
                         // Is this the texture we are looking for?
-                        if ( txName == it.second[i] ) {
+                        if ( txName == i) {
                             // Yes, move it to the suppressed map
                             section->SuppressedMeshes[mit->first] = mit->second;
                             mit = section->WorldMeshes.erase( mit );
@@ -6667,10 +6665,8 @@ void GothicAPI::PutCustomPolygonsIntoBspTreeRec( BspInfo* base ) {
         std::vector<WorldMeshSectionInfo*> sections;
         GetIntersectingSections( base->OriginalNode->BBox3D.Min, base->OriginalNode->BBox3D.Max, sections );
 
-        for ( size_t i = 0; i < sections.size(); i++ ) {
-            for ( size_t p = 0; p < sections[i]->SectionPolygons.size(); p++ ) {
-                zCPolygon* poly = sections[i]->SectionPolygons[p];
-
+        for (auto& section : sections) {
+            for (auto poly : section->SectionPolygons) {
                 if ( !poly->GetMaterial() || // Skip stuff with alpha-channel or not set material
                     poly->GetMaterial()->HasAlphaTest() )
                     continue;
@@ -6697,10 +6693,8 @@ void GothicAPI::PutCustomPolygonsIntoBspTreeRec( BspInfo* base ) {
 
 /** Returns the sections intersecting the given boundingboxes */
 void GothicAPI::GetIntersectingSections( const XMFLOAT3& min, const XMFLOAT3& max, std::vector<WorldMeshSectionInfo*>& sections ) {
-    for ( std::map<int, std::map<int, WorldMeshSectionInfo>>::iterator itx = Engine::GAPI->GetWorldSections().begin(); itx != Engine::GAPI->GetWorldSections().end(); itx++ ) {
-        for ( std::map<int, WorldMeshSectionInfo>::iterator ity = itx->second.begin(); ity != itx->second.end(); ity++ ) {
-            WorldMeshSectionInfo& section = ity->second;
-
+    for (auto& valx : Engine::GAPI->GetWorldSections() | std::views::values) {
+        for (auto& section : valx | std::views::values) {
             if ( Toolbox::AABBsOverlapping( section.BoundingBox.Min, section.BoundingBox.Max, min, max ) ) {
                 sections.push_back( &section );
             }
@@ -6710,28 +6704,26 @@ void GothicAPI::GetIntersectingSections( const XMFLOAT3& min, const XMFLOAT3& ma
 
 /** Generates zCPolygons for the loaded sections */
 void GothicAPI::CreatezCPolygonsForSections() {
-    for ( std::map<int, std::map<int, WorldMeshSectionInfo>>::iterator itx = Engine::GAPI->GetWorldSections().begin(); itx != Engine::GAPI->GetWorldSections().end(); itx++ ) {
-        for ( std::map<int, WorldMeshSectionInfo>::iterator ity = itx->second.begin(); ity != itx->second.end(); ity++ ) {
-            WorldMeshSectionInfo& section = ity->second;
-
-            for ( auto it = section.WorldMeshes.begin(); it != section.WorldMeshes.end(); ++it ) {
-                if ( !it->first.Material ||
-                    it->first.Material->HasAlphaTest() )
+    for (auto& sectionsX : Engine::GAPI->GetWorldSections() | std::views::values) {
+        for (auto& section : sectionsX | std::views::values) {
+            for ( auto& [first, second] : section.WorldMeshes) {
+                if ( !first.Material ||
+                    first.Material->HasAlphaTest() )
                     continue;
 
-                it->first.Material->SetAlphaFunc( zMAT_ALPHA_FUNC_NONE );
+                first.Material->SetAlphaFunc( zMAT_ALPHA_FUNC_NONE );
 
                 // The world mesh only keeps WorldVertexCPU now, so rebuild the full vertices this wants.
                 // Per-vertex normals come out zero; zCPolygon::CalcNormal() still derives the polygon plane
                 // from the positions, which is what the BSP/collision side of this path uses.
-                std::vector<ExVertexStruct> rebuilt( it->second->CpuVertices.size() );
-                for ( size_t v = 0; v < it->second->CpuVertices.size(); ++v ) {
-                    rebuilt[v].Position = it->second->CpuVertices[v].Position;
-                    rebuilt[v].TexCoord = it->second->CpuVertices[v].TexCoord;
-                    rebuilt[v].TexCoord2 = it->second->CpuVertices[v].TexCoord2;
+                std::vector<ExVertexStruct> rebuilt( second->CpuVertices.size() );
+                for ( size_t v = 0; v < second->CpuVertices.size(); ++v ) {
+                    rebuilt[v].Position = second->CpuVertices[v].Position;
+                    rebuilt[v].TexCoord = second->CpuVertices[v].TexCoord;
+                    rebuilt[v].TexCoord2 = second->CpuVertices[v].TexCoord2;
                 }
 
-                WorldConverter::ConvertExVerticesTozCPolygons( rebuilt, it->second->Indices, it->first.Material, section.SectionPolygons );
+                WorldConverter::ConvertExVerticesTozCPolygons( rebuilt, second->Indices, first.Material, section.SectionPolygons );
             }
         }
     }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5898,6 +5898,8 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "General", "PortalCullingNearRadius", float_to_string( s.PortalCullingNearRadius, 1 ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "EnablePortalShadowSkip", to_string_locale_independent( s.EnablePortalShadowSkip ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "EnableHorizonCulling", to_string_locale_independent( s.EnableHorizonCulling ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "EnableMeshOptimization", to_string_locale_independent( s.EnableMeshOptimization ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "EnableShadowIndexBuffers", to_string_locale_independent( s.EnableShadowIndexBuffers ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "FpsLimit", to_string_locale_independent( s.FpsLimit ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "PausedFpsLimit", to_string_locale_independent( s.PausedFpsLimit ).c_str(), ini.c_str() );
     
@@ -6083,6 +6085,8 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.PortalCullingNearRadius = GetPrivateProfileFloatA( "General", "PortalCullingNearRadius", ds.PortalCullingNearRadius, ini );
         s.EnablePortalShadowSkip = GetPrivateProfileBoolA( "General", "EnablePortalShadowSkip", ds.EnablePortalShadowSkip, ini );
         s.EnableHorizonCulling = GetPrivateProfileBoolA( "General", "EnableHorizonCulling", ds.EnableHorizonCulling, ini );
+        s.EnableMeshOptimization = GetPrivateProfileBoolA( "General", "EnableMeshOptimization", ds.EnableMeshOptimization, ini );
+        s.EnableShadowIndexBuffers = GetPrivateProfileBoolA( "General", "EnableShadowIndexBuffers", ds.EnableShadowIndexBuffers, ini );
         s.FpsLimit = GetPrivateProfileIntA( "General", "FpsLimit", 0, ini.c_str() );
         s.PausedFpsLimit = GetPrivateProfileIntA( "General", "PausedFpsLimit", ds.PausedFpsLimit, ini.c_str() );
         // Not optional: an unthrottled paused loop crashes drivers, so the ini can only pick a value

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4617,6 +4617,7 @@ void GothicAPI::CollectVisibleVobs(
         renderQueue.lights.clear();
 
         const bool lightUpdateEnabled = RendererState.RendererSettings.EnablePointlightShadows >= GothicRendererSettings::PLS_UPDATE_DYNAMIC;
+        const bool lightShadowsEnabled = RendererState.RendererSettings.EnablePointlightShadows >= GothicRendererSettings::PLS_STATIC_ONLY;
         for ( auto [distSq, vi] : lightWithDist ) {
             renderQueue.lights.push_back( vi );
             vi->VisibleInFrame = true;
@@ -4630,9 +4631,14 @@ void GothicAPI::CollectVisibleVobs(
                 if ( distSq < (lightRange * lightRange) )
                     vi->UpdateShadows = true;
             }
-            const bool pfxNeedsBake = vi->IsStaticVobLight && (!vi->LightShadowBuffers || !vi->LightShadowBuffers->IsShadowReady());
-            if ( pfxNeedsBake )
-                vi->UpdateShadows = true;
+            // not else!
+            if ( lightShadowsEnabled ) {
+                // just always update static lights, they should be pretty cheap. We limit them anyways.
+                if ( vi->IsStaticVobLight || !vi->IsPFXVobLight || vi->IsIndoorVob ) {
+                    vi->UpdateShadows = true;
+                }
+            }
+
         }
     }
 }

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -826,6 +826,8 @@ struct GothicRendererSettings {
         DoZPrepass = false;
         SortRenderQueue = false;
         DrawThreaded = false;
+        EnableMeshOptimization = true;
+        EnableShadowIndexBuffers = true;
 
         WindQuality = WIND_QUALITY_ADVANCED;
         HeroAffectsObjects = true;
@@ -1107,6 +1109,18 @@ struct GothicRendererSettings {
     bool EnableHorizonCulling;
     bool SortRenderQueue;
     bool DrawThreaded;
+    /** Run meshoptimizer's vertex-cache/fetch reorder (+ face reorder) on world sections and VOB
+        sub-meshes at load time. This is most of what makes big worlds slow to load; off leaves geometry
+        in its as-authored order (correct, just worse GPU vertex-cache/fetch locality at runtime). Also
+        gates shadow-index welding and LOD simplification, both byproducts of the same pass - see
+        EnableShadowIndexBuffers. A world/VOB set already optimized this session is memoized regardless
+        (MeshOptimizeCache.h), so this only controls whether the FIRST load in a session pays for it. */
+    bool EnableMeshOptimization;
+    /** Build the separate welded shadow index buffer (MeshShadowIndexBuilder.h) when
+        EnableMeshOptimization is on. Off falls back to the render index buffer for shadow passes
+        (slightly more shadow-map vertex work, no alpha-test capability loss - see
+        MeshShadowIndexBuilder.h) in exchange for skipping the weld and one buffer per sub-mesh. */
+    bool EnableShadowIndexBuffers;
     EPointLightShadowMode EnablePointlightShadows;
     float MinLightShadowUpdateRange;
     bool PartialDynamicShadowUpdates;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -1355,6 +1355,12 @@ struct GothicRendererSettings {
             bool GenerateAONormalsFromDepth; // Forward+: build smooth normals from depth for SAO/ASSAO
             bool ForceFeatureLevel10;
         } FeatureSet;
+        struct {
+            // Draws a wireframe range-sphere at every active point light and opens an ImGui window with
+            // stats + the raw shadow-cube faces (unwrapped as a cross) for whichever light is nearest the
+            // camera. See ImGuiShim::RenderPointLightShadowDebugWindow.
+            bool Enabled;
+        } PointLightDebug;
     } DebugSettings;
 
     bool GetIsTAAEnabled() const {

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -419,6 +419,15 @@ void ImGuiShim::RenderPointLightShadowDebugWindow() {
         nearest->IsTiledSlotLowRes() ? 1 : 0, nearest->GetShadowCubeTexture() ? "yes" : "no" );
     ImGui::Text( "IsPFXVobLight %d   IsStaticVobLight %d", nearestInfo->IsPFXVobLight ? 1 : 0,
         nearestInfo->IsStaticVobLight ? 1 : 0 );
+    ImGui::Text( "Vob->IsEnabled %d   VisibleInFrame %d   MissingFrames %d", nearestInfo->Vob->IsEnabled() ? 1 : 0,
+        nearestInfo->VisibleInFrame ? 1 : 0, nearest->GetMissingFrames() );
+    ImGui::SetItemTooltip( "IsEnabled is zCVobLight's own on/off bit (isTurnedOn) - if this reads 0 while the\n"
+        "light visually looks lit, the light vob itself is disabled by game/script state and GD3D11\n"
+        "correctly skips it (both lighting and shadowing); the visible glow is coming from something\n"
+        "else (a PFX/flame mesh, an unrelated light). MissingFrames counts consecutive frames this\n"
+        "light has been absent (disabled or out of VisibleInFrame) since its shadow resources were\n"
+        "last held; it only releases its slot past the retention window in DrawPointlightShadows, so a\n"
+        "light that blinks on/off keeps its progress instead of restarting its bake every time." );
     ImGui::Text( "LastRenderedPosition (%.1f, %.1f, %.1f)", nearestInfo->LastRenderedPosition.x,
         nearestInfo->LastRenderedPosition.y, nearestInfo->LastRenderedPosition.z );
     ImGui::SetItemTooltip( "Set by D3D11PointLight::RenderCubemap right after a real render - if this stays\n"
@@ -428,9 +437,10 @@ void ImGuiShim::RenderPointLightShadowDebugWindow() {
         ImGui::TextColored( ImVec4( 1.0f, 0.3f, 0.3f, 1.0f ),
             "This light has NO shadow map/tiled slot at all - it lights unshadowed by design\n"
             "(no caster geometry was ever tested for it), not because of a bias/leak bug.\n"
-            "If this is the light causing the bleed you're chasing, look at why it never got a\n"
-            "slot: EnablePointlightShadows mode, tiled-slot budget/eviction, or DrawnOnce never\n"
-            "having fired for it yet." );
+            "If this is the light causing the bleed you're chasing, check Vob->IsEnabled above first -\n"
+            "a disabled light is correctly skipped, its glow is coming from something else. Otherwise\n"
+            "look at why it never got a slot: EnablePointlightShadows mode, tiled-slot budget/eviction,\n"
+            "or DrawnOnce never having fired for it yet." );
         ImGui::End();
         return;
     }

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1716,6 +1716,20 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
             "the per-instance near/far split comes from the cull compute shader when that\n"
             "is on, and from the CPU instance upload when it is off." );
 
+        ImGui::Checkbox( "Optimize meshes on load", &settings.EnableMeshOptimization );
+        ImGui::SetItemTooltip( "Reorder world-section and VOB geometry for GPU vertex-cache/fetch locality\n"
+            "when it is first converted. This is most of what makes a big world slow to load;\n"
+            "turning it off trades some runtime GPU cost for faster loading. Also gates shadow-\n"
+            "index and LOD building below, since both ride the same pass. A world/VOB already\n"
+            "optimized this session is remembered regardless, so this only affects the FIRST\n"
+            "time each one loads. Takes effect on the next world load." );
+        ImGui::BeginDisabled( !settings.EnableMeshOptimization );
+        ImGui::Checkbox( "Build shadow index buffers", &settings.EnableShadowIndexBuffers );
+        ImGui::SetItemTooltip( "Weld a separate, smaller index buffer for shadow passes. Off falls back to\n"
+            "the render index buffer for shadows (more vertex work in the shadow pass, no\n"
+            "visual change) and skips one buffer per sub-mesh. Takes effect on the next world load." );
+        ImGui::EndDisabled();
+
         // ImGui::Checkbox( "Draw Sky", &settings.DrawSky );
         if ( ImGui::Checkbox( "Draw Fog", &settings.DrawFog ) ) {
             if ( Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D11 ) {

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -8,6 +8,10 @@
 #include "ImGuiEditorView.h"
 #include "MorphGpu.h"
 #include "zCParser.h"
+#include "D3D11PointLight.h"
+#include "BaseLineRenderer.h"
+#include "WorldObjects.h"
+#include "zCVobLight.h"
 #include <sstream>
 #include <map>
 #include <vector>
@@ -266,6 +270,8 @@ void ImGuiShim::BuildFrameUI()
         m_EditorView->Render();
     }
 
+    RenderPointLightShadowDebugWindow();
+
     if ( memcmp( &oldSettings, &Engine::GAPI->GetRendererState().RendererSettings, sizeof( GothicRendererSettings ) ) != 0 ) {
         if ( oldSettings.GraphicsPreset == Engine::GAPI->GetRendererState().RendererSettings.GraphicsPreset ) {
             Engine::GAPI->GetRendererState().RendererSettings.GraphicsPreset = GothicRendererSettings::E_GraphicsPreset::GRAPHICS_CUSTOM;
@@ -288,6 +294,187 @@ void ImGuiShim::CallEndFrameScript()
     if ( m_endFrameFn != -1 ) {
         zCParser::GetParser()->CallFunc( m_endFrameFn );
     }
+}
+
+namespace {
+    // Three orthogonal great-circles (XY/XZ/YZ) - a cheap wireframe approximation of a sphere, good enough
+    // to eyeball a light's range/position against the surrounding geometry.
+    void AddDebugWireSphere( BaseLineRenderer* lr, const XMFLOAT3& center, float radius, const XMFLOAT4& color, int segments = 32 ) {
+        if ( !lr || radius <= 0.0f ) {
+            return;
+        }
+        for ( int plane = 0; plane < 3; ++plane ) {
+            XMFLOAT3 prev{};
+            for ( int i = 0; i <= segments; ++i ) {
+                float t = (XM_2PI * static_cast<float>(i)) / static_cast<float>(segments);
+                float c = radius * cosf( t );
+                float s = radius * sinf( t );
+                XMFLOAT3 p;
+                switch ( plane ) {
+                case 0: p = XMFLOAT3( center.x + c, center.y + s, center.z ); break; // XY
+                case 1: p = XMFLOAT3( center.x + c, center.y, center.z + s ); break; // XZ
+                default: p = XMFLOAT3( center.x, center.y + c, center.z + s ); break; // YZ
+                }
+                if ( i > 0 ) {
+                    lr->AddLine( LineVertex( prev, color ), LineVertex( p, color ) );
+                }
+                prev = p;
+            }
+        }
+    }
+
+    // Kept alive across frames purely so ComPtr::Reset() releases the previous frame's SRVs before we
+    // create new ones - these are debug-only, rebuilt every frame the window is open, never bound anywhere
+    // else, so there's no lifetime hazard in just recreating them.
+    std::array<Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>, 6> s_pointLightDebugFaceSRVs;
+
+    void RebuildPointLightDebugFaceSRVs( const Microsoft::WRL::ComPtr<ID3D11Device1>& device, ID3D11Texture2D* tex, UINT baseSlice ) {
+        for ( UINT face = 0; face < 6; ++face ) {
+            D3D11_SHADER_RESOURCE_VIEW_DESC desc = {};
+            desc.Format = DXGI_FORMAT_R16_UNORM;
+            desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+            desc.Texture2DArray.MostDetailedMip = 0;
+            desc.Texture2DArray.MipLevels = 1;
+            desc.Texture2DArray.FirstArraySlice = baseSlice + face;
+            desc.Texture2DArray.ArraySize = 1;
+            s_pointLightDebugFaceSRVs[face].Reset();
+            device->CreateShaderResourceView( tex, &desc, s_pointLightDebugFaceSRVs[face].ReleaseAndGetAddressOf() );
+        }
+    }
+}
+
+/** Debug-only visualization to help diagnose point-light shadow bugs (light bleed/self-occlusion) without
+    guessing blind: draws every active light's range as a wireframe sphere (color-coded by shadow state) and
+    shows the raw shadow-cube depth faces for whichever light is nearest the camera, unfolded as a cross. */
+void ImGuiShim::RenderPointLightShadowDebugWindow() {
+    if ( Engine::GraphicsEngine->GetBackendAPI() != EGraphicsEngineBackend::D3D11 ) {
+        return; // Point-light cube visualization only implemented for the D3D11 backend so far.
+    }
+
+    auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+    if ( !settings.DebugSettings.PointLightDebug.Enabled ) {
+        return;
+    }
+
+    BaseLineRenderer* lr = Engine::GraphicsEngine->GetLineRenderer();
+    const XMFLOAT3 camPos = Engine::GAPI->GetCameraPosition();
+
+    D3D11PointLight* nearest = nullptr;
+    VobLightInfo* nearestInfo = nullptr;
+    float nearestDistSq = std::numeric_limits<float>::max();
+
+    for ( auto& vobLightPair : Engine::GAPI->VobLightMap ) {
+        VobLightInfo* info = vobLightPair.second;
+        if ( !info || !info->Vob || !info->LightShadowBuffers ) {
+            continue;
+        }
+        auto* pl = static_cast<D3D11PointLight*>( info->LightShadowBuffers.get() );
+        const bool hasMap = pl->HasAnyShadowMap();
+
+        const XMFLOAT3 pos = info->Vob->GetPositionWorld();
+        const float range = info->Vob->GetLightRange();
+
+        // Color-codes shadow readiness so a glance shows which lights actually have valid depth data:
+        // red = NO shadow map at all (this light can't cast any shadow - unshadowed/full bleed by design,
+        // not a bias bug), yellow = has a map but the static pass hasn't baked yet, green = static-ready.
+        const XMFLOAT4 color = !hasMap ? XMFLOAT4( 1.0f, 0.2f, 0.2f, 1.0f )
+            : pl->IsStaticShadowReady() ? XMFLOAT4( 0.2f, 1.0f, 0.2f, 1.0f )
+                                         : XMFLOAT4( 1.0f, 1.0f, 0.2f, 1.0f );
+        AddDebugWireSphere( lr, pos, range, color );
+
+        // Nearest-to-camera regardless of shadow-map state: a light without a map is exactly the kind of
+        // thing we need to be able to select and report on, not skip past in favor of a farther light that
+        // happens to have one.
+        const float dx = pos.x - camPos.x, dy = pos.y - camPos.y, dz = pos.z - camPos.z;
+        const float distSq = dx * dx + dy * dy + dz * dz;
+        if ( distSq < nearestDistSq ) {
+            nearestDistSq = distSq;
+            nearest = pl;
+            nearestInfo = info;
+        }
+    }
+
+    ImGui::SetNextWindowSize( ImVec2( 620, 620 ), ImGuiCond_FirstUseEver );
+    if ( !ImGui::Begin( "Point Light Shadow Debug" ) ) {
+        ImGui::End();
+        return;
+    }
+
+    if ( !nearest || !nearestInfo ) {
+        ImGui::TextUnformatted( "No point light with an allocated shadow map found nearby." );
+        ImGui::End();
+        return;
+    }
+
+    const XMFLOAT3 pos = nearestInfo->Vob->GetPositionWorld();
+    const float range = nearestInfo->Vob->GetLightRange();
+    const float dist = sqrtf( nearestDistSq );
+
+    ImGui::Text( "Nearest light: pos (%.1f, %.1f, %.1f)  range %.1f  dist-to-cam %.1f", pos.x, pos.y, pos.z, range, dist );
+    ImGui::Text( "zNear %.4f   zFar %.1f", nearest->GetDebugZNear(), nearest->GetDebugZFar() );
+    ImGui::Text( "Resolution %d   DrawnOnce %d   StaticReady %d   DynOverlay %d",
+        nearest->GetShadowMapResolution(), nearest->NotYetDrawn() ? 0 : 1,
+        nearest->IsStaticShadowReady() ? 1 : 0, nearest->HasDynamicShadowOverlay() ? 1 : 0 );
+    ImGui::Text( "Tiled slot %d (lowRes %d)   Legacy cube: %s", nearest->GetTiledSlot(),
+        nearest->IsTiledSlotLowRes() ? 1 : 0, nearest->GetShadowCubeTexture() ? "yes" : "no" );
+
+    if ( !nearest->HasAnyShadowMap() ) {
+        ImGui::TextColored( ImVec4( 1.0f, 0.3f, 0.3f, 1.0f ),
+            "This light has NO shadow map/tiled slot at all - it lights unshadowed by design\n"
+            "(no caster geometry was ever tested for it), not because of a bias/leak bug.\n"
+            "If this is the light causing the bleed you're chasing, look at why it never got a\n"
+            "slot: EnablePointlightShadows mode, tiled-slot budget/eviction, or DrawnOnce never\n"
+            "having fired for it yet." );
+        ImGui::End();
+        return;
+    }
+
+    ID3D11Texture2D* cubeTex = nearest->GetShadowCubeTexture();
+    UINT baseSlice = 0;
+    if ( !cubeTex ) {
+        cubeTex = nearest->GetTiledShadowCubeTexture();
+        const int tiledBase = nearest->GetTiledFaceBaseSlice();
+        baseSlice = tiledBase >= 0 ? static_cast<UINT>(tiledBase) : 0;
+    }
+
+    if ( !cubeTex ) {
+        ImGui::TextUnformatted( "No cube texture available for this light yet (not rendered this session)." );
+        ImGui::End();
+        return;
+    }
+
+    const auto& device = reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine)->GetDevice();
+    RebuildPointLightDebugFaceSRVs( device, cubeTex, baseSlice );
+
+    // Cube faces laid out as an unfolded cross, matching D3D's cubemap face order (+X,-X,+Y,-Y,+Z,-Z).
+    //        [ +Y ]
+    // [ -X ] [ +Z ] [ +X ] [ -Z ]
+    //        [ -Y ]
+    const ImVec2 sz( 110.0f, 110.0f );
+    const char* faceNames[6] = { "+X", "-X", "+Y", "-Y", "+Z", "-Z" };
+
+    auto imgAt = [&]( int face ) {
+        if ( s_pointLightDebugFaceSRVs[face] ) {
+            ImGui::Image( (ImTextureID)(intptr_t)s_pointLightDebugFaceSRVs[face].Get(), sz );
+        } else {
+            ImGui::Dummy( sz );
+        }
+        ImGui::SetItemTooltip( "Face %s - raw stored linear distance (white = far/unoccluded, black = near/occluded)", faceNames[face] );
+    };
+
+    ImGui::Dummy( sz ); ImGui::SameLine();
+    imgAt( 2 ); // +Y
+
+    imgAt( 1 ); ImGui::SameLine(); // -X
+    imgAt( 4 ); ImGui::SameLine(); // +Z
+    imgAt( 0 ); ImGui::SameLine(); // +X
+    imgAt( 5 );                    // -Z
+
+    ImGui::Dummy( sz ); ImGui::SameLine();
+    imgAt( 3 ); // -Y
+
+    ImGui::TextUnformatted( "White = unoccluded/far (linear distance/zFar close to 1.0), black = near/occluded." );
+    ImGui::End();
 }
 
 void ImGuiShim::RenderLoop()
@@ -1892,6 +2079,10 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
             }
 
             if (ImGui::BeginTabItem("Shadows", nullptr, ImGuiTabItemFlags_::ImGuiTabItemFlags_NoReorder)) {
+                ImGui::Checkbox("Point light shadow debug (D3D11)", &settings.DebugSettings.PointLightDebug.Enabled );
+                ImGui::SetItemTooltip("Draws a wireframe range-sphere at every active point light and opens a window\n"
+                                      "showing stats + the raw shadow-cube faces for whichever light is nearest the camera.");
+
                 ImGui::Checkbox("Lazy update", &settings.DebugSettings.ShadowCascades.LazyCascadeUpdate );
                 ImGui::SetItemTooltip("Update last cascades less frequently to improve performance, may cause uneven frametimes");
 

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -417,6 +417,12 @@ void ImGuiShim::RenderPointLightShadowDebugWindow() {
         nearest->IsStaticShadowReady() ? 1 : 0, nearest->HasDynamicShadowOverlay() ? 1 : 0 );
     ImGui::Text( "Tiled slot %d (lowRes %d)   Legacy cube: %s", nearest->GetTiledSlot(),
         nearest->IsTiledSlotLowRes() ? 1 : 0, nearest->GetShadowCubeTexture() ? "yes" : "no" );
+    ImGui::Text( "IsPFXVobLight %d   IsStaticVobLight %d", nearestInfo->IsPFXVobLight ? 1 : 0,
+        nearestInfo->IsStaticVobLight ? 1 : 0 );
+    ImGui::Text( "LastRenderedPosition (%.1f, %.1f, %.1f)", nearestInfo->LastRenderedPosition.x,
+        nearestInfo->LastRenderedPosition.y, nearestInfo->LastRenderedPosition.z );
+    ImGui::SetItemTooltip( "Set by D3D11PointLight::RenderCubemap right after a real render - if this stays\n"
+        "(0,0,0) while DrawnOnce/StaticReady are true, the light is caching a bake that never actually ran." );
 
     if ( !nearest->HasAnyShadowMap() ) {
         ImGui::TextColored( ImVec4( 1.0f, 0.3f, 0.3f, 1.0f ),

--- a/D3D11Engine/ImGuiShim.h
+++ b/D3D11Engine/ImGuiShim.h
@@ -88,6 +88,11 @@ private:
     void RenderAdvancedSettingsWindow();
     void RenderAdvancedColumn2(GothicRendererSettings& settings, GothicAPI* gapi);
 
+    /** Debug-only: draws a wireframe range-sphere at every active point light and shows the raw
+        shadow-cube faces for whichever one is nearest the camera. Gated on
+        DebugSettings.PointLightDebug.Enabled; D3D11 backend only. */
+    void RenderPointLightShadowDebugWindow();
+
     /** Backend-agnostic per-frame UI construction (settings/editor windows + script hooks).
         Called between ImGui::NewFrame() and ImGui::Render() by both backend render loops. */
     void BuildFrameUI();

--- a/D3D11Engine/MeshOptimizeCache.h
+++ b/D3D11Engine/MeshOptimizeCache.h
@@ -24,25 +24,28 @@
     In-memory tier bounded by the number of DISTINCT sub-meshes the session has ever converted - same
     growth shape as SharedVisualRegistry. Acceptable because an entry holds only small CPU-side index/
     vertex arrays, never a GPU buffer, so it does not touch the 32-bit VA budget the pooling rules in
-    CLAUDE.md are about. The on-disk tier is one small file per distinct sub-mesh ever seen, same shape as
-    the D3D11/D3D12 shader caches (ShaderCacheHash.h) it's modeled on - deleting the meshoptcache
-    directory is always safe, it just repays the CPU cost on the next load. kMeshCacheFormatVersion
-    exists for the same reason kDxbcCacheArgsRevision does in D3D11ShaderManager.cpp: bump it whenever a
-    change to MeshShadowIndexBuilder.h, MeshLodBuilder.h, this record layout, or the vendored
-    meshoptimizer version would make an old file's bytes stop matching what a fresh run produces - old
-    files are simply orphaned, never misread (the version is part of the validity check). */
+    CLAUDE.md are about. The on-disk tier is one row per distinct sub-mesh ever seen in a single SQLite
+    database (cache\meshes.db, via SqliteBlobStore) - tens of thousands of mostly-tiny entries is exactly
+    the shape a single DB beats a directory of loose files on (fewer file-system objects for the AV
+    scanner/NTFS to chew through during a load burst). Deleting cache\meshes.db is always safe, it just
+    repays the CPU cost on the next load. kFormatVersion below exists for the same reason
+    kDxbcCacheArgsRevision does in D3D11ShaderManager.cpp: bump it whenever a change to
+    MeshShadowIndexBuilder.h, MeshLodBuilder.h, this record layout, or the vendored meshoptimizer version
+    would make a previously-stored row's bytes stop matching what a fresh run produces today - old rows
+    are simply orphaned (dead weight, harmless), never misread, since the version is part of the record
+    and checked before anything else is trusted. */
 
 #include "VertexTypes.h"
 #include "Logger.h"
 #include "ShaderCacheHash.h"
+#include "SqliteBlobStore.h"
+#include "ByteCursor.h"
 #include "Engine.h"
 #include "GothicAPI.h"
 
 #include <atomic>
 #include <cstdint>
-#include <cstdio>
 #include <cstring>
-#include <fstream>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -84,91 +87,88 @@ namespace MeshOptimizeCache {
     }
 
     namespace Disk {
-        // Bump on any change that would make a previously-written file's bytes stop matching what a
-        // fresh OptimizeFaces/OptimizeVertices run produces today - see the header comment.
+        // Bump on any change that would make a previously-stored row's bytes stop matching what a fresh
+        // OptimizeFaces/OptimizeVertices run produces today - see the header comment.
         constexpr uint32_t kFormatVersion = 1;
-        constexpr uint32_t kMaxElements = 8u << 20;   // sanity cap against a corrupted/truncated file
+        constexpr uint32_t kMaxElements = 8u << 20;   // sanity cap against a corrupted/truncated record
 
-        inline std::string CacheFilePath( uint64_t key, bool createDir ) {
-            const std::string dir = Engine::GAPI->GetStartDirectory() + "\\" + ENGINE_BASE_DIR + "meshoptcache\\";
-            if ( createDir ) {
-                const std::string parent = Engine::GAPI->GetStartDirectory() + "\\" + ENGINE_BASE_DIR;
-                CreateDirectoryA( parent.c_str(), nullptr );
-                if ( !CreateDirectoryA( dir.c_str(), nullptr ) && GetLastError() != ERROR_ALREADY_EXISTS ) {
-                    return "";
-                }
-            }
-            char name[32] = {};
-            sprintf_s( name, "%016llx.meshopt", static_cast<unsigned long long>( key ) );
-            return dir + name;
+        inline SqliteBlobStore& GetStore() {
+            // Constructed on first use (magic-static, thread-safe) - by the time any mesh conversion
+            // runs, GetStartDirectory() is already valid.
+            static SqliteBlobStore s_store( Engine::GAPI->GetStartDirectory() + R"(\system\GD3D11\cache\meshes.db)" );
+            return s_store;
         }
 
-        template<typename T> bool ReadPod( std::ifstream& in, T& out ) {
-            return static_cast<bool>( in.read( reinterpret_cast<char*>( &out ), sizeof( T ) ) );
+        template<typename T> void AppendPod( std::vector<uint8_t>& buf, const T& value ) {
+            const uint8_t* p = reinterpret_cast<const uint8_t*>( &value );
+            buf.insert( buf.end(), p, p + sizeof( T ) );
         }
-        template<typename T> void WritePod( std::ofstream& out, const T& value ) {
-            out.write( reinterpret_cast<const char*>( &value ), sizeof( T ) );
-        }
-        template<typename T> bool ReadVector( std::ifstream& in, std::vector<T>& out, uint32_t count ) {
-            if ( count > kMaxElements ) return false;
-            out.resize( count );
-            return count == 0 || static_cast<bool>( in.read( reinterpret_cast<char*>( out.data() ),
-                static_cast<std::streamsize>( count ) * sizeof( T ) ) );
-        }
-        template<typename T> void WriteVector( std::ofstream& out, const std::vector<T>& v ) {
+        template<typename T> void AppendVector( std::vector<uint8_t>& buf, const std::vector<T>& v ) {
             if ( !v.empty() ) {
-                out.write( reinterpret_cast<const char*>( v.data() ),
-                    static_cast<std::streamsize>( v.size() * sizeof( T ) ) );
+                const uint8_t* p = reinterpret_cast<const uint8_t*>( v.data() );
+                buf.insert( buf.end(), p, p + v.size() * sizeof( T ) );
             }
         }
+
+        // Cursor over the blob TryGet hands back - the on-disk record layout is unchanged from the old
+        // per-file cache, just read from memory now instead of an ifstream.
+        struct Cursor {
+            const uint8_t* p;
+            const uint8_t* end;
+            template<typename T> bool ReadPod( T& out ) {
+                if ( static_cast<size_t>( end - p ) < sizeof( T ) ) return false;
+                memcpy( &out, p, sizeof( T ) );
+                p += sizeof( T );
+                return true;
+            }
+            template<typename T> bool ReadVector( std::vector<T>& out, uint32_t count ) {
+                if ( count > kMaxElements ) return false;
+                const size_t bytes = static_cast<size_t>( count ) * sizeof( T );
+                if ( static_cast<size_t>( end - p ) < bytes ) return false;
+                out.resize( count );
+                if ( bytes ) memcpy( out.data(), p, bytes );
+                p += bytes;
+                return true;
+            }
+        };
 
         inline bool TryLoad( uint64_t key, Entry& out ) {
-            const std::string path = CacheFilePath( key, false );
-            if ( path.empty() ) return false;
-            std::ifstream in( path, std::ios::binary );
-            if ( !in ) return false;
+            std::vector<uint8_t> blob;
+            if ( !GetStore().TryGet( key, blob ) || blob.size() < 4 ) return false;
+            if ( memcmp( blob.data(), "GMOC", 4 ) != 0 ) return false;
 
-            char magic[4] = {};
+            Cursor c{ blob.data() + 4, blob.data() + blob.size() };
             uint32_t version = 0;
             uint64_t storedKey = 0;
             uint32_t vertexCount = 0, indexCount = 0, shadowCount = 0, lodCount = 0;
-            if ( !in.read( magic, 4 ) || memcmp( magic, "GMOC", 4 ) != 0 ) return false;
-            if ( !ReadPod( in, version ) || version != kFormatVersion ) return false;
-            if ( !ReadPod( in, storedKey ) || storedKey != key ) return false;
-            if ( !ReadPod( in, vertexCount ) || !ReadPod( in, indexCount ) ||
-                !ReadPod( in, shadowCount ) || !ReadPod( in, lodCount ) ) return false;
+            if ( !c.ReadPod( version ) || version != kFormatVersion ) return false;
+            if ( !c.ReadPod( storedKey ) || storedKey != key ) return false;
+            if ( !c.ReadPod( vertexCount ) || !c.ReadPod( indexCount ) ||
+                !c.ReadPod( shadowCount ) || !c.ReadPod( lodCount ) ) return false;
 
-            return ReadVector( in, out.Vertices, vertexCount ) && ReadVector( in, out.Indices, indexCount ) &&
-                ReadVector( in, out.ShadowIndices, shadowCount ) && ReadVector( in, out.LodIndices, lodCount );
+            return c.ReadVector( out.Vertices, vertexCount ) && c.ReadVector( out.Indices, indexCount ) &&
+                c.ReadVector( out.ShadowIndices, shadowCount ) && c.ReadVector( out.LodIndices, lodCount );
         }
 
-        // Writes to a temp file and renames, so a crash (or another worker thread writing the same,
-        // byte-identical, content) mid-write can't leave a torn entry.
         inline void Store( uint64_t key, const Entry& e ) {
             if ( e.Indices.empty() || e.Vertices.empty() ) return;
-            const std::string path = CacheFilePath( key, true );
-            if ( path.empty() ) return;
-            const std::string tmp = path + ".tmp";
 
-            {
-                std::ofstream out( tmp, std::ios::binary | std::ios::trunc );
-                if ( !out ) return;
-                out.write( "GMOC", 4 );
-                WritePod( out, kFormatVersion );
-                WritePod( out, key );
-                WritePod( out, static_cast<uint32_t>( e.Vertices.size() ) );
-                WritePod( out, static_cast<uint32_t>( e.Indices.size() ) );
-                WritePod( out, static_cast<uint32_t>( e.ShadowIndices.size() ) );
-                WritePod( out, static_cast<uint32_t>( e.LodIndices.size() ) );
-                WriteVector( out, e.Vertices );
-                WriteVector( out, e.Indices );
-                WriteVector( out, e.ShadowIndices );
-                WriteVector( out, e.LodIndices );
-                if ( !out ) { out.close(); DeleteFileA( tmp.c_str() ); return; }
-            }
-            if ( !MoveFileExA( tmp.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING ) ) {
-                DeleteFileA( tmp.c_str() );
-            }
+            std::vector<uint8_t> blob;
+            blob.reserve( 32 + e.Vertices.size() * sizeof( ExVertexStruct ) +
+                ( e.Indices.size() + e.ShadowIndices.size() + e.LodIndices.size() ) * sizeof( VERTEX_INDEX ) );
+            blob.insert( blob.end(), reinterpret_cast<const uint8_t*>( "GMOC" ), reinterpret_cast<const uint8_t*>( "GMOC" ) + 4 );
+            AppendPod( blob, kFormatVersion );
+            AppendPod( blob, key );
+            AppendPod( blob, static_cast<uint32_t>( e.Vertices.size() ) );
+            AppendPod( blob, static_cast<uint32_t>( e.Indices.size() ) );
+            AppendPod( blob, static_cast<uint32_t>( e.ShadowIndices.size() ) );
+            AppendPod( blob, static_cast<uint32_t>( e.LodIndices.size() ) );
+            AppendVector( blob, e.Vertices );
+            AppendVector( blob, e.Indices );
+            AppendVector( blob, e.ShadowIndices );
+            AppendVector( blob, e.LodIndices );
+
+            GetStore().Put( key, blob.data(), blob.size() );
         }
     }   // namespace Disk
 

--- a/D3D11Engine/MeshOptimizeCache.h
+++ b/D3D11Engine/MeshOptimizeCache.h
@@ -1,0 +1,233 @@
+#pragma once
+
+/** Memoization for the CPU cost of GfxVertexBuffer::OptimizeVertices (vertex-cache/fetch reorder,
+    shadow-index welding, LOD simplification) - see WorldConverter.cpp's OptimizeMeshBuffers, the sole
+    caller. Two tiers: an in-memory map for this session, and an on-disk cache under
+    system\GD3D11\meshoptcache\ so the FIRST load of a session benefits too, on the second and later
+    runs of the game.
+
+    Gothic reloads the SAME world and VOB geometry many times, both within one session (leaving/
+    re-entering a world, reloading a save, walking back into a camp) and across separate game launches,
+    and meshopt's output is a pure function of the input vertex/index bytes plus which optional outputs
+    were asked for. A hit skips the vertex-cache optimization, the shadow weld and the min-error
+    simplification pass entirely, which is where load-time actually goes.
+    RendererSettings.EnableMeshOptimization/EnableShadowIndexBuffers exist to let a player skip that work
+    in the FIRST place; this is what stops any OTHER load - this session or a future one - from paying
+    for it again.
+
+    Keyed on a content hash of the PRE-optimization (vertices, indices), not on any Gothic-side pointer -
+    zCProgMeshProto/zCSubMesh objects do not reliably survive a world change (ZenGin's own resource
+    manager purges and reloads them independently of GD3D11), but the bytes a given source asset produces
+    do not change. Self-validating: two different source meshes colliding on the same hash would have to
+    produce identical bytes, in which case optimizing them identically is correct anyway.
+
+    In-memory tier bounded by the number of DISTINCT sub-meshes the session has ever converted - same
+    growth shape as SharedVisualRegistry. Acceptable because an entry holds only small CPU-side index/
+    vertex arrays, never a GPU buffer, so it does not touch the 32-bit VA budget the pooling rules in
+    CLAUDE.md are about. The on-disk tier is one small file per distinct sub-mesh ever seen, same shape as
+    the D3D11/D3D12 shader caches (ShaderCacheHash.h) it's modeled on - deleting the meshoptcache
+    directory is always safe, it just repays the CPU cost on the next load. kMeshCacheFormatVersion
+    exists for the same reason kDxbcCacheArgsRevision does in D3D11ShaderManager.cpp: bump it whenever a
+    change to MeshShadowIndexBuilder.h, MeshLodBuilder.h, this record layout, or the vendored
+    meshoptimizer version would make an old file's bytes stop matching what a fresh run produces - old
+    files are simply orphaned, never misread (the version is part of the validity check). */
+
+#include "VertexTypes.h"
+#include "Logger.h"
+#include "ShaderCacheHash.h"
+#include "Engine.h"
+#include "GothicAPI.h"
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace MeshOptimizeCache {
+
+    /** `wantShadow`/`wantLod` are folded into the key so a session that turns on
+        EnableShadowIndexBuffers partway through - or that mixes D3D11/D3D12 results, the only thing that
+        varies LOD - never gets served a hit that is missing an output it now needs. */
+    inline uint64_t Hash( const std::vector<VERTEX_INDEX>& indices, const std::vector<ExVertexStruct>& vertices,
+        bool wantShadow, bool wantLod ) {
+        uint64_t h = ShaderCacheHash::HashBytes( indices.data(), indices.size() * sizeof( VERTEX_INDEX ) );
+        h = ShaderCacheHash::HashBytes( vertices.data(), vertices.size() * sizeof( ExVertexStruct ), h );
+        const uint8_t flags = static_cast<uint8_t>( wantShadow ) | ( static_cast<uint8_t>( wantLod ) << 1 );
+        return ShaderCacheHash::HashBytes( &flags, sizeof( flags ), h );
+    }
+
+    struct Entry {
+        std::vector<ExVertexStruct> Vertices;
+        std::vector<VERTEX_INDEX> Indices;
+        std::vector<VERTEX_INDEX> ShadowIndices;
+        std::vector<VERTEX_INDEX> LodIndices;
+    };
+
+    // Worker-pool concurrent: BuildWorldMeshBuffers optimizes many sub-meshes at once (see
+    // WorldConverter.cpp's batched jobs), and VOB visual extraction runs on the same pool.
+    inline std::mutex g_Mutex;
+    inline gtl::flat_hash_map<uint64_t, Entry> g_Cache;
+    inline std::atomic<uint32_t> g_MemHits{ 0 }, g_DiskHits{ 0 }, g_Misses{ 0 };
+
+    inline void ReportStats() {
+        const uint32_t total = g_MemHits + g_DiskHits + g_Misses;
+        // Same cadence rule as MeshLod::ReportStats / MeshShadow::ReportStats: first lookup, then every
+        // 500, so silence is never ambiguous between "nothing ran" and "fewer than N lookups happened".
+        if ( total != 1 && ( total == 0 || total % 500 != 0 ) ) return;
+        LogInfo() << "Mesh optimize cache: " << g_MemHits.load() << " mem-hit, " << g_DiskHits.load()
+            << " disk-hit / " << total << " lookups (" << g_Cache.size() << " resident, "
+            << g_Misses.load() << " computed)";
+    }
+
+    namespace Disk {
+        // Bump on any change that would make a previously-written file's bytes stop matching what a
+        // fresh OptimizeFaces/OptimizeVertices run produces today - see the header comment.
+        constexpr uint32_t kFormatVersion = 1;
+        constexpr uint32_t kMaxElements = 8u << 20;   // sanity cap against a corrupted/truncated file
+
+        inline std::string CacheFilePath( uint64_t key, bool createDir ) {
+            const std::string dir = Engine::GAPI->GetStartDirectory() + "\\" + ENGINE_BASE_DIR + "meshoptcache\\";
+            if ( createDir ) {
+                const std::string parent = Engine::GAPI->GetStartDirectory() + "\\" + ENGINE_BASE_DIR;
+                CreateDirectoryA( parent.c_str(), nullptr );
+                if ( !CreateDirectoryA( dir.c_str(), nullptr ) && GetLastError() != ERROR_ALREADY_EXISTS ) {
+                    return "";
+                }
+            }
+            char name[32] = {};
+            sprintf_s( name, "%016llx.meshopt", static_cast<unsigned long long>( key ) );
+            return dir + name;
+        }
+
+        template<typename T> bool ReadPod( std::ifstream& in, T& out ) {
+            return static_cast<bool>( in.read( reinterpret_cast<char*>( &out ), sizeof( T ) ) );
+        }
+        template<typename T> void WritePod( std::ofstream& out, const T& value ) {
+            out.write( reinterpret_cast<const char*>( &value ), sizeof( T ) );
+        }
+        template<typename T> bool ReadVector( std::ifstream& in, std::vector<T>& out, uint32_t count ) {
+            if ( count > kMaxElements ) return false;
+            out.resize( count );
+            return count == 0 || static_cast<bool>( in.read( reinterpret_cast<char*>( out.data() ),
+                static_cast<std::streamsize>( count ) * sizeof( T ) ) );
+        }
+        template<typename T> void WriteVector( std::ofstream& out, const std::vector<T>& v ) {
+            if ( !v.empty() ) {
+                out.write( reinterpret_cast<const char*>( v.data() ),
+                    static_cast<std::streamsize>( v.size() * sizeof( T ) ) );
+            }
+        }
+
+        inline bool TryLoad( uint64_t key, Entry& out ) {
+            const std::string path = CacheFilePath( key, false );
+            if ( path.empty() ) return false;
+            std::ifstream in( path, std::ios::binary );
+            if ( !in ) return false;
+
+            char magic[4] = {};
+            uint32_t version = 0;
+            uint64_t storedKey = 0;
+            uint32_t vertexCount = 0, indexCount = 0, shadowCount = 0, lodCount = 0;
+            if ( !in.read( magic, 4 ) || memcmp( magic, "GMOC", 4 ) != 0 ) return false;
+            if ( !ReadPod( in, version ) || version != kFormatVersion ) return false;
+            if ( !ReadPod( in, storedKey ) || storedKey != key ) return false;
+            if ( !ReadPod( in, vertexCount ) || !ReadPod( in, indexCount ) ||
+                !ReadPod( in, shadowCount ) || !ReadPod( in, lodCount ) ) return false;
+
+            return ReadVector( in, out.Vertices, vertexCount ) && ReadVector( in, out.Indices, indexCount ) &&
+                ReadVector( in, out.ShadowIndices, shadowCount ) && ReadVector( in, out.LodIndices, lodCount );
+        }
+
+        // Writes to a temp file and renames, so a crash (or another worker thread writing the same,
+        // byte-identical, content) mid-write can't leave a torn entry.
+        inline void Store( uint64_t key, const Entry& e ) {
+            if ( e.Indices.empty() || e.Vertices.empty() ) return;
+            const std::string path = CacheFilePath( key, true );
+            if ( path.empty() ) return;
+            const std::string tmp = path + ".tmp";
+
+            {
+                std::ofstream out( tmp, std::ios::binary | std::ios::trunc );
+                if ( !out ) return;
+                out.write( "GMOC", 4 );
+                WritePod( out, kFormatVersion );
+                WritePod( out, key );
+                WritePod( out, static_cast<uint32_t>( e.Vertices.size() ) );
+                WritePod( out, static_cast<uint32_t>( e.Indices.size() ) );
+                WritePod( out, static_cast<uint32_t>( e.ShadowIndices.size() ) );
+                WritePod( out, static_cast<uint32_t>( e.LodIndices.size() ) );
+                WriteVector( out, e.Vertices );
+                WriteVector( out, e.Indices );
+                WriteVector( out, e.ShadowIndices );
+                WriteVector( out, e.LodIndices );
+                if ( !out ) { out.close(); DeleteFileA( tmp.c_str() ); return; }
+            }
+            if ( !MoveFileExA( tmp.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING ) ) {
+                DeleteFileA( tmp.c_str() );
+            }
+        }
+    }   // namespace Disk
+
+    /** On a hit (memory, then disk), overwrites indices/vertices/shadowIndices/lodIndices with the
+        cached, already-optimized result and returns true - the caller skips OptimizeFaces/
+        OptimizeVertices entirely. A disk hit is folded into the in-memory map so the rest of this
+        session skips the file read too. */
+    inline bool TryGet( uint64_t key, std::vector<VERTEX_INDEX>& indices, std::vector<ExVertexStruct>& vertices,
+        std::vector<VERTEX_INDEX>* shadowIndices, std::vector<VERTEX_INDEX>* lodIndices ) {
+        {
+            std::scoped_lock lock( g_Mutex );
+            auto it = g_Cache.find( key );
+            if ( it != g_Cache.end() ) {
+                indices = it->second.Indices;
+                vertices = it->second.Vertices;
+                if ( shadowIndices ) *shadowIndices = it->second.ShadowIndices;
+                if ( lodIndices ) *lodIndices = it->second.LodIndices;
+                ++g_MemHits;
+                ReportStats();
+                return true;
+            }
+        }
+
+        Entry disk;
+        if ( Disk::TryLoad( key, disk ) ) {
+            indices = disk.Indices;
+            vertices = disk.Vertices;
+            if ( shadowIndices ) *shadowIndices = disk.ShadowIndices;
+            if ( lodIndices ) *lodIndices = disk.LodIndices;
+            {
+                std::scoped_lock lock( g_Mutex );
+                g_Cache.emplace( key, std::move( disk ) );
+            }
+            ++g_DiskHits;
+            ReportStats();
+            return true;
+        }
+
+        ++g_Misses;
+        ReportStats();
+        return false;
+    }
+
+    inline void Put( uint64_t key, const std::vector<VERTEX_INDEX>& indices, const std::vector<ExVertexStruct>& vertices,
+        const std::vector<VERTEX_INDEX>* shadowIndices, const std::vector<VERTEX_INDEX>* lodIndices ) {
+        Entry e;
+        e.Indices = indices;
+        e.Vertices = vertices;
+        if ( shadowIndices ) {
+            e.ShadowIndices = *shadowIndices;
+        }
+        if ( lodIndices ) {
+            e.LodIndices = *lodIndices;
+        }
+
+        Disk::Store( key, e );
+
+        std::scoped_lock lock( g_Mutex );
+        g_Cache.emplace( key, std::move( e ) );
+    }
+
+}   // namespace MeshOptimizeCache

--- a/D3D11Engine/SqliteBlobStore.cpp
+++ b/D3D11Engine/SqliteBlobStore.cpp
@@ -1,0 +1,152 @@
+#include "pch.h"
+#include "SqliteBlobStore.h"
+#include "Toolbox.h"
+#include "Logger.h"
+
+#include <sqlite3.h>
+#include <algorithm>
+#include <filesystem>
+#include <vector>
+
+namespace {
+    bool Exec( sqlite3* db, const char* sql ) {
+        char* errMsg = nullptr;
+        const int rc = sqlite3_exec( db, sql, nullptr, nullptr, &errMsg );
+        if ( rc != SQLITE_OK ) {
+            LogWarn() << "SqliteBlobStore: " << ( errMsg ? errMsg : sqlite3_errstr( rc ) );
+            sqlite3_free( errMsg );
+            return false;
+        }
+        return true;
+    }
+
+    // Every live SqliteBlobStore registers itself here so CloseAll() can find it - see the .h comment on
+    // why this can't just be "let them destruct as function-local statics".
+    std::mutex g_RegistryMutex;
+    std::vector<SqliteBlobStore*> g_Instances;
+}
+
+SqliteBlobStore::SqliteBlobStore( const std::string& path ) {
+    {
+        std::scoped_lock lock( g_RegistryMutex );
+        g_Instances.push_back( this );
+    }
+
+    const std::filesystem::path p( path );
+    if ( p.has_parent_path() ) {
+        Toolbox::CreateDirectoryRecursive( p.parent_path().string() );
+    }
+
+    sqlite3* db = nullptr;
+    if ( sqlite3_open_v2( path.c_str(), &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr ) != SQLITE_OK ) {
+        LogWarn() << "SqliteBlobStore: failed to open " << path << " - caching disabled for this store.";
+        if ( db ) sqlite3_close( db );
+        return;
+    }
+
+    // WAL: a reader on another thread (once it has m_mutex) never blocks behind a writer mid-transaction.
+    // NORMAL sync: this is a cache, not a ledger - losing the last few writes to a power cut is exactly
+    // as safe as never having cached them, and trading that away is the entire point of WAL+NORMAL.
+    if ( !Exec( db, "PRAGMA journal_mode=WAL;" ) ||
+        !Exec( db, "PRAGMA synchronous=NORMAL;" ) ||
+        !Exec( db, "CREATE TABLE IF NOT EXISTS blobs (key INTEGER PRIMARY KEY, data BLOB NOT NULL);" ) ) {
+        sqlite3_close( db );
+        return;
+    }
+
+    // Upsert pre-sizes the row's blob with zeroblob() so Put() can then open it for incremental WRITE by
+    // rowid - `key` IS the rowid (INTEGER PRIMARY KEY), so no SELECT is needed to find it afterward.
+    sqlite3_stmt* upsertStmt = nullptr;
+    sqlite3_stmt* deleteStmt = nullptr;
+    if ( sqlite3_prepare_v2( db,
+            "INSERT INTO blobs(key, data) VALUES(?1, zeroblob(?2)) "
+            "ON CONFLICT(key) DO UPDATE SET data=zeroblob(?2);",
+            -1, &upsertStmt, nullptr ) != SQLITE_OK ||
+        sqlite3_prepare_v2( db, "DELETE FROM blobs WHERE key=?1;", -1, &deleteStmt, nullptr ) != SQLITE_OK ) {
+        if ( upsertStmt ) sqlite3_finalize( upsertStmt );
+        if ( deleteStmt ) sqlite3_finalize( deleteStmt );
+        sqlite3_close( db );
+        return;
+    }
+
+    m_db = db;
+    m_upsertStmt = upsertStmt;
+    m_deleteStmt = deleteStmt;
+}
+
+SqliteBlobStore::~SqliteBlobStore() {
+    {
+        std::scoped_lock lock( g_RegistryMutex );
+        g_Instances.erase( std::remove( g_Instances.begin(), g_Instances.end(), this ), g_Instances.end() );
+    }
+    Close();
+}
+
+void SqliteBlobStore::Close() {
+    std::scoped_lock lock( m_mutex );
+    if ( m_upsertStmt ) { sqlite3_finalize( m_upsertStmt ); m_upsertStmt = nullptr; }
+    if ( m_deleteStmt ) { sqlite3_finalize( m_deleteStmt ); m_deleteStmt = nullptr; }
+    if ( m_db ) {
+        // The last connection to a WAL-mode database closing cleanly is what makes SQLite checkpoint
+        // and delete its -wal/-shm files - see the .h comment on CloseAll(). If some other handle to
+        // the same file is still open (shouldn't happen - one SqliteBlobStore per db path, one
+        // connection per instance) that checkpoint is simply skipped; sqlite3_close() itself still
+        // succeeds either way.
+        sqlite3_close( m_db );
+        m_db = nullptr;
+    }
+}
+
+void SqliteBlobStore::CloseAll() {
+    std::vector<SqliteBlobStore*> instances;
+    {
+        std::scoped_lock lock( g_RegistryMutex );
+        instances = g_Instances;   // snapshot - Close() below never touches g_Instances itself
+    }
+    for ( SqliteBlobStore* store : instances ) {
+        store->Close();
+    }
+}
+
+bool SqliteBlobStore::TryGet( uint64_t key, std::vector<uint8_t>& outData ) const {
+    if ( !m_db ) return false;
+    std::scoped_lock lock( m_mutex );
+
+    sqlite3_blob* blob = nullptr;
+    if ( sqlite3_blob_open( m_db, "main", "blobs", "data", static_cast<sqlite3_int64>( key ), 0, &blob ) != SQLITE_OK ) {
+        return false;   // no row for this key - a miss, not an error
+    }
+
+    const int size = sqlite3_blob_bytes( blob );
+    outData.resize( static_cast<size_t>( size ) );
+    const bool ok = size == 0 || sqlite3_blob_read( blob, outData.data(), size, 0 ) == SQLITE_OK;
+    sqlite3_blob_close( blob );
+    return ok;
+}
+
+void SqliteBlobStore::Put( uint64_t key, const void* data, size_t size ) {
+    if ( !m_db || size == 0 ) return;
+    std::scoped_lock lock( m_mutex );
+
+    sqlite3_reset( m_upsertStmt );
+    sqlite3_bind_int64( m_upsertStmt, 1, static_cast<sqlite3_int64>( key ) );
+    sqlite3_bind_int64( m_upsertStmt, 2, static_cast<sqlite3_int64>( size ) );
+    if ( sqlite3_step( m_upsertStmt ) != SQLITE_DONE ) {
+        return;
+    }
+
+    sqlite3_blob* blob = nullptr;
+    if ( sqlite3_blob_open( m_db, "main", "blobs", "data", static_cast<sqlite3_int64>( key ), 1, &blob ) != SQLITE_OK ) {
+        return;
+    }
+    sqlite3_blob_write( blob, data, static_cast<int>( size ), 0 );
+    sqlite3_blob_close( blob );
+}
+
+void SqliteBlobStore::Erase( uint64_t key ) {
+    if ( !m_db ) return;
+    std::scoped_lock lock( m_mutex );
+    sqlite3_reset( m_deleteStmt );
+    sqlite3_bind_int64( m_deleteStmt, 1, static_cast<sqlite3_int64>( key ) );
+    sqlite3_step( m_deleteStmt );
+}

--- a/D3D11Engine/SqliteBlobStore.h
+++ b/D3D11Engine/SqliteBlobStore.h
@@ -1,0 +1,68 @@
+#pragma once
+
+/** Generic key -> blob cache backed by one SQLite database file, using SQLite's incremental BLOB I/O API
+    (sqlite3_blob_open/read/write, sqlite3.org/c3ref/blob_open.html) so a lookup or store never needs a
+    full row copied through bound parameters. Consumers never see SQLite: this is a plain
+    uint64-key -> bytes store (TryGet/Put/Erase) - no schema, no SQL, nothing sqlite-shaped leaks into the
+    header or the call sites that use it.
+
+    One instance IS one database file/connection. Every call is internally serialized (see .cpp): this
+    exists to back the mesh-optimize and shader on-disk caches, which are all load-time-only work (never
+    the frame path), so a single mutex per store costs nothing that matters here and keeps correctness
+    independent of how the vendored SQLite was built (threading mode etc). Safe to call from multiple
+    threads - callers on GD3D11's worker pool do exactly that.
+
+    If the database can't be opened or created (read-only install, locked file, first run before the
+    directory exists, ...) the store silently becomes a no-op: every TryGet is a miss, every Put/Erase
+    does nothing. A broken cache degrades to "no caching", not a failed world/shader load. */
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+class SqliteBlobStore {
+public:
+    /** Opens (creating if needed, including the parent directory) the database at `path`. */
+    explicit SqliteBlobStore( const std::string& path );
+    ~SqliteBlobStore();
+
+    SqliteBlobStore( const SqliteBlobStore& ) = delete;
+    SqliteBlobStore& operator=( const SqliteBlobStore& ) = delete;
+
+    bool IsOpen() const { return m_db != nullptr; }
+
+    /** Reads the blob stored under `key` into `outData` and returns true, or leaves `outData` untouched
+        and returns false if absent (or the store failed to open). */
+    bool TryGet( uint64_t key, std::vector<uint8_t>& outData ) const;
+
+    /** Stores, or overwrites, the blob under `key`. No-op if the store failed to open. */
+    void Put( uint64_t key, const void* data, size_t size );
+
+    /** Removes `key` if present. No-op if the store failed to open or the key is absent. */
+    void Erase( uint64_t key );
+
+    /** Finalizes the prepared statements and closes the connection. Idempotent, and safe to call even
+        though every TryGet/Put/Erase already null-checks - after this, the instance is just a permanent
+        no-op store (matches what "failed to open" already looks like) rather than a dangling handle.
+        Closing the LAST connection to a WAL-mode database is what makes SQLite checkpoint and delete its
+        -wal/-shm files; see CloseAll(). */
+    void Close();
+
+    /** Closes every SqliteBlobStore instance currently alive (every on-disk cache: mesh, D3D11 shader,
+        D3D12 shader). Call this once from the engine's own shutdown path.
+
+        Why this exists instead of relying on these being function-local statics that destruct
+        themselves: Engine::OnShutDown() calls exit(0) as a deliberate workaround for a crash on the
+        normal teardown path, and it does so from DllMain(DLL_PROCESS_DETACH) - under the loader lock,
+        with no guarantee any other thread still touching a store has been stopped first. Whether static
+        destructors still run cleanly through that is not something to bet a "did the -wal/-shm file get
+        deleted" outcome on. An explicit, single, ordered CloseAll() call is deterministic regardless. */
+    static void CloseAll();
+
+private:
+    struct sqlite3* m_db = nullptr;
+    struct sqlite3_stmt* m_upsertStmt = nullptr;
+    struct sqlite3_stmt* m_deleteStmt = nullptr;
+    mutable std::mutex m_mutex;
+};

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -24,6 +24,7 @@
 #include "zCQuadMark.h"
 #include <meshoptimizer/src/meshoptimizer.h>
 #include "MeshManager.h"
+#include "MeshOptimizeCache.h"
 #include "SharedVisualRegistry.h"
 #include "AsyncVisualExtractor.h"
 #include "MorphBlend.h"
@@ -49,6 +50,45 @@ namespace {
             meshInfo->ShadowIndices.size() * sizeof( VERTEX_INDEX ),
             D3D11VertexBuffer::B_INDEXBUFFER,
             D3D11VertexBuffer::U_IMMUTABLE );
+    }
+
+    /** Runs OptimizeFaces + OptimizeVertices for one sub-mesh, honoring RendererSettings.
+        EnableMeshOptimization/EnableShadowIndexBuffers and reusing a prior lookup's result for
+        byte-identical input this session (MeshOptimizeCache.h) - the sole call site for both.
+
+        Turning EnableMeshOptimization off leaves indices/vertices in their as-authored order (correct,
+        just worse GPU vertex-cache/fetch locality) and shadowIndices/lodIndices empty, which every
+        consumer already reads as "use the render buffer / no reduced level" - see
+        MeshShadowIndexBuilder.h and MeshLodBuilder.h. `lodIndices` is passed through as-is (null on
+        every D3D11 call site, matching LodIndices being D3D12-only - see WorldObjects.h). */
+    void OptimizeMeshBuffers( GfxVertexBuffer* vertexBuffer, std::vector<VERTEX_INDEX>& indices,
+        std::vector<ExVertexStruct>& vertices, std::vector<VERTEX_INDEX>* shadowIndices,
+        std::vector<VERTEX_INDEX>* lodIndices ) {
+        if ( shadowIndices ) {
+            shadowIndices->clear();
+        }
+        if ( lodIndices ) {
+            lodIndices->clear();
+        }
+
+        const auto& s = Engine::GAPI->GetRendererState().RendererSettings;
+        if ( !s.EnableMeshOptimization || indices.empty() || vertices.empty() ) {
+            return;
+        }
+
+        std::vector<VERTEX_INDEX>* const wantShadow = s.EnableShadowIndexBuffers ? shadowIndices : nullptr;
+
+        const uint64_t key = MeshOptimizeCache::Hash( indices, vertices, wantShadow != nullptr, lodIndices != nullptr );
+        if ( MeshOptimizeCache::TryGet( key, indices, vertices, wantShadow, lodIndices ) ) {
+            return;
+        }
+
+        vertexBuffer->OptimizeFaces( indices.data(), reinterpret_cast<byte*>(vertices.data()),
+            indices.size(), vertices.size(), sizeof( ExVertexStruct ) );
+        vertexBuffer->OptimizeVertices( indices.data(), reinterpret_cast<byte*>(vertices.data()),
+            indices.size(), vertices.size(), sizeof( ExVertexStruct ), wantShadow, lodIndices );
+
+        MeshOptimizeCache::Put( key, indices, vertices, wantShadow, lodIndices );
     }
 
     /** ZENGIN's zPMINDEX_NONE: terminator of a WedgeMap collapse chain. */
@@ -277,20 +317,8 @@ namespace {
         // because they move the whole ExVertexStruct stride, including Tangent).
         GenerateTangents( mesh->Vertices, mesh->Indices );
 
-        // Optimize faces
-        mesh->MeshVertexBuffer->OptimizeFaces( &mesh->Indices[0],
-            reinterpret_cast<byte*>(&mesh->Vertices[0]),
-            mesh->Indices.size(),
-            mesh->Vertices.size(),
-            sizeof( ExVertexStruct ) );
-
-        // Then optimize vertices
-        mesh->MeshVertexBuffer->OptimizeVertices( &mesh->Indices[0],
-            reinterpret_cast<byte*>(&mesh->Vertices[0]),
-            mesh->Indices.size(),
-            mesh->Vertices.size(),
-            sizeof( ExVertexStruct ),
-            &mesh->ShadowIndices );
+        // Optimize faces/vertices (optional - see RendererSettings.EnableMeshOptimization)
+        OptimizeMeshBuffers( mesh->MeshVertexBuffer.get(), mesh->Indices, mesh->Vertices, &mesh->ShadowIndices, nullptr );
 
         // Init and fill them
         mesh->MeshVertexBuffer->Init( &mesh->Vertices[0], mesh->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
@@ -460,18 +488,9 @@ void WorldConverter::WorldMeshCollectPolyRange( const float3& position, float ra
         Engine::GraphicsEngine->CreateVertexBuffer( it.second->MeshVertexBuffer );
         Engine::GraphicsEngine->CreateVertexBuffer( it.second->MeshIndexBuffer );
 
-        // Optimize index and vertex locality before uploading immutable buffers.
-        it.second->MeshVertexBuffer->OptimizeFaces( it.second->Indices.data(),
-            reinterpret_cast<byte*>( it.second->Vertices.data() ),
-            it.second->Indices.size(),
-            it.second->Vertices.size(),
-            sizeof( ExVertexStruct ) );
-        it.second->MeshVertexBuffer->OptimizeVertices( it.second->Indices.data(),
-            reinterpret_cast<byte*>( it.second->Vertices.data() ),
-            it.second->Indices.size(),
-            it.second->Vertices.size(),
-            sizeof( ExVertexStruct ),
-            &it.second->ShadowIndices );
+        // Optimize index and vertex locality before uploading immutable buffers (optional).
+        OptimizeMeshBuffers( it.second->MeshVertexBuffer.get(), it.second->Indices, it.second->Vertices,
+            &it.second->ShadowIndices, nullptr );
 
         // Init and fill them
         it.second->MeshVertexBuffer->Init( &it.second->Vertices[0], it.second->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
@@ -648,20 +667,9 @@ XRESULT WorldConverter::LoadWorldMeshFromFile( const std::string& file, std::map
                 Engine::GraphicsEngine->CreateVertexBuffer( it.second->MeshVertexBuffer );
                 Engine::GraphicsEngine->CreateVertexBuffer( it.second->MeshIndexBuffer );
 
-                // Optimize faces
-                it.second->MeshVertexBuffer->OptimizeFaces( &it.second->Indices[0],
-                    reinterpret_cast<byte*>(&it.second->Vertices[0]),
-                    it.second->Indices.size(),
-                    it.second->Vertices.size(),
-                    sizeof( ExVertexStruct ) );
-
-                // Then optimize vertices
-                it.second->MeshVertexBuffer->OptimizeVertices( &it.second->Indices[0],
-                    reinterpret_cast<byte*>(&it.second->Vertices[0]),
-                    it.second->Indices.size(),
-                    it.second->Vertices.size(),
-                    sizeof( ExVertexStruct ),
-                    &it.second->ShadowIndices );
+                // Optimize faces/vertices (optional - see RendererSettings.EnableMeshOptimization)
+                OptimizeMeshBuffers( it.second->MeshVertexBuffer.get(), it.second->Indices, it.second->Vertices,
+                    &it.second->ShadowIndices, nullptr );
 
                 // Init and fill them
                 it.second->MeshVertexBuffer->Init( &it.second->Vertices[0], it.second->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
@@ -1439,18 +1447,8 @@ void WorldConverter::Extract3DSMeshFromVisual( zCProgMeshProto* visual, MeshVisu
         Engine::GraphicsEngine->CreateVertexBuffer( mi->MeshVertexBuffer );
         Engine::GraphicsEngine->CreateVertexBuffer( mi->MeshIndexBuffer );
 
-        // Optimize static submesh ordering for better cache and vertex fetch locality.
-        mi->MeshVertexBuffer->OptimizeFaces( mi->Indices.data(),
-            reinterpret_cast<byte*>( mi->Vertices.data() ),
-            mi->Indices.size(),
-            mi->Vertices.size(),
-            sizeof( ExVertexStruct ) );
-        mi->MeshVertexBuffer->OptimizeVertices( mi->Indices.data(),
-            reinterpret_cast<byte*>( mi->Vertices.data() ),
-            mi->Indices.size(),
-            mi->Vertices.size(),
-            sizeof( ExVertexStruct ),
-            &mi->ShadowIndices );
+        // Optimize static submesh ordering for better cache and vertex fetch locality (optional).
+        OptimizeMeshBuffers( mi->MeshVertexBuffer.get(), mi->Indices, mi->Vertices, &mi->ShadowIndices, nullptr );
 
         // Init and fill it
         mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ) );
@@ -1704,20 +1702,8 @@ namespace {
             Engine::GraphicsEngine->CreateVertexBuffer( mi->MeshVertexBuffer );
             Engine::GraphicsEngine->CreateVertexBuffer( mi->MeshIndexBuffer );
 
-            // Optimize faces
-            mi->MeshVertexBuffer->OptimizeFaces( &mi->Indices[0],
-                reinterpret_cast<byte*>(&mi->Vertices[0]),
-                mi->Indices.size(),
-                mi->Vertices.size(),
-                sizeof( ExVertexStruct ) );
-
-            // Then optimize vertices
-            mi->MeshVertexBuffer->OptimizeVertices( &mi->Indices[0],
-                reinterpret_cast<byte*>(&mi->Vertices[0]),
-                mi->Indices.size(),
-                mi->Vertices.size(),
-                sizeof( ExVertexStruct ),
-                &mi->ShadowIndices );
+            // Optimize faces/vertices (optional - see RendererSettings.EnableMeshOptimization)
+            OptimizeMeshBuffers( mi->MeshVertexBuffer.get(), mi->Indices, mi->Vertices, &mi->ShadowIndices, nullptr );
 
             // Init and fill it
             mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ), D3D11VertexBuffer::B_VERTEXBUFFER, D3D11VertexBuffer::U_IMMUTABLE );
@@ -1896,18 +1882,8 @@ void WorldConverter::ExtractProgMeshProtoFromMesh( zCMesh* mesh, MeshVisualInfo*
     Engine::GraphicsEngine->CreateVertexBuffer( mi->MeshVertexBuffer );
     Engine::GraphicsEngine->CreateVertexBuffer( mi->MeshIndexBuffer );
 
-    // Optimize static mesh ordering for better cache and vertex fetch locality.
-    mi->MeshVertexBuffer->OptimizeFaces( mi->Indices.data(),
-        reinterpret_cast<byte*>( mi->Vertices.data() ),
-        mi->Indices.size(),
-        mi->Vertices.size(),
-        sizeof( ExVertexStruct ) );
-    mi->MeshVertexBuffer->OptimizeVertices( mi->Indices.data(),
-        reinterpret_cast<byte*>( mi->Vertices.data() ),
-        mi->Indices.size(),
-        mi->Vertices.size(),
-        sizeof( ExVertexStruct ),
-        &mi->ShadowIndices );
+    // Optimize static mesh ordering for better cache and vertex fetch locality (optional).
+    OptimizeMeshBuffers( mi->MeshVertexBuffer.get(), mi->Indices, mi->Vertices, &mi->ShadowIndices, nullptr );
 
     // Init and fill it
     mi->MeshVertexBuffer->Init( &mi->Vertices[0], mi->Vertices.size() * sizeof( ExVertexStruct ) );
@@ -2504,20 +2480,8 @@ void WorldConverter::Extract3DSMeshFromVisual2( zCProgMeshProto* visual, MeshVis
             // the backend closest to the 32-bit VA ceiling. Asking for no LOD skips the meshopt
             // simplification pass and leaves LodIndices empty, so nothing downstream allocates.
 
-            // Optimize faces
-            mi->MeshVertexBuffer->OptimizeFaces(&mi->Indices[0],
-                reinterpret_cast<byte*>(&mi->Vertices[0]),
-                mi->Indices.size(),
-                mi->Vertices.size(),
-                sizeof( ExVertexStruct ) );
-
-            // Then optimize vertices
-            mi->MeshVertexBuffer->OptimizeVertices( &mi->Indices[0],
-                reinterpret_cast<byte*>(&mi->Vertices[0]),
-                mi->Indices.size(),
-                mi->Vertices.size(),
-                sizeof( ExVertexStruct ),
-                &mi->ShadowIndices,
+            // Optimize faces/vertices (optional - see RendererSettings.EnableMeshOptimization)
+            OptimizeMeshBuffers( mi->MeshVertexBuffer.get(), mi->Indices, mi->Vertices, &mi->ShadowIndices,
                 Engine::IsD3D12Backend ? &mi->LodIndices : nullptr );
 
             // Init and fill it

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -629,7 +629,7 @@ XRESULT WorldConverter::LoadWorldMeshFromFile( const std::string& file, std::map
     if ( !missingTextures.empty() ) {
         std::string ms = "\nMissing materials for custom-mesh:\n";
 
-        for ( auto it = missingTextures.begin(); it != missingTextures.end(); it++ ) {
+        for ( auto it = missingTextures.begin(); it != missingTextures.end(); ++it ) {
             ms += "\t" + (*it) + "\n";
         }
 

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -1620,45 +1620,22 @@ void WorldConverter::ExtractSkeletalMeshFromVob( zCModel* model, std::span<zCMes
 }
 
 /** Extracts a zCProgMeshProto from a zCModel */
-void WorldConverter::ExtractProgMeshProtoFromModel( zCModel* model, MeshVisualInfo* meshInfo ) {
-    ZoneScoped;
-
-    XMFLOAT3 bbmin = XMFLOAT3( FLT_MAX, FLT_MAX, FLT_MAX );
-    XMFLOAT3 bbmax = XMFLOAT3( -FLT_MAX, -FLT_MAX, -FLT_MAX );
-
-    std::list<std::vector<ExVertexStruct>*> vertexBuffers;
-    std::list<std::vector<VERTEX_INDEX>*> indexBuffers;
-    std::list<MeshInfo*> meshInfos;
-
-    model->UpdateAttachedVobs();
-    model->UpdateMeshLibTexAniState();
-
-    const std::string_view visualName = model->GetModelName();
-    zCArray<zCModelNodeInst*>* nodeList = model->GetNodeList();
-    for ( int i = 0; i < nodeList->NumInArray; i++ ) {
-        zCModelNodeInst* node = nodeList->Array[i];
-        if ( !node->NodeVisual )
-            continue;
-
-        const char* ext = node->NodeVisual->GetFileExtension( 0 );
-
-        bool isMMS = strcmp( ext, ".MMS" ) == 0;
-        if ( !isMMS && strcmp( ext, ".3DS" ) != 0 )
-            continue;
-
-        zCProgMeshProto* visual = static_cast<zCProgMeshProto*>(node->NodeVisual);
-        if ( isMMS ) {
-            visual = reinterpret_cast<zCMorphMesh*>(node->NodeVisual)->GetMorphMesh();
-        }
+namespace {
+    /** Converts one node's submeshes (indices/vertices, meshopt optimization, buffer creation) and appends
+        the result into meshInfo/vertexBuffers/indexBuffers/meshInfos. Shared by ExtractProgMeshProtoFromModel
+        (main thread) and ExtractProgMeshProtoFromModelAsync's worker job - 'nodeTrafoObjToCam' is a snapshot
+        of node->TrafoObjToCam rather than the live node, since the async path may run this after the node
+        list has moved on (see ExtractProgMeshProtoFromModelAsync). Nothing in here touches ZENGIN state,
+        matching what Extract3DSMeshFromVisual2 (also worker-called) already relies on for CreateVertexBuffer/
+        GetRendererState/GetMaterialInfoFrom. */
+    void ConvertModelNodeSubmeshes( zCProgMeshProto* visual, const XMFLOAT4X4& nodeTrafoObjToCam,
+            const std::string& visualName, MeshVisualInfo* meshInfo,
+            std::list<std::vector<ExVertexStruct>*>& vertexBuffers,
+            std::list<std::vector<VERTEX_INDEX>*>& indexBuffers,
+            std::list<MeshInfo*>& meshInfos,
+            XMFLOAT3& bbmin, XMFLOAT3& bbmax ) {
         XMFLOAT3* posList = visual->GetPositionList()->Array;
-
-        // Calculate transform for this node
-        zCModelNodeInst* parent = node->ParentNode;
-        if ( parent ) {
-            XMStoreFloat4x4( &node->TrafoObjToCam, XMLoadFloat4x4( &parent->TrafoObjToCam ) * XMLoadFloat4x4( &node->Trafo ) );
-        } else {
-            node->TrafoObjToCam = node->Trafo;
-        }
+        XMMATRIX nodeTrafo = XMMatrixTranspose( XMLoadFloat4x4( &nodeTrafoObjToCam ) );
 
         std::vector<ExVertexStruct> vertices;
         std::vector<VERTEX_INDEX> indices;
@@ -1685,7 +1662,6 @@ void WorldConverter::ExtractProgMeshProtoFromModel( zCModel* model, MeshVisualIn
                 vertices.emplace_back();
 
                 ExVertexStruct& vx = vertices.back();
-                XMMATRIX nodeTrafo = XMMatrixTranspose( XMLoadFloat4x4( &node->TrafoObjToCam ) );
                 XMStoreFloat3( &vx.Position, XMVector3TransformCoord( XMLoadFloat3( &posList[wedge.position] ), nodeTrafo ) );
                 vx.TexCoord = wedge.texUV;
                 // The position bakes the node's bind-pose transform in (above); the normal must rotate by the SAME
@@ -1770,39 +1746,94 @@ void WorldConverter::ExtractProgMeshProtoFromModel( zCModel* model, MeshVisualIn
         }
     }
 
-    std::vector<ExVertexStruct> wrappedVertices;
-    std::vector<unsigned int> wrappedIndices;
-    std::vector<unsigned int> offsets;
+    /** Wraps up a MeshVisualInfo once every node's submeshes have been converted: builds the fat
+        vertex/index buffer offsets and the bounding box/Visual/VisualName fields. Shared tail of
+        ExtractProgMeshProtoFromModel and ExtractProgMeshProtoFromModelAsync's worker job. */
+    void FinishProgMeshProtoFromModel( MeshVisualInfo* meshInfo, zCVisual* visual, const std::string& visualName,
+            std::list<std::vector<ExVertexStruct>*>& vertexBuffers,
+            std::list<std::vector<VERTEX_INDEX>*>& indexBuffers,
+            std::list<MeshInfo*>& meshInfos,
+            XMFLOAT3 bbmin, XMFLOAT3 bbmax ) {
+        std::vector<ExVertexStruct> wrappedVertices;
+        std::vector<unsigned int> wrappedIndices;
+        std::vector<unsigned int> offsets;
 
-    if ( !vertexBuffers.empty() ) {
-        // Calculate fat vertexbuffer
-        WorldConverter::WrapVertexBuffers( vertexBuffers, indexBuffers, wrappedVertices, wrappedIndices, offsets );
+        if ( !vertexBuffers.empty() ) {
+            // Calculate fat vertexbuffer
+            WorldConverter::WrapVertexBuffers( vertexBuffers, indexBuffers, wrappedVertices, wrappedIndices, offsets );
 
-        // Propergate the offsets
-        int i = 0;
-        for ( auto const& it : meshInfos ) {
-            it->BaseIndexLocation = offsets[i++];
+            // Propergate the offsets
+            int i = 0;
+            for ( auto const& it : meshInfos ) {
+                it->BaseIndexLocation = offsets[i++];
+            }
+
+            // FullMesh's buffers are gone - see the note in Extract3DSMeshFromVisual2. Nothing ever bound
+            // them; only BaseIndexLocation above is actually consumed.
         }
 
-        // FullMesh's buffers are gone - see the note in Extract3DSMeshFromVisual2. Nothing ever bound
-        // them; only BaseIndexLocation above is actually consumed.
+        // No usable node visual at all: leave a degenerate-but-finite box. The ±FLT_MAX
+        // seeds would otherwise survive into MeshSize as an infinity, and MeshSize drives
+        // the small-vob/draw-distance and pointlight-shadow cull radii.
+        if ( vertexBuffers.empty() ) {
+            bbmin = XMFLOAT3( 0, 0, 0 );
+            bbmax = XMFLOAT3( 0, 0, 0 );
+        }
+
+        meshInfo->BBox.Min = bbmin;
+        meshInfo->BBox.Max = bbmax;
+        XMStoreFloat( &meshInfo->MeshSize, XMVector3Length( (XMLoadFloat3( &bbmin ) - XMLoadFloat3( &bbmax )) ) );
+        XMStoreFloat3( &meshInfo->MidPoint, 0.5f * (XMLoadFloat3( &bbmin ) + XMLoadFloat3( &bbmax )) );
+
+        meshInfo->Visual = visual;
+        meshInfo->VisualName = visualName;
+    }
+}
+
+void WorldConverter::ExtractProgMeshProtoFromModel( zCModel* model, MeshVisualInfo* meshInfo ) {
+    ZoneScoped;
+
+    XMFLOAT3 bbmin = XMFLOAT3( FLT_MAX, FLT_MAX, FLT_MAX );
+    XMFLOAT3 bbmax = XMFLOAT3( -FLT_MAX, -FLT_MAX, -FLT_MAX );
+
+    std::list<std::vector<ExVertexStruct>*> vertexBuffers;
+    std::list<std::vector<VERTEX_INDEX>*> indexBuffers;
+    std::list<MeshInfo*> meshInfos;
+
+    model->UpdateAttachedVobs();
+    model->UpdateMeshLibTexAniState();
+
+    const std::string visualName( model->GetModelName() );
+    zCArray<zCModelNodeInst*>* nodeList = model->GetNodeList();
+    for ( int i = 0; i < nodeList->NumInArray; i++ ) {
+        zCModelNodeInst* node = nodeList->Array[i];
+        if ( !node->NodeVisual )
+            continue;
+
+        const char* ext = node->NodeVisual->GetFileExtension( 0 );
+
+        bool isMMS = strcmp( ext, ".MMS" ) == 0;
+        if ( !isMMS && strcmp( ext, ".3DS" ) != 0 )
+            continue;
+
+        zCProgMeshProto* visual = static_cast<zCProgMeshProto*>(node->NodeVisual);
+        if ( isMMS ) {
+            visual = reinterpret_cast<zCMorphMesh*>(node->NodeVisual)->GetMorphMesh();
+        }
+
+        // Calculate transform for this node
+        zCModelNodeInst* parent = node->ParentNode;
+        if ( parent ) {
+            XMStoreFloat4x4( &node->TrafoObjToCam, XMLoadFloat4x4( &parent->TrafoObjToCam ) * XMLoadFloat4x4( &node->Trafo ) );
+        } else {
+            node->TrafoObjToCam = node->Trafo;
+        }
+
+        ConvertModelNodeSubmeshes( visual, node->TrafoObjToCam, visualName, meshInfo,
+            vertexBuffers, indexBuffers, meshInfos, bbmin, bbmax );
     }
 
-    // No usable node visual at all: leave a degenerate-but-finite box. The ±FLT_MAX
-    // seeds would otherwise survive into MeshSize as an infinity, and MeshSize drives
-    // the small-vob/draw-distance and pointlight-shadow cull radii.
-    if ( vertexBuffers.empty() ) {
-        bbmin = XMFLOAT3( 0, 0, 0 );
-        bbmax = XMFLOAT3( 0, 0, 0 );
-    }
-
-    meshInfo->BBox.Min = bbmin;
-    meshInfo->BBox.Max = bbmax;
-    XMStoreFloat( &meshInfo->MeshSize, XMVector3Length( (XMLoadFloat3( &bbmin ) - XMLoadFloat3( &bbmax )) ) );
-    XMStoreFloat3( &meshInfo->MidPoint, 0.5f * (XMLoadFloat3( &bbmin ) + XMLoadFloat3( &bbmax )) );
-
-    meshInfo->Visual = model;
-    meshInfo->VisualName = visualName;
+    FinishProgMeshProtoFromModel( meshInfo, model, visualName, vertexBuffers, indexBuffers, meshInfos, bbmin, bbmax );
 }
 
 /** Extracts a zCProgMeshProto from a zCMesh */
@@ -2156,6 +2187,89 @@ void WorldConverter::ExtractNodeVisualAsync( int index, zCModelNodeInst* node, g
     std::scoped_lock lock( s_PendingNodeVisualsMutex );
     PruneFinishedNodeVisualsLocked();
     s_PendingNodeVisuals.emplace_back( mi, nodeVisual, std::move( task ) );
+}
+
+/** Same as ExtractProgMeshProtoFromModel, but hands the meshoptimizer/buffer-creation part to a worker
+    thread. See the header for the contract. */
+void WorldConverter::ExtractProgMeshProtoFromModelAsync( zCModel* model, MeshVisualInfo* meshInfo ) {
+    ZoneScoped;
+
+    if ( !Engine::WorkerThreadPool ) {
+        ExtractProgMeshProtoFromModel( model, meshInfo );
+        return;
+    }
+
+    model->UpdateAttachedVobs();
+    model->UpdateMeshLibTexAniState();
+
+    // Snapshot every eligible node's (visual, bind-pose transform) up front: node->TrafoObjToCam is
+    // ZENGIN state that must be computed here on the game thread, but reading it back out of the node
+    // later from a worker would race the animation system. The submesh conversion itself only reads
+    // the visual's own wedge/position arrays, which - like Extract3DSMeshFromVisual2's - are written
+    // once at load and safe to read off-thread.
+    struct ModelNodeMeshSource {
+        zCProgMeshProto* Visual;
+        XMFLOAT4X4 Trafo;
+    };
+    std::vector<ModelNodeMeshSource> sources;
+
+    const std::string visualName( model->GetModelName() );
+    zCArray<zCModelNodeInst*>* nodeList = model->GetNodeList();
+    for ( int i = 0; i < nodeList->NumInArray; i++ ) {
+        zCModelNodeInst* node = nodeList->Array[i];
+        if ( !node->NodeVisual )
+            continue;
+
+        const char* ext = node->NodeVisual->GetFileExtension( 0 );
+
+        bool isMMS = strcmp( ext, ".MMS" ) == 0;
+        if ( !isMMS && strcmp( ext, ".3DS" ) != 0 )
+            continue;
+
+        zCProgMeshProto* visual = static_cast<zCProgMeshProto*>(node->NodeVisual);
+        if ( isMMS ) {
+            visual = reinterpret_cast<zCMorphMesh*>(node->NodeVisual)->GetMorphMesh();
+        }
+
+        zCModelNodeInst* parent = node->ParentNode;
+        if ( parent ) {
+            XMStoreFloat4x4( &node->TrafoObjToCam, XMLoadFloat4x4( &parent->TrafoObjToCam ) * XMLoadFloat4x4( &node->Trafo ) );
+        } else {
+            node->TrafoObjToCam = node->Trafo;
+        }
+
+        sources.push_back( { visual, node->TrafoObjToCam } );
+    }
+
+    meshInfo->Ready.store( false, std::memory_order_relaxed );
+
+    // Keep the model (and therefore every node visual it still owns) alive for the worker's duration.
+    zCObject_AddRef( model );
+
+    auto task = Engine::WorkerThreadPool->enqueue( [sources = std::move( sources ), meshInfo, visualName, model]
+            ( const std::stop_token& token ) {
+        // Unlike ExtractNodeVisualAsync's job, 'meshInfo' lives in a long-lived map (GothicAPI::
+        // ParticleEffectProgMeshes / StaticMeshVisuals) that only (re-)triggers extraction when no entry
+        // exists yet - see Extract3DSMeshFromVisual2Async for why cancellation must not skip the work.
+        XMFLOAT3 bbmin = XMFLOAT3( FLT_MAX, FLT_MAX, FLT_MAX );
+        XMFLOAT3 bbmax = XMFLOAT3( -FLT_MAX, -FLT_MAX, -FLT_MAX );
+
+        std::list<std::vector<ExVertexStruct>*> vertexBuffers;
+        std::list<std::vector<VERTEX_INDEX>*> indexBuffers;
+        std::list<MeshInfo*> meshInfos;
+
+        for ( const auto& source : sources ) {
+            ConvertModelNodeSubmeshes( source.Visual, source.Trafo, visualName, meshInfo,
+                vertexBuffers, indexBuffers, meshInfos, bbmin, bbmax );
+        }
+
+        FinishProgMeshProtoFromModel( meshInfo, model, visualName, vertexBuffers, indexBuffers, meshInfos, bbmin, bbmax );
+        meshInfo->Ready.store( true, std::memory_order_release );
+    } );
+
+    std::scoped_lock lock( s_PendingNodeVisualsMutex );
+    PruneFinishedNodeVisualsLocked();
+    s_PendingNodeVisuals.emplace_back( meshInfo, static_cast<zCVisual*>( model ), std::move( task ) );
 }
 
 void WorldConverter::Extract3DSMeshFromVisual2Async( zCVisual* holdVisual, zCProgMeshProto* pm, MeshVisualInfo* meshInfo ) {

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -511,9 +511,10 @@ XRESULT WorldConverter::LoadWorldMeshFromFile( const std::string& file, std::map
 
     // Check if we have this file cached
     bool loadedFromCache = false;
-    if ( Toolbox::FileExists( (file + ".mcache").c_str() ) ) {
+    std::string fileName = file + ".mcache";
+    if ( Toolbox::FileExists( fileName ) ) {
         // Load the meshfile, cached
-        if ( mesh->LoadMesh( (file + ".mcache").c_str(), worldScale ) == XR_SUCCESS ) {
+        if ( mesh->LoadMesh( fileName, worldScale ) == XR_SUCCESS ) {
             loadedFromCache = true;
         } else {
             // Incompatible/stale cache (e.g. vertex-format version bump): discard and rebuild.
@@ -611,7 +612,7 @@ XRESULT WorldConverter::LoadWorldMeshFromFile( const std::string& file, std::map
             bbmax.y = bbmax.y < v[0]->Position.y ? v[0]->Position.y : bbmax.y;
             bbmax.z = bbmax.z < v[0]->Position.z ? v[0]->Position.z : bbmax.z;
 
-            if ( section.WorldMeshes.find( key ) == section.WorldMeshes.end() ) {
+            if (!section.WorldMeshes.contains( key ) ) {
                 key.Info = Engine::GAPI->GetMaterialInfoFrom( key.Material );
 
                 section.WorldMeshes[key] = new WorldMeshInfo;

--- a/D3D11Engine/WorldConverter.h
+++ b/D3D11Engine/WorldConverter.h
@@ -94,6 +94,14 @@ public:
     /** Extracts a zCProgMeshProto from a zCModel */
     static void ExtractProgMeshProtoFromModel( zCModel* model, MeshVisualInfo* meshInfo );
 
+    /** Same as ExtractProgMeshProtoFromModel, but hands the expensive part (vertex unpacking, meshoptimizer,
+        buffer creation) for every node to a worker thread, same idea as ExtractNodeVisualAsync. The ZENGIN-
+        mutating part (UpdateAttachedVobs/UpdateMeshLibTexAniState/node->TrafoObjToCam) still runs here on
+        the game thread; only a snapshot of each node's resolved visual + transform crosses over. Sets
+        meshInfo->Ready false immediately and flips it true when the worker finishes - callers must not draw
+        from meshInfo until then. Falls back to the synchronous call when there is no worker pool. */
+    static void ExtractProgMeshProtoFromModelAsync( zCModel* model, MeshVisualInfo* meshInfo );
+
     /** Extracts a zCProgMeshProto from a zCMesh */
     static void ExtractProgMeshProtoFromMesh( zCMesh* mesh, MeshVisualInfo* meshInfo );
 

--- a/D3D11Engine/WorldObjects.cpp
+++ b/D3D11Engine/WorldObjects.cpp
@@ -109,7 +109,7 @@ SkeletalMeshInfo::~SkeletalMeshInfo() {
 
 /** Clears the cache for the given progmesh */
 void SectionInstanceCache::ClearCacheForStatic( MeshVisualInfo* pm ) {
-    if ( InstanceCache.find( pm ) != InstanceCache.end() ) {
+    if ( InstanceCache.contains( pm ) ) {
         InstanceCache[pm].reset();
         InstanceCacheData[pm].clear();
     }

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -438,6 +438,7 @@ struct VobLightInfo {
         Vob{},
         VisibleInRenderPass{},
         IsPFXVobLight{},
+        IsStaticVobLight{},
         IsIndoorVob{},
         ParentBSPNodes{},
         LightShadowBuffers{},
@@ -460,7 +461,7 @@ struct VobLightInfo {
     /** Flag to see if this vob was drawn in the current render pass. Used to collect the same vob only once. Cleared immediately. */
     std::atomic<size_t> VisibleInRenderPass;
     bool IsPFXVobLight;
-
+    bool IsStaticVobLight;
     /** True if this is an indoor-vob */
     bool IsIndoorVob;
 

--- a/D3D11Engine/include/ImGuizmo/src/ImCurveEdit.cpp
+++ b/D3D11Engine/include/ImGuizmo/src/ImCurveEdit.cpp
@@ -293,7 +293,7 @@ namespace ImCurveEdit
 
          for (size_t p = 0; p < ptCount; p++)
          {
-            const int drawState = DrawPoint(draw_list, pointToRange(pts[p]), viewSize, offset, (selection.find({ int(c), int(p) }) != selection.end() && movingCurve == -1 && !scrollingV));
+            const int drawState = DrawPoint(draw_list, pointToRange(pts[p]), viewSize, offset, (selection.contains({ int(c), int(p) }) && movingCurve == -1 && !scrollingV));
             if (drawState && movingCurve == -1 && !selectingQuad)
             {
                overCurveOrPoint = true;
@@ -301,7 +301,7 @@ namespace ImCurveEdit
                overCurve = -1;
                if (drawState == 2)
                {
-                  if (!io.KeyShift && selection.find({ int(c), int(p) }) == selection.end())
+                  if (!io.KeyShift && !selection.contains({ int(c), int(p) }))
                      selection.clear();
                   selection.insert({ int(c), int(p) });
                }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
     "directxmath",
     "directxtk",
     "directx-headers",
-    "directx12-agility"
+    "directx12-agility",
+    "sqlite3"
   ]
 }


### PR DESCRIPTION
- Static lights now always get collected with the intention of being re-drawn.
  - more agressive portal filtering for static lights
  - aggressive light clamping for indoor lights when they don't have a shadowmap yet.
  - fix crash in `GothicAPI::DrawSkeletalMeshVob`
- ProgMeshes now follow the rest and also get loaded and optimized in worker threads.
- Allow disabling `Optimize meshes on load` & `Build shadow index buffers`
- Cache optimized Vertex/Index buffers per mesh.
- On-Disk caches rework
  - instead of loose files we now use a sqlite3 database per-kind (d3d11_shaders, d3d12_shaders, meshes). Reducing disk-IO and also footprint as many meshes and shaders are well below 4k in size.
- chore: use modern c++ ::contains and use ranges-loops in a few more places.