### PR TITLE
feat(dx12): rain SSR. fix(dx11): fix broken lightDir, disable in-memory mesh cache after world load. Apply scene-wettness also for pointlights

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -197,7 +197,17 @@ struct DS_PointLightConstantBuffer {
 
     float3 PL_LightScreenPos;
     float PL_Pad3;
+
+    // Rain wetness (frame-constant, re-sent with every light like PL_InvView above): lets the point-light
+    // passes darken/dampen a wet pixel the same way PS_DS_AtmosphericScattering.hlsl's ApplySceneWettness
+    // does for the sun/ambient term, instead of adding un-wetted brightness on top of it. See
+    // ApplyPointLightWetness (Shaders/include/RainWetnessSample.h).
+    XMFLOAT4X4 PL_RainViewProj;
+    float PL_SceneWettness;
+    float3 PL_Pad4;
 };
+static_assert( sizeof( DS_PointLightConstantBuffer ) == 240,
+    "DS_PointLightConstantBuffer (b0) layout must match PS_DS_PointLight.hlsl / PS_DS_PointLightDynShadow.hlsl" );
 
 constexpr int MAX_CSM_CASCADES = 4;
 
@@ -468,7 +478,16 @@ struct TiledShadingConstantBuffer {
     float ClusterNearZ;   // cluster Z range; must match the CS_LightCulling dispatch
     float ClusterFarZ;
     XMFLOAT4X4 InvView; // For world-space reconstruction (shadow sampling)
+
+    // Rain wetness (frame-constant): lets CS_TiledShading.hlsl darken/dampen a wet pixel once, before its
+    // light loop, the same way PS_DS_AtmosphericScattering.hlsl's ApplySceneWettness does for the sun/
+    // ambient term. See ApplyPointLightWetness (Shaders/include/RainWetnessSample.h).
+    XMFLOAT4X4 RainViewProj;
+    float SceneWettness;
+    float3 WetnessPad;
 };
+static_assert( sizeof( TiledShadingConstantBuffer ) == 192,
+    "TiledShadingConstantBuffer (b0) layout must match CS_TiledShading.hlsl" );
 
 struct ForwardPlusTileConstantBuffer {
     float2 ViewportSize;

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -513,7 +513,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>TRACY_ENABLE1;TRACY_ON_DEMAND1;PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TRACY_ENABLE;TRACY_ON_DEMAND;PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ExceptionHandling>Sync</ExceptionHandling>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -1523,6 +1523,21 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12Motion.cpp">
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_12f|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_G1_AVX2|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='G2_Debug|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_Spacer|Win32'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt_G1|Win32'">../pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12Ssr.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET|Win32'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Spacer_NET_G1|Win32'">../pch.h</PrecompiledHeaderFile>

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -734,7 +734,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -812,7 +812,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_SPACER;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER 0x0601;_WIN32_WINNT 0x0601;NTDDI_VERSION 0x06010000;_WIN7_PLATFORM_UPDATE 1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_SPACER;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER 0x0601;_WIN32_WINNT 0x0601;NTDDI_VERSION 0x06010000;_WIN7_PLATFORM_UPDATE 1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ExceptionHandling>Async</ExceptionHandling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -848,7 +848,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;BUILD_GOTHIC_1_CLASSIC;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_1_08k;BUILD_GOTHIC_1_CLASSIC;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4005;4530;4577;6246;6322;26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -513,7 +513,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G2_SYSTEM_PATH)\ddraw.pdb"</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>TRACY_ENABLE;TRACY_ON_DEMAND;PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TRACY_ENABLE1;TRACY_ON_DEMAND1;PUBLIC_RELEASE;_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;BUILD_GOTHIC_2_6_fix;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;D3D11ENGINE_EXPORTS;NOMINMAX;%(PreprocessorDefinitions);WINVER=0x0601;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;_WIN7_PLATFORM_UPDATE=1;_XM_DISABLE_INTEL_SVML_</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ExceptionHandling>Sync</ExceptionHandling>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -1068,6 +1068,9 @@
     <ClCompile Include="D3D12Engine\D3D12Taa.cpp">
       <Filter>Engine\D3D12</Filter>
     </ClCompile>
+    <ClCompile Include="D3D12Engine\D3D12Ssr.cpp">
+      <Filter>Engine\D3D12</Filter>
+    </ClCompile>
     <ClCompile Include="D3D12Engine\D3D12DoF.cpp">
       <Filter>Engine\D3D12</Filter>
     </ClCompile>

--- a/D3D11Engine/D3D11LegacyDeferredShading.cpp
+++ b/D3D11Engine/D3D11LegacyDeferredShading.cpp
@@ -9,6 +9,8 @@
 #include "D3D11_Helpers.h"
 #include "zCVobLight.h"
 #include "GMesh.h"
+#include "D3D11Effect.h"
+#include "D3D11ShadowMap.h"
 
 XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
     std::vector<VobLightInfo*>& lights,
@@ -62,10 +64,23 @@ XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
 
     plcb.PL_ViewportSize = Engine::GraphicsEngine->GetResolution();
 
+    // Rain wetness (frame-constant, same source data PS_DS_AtmosphericScattering.hlsl's
+    // DS_ScreenQuadConstantBuffer.SQ_RainViewProj is filled from — see D3D11ShadowMap.cpp) so the
+    // point-light passes can darken/dampen wet ground consistently with the sun/ambient pass instead
+    // of ignoring wetness entirely (see RainWetnessSample.h).
+    XMStoreFloat4x4( &plcb.PL_RainViewProj,
+        XMLoadFloat4x4( &graphicsEngine->Effects->GetRainShadowmapCameraRepl().ProjectionReplacement ) *
+        XMLoadFloat4x4( &graphicsEngine->Effects->GetRainShadowmapCameraRepl().ViewReplacement ) );
+    plcb.PL_SceneWettness = Engine::GAPI->GetSceneWetness();
+
     color.BindToPixelShader( context.Get(), 0 );
     normals.BindToPixelShader( context.Get(), 1 );
     specular.BindToPixelShader( context.Get(), 7 );
     depthCopy.BindToPixelShader( context.Get(), 2 );
+    // Same texture/slot PS_DS_AtmosphericScattering.hlsl binds it to (D3D11ShadowMap.h's TX_RainShadowmap
+    // slot); SS_Comp (s2) is already bound for the whole frame by that same earlier pass.
+    if ( RenderToDepthStencilBuffer* rainShadowmap = graphicsEngine->Effects->GetRainShadowmap() )
+        rainShadowmap->BindToPixelShader( context.Get(), TX_RainShadowmap );
 
     // Mirrors D3D12 BuildFrameLightBuffer's post-selection range clamp (D3D12Scene.cpp): a light that
     // ends up with no shadow cube shades unshadowed and bleeds through walls. Clamping its range to a

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -476,7 +476,12 @@ XRESULT D3D11ShadowMap::PrepareRender()
     m_CascadeSplits.clear();
     m_CascadeSplits.insert( m_CascadeSplits.begin(), splits.begin(), splits.end() );
 
-    // Get current light direction from atmosphere
+    // Get current light direction from atmosphere.
+    // PrepareRender() runs before DrawSky() this frame, so GetAtmosphereCB() would otherwise still hold
+    // last frame's values; force a refresh here so AC_LightPos is never stale/zero (matches the D3D12
+    // path, see D3D12ShadowMap::ComputeCascadeMatrices). Does not render, just computes atmosphere data.
+    Engine::GAPI->GetSky()->RenderSky();
+
     XMVECTOR currentDir = XMLoadFloat3( &Engine::GAPI->GetSky()->GetAtmosphereCB().AC_LightPos );
     currentDir = XMVector3Normalize( currentDir );
 

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -11,6 +11,7 @@
 #include "D3D11_Helpers.h"
 #include "RenderToTextureBuffer.h"
 #include "zCVobLight.h"
+#include "D3D11Effect.h"
 
 using namespace DirectX;
 using Microsoft::WRL::ComPtr;
@@ -378,6 +379,15 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
         shadeCB.ClusterFarZ = std::max( CLUSTER_MIN_FAR_Z, settings.VisualFXDrawRadius );
         XMStoreFloat4x4( &shadeCB.InvView, XMMatrixInverse( nullptr, viewRaw ) );
 
+        // Rain wetness (same source data PS_DS_AtmosphericScattering.hlsl's SQ_RainViewProj is filled
+        // from — see D3D11ShadowMap.cpp) so this, the PRIMARY point-light path, darkens/dampens wet
+        // ground consistently with the sun/ambient pass instead of ignoring wetness entirely (see
+        // RainWetnessSample.h).
+        XMStoreFloat4x4( &shadeCB.RainViewProj,
+            XMLoadFloat4x4( &graphicsEngine->Effects->GetRainShadowmapCameraRepl().ProjectionReplacement ) *
+            XMLoadFloat4x4( &graphicsEngine->Effects->GetRainShadowmapCameraRepl().ViewReplacement ) );
+        shadeCB.SceneWettness = Engine::GAPI->GetSceneWetness();
+
         csTiledShading->UpdateBuffer("TiledShadingConstantBuffer", &shadeCB, sizeof(shadeCB));
 
         // Bind GBuffer SRVs to CS
@@ -393,6 +403,11 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
         // Bind tiled data SRVs
         context->CSSetShaderResources( 8, 1, m_LightBufferSRV.GetAddressOf() );
         context->CSSetShaderResources( 9, 1, m_LightGridSRV.GetAddressOf() );
+
+        // Rain shadowmap for ApplyPointLightWetness — same texture PS_DS_AtmosphericScattering.hlsl binds
+        // at D3D11ShadowMap.h's TX_RainShadowmap slot, here on the CS stage instead of PS.
+        if ( RenderToDepthStencilBuffer* rainShadowmap = graphicsEngine->Effects->GetRainShadowmap() )
+            context->CSSetShaderResources( TX_RainShadowmap, 1, rainShadowmap->GetShaderResView().GetAddressOf() );
 
         // Bind comparison sampler unconditionally — the runtime validates at Dispatch
         // even if the shader branches around SampleCmpLevelZero

--- a/D3D11Engine/D3D12Engine/D3D12AO.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12AO.cpp
@@ -122,12 +122,14 @@ bool D3D12GraphicsEngine::CreateAOResources( INT2 size ) {
 }
 
 void D3D12GraphicsEngine::UploadAoScreenConstants() {
-    // The screen-space AO block of the shared shadow CB: 1/screen-size, which the lit pixel shaders multiply
-    // SV_Position by to get the mask UV. Written UNCONDITIONALLY every frame (AO on or off) — a frame that
-    // skipped it would sample through whatever resolution happened to be current when it was last written.
+    // The screen-space AO + opaque-SSR-reprojection block of the shared shadow CB: 1/screen-size (which the
+    // lit pixel shaders multiply SV_Position by to get the mask UV) plus the previous-frame color/depth
+    // indices + view-proj the SSR march reprojects through (see the AoScreenCBData header comment). Written
+    // UNCONDITIONALLY every frame (AO/SSR on or off) — a frame that skipped it would sample through whatever
+    // resolution/history happened to be current when it was last written.
     // The writers of m_ShadowCB must tile exactly: D3D12ShadowMap::Prepare owns [0, kWetnessCbOffset),
-    // UploadWetnessConstants [kWetnessCbOffset, kAoReprojCbOffset), this the next 80 bytes (of which only the
-    // first 8 are live) and UploadSkyIblConstants the rest. The CB is 512 bytes.
+    // UploadWetnessConstants [kWetnessCbOffset, kAoReprojCbOffset), this the next 80 bytes, and
+    // UploadSkyIblConstants the rest. The CB is 512 bytes.
     static_assert( kWetnessCbOffset + sizeof( WetnessCBData ) == kAoReprojCbOffset,
         "the AO screen block must start right after the wetness block" );
     static_assert( sizeof( AoScreenCBData ) <= kAoReprojCbReservedBytes, "AO screen block overflows its slot" );
@@ -136,6 +138,22 @@ void D3D12GraphicsEngine::UploadAoScreenConstants() {
     AoScreenCBData cb = {};
     cb.InvResX = m_Resolution.x > 0 ? 1.0f / static_cast<float>( m_Resolution.x ) : 0.0f;
     cb.InvResY = m_Resolution.y > 0 ? 1.0f / static_cast<float>( m_Resolution.y ) : 0.0f;
+
+    // Opaque SSR: MaxSteps == 0 (the default when history isn't ready or the setting is Disabled) is the
+    // shader's whole "don't bother" gate, so every early-out below just leaves the step counts at 0 rather
+    // than skipping the memcpy — a partially-written CB is worse than a correctly-zeroed one.
+    UINT maxSteps = 0, refineSteps = 0;
+    if ( m_SsrHistoryValid && m_SsrPrevColorSrvSlot != UINT_MAX && m_SsrPrevDepthSrvSlot != UINT_MAX ) {
+        auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
+        SsrStepsForQuality( settings.OpaqueSSRQuality, maxSteps, refineSteps );
+    }
+    if ( maxSteps > 0 && maxSteps <= 0xFFu && refineSteps <= 0xFFu
+        && m_SsrPrevColorSrvSlot <= kSsrIndexMask && m_SsrPrevDepthSrvSlot <= kSsrIndexMask ) {
+        cb.SsrPrevColorIndex = m_SsrPrevColorSrvSlot | ( maxSteps << kSsrStepsShift );
+        cb.SsrPrevDepthIndex = m_SsrPrevDepthSrvSlot | ( refineSteps << kSsrStepsShift );
+        cb.SsrPrevViewProj = m_PrevViewProjUnjittered;
+    }
+
     memcpy( m_ShadowCBMapped[m_FrameIndex] + kAoReprojCbOffset, &cb, sizeof( cb ) );
 }
 

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -219,6 +219,20 @@ inline bool GetSkipDefaultHeapCopyAfterUpload() {
     return DefaultUploadHeapType == D3D12_HEAP_TYPE_GPU_UPLOAD;
 }
 
+// Screen-space reflection step-count tiers, shared by water (D3D12Water.cpp) and opaque-surface SSR
+// (D3D12AO.cpp's UploadAoScreenConstants — see D3D12_SSR_WET_SURFACES_PLAN.md). `quality` is
+// GothicRendererSettings::E_WaterSSRQuality (0=Disabled/1=Low/2=Medium/3=High) passed as a plain int, to
+// avoid pulling GothicGraphicsState.h into this widely-included header — both callers already have the
+// real enum type in scope and pass it in, implicitly converted.
+inline void SsrStepsForQuality( int quality, UINT& maxSteps, UINT& refineSteps ) {
+    switch ( quality ) {
+    case 1: maxSteps = 12; refineSteps = 4; break;   // WATER_SSR_LOW
+    case 2: maxSteps = 24; refineSteps = 5; break;   // WATER_SSR_MEDIUM
+    case 3: maxSteps = 48; refineSteps = 6; break;   // WATER_SSR_HIGH
+    default: maxSteps = 0; refineSteps = 0; break;   // WATER_SSR_DISABLED
+    }
+}
+
 // HDR scene-color format: the 3D passes accumulate lighting here in linear-ish FLOAT (values may
 // exceed 1.0), then the tonemap resolve writes the swapchain. Shared by the engine-core target
 // creation and the post-FX (bloom/luminance) passes that sample it.

--- a/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
+++ b/D3D11Engine/D3D12Engine/D3D12EngineCommon.h
@@ -14,6 +14,7 @@
 #include "D3D12TracyDebug.h"
 #include "../widenarrow.h"
 #include "../ConstantBufferStructs.h"   // VobInstanceInfo — held by value in FrameAttachDraw
+#include "../Shaders/D3D12/include/GPULightShared.h"   // GPULight — one definition, shared with HLSL
 
 class zCTexture;
 class zCVob;
@@ -92,38 +93,10 @@ struct FrameAttachDraw {
     bool                        batchable;
 };
 
-// Per-frame GPU point light. Filled by BuildFrameLightBuffer (D3D12Scene.cpp); the point-shadow slot
-// selection (D3D12PointShadows::SelectShadowedLights) reads Range/PositionWorld/Color.w and writes
-// ShadowCubeIndex/ShadowOrigin/ShadowRange. Mirrored in HLSL by Shaders/D3D12/include/ForwardPlusTypes.hlsl
-// and LightCull.hlsl's TiledPointLight — all three MUST be changed together.
-//
-// This USED to be byte-identical to D3D11's 48-byte TiledPointLight; it deliberately is not any more. The
-// D3D12 backend needs a light to be able to sample a shadow cube that is NOT centred on itself:
-//   * clustered static lights (the 10-30 "atmospheric" fill lights a Gothic room is lit with) share ONE cube
-//     rendered from their cluster centroid, so the cube lookup origin/far-plane differ from the light's own;
-//   * the shadow tier bit selects which cube array the slot lives in (see kShadowTierLow).
-// The two shader sides are separate declarations, so D3D11's TiledPointLight is unaffected.
-struct GPULight {
-    DirectX::XMFLOAT3 PositionView;    // 0
-    float             Range;           // 12  shading falloff radius (range-clamped for unshadowed statics)
-    DirectX::XMFLOAT4 Color;           // 16  (.w = static flag 0/1)
-    DirectX::XMFLOAT3 PositionWorld;   // 32
-    int32_t           ShadowCubeIndex; // 44  -1 = no shadow, else slot | tier bit (see kShadowTierLow)
-    DirectX::XMFLOAT3 ShadowOrigin;    // 48  cube centre — == PositionWorld unless this light is clustered
-    float             ShadowRange;     // 60  cube far-plane basis (far = ShadowRange*2) — == Range unless clustered
-};
-static_assert( sizeof( GPULight ) == 64, "GPULight must match the HLSL GPULight in ForwardPlusTypes.hlsl" );
-
-// High bit of GPULight::ShadowCubeIndex selecting the LOW-RESOLUTION static cube array
-// (D3D12PointShadows::kStaticCubeSize) over the full-res dynamic one. Bit 30, so the value stays a positive
-// int and the existing "ShadowCubeIndex >= 0 means shadowed" test in every shader keeps working untouched;
-// the slot itself is the low 30 bits. Mirrored as kShadowTierLow in ForwardPlusTypes.hlsl.
-constexpr int32_t kShadowTierLow = 0x40000000;
-// Bit 29: this light's slot also has a valid DYNAMIC (skeletal overlay) cube, so the lit pass samples the
-// dynamic array as well and mins the two results. Full-res slots only — the low tier has no dynamic twin.
-// Absent = pure static shadow, and no second sample is taken. Mirrored in ForwardPlusTypes.hlsl.
-constexpr int32_t kShadowHasDynamic = 0x20000000;
-constexpr int32_t kShadowSlotMask = 0x1FFFFFFF;
+// GPULight (per-frame GPU point light) and its shadow-tier bit constants now live in
+// Shaders/D3D12/include/GPULightShared.h (#included above) — one definition compiled as both C++ here
+// and HLSL in ForwardPlusTypes.hlsl/LightCull.hlsl, instead of three hand-synced copies.
+static_assert( sizeof( GPULight ) == 64, "GPULight must match the HLSL GPULight in GPULightShared.h" );
 
 // This frame's visible-VOB instance-ring snapshot (UploadFrameVobInstances) — the depth prepass, the color
 // pass AND the point-shadow static-VOB gather all draw from it. Defined in D3D12Scene.cpp.

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -1727,6 +1727,7 @@ bool D3D12GraphicsEngine::CreateRenderResolutionTargets( INT2 renderSize ) {
     m_AppliedAoResolution = Engine::GAPI->GetRendererState().RendererSettings.AoResolution;
     CreateMotionResources( renderSize ); // motion-vector + normal G-buffer; prepass falls back to depth-only
     CreateTaaResources( renderSize );    // also drops the history, which any resolution change invalidates
+    CreateSsrHistoryResources( renderSize ); // opaque-SSR previous-frame color+depth; see D3D12Ssr.cpp
     // DoF textures are built lazily (~20 MB of VA, off by default), so only re-size them if they exist.
     // Clearing the attempted flag lets a previous failure retry.
     m_DoFCreateAttempted = false;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -1312,13 +1312,33 @@ private:
     // in this frame's screen space and needs no reprojection. In exchange RenderSSAO round-trips the depth
     // buffer DEPTH_WRITE <-> NON_PIXEL_SHADER_RESOURCE and serialises against the prepass, as BuildHiZ does.
     //
-    // 80 bytes of the shared shadow CB, between the wetness block and the sky-IBL tail. Only the leading float2
-    // is live (1/screen-size, to turn SV_Position into a mask UV); the rest is the hole the old reprojection
-    // constants left, kept because five HLSL cbuffer layouts bake in the offsets after it.
+    // 80 bytes of the shared shadow CB, between the wetness block and the sky-IBL tail. Originally just the
+    // leading float2 (1/screen-size, to turn SV_Position into a mask UV) plus an unused hole left by an old
+    // AO-mask reprojection scheme — now that hole is reused for the OPAQUE-SURFACE SSR reprojection inputs
+    // (see D3D12_SSR_WET_SURFACES_PLAN.md / D3D12Ssr.cpp): it needed exactly "a previous-frame view-proj +
+    // a depth index", which is precisely what this slot was originally sized for. Packing:
+    //   SsrPrevColorIndex/SsrPrevDepthIndex: low 24 bits = bindless SRV heap slot (kSsrIndexMask), top 8
+    //     bits = step count (kSsrStepsShift) — MaxSteps rides the color index, RefineSteps the depth index,
+    //     mirroring the ORM-slot packing convention in PBRLighting.hlsl's SampleOrm. MaxSteps == 0 means
+    //     "SSR off" (matches D3D12Water.cpp's WaterCBData::SsrMaxSteps convention) and is the only bit the
+    //     shader needs to check before doing any of the rest of the march.
+    //   SsrPrevViewProj: previous frame's UNJITTERED view-projection (same source as MotionCB's
+    //     PrevViewProj, D3D12Motion.cpp's m_PrevViewProjUnjittered) — reprojects a world position marched
+    //     in THIS frame into the UV space of m_SsrPrevColor/m_SsrPrevDepth.
+    // Five HLSL cbuffer layouts (World/Vob/Skeletal/Vegetation/Decal) bake in the offsets after this block,
+    // so its total size must stay 80 bytes even as its contents change.
     static constexpr UINT kAoReprojCbOffset = 352;
     static constexpr UINT kAoReprojCbReservedBytes = 80;
-    struct AoScreenCBData { float InvResX; float InvResY; float _pad[2]; };
-    void UploadAoScreenConstants();           // publishes AoInvRes into the shadow CB (unconditional, every frame)
+    static constexpr UINT kSsrIndexMask = 0x00FFFFFFu;
+    static constexpr UINT kSsrStepsShift = 24;
+    struct AoScreenCBData {
+        float InvResX; float InvResY;
+        UINT SsrPrevColorIndex;   // low 24 bits: SRV slot; top 8 bits: SsrMaxSteps (0 = disabled)
+        UINT SsrPrevDepthIndex;   // low 24 bits: SRV slot; top 8 bits: SsrRefineSteps
+        DirectX::XMFLOAT4X4 SsrPrevViewProj;
+    };
+    static_assert( sizeof( AoScreenCBData ) == 80, "AoScreenCBData must fill its 80-byte shadow-CB slot exactly" );
+    void UploadAoScreenConstants();           // publishes AoInvRes + the SSR reprojection block into the shadow CB (unconditional, every frame)
     bool CreateAOResources( INT2 size );      // (re)builds m_AOMask/m_AOBlurTemp + persistent SRV/UAV slots
     void RenderSSAO();                        // the AO entry point: publishes the AO constants, then runs XeGTAO or simple SSAO
     void RenderSimpleSSAO();                  // main estimate -> separable blur (Shaders/D3D12/SSAO.hlsl)
@@ -1695,6 +1715,36 @@ private:
 
     bool LoadReflectionCube();                // one-time, non-fatal (mirrors LoadDistortionTexture)
     bool CreateWaterConstantBuffers();        // one-time: the per-frame-in-flight water/atmosphere CB ring
+
+    // ---- Opaque-surface SSR temporal history (D3D12Ssr.cpp) ----
+    // Reflecting on-screen OPAQUE geometry from inside the Forward+ lit pass has a chicken-and-egg problem:
+    // the pass shading pixel P cannot see the finished color/depth of pixels the GPU hasn't rasterized yet
+    // THIS frame. D3D12Water.cpp dodges this by running AFTER the opaque pass and reading a same-frame copy,
+    // but that trick only works for a surface (water) that is itself drawn after everything it reflects —
+    // it cannot make opaque geometry reflect other opaque geometry within one pass.
+    //
+    // The standard fix for a forward renderer with no G-buffer is TEMPORAL SSR: march against the PREVIOUS
+    // frame's finished opaque color+depth (reprojected with the camera-history matrices already tracked for
+    // motion vectors, m_PrevViewProjUnjittered/m_CurViewProjUnjittered — see D3D12Motion.cpp), at the cost of
+    // a one-frame lag. Single buffer, not ping-ponged: mirrors D3D12Taa.cpp's m_TaaPrevDepth reasoning
+    // exactly — this frame's consumer (a future SSR march in World.hlsl/Vob.hlsl/Skeletal.hlsl) reads it
+    // EARLY in the frame and CaptureSsrOpaqueHistory overwrites it LATER in the same frame, after opaque
+    // geometry is final; since the whole frame executes in submission order on one direct queue, that read
+    // always happens-before that write, so no second buffer is needed to avoid a cross-frame race.
+    //
+    // This increment only builds the capture — nothing reads these buffers yet. See
+    // D3D12_SSR_WET_SURFACES_PLAN.md (repo root) for the marcher this feeds next.
+    Microsoft::WRL::ComPtr<ID3D12Resource>      m_SsrPrevColor;
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_SsrPrevColorAlloc;
+    Microsoft::WRL::ComPtr<ID3D12Resource>      m_SsrPrevDepth;
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation> m_SsrPrevDepthAlloc;
+    static constexpr D3D12_RESOURCE_STATES kSsrPrevReadState =
+        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+    UINT m_SsrPrevColorSrvSlot = UINT_MAX;
+    UINT m_SsrPrevDepthSrvSlot = UINT_MAX;
+    bool m_SsrHistoryValid = false;   // false until the first CaptureSsrOpaqueHistory() has run this world/resize
+    bool CreateSsrHistoryResources( INT2 size );   // (re)builds the two persistent history textures + their SRVs
+    void CaptureSsrOpaqueHistory();                // copies the finished opaque scene color+depth; post-opaque/pre-water
 
     // Rain/snow particles (D3D12 rain parity, step 1: buffers + CS advance only — no draw yet). Mirrors
     // D3D11Effect's RainBufferStatic/RainBufferDrawFrom, but as plain StructuredBuffers bound via ROOT

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -2412,6 +2412,10 @@ XRESULT D3D12GraphicsEngine::OnStartWorldRendering() {
 		DrawDecalList( decals, true );
 	}
 
+	// Opaque scene is now final (world/skeletal/VOBs/vegetation/opaque decals) — snapshot it for NEXT frame's
+	// SSR march before water/transparents draw over it. See D3D12Ssr.cpp.
+	CaptureSsrOpaqueHistory();
+
 	// Water stays out of the queue: it samples the scene behind it, so it cannot be re-ordered freely.
 	DrawWaterSurfaces();
 

--- a/D3D11Engine/D3D12Engine/D3D12Ssr.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Ssr.cpp
@@ -1,0 +1,135 @@
+// D3D12GraphicsEngine — opaque-surface SSR temporal history capture.
+//
+// See the header comment on m_SsrPrevColor/m_SsrPrevDepth (D3D12GraphicsEngine.h) for why this is a
+// TEMPORAL capture (previous frame, not this frame) rather than the same-frame copy trick D3D12Water.cpp
+// uses: reflecting on-screen opaque geometry from INSIDE the Forward+ opaque pass cannot read this same
+// frame's still-being-rasterized color/depth, so the source has to be one frame old.
+//
+// This file currently only builds and fills the two history textures — nothing reads them yet. The
+// consumer (a screen-space ray march in World.hlsl/Vob.hlsl/Skeletal.hlsl, reprojected through
+// m_PrevViewProjUnjittered) is the next increment; see D3D12_SSR_WET_SURFACES_PLAN.md (repo root).
+#include "../pch.h"
+#include "D3D12GraphicsEngine.h"
+#include "D3D12ResourceCreate.h"
+#include "../Engine.h"
+#include "../GothicAPI.h"
+
+using Microsoft::WRL::ComPtr;
+#include "D3D12EngineCommon.h"
+
+/** (Re)creates the two persistent history textures. Called from the same resize path as the motion/TAA
+    resources (CreateFrameResources); heap slots persist across resizes, only the resources and views are
+    rebuilt. */
+bool D3D12GraphicsEngine::CreateSsrHistoryResources( INT2 size ) {
+    m_SsrHistoryValid = false;   // stale after any resize — last frame's buffer covered a different resolution
+    if ( size.x < 4 || size.y < 4 ) return false;
+    ID3D12Device* device = m_Device.GetDevice();
+    if ( !device || !m_Allocator ) return false;
+
+    D3D12MA::ALLOCATION_DESC heapDefault = {};
+    heapDefault.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
+    // Color: same format as the scene color, so the eventual march's hit sample needs no conversion.
+    {
+        D3D12_RESOURCE_DESC dd = {};
+        dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+        dd.Width = static_cast<UINT64>( size.x );
+        dd.Height = static_cast<UINT>( size.y );
+        dd.DepthOrArraySize = 1;
+        dd.MipLevels = 1;
+        dd.Format = kSceneColorFormat;
+        dd.SampleDesc.Count = 1;
+        dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+        if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, kSsrPrevReadState,
+            nullptr, m_SsrPrevColorAlloc.ReleaseAndGetAddressOf(),
+            IID_PPV_ARGS( m_SsrPrevColor.ReleaseAndGetAddressOf() ) ) ) ) {
+            LogWarn() << "D3D12: failed to create the SSR previous-frame color history (" << size.x << "x" << size.y << ").";
+            return false;
+        }
+        m_SsrPrevColor->SetName( L"SsrPrevColor" );
+    }
+
+    // Depth: plain R32_FLOAT, not R32_TYPELESS+ALLOW_DEPTH_STENCIL — this is never bound as a real depth
+    // target, only ever CopyResource's destination and an SRV source. Same reasoning as D3D12Water.cpp's
+    // WaterDepthCopy: CopyResource only needs format-FAMILY compatibility with m_DepthBuffer's typeless
+    // resource, not matching resource flags.
+    {
+        D3D12_RESOURCE_DESC dd = {};
+        dd.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+        dd.Width = static_cast<UINT64>( size.x );
+        dd.Height = static_cast<UINT>( size.y );
+        dd.DepthOrArraySize = 1;
+        dd.MipLevels = 1;
+        dd.Format = DXGI_FORMAT_R32_FLOAT;
+        dd.SampleDesc.Count = 1;
+        dd.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+        if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, kSsrPrevReadState,
+            nullptr, m_SsrPrevDepthAlloc.ReleaseAndGetAddressOf(),
+            IID_PPV_ARGS( m_SsrPrevDepth.ReleaseAndGetAddressOf() ) ) ) ) {
+            LogWarn() << "D3D12: failed to create the SSR previous-frame depth history (" << size.x << "x" << size.y << ").";
+            return false;
+        }
+        m_SsrPrevDepth->SetName( L"SsrPrevDepth" );
+    }
+
+    auto ensureSlot = [&]( UINT& slot ) -> bool {
+        if ( slot == UINT_MAX ) slot = AllocateSrvSlot();
+        return slot != UINT_MAX;
+        };
+    if ( !ensureSlot( m_SsrPrevColorSrvSlot ) || !ensureSlot( m_SsrPrevDepthSrvSlot ) ) return false;
+
+    D3D12_SHADER_RESOURCE_VIEW_DESC srv = {};
+    srv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    srv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    srv.Texture2D.MipLevels = 1;
+    srv.Format = kSceneColorFormat;
+    device->CreateShaderResourceView( m_SsrPrevColor.Get(), &srv, GetSrvCpuHandle( m_SsrPrevColorSrvSlot ) );
+    srv.Format = DXGI_FORMAT_R32_FLOAT;
+    device->CreateShaderResourceView( m_SsrPrevDepth.Get(), &srv, GetSrvCpuHandle( m_SsrPrevDepthSrvSlot ) );
+
+    return true;
+}
+
+/** Snapshots the just-finished OPAQUE scene (color + depth) into the SSR history textures, for next frame's
+    reflection march to read. Called once per frame, after the last opaque draw (including opaque decals) and
+    BEFORE water/transparents — mirrors D3D12Water.cpp's own scene/depth copy timing, except this copy is kept
+    across the frame boundary instead of being consumed the same frame. Deliberately excludes water and
+    transparents: the SSR plan only ever needs to reflect opaque wet/glossy surfaces, and capturing after
+    them would mean fighting water's own Z-prepass and alpha-blended overdraw for no benefit yet.
+
+    Single buffer, not ping-ponged, deliberately: mirrors D3D12Taa.cpp's m_TaaPrevDepth reasoning exactly — a
+    read of this frame's history (once a consumer exists) is always ordered, in the command stream, before
+    this frame's own capture below, and the whole frame executes in submission order on one direct queue, so
+    there is no cross-frame hazard from reusing a single resource. */
+void D3D12GraphicsEngine::CaptureSsrOpaqueHistory() {
+    if ( !m_FrameOpen || !m_CmdList || !m_SceneColor || !m_DepthBuffer ) return;
+    if ( !m_SsrPrevColor || !m_SsrPrevDepth ) return;
+
+    DX_ZONE( m_CmdList.Get(), "SSR history capture" );
+    TracyD3D12ZoneCGX( m_CmdList.Get(), "SSR history capture" );
+
+    m_CmdList->OMSetRenderTargets( 0, nullptr, FALSE, nullptr );
+
+    const D3D12_RESOURCE_STATES sceneFrom = m_SceneColorInPixelState
+        ? D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_RENDER_TARGET;
+    m_CmdList->TransitionBarriers( {
+        { m_SceneColor.Get(), sceneFrom, D3D12_RESOURCE_STATE_COPY_SOURCE },
+        { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_COPY_SOURCE },
+        { m_SsrPrevColor.Get(), kSsrPrevReadState, D3D12_RESOURCE_STATE_COPY_DEST },
+        { m_SsrPrevDepth.Get(), kSsrPrevReadState, D3D12_RESOURCE_STATE_COPY_DEST },
+        } );
+
+    m_CmdList->CopyResource( m_SsrPrevColor.Get(), m_SceneColor.Get() );
+    m_CmdList->CopyResource( m_SsrPrevDepth.Get(), m_DepthBuffer.Get() );
+
+    m_CmdList->TransitionBarriers( {
+        { m_SceneColor.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET },
+        { m_DepthBuffer.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE },
+        { m_SsrPrevColor.Get(), D3D12_RESOURCE_STATE_COPY_DEST, kSsrPrevReadState },
+        { m_SsrPrevDepth.Get(), D3D12_RESOURCE_STATE_COPY_DEST, kSsrPrevReadState },
+        } );
+    m_SceneColorInPixelState = false;
+
+    BindSceneColorTarget();
+    m_SsrHistoryValid = true;
+}

--- a/D3D11Engine/D3D12Engine/D3D12Water.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Water.cpp
@@ -73,15 +73,8 @@ namespace {
     // pass uses) because only the water PS ever reads them.
     constexpr D3D12_RESOURCE_STATES kWaterCopyReadState = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 
-    // D3D11's SSR_QUALITY permutation table (PS_Water.hlsl lines 72-81), as runtime loop bounds.
-    void SsrStepsForQuality( int quality, UINT& maxSteps, UINT& refineSteps ) {
-        switch ( quality ) {
-        case GothicRendererSettings::WATER_SSR_LOW:    maxSteps = 12; refineSteps = 4; break;
-        case GothicRendererSettings::WATER_SSR_MEDIUM: maxSteps = 24; refineSteps = 5; break;
-        case GothicRendererSettings::WATER_SSR_HIGH:   maxSteps = 48; refineSteps = 6; break;
-        default:                                       maxSteps = 0;  refineSteps = 0; break;
-        }
-    }
+    // D3D11's SSR_QUALITY permutation table (PS_Water.hlsl lines 72-81), as runtime loop bounds. Shared
+    // with opaque-surface SSR (D3D12AO.cpp) via D3D12EngineCommon.h's SsrStepsForQuality.
 
     // DDS_HEADER.dwCaps2 bits (the cubemap flags live outside DDSFormat.h's pixel-format tables).
     constexpr uint32_t kDdsCaps2Cubemap = 0x00000200;

--- a/D3D11Engine/GSky.cpp
+++ b/D3D11Engine/GSky.cpp
@@ -236,7 +236,10 @@ XRESULT GSky::RenderSky() {
     }
 
     XMFLOAT3 camPos = Engine::GAPI->GetCameraPosition();
-    XMFLOAT3 LightDir = {};
+    // Default to the last known-good direction rather than zero: a zero light direction
+    // normalizes to the zero vector, which later blows up XMMatrixLookToLH in the shadow
+    // cascade code (EyeDirection == 0 assert) when no outdoor sky controller is available.
+    XMFLOAT3 LightDir = Atmosphere.LightDirection;
 
     if ( Engine::GAPI->GetRendererState().RendererSettings.ReplaceSunDirection ) {
         LightDir = Atmosphere.LightDirection;
@@ -246,6 +249,11 @@ XRESULT GSky::RenderSky() {
             LightDir = sc->GetSunWorldPosition( Atmosphere.SkyTimeScale );
             Atmosphere.LightDirection = LightDir;
         }
+    }
+    if ( LightDir.x == 0.0f && LightDir.y == 0.0f && LightDir.z == 0.0f ) {
+        // Still degenerate (e.g. very first frame, before any valid direction was ever seen).
+        // Fall back to a fixed, arbitrary-but-non-zero direction instead of crashing downstream.
+        LightDir = XMFLOAT3( 0.0f, -1.0f, 0.0f );
     }
     XMStoreFloat3( &LightDir, XMVector3Normalize( XMLoadFloat3( &LightDir ) ) );
     //Atmosphere.SpherePosition.y = -Atmosphere.InnerRadius;

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5977,6 +5977,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "Display", "WindStrength", to_string_locale_independent( s.GlobalWindStrength ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "WaterWaveAnimation", to_string_locale_independent( s.EnableWaterAnimation ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "WaterSSRQuality", to_string_locale_independent( (int)s.WaterSSRQuality ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "OpaqueSSRQuality", to_string_locale_independent( (int)s.OpaqueSSRQuality ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "HeroAffectsObjects", to_string_locale_independent( s.HeroAffectsObjects ? TRUE : FALSE ).c_str(), ini.c_str() );
     
 
@@ -6223,6 +6224,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         // Backward compat: legacy [Display]/WaterSSR bool maps to Medium/Disabled when the
         // new WaterSSRQuality key is absent.
         s.WaterSSRQuality = static_cast<GothicRendererSettings::E_WaterSSRQuality>(std::clamp<INT>(GetPrivateProfileIntA("Display", "WaterSSRQuality", ds.WaterSSRQuality, ini.c_str()), 0, 3));
+        s.OpaqueSSRQuality = static_cast<GothicRendererSettings::E_WaterSSRQuality>(std::clamp<INT>(GetPrivateProfileIntA("Display", "OpaqueSSRQuality", ds.OpaqueSSRQuality, ini.c_str()), 0, 3));
         s.HeroAffectsObjects = GetPrivateProfileBoolA( "Display", "HeroAffectsObjects", ds.HeroAffectsObjects, ini );
 
         if ( GetPrivateProfileBoolA( "SMAA", "Enabled", false, ini ) ) {

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -8,6 +8,7 @@
 #include "BaseGraphicsEngine.h"
 #include "zCPolygon.h"
 #include "WorldConverter.h"
+#include "MeshOptimizeCache.h"
 #include "HookedFunctions.h"
 #include "zCMaterial.h"
 #include "zCTexture.h"
@@ -1015,6 +1016,10 @@ void GothicAPI::OnGeometryLoaded( zCBspTree* tree ) {
 
 /** Called when the game is about to load a new level */
 void GothicAPI::OnLoadWorld( const std::string& levelName, int loadMode ) {
+    // Arm the mesh-optimize in-memory cache for the duration of this load - see MeshOptimizeCache.h.
+    // Disarmed again at the end of OnWorldLoaded once conversion work is done.
+    MeshOptimizeCache::SetMemoryCache( true );
+
     _canClearVobsByVisual = true;
     if ( (loadMode == zWLD_LOAD_GAME_STARTUP || loadMode == zWLD_LOAD_GAME_SAVED_STAT) ) {
         if ( !levelName.empty() ) {
@@ -1117,6 +1122,10 @@ void GothicAPI::OnWorldLoaded() {
 #endif
 
     _canClearVobsByVisual = false;
+
+    // World load is done - drop the mesh-optimize in-memory cache back to disk-only so it doesn't
+    // keep growing across the rest of the session (see MeshOptimizeCache.h).
+    MeshOptimizeCache::SetMemoryCache( false );
 }
 
 void GothicAPI::LoadRendererWorldSettings( GothicRendererSettings& s )

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5951,6 +5951,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "General", "EnablePortalShadowSkip", to_string_locale_independent( s.EnablePortalShadowSkip ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "EnableMeshOptimization", to_string_locale_independent( s.EnableMeshOptimization ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "EnableShadowIndexBuffers", to_string_locale_independent( s.EnableShadowIndexBuffers ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "General", "MeshOptimizeCacheFlags", to_string_locale_independent( s.MeshOptimizeCacheFlags ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "FpsLimit", to_string_locale_independent( s.FpsLimit ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "General", "PausedFpsLimit", to_string_locale_independent( s.PausedFpsLimit ).c_str(), ini.c_str() );
     
@@ -6138,6 +6139,7 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.EnablePortalShadowSkip = GetPrivateProfileBoolA( "General", "EnablePortalShadowSkip", ds.EnablePortalShadowSkip, ini );
         s.EnableMeshOptimization = GetPrivateProfileBoolA( "General", "EnableMeshOptimization", ds.EnableMeshOptimization, ini );
         s.EnableShadowIndexBuffers = GetPrivateProfileBoolA( "General", "EnableShadowIndexBuffers", ds.EnableShadowIndexBuffers, ini );
+        s.MeshOptimizeCacheFlags = GetPrivateProfileSignedIntA( "General", "MeshOptimizeCacheFlags", ds.MeshOptimizeCacheFlags, ini );
         s.FpsLimit = GetPrivateProfileIntA( "General", "FpsLimit", 0, ini.c_str() );
         s.PausedFpsLimit = GetPrivateProfileIntA( "General", "PausedFpsLimit", ds.PausedFpsLimit, ini.c_str() );
         // Not optional: an unthrottled paused loop crashes drivers, so the ini can only pick a value

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4450,6 +4450,9 @@ void GothicAPI::CollectVisibleVobs(
     ctx.drawFlags.CollectIndoorVobs = true;
     ctx.drawFlags.CollectMobs = true;
     ctx.drawFlags.CollectLights = true;
+    // ~15m: a torch or campfire the player stands next to stays lit when he turns around.
+    constexpr float kKeepCloseLightsRange = 1500.0f;
+    ctx.keepLightsWithinRange = kKeepCloseLightsRange;
 
     // This overload is the main camera pass of both backends, and the only place portal culling
     // applies: shadow passes need casters from rooms the player cannot see into.
@@ -6989,6 +6992,8 @@ static void CollectLeafVobs(
     const float vobOutdoorSmallDistSq = ctx.drawDistancesSq.OutdoorVobsSmall;
     const float visualFXDrawRadius = ctx.drawDistances.VisualFX;
     const float visualFXDrawRadiusSq = ctx.drawDistancesSq.VisualFX;
+    // 0 for every pass that doesn't want the close-light exemption, which makes the test below a no-op.
+    const float keepCloseLightsDistSq = ctx.keepLightsWithinRange * ctx.keepLightsWithinRange;
     const XMVECTOR cameraPosition = XMLoadFloat3( &ctx.cameraPosition );
     const bool collectIndoorVobs = ctx.drawFlags.CollectIndoorVobs;
     const bool collectMobs = ctx.drawFlags.CollectMobs;
@@ -7131,8 +7136,9 @@ static void CollectLeafVobs(
             if ( !visitor->Visit( vi ) ) continue;
 
 
-            // Cull any lights that are not visible even though they are in range
-            if ( clipResult != ContainmentType::CONTAINS) {
+            // Cull any lights that are not visible even though they are in range. Lights inside the
+            // close sphere skip the test and are kept; it reuses the range test's own distance.
+            if ( clipResult != ContainmentType::CONTAINS && lightCameraDistSq >= keepCloseLightsDistSq ) {
                 BoundingSphere lightSphere;
                 lightSphere.Center = vob->GetPositionWorld();
                 lightSphere.Radius = lightRange;

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -55,6 +55,10 @@ struct RndCullContext {
         it here rather than at draw time also skips its instance upload and indirect command. */
     float minVobSize = 0.0f;
 
+    /** Keep point lights within this many units of the camera even when their sphere misses the frustum,
+        so a light the player turns away from doesn't blink out and surrender its shadow cube. 0 = off. */
+    float keepLightsWithinRange = 0.0f;
+
     struct
     {
         float OutdoorVobs;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -572,13 +572,18 @@ struct GTAOSettings {
 /** D3D12 only: the discrete roughness values the default (no _FX/_ORM map) material can be set to.
     The D3D12 backend can't sample an arbitrary roughness for these materials — it hands the shader a
     bindless 1x1 ORM texture, so every selectable value needs its own texture created up front (see
-    D3D12GraphicsEngine::CreateWhiteTexture / m_DefaultOrmTextures). Nine steps of 0.05 from 0.50 to 0.90
-    is nine 1x1 textures, i.e. nothing, and covers everything from damp stone to chalky plaster.
+    D3D12GraphicsEngine::CreateWhiteTexture / m_DefaultOrmTextures). 14 steps of 0.05 from 0.25 to 0.90
+    is 14 1x1 textures, i.e. nothing, and covers everything from damp stone to chalky plaster. kMin is
+    floored at 0.25 deliberately: below that the GGX specular lobe (PBRLighting.hlsl's
+    PBR_DistributionGGX) gets so tight that a directional-light highlight almost never lines up with
+    a given pixel, and with no local reflection probes the lost specular energy has nowhere to go —
+    default (no-map) materials just read as uniformly darker rather than glossier. Real materials with
+    an authored _ORM map are unaffected; they aren't limited to this step table.
     Kept here rather than in the D3D12 headers so ImGuiShim can drive the slider without including them. */
 namespace DefaultRoughness {
-    constexpr float kMin  = 0.50f;
+    constexpr float kMin  = 0.25f;
     constexpr float kStep = 0.05f;
-    constexpr int   kNumSteps = 9;                          // 0.50 0.55 ... 0.90
+    constexpr int   kNumSteps = 14;                         // 0.25 0.30 ... 0.90
     constexpr float kMax = kMin + kStep * ( kNumSteps - 1 );
 
     /** Roughness for step index i (clamped). */

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -840,7 +840,7 @@ struct GothicRendererSettings {
         DrawThreaded = false;
         EnableMeshOptimization = true;
         EnableShadowIndexBuffers = true;
-        MeshOptimizeCacheFlags = MOC_DISK | MOC_MEMORY;
+        MeshOptimizeCacheFlags = MOC_DISK;
 
         WindQuality = WIND_QUALITY_ADVANCED;
         HeroAffectsObjects = true;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -840,6 +840,7 @@ struct GothicRendererSettings {
         DrawThreaded = false;
         EnableMeshOptimization = true;
         EnableShadowIndexBuffers = true;
+        MeshOptimizeCacheFlags = MOC_DISK | MOC_MEMORY;
 
         WindQuality = WIND_QUALITY_ADVANCED;
         HeroAffectsObjects = true;
@@ -1130,6 +1131,14 @@ struct GothicRendererSettings {
         (slightly more shadow-map vertex work, no alpha-test capability loss - see
         MeshShadowIndexBuilder.h) in exchange for skipping the weld and one buffer per sub-mesh. */
     bool EnableShadowIndexBuffers;
+    // Which tiers of the mesh-optimize cache (MeshOptimizeCache.h) may serve/store a hit, as an OR of
+    // flags. MOC_MEMORY is only ever armed for one world load regardless of this flag - see MeshOptimizeCache.h.
+    enum EMeshOptimizeCacheFlags : int {
+        MOC_OFF = 0,
+        MOC_DISK = 1 << 0,
+        MOC_MEMORY = 1 << 1,
+    };
+    int MeshOptimizeCacheFlags;
     EPointLightShadowMode EnablePointlightShadows;
     float MinLightShadowUpdateRange;
     bool PartialDynamicShadowUpdates;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -840,7 +840,7 @@ struct GothicRendererSettings {
         DrawThreaded = false;
         EnableMeshOptimization = true;
         EnableShadowIndexBuffers = true;
-        MeshOptimizeCacheFlags = MOC_DISK;
+        MeshOptimizeCacheFlags = MOC_DISK | MOC_MEMORY;
 
         WindQuality = WIND_QUALITY_ADVANCED;
         HeroAffectsObjects = true;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -924,6 +924,7 @@ struct GothicRendererSettings {
         BinkVideoRunning = false;
         EnableWaterAnimation = false;
         WaterSSRQuality = WATER_SSR_MEDIUM;
+        OpaqueSSRQuality = WATER_SSR_MEDIUM;   // D3D12 only — temporal SSR on wet/glossy opaque surfaces
 
         GraphicsPreset = E_GraphicsPreset::GRAPHICS_MEDIUM;
         AllowSelfShadowingPointlights = false;
@@ -1304,6 +1305,10 @@ struct GothicRendererSettings {
     bool BinkVideoRunning;
     bool EnableWaterAnimation;
     E_WaterSSRQuality WaterSSRQuality;
+    // D3D12 only: temporal SSR on opaque wet/glossy surfaces (D3D12Ssr.cpp's history + the Forward+ PS
+    // marcher). Reuses E_WaterSSRQuality's step-count tiers/DISABLED value rather than a parallel enum —
+    // same quality/cost tradeoff, different geometry class. See D3D12_SSR_WET_SURFACES_PLAN.md.
+    E_WaterSSRQuality OpaqueSSRQuality;
     E_AntiAliasingMode AntiAliasingMode;
     E_SharpeningMode SharpeningMode;
     E_GraphicsPreset GraphicsPreset;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -78,6 +78,21 @@ int GetDpi( HWND hWnd )
 }
 
 namespace {
+    
+    template<typename T>
+    struct ListItem
+    {
+        const char* label;
+        T value;
+        const char* toolTip;
+        
+        constexpr ListItem(const char* label, const T value) noexcept :
+            label(label), value(value), toolTip(nullptr) {}
+        
+        constexpr ListItem(const char* label, const T value, const char* toolTip) noexcept :
+            label(label), value(value), toolTip(toolTip) {}
+    };
+    
     // SRV-descriptor callbacks for imgui_impl_dx12: it needs to allocate/free shader-visible
     // descriptors for its textures (font atlas + any user textures). We route these through the
     // D3D12GraphicsEngine's shader-visible heap (passed via ImGui_ImplDX12_InitInfo::UserData).
@@ -571,24 +586,29 @@ void ImGuiShim::OnResize( INT2 newSize )
 }
 
 template <typename T>
-bool ImComboBoxC( const char* id, const std::vector<std::pair<const char*, T>>& items, T* storage, const std::function<void()>& selected ) {
-    if ( storage == nullptr || items.size() == 0 ) {
+bool ImComboBox( const char* id, const ListItem<T> *items, size_t numItems, T* storage, const std::move_only_function<void() const>& selected = []{} ) {
+    if ( storage == nullptr || numItems == 0 ) {
         return ImGui::BeginCombo( id, "invalid storage" );
     }
-    std::pair<const char*, T> selectedItem = items[0];
-    for ( auto& it : items ) {
-        if ( it.second == *storage ) {
+    ListItem<T> selectedItem = items[0];
+    for ( size_t i = 0; i < numItems; i++ ) {
+        const auto& it = items[i];
+        if ( it.value == *storage ) {
             selectedItem = it;
             break;
         }
     }
-    if ( ImGui::BeginCombo( id, selectedItem.first ) ) {
-        for ( size_t i = 0; i < items.size(); i++ ) {
-            bool isSelected = (*storage == items[i].second);
+    if ( ImGui::BeginCombo( id, selectedItem.label ) ) {
+        for ( size_t i = 0; i < numItems; i++ ) {
+            bool isSelected = (*storage == items[i].value);
 
-            if ( ImGui::Selectable( items[i].first, isSelected ) ) {
-                *storage = items[i].second;
-                selected();
+            if ( ImGui::Selectable( items[i].label, isSelected ) ) {
+                *storage = items[i].value;
+                if (selected) selected();
+            }
+            
+            if ( items[i].toolTip ) {
+                ImGui::SetItemTooltip( "%s", items[i].toolTip );
             }
 
             if ( isSelected ) {
@@ -600,66 +620,14 @@ bool ImComboBoxC( const char* id, const std::vector<std::pair<const char*, T>>& 
     return false;
 }
 
-template <typename T>
-bool ImComboBoxCT( const char* id, const std::vector<std::tuple<const char*, T, const char*>>& items, T* storage, const std::function<void()>& selected ) {
-    if ( storage == nullptr || items.size() == 0 ) {
-        return ImGui::BeginCombo( id, "invalid storage" );
-    }
-    auto selectedItem = items[0];
-    for ( auto& it : items ) {
-        if ( std::get<1>( it ) == *storage ) {
-            selectedItem = it;
-            break;
-        }
-    }
-    if ( ImGui::BeginCombo( id, std::get<0>( selectedItem )) ) {
-        for ( size_t i = 0; i < items.size(); i++ ) {
-            bool isSelected = (*storage == std::get<1>( items[i] ));
-
-            if ( ImGui::Selectable( std::get<0>( items[i] ), isSelected ) ) {
-                *storage = std::get<1>( items[i] );
-                selected();
-            }
-            if ( std::get<2>(items[i]) ) {
-                ImGui::SetItemTooltip( "%s", std::get<2>( items[i] ) );
-            }
-
-            if ( isSelected ) {
-                ImGui::SetItemDefaultFocus();
-            }
-        }
-        return true;
-    }
-    return false;
+template <typename T, size_t N>
+bool ImComboBox( const char* id, const ListItem<T>(&items)[N], T* storage, const std::move_only_function<void() const>& selected = []{}) {
+    return ImComboBox( id, items, N, storage, selected );
 }
 
 template <typename T>
-bool ImComboBox( const char* id, const std::vector<std::pair<const char*, T>>& items, T* storage ) {
-    if ( storage == nullptr || items.size() == 0 ) {
-        return ImGui::BeginCombo( id, "invalid storage" );
-    }
-    std::pair<const char*, T> selectedItem = items[0];
-    for ( auto& it : items ) {
-        if ( it.second == *storage ) {
-            selectedItem = it;
-            break;
-        }
-    }
-    if ( ImGui::BeginCombo( id, selectedItem.first ) ) {
-        for ( size_t i = 0; i < items.size(); i++ ) {
-            bool isSelected = (*storage == items[i].second);
-
-            if ( ImGui::Selectable( items[i].first, isSelected ) ) {
-                *storage = items[i].second;
-            }
-
-            if ( isSelected ) {
-                ImGui::SetItemDefaultFocus();
-            }
-        }
-        return true;
-    }
-    return false;
+bool ImComboBox( const char* id, const std::vector<ListItem<T>>& items, T* storage, const std::move_only_function<void() const>& selected = []{} ) {
+    return ImComboBox( id, items.data(), items.size(), storage, selected );
 }
 
 void ImText( const char* label, const ImVec2& size ) {
@@ -912,7 +880,7 @@ void ImGuiShim::RenderSettingsWindowModern() {
             if ( settings.Upscaler == GothicRendererSettings::UPSCALER_FSR_3 ) {
                 settings.ResolutionScalePercent = std::clamp( settings.ResolutionScalePercent, 33, 100 );
                 // Display "levels" as typical for FSR
-                static std::vector<std::pair<const char*, int>> fsrLevels = {
+                constexpr ListItem<int> fsrLevels[] = {
                     { "Native AA", 100 },
                     { "High Quality", 83 },
                     { "Quality", 75 },
@@ -940,16 +908,16 @@ void ImGuiShim::RenderSettingsWindowModern() {
             }
 
             ImText( "Upscaler", buttonWidth ); ImGui::SameLine();
-            static std::vector<std::pair<const char*, GothicRendererSettings::E_Upscaler>> upscalers = {
+            constexpr ListItem<GothicRendererSettings::E_Upscaler> upscalers[] = {
                 { "Simple", GothicRendererSettings::E_Upscaler::UPSCALER_DEFAULT },
                 { "FSR 1", GothicRendererSettings::E_Upscaler::UPSCALER_FSR_1 },
                 { "FSR 3", GothicRendererSettings::E_Upscaler::UPSCALER_FSR_3 },
             };
-            static std::vector<std::pair<const char*, GothicRendererSettings::E_Upscaler>> upscalersNoFsr1 = {
+            constexpr ListItem<GothicRendererSettings::E_Upscaler> upscalersNoFsr1[] = {
                 { "Simple", GothicRendererSettings::E_Upscaler::UPSCALER_DEFAULT },
                 { "FSR 3", GothicRendererSettings::E_Upscaler::UPSCALER_FSR_3 },
             };
-            if ( ImComboBox( "##Upscaler", noFsr1 ? upscalersNoFsr1 : upscalers, &settings.Upscaler ) ) {
+            if ( ImComboBox( "##Upscaler", noFsr1 ? upscalersNoFsr1 : upscalers, noFsr1 ? std::size(upscalersNoFsr1) : std::size(upscalers), &settings.Upscaler ) ) {
                 ImGui::EndCombo();
             }
             if ( noFsr1 ) {
@@ -980,7 +948,7 @@ void ImGuiShim::RenderSettingsWindowModern() {
 
             GothicRendererSettings& settings = Engine::GAPI->GetRendererState().RendererSettings;
 
-            static std::vector<std::pair<const char*, int>> graphicsPresets = {
+            constexpr ListItem<int> graphicsPresets[] = {
                 {"Custom", GothicRendererSettings::E_GraphicsPreset::GRAPHICS_CUSTOM},
                 {"Low", GothicRendererSettings::E_GraphicsPreset::GRAPHICS_LOW},
                 {"Medium", GothicRendererSettings::E_GraphicsPreset::GRAPHICS_MEDIUM},
@@ -991,7 +959,7 @@ void ImGuiShim::RenderSettingsWindowModern() {
             ImGui::TextUnformatted( "Graphics Preset" ); ImGui::SameLine();
 
             ImGui::PushItemWidth( 250 );
-            if ( ImComboBoxC( "##GraphicsPreset", graphicsPresets, (int*)&settings.GraphicsPreset, [&settings]() {
+            if ( ImComboBox( "##GraphicsPreset", graphicsPresets, (int*)&settings.GraphicsPreset, [&settings]() {
                 settings.ApplyGraphicsPreset();
                 } ) ) {
                 ImGui::EndCombo();
@@ -1115,7 +1083,7 @@ void ImGuiShim::RenderSettingsWindow()
         GothicRendererSettings& settings = Engine::GAPI->GetRendererState().RendererSettings;
         FixupSettings(settings);
 
-        static std::vector<std::pair<const char*, int>> graphicsPresets = {
+        constexpr ListItem<int> graphicsPresets[] = {
             {"Custom", GothicRendererSettings::E_GraphicsPreset::GRAPHICS_CUSTOM},
             {"Low", GothicRendererSettings::E_GraphicsPreset::GRAPHICS_LOW},
             {"Medium", GothicRendererSettings::E_GraphicsPreset::GRAPHICS_MEDIUM},
@@ -1126,7 +1094,7 @@ void ImGuiShim::RenderSettingsWindow()
         ImGui::TextUnformatted("Graphics Preset"); ImGui::SameLine();
         
         ImGui::PushItemWidth( 250 );
-        if ( ImComboBoxC( "##GraphicsPreset", graphicsPresets, (int*)&settings.GraphicsPreset, [&settings]() {
+        if ( ImComboBox( "##GraphicsPreset", graphicsPresets, (int*)&settings.GraphicsPreset, [&settings]() {
             settings.ApplyGraphicsPreset();
             } ) ) {
             ImGui::EndCombo();
@@ -1150,13 +1118,13 @@ void ImGuiShim::RenderSettingsWindow()
                 Engine::GAPI->UpdateTextureMaxSize();
             }
 
-            static std::vector<std::tuple<const char*, AOMode, const char*>> aoModes = {
+            constexpr ListItem<AOMode> aoModes[] = {
                     {"Disabled", AOMode::AO_NONE, nullptr},
                     {"HBAO+", AOMode::AO_HBAO, "NVIDIA HBAO+ (Horizon-Based Ambient Occlusion Plus)"},
                     {"SAO", AOMode::AO_SAO, nullptr},
                     {"ASSAO / XeGTAO", AOMode::AO_ASSAO, "D3D11: Intel ASSAO (Adaptive Screen Space Ambient Occlusion).\nD3D12: Intel XeGTAO (ground-truth ambient occlusion)."},
             };
-            if ( ImComboBoxCT( "AO Mode", aoModes, &settings.AoMode, [] {
+            if ( ImComboBox( "AO Mode", aoModes, &settings.AoMode, [] {
                 if ( Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D11 ) {
                     Engine::GraphicsEngine->ReloadShaders( ShaderCategory::Other );
                 }
@@ -1174,7 +1142,7 @@ void ImGuiShim::RenderSettingsWindow()
 
             ImGui::Checkbox( "Depth of Field", &settings.EnableDoF );
             ImGui::SetItemTooltip( "Enable Depth of Field with bokeh blur." );
-            static std::vector<std::tuple<const char*, GothicRendererSettings::E_AntiAliasingMode, const char*>> antiAliasing = {
+            constexpr ListItem<GothicRendererSettings::E_AntiAliasingMode> antiAliasing[] = {
                 {"Disabled", GothicRendererSettings::E_AntiAliasingMode::AA_NONE, nullptr },
                 {"SMAA", GothicRendererSettings::E_AntiAliasingMode::AA_SMAA, nullptr },
                 {"TAA", GothicRendererSettings::E_AntiAliasingMode::AA_TAA, "Temporal Anti-Aliasing" },
@@ -1184,7 +1152,7 @@ void ImGuiShim::RenderSettingsWindow()
             {
                 ImGui::PushID( "AntiAliasingSettings" );
                 auto selectedMode = settings.AntiAliasingMode;
-                if ( ImComboBoxCT( "Anti Aliasing", antiAliasing, &selectedMode, [&selectedMode, &settings] {
+                if ( ImComboBox( "Anti Aliasing", antiAliasing, &selectedMode, [&selectedMode, &settings] {
                     if ( selectedMode == GothicRendererSettings::E_AntiAliasingMode::AA_FSR ) {
                         settings.Upscaler = GothicRendererSettings::E_Upscaler::UPSCALER_FSR_3;
                     }
@@ -1196,7 +1164,7 @@ void ImGuiShim::RenderSettingsWindow()
             }
 
             if ( settings.RendererMode == GothicRendererSettings::RM_ForwardPlus ) {
-                static const std::vector<std::pair<const char*, int>> msaaSamples = {
+                static const std::vector<ListItem<int>> msaaSamples = {
                     { "Off", 1 },
                     { "2x",  2 },
                     { "4x",  4 },
@@ -1213,12 +1181,12 @@ void ImGuiShim::RenderSettingsWindow()
                 shadersToReload |= ShaderCategory::LightsAndShadows;
             }
             {
-                static std::vector<std::pair<const char*, GothicRendererSettings::E_ShadowFilterMode>> shadowFilterModes = {
+                constexpr ListItem<GothicRendererSettings::E_ShadowFilterMode> shadowFilterModes[] = {
                     {"Disabled", GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_DISABLED},
                     {"Simple", GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_SIMPLE},
                     {"PCSS", GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_PCSS},
                 };
-                if ( ImComboBoxC( "Shadow filtering", shadowFilterModes, &settings.ShadowFilterMode, [&shadersToReload]() {
+                if ( ImComboBox( "Shadow filtering", shadowFilterModes, &settings.ShadowFilterMode, [&shadersToReload]() {
                     shadersToReload |= ShaderCategory::LightsAndShadows;
                     } ) ) {
                     ImGui::EndCombo();
@@ -1338,7 +1306,7 @@ void ImGuiShim::RenderSettingsWindow()
             if ( settings.Upscaler == GothicRendererSettings::UPSCALER_FSR_3 ) {
                 settings.ResolutionScalePercent = std::clamp( settings.ResolutionScalePercent, 33, 100 );
                 // Display "levels" as typical for FSR
-                static std::vector<std::pair<const char*, int>> fsrLevels = {
+                constexpr ListItem<int> fsrLevels[] = {
                     { "Native AA", 100 },
                     { "High Quality", 83 },
                     { "Quality", 75 },
@@ -1365,16 +1333,18 @@ void ImGuiShim::RenderSettingsWindow()
             }
 
             ImText( "Upscaler", buttonWidth ); ImGui::SameLine();
-            static std::vector<std::pair<const char*, GothicRendererSettings::E_Upscaler>> upscalers = {
+            constexpr ListItem<GothicRendererSettings::E_Upscaler> upscalers[] = {
                 { "Simple", GothicRendererSettings::E_Upscaler::UPSCALER_DEFAULT },
                 { "FSR 1", GothicRendererSettings::E_Upscaler::UPSCALER_FSR_1 },
                 { "FSR 3", GothicRendererSettings::E_Upscaler::UPSCALER_FSR_3 },
             };
-            static std::vector<std::pair<const char*, GothicRendererSettings::E_Upscaler>> upscalersNoFsr1 = {
+            constexpr ListItem<GothicRendererSettings::E_Upscaler> upscalersNoFsr1[] = {
                 { "Simple", GothicRendererSettings::E_Upscaler::UPSCALER_DEFAULT },
                 { "FSR 3", GothicRendererSettings::E_Upscaler::UPSCALER_FSR_3 },
             };
-            if ( ImComboBox( "##Upscaler", noFsr1 ? upscalersNoFsr1 : upscalers, &settings.Upscaler ) ) {
+            if ( noFsr1
+                ? ImComboBox( "##Upscaler", upscalersNoFsr1, &settings.Upscaler )
+                : ImComboBox( "##Upscaler", upscalers, &settings.Upscaler ) ) {
                 ImGui::EndCombo();
             }
             if ( noFsr1 ) {
@@ -1394,7 +1364,7 @@ void ImGuiShim::RenderSettingsWindow()
 
 
             ImText( "Texture Quality", buttonWidth ); ImGui::SameLine();
-            static std::vector<std::pair<const char*, int>> QualityOptions = {
+            constexpr ListItem<int> QualityOptions[] = {
                 { "Very Low", static_cast<int>(GothicRendererSettings::TX_QUALITY::VeryLow) },
                 { "Low", static_cast<int>(GothicRendererSettings::TX_QUALITY::Low) },
                 { "Medium", static_cast<int>(GothicRendererSettings::TX_QUALITY::Medium) },
@@ -1403,16 +1373,16 @@ void ImGuiShim::RenderSettingsWindow()
                 { "Extreme", static_cast<int>(GothicRendererSettings::TX_QUALITY::MAX) }, // TODO: this should depend on the GPU capabilities like in the original game
             };
             
-            if (settings.textureMaxSize > QualityOptions.back().second) {
-                settings.textureMaxSize = QualityOptions.back().second;
+            if (settings.textureMaxSize > QualityOptions[std::size(QualityOptions)-1].value) {
+                settings.textureMaxSize = QualityOptions[std::size(QualityOptions)-1].value;
                 Engine::GAPI->UpdateTextureMaxSize();
             }
-            if (settings.textureMaxSize < QualityOptions.front().second) {
-                settings.textureMaxSize = QualityOptions.front().second;
+            if (settings.textureMaxSize < QualityOptions[0].value) {
+                settings.textureMaxSize = QualityOptions[0].value;
                 Engine::GAPI->UpdateTextureMaxSize();
             }
 
-            if (ImComboBoxC("##TextureQuality", QualityOptions, &settings.textureMaxSize, []{
+            if (ImComboBox("##TextureQuality", QualityOptions, &settings.textureMaxSize, []{
                 Engine::GAPI->UpdateTextureMaxSize();
             } ))
             {
@@ -1424,14 +1394,14 @@ void ImGuiShim::RenderSettingsWindow()
             ImGui::SameLine();
 
             static auto displayModeState = InterpretWindowMode( settings );
-            static std::vector<std::tuple<const char*, WindowModes, const char*>> DisplayEnums = {
+            constexpr ListItem<WindowModes> DisplayEnums[] = {
                 { "Fullscreen Borderless", WindowModes::WINDOW_MODE_FULLSCREEN_BORDERLESS, nullptr },
                 { "Fullscreen Lowlatency [*]", WindowModes::WINDOW_MODE_FULLSCREEN_LOWLATENCY, "switching requires restarting the game"},
                 { "Fullscreen Exclusive [*]", WindowModes::WINDOW_MODE_FULLSCREEN_EXCLUSIVE, "switching requires restarting the game"},
                 { "Windowed", WindowModes::WINDOW_MODE_WINDOWED, nullptr},
             };
             
-            if ( ImComboBoxCT( "##DisplayMode", DisplayEnums, &displayModeState, [&settings] {
+            if ( ImComboBox( "##DisplayMode", DisplayEnums, &displayModeState, [&settings] {
                 // selected
                 settings.ChangeWindowPreset = displayModeState;
                 } ) ) {
@@ -1442,7 +1412,7 @@ void ImGuiShim::RenderSettingsWindow()
 
             // Resolutions are restricted to these five power-of-two steps — 8192 is the hard ceiling on both
             // backends/feature levels (a 16384 cascade slice is ~1GB, not worth the VRAM for a shadow map).
-            const static std::vector<std::pair<const char*, int>> shadowMapSizes = {
+            constexpr ListItem<int> shadowMapSizes[] = {
                 {"very low", 512},
                 {"low", 1024},
                 {"medium", 2048},
@@ -1450,7 +1420,7 @@ void ImGuiShim::RenderSettingsWindow()
                 {"very high", 8192},
             };
 
-            if ( ImComboBoxC( "##ShadowQuality", shadowMapSizes, &settings.ShadowMapSize, [&shadersToReload]{
+            if ( ImComboBox( "##ShadowQuality", shadowMapSizes, &settings.ShadowMapSize, [&shadersToReload]{
                 if ( Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D11 ) {
                     shadersToReload |= ShaderCategory::LightsAndShadows;
                 }
@@ -1460,14 +1430,14 @@ void ImGuiShim::RenderSettingsWindow()
 
             ImText( "Dynamic Shadows", buttonWidth ); ImGui::SameLine();
             
-            const static std::vector<std::tuple<const char*, GothicRendererSettings::EPointLightShadowMode, const char*>> dynamicShadowValues = {
+            constexpr ListItem<GothicRendererSettings::EPointLightShadowMode> dynamicShadowValues[] = {
                 { "Off", GothicRendererSettings::EPointLightShadowMode::PLS_DISABLED, nullptr },
                 { "Static", GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY, nullptr },
                 { "Dynamic Update", GothicRendererSettings::EPointLightShadowMode::PLS_UPDATE_DYNAMIC, nullptr },
                 { "Full", GothicRendererSettings::EPointLightShadowMode::PLS_FULL, "Very expensive. Don't use unless you encounter visual bugs." },
             };
 
-            if ( ImComboBoxCT( "##DynamicShadows", dynamicShadowValues, &settings.EnablePointlightShadows, [] {} ) ) {
+            if ( ImComboBox( "##DynamicShadows", dynamicShadowValues, &settings.EnablePointlightShadows, [] {} ) ) {
                 ImGui::EndCombo();
             }
 
@@ -1761,7 +1731,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
 
         ImGui::DragFloat( "Exposure", &settings.Exposure, 0.01f, 0.0f, 8.0f, "%.2f" );
 
-        static std::vector<std::pair<const char*, int>> hdrToneMapValues = {
+        constexpr ListItem<int> hdrToneMapValues[] = {
             {"ToneMap_jafEq4", 0},
             {"Uncharted2Tonemap", 1},
             {"ACESFilmTonemap", 2},
@@ -1771,7 +1741,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         };
 
         ImGui::BeginDisabled( !settings.EnableHDR );
-        if ( ImComboBoxC( "HDR ToneMap", hdrToneMapValues, reinterpret_cast<int*>(&settings.HDRToneMap), []
+        if ( ImComboBox( "HDR ToneMap", hdrToneMapValues, reinterpret_cast<int*>(&settings.HDRToneMap), []
         {
             if ( Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D11 ) {
                 Engine::GraphicsEngine->ReloadShaders( ShaderCategory::Tonemapping );
@@ -1860,14 +1830,14 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         ImGui::Checkbox( "DynamicLighting", &settings.EnableDynamicLighting );
         ImGui::BeginDisabled( !settings.EnableDynamicLighting );
         {
-            const static std::vector<std::tuple<const char*, GothicRendererSettings::EPointLightShadowMode, const char*>> dynamicShadowValues = {
+            constexpr ListItem<GothicRendererSettings::EPointLightShadowMode> dynamicShadowValues[] = {
                 { "Off", GothicRendererSettings::EPointLightShadowMode::PLS_DISABLED, nullptr },
                 { "Static", GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY, nullptr },
                 { "Dynamic Update", GothicRendererSettings::EPointLightShadowMode::PLS_UPDATE_DYNAMIC, nullptr },
                 { "Full", GothicRendererSettings::EPointLightShadowMode::PLS_FULL, "Very expensive. Don't use unless you encounter visual bugs." },
             };
 
-            if ( ImComboBoxCT( "##DynamicShadows", dynamicShadowValues, &settings.EnablePointlightShadows, [] {} ) ) {
+            if ( ImComboBox( "##DynamicShadows", dynamicShadowValues, &settings.EnablePointlightShadows, [] {} ) ) {
                 ImGui::EndCombo();
             }
 
@@ -1906,7 +1876,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
 
         // Resolutions are restricted to these five power-of-two steps — 8192 is the hard ceiling on both
         // backends/feature levels (a 16384 cascade slice is ~1GB, not worth the VRAM for a shadow map).
-        static std::vector<std::pair<const char*, int>> shadowMapSizes = {
+        constexpr ListItem<int> shadowMapSizes[] = {
           {"512", 512},
           {"1024", 1024},
           {"2048", 2048},
@@ -1924,7 +1894,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
             ImGui::DragFloat( "Fixed shadow frequency", &settings.SmoothShadowFrequency, 200.0f, 1, 20000.f, "%.0f", ImGuiSliderFlags_::ImGuiSliderFlags_ClampOnInput );
             ImGui::SetItemTooltip( "on: Higher values mean more frequent shadow position updates.\noff: real-time shadow updates." );
 
-            if ( ImComboBoxC( "ShadowmapSize", shadowMapSizes, (int*)(&settings.ShadowMapSize), []() { 
+            if ( ImComboBox( "ShadowmapSize", shadowMapSizes, (int*)(&settings.ShadowMapSize), []() { 
                 if ( Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D11 ) {
                     Engine::GraphicsEngine->ReloadShaders( ShaderCategory::LightsAndShadows );
                 }
@@ -1957,7 +1927,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
 
             ImGui::BeginDisabled( settings.NumShadowCascades <= 1 );
             {
-                static std::vector<std::pair<const char*, GothicRendererSettings::E_ShadowFrustumCulling>> shadowFrustumCullingModes = {
+                constexpr ListItem<GothicRendererSettings::E_ShadowFrustumCulling> shadowFrustumCullingModes[] = {
                     {"Disabled", GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_DISABLED},
                     {"Conservative", GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_CONSERVATIVE},
                     {"Aggressive", GothicRendererSettings::E_ShadowFrustumCulling::SHD_FRUSTUM_CULLING_AGGRESSIVE},
@@ -1970,12 +1940,12 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
             }
 
             {
-                static std::vector<std::pair<const char*, GothicRendererSettings::E_ShadowFilterMode>> shadowFilterModes = {
+                constexpr ListItem<GothicRendererSettings::E_ShadowFilterMode> shadowFilterModes[] = {
                     {"Disabled", GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_DISABLED},
                     {"Simple", GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_SIMPLE},
                     {"PCSS", GothicRendererSettings::E_ShadowFilterMode::SHADOW_FILTER_PCSS},
                 };
-                if ( ImComboBoxC( "Shadow filtering", shadowFilterModes, &settings.ShadowFilterMode, []() {
+                if ( ImComboBox( "Shadow filtering", shadowFilterModes, &settings.ShadowFilterMode, []() {
                     if ( Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D11 ) {
                         Engine::GraphicsEngine->ReloadShaders( ShaderCategory::LightsAndShadows );
                     }
@@ -2258,7 +2228,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 ImGui::SetItemTooltip("Allow Driver Extensions (AMD, Nvidia, Intel).\nRequires restart.");
 
                 {
-                    static const std::vector<std::pair<const char*, GothicRendererSettings::E_RendererMode>> rendererModes = {
+                    static const std::vector<ListItem<GothicRendererSettings::E_RendererMode>> rendererModes = {
                         { "Deferred",   GothicRendererSettings::RM_Deferred },
                         { "Forward+",   GothicRendererSettings::RM_ForwardPlus },
                     };
@@ -2268,7 +2238,7 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                     ImGui::SetItemTooltip( "Deferred: GBuffer + tiled deferred lighting.  Forward+: depth prepass + per-pixel lit geometry pass." );
                 }
                 if ( settings.RendererMode == GothicRendererSettings::RM_ForwardPlus ) {
-                    static const std::vector<std::pair<const char*, int>> msaaSamples = {
+                    static const std::vector<ListItem<int>> msaaSamples = {
                         { "Off", 1 },
                         { "2x",  2 },
                         { "4x",  4 },
@@ -2311,12 +2281,12 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
                 }
                 ImGui::SetItemTooltip("Enables support for BC5 compressed Normalmaps.");
 
-                static const std::vector<std::pair<const char*, int>> normalMapType = {
+                static const std::vector<ListItem<int>> normalMapType = {
                     { "Disabled",   0 },
                     { "OpenGL (Y+)",   1 }, 
                     { "DirectX (Y-)",   2 },
                 };
-                if ( ImComboBoxC( "Normalmapping texture mode", normalMapType, &settings.AllowNormalmaps, []
+                if ( ImComboBox( "Normalmapping texture mode", normalMapType, &settings.AllowNormalmaps, []
                 {
                     if ( Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D11 ) {
                         Engine::GraphicsEngine->ReloadShaders();
@@ -2427,13 +2397,13 @@ void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) 
             ImGui::SeparatorText( "Ambient Occlusion" );
             {
                 ImGui::PushID( "AOSettings" );
-                static std::vector<std::tuple<const char*, AOMode, const char*>> aoModes = {
+                constexpr ListItem<AOMode> aoModes[] = {
                     {"Disabled", AOMode::AO_NONE, nullptr},
                     {"HBAO+", AOMode::AO_HBAO, "NVIDIA HBAO+ (Horizon-Based Ambient Occlusion Plus)"},
                     {"SAO", AOMode::AO_SAO, nullptr},
                     {"ASSAO / XeGTAO", AOMode::AO_ASSAO, "D3D11: Intel ASSAO (Adaptive Screen Space Ambient Occlusion).\nD3D12: Intel XeGTAO (ground-truth ambient occlusion)."},
                 };
-                if ( ImComboBoxCT( "AO Mode", aoModes, &settings.AoMode, [] {
+                if ( ImComboBox( "AO Mode", aoModes, &settings.AoMode, [] {
                     if ( Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D11 ) {
                         Engine::GraphicsEngine->ReloadShaders( ShaderCategory::Other );
                     }
@@ -2445,7 +2415,7 @@ void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) 
                 // D3D12 only; rebuild happens next frame in ApplyPendingAoResolutionChange.
                 if ( settings.AoMode != AOMode::AO_NONE
                     && settings.GraphicsAPI == GothicRendererSettings::GRAPHICS_API_D3D12 ) {
-                    static std::vector<std::pair<const char*, AoResolutionScale>> aoResolutions = {
+                    constexpr ListItem<AoResolutionScale> aoResolutions[] = {
                         { "Full", AoResolutionScale::Full },
                         { "Half", AoResolutionScale::Half },
                     };
@@ -2469,17 +2439,17 @@ void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) 
                     }
 
                     ImGui::Checkbox( "Enable Blur", &settings.HbaoSettings.EnableBlur );
-                    static std::vector<std::pair<const char*, int>> ssaoRadi = { {"2", 0}, {"4", 1} };
+                    constexpr ListItem<int> ssaoRadi[] = { {"2", 0}, {"4", 1} };
                     if ( ImComboBox( "SSAO radius", ssaoRadi, &settings.HbaoSettings.SsaoBlurRadius ) ) {
                         ImGui::EndCombo();
                     }
                     ImGui::DragFloat( "BlurSharpness", &settings.HbaoSettings.BlurSharpness, 0.01f );
-                    static std::vector<std::pair<const char*, int>> blendMode = { {"Replace", 0}, {"Multiply", 1} };
+                    constexpr ListItem<int> blendMode[] = { {"Replace", 0}, {"Multiply", 1} };
                     if ( ImComboBox( "BlendMode", blendMode, &settings.HbaoSettings.BlendMode ) ) {
                         ImGui::EndCombo();
                     }
 
-                    static std::vector<std::pair<const char*, int>> stepCount = { {"4", 0}, {"8", 1} };
+                    constexpr ListItem<int> stepCount[] = { {"4", 0}, {"8", 1} };
                     if ( ImComboBox( "SSAO steps", stepCount, &settings.HbaoSettings.SsaoStepCount ) ) {
                         ImGui::EndCombo();
                     }
@@ -2498,7 +2468,7 @@ void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) 
                     ImGui::SeparatorText( "XeGTAO Settings (D3D12)" );
                     ImGui::TextUnformatted( "Intel XeGTAO — ground-truth ambient occlusion." );
 
-                    static std::vector<std::pair<const char*, int>> gtaoQuality = {
+                    constexpr ListItem<int> gtaoQuality[] = {
                         {"Low", 0}, {"Medium", 1}, {"High", 2}, {"Ultra", 3}
                     };
                     if ( ImComboBox( "Quality Level", gtaoQuality, &settings.GtaoSettings.QualityLevel ) ) {
@@ -2506,7 +2476,7 @@ void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) 
                     }
                     ImGui::SetItemTooltip( "Higher levels take more samples per pixel (slices x steps: 1x2, 2x2, 3x3, 9x3)." );
 
-                    static std::vector<std::pair<const char*, int>> gtaoDenoise = {
+                    constexpr ListItem<int> gtaoDenoise[] = {
                         {"Disabled", 0}, {"Sharp", 1}, {"Medium", 2}, {"Soft", 3}
                     };
                     if ( ImComboBox( "Denoising", gtaoDenoise, &settings.GtaoSettings.DenoisePasses ) ) {
@@ -2569,7 +2539,7 @@ void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) 
                     ImGui::SetItemTooltip( "[0.0, ~] Distance to start fading out the effect." );
                     ImGui::DragFloat( "Fade Out To", &settings.AssaoSettings.FadeOutTo, 1.0f, 0.0f, 0.0f, "%.0f" );
                     ImGui::SetItemTooltip( "[0.0, ~] Distance at which the effect is fully faded out." );
-                    static std::vector<std::pair<const char*, int>> assaoQuality = {
+                    constexpr ListItem<int> assaoQuality[] = {
                         {"Lowest (-1)", -1}, {"Low (0)", 0}, {"Medium (1)", 1}, {"High (2)", 2}, {"Very High/Adaptive (3)", 3}
                     };
                     if ( ImComboBox( "Quality Level", assaoQuality, &settings.AssaoSettings.QualityLevel ) ) {
@@ -2593,14 +2563,14 @@ void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) 
         ImGui::SeparatorText( "Anti Aliasing" );
         {
             ImGui::PushID( "AntiAliasingSettings" );
-            static std::vector<std::pair<const char*, GothicRendererSettings::E_AntiAliasingMode>> antiAliasing = {
+            constexpr ListItem<GothicRendererSettings::E_AntiAliasingMode> antiAliasing[] = {
                 {"Disabled", GothicRendererSettings::E_AntiAliasingMode::AA_NONE},
                 {"SMAA", GothicRendererSettings::E_AntiAliasingMode::AA_SMAA},
                 {"TAA", GothicRendererSettings::E_AntiAliasingMode::AA_TAA},
                 {"FSR 3", GothicRendererSettings::E_AntiAliasingMode::AA_FSR},
             };
             auto selectedMode = settings.AntiAliasingMode;
-            if ( ImComboBoxC( "Anti Aliasing", antiAliasing, &selectedMode, [&selectedMode, &settings] {
+            if ( ImComboBox( "Anti Aliasing", antiAliasing, &selectedMode, [&selectedMode, &settings] {
                 if ( selectedMode == GothicRendererSettings::E_AntiAliasingMode::AA_FSR ) {
                     settings.Upscaler = GothicRendererSettings::E_Upscaler::UPSCALER_FSR_3;
                 }
@@ -2612,7 +2582,7 @@ void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) 
         }
 
         if ( settings.RendererMode == GothicRendererSettings::RM_ForwardPlus ) {
-            static const std::vector<std::pair<const char*, int>> msaaSamples = {
+            static const std::vector<ListItem<int>> msaaSamples = {
                 { "Off", 1 },
                 { "2x",  2 },
                 { "4x",  4 },
@@ -2627,7 +2597,7 @@ void RenderAdvancedColumn4( GothicRendererSettings& settings, GothicAPI* gapi ) 
         ImGui::SeparatorText( "Sharpening" );
         {
             ImGui::PushID( "SharpeningSettings" );
-            static std::vector<std::pair<const char*, GothicRendererSettings::E_SharpeningMode>> sharpenModes = {
+            constexpr ListItem<GothicRendererSettings::E_SharpeningMode> sharpenModes[] = {
                 {"Disabled", GothicRendererSettings::E_SharpeningMode::SHARPEN_NONE},
                 {"Simple", GothicRendererSettings::E_SharpeningMode::SHARPEN_SIMPLE},
                 {"CAS", GothicRendererSettings::E_SharpeningMode::SHARPEN_CAS},

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1725,8 +1725,9 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         ImGui::SetItemTooltip( "Also remember already-optimized meshes in RAM for the duration of the current\n"
             "world load, so re-converting the same mesh twice in one load (shared VOB visuals,\n"
             "e.g.) skips the disk read too. Never kept beyond one load regardless of this setting,\n"
-            "to avoid growing unbounded over a long play session in this 32-bit process. Takes\n"
-            "effect on the next world load." );
+            "to avoid growing unbounded over a long play session in this 32-bit process, and capped\n"
+            "at a fixed RAM budget even within one load so a single huge world can't do the same.\n"
+            "Takes effect on the next world load." );
         ImGui::EndDisabled();
 
         // ImGui::Checkbox( "Draw Sky", &settings.DrawSky );

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -585,52 +585,55 @@ void ImGuiShim::OnResize( INT2 newSize )
     ImGuiCollectResolutions( Resolutions );
 }
 
-template <typename T>
-bool ImComboBox( const char* id, const ListItem<T> *items, size_t numItems, T* storage, const std::move_only_function<void() const>& selected = []{} ) {
-    if ( storage == nullptr || numItems == 0 ) {
-        return ImGui::BeginCombo( id, "invalid storage" );
-    }
-    ListItem<T> selectedItem = items[0];
-    for ( size_t i = 0; i < numItems; i++ ) {
-        const auto& it = items[i];
-        if ( it.value == *storage ) {
-            selectedItem = it;
-            break;
+namespace Internal
+{
+    template <typename T>
+    static bool ImComboBox( const char* id, const ListItem<T> *items, size_t numItems, T* storage, const std::move_only_function<void() const>& selected = []{} ) {
+        if ( storage == nullptr || numItems == 0 ) {
+            return ImGui::BeginCombo( id, "invalid storage" );
         }
-    }
-    if ( ImGui::BeginCombo( id, selectedItem.label ) ) {
+        ListItem<T> selectedItem = items[0];
         for ( size_t i = 0; i < numItems; i++ ) {
-            bool isSelected = (*storage == items[i].value);
-
-            if ( ImGui::Selectable( items[i].label, isSelected ) ) {
-                *storage = items[i].value;
-                if (selected) selected();
-            }
-            
-            if ( items[i].toolTip ) {
-                ImGui::SetItemTooltip( "%s", items[i].toolTip );
-            }
-
-            if ( isSelected ) {
-                ImGui::SetItemDefaultFocus();
+            const auto& it = items[i];
+            if ( it.value == *storage ) {
+                selectedItem = it;
+                break;
             }
         }
-        return true;
+        if ( ImGui::BeginCombo( id, selectedItem.label ) ) {
+            for ( size_t i = 0; i < numItems; i++ ) {
+                bool isSelected = (*storage == items[i].value);
+
+                if ( ImGui::Selectable( items[i].label, isSelected ) ) {
+                    *storage = items[i].value;
+                    if (selected) selected();
+                }
+                
+                if ( items[i].toolTip ) {
+                    ImGui::SetItemTooltip( "%s", items[i].toolTip );
+                }
+
+                if ( isSelected ) {
+                    ImGui::SetItemDefaultFocus();
+                }
+            }
+            return true;
+        }
+        return false;
     }
-    return false;
 }
 
 template <typename T, size_t N>
-bool ImComboBox( const char* id, const ListItem<T>(&items)[N], T* storage, const std::move_only_function<void() const>& selected = []{}) {
-    return ImComboBox( id, items, N, storage, selected );
+static bool ImComboBox( const char* id, const ListItem<T>(&items)[N], T* storage, const std::move_only_function<void() const>& selected = []{}) {
+    return Internal::ImComboBox( id, items, N, storage, selected );
 }
 
 template <typename T>
-bool ImComboBox( const char* id, const std::vector<ListItem<T>>& items, T* storage, const std::move_only_function<void() const>& selected = []{} ) {
-    return ImComboBox( id, items.data(), items.size(), storage, selected );
+static bool ImComboBox( const char* id, const std::vector<ListItem<T>>& items, T* storage, const std::move_only_function<void() const>& selected = []{} ) {
+    return Internal::ImComboBox( id, items.data(), items.size(), storage, selected );
 }
 
-void ImText( const char* label, const ImVec2& size ) {
+static void ImText( const char* label, const ImVec2& size ) {
     auto& col = ImGui::GetStyleColorVec4( ImGuiCol_::ImGuiCol_Button );
 
     ImGui::PushStyleColor( ImGuiCol_::ImGuiCol_ButtonActive, col );
@@ -645,7 +648,7 @@ void ImText( const char* label, const ImVec2& size ) {
 
 // Helper function to edit a direction vector using ImGuizmo::ViewManipulate
 // Returns true if the direction was modified
-bool ImGuizmoDirectionEdit( const char* label, XMFLOAT3& direction, float widgetSize = 100.0f )
+static bool ImGuizmoDirectionEdit( const char* label, XMFLOAT3& direction, float widgetSize = 100.0f )
 {
     // Normalize the input direction
     XMVECTOR dirVec = XMLoadFloat3( &direction );
@@ -917,7 +920,9 @@ void ImGuiShim::RenderSettingsWindowModern() {
                 { "Simple", GothicRendererSettings::E_Upscaler::UPSCALER_DEFAULT },
                 { "FSR 3", GothicRendererSettings::E_Upscaler::UPSCALER_FSR_3 },
             };
-            if ( ImComboBox( "##Upscaler", noFsr1 ? upscalersNoFsr1 : upscalers, noFsr1 ? std::size(upscalersNoFsr1) : std::size(upscalers), &settings.Upscaler ) ) {
+            if ( noFsr1
+                ? ImComboBox( "##Upscaler", upscalersNoFsr1, &settings.Upscaler )
+                : ImComboBox( "##Upscaler", upscalers, &settings.Upscaler ) ) {
                 ImGui::EndCombo();
             }
             if ( noFsr1 ) {

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1715,6 +1715,18 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         ImGui::SetItemTooltip( "Weld a separate, smaller index buffer for shadow passes. Off falls back to\n"
             "the render index buffer for shadows (more vertex work in the shadow pass, no\n"
             "visual change) and skips one buffer per sub-mesh. Takes effect on the next world load." );
+
+        ImGui::CheckboxFlags( "Cache on disk##MeshOptCacheDisk", &settings.MeshOptimizeCacheFlags, GothicRendererSettings::MOC_DISK );
+        ImGui::SetItemTooltip( "Remember already-optimized meshes in system\\GD3D11\\cache\\meshes.db so a\n"
+            "world/VOB that has been loaded before, even in an earlier session, skips this pass\n"
+            "entirely. Off skips reading and writing that file. Takes effect on the next lookup." );
+        ImGui::SameLine();
+        ImGui::CheckboxFlags( "Cache in memory##MeshOptCacheMemory", &settings.MeshOptimizeCacheFlags, GothicRendererSettings::MOC_MEMORY );
+        ImGui::SetItemTooltip( "Also remember already-optimized meshes in RAM for the duration of the current\n"
+            "world load, so re-converting the same mesh twice in one load (shared VOB visuals,\n"
+            "e.g.) skips the disk read too. Never kept beyond one load regardless of this setting,\n"
+            "to avoid growing unbounded over a long play session in this 32-bit process. Takes\n"
+            "effect on the next world load." );
         ImGui::EndDisabled();
 
         // ImGui::Checkbox( "Draw Sky", &settings.DrawSky );

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1270,6 +1270,17 @@ void ImGuiShim::RenderSettingsWindow()
                     shadersToReload |= ShaderCategory::Water; // recompile PS_Water with the new SSR_QUALITY
                 }
             }
+            // D3D12 only, and only meaningful once the temporal SSR marcher (D3D12_SSR_WET_SURFACES_PLAN.md)
+            // reads this — no shader-recompile trigger needed either way: D3D12 treats quality as a runtime
+            // loop-bound uniform, same as WaterSSRQuality's own D3D12 path (see D3D12Water.cpp).
+            if ( Engine::GraphicsEngine && Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D12 ) {
+                const char* opaqueSsrLevels[] = { "Disabled", "Low", "Medium", "High" };
+                int opaqueSsr = settings.OpaqueSSRQuality;
+                if ( ImGui::Combo( "Wet Surface Reflections (SSR)", &opaqueSsr, opaqueSsrLevels, IM_ARRAYSIZE( opaqueSsrLevels ) ) ) {
+                    settings.OpaqueSSRQuality = (GothicRendererSettings::E_WaterSSRQuality)opaqueSsr;
+                }
+                ImGui::SetItemTooltip( "Temporal screen-space reflections on wet/glossy ground and metal. One frame of lag; D3D12 only." );
+            }
             ImGui::Checkbox( "Limit Light Intensity", &settings.LimitLightIntesity );
             ImGui::Checkbox( "Draw World Section Intersections", &settings.DrawSectionIntersections );
             ImGui::SetItemTooltip( "This option draws every world chunk that intersect with GD3D11 world draw distance." );

--- a/D3D11Engine/MeshOptimizeCache.h
+++ b/D3D11Engine/MeshOptimizeCache.h
@@ -1,44 +1,22 @@
 #pragma once
 
-/** Memoization for the CPU cost of GfxVertexBuffer::OptimizeVertices (vertex-cache/fetch reorder,
-    shadow-index welding, LOD simplification) - see WorldConverter.cpp's OptimizeMeshBuffers, the sole
-    caller. Two tiers: an in-memory map for this session, and an on-disk cache under
-    system\GD3D11\meshoptcache\ so the FIRST load of a session benefits too, on the second and later
-    runs of the game.
+/** Memoizes GfxVertexBuffer::OptimizeVertices (vertex-cache reorder, shadow-index weld, LOD
+    simplification) - see WorldConverter.cpp's OptimizeMeshBuffers, the sole caller. Two tiers: an
+    in-memory map and an on-disk SQLite DB (cache\meshes.db), each independently gated by the
+    caller-supplied GothicRendererSettings::MeshOptimizeCacheFlags mask.
 
-    Gothic reloads the SAME world and VOB geometry many times, both within one session (leaving/
-    re-entering a world, reloading a save, walking back into a camp) and across separate game launches,
-    and meshopt's output is a pure function of the input vertex/index bytes plus which optional outputs
-    were asked for. A hit skips the vertex-cache optimization, the shadow weld and the min-error
-    simplification pass entirely, which is where load-time actually goes.
-    RendererSettings.EnableMeshOptimization/EnableShadowIndexBuffers exist to let a player skip that work
-    in the FIRST place; this is what stops any OTHER load - this session or a future one - from paying
-    for it again.
+    Keyed on a content hash of the pre-optimization vertices/indices, not a Gothic-side pointer -
+    zCProgMeshProto/zCSubMesh don't reliably survive a world change, but the bytes a given source
+    asset produces don't.
 
-    Keyed on a content hash of the PRE-optimization (vertices, indices), not on any Gothic-side pointer -
-    zCProgMeshProto/zCSubMesh objects do not reliably survive a world change (ZenGin's own resource
-    manager purges and reloads them independently of GD3D11), but the bytes a given source asset produces
-    do not change. Self-validating: two different source meshes colliding on the same hash would have to
-    produce identical bytes, in which case optimizing them identically is correct anyway.
+    The memory tier is only armed for the span of one world load (SetMemoryCache, called from
+    GothicAPI::OnLoadWorld/OnWorldLoaded) even when its flag is set - unbounded growth across a whole
+    play session, not one load, is what exhausts the 32-bit address space. Disarming clears the map so
+    the memory is actually freed.
 
-    In-memory tier is only kept ARMED for the duration of one world load (GothicAPI::OnLoadWorld ->
-    OnWorldLoaded calls SetMemoryCache(true)/(false) below) - unbounded growth across an entire play
-    session, not one load, is what was actually exhausting the 32-bit address space, since Gothic
-    reloads worlds/VOBs repeatedly over hours of play. Disarming clears the map immediately so the
-    memory is freed, not just stopped from growing; every lookup after that falls through to the
-    on-disk tier at a small IO cost instead of being memoized in RAM. While armed, an entry holds only
-    small CPU-side index/vertex arrays, never a GPU buffer, so it does not touch the 32-bit VA budget
-    the pooling rules in CLAUDE.md are about. The on-disk tier is one row per distinct sub-mesh ever seen
-    in a single SQLite
-    database (cache\meshes.db, via SqliteBlobStore) - tens of thousands of mostly-tiny entries is exactly
-    the shape a single DB beats a directory of loose files on (fewer file-system objects for the AV
-    scanner/NTFS to chew through during a load burst). Deleting cache\meshes.db is always safe, it just
-    repays the CPU cost on the next load. kFormatVersion below exists for the same reason
-    kDxbcCacheArgsRevision does in D3D11ShaderManager.cpp: bump it whenever a change to
-    MeshShadowIndexBuilder.h, MeshLodBuilder.h, this record layout, or the vendored meshoptimizer version
-    would make a previously-stored row's bytes stop matching what a fresh run produces today - old rows
-    are simply orphaned (dead weight, harmless), never misread, since the version is part of the record
-    and checked before anything else is trusted. */
+    kFormatVersion guards the on-disk record layout, same idea as kDxbcCacheArgsRevision in
+    D3D11ShaderManager.cpp - bump it whenever MeshShadowIndexBuilder.h/MeshLodBuilder.h/meshoptimizer
+    change enough to invalidate old rows; stale rows are just orphaned, never misread. */
 
 #include "VertexTypes.h"
 #include "Logger.h"
@@ -57,9 +35,8 @@
 
 namespace MeshOptimizeCache {
 
-    /** `wantShadow`/`wantLod` are folded into the key so a session that turns on
-        EnableShadowIndexBuffers partway through - or that mixes D3D11/D3D12 results, the only thing that
-        varies LOD - never gets served a hit that is missing an output it now needs. */
+    // wantShadow/wantLod fold into the key so toggling those settings never serves a hit missing an
+    // output it now needs.
     inline uint64_t Hash( const std::vector<VERTEX_INDEX>& indices, const std::vector<ExVertexStruct>& vertices,
         bool wantShadow, bool wantLod ) {
         uint64_t h = ShaderCacheHash::HashBytes( indices.data(), indices.size() * sizeof( VERTEX_INDEX ) );
@@ -75,25 +52,27 @@ namespace MeshOptimizeCache {
         std::vector<VERTEX_INDEX> LodIndices;
     };
 
-    // Worker-pool concurrent: BuildWorldMeshBuffers optimizes many sub-meshes at once (see
-    // WorldConverter.cpp's batched jobs), and VOB visual extraction runs on the same pool.
+    // Worker-pool concurrent: mesh conversion batches jobs across threads.
     inline std::mutex g_Mutex;
     inline gtl::flat_hash_map<uint64_t, Entry> g_Cache;
     inline std::atomic<uint32_t> g_MemHits{ 0 }, g_DiskHits{ 0 }, g_Misses{ 0 };
-    inline std::atomic<bool> g_MemoryCacheEnabled{ true };
+    inline std::atomic<bool> g_MemoryArmed{ true };
 
-    /** Arms/disarms the in-memory tier - see the header comment for why. Call with true right before a
-        world load's mesh conversion work starts and false once it's done; disarming drops any entries
-        already resident so the memory is actually released. Safe to call from the main thread while
-        worker-pool lookups are in flight (TryGet/Put) - both paths take g_Mutex around the memory
-        tier and read g_MemoryCacheEnabled fresh on every call, so a race just means a lookup right at
-        the boundary happens to land on one side or the other of it, never a torn read. */
+    // Arms/disarms the memory tier for the span of one world load - see the header comment. Disarming
+    // clears the map so the memory is actually released, not just stopped from growing.
     inline void SetMemoryCache( bool on ) {
-        g_MemoryCacheEnabled = on;
+        g_MemoryArmed = on;
         if ( !on ) {
             std::scoped_lock lock( g_Mutex );
             g_Cache.clear();
         }
+    }
+
+    inline bool MemoryTierActive( int flags ) {
+        return ( flags & GothicRendererSettings::MOC_MEMORY ) != 0 && g_MemoryArmed.load();
+    }
+    inline bool DiskTierActive( int flags ) {
+        return ( flags & GothicRendererSettings::MOC_DISK ) != 0;
     }
 
     inline void ReportStats() {
@@ -107,14 +86,12 @@ namespace MeshOptimizeCache {
     }
 
     namespace Disk {
-        // Bump on any change that would make a previously-stored row's bytes stop matching what a fresh
-        // OptimizeFaces/OptimizeVertices run produces today - see the header comment.
+        // Bump on any change that invalidates previously-stored rows - see the header comment.
         constexpr uint32_t kFormatVersion = 1;
         constexpr uint32_t kMaxElements = 8u << 20;   // sanity cap against a corrupted/truncated record
 
         inline SqliteBlobStore& GetStore() {
-            // Constructed on first use (magic-static, thread-safe) - by the time any mesh conversion
-            // runs, GetStartDirectory() is already valid.
+            // Magic-static: constructed on first use, once GetStartDirectory() is valid.
             static SqliteBlobStore s_store( Engine::GAPI->GetStartDirectory() + R"(\system\GD3D11\cache\meshes.db)" );
             return s_store;
         }
@@ -130,8 +107,7 @@ namespace MeshOptimizeCache {
             }
         }
 
-        // Cursor over the blob TryGet hands back - the on-disk record layout is unchanged from the old
-        // per-file cache, just read from memory now instead of an ifstream.
+        // Cursor over the blob SqliteBlobStore::TryGet hands back.
         struct Cursor {
             const uint8_t* p;
             const uint8_t* end;
@@ -192,13 +168,11 @@ namespace MeshOptimizeCache {
         }
     }   // namespace Disk
 
-    /** On a hit (memory, then disk), overwrites indices/vertices/shadowIndices/lodIndices with the
-        cached, already-optimized result and returns true - the caller skips OptimizeFaces/
-        OptimizeVertices entirely. A disk hit is folded into the in-memory map so the rest of this
-        session skips the file read too. */
+    // On a hit (memory, then disk), overwrites indices/vertices/shadowIndices/lodIndices with the cached
+    // result and returns true. `flags` is RendererSettings.MeshOptimizeCacheFlags.
     inline bool TryGet( uint64_t key, std::vector<VERTEX_INDEX>& indices, std::vector<ExVertexStruct>& vertices,
-        std::vector<VERTEX_INDEX>* shadowIndices, std::vector<VERTEX_INDEX>* lodIndices ) {
-        {
+        std::vector<VERTEX_INDEX>* shadowIndices, std::vector<VERTEX_INDEX>* lodIndices, int flags ) {
+        if ( MemoryTierActive( flags ) ) {
             std::scoped_lock lock( g_Mutex );
             auto it = g_Cache.find( key );
             if ( it != g_Cache.end() ) {
@@ -212,19 +186,21 @@ namespace MeshOptimizeCache {
             }
         }
 
-        Entry disk;
-        if ( Disk::TryLoad( key, disk ) ) {
-            indices = disk.Indices;
-            vertices = disk.Vertices;
-            if ( shadowIndices ) *shadowIndices = disk.ShadowIndices;
-            if ( lodIndices ) *lodIndices = disk.LodIndices;
-            if ( g_MemoryCacheEnabled ) {
-                std::scoped_lock lock( g_Mutex );
-                g_Cache.emplace( key, std::move( disk ) );
+        if ( DiskTierActive( flags ) ) {
+            Entry disk;
+            if ( Disk::TryLoad( key, disk ) ) {
+                indices = disk.Indices;
+                vertices = disk.Vertices;
+                if ( shadowIndices ) *shadowIndices = disk.ShadowIndices;
+                if ( lodIndices ) *lodIndices = disk.LodIndices;
+                if ( MemoryTierActive( flags ) ) {
+                    std::scoped_lock lock( g_Mutex );
+                    g_Cache.emplace( key, std::move( disk ) );
+                }
+                ++g_DiskHits;
+                ReportStats();
+                return true;
             }
-            ++g_DiskHits;
-            ReportStats();
-            return true;
         }
 
         ++g_Misses;
@@ -233,7 +209,11 @@ namespace MeshOptimizeCache {
     }
 
     inline void Put( uint64_t key, const std::vector<VERTEX_INDEX>& indices, const std::vector<ExVertexStruct>& vertices,
-        const std::vector<VERTEX_INDEX>* shadowIndices, const std::vector<VERTEX_INDEX>* lodIndices ) {
+        const std::vector<VERTEX_INDEX>* shadowIndices, const std::vector<VERTEX_INDEX>* lodIndices, int flags ) {
+        if ( !MemoryTierActive( flags ) && !DiskTierActive( flags ) ) {
+            return;
+        }
+
         Entry e;
         e.Indices = indices;
         e.Vertices = vertices;
@@ -244,9 +224,11 @@ namespace MeshOptimizeCache {
             e.LodIndices = *lodIndices;
         }
 
-        Disk::Store( key, e );
+        if ( DiskTierActive( flags ) ) {
+            Disk::Store( key, e );
+        }
 
-        if ( g_MemoryCacheEnabled ) {
+        if ( MemoryTierActive( flags ) ) {
             std::scoped_lock lock( g_Mutex );
             g_Cache.emplace( key, std::move( e ) );
         }

--- a/D3D11Engine/MeshOptimizeCache.h
+++ b/D3D11Engine/MeshOptimizeCache.h
@@ -14,6 +14,9 @@
     play session, not one load, is what exhausts the 32-bit address space. Disarming clears the map so
     the memory is actually freed.
 
+    Per-load scoping alone isn't enough for one huge world, so kMemoryBudgetBytes below also caps the
+    memory tier's resident size; past that, entries just aren't memoized (the unbounded disk tier still is).
+
     kFormatVersion guards the on-disk record layout, same idea as kDxbcCacheArgsRevision in
     D3D11ShaderManager.cpp - bump it whenever MeshShadowIndexBuilder.h/MeshLodBuilder.h/meshoptimizer
     change enough to invalidate old rows; stale rows are just orphaned, never misread. */
@@ -52,11 +55,21 @@ namespace MeshOptimizeCache {
         std::vector<VERTEX_INDEX> LodIndices;
     };
 
+    inline size_t EntryBytes( const Entry& e ) {
+        return e.Vertices.size() * sizeof( ExVertexStruct ) +
+            ( e.Indices.size() + e.ShadowIndices.size() + e.LodIndices.size() ) * sizeof( VERTEX_INDEX );
+    }
+
     // Worker-pool concurrent: mesh conversion batches jobs across threads.
     inline std::mutex g_Mutex;
     inline gtl::flat_hash_map<uint64_t, Entry> g_Cache;
     inline std::atomic<uint32_t> g_MemHits{ 0 }, g_DiskHits{ 0 }, g_Misses{ 0 };
     inline std::atomic<bool> g_MemoryArmed{ true };
+
+    // Resident-byte cap for the memory tier - see the header comment.
+    constexpr size_t kMemoryBudgetBytes = 512ull << 20;   // 512 MiB
+    inline size_t g_CacheBytes = 0;   // guarded by g_Mutex, not atomic - always touched under lock below
+    inline std::atomic<bool> g_BudgetCapLogged{ false };
 
     // Arms/disarms the memory tier for the span of one world load - see the header comment. Disarming
     // clears the map so the memory is actually released, not just stopped from growing.
@@ -65,7 +78,24 @@ namespace MeshOptimizeCache {
         if ( !on ) {
             std::scoped_lock lock( g_Mutex );
             g_Cache.clear();
+            g_CacheBytes = 0;
+            g_BudgetCapLogged = false;
         }
+    }
+
+    // Inserts into g_Cache only if under kMemoryBudgetBytes; caller already holds g_Mutex. Logs once
+    // when the budget first gets hit, per CLAUDE.md's rule on silent caps.
+    inline void TryInsertLocked( uint64_t key, Entry&& e ) {
+        const size_t bytes = EntryBytes( e );
+        if ( g_CacheBytes + bytes > kMemoryBudgetBytes ) {
+            if ( !g_BudgetCapLogged.exchange( true ) ) {
+                LogInfo() << "Mesh optimize cache: memory tier hit its " << ( kMemoryBudgetBytes >> 20 )
+                    << " MiB budget - further entries this load are disk-only/recomputed, not memoized.";
+            }
+            return;
+        }
+        g_CacheBytes += bytes;
+        g_Cache.emplace( key, std::move( e ) );
     }
 
     inline bool MemoryTierActive( int flags ) {
@@ -195,7 +225,7 @@ namespace MeshOptimizeCache {
                 if ( lodIndices ) *lodIndices = disk.LodIndices;
                 if ( MemoryTierActive( flags ) ) {
                     std::scoped_lock lock( g_Mutex );
-                    g_Cache.emplace( key, std::move( disk ) );
+                    TryInsertLocked( key, std::move( disk ) );
                 }
                 ++g_DiskHits;
                 ReportStats();
@@ -230,7 +260,7 @@ namespace MeshOptimizeCache {
 
         if ( MemoryTierActive( flags ) ) {
             std::scoped_lock lock( g_Mutex );
-            g_Cache.emplace( key, std::move( e ) );
+            TryInsertLocked( key, std::move( e ) );
         }
     }
 

--- a/D3D11Engine/MeshOptimizeCache.h
+++ b/D3D11Engine/MeshOptimizeCache.h
@@ -21,10 +21,15 @@
     do not change. Self-validating: two different source meshes colliding on the same hash would have to
     produce identical bytes, in which case optimizing them identically is correct anyway.
 
-    In-memory tier bounded by the number of DISTINCT sub-meshes the session has ever converted - same
-    growth shape as SharedVisualRegistry. Acceptable because an entry holds only small CPU-side index/
-    vertex arrays, never a GPU buffer, so it does not touch the 32-bit VA budget the pooling rules in
-    CLAUDE.md are about. The on-disk tier is one row per distinct sub-mesh ever seen in a single SQLite
+    In-memory tier is only kept ARMED for the duration of one world load (GothicAPI::OnLoadWorld ->
+    OnWorldLoaded calls SetMemoryCache(true)/(false) below) - unbounded growth across an entire play
+    session, not one load, is what was actually exhausting the 32-bit address space, since Gothic
+    reloads worlds/VOBs repeatedly over hours of play. Disarming clears the map immediately so the
+    memory is freed, not just stopped from growing; every lookup after that falls through to the
+    on-disk tier at a small IO cost instead of being memoized in RAM. While armed, an entry holds only
+    small CPU-side index/vertex arrays, never a GPU buffer, so it does not touch the 32-bit VA budget
+    the pooling rules in CLAUDE.md are about. The on-disk tier is one row per distinct sub-mesh ever seen
+    in a single SQLite
     database (cache\meshes.db, via SqliteBlobStore) - tens of thousands of mostly-tiny entries is exactly
     the shape a single DB beats a directory of loose files on (fewer file-system objects for the AV
     scanner/NTFS to chew through during a load burst). Deleting cache\meshes.db is always safe, it just
@@ -75,6 +80,21 @@ namespace MeshOptimizeCache {
     inline std::mutex g_Mutex;
     inline gtl::flat_hash_map<uint64_t, Entry> g_Cache;
     inline std::atomic<uint32_t> g_MemHits{ 0 }, g_DiskHits{ 0 }, g_Misses{ 0 };
+    inline std::atomic<bool> g_MemoryCacheEnabled{ true };
+
+    /** Arms/disarms the in-memory tier - see the header comment for why. Call with true right before a
+        world load's mesh conversion work starts and false once it's done; disarming drops any entries
+        already resident so the memory is actually released. Safe to call from the main thread while
+        worker-pool lookups are in flight (TryGet/Put) - both paths take g_Mutex around the memory
+        tier and read g_MemoryCacheEnabled fresh on every call, so a race just means a lookup right at
+        the boundary happens to land on one side or the other of it, never a torn read. */
+    inline void SetMemoryCache( bool on ) {
+        g_MemoryCacheEnabled = on;
+        if ( !on ) {
+            std::scoped_lock lock( g_Mutex );
+            g_Cache.clear();
+        }
+    }
 
     inline void ReportStats() {
         const uint32_t total = g_MemHits + g_DiskHits + g_Misses;
@@ -198,7 +218,7 @@ namespace MeshOptimizeCache {
             vertices = disk.Vertices;
             if ( shadowIndices ) *shadowIndices = disk.ShadowIndices;
             if ( lodIndices ) *lodIndices = disk.LodIndices;
-            {
+            if ( g_MemoryCacheEnabled ) {
                 std::scoped_lock lock( g_Mutex );
                 g_Cache.emplace( key, std::move( disk ) );
             }
@@ -226,8 +246,10 @@ namespace MeshOptimizeCache {
 
         Disk::Store( key, e );
 
-        std::scoped_lock lock( g_Mutex );
-        g_Cache.emplace( key, std::move( e ) );
+        if ( g_MemoryCacheEnabled ) {
+            std::scoped_lock lock( g_Mutex );
+            g_Cache.emplace( key, std::move( e ) );
+        }
     }
 
 }   // namespace MeshOptimizeCache

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -1,6 +1,7 @@
 #include "DS_Defines.h"
 #include "DepthReconstruction.h"
 #include "include/PointLightShadows.h"
+#include "include/RainWetnessSample.h"
 
 #define TILE_SIZE 16
 
@@ -30,6 +31,11 @@ cbuffer TiledShadingConstantBuffer : register( b0 ) {
     float ClusterNearZ;   // must match what CS_LightCulling was dispatched with
     float ClusterFarZ;
     matrix InvView; // For world-space reconstruction (shadow sampling)
+
+    // Rain wetness, frame-constant (see ApplyPointLightWetness / RainWetnessSample.h).
+    matrix RainViewProj;
+    float SceneWettness;
+    float3 WetnessPad;
 };
 
 SamplerComparisonState SS_Comp : register( s2 );
@@ -37,6 +43,7 @@ Texture2D TX_Diffuse : register( t0 );
 Texture2D TX_Nrm : register( t1 );
 Texture2D TX_Depth : register( t2 );
 Texture2D TX_SI_SP : register( t7 );
+Texture2D TX_RainShadowmap : register( t4 );
 
 StructuredBuffer<TiledPointLight> SB_Lights : register( t8 );
 StructuredBuffer<LightGrid> SB_LightGrid : register( t9 );
@@ -75,6 +82,15 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
     // World-space position for shadow sampling (computed once, shared by all shadowed lights)
     float3 wsPosition = mul( float4( vsPosition, 1 ), InvView ).xyz;
     float3 wsNormal = normalize( mul( float4( normal, 0 ), InvView ).xyz );
+
+    // Rain wetness: darken/dampen this pixel's diffuse/specular ONCE, before the light loop below, so
+    // every overlapping light shades against wet ground consistently with what
+    // PS_DS_AtmosphericScattering.hlsl already did for the sun/ambient term — instead of each light
+    // additively blending un-wetted brightness on top of it (see RainWetnessSample.h's header for the
+    // bug this fixes; this is the primary point-light path lights use, PS_DS_PointLight.hlsl only
+    // handles the shadow-cube-overflow fallback).
+    ApplyPointLightWetness( wsPosition, wsNormal, TX_RainShadowmap, SS_Comp, RainViewProj, SceneWettness,
+        diffuse.rgb, specIntensity, specPower );
 
     // Compute tile index
     uint tileX = pixelCoord.x / TILE_SIZE;

--- a/D3D11Engine/Shaders/D3D12/AdvanceRain.hlsl
+++ b/D3D11Engine/Shaders/D3D12/AdvanceRain.hlsl
@@ -19,18 +19,7 @@ cbuffer AdvanceRainCB : register( b0 )
     float3 AR_Pad1;
 };
 
-struct RainParticleDynamic
-{
-    float3 position;
-    float3 velocity;
-};
-
-struct RainParticleStatic
-{
-    float3 seed;
-    float  randomBrightness;
-    int    drawMode;
-};
+#include "include/RainParticleTypes.hlsl"
 
 StructuredBuffer<RainParticleStatic>     StaticData  : register( t0 );
 RWStructuredBuffer<RainParticleDynamic>  DynamicData : register( u0 );

--- a/D3D11Engine/Shaders/D3D12/Decal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Decal.hlsl
@@ -44,14 +44,16 @@ cbuffer ShadowCB : register(b3)
     float4x4 RainViewProj;
     float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
     uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // --- Screen-space AO block, 80 bytes, written by UploadAoScreenConstants (kAoReprojCbOffset). Only the
-    // first float2 is live: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask UV with.
-    // The other 72 bytes are the hole left by the AO REPROJECTION constants (previous-frame view-proj + depth
-    // index) from back when the mask was built off a previous-frame depth SNAPSHOT; RenderSSAO now runs off
-    // THIS frame's depth prepass and nothing reprojects. The hole stays so the sky-IBL tail below keeps its
-    // byte offset (kSkyIblCbOffset = 432). Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl.
-    float2   AoInvRes;          float2 _aopad0;
-    float4   _aoReserved[4];
+    // --- Screen-space AO / opaque-SSR-reprojection block, 80 bytes, written by UploadAoScreenConstants
+    // (kAoReprojCbOffset). AoInvRes: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask
+    // UV with. SsrPrevColorIndex/SsrPrevDepthIndex + SsrPrevViewProj: the previous-frame opaque scene
+    // color/depth (D3D12Ssr.cpp's m_SsrPrevColor/m_SsrPrevDepth) and the view-proj to reproject into their
+    // UV space — see PBRLighting.hlsl's opaque-SSR march and D3D12_SSR_WET_SURFACES_PLAN.md. Each index's
+    // low 24 bits are the bindless SRV slot, top 8 bits the step count for that pass (MaxSteps/RefineSteps);
+    // MaxSteps == 0 means SSR is off. Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl — the
+    // sky-IBL tail below relies on this block staying exactly 80 bytes (kSkyIblCbOffset = 432).
+    float2   AoInvRes;          uint SsrPrevColorIndex; uint SsrPrevDepthIndex;
+    float4x4 SsrPrevViewProj;
     uint     SkyIrradianceIndex; uint  SkySpecularIndex;  float SkySpecularMips; float SkyIblIntensity;
 };
 Texture2DArray          ShadowMap : register(t4);

--- a/D3D11Engine/Shaders/D3D12/Decal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Decal.hlsl
@@ -16,14 +16,9 @@
 // feeds). The quad's own plane normal carries the shading, flipped toward the viewer because decals render
 // with CULL_NONE.
 cbuffer FrameCB : register(b0) { float4x4 ViewProj; };   // default column-major packing (see world shader)
-cbuffer FogCB   : register(b1) { float3 FogColor; float FogNear; float3 CamPosWS; float FogFar; };
-// ProjA/ProjB/NearZ/FarZ feed PBRLighting.hlsl's ComputeZSlice (clustered Forward+, P2.14) — see World.hlsl.
-cbuffer LightCB : register(b2) {
-    uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex;
-    float ProjA; float ProjB; float NearZ; float FarZ;
-};
-
+#include "include/FogCB.hlsl"
 #include "include/ForwardPlusTypes.hlsl"
+#include "include/LightCB.hlsl"
 
 // Forward+ tiled point lights (root-descriptor SRVs + per-cluster mask) — same t1/t2 the world pass binds.
 StructuredBuffer<GPULight>  Lights        : register(t1);
@@ -32,35 +27,13 @@ StructuredBuffer<LightGrid> LightGridBuf  : register(t2);
 Texture2D    tx  : register(t0);
 SamplerState smp : register(s0);   // linear CLAMP: a decal is a single [0,1] sprite; wrap would bleed the edge
 
-// Must stay byte-identical to World/Vob/Skeletal.hlsl's ShadowCB and the CPU-side upload structs.
-cbuffer ShadowCB : register(b3)
-{
-    float4x4 CascadeViewProj[NUM_CSM_CASCADES];
-    float3   SunDirWS;          float ShadowMapSize;
-    float3   SunColor;          float SunIntensity;
-    float3   CascadeTexelWorld; float AmbientStrength;
-    float    ShadowAOStrength;  float WorldAOStrength;
-    float    SkyOccStrength;    float SunSpecularEnabled;
-    float4x4 RainViewProj;
-    float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
-    uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // --- Screen-space AO / opaque-SSR-reprojection block, 80 bytes, written by UploadAoScreenConstants
-    // (kAoReprojCbOffset). AoInvRes: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask
-    // UV with. SsrPrevColorIndex/SsrPrevDepthIndex + SsrPrevViewProj: the previous-frame opaque scene
-    // color/depth (D3D12Ssr.cpp's m_SsrPrevColor/m_SsrPrevDepth) and the view-proj to reproject into their
-    // UV space — see PBRLighting.hlsl's opaque-SSR march and D3D12_SSR_WET_SURFACES_PLAN.md. Each index's
-    // low 24 bits are the bindless SRV slot, top 8 bits the step count for that pass (MaxSteps/RefineSteps);
-    // MaxSteps == 0 means SSR is off. Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl — the
-    // sky-IBL tail below relies on this block staying exactly 80 bytes (kSkyIblCbOffset = 432).
-    float2   AoInvRes;          uint SsrPrevColorIndex; uint SsrPrevDepthIndex;
-    float4x4 SsrPrevViewProj;
-    uint     SkyIrradianceIndex; uint  SkySpecularIndex;  float SkySpecularMips; float SkyIblIntensity;
-};
+// Single source of truth for this layout: include/ShadowCB.hlsl (also bound by World/Vob/Skeletal/
+// Vegetation.hlsl at their own registers — see that file for the byte-offset notes).
+#include "include/ShadowCB.hlsl"
 Texture2DArray          ShadowMap : register(t4);
 SamplerComparisonState  shadowCmp : register(s2);
 TextureCubeArray        PointShadowCubes : register(t5);
-// Simple-SSAO mask (bindless, set once per frame — see D3D12GraphicsEngine::RenderSSAO/m_ActiveAOMaskSrvSlot).
-cbuffer AOCB : register(b7) { uint AoMaskIndex; };
+#include "include/AOCB.hlsl"
 SamplerState smpAoClamp : register(s1);
 #include "include/ScreenSpaceAO.hlsl"
 // SrgbToLinear, ComputeSunShadow, ComputeSunLightingPBR and AccumTiledPointLights live here — the same

--- a/D3D11Engine/Shaders/D3D12/LightCull.hlsl
+++ b/D3D11Engine/Shaders/D3D12/LightCull.hlsl
@@ -1,28 +1,14 @@
-#define TILE_SIZE 16u
-#define MAX_ACTIVE_LIGHTS 1024u
-#define MASK_WORDS (MAX_ACTIVE_LIGHTS / 32u)
-#define NUM_Z_SLICES 16u
+// TILE_SIZE/MAX_ACTIVE_LIGHTS/MASK_WORDS/NUM_Z_SLICES/GPULight/LightGrid come from ForwardPlusTypes.hlsl —
+// the same declarations World/Vob/Skeletal/Vegetation/Decal.hlsl bind their StructuredBuffer<GPULight> to,
+// so a stride/layout change can no longer drift between the cull pass and the lit shaders that consume its
+// output. (LightCB itself is NOT pulled in — see the note there; this pass has its own CullCB below.)
+#include "include/ForwardPlusTypes.hlsl"
 
 // One thread group per SCREEN TILE (not per cluster): the group culls once against the tile's infinite frustum
 // column, then bins the survivors into all NUM_Z_SLICES slices itself. See CSMain's header for why.
 #define CULL_GROUP_SIZE 64u
 
-// MUST stay layout-identical to GPULight (C++ D3D12EngineCommon.h / HLSL include/ForwardPlusTypes.hlsl) — this
-// is a StructuredBuffer, so a stride mismatch silently misindexes EVERY light. The cull only reads
-// PositionView/Range; the trailing fields are here purely to keep the 64-byte stride.
-struct TiledPointLight {
-    float3 PositionView; float Range;
-    float4 Color;
-    float3 PositionWorld; int ShadowCubeIndex;
-    float3 ShadowOrigin;  float ShadowRange;
-};
-// Clustered Forward+ (P2.14): a MAX_ACTIVE_LIGHTS-bit membership mask, one bit per light in
-// SB_Lights[0..MAX_ACTIVE_LIGHTS). MASK_WORDS * 4 bytes, same layout as ForwardPlusTypes.hlsl's copy.
-// WordOccupancy: bit w set iff Mask[w] != 0, so the pixel shader can skip the empty words instead of walking all
-// MASK_WORDS of them. See the fuller note on ForwardPlusTypes.hlsl's copy — the two MUST stay layout-identical.
-struct LightGrid { uint WordOccupancy; uint Mask[MASK_WORDS]; };
-
-StructuredBuffer<TiledPointLight> SB_Lights   : register(t0);
+StructuredBuffer<GPULight>        SB_Lights    : register(t0);
 RWStructuredBuffer<LightGrid>     RW_LightGrid : register(u0);
 
 cbuffer CullCB : register(b0) {
@@ -107,7 +93,7 @@ void CSMain( uint3 groupID : SV_GroupID, uint ti : SV_GroupIndex ) {
         // NOTE: no early-out/continue here — every lane must reach the wave ops below with the same activity
         // mask, so out-of-range lanes fall through with hit=false instead of exiting the loop.
         if ( li < lightCount ) {
-            const TiledPointLight L = SB_Lights[li];
+            const GPULight L = SB_Lights[li];
             const float3 c = L.PositionView;
             const float  r = L.Range * 1.05;
 

--- a/D3D11Engine/Shaders/D3D12/Preview.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Preview.hlsl
@@ -29,7 +29,7 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
 // Ghost/transparency VOBs (D3D12PipelineState::CreateGhost): reuses VSMain's single-object World/ViewProj
 // layout. Mirrors D3D11's PS_Transparency — unlit diffuse sample, alpha multiplied by a per-vob fade factor,
 // no alpha-clip (a fading ghost should smoothly disappear, not pop).
-cbuffer GhostCB : register(b2) { float GhostAlpha; float3 _GhostPad; };
+#include "include/GhostCB.hlsl"
 
 // Verbatim copy of include/PBRLighting.hlsl's helper (that header pulls in the whole Forward+ lighting
 // stack, which this standalone shader has no root signature for). NOTE the `select` — a vector ternary is

--- a/D3D11Engine/Shaders/D3D12/Rain.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Rain.hlsl
@@ -44,18 +44,7 @@ cbuffer RainShadowCB : register( b3 )
     uint     RainShadowSrvIndex;
 };
 
-struct RainParticleDynamic
-{
-    float3 position;
-    float3 velocity;
-};
-
-struct RainParticleStatic
-{
-    float3 seed;
-    float  randomBrightness;
-    int    drawMode;
-};
+#include "include/RainParticleTypes.hlsl"
 
 StructuredBuffer<RainParticleDynamic> DynamicData : register( t0 );
 StructuredBuffer<RainParticleStatic>  StaticData  : register( t1 );

--- a/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
@@ -157,13 +157,12 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     float shadow = ComputeSunShadow( i.wpos, N, vertLighting );
     // Scene wetness (rain) — see World.hlsl's PSMain for why this runs after the cascade lookup.
     float3 V = normalize( CamPosWS - i.wpos );
-    float wetSheen;
-    float wetness = ApplySceneWetness( i.wpos, V, N, albedo, orm.g, wetSheen );
+    float wetness = ApplySceneWetness( i.wpos, N, albedo, orm.g );
     float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= mad(wetness, 0.8 - 1.0, 1.0);
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );   // dynamic point lights on top (PBR)
-    rgb += wetSheen * ( 1.0 + shadow ) * SrgbToLinear( SunColor ) * SunIntensity;
+    // No fixed-direction wet sheen here — see Wetness.hlsl's ApplySceneWetness header comment.
     // Opaque-surface SSR (temporal, D3D12 only) — see World.hlsl's PSMain for the full explanation. The
     // weight MUST be PBR_FresnelSchlick, not an ad hoc curve (see EvaluateOpaqueSSR's header comment).
     {

--- a/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
@@ -17,15 +17,14 @@ cbuffer InstanceCB : register(b1)
 // SkeletalDrawCommand indirect signature — a separate previous-bone CB would have needed a third root CBV in
 // every skeletal command. 192 is 2 * NUM_MAX_BONES; only the allocated prefix is ever indexed.
 cbuffer BonesCB    : register(b2) { float4x4 Bones[192]; };
-cbuffer FogCB      : register(b3) { float3 FogColor; float FogNear; float3 CamPosWS; float FogFar; };
-// Forward+ tiled: light count + tiles/row + low-res cube heap slot. ProjA/ProjB/NearZ/FarZ feed
-// PBRLighting.hlsl's ComputeZSlice (clustered Forward+, P2.14) — see World.hlsl.
-cbuffer LightCB    : register(b4) {
-    uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex;
-    float ProjA; float ProjB; float NearZ; float FarZ;
-};
-
+#define FOGCB_REGISTER b3
+#include "include/FogCB.hlsl"
+#undef FOGCB_REGISTER
 #include "include/ForwardPlusTypes.hlsl"
+// Skeletal already uses b3 (fog), so its LightCB lands at b4 (world/VOB use b2).
+#define LIGHTCB_REGISTER b4
+#include "include/LightCB.hlsl"
+#undef LIGHTCB_REGISTER
 
 // Forward+ tiled point lights (root-descriptor SRVs + per-cluster mask) — see the world shader for the rationale.
 StructuredBuffer<GPULight>  Lights        : register(t1);
@@ -38,40 +37,9 @@ SamplerState smp : register(s0);
 
 // CSM sun-shadow sampling (P2.9c-4b). Skeletal already uses b3 (fog) + b4 (light count), so the shadow CB
 // lands at b5 here (world/VOB use b3); t4/s2 are free. Same select+PCF math as the world/VOB block.
-cbuffer ShadowCB : register(b5)
-{
-    float4x4 CascadeViewProj[NUM_CSM_CASCADES];
-    float3   SunDirWS;          float ShadowMapSize;
-    float3   SunColor;          float SunIntensity;
-    float3   CascadeTexelWorld; float AmbientStrength;
-    float    ShadowAOStrength;  float WorldAOStrength;   // vertLighting -> AO modulation weights
-    // How hard baked vertex light gates the sky-IBL AMBIENT term (PBRLighting.hlsl ComputeSunLightingPBR).
-    // 0 = the old unoccluded behaviour, 1 = interiors get no sky ambient at all. See the note there.
-    float    SkyOccStrength;    float SunSpecularEnabled;
-    // Scene-wetness (rain) tail — see World.hlsl for the layout notes; must stay identical in all three
-    // lit shaders and in the CPU-side WetnessCBData.
-    float4x4 RainViewProj;
-    float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
-    uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // --- Screen-space AO / opaque-SSR-reprojection block, 80 bytes, written by UploadAoScreenConstants
-    // (kAoReprojCbOffset). AoInvRes: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask
-    // UV with. SsrPrevColorIndex/SsrPrevDepthIndex + SsrPrevViewProj: the previous-frame opaque scene
-    // color/depth (D3D12Ssr.cpp's m_SsrPrevColor/m_SsrPrevDepth) and the view-proj to reproject into their
-    // UV space — see PBRLighting.hlsl's opaque-SSR march and D3D12_SSR_WET_SURFACES_PLAN.md. Each index's
-    // low 24 bits are the bindless SRV slot, top 8 bits the step count for that pass (MaxSteps/RefineSteps);
-    // MaxSteps == 0 means SSR is off. Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl — the
-    // sky-IBL tail below relies on this block staying exactly 80 bytes (kSkyIblCbOffset = 432).
-    float2   AoInvRes;          uint SsrPrevColorIndex; uint SsrPrevDepthIndex;
-    float4x4 SsrPrevViewProj;
-    // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
-    // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
-    // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.
-    // Keep in sync across World/Vob/Skeletal/Vegetation.hlsl and the SkyIblCBData struct on the CPU side.
-    // NOTE: SkyIblIntensity is the COMPLETE ambient scale for the IBL path (user knob x radiance
-    // normalization x an UNHALVED ShadowStrength), premultiplied by UploadSkyIblConstants. The IBL branch
-    // must not also apply AmbientStrength — that one still belongs to the flat fallback branch only.
-    uint     SkyIrradianceIndex; uint  SkySpecularIndex;  float SkySpecularMips; float SkyIblIntensity;
-};
+#define SHADOWCB_REGISTER b5
+#include "include/ShadowCB.hlsl"
+#undef SHADOWCB_REGISTER
 Texture2DArray          ShadowMap : register(t4);
 SamplerComparisonState  shadowCmp : register(s2);
 // Per-material bindless indices (root consts b6): SM6.6 ResourceDescriptorHeap[...] indices for this material's
@@ -80,7 +48,7 @@ SamplerComparisonState  shadowCmp : register(s2);
 // bits pack the FxMap's channel layout for SampleOrm() to decode (see PBRLighting.hlsl). MatDiffuseIndex is
 // always valid too (the 1x1 black texture when the material's texture isn't cached in yet), and replaces what
 // used to be a per-material descriptor-table bind — same layout the world/VOB ExecuteIndirect commands push.
-cbuffer MaterialCB : register(b6) { uint MatNormalIndex; uint MatOrmIndex; uint MatDiffuseIndex; };
+#include "include/MaterialCB.hlsl"
 // The diffuse for every non-ghost entry point. One helper so the color/prepass/shadow-clip variants can never
 // drift apart on which slot or sampler they read.
 float4 SampleSkelDiffuse( float2 uv )
@@ -91,7 +59,9 @@ float4 SampleSkelDiffuse( float2 uv )
 TextureCubeArray        PointShadowCubes : register(t5);   // point-light shadow cubes (P2.10d), R16 linear depth
 // Simple-SSAO mask (bindless, set once per frame — see D3D12GraphicsEngine::RenderSSAO/m_ActiveAOMaskSrvSlot).
 // b8, not b7: b7 is GhostCB below, read only by the separate GhostSkeletal root sig/PSO (PSGhost), not PSMain.
-cbuffer AOCB : register(b8) { uint AoMaskIndex; };
+#define AOCB_REGISTER b8
+#include "include/AOCB.hlsl"
+#undef AOCB_REGISTER
 // Point-clamp for the AO mask — see World.hlsl's identical declaration for why Sample (not Load) is required.
 SamplerState smpAoClamp : register(s1);
 // SampleScreenSpaceAO — see World.hlsl; needs AOCB/smpAoClamp declared above.
@@ -218,7 +188,9 @@ void PSShadowClip( VS_DEPTH_OUT i )
 // sample, alpha multiplied by a per-vob fade factor, no alpha-clip (a fading ghost should smoothly disappear,
 // not pop). Mirrors D3D11's PS_TransparencySkel / the non-skeletal PSGhost in Preview.hlsl — including its
 // sRGB linearize, which both ghost shaders need and neither originally had (see the note in PSGhost).
-cbuffer GhostCB : register(b7) { float GhostAlpha; float3 _GhostPad; }
+#define GHOSTCB_REGISTER b7
+#include "include/GhostCB.hlsl"
+#undef GHOSTCB_REGISTER
 
 float4 PSGhost( VS_DEPTH_OUT i ) : SV_TARGET
 {

--- a/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
@@ -53,14 +53,16 @@ cbuffer ShadowCB : register(b5)
     float4x4 RainViewProj;
     float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
     uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // --- Screen-space AO block, 80 bytes, written by UploadAoScreenConstants (kAoReprojCbOffset). Only the
-    // first float2 is live: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask UV with.
-    // The other 72 bytes are the hole left by the AO REPROJECTION constants (previous-frame view-proj + depth
-    // index) from back when the mask was built off a previous-frame depth SNAPSHOT; RenderSSAO now runs off
-    // THIS frame's depth prepass and nothing reprojects. The hole stays so the sky-IBL tail below keeps its
-    // byte offset (kSkyIblCbOffset = 432). Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl.
-    float2   AoInvRes;          float2 _aopad0;
-    float4   _aoReserved[4];
+    // --- Screen-space AO / opaque-SSR-reprojection block, 80 bytes, written by UploadAoScreenConstants
+    // (kAoReprojCbOffset). AoInvRes: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask
+    // UV with. SsrPrevColorIndex/SsrPrevDepthIndex + SsrPrevViewProj: the previous-frame opaque scene
+    // color/depth (D3D12Ssr.cpp's m_SsrPrevColor/m_SsrPrevDepth) and the view-proj to reproject into their
+    // UV space — see PBRLighting.hlsl's opaque-SSR march and D3D12_SSR_WET_SURFACES_PLAN.md. Each index's
+    // low 24 bits are the bindless SRV slot, top 8 bits the step count for that pass (MaxSteps/RefineSteps);
+    // MaxSteps == 0 means SSR is off. Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl — the
+    // sky-IBL tail below relies on this block staying exactly 80 bytes (kSkyIblCbOffset = 432).
+    float2   AoInvRes;          uint SsrPrevColorIndex; uint SsrPrevDepthIndex;
+    float4x4 SsrPrevViewProj;
     // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
     // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
     // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.
@@ -162,6 +164,15 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     rgb *= mad(wetness, 0.8 - 1.0, 1.0);
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );   // dynamic point lights on top (PBR)
     rgb += wetSheen * ( 1.0 + shadow ) * SrgbToLinear( SunColor ) * SunIntensity;
+    // Opaque-surface SSR (temporal, D3D12 only) — see World.hlsl's PSMain for the full explanation. The
+    // weight MUST be PBR_FresnelSchlick, not an ad hoc curve (see EvaluateOpaqueSSR's header comment).
+    {
+        float ssrConfidence;
+        float3 ssrColor = EvaluateOpaqueSSR( i.wpos, N, V, orm.g, ssrConfidence );
+        float3 ssrF0 = lerp( float3( 0.04, 0.04, 0.04 ), albedo, orm.b );
+        float3 ssrFresnel = PBR_FresnelSchlick( saturate( dot( N, V ) ), ssrF0 );
+        rgb += ssrColor * ssrConfidence * ssrFresnel;
+    }
     rgb *= 1.0f + step( 1.5f, i.col.a );   // focus highlight
     float f = saturate( ( i.fogDist - FogNear ) / max( 1.0, FogFar - FogNear ) );
     return float4( lerp( rgb, SrgbToLinear( FogColor ), f ), 1.0 );

--- a/D3D11Engine/Shaders/D3D12/Vegetation.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Vegetation.hlsl
@@ -44,14 +44,16 @@ cbuffer ShadowCB : register(b4)
     float4x4 RainViewProj;
     float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
     uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // --- Screen-space AO block, 80 bytes, written by UploadAoScreenConstants (kAoReprojCbOffset). Only the
-    // first float2 is live: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask UV with.
-    // The other 72 bytes are the hole left by the AO REPROJECTION constants (previous-frame view-proj + depth
-    // index) from back when the mask was built off a previous-frame depth SNAPSHOT; RenderSSAO now runs off
-    // THIS frame's depth prepass and nothing reprojects. The hole stays so the sky-IBL tail below keeps its
-    // byte offset (kSkyIblCbOffset = 432). Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl.
-    float2   AoInvRes;          float2 _aopad0;
-    float4   _aoReserved[4];
+    // --- Screen-space AO / opaque-SSR-reprojection block, 80 bytes, written by UploadAoScreenConstants
+    // (kAoReprojCbOffset). AoInvRes: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask
+    // UV with. SsrPrevColorIndex/SsrPrevDepthIndex + SsrPrevViewProj: the previous-frame opaque scene
+    // color/depth (D3D12Ssr.cpp's m_SsrPrevColor/m_SsrPrevDepth) and the view-proj to reproject into their
+    // UV space — see PBRLighting.hlsl's opaque-SSR march and D3D12_SSR_WET_SURFACES_PLAN.md. Each index's
+    // low 24 bits are the bindless SRV slot, top 8 bits the step count for that pass (MaxSteps/RefineSteps);
+    // MaxSteps == 0 means SSR is off. Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl — the
+    // sky-IBL tail below relies on this block staying exactly 80 bytes (kSkyIblCbOffset = 432).
+    float2   AoInvRes;          uint SsrPrevColorIndex; uint SsrPrevDepthIndex;
+    float4x4 SsrPrevViewProj;
     // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
     // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
     // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.

--- a/D3D11Engine/Shaders/D3D12/Vegetation.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Vegetation.hlsl
@@ -11,14 +11,13 @@ cbuffer GrassCB : register(b1)
     float G_Time;             float G_WindStrength;    float G_HeroAffectStrength; float G_PrevTime;
     float3 G_PlayerPosWS;     float _gpad1;
 };
-cbuffer FogCB : register(b2) { float3 FogColor; float FogNear; float3 CamPosWS; float FogFar; };
-// ProjA/ProjB/NearZ/FarZ feed PBRLighting.hlsl's ComputeZSlice (clustered Forward+, P2.14) — see World.hlsl.
-cbuffer LightCB : register(b3) {
-    uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex;
-    float ProjA; float ProjB; float NearZ; float FarZ;
-};
-
+#define FOGCB_REGISTER b2
+#include "include/FogCB.hlsl"
+#undef FOGCB_REGISTER
 #include "include/ForwardPlusTypes.hlsl"
+#define LIGHTCB_REGISTER b3
+#include "include/LightCB.hlsl"
+#undef LIGHTCB_REGISTER
 
 // Forward+ tiled point lights (root-descriptor SRVs + per-cluster mask) — see World.hlsl for the rationale.
 StructuredBuffer<GPULight>  Lights        : register(t2);
@@ -28,41 +27,12 @@ Texture2D    tx       : register(t0);   // grass blade texture (GVegetationBox::
 Texture2D    txGround : register(t1);   // ground/undercoat texture (GVegetationBox::MeshTexture) — tints the blades
 SamplerState smp       : register(s0);
 
-cbuffer ShadowCB : register(b4)
-{
-    float4x4 CascadeViewProj[NUM_CSM_CASCADES];
-    float3   SunDirWS;          float ShadowMapSize;
-    float3   SunColor;          float SunIntensity;
-    float3   CascadeTexelWorld; float AmbientStrength;
-    float    ShadowAOStrength;  float WorldAOStrength;   // vertLighting -> AO modulation weights
-    // How hard baked vertex light gates the sky-IBL AMBIENT term (PBRLighting.hlsl ComputeSunLightingPBR).
-    // 0 = the old unoccluded behaviour, 1 = interiors get no sky ambient at all. See the note there.
-    float    SkyOccStrength;    float SunSpecularEnabled;
-    // Scene-wetness (rain) block. Grass applies no wetness (no Wetness.hlsl include here), but the fields must
-    // be declared so the sky-IBL tail below lands at the byte offset UploadSkyIblConstants writes it to — this
-    // CB is the same 512-byte resource World/Vob/Skeletal bind, three disjoint writers into one layout.
-    float4x4 RainViewProj;
-    float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
-    uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // --- Screen-space AO / opaque-SSR-reprojection block, 80 bytes, written by UploadAoScreenConstants
-    // (kAoReprojCbOffset). AoInvRes: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask
-    // UV with. SsrPrevColorIndex/SsrPrevDepthIndex + SsrPrevViewProj: the previous-frame opaque scene
-    // color/depth (D3D12Ssr.cpp's m_SsrPrevColor/m_SsrPrevDepth) and the view-proj to reproject into their
-    // UV space — see PBRLighting.hlsl's opaque-SSR march and D3D12_SSR_WET_SURFACES_PLAN.md. Each index's
-    // low 24 bits are the bindless SRV slot, top 8 bits the step count for that pass (MaxSteps/RefineSteps);
-    // MaxSteps == 0 means SSR is off. Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl — the
-    // sky-IBL tail below relies on this block staying exactly 80 bytes (kSkyIblCbOffset = 432).
-    float2   AoInvRes;          uint SsrPrevColorIndex; uint SsrPrevDepthIndex;
-    float4x4 SsrPrevViewProj;
-    // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
-    // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
-    // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.
-    // Keep in sync across World/Vob/Skeletal/Vegetation.hlsl and the SkyIblCBData struct on the CPU side.
-    // NOTE: SkyIblIntensity is the COMPLETE ambient scale for the IBL path (user knob x radiance
-    // normalization x an UNHALVED ShadowStrength), premultiplied by UploadSkyIblConstants. The IBL branch
-    // must not also apply AmbientStrength — that one still belongs to the flat fallback branch only.
-    uint     SkyIrradianceIndex; uint  SkySpecularIndex;  float SkySpecularMips; float SkyIblIntensity;
-};
+// Grass applies no wetness (no Wetness.hlsl include here), but ShadowCB.hlsl's fields must still be
+// declared so the sky-IBL tail lands at the byte offset UploadSkyIblConstants writes it to — this CB is
+// the same 512-byte resource World/Vob/Skeletal bind, four disjoint writers into one layout.
+#define SHADOWCB_REGISTER b4
+#include "include/ShadowCB.hlsl"
+#undef SHADOWCB_REGISTER
 Texture2DArray          ShadowMap : register(t5);
 SamplerComparisonState  shadowCmp : register(s2);
 // PBRLighting.hlsl's AccumTiledPointLights hard-requires this symbol to exist (it samples it for any nearby
@@ -70,7 +40,9 @@ SamplerComparisonState  shadowCmp : register(s2);
 TextureCubeArray        PointShadowCubes : register(t6);
 // Simple-SSAO mask (bindless, set once per frame — see D3D12GraphicsEngine::RenderSSAO/m_ActiveAOMaskSrvSlot).
 // b5: b0..b4 above are all spoken for on this root sig.
-cbuffer AOCB : register(b5) { uint AoMaskIndex; };
+#define AOCB_REGISTER b5
+#include "include/AOCB.hlsl"
+#undef AOCB_REGISTER
 // Point-clamp for the AO mask — see World.hlsl for why Sample, not Load.
 SamplerState smpAoClamp : register(s1);
 // SampleScreenSpaceAO — see World.hlsl; needs AOCB/smpAoClamp declared above.

--- a/D3D11Engine/Shaders/D3D12/Vob.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Vob.hlsl
@@ -1,10 +1,5 @@
 cbuffer WorldCB : register(b0) { float4x4 ViewProj; };   // default column-major packing (see world shader)
-cbuffer FogCB   : register(b1) { float3 FogColor; float FogNear; float3 CamPosWS; float FogFar; };
-// ProjA/ProjB/NearZ/FarZ feed PBRLighting.hlsl's ComputeZSlice (clustered Forward+, P2.14) — see World.hlsl.
-cbuffer LightCB : register(b2) {
-    uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex;
-    float ProjA; float ProjB; float NearZ; float FarZ;
-};
+#include "include/FogCB.hlsl"
 // Wind sway for instanced VOBs (flags/foliage). Mirrors D3D11's WindParams cbuffer (VS_ExInstancedObj.hlsl);
 // minHeight/maxHeight are the flat (non-WIND_META_SRV) per-visual bounding-box fallback, refreshed per visual
 // by DrawVobsInstanced before each visual's draw calls (see WindMinHeight/WindMaxHeight below).
@@ -16,6 +11,7 @@ cbuffer WindCB : register(b4)
 };
 
 #include "include/ForwardPlusTypes.hlsl"
+#include "include/LightCB.hlsl"
 #include "include/Wind.hlsl"
 
 // Forward+ tiled point lights (root-descriptor SRVs + per-tile grid)
@@ -25,50 +21,17 @@ StructuredBuffer<LightGrid> LightGridBuf  : register(t2);
 Texture2D    tx  : register(t0);
 SamplerState smp : register(s0);
 
-cbuffer ShadowCB : register(b3)
-{
-    float4x4 CascadeViewProj[NUM_CSM_CASCADES];
-    float3   SunDirWS;          float ShadowMapSize;
-    float3   SunColor;          float SunIntensity;
-    float3   CascadeTexelWorld; float AmbientStrength;
-    float    ShadowAOStrength;  float WorldAOStrength;   // vertLighting -> AO modulation weights
-    // How hard baked vertex light gates the sky-IBL AMBIENT term (PBRLighting.hlsl ComputeSunLightingPBR).
-    // 0 = the old unoccluded behaviour, 1 = interiors get no sky ambient at all. See the note there.
-    float    SkyOccStrength;    float SunSpecularEnabled;
-    // Scene-wetness (rain) tail — see World.hlsl for the layout notes; must stay identical in all three
-    // lit shaders and in the CPU-side WetnessCBData.
-    float4x4 RainViewProj;
-    float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
-    uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // --- Screen-space AO / opaque-SSR-reprojection block, 80 bytes, written by UploadAoScreenConstants
-    // (kAoReprojCbOffset). AoInvRes: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask
-    // UV with. SsrPrevColorIndex/SsrPrevDepthIndex + SsrPrevViewProj: the previous-frame opaque scene
-    // color/depth (D3D12Ssr.cpp's m_SsrPrevColor/m_SsrPrevDepth) and the view-proj to reproject into their
-    // UV space — see PBRLighting.hlsl's opaque-SSR march and D3D12_SSR_WET_SURFACES_PLAN.md. Each index's
-    // low 24 bits are the bindless SRV slot, top 8 bits the step count for that pass (MaxSteps/RefineSteps);
-    // MaxSteps == 0 means SSR is off. Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl — the
-    // sky-IBL tail below relies on this block staying exactly 80 bytes (kSkyIblCbOffset = 432).
-    float2   AoInvRes;          uint SsrPrevColorIndex; uint SsrPrevDepthIndex;
-    float4x4 SsrPrevViewProj;
-    // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
-    // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
-    // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.
-    // Keep in sync across World/Vob/Skeletal/Vegetation.hlsl and the SkyIblCBData struct on the CPU side.
-    // NOTE: SkyIblIntensity is the COMPLETE ambient scale for the IBL path (user knob x radiance
-    // normalization x an UNHALVED ShadowStrength), premultiplied by UploadSkyIblConstants. The IBL branch
-    // must not also apply AmbientStrength — that one still belongs to the flat fallback branch only.
-    uint     SkyIrradianceIndex; uint  SkySpecularIndex;  float SkySpecularMips; float SkyIblIntensity;
-};
+// (SHADOWCB_REGISTER defaults to b3, which is what Vob wants.)
+#include "include/ShadowCB.hlsl"
 Texture2DArray          ShadowMap : register(t4);
 SamplerComparisonState  shadowCmp : register(s2);
 // MatDiffuseIndex (3rd field) is read only by the *Bindless PS variants below — the ExecuteIndirect VOB path
 // (P2.12) sets the diffuse SRV heap slot as a root constant instead of a per-draw t0 descriptor table, so the
 // whole instanced-VOB pass (color/depth/shadow) submits as one ExecuteIndirect. The classic t0-table PS
 // (PSMain/PSDepthClip/PSShadowClip, used by node attachments) simply never reads the 3rd field.
-cbuffer MaterialCB : register(b6) { uint MatNormalIndex; uint MatOrmIndex; uint MatDiffuseIndex; };
+#include "include/MaterialCB.hlsl"
 TextureCubeArray        PointShadowCubes : register(t5);
-// Simple-SSAO mask (bindless, set once per frame — see D3D12GraphicsEngine::RenderSSAO/m_ActiveAOMaskSrvSlot).
-cbuffer AOCB : register(b7) { uint AoMaskIndex; };
+#include "include/AOCB.hlsl"
 // Point-clamp for the AO mask — see World.hlsl's identical declaration for why Sample (not Load) is required.
 SamplerState smpAoClamp : register(s1);
 // SampleScreenSpaceAO — see World.hlsl; needs AOCB/smpAoClamp declared above.

--- a/D3D11Engine/Shaders/D3D12/Vob.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Vob.hlsl
@@ -40,14 +40,16 @@ cbuffer ShadowCB : register(b3)
     float4x4 RainViewProj;
     float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
     uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // --- Screen-space AO block, 80 bytes, written by UploadAoScreenConstants (kAoReprojCbOffset). Only the
-    // first float2 is live: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask UV with.
-    // The other 72 bytes are the hole left by the AO REPROJECTION constants (previous-frame view-proj + depth
-    // index) from back when the mask was built off a previous-frame depth SNAPSHOT; RenderSSAO now runs off
-    // THIS frame's depth prepass and nothing reprojects. The hole stays so the sky-IBL tail below keeps its
-    // byte offset (kSkyIblCbOffset = 432). Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl.
-    float2   AoInvRes;          float2 _aopad0;
-    float4   _aoReserved[4];
+    // --- Screen-space AO / opaque-SSR-reprojection block, 80 bytes, written by UploadAoScreenConstants
+    // (kAoReprojCbOffset). AoInvRes: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask
+    // UV with. SsrPrevColorIndex/SsrPrevDepthIndex + SsrPrevViewProj: the previous-frame opaque scene
+    // color/depth (D3D12Ssr.cpp's m_SsrPrevColor/m_SsrPrevDepth) and the view-proj to reproject into their
+    // UV space — see PBRLighting.hlsl's opaque-SSR march and D3D12_SSR_WET_SURFACES_PLAN.md. Each index's
+    // low 24 bits are the bindless SRV slot, top 8 bits the step count for that pass (MaxSteps/RefineSteps);
+    // MaxSteps == 0 means SSR is off. Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl — the
+    // sky-IBL tail below relies on this block staying exactly 80 bytes (kSkyIblCbOffset = 432).
+    float2   AoInvRes;          uint SsrPrevColorIndex; uint SsrPrevDepthIndex;
+    float4x4 SsrPrevViewProj;
     // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
     // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
     // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.
@@ -157,6 +159,15 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     rgb *= mad(wetness, 0.8 - 1.0, 1.0);
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
     rgb += wetSheen * ( 1.0 + shadow ) * SrgbToLinear( SunColor ) * SunIntensity;
+    // Opaque-surface SSR (temporal, D3D12 only) — see World.hlsl's PSMain for the full explanation. The
+    // weight MUST be PBR_FresnelSchlick, not an ad hoc curve (see EvaluateOpaqueSSR's header comment).
+    {
+        float ssrConfidence;
+        float3 ssrColor = EvaluateOpaqueSSR( i.wpos, N, V, orm.g, ssrConfidence );
+        float3 ssrF0 = lerp( float3( 0.04, 0.04, 0.04 ), albedo, orm.b );
+        float3 ssrFresnel = PBR_FresnelSchlick( saturate( dot( N, V ) ), ssrF0 );
+        rgb += ssrColor * ssrConfidence * ssrFresnel;
+    }
     rgb *= 1.0f + step( 1.5f, i.focus );   // focus highlight
     float f = saturate( ( i.fogDist - FogNear ) / max( 1.0, FogFar - FogNear ) );
     return float4( lerp( rgb, SrgbToLinear( FogColor ), f ), 1.0 );
@@ -256,6 +267,15 @@ float4 PSMainBindless( VS_OUT i ) : SV_TARGET
     rgb *= mad(wetness, 0.8 - 1.0, 1.0);
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
     rgb += wetSheen * ( 1.0 + shadow ) * SrgbToLinear( SunColor ) * SunIntensity;
+    // Opaque-surface SSR (temporal, D3D12 only) — see World.hlsl's PSMain for the full explanation. The
+    // weight MUST be PBR_FresnelSchlick, not an ad hoc curve (see EvaluateOpaqueSSR's header comment).
+    {
+        float ssrConfidence;
+        float3 ssrColor = EvaluateOpaqueSSR( i.wpos, N, V, orm.g, ssrConfidence );
+        float3 ssrF0 = lerp( float3( 0.04, 0.04, 0.04 ), albedo, orm.b );
+        float3 ssrFresnel = PBR_FresnelSchlick( saturate( dot( N, V ) ), ssrF0 );
+        rgb += ssrColor * ssrConfidence * ssrFresnel;
+    }
     rgb *= 1.0f + step( 1.5f, i.focus );   // focus highlight
     float f = saturate( ( i.fogDist - FogNear ) / max( 1.0, FogFar - FogNear ) );
     return float4( lerp( rgb, SrgbToLinear( FogColor ), f ), 1.0 );

--- a/D3D11Engine/Shaders/D3D12/Vob.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Vob.hlsl
@@ -152,13 +152,12 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     float shadow = ComputeSunShadow( i.wpos, N, vertLighting );
     // Scene wetness (rain) — see World.hlsl's PSMain for why this runs after the cascade lookup.
     float3 V = normalize( CamPosWS - i.wpos );
-    float wetSheen;
-    float wetness = ApplySceneWetness( i.wpos, V, N, albedo, orm.g, wetSheen );
+    float wetness = ApplySceneWetness( i.wpos, N, albedo, orm.g );
     float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= mad(wetness, 0.8 - 1.0, 1.0);
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
-    rgb += wetSheen * ( 1.0 + shadow ) * SrgbToLinear( SunColor ) * SunIntensity;
+    // No fixed-direction wet sheen here — see Wetness.hlsl's ApplySceneWetness header comment.
     // Opaque-surface SSR (temporal, D3D12 only) — see World.hlsl's PSMain for the full explanation. The
     // weight MUST be PBR_FresnelSchlick, not an ad hoc curve (see EvaluateOpaqueSSR's header comment).
     {
@@ -260,13 +259,12 @@ float4 PSMainBindless( VS_OUT i ) : SV_TARGET
     float shadow = ComputeSunShadow( i.wpos, N, vertLighting );
     // Scene wetness (rain) — see World.hlsl's PSMain for why this runs after the cascade lookup.
     float3 V = normalize( CamPosWS - i.wpos );
-    float wetSheen;
-    float wetness = ApplySceneWetness( i.wpos, V, N, albedo, orm.g, wetSheen );
+    float wetness = ApplySceneWetness( i.wpos, N, albedo, orm.g );
     float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= mad(wetness, 0.8 - 1.0, 1.0);
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
-    rgb += wetSheen * ( 1.0 + shadow ) * SrgbToLinear( SunColor ) * SunIntensity;
+    // No fixed-direction wet sheen here — see Wetness.hlsl's ApplySceneWetness header comment.
     // Opaque-surface SSR (temporal, D3D12 only) — see World.hlsl's PSMain for the full explanation. The
     // weight MUST be PBR_FresnelSchlick, not an ad hoc curve (see EvaluateOpaqueSSR's header comment).
     {

--- a/D3D11Engine/Shaders/D3D12/World.hlsl
+++ b/D3D11Engine/Shaders/D3D12/World.hlsl
@@ -41,14 +41,16 @@ cbuffer ShadowCB : register(b3)
     float4x4 RainViewProj;
     float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
     uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // --- Screen-space AO block, 80 bytes, written by UploadAoScreenConstants (kAoReprojCbOffset). Only the
-    // first float2 is live: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask UV with.
-    // The other 72 bytes are the hole left by the AO REPROJECTION constants (previous-frame view-proj + depth
-    // index) from back when the mask was built off a previous-frame depth SNAPSHOT; RenderSSAO now runs off
-    // THIS frame's depth prepass and nothing reprojects. The hole stays so the sky-IBL tail below keeps its
-    // byte offset (kSkyIblCbOffset = 432). Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl.
-    float2   AoInvRes;          float2 _aopad0;
-    float4   _aoReserved[4];
+    // --- Screen-space AO / opaque-SSR-reprojection block, 80 bytes, written by UploadAoScreenConstants
+    // (kAoReprojCbOffset). AoInvRes: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask
+    // UV with. SsrPrevColorIndex/SsrPrevDepthIndex + SsrPrevViewProj: the previous-frame opaque scene
+    // color/depth (D3D12Ssr.cpp's m_SsrPrevColor/m_SsrPrevDepth) and the view-proj to reproject into their
+    // UV space — see PBRLighting.hlsl's opaque-SSR march and D3D12_SSR_WET_SURFACES_PLAN.md. Each index's
+    // low 24 bits are the bindless SRV slot, top 8 bits the step count for that pass (MaxSteps/RefineSteps);
+    // MaxSteps == 0 means SSR is off. Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl — the
+    // sky-IBL tail below relies on this block staying exactly 80 bytes (kSkyIblCbOffset = 432).
+    float2   AoInvRes;          uint SsrPrevColorIndex; uint SsrPrevDepthIndex;
+    float4x4 SsrPrevViewProj;
     // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
     // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
     // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.
@@ -191,6 +193,17 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
     // Additive wet sheen (D3D11's specWet, boosted where the sun actually reaches: specWet += specWet * shadow).
     rgb += wetSheen * ( 1.0 + shadow ) * SrgbToLinear( SunColor ) * SunIntensity;
+    // Opaque-surface SSR (temporal, D3D12 only) — additive, physically-weighted reflection sheen; 0
+    // confidence on any miss reproduces today's output exactly. The weight MUST be PBR_FresnelSchlick, not
+    // an ad hoc curve — see PBRLighting.hlsl's EvaluateOpaqueSSR header comment for why (a stronger weight
+    // shipped and fed back into runaway brightness on the first GPU test).
+    {
+        float ssrConfidence;
+        float3 ssrColor = EvaluateOpaqueSSR( i.wpos, N, V, orm.g, ssrConfidence );
+        float3 ssrF0 = lerp( float3( 0.04, 0.04, 0.04 ), albedo, orm.b );
+        float3 ssrFresnel = PBR_FresnelSchlick( saturate( dot( N, V ) ), ssrF0 );
+        rgb += ssrColor * ssrConfidence * ssrFresnel;
+    }
     // Linear distance fog toward the (linearized) atmosphere color — keeps the HDR buffer consistently linear.
     float f = saturate( ( i.fogDist - FogNear ) / max( 1.0, FogFar - FogNear ) );
     rgb = lerp( rgb, SrgbToLinear( FogColor ), f );

--- a/D3D11Engine/Shaders/D3D12/World.hlsl
+++ b/D3D11Engine/Shaders/D3D12/World.hlsl
@@ -1,15 +1,10 @@
 // Default (column-major) matrix packing — matches D3D11's VS_ExPacked, which reads the same
 // row-major XMFLOAT4X4 bytes we upload here, so mul(float4(pos,1), ViewProj) is byte-for-byte identical.
 cbuffer WorldCB : register(b0) { float4x4 ViewProj; };
-cbuffer FogCB   : register(b1) { float3 FogColor; float FogNear; float3 CamPosWS; float FogFar; };
-// Forward+ tiled: light count + tiles/row + low-res cube heap slot. ProjA/ProjB/NearZ/FarZ feed
-// PBRLighting.hlsl's ComputeZSlice (clustered Forward+, P2.14) — see that header for what each means.
-cbuffer LightCB : register(b2) {
-    uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex;
-    float ProjA; float ProjB; float NearZ; float FarZ;
-};
-
+#include "include/FogCB.hlsl"
 #include "include/ForwardPlusTypes.hlsl"
+// LightCB (LIGHTCB_REGISTER = b2, the default) — light count + tiles/row + cluster Z-slice basis.
+#include "include/LightCB.hlsl"
 
 // Bound as a ROOT descriptor SRV (no descriptor-table slot). The per-cluster mask produced by the light-cull
 // compute (DispatchLightCulling) narrows this loop to only the lights visible in this pixel's cluster.
@@ -24,42 +19,8 @@ SamplerState smp : register(s0);
 // s2 = a LESS_EQUAL PCF comparison sampler. Uploaded row-major, read column-major → mul(pos, CascadeVP[c])
 // matches the caster exactly. Shadow modulates the BAKED vertex lighting (darken sun-facing surfaces the
 // sun can't reach); replacing baked lighting with a full computed sun term (FP_ComputeSunLighting) is later.
-cbuffer ShadowCB : register(b3)
-{
-    float4x4 CascadeViewProj[NUM_CSM_CASCADES];
-    float3   SunDirWS;          float ShadowMapSize;    // dir TOWARD sun; shadow-map resolution
-    float3   SunColor;          float SunIntensity;     // sun color (sRGB) + strength (0 when sun below horizon)
-    float3   CascadeTexelWorld; float AmbientStrength;  // world units/texel; SQ_ShadowStrength (ambient/sky term)
-    float    ShadowAOStrength;  float WorldAOStrength;   // vertLighting -> AO modulation weights
-    // How hard baked vertex light gates the sky-IBL AMBIENT term (PBRLighting.hlsl ComputeSunLightingPBR).
-    // 0 = the old unoccluded behaviour, 1 = interiors get no sky ambient at all. See the note there.
-    float    SkyOccStrength;    float SunSpecularEnabled;
-    // --- Scene wetness (rain) tail, uploaded separately by UploadWetnessConstants after the rain shadow
-    // pass has computed this frame's rain camera. Keep in sync with Vob.hlsl/Skeletal.hlsl and the
-    // WetnessCBData struct on the CPU side. RainShadowIndex/DistortionIndex are 0xFFFFFFFF when the rain
-    // shadowmap / distortion2.dds isn't available, which disables the effect entirely.
-    float4x4 RainViewProj;
-    float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
-    uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
-    // --- Screen-space AO / opaque-SSR-reprojection block, 80 bytes, written by UploadAoScreenConstants
-    // (kAoReprojCbOffset). AoInvRes: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask
-    // UV with. SsrPrevColorIndex/SsrPrevDepthIndex + SsrPrevViewProj: the previous-frame opaque scene
-    // color/depth (D3D12Ssr.cpp's m_SsrPrevColor/m_SsrPrevDepth) and the view-proj to reproject into their
-    // UV space — see PBRLighting.hlsl's opaque-SSR march and D3D12_SSR_WET_SURFACES_PLAN.md. Each index's
-    // low 24 bits are the bindless SRV slot, top 8 bits the step count for that pass (MaxSteps/RefineSteps);
-    // MaxSteps == 0 means SSR is off. Keep in sync across World/Vob/Skeletal/Vegetation/Decal.hlsl — the
-    // sky-IBL tail below relies on this block staying exactly 80 bytes (kSkyIblCbOffset = 432).
-    float2   AoInvRes;          uint SsrPrevColorIndex; uint SsrPrevDepthIndex;
-    float4x4 SsrPrevViewProj;
-    // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
-    // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
-    // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.
-    // Keep in sync across World/Vob/Skeletal/Vegetation.hlsl and the SkyIblCBData struct on the CPU side.
-    // NOTE: SkyIblIntensity is the COMPLETE ambient scale for the IBL path (user knob x radiance
-    // normalization x an UNHALVED ShadowStrength), premultiplied by UploadSkyIblConstants. The IBL branch
-    // must not also apply AmbientStrength — that one still belongs to the flat fallback branch only.
-    uint     SkyIrradianceIndex; uint  SkySpecularIndex;  float SkySpecularMips; float SkyIblIntensity;
-};
+// (SHADOWCB_REGISTER defaults to b3, which is what World wants.)
+#include "include/ShadowCB.hlsl"
 Texture2DArray          ShadowMap : register(t4);
 SamplerComparisonState  shadowCmp : register(s2);
 // Per-material bindless indices (root consts b6): SM6.6 ResourceDescriptorHeap[...] indices for this material's
@@ -67,14 +28,12 @@ SamplerComparisonState  shadowCmp : register(s2);
 // draw — so the diffuse is sampled bindless too (no per-draw descriptor table). MatNormalIndex == 0xFFFFFFFF ->
 // no normal map (skip perturb); MatOrmIndex is always valid (1x1 default = AO 1 / rough 0.5 / metal 0) and its
 // top 2 bits pack the FxMap's channel layout for SampleOrm() to decode (see PBRLighting.hlsl).
-// MatNormalStrength scales the normal-map perturb: 1.0 for a real material normalmap, or the weak
-// DEFAULT_NOISE_NORMALMAP_STRENGTH (0.10) when it's raining and MatNormalIndex is instead the rain-distortion
-// texture standing in for a missing normalmap (wet-ground look, mirrors D3D11GraphicsEngine::BindTextureNRFX).
-cbuffer MaterialCB : register(b6) { uint MatNormalIndex; uint MatOrmIndex; uint MatDiffuseIndex; float MatNormalStrength; };
+// World also gets MatNormalStrength (the world-only extra field — see include/MaterialCB.hlsl).
+#define MATERIALCB_EXTRA_FIELDS float MatNormalStrength;
+#include "include/MaterialCB.hlsl"
+#undef MATERIALCB_EXTRA_FIELDS
 TextureCubeArray        PointShadowCubes : register(t5);   // point-light shadow cubes (P2.10d), R16 linear depth
-// Simple-SSAO mask (bindless, set once per frame — see D3D12GraphicsEngine::RenderSSAO/m_ActiveAOMaskSrvSlot).
-// Points at the white 1x1 texture (mask = no occlusion) when SSAO is disabled/unavailable.
-cbuffer AOCB : register(b7) { uint AoMaskIndex; };
+#include "include/AOCB.hlsl"
 // Point-clamp for the AO mask: MUST be Sample-based (normalized UV, CLAMP addressing), not Load — Load() with
 // raw pixel coords returns 0 out-of-bounds, which the 1x1 "AO disabled" fallback always is at screen res.
 SamplerState smpAoClamp : register(s1);

--- a/D3D11Engine/Shaders/D3D12/World.hlsl
+++ b/D3D11Engine/Shaders/D3D12/World.hlsl
@@ -185,14 +185,14 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     // Scene wetness (rain). Deliberately AFTER the cascade lookup: D3D11 also samples the sun shadow with
     // the undeformed normal and only then runs ApplySceneWettness. Perturbs N/albedo/roughness in place.
     float3 V = normalize( CamPosWS - i.wpos );
-    float wetSheen;
-    float wetness = ApplySceneWetness( i.wpos, V, N, albedo, orm.g, wetSheen );
+    float wetness = ApplySceneWetness( i.wpos, N, albedo, orm.g );
     float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= mad(wetness, 0.8 - 1.0, 1.0);   // D3D11 dims the SUN light color 20% where the surface is wet
     rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
-    // Additive wet sheen (D3D11's specWet, boosted where the sun actually reaches: specWet += specWet * shadow).
-    rgb += wetSheen * ( 1.0 + shadow ) * SrgbToLinear( SunColor ) * SunIntensity;
+    // No fixed-direction wet sheen here — see ApplySceneWetness's header comment for why D3D12 drops that
+    // D3D11 hack in favor of the real Cook-Torrance sun specular (already fed by the roughness dip above)
+    // plus the opaque-surface SSR below.
     // Opaque-surface SSR (temporal, D3D12 only) — additive, physically-weighted reflection sheen; 0
     // confidence on any miss reproduces today's output exactly. The weight MUST be PBR_FresnelSchlick, not
     // an ad hoc curve — see PBRLighting.hlsl's EvaluateOpaqueSSR header comment for why (a stronger weight

--- a/D3D11Engine/Shaders/D3D12/include/AOCB.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/AOCB.hlsl
@@ -1,0 +1,13 @@
+// Simple-SSAO mask slot (bindless, set once per frame — see D3D12GraphicsEngine::RenderSSAO/
+// m_ActiveAOMaskSrvSlot). Points at the white 1x1 texture (mask = no occlusion) when SSAO is
+// disabled/unavailable. Register differs per shader — #define AOCB_REGISTER before including this file.
+#ifndef D3D12_AOCB_HLSL
+#define D3D12_AOCB_HLSL
+
+#ifndef AOCB_REGISTER
+#define AOCB_REGISTER b7
+#endif
+
+cbuffer AOCB : register(AOCB_REGISTER) { uint AoMaskIndex; };
+
+#endif // D3D12_AOCB_HLSL

--- a/D3D11Engine/Shaders/D3D12/include/FogCB.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/FogCB.hlsl
@@ -1,0 +1,13 @@
+// Per-frame distance-fog + camera-position constants, shared verbatim across World/Vob/Skeletal/
+// Vegetation/Decal.hlsl. Register differs per shader (each root sig has different b-slot occupancy) —
+// #define FOGCB_REGISTER before including this file.
+#ifndef D3D12_FOGCB_HLSL
+#define D3D12_FOGCB_HLSL
+
+#ifndef FOGCB_REGISTER
+#define FOGCB_REGISTER b1
+#endif
+
+cbuffer FogCB : register(FOGCB_REGISTER) { float3 FogColor; float FogNear; float3 CamPosWS; float FogFar; };
+
+#endif // D3D12_FOGCB_HLSL

--- a/D3D11Engine/Shaders/D3D12/include/ForwardPlusTypes.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/ForwardPlusTypes.hlsl
@@ -25,8 +25,9 @@
 #define NUM_Z_SLICES 16u
 #define NUM_CSM_CASCADES 3
 
-// Per-frame visible point light (torches/campfires/spells), 64 B. Must stay in lockstep with the C++ GPULight
-// in D3D12Engine/D3D12EngineCommon.h and with LightCull.hlsl's TiledPointLight copy.
+// Per-frame visible point light (torches/campfires/spells), 64 B, and its shadow-tier bit constants — ONE
+// definition shared verbatim with the C++ GPULight in D3D12Engine/D3D12EngineCommon.h and with LightCull.hlsl
+// (which binds the same StructuredBuffer<GPULight> rather than keeping its own TiledPointLight copy).
 // Forward shaders read PositionWorld/Range/Color for shading (Color.w = 0 for an isStatic() light, and is used as
 // the specular scale so those diffuse-only fill lights cast no highlight); PositionView feeds the tile cull;
 // ShadowCubeIndex/ShadowOrigin/ShadowRange feed the point-shadow lookup.
@@ -34,12 +35,8 @@
 // ShadowOrigin/ShadowRange are the CUBE's centre and far-plane basis, which are NOT the light's own whenever
 // several co-located static lights share one cube (see the clustering in BuildFrameLightBuffer). Shading
 // always uses PositionWorld/Range; only SamplePointShadow uses the Shadow* pair.
-struct GPULight {
-    float3 PositionView; float Range;
-    float4 Color;
-    float3 PositionWorld; int ShadowCubeIndex;
-    float3 ShadowOrigin;  float ShadowRange;
-};
+#include "GPULightShared.h"
+
 // Clustered Forward+ grid cell: a MAX_ACTIVE_LIGHTS-bit membership mask over the frame's active light list (bit
 // i set = light i is visible in this cluster), NOT an {Offset,Count} index slice — see LightCull.hlsl/
 // PBRLighting.hlsl's AccumTiledPointLights. (MASK_WORDS + 1) * 4 bytes per cluster.
@@ -50,10 +47,8 @@ struct GPULight {
 // entry cannot spin away. MASK_WORDS is 32, so the summary fits exactly one word.
 struct LightGrid { uint WordOccupancy; uint Mask[MASK_WORDS]; };
 
-// ShadowCubeIndex encoding: -1 = unshadowed, else (slot | tier). Bit 30 selects the low-res static cube array
-// over the full-res dynamic one, and keeps the value positive so "ShadowCubeIndex >= 0" still means shadowed.
-static const int kShadowTierLow  = 0x40000000;
-// Bit 29: the slot also has a valid dynamic (skeletal overlay) cube — sample it too and min the two results.
-// Full-res slots only; absent means a pure static shadow and no second sample. Mirrors D3D12EngineCommon.h.
-static const int kShadowHasDynamic = 0x20000000;
-static const int kShadowSlotMask = 0x1FFFFFFF;
+// LightCB (the per-frame tiled/clustered params cbuffer) is declared separately in LightCB.hlsl, NOT
+// included from here: LightCull.hlsl wants GPULight/LightGrid/the constants above but has no LightCB of
+// its own (it has CullCB instead), and an unreferenced cbuffer declaration still reserves its register
+// in the compiled shader's reflection — pulling one in unconditionally would leak an unwanted binding
+// into LightCull's compute root signature. World/Vob/Skeletal/Vegetation/Decal.hlsl include both files.

--- a/D3D11Engine/Shaders/D3D12/include/GPULightShared.h
+++ b/D3D11Engine/Shaders/D3D12/include/GPULightShared.h
@@ -1,0 +1,42 @@
+// Per-frame GPU point light — the ONE definition, compiled both as HLSL (ForwardPlusTypes.hlsl,
+// LightCull.hlsl) and as C++ (D3D12EngineCommon.h). Filled by BuildFrameLightBuffer (D3D12Scene.cpp);
+// the point-shadow slot selection (D3D12PointShadows::SelectShadowedLights) reads
+// Range/PositionWorld/Color.w and writes ShadowCubeIndex/ShadowOrigin/ShadowRange.
+//
+// float3/float4 need no translation: Types.h already gives the C++ side HLSL-named, layout-compatible
+// wrappers around DirectX::XMFLOAT3/XMFLOAT4 (no extra data members, no vtable), so this single struct
+// body is valid on both sides verbatim — no cpp<->hlsl type-mapping shim needed (contrast XeGTAO.h,
+// which DOES need one because its fields include `uint`).
+//
+// This USED to be byte-identical to D3D11's 48-byte TiledPointLight; it deliberately is not any more.
+// The D3D12 backend needs a light to be able to sample a shadow cube that is NOT centred on itself:
+//   * clustered static lights (the 10-30 "atmospheric" fill lights a Gothic room is lit with) share ONE
+//     cube rendered from their cluster centroid, so the cube lookup origin/far-plane differ from the
+//     light's own;
+//   * the shadow tier bit selects which cube array the slot lives in (see kShadowTierLow below).
+// D3D11's own TiledPointLight is a separate, unaffected declaration.
+#ifndef GD3D12_GPULIGHT_SHARED_H
+#define GD3D12_GPULIGHT_SHARED_H
+
+struct GPULight {
+    float3 PositionView;    // 0
+    float  Range;           // 12  shading falloff radius (range-clamped for unshadowed statics)
+    float4 Color;           // 16  (.w = static flag 0/1)
+    float3 PositionWorld;   // 32
+    int    ShadowCubeIndex; // 44  -1 = no shadow, else slot | tier bit (see kShadowTierLow)
+    float3 ShadowOrigin;    // 48  cube centre — == PositionWorld unless this light is clustered
+    float  ShadowRange;     // 60  cube far-plane basis (far = ShadowRange*2) — == Range unless clustered
+};
+
+// High bit of ShadowCubeIndex selecting the LOW-RESOLUTION static cube array (D3D12PointShadows::
+// kStaticCubeSize) over the full-res dynamic one. Bit 30, so the value stays a positive int and the
+// existing "ShadowCubeIndex >= 0 means shadowed" test in every shader keeps working untouched; the slot
+// itself is the low 30 bits.
+static const int kShadowTierLow = 0x40000000;
+// Bit 29: this light's slot also has a valid DYNAMIC (skeletal overlay) cube, so the lit pass samples
+// the dynamic array as well and mins the two results. Full-res slots only — the low tier has no dynamic
+// twin. Absent = pure static shadow, and no second sample is taken.
+static const int kShadowHasDynamic = 0x20000000;
+static const int kShadowSlotMask = 0x1FFFFFFF;
+
+#endif // GD3D12_GPULIGHT_SHARED_H

--- a/D3D11Engine/Shaders/D3D12/include/GhostCB.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/GhostCB.hlsl
@@ -1,0 +1,14 @@
+// Ghost/transparency fade (D3D12PipelineState::CreateGhost): a per-vob fade alpha multiplied onto the
+// unlit diffuse sample, no alpha-clip (a fading ghost should smoothly disappear, not pop). Shared by
+// Preview.hlsl and Skeletal.hlsl's PSGhost. Register differs per shader — #define GHOSTCB_REGISTER
+// before including this file.
+#ifndef D3D12_GHOSTCB_HLSL
+#define D3D12_GHOSTCB_HLSL
+
+#ifndef GHOSTCB_REGISTER
+#define GHOSTCB_REGISTER b2
+#endif
+
+cbuffer GhostCB : register(GHOSTCB_REGISTER) { float GhostAlpha; float3 _GhostPad; };
+
+#endif // D3D12_GHOSTCB_HLSL

--- a/D3D11Engine/Shaders/D3D12/include/LightCB.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/LightCB.hlsl
@@ -1,0 +1,19 @@
+// Forward+ tiled/clustered per-frame params: light count + tiles/row + low-res/dynamic point-shadow cube heap
+// slots + the cluster Z-slice basis (ProjA/ProjB/NearZ/FarZ feed PBRLighting.hlsl's ComputeZSlice, and
+// LightCull.hlsl's own CullCB carries the same NearZ/FarZ for the culling pass). Shared by World/Vob/
+// Skeletal/Vegetation/Decal.hlsl; NOT by LightCull.hlsl (see the note in ForwardPlusTypes.hlsl for why).
+// Register differs per shader (each root sig has different b-slot occupancy) — #define LIGHTCB_REGISTER
+// before including this file.
+#ifndef D3D12_LIGHTCB_HLSL
+#define D3D12_LIGHTCB_HLSL
+
+#ifndef LIGHTCB_REGISTER
+#define LIGHTCB_REGISTER b2
+#endif
+
+cbuffer LightCB : register(LIGHTCB_REGISTER) {
+    uint LightCount; uint NumTilesX; uint LimitLightIntensity; uint PointShadowLowIndex; uint PointShadowDynIndex;
+    float ProjA; float ProjB; float NearZ; float FarZ;
+};
+
+#endif // D3D12_LIGHTCB_HLSL

--- a/D3D11Engine/Shaders/D3D12/include/MaterialCB.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/MaterialCB.hlsl
@@ -1,0 +1,23 @@
+// Per-material bindless indices (root consts): SM6.6 ResourceDescriptorHeap[...] slots for this
+// material's normal/ORM/diffuse maps, shared by World/Vob/Skeletal.hlsl. MatNormalIndex == 0xFFFFFFFF
+// -> no normal map (skip perturb); MatOrmIndex is always valid (1x1 default = AO 1 / rough 0.5 / metal 0)
+// and its top 2 bits pack the FxMap's channel layout for SampleOrm() to decode (see PBRLighting.hlsl).
+// MatDiffuseIndex is always valid too (1x1 black fallback while a material's texture isn't cached in).
+//
+// Register differs per shader — #define MATERIALCB_REGISTER before including this file. World.hlsl also
+// appends MatNormalStrength (scales the normal-map perturb: 1.0 for a real normalmap, or the weak
+// DEFAULT_NOISE_NORMALMAP_STRENGTH (0.10) when raining and MatNormalIndex is the rain-distortion texture
+// standing in for a missing normalmap) — #define MATERIALCB_EXTRA_FIELDS before including for that.
+#ifndef D3D12_MATERIALCB_HLSL
+#define D3D12_MATERIALCB_HLSL
+
+#ifndef MATERIALCB_REGISTER
+#define MATERIALCB_REGISTER b6
+#endif
+#ifndef MATERIALCB_EXTRA_FIELDS
+#define MATERIALCB_EXTRA_FIELDS
+#endif
+
+cbuffer MaterialCB : register(MATERIALCB_REGISTER) { uint MatNormalIndex; uint MatOrmIndex; uint MatDiffuseIndex; MATERIALCB_EXTRA_FIELDS };
+
+#endif // D3D12_MATERIALCB_HLSL

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -313,7 +313,18 @@ float3 PBR_DirectLighting( float3 baseColor, float3 lightColor, float3 N, float3
     float3 H = normalize( V + L );
     float NdotH = saturate( dot( N, H ) );
     float VdotH = saturate( dot( V, H ) );
-    float  cr = PBR_SafeRoughness( roughness * roughness );   // perceptual->physical (the branch squares here)
+    // PBR_DistributionGGX/PBR_GeometrySchlickGGX both take PERCEPTUAL roughness and do their own internal
+    // a=roughness*roughness conversion (matching the standard Karis/Epic GGX helper shape they're written
+    // as) — do NOT square here first. This used to read `PBR_SafeRoughness(roughness*roughness)`, which fed
+    // an already-squared alpha into functions that square it AGAIN, producing an effective a2==roughness^8
+    // instead of roughness^4. That over-tightened the NDF so severely that any roughness below ~0.8 or so
+    // collapsed the specular lobe to a near-invisible pinpoint (surface reads as flat diffuse, since only
+    // the roughness-independent diffuse term remains visible), while roughness near 1.0 stayed wide enough
+    // to actually show up — i.e. RAISING roughness looked GLOSSIER and lowering it looked MORE diffuse,
+    // backwards from every other roughness convention in this file (EvaluateSkyIBL, EnvBRDFApprox,
+    // ComputeSpecularOcclusion all correctly take perceptual roughness untouched). Reported 2026-08-28 by
+    // the maintainer testing the DefaultMaterialRoughness debug slider.
+    float  cr = PBR_SafeRoughness( roughness );
     float  cm = saturate( metallic );
     float3 F0 = lerp( float3( 0.04, 0.04, 0.04 ), baseColor, cm );
     float  D = PBR_DistributionGGX( NdotH, cr );

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -23,6 +23,11 @@
 // signature changes — LightCB already had a spare 4th root constant in every one of these shaders.
 // (HLSL globals are visible by name across the whole translation unit regardless of #include position, but
 // they must be DECLARED — i.e. appear earlier in the file — before this header's functions reference them.)
+//
+// EvaluateOpaqueSSR (below) additionally needs: `uint SsrPrevColorIndex; uint SsrPrevDepthIndex;
+// float4x4 SsrPrevViewProj;` in ShadowCB's screen-space-AO block (see World.hlsl's cbuffer for the exact
+// layout) and `SamplerState smpAoClamp` declared before this include — the same sampler
+// include/ScreenSpaceAO.hlsl already requires, reused rather than adding a second clamp sampler.
 
 // De-lights diffuse textures by lifting baked shadows and softening baked highlights
 float3 DelightDiffuse( float3 linearAlbedo )
@@ -634,4 +639,169 @@ float3 AccumTiledPointLights( float3 svpos, float3 wpos, float3 N, float3 albedo
     // ForwardPlusLighting.hlsl / CS_TiledShading.hlsl MAX-blend mode) to avoid overexposure where many
     // point lights overlap.
     return LimitLightIntensity != 0 ? maxLit : total;
+}
+
+// --- Opaque-surface screen-space reflections (TEMPORAL) ------------------------------------------------
+// Marches THIS frame's world-space reflection ray and samples the PREVIOUS frame's captured opaque scene
+// (D3D12Ssr.cpp's m_SsrPrevColor/m_SsrPrevDepth, reached bindlessly via SsrPrevColorIndex/SsrPrevDepthIndex),
+// reprojected through SsrPrevViewProj. See D3D12_SSR_WET_SURFACES_PLAN.md for why this is temporal rather
+// than same-frame: Forward+ has no per-pixel roughness G-buffer, and same-frame opaque-reflecting-opaque is
+// a chicken-and-egg problem no G-buffer addition solves cheaply.
+//
+// Algorithm mirrors Water.hlsl's TraceWaterSSR (uniform march + binary-search refine, front->behind
+// crossing test, thickness-gated hit) with one structural difference: Water marches in VIEW space against
+// an explicit View matrix; this has no previous-frame VIEW matrix available, only the combined
+// SsrPrevViewProj, so it marches in WORLD space and compares LINEARIZED HARDWARE DEPTH at each sample
+// instead (SsrLinearizeDepth, same reversed-Z formula ComputeZSlice above already uses).
+//
+// APPROXIMATION: ProjA/ProjB are THIS frame's projection terms, applied to linearize depth that was
+// captured under the PREVIOUS frame's projection. Gothic's FOV/near/far do not change frame-to-frame during
+// normal play (only via a settings change, which already invalidates the whole history through
+// m_SsrHistoryValid), so reusing them is safe in practice — if that assumption ever breaks, the fix is a
+// second uploaded ProjA/ProjB pair for the previous frame, not re-deriving one here.
+//
+// COMPOSITING NOTE (revisit before calling this feature finished): the call site adds this result on top of
+// ComputeSunLightingPBR's output as a confidence-weighted sheen — the same additive shape Wetness.hlsl's
+// `sheen` already uses — rather than precisely replacing EvaluateSkyIBL's specular term inside
+// ComputeSunLightingPBR. That is a deliberate simplification for this increment (it needs no change to
+// ComputeSunLightingPBR's signature) and is not perfectly energy-conserving: a very smooth, very reflective
+// surface could show both the sky-IBL specular AND this term. Acceptable for first light because the
+// roughness gate below (0.35) already limits it to a small slice of materials; tighten by subtracting an
+// estimate of the IBL specular this replaces if double-brightening is visible on the maintainer's GPU test.
+//
+// CALL-SITE WEIGHT MUST BE PBR_FresnelSchlick, NOT AN AD HOC CURVE. The first GPU test (2026-08-28)
+// shipped with `lerp(0.2, 1.0, pow(1-NdotV,2))` as the reflectance weight — 5-25x more energy than a real
+// dielectric's ~0.04 normal-incidence reflectance — and produced white-blowout patches on roof ridges. This
+// is TEMPORAL SSR: the sampled history already contains last frame's SSR contribution, so any per-generation
+// gain above what the surface would really reflect compounds every frame instead of settling. Always weight
+// the returned color by `PBR_FresnelSchlick(saturate(dot(N,V)), F0)` where
+// `F0 = lerp(float3(0.04,0.04,0.04), albedo, metallic)` — the same F0 the direct-lighting term already
+// uses — never a hand-tuned curve, however plausible it looks in isolation on one frame.
+// Must match D3D12GraphicsEngine.h's kSsrIndexMask/kSsrStepsShift exactly (the CPU side packs, this unpacks).
+static const uint  kSsrIndexMask = 0x00FFFFFFu;
+static const uint  kSsrStepsShift = 24;
+static const float kSsrOpaqueRoughnessGate = 0.35;
+static const float SSR_OPAQUE_THICKNESS    = 150.0;   // world units — see Wetness.hlsl's ~100 units/metre note
+static const float SSR_OPAQUE_START_BIAS   = 8.0;
+// Minimum world-space travel before a crossing may be ACCEPTED as a hit (it is still tracked/refined below
+// this distance, just not returned). Thin/convex geometry — roof ridges and eaves above all — puts the
+// reflection ray's very first step back within its own silhouette at close range: `origin` sits only
+// SSR_OPAQUE_START_BIAS off the true surface, so a ray that grazes back toward the same ridge can register a
+// "hit" against itself within a few world units. Confidence there is maximal (near-zero travelled -> no
+// distance fade, on-screen UV -> no edge fade) and the sampled color is the pixel's OWN recent history, which
+// is a 1:1 feedback loop with no damping — exactly what produced the white-blowout patches seen on roof
+// ridges in the first GPU test. Requiring real travel before a hit counts breaks that direct self-feedback.
+static const float SSR_OPAQUE_MIN_HIT_DISTANCE = 60.0;
+// Hard safety cap on ANY single sample fed back into next frame's history, independent of the energy model
+// at the call site. Temporal SSR reads a buffer that already contains last frame's SSR contribution, so any
+// per-generation gain above 1.0 compounds; this is the backstop against a future change accidentally
+// reintroducing runaway brightness the way the original ad hoc (non-physical) Fresnel weight did.
+static const float SSR_OPAQUE_MAX_LUMINANCE = 4.0;
+// FIXED step length, deliberately NOT `SSR_OPAQUE_MAX_DISTANCE / maxSteps` the way Water.hlsl's
+// TraceWaterSSR scales its water-reflection quality tiers. Water's target is a flat, distant sky/ocean
+// reflection, where a coarser step at low quality is a pure fidelity tradeoff. Architectural reflections
+// are close-range: at Low quality's 12 steps, `3000/12 = 250` world units per step is bigger than the
+// ENTIRE near-field self-intersection guard above (60-120 units) — the ray's first step jumps straight past
+// it, so the guard did nothing at Low/Medium and coarse steps could also bracket the wrong surface on thin
+// geometry (a roof ridge) instead of just losing fidelity. Quality must instead control how FAR the ray
+// reaches (maxSteps * this fixed length), never how coarsely it samples.
+static const float SSR_OPAQUE_STEP_LENGTH = 40.0;
+
+float SsrLinearizeDepth( float raw ) { return ProjB / max( raw - ProjA, 1e-8 ); }
+
+bool SsrProjectToPrevUV( float3 posWS, out float2 uv, out float rawDepth )
+{
+    float4 clip = mul( float4( posWS, 1.0 ), SsrPrevViewProj );
+    if ( clip.w <= 0.0 ) { uv = float2( 0.0, 0.0 ); rawDepth = 0.0; return false; }
+    uv = ( clip.xy / clip.w ) * float2( 0.5, -0.5 ) + 0.5;
+    rawDepth = clip.z / clip.w;
+    return true;
+}
+
+// Returns the reflected color and, via `confidence` ([0,1], 0 on any miss/gate/disocclusion), how much of
+// it the caller should blend in. A 0 confidence must be indistinguishable from SSR never having run.
+float3 EvaluateOpaqueSSR( float3 wpos, float3 N, float3 V, float roughness, out float confidence )
+{
+    confidence = 0.0;
+    uint maxSteps = SsrPrevColorIndex >> kSsrStepsShift;
+    if ( maxSteps == 0 || roughness > kSsrOpaqueRoughnessGate ) return float3( 0.0, 0.0, 0.0 );
+    uint refineSteps = SsrPrevDepthIndex >> kSsrStepsShift;
+    uint colorIdx = SsrPrevColorIndex & kSsrIndexMask;
+    uint depthIdx = SsrPrevDepthIndex & kSsrIndexMask;
+    Texture2D<float> prevDepthTex = ResourceDescriptorHeap[depthIdx];
+
+    float3 R = reflect( -V, N );
+    float3 origin = wpos + N * SSR_OPAQUE_START_BIAS;
+    const float stepLen = SSR_OPAQUE_STEP_LENGTH;
+    // Effective reach for this quality tier — Low/Medium/High trade MAX DISTANCE, never step coarseness.
+    const float maxDistance = stepLen * (float)maxSteps;
+
+    float2 prevUV; float rawAtOrigin;
+    if ( !SsrProjectToPrevUV( origin, prevUV, rawAtOrigin ) ) return float3( 0.0, 0.0, 0.0 );
+    float prevLinPos = SsrLinearizeDepth( rawAtOrigin );
+    float prevLinScene = SsrLinearizeDepth( prevDepthTex.SampleLevel( smpAoClamp, prevUV, 0 ) );
+    float prevDelta = prevLinPos - prevLinScene;
+
+    float3 curPos = origin;
+    float travelled = SSR_OPAQUE_START_BIAS;
+
+    [loop]
+    for ( uint i = 0; i < maxSteps; ++i )
+    {
+        curPos += R * stepLen;
+        travelled += stepLen;
+
+        float2 uv; float rawPos;
+        if ( !SsrProjectToPrevUV( curPos, uv, rawPos ) ) return float3( 0.0, 0.0, 0.0 );
+        if ( any( uv < 0.0 ) || any( uv > 1.0 ) ) return float3( 0.0, 0.0, 0.0 );
+
+        float linPos = SsrLinearizeDepth( rawPos );
+        float linScene = SsrLinearizeDepth( prevDepthTex.SampleLevel( smpAoClamp, uv, 0 ) );
+        float curDelta = linPos - linScene;
+
+        // Front -> behind crossing (same guard as Water.hlsl's TraceWaterSSR): only accept it if the scene
+        // surface sits at or behind where the ray was still in front, so a screen-space silhouette (the
+        // player's own shadowed depth, say) cannot fake a hit by teleporting the scene depth nearer. The
+        // travelled >= MIN_HIT_DISTANCE guard additionally rejects a self-intersection against the surface
+        // the ray started on — see SSR_OPAQUE_MIN_HIT_DISTANCE's header comment.
+        if ( prevDelta < 0.0 && curDelta >= 0.0 && linScene >= prevLinPos - SSR_OPAQUE_THICKNESS
+            && travelled >= SSR_OPAQUE_MIN_HIT_DISTANCE )
+        {
+            float3 lo = curPos - R * stepLen;
+            float3 hi = curPos;
+            float2 hitUV = uv;
+            float hitGap = curDelta;
+            [loop]
+            for ( uint j = 0; j < refineSteps; ++j )
+            {
+                float3 mid = ( lo + hi ) * 0.5;
+                float2 midUV; float midRaw;
+                if ( !SsrProjectToPrevUV( mid, midUV, midRaw ) ) break;
+                float midGap = SsrLinearizeDepth( midRaw ) - SsrLinearizeDepth( prevDepthTex.SampleLevel( smpAoClamp, midUV, 0 ) );
+                if ( midGap >= 0.0 ) { hi = mid; hitUV = midUV; hitGap = midGap; }
+                else                 { lo = mid; }
+            }
+
+            if ( hitGap < SSR_OPAQUE_THICKNESS )
+            {
+                float2 edge = smoothstep( 0.0, 0.02, hitUV ) * smoothstep( 0.0, 0.02, 1.0 - hitUV );
+                float distFade = saturate( 1.0 - travelled / maxDistance );
+                // Near-field fade in from MIN_HIT_DISTANCE rather than a hard on/off, so the guard above
+                // doesn't trade a feedback blowup for a visible confidence cliff at its threshold.
+                float nearFade = smoothstep( SSR_OPAQUE_MIN_HIT_DISTANCE, SSR_OPAQUE_MIN_HIT_DISTANCE * 2.0, travelled );
+                confidence = edge.x * edge.y * distFade * nearFade;
+                Texture2D prevColorTex = ResourceDescriptorHeap[colorIdx];
+                float3 hitColor = prevColorTex.SampleLevel( smpAoClamp, hitUV, 0 ).rgb;
+                // Safety clamp (see SSR_OPAQUE_MAX_LUMINANCE) — bounds per-generation feedback gain
+                // regardless of what energy weight the call site applies.
+                float hitLum = dot( hitColor, float3( 0.3333, 0.3333, 0.3333 ) );
+                if ( hitLum > SSR_OPAQUE_MAX_LUMINANCE ) hitColor *= SSR_OPAQUE_MAX_LUMINANCE / hitLum;
+                return hitColor;
+            }
+        }
+
+        prevDelta = curDelta;
+        prevLinPos = linPos;
+    }
+    return float3( 0.0, 0.0, 0.0 );
 }

--- a/D3D11Engine/Shaders/D3D12/include/RainParticleTypes.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/RainParticleTypes.hlsl
@@ -1,0 +1,24 @@
+// Rain/snow particle records, shared by AdvanceRain.hlsl (the CS that integrates them) and Rain.hlsl
+// (the VS/PS billboard draw). Layout-mirrors D3D11/D3D12's shared CPU struct of the same name in
+// WorldObjects.h (RainParticleDynamic/RainParticleStatic) — the CPU never needs its own HLSL-facing
+// header for these since D3D12Rain.cpp already includes WorldObjects.h directly, but a stride mismatch
+// against THAT struct would silently corrupt every particle, so keep the two in lockstep by hand.
+#ifndef D3D12_RAINPARTICLETYPES_HLSL
+#define D3D12_RAINPARTICLETYPES_HLSL
+
+// Mutable per-particle data, updated every frame by the advance CS.
+struct RainParticleDynamic
+{
+    float3 position;
+    float3 velocity;
+};
+
+// Immutable per-particle data, set once at initialization. Bound as StructuredBuffer SRV.
+struct RainParticleStatic
+{
+    float3 seed;
+    float  randomBrightness;
+    int    drawMode;
+};
+
+#endif // D3D12_RAINPARTICLETYPES_HLSL

--- a/D3D11Engine/Shaders/D3D12/include/ShadowCB.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/ShadowCB.hlsl
@@ -1,0 +1,56 @@
+// Per-frame CSM sun-shadow + scene-wetness + AO/SSR-reprojection + sky-IBL constants — ONE 512-byte
+// buffer shared by World/Vob/Skeletal/Vegetation/Decal.hlsl, and the single source of truth for its
+// HLSL layout (used to be five hand-synced copies, one per shader). Register differs per shader (each
+// root sig has different b-slot occupancy) — #define SHADOWCB_REGISTER before including this file.
+//
+// The buffer is written by several disjoint CPU-side passes at fixed byte offsets, not as one struct:
+//   [0,   256) D3D12ShadowMap::Prepare       — CSM cascades + sun dir/color/ambient (head, below)
+//   [256, 352) UploadWetnessConstants        — WetnessCBData (D3D12GraphicsEngine.h)
+//   [352, 432) UploadAoScreenConstants       — AoScreenCBData (kAoReprojCbOffset = 352)
+//   [432, ...) UploadSkyIblConstants         — SkyIblCBData   (kSkyIblCbOffset  = 432)
+// Vegetation.hlsl applies no wetness/SSR and reads no ShadowMap.hlsl helpers for those fields, but must
+// still declare them so its copy of this same 512-byte resource keeps the sky-IBL tail at the right
+// offset — three (four, with Decal) disjoint writers into one layout.
+#ifndef D3D12_SHADOWCB_HLSL
+#define D3D12_SHADOWCB_HLSL
+
+#ifndef SHADOWCB_REGISTER
+#define SHADOWCB_REGISTER b3
+#endif
+
+cbuffer ShadowCB : register(SHADOWCB_REGISTER)
+{
+    float4x4 CascadeViewProj[NUM_CSM_CASCADES];
+    float3   SunDirWS;          float ShadowMapSize;    // dir TOWARD sun; shadow-map resolution
+    float3   SunColor;          float SunIntensity;     // sun color (sRGB) + strength (0 when sun below horizon)
+    float3   CascadeTexelWorld; float AmbientStrength;  // world units/texel; SQ_ShadowStrength (ambient/sky term)
+    float    ShadowAOStrength;  float WorldAOStrength;   // vertLighting -> AO modulation weights
+    // How hard baked vertex light gates the sky-IBL AMBIENT term (PBRLighting.hlsl ComputeSunLightingPBR).
+    // 0 = the old unoccluded behaviour, 1 = interiors get no sky ambient at all. See the note there.
+    float    SkyOccStrength;    float SunSpecularEnabled;
+    // --- Scene wetness (rain) tail, uploaded separately by UploadWetnessConstants after the rain shadow
+    // pass has computed this frame's rain camera. RainShadowIndex/DistortionIndex are 0xFFFFFFFF when the
+    // rain shadowmap / distortion2.dds isn't available, which disables the effect entirely.
+    float4x4 RainViewProj;
+    float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
+    uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
+    // --- Screen-space AO / opaque-SSR-reprojection block, 80 bytes, written by UploadAoScreenConstants
+    // (kAoReprojCbOffset). AoInvRes: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask
+    // UV with. SsrPrevColorIndex/SsrPrevDepthIndex + SsrPrevViewProj: the previous-frame opaque scene
+    // color/depth (D3D12Ssr.cpp's m_SsrPrevColor/m_SsrPrevDepth) and the view-proj to reproject into their
+    // UV space — see PBRLighting.hlsl's opaque-SSR march and D3D12_SSR_WET_SURFACES_PLAN.md. Each index's
+    // low 24 bits are the bindless SRV slot, top 8 bits the step count for that pass (MaxSteps/RefineSteps);
+    // MaxSteps == 0 means SSR is off. This block must stay exactly 80 bytes — the sky-IBL tail below relies
+    // on it landing at kSkyIblCbOffset = 432.
+    float2   AoInvRes;          uint SsrPrevColorIndex; uint SsrPrevDepthIndex;
+    float4x4 SsrPrevViewProj;
+    // --- Sky IBL tail, uploaded by UploadSkyIblConstants (kSkyIblCbOffset = 432). The bindless indices of the
+    // sky irradiance + prefiltered-specular cubes built by Shaders/D3D12/SkyIbl.hlsl. Both are 0xFFFFFFFF when
+    // the IBL is unavailable or switched off, which makes EvaluateSkyIBL fall back to the flat ambient term.
+    // NOTE: SkyIblIntensity is the COMPLETE ambient scale for the IBL path (user knob x radiance
+    // normalization x an UNHALVED ShadowStrength), premultiplied by UploadSkyIblConstants. The IBL branch
+    // must not also apply AmbientStrength — that one still belongs to the flat fallback branch only.
+    uint     SkyIrradianceIndex; uint  SkySpecularIndex;  float SkySpecularMips; float SkyIblIntensity;
+};
+
+#endif // D3D12_SHADOWCB_HLSL

--- a/D3D11Engine/Shaders/D3D12/include/Wetness.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/Wetness.hlsl
@@ -153,21 +153,78 @@ float3 ApplyRainNormalDeformation( float3 wsNormal, float3 wsPosition )
     return normalize( n );
 }
 
-// Applies scene wetness at one fragment. N / albedo / roughness are modified in place; `sheen` returns
-// D3D11's specAdd (the additive wet shine), which the caller adds AFTER lighting so it isn't scaled by
-// N.L. Returns localWettness [0,1] — 0 means "nothing was changed", which callers use to skip the
-// remaining wetness work. Call with the UNPERTURBED-by-wetness normal and BEFORE the sun shadow lookup,
-// matching D3D11 (it computes `shadow` from the G-buffer normal, then deforms).
-float ApplySceneWetness( float3 wpos, float3 V, inout float3 N, inout float3 albedo,
-                         inout float roughness, out float sheen )
+// Puddles: localized pooled water on FLAT ground, distinct from the generic wet-surface sheen every
+// exposed pixel gets above. Without this, a pitched roof and a flat street get the SAME roughness dip
+// (0.10) because ApplySceneWetness's only directionality test is "faces up at all" — a 30-degree roof
+// pitch passes that easily. Real puddles only form on near-horizontal surfaces, so PUDDLE_FLATNESS_MIN is a
+// much stricter dot(N,up) threshold than the generic wetness exposure test above.
+//
+// The mask itself reuses the already-bound rain distortion texture (distortion2.dds, DistortionIndex) as a
+// noise field — sampled PLANAR in world XZ and read STATICALLY (no RainTime scroll): a puddle's SHAPE
+// shouldn't animate, only the ripple normal already handles the animated part. Thresholding that noise
+// against the current wetness level is what makes puddles GROW as rain accumulates (SceneWetness rising
+// drives the threshold down, so more of the noise field clears it) and shrink as the ground dries, instead
+// of a fixed blob pattern that pops in at full size the moment it starts raining.
+//
+// TWO octaves, not one: this texture's own large-scale use elsewhere in this file (ApplyRainNormalDeformation
+// samples it at roughly a 3300-10000 world-unit tile, for smooth WAVE features) is exactly what a single
+// puddle-scale sample must NOT reuse — at that tile size the field barely varies across a normal courtyard,
+// so thresholding it just draws the one edge of a near-linear gradient stretched across the whole visible
+// area: a puddle that reads as a straight 1-2 meter-wide line, not a pool. PUDDLE_NOISE_WORLD_SCALE is a
+// puddle-appropriate few-metre tile so multiple blobs fit in a courtyard; PUDDLE_DETAIL_WORLD_SCALE is a
+// smaller second sample multiplied in purely to break the blob's perimeter into something irregular.
+static const float PUDDLE_FLATNESS_MIN = 0.92;           // dot(N,up); excludes pitched roofs, keeps flat ground/rooftops
+static const float PUDDLE_NOISE_WORLD_SCALE  = 400.0;    // world units per tile — puddle-placement scale (~4 m)
+static const float PUDDLE_DETAIL_WORLD_SCALE = 120.0;    // world units per tile — perimeter-irregularity scale (~1.2 m)
+
+// Returns puddle intensity [0,1] at this fragment: 0 = ordinary wet surface, 1 = fully pooled/mirror-flat.
+// `geomN` must be the UNPERTURBED geometric normal (before ApplyRainNormalDeformation's ripple), or a
+// rippled wall normal could transiently point "up" and read as flat.
+float ComputePuddleMask( float3 geomN, float3 wsPosition, float wetness )
 {
-    sheen = 0.0;
+    float flatness = saturate( ( dot( geomN, float3( 0, 1, 0 ) ) - PUDDLE_FLATNESS_MIN ) / ( 1.0 - PUDDLE_FLATNESS_MIN ) );
+    if ( flatness <= 0.0 ) return 0.0;
+
+    Texture2D distTex = ResourceDescriptorHeap[DistortionIndex];
+    float placement = distTex.SampleLevel( smp, wsPosition.xz / PUDDLE_NOISE_WORLD_SCALE, 0 ).r;
+    // Offset the second sample's UV origin so it isn't just a scaled copy of the same pattern (which would
+    // still line up into bands at some scale ratios) — an arbitrary irrational-ish shift is enough.
+    float detail = distTex.SampleLevel( smp, wsPosition.xz / PUDDLE_DETAIL_WORLD_SCALE + 17.31, 0 ).g;
+    float noise = placement * 0.7 + detail * 0.3;
+
+    // Higher wetness lowers the threshold the noise has to clear, so puddles spread as rain persists. The
+    // 0.08 half-width keeps the pooled/dry boundary from being a hard, aliased edge.
+    float threshold = lerp( 0.85, 0.35, saturate( wetness ) );
+    float pooled = smoothstep( threshold - 0.08, threshold + 0.08, noise );
+    return pooled * flatness;
+}
+
+// Applies scene wetness at one fragment. N / albedo / roughness are modified in place. Returns
+// localWettness [0,1] — 0 means "nothing was changed", which callers use to skip the remaining wetness
+// work. Call with the UNPERTURBED-by-wetness normal and BEFORE the sun shadow lookup, matching D3D11 (it
+// computes `shadow` from the G-buffer normal, then deforms).
+//
+// NO STYLIZED SHEEN HERE (deliberate D3D12 divergence from D3D11, decided 2026-08-28). D3D11's
+// PS_DS_AtmosphericScattering.hlsl adds three fixed-direction "sparkle" highlights on top of this
+// (`l1 = normalize(0,0.5,-1)`, etc. — literal constants, never SunDirWS or any real light/reflection
+// direction). It reads as a decorative hack because it is one: those directions don't track the sun, the
+// camera, or the environment, so the highlight they produce sits in a fixed relationship to the world/view
+// regardless of actual lighting conditions — reported by the maintainer as "random specular highlights that
+// stay in one place" and correctly identified as looking wrong. D3D12 already has a CORRECT alternative for
+// exactly this ("wet ground should look shinier"): the roughness dip a few lines below feeds directly into
+// ComputeSunLightingPBR's Cook-Torrance sun term (PBRLighting.hlsl), which DOES respond properly to the
+// real sun direction, view angle and roughness, and puddled pixels (near-mirror roughness) additionally get
+// EvaluateOpaqueSSR's real environment reflection. Porting the fixed-direction sheen would only add fake,
+// redundant energy on top of lighting that is already physically correct.
+float ApplySceneWetness( float3 wpos, inout float3 N, inout float3 albedo, inout float roughness )
+{
     if ( SceneWetness <= 0.0 || RainShadowIndex == 0xffffffff || DistortionIndex == 0xffffffff )
         return 0.0;   // not raining / drying done, or the rain map / distortion2.dds never loaded
 
     float wetness = SampleRainReach( wpos ) * SceneWetness;
     if ( wetness < 0.001 ) return 0.0;   // matches D3D11's pixelWettnes cutoff
 
+    float3 geomN = N;   // captured before ApplyRainNormalDeformation ripples it — see ComputePuddleMask's requirement
     float3 wetNormal = ApplyRainNormalDeformation( N, wpos );
 
     // Downward-facing surfaces (undersides, ceilings) stay dry; upward-facing ones collect the most
@@ -179,29 +236,28 @@ float ApplySceneWetness( float3 wpos, float3 V, inout float3 N, inout float3 alb
     wetness *= exposure * exposure;
     if ( wetness <= 0.0 ) return 0.0;
 
-    // Only ripple while it is actually RAINING (RainFxWeight), not while the ground is drying out.
-    N = normalize( lerp( N, wetNormal, RainFxWeight * wetness * 0.5 ) );
+    // Puddles: a stricter, flat-ground-only pool on top of the generic wet-surface sheen above. See
+    // ComputePuddleMask's header comment for why this needs its own (much tighter) flatness test.
+    float puddle = ComputePuddleMask( geomN, wpos, wetness );
+
+    // Only ripple while it is actually RAINING (RainFxWeight), not while the ground is drying out. Pooled
+    // water stays closer to a flat mirror than a rippling wet wall, so puddle pixels get less of the
+    // tri-planar ripple deformation blended in.
+    N = normalize( lerp( N, wetNormal, RainFxWeight * wetness * 0.5 * ( 1.0 - puddle * 0.8 ) ) );
 
     // PBR stand-in for D3D11's "specPower -> 150, specIntensity -> 0": water is smooth, so pull
-    // roughness toward glossy and let Cook-Torrance tighten the existing highlights.
-    roughness = lerp( roughness, 0.10, wetness );
+    // roughness toward glossy and let Cook-Torrance tighten the existing highlights. Puddle pixels go all
+    // the way to near-mirror (0.02) instead of the generic wet-surface floor (0.10) — this is also what
+    // clears EvaluateOpaqueSSR's roughness gate (PBRLighting.hlsl), so a puddle shows an actual reflection
+    // of its surroundings rather than just the fixed-direction sheen below.
+    float targetRoughness = lerp( 0.10, 0.02, puddle );
+    roughness = lerp( roughness, targetRoughness, wetness );
 
-    // Desaturate + darken (D3D11's wetPixel).
+    // Desaturate + darken (D3D11's wetPixel) — pooled water darkens further still, matching how a puddle
+    // reads visually darker/more reflective than a merely damp surface under overcast rain light.
     float lum = dot( albedo, float3( 0.3333, 0.3333, 0.3333 ) );
-    albedo = lerp( albedo, lerp( lum.xxx, albedo, 0.75 ) * 0.75, wetness );
+    float darkenAmount = lerp( 0.75, 0.55, puddle );
+    albedo = lerp( albedo, lerp( lum.xxx, albedo, darkenAmount ) * darkenAmount, wetness );
 
-    // The three fixed-direction sheen highlights. D3D11 builds l1 already in view space and rotates
-    // l2/l3 world->view; here all three are world-space (the effect is a stylized sheen, not a
-    // physical reflection, so the absolute directions only set where the shine sits on the ground).
-    const float specPower = 150.0;
-    float3 l1 = normalize( float3(  0.0,   0.5,  -1.0   ) );
-    float3 l2 = normalize( float3( -0.333, 0.533, 0.333 ) );
-    float3 l3 = normalize( float3(  0.0,   0.566, -0.666 ) );
-    float s1 = saturate( dot( N, normalize( l1 + V ) ) );
-    float s2 = saturate( dot( N, normalize( l2 + V ) ) );
-    float s3 = saturate( dot( N, normalize( l3 + V ) ) );
-    float reflection = pow( s1, specPower ) * 0.7 + pow( s2, specPower ) * 0.7 + pow( s3, specPower ) * 0.6;
-
-    sheen = reflection * wetness * lerp( 0.08, 0.10, RainFxWeight );
     return wetness;
 }

--- a/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
@@ -4,25 +4,31 @@
 #include <DS_Defines.h>
 #include "DepthReconstruction.h"
 #include "include/PointLightShadows.h"
+#include "include/RainWetnessSample.h"
 
 cbuffer DS_PointLightConstantBuffer : register( b0 )
 {
 	float4 PL_Color;
-	
+
 	float PL_Range;
 	float3 Pl_PositionWorld;
-	
+
 	float PL_Outdoor;
 	float3 Pl_PositionView;
-	
+
 	float2 PL_ViewportSize;
 	float2 PL_JitterOffset;
-	
+
 	float4 PL_ProjParams; // x = 1/P._11, y = 1/P._22, z = P._43, w = P._33
-	matrix PL_InvView; // Optimize out!
-	
+	matrix PL_InvView;
+
 	float3 PL_LightScreenPos;
 	float PL_Pad3;
+
+	// Rain wetness, frame-constant (see ApplyPointLightWetness / RainWetnessSample.h).
+	matrix PL_RainViewProj;
+	float PL_SceneWettness;
+	float3 PL_Pad4;
 };
 
 //--------------------------------------------------------------------------------------
@@ -30,10 +36,12 @@ cbuffer DS_PointLightConstantBuffer : register( b0 )
 //--------------------------------------------------------------------------------------
 SamplerState SS_Linear : register( s0 );
 SamplerState SS_samMirror : register( s1 );
+SamplerComparisonState SS_Comp : register( s2 );
 Texture2D	TX_Diffuse : register( t0 );
 Texture2D	TX_Nrm : register( t1 );
 Texture2D	TX_Depth : register( t2 );
 Texture2D	TX_SI_SP : register( t7 );
+Texture2D	TX_RainShadowmap : register( t4 );
 
 //--------------------------------------------------------------------------------------
 // Input / Output structures
@@ -112,25 +120,33 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	// Reconstruct VS World Position from depth
 	float expDepth = TX_Depth.Sample(SS_Linear, uv).r;
 	float3 vsPosition = VSPositionFromDepth(expDepth, uv);
-	
+	float3 wsPosition = mul(float4(vsPosition, 1), PL_InvView).xyz;
+	float3 wsNormal = normalize(mul(float4(normal, 0), PL_InvView).xyz);
+
+	// Rain wetness: darken/dampen this light's contribution consistently with what
+	// PS_DS_AtmosphericScattering.hlsl already did for the sun/ambient term, instead of adding
+	// un-wetted brightness on top of it (see RainWetnessSample.h's header for the bug this fixes).
+	ApplyPointLightWetness(wsPosition, wsNormal, TX_RainShadowmap, SS_Comp, PL_RainViewProj, PL_SceneWettness,
+		diffuse.rgb, specIntensity, specPower);
+
 	// Get direction and distance from the light to that position
 	float3 lightDir = Pl_PositionView - vsPosition;
 	float distance = length(lightDir);
 	lightDir /= distance; // Normalize the direction
-	
+
 	// Do some simple NdL-Lighting
 	float ndl = max(0, dot(lightDir, normal));
-	
+
 	// Compute range falloff
 	float falloff = PLS_ComputeRangeFalloff(distance, PL_Range);
 	//float falloff = saturate(1.0f / (pow(distance / PL_Range * 2, 2)));
-	
+
 	// Compute specular lighting
 	float3 V = normalize(-vsPosition);
 	float3 H = normalize(lightDir + V);
 	float spec = PLS_CalcBlinnPhongLighting(normal, H) * PL_Color.w;
 	float specMod = PLS_ComputeSpecMod(diffuse.rgb);
-	
+
 	// Blend this with the light color, world diffuse and specular term.
 	float3 lighting = PLS_ComputePointLightLighting(diffuse.rgb, PL_Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod);
 	

--- a/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
@@ -4,25 +4,31 @@
 #include <DS_Defines.h>
 #include "DepthReconstruction.h"
 #include "include/PointLightShadows.h"
+#include "include/RainWetnessSample.h"
 
 cbuffer DS_PointLightConstantBuffer : register( b0 )
 {
 	float4 PL_Color;
-	
+
 	float PL_Range;
 	float3 Pl_PositionWorld;
-	
+
 	float PL_Outdoor;
 	float3 Pl_PositionView;
-	
+
 	float2 PL_ViewportSize;
 	float2 PL_JitterOffset;
-	
+
 	float4 PL_ProjParams; // x = 1/P._11, y = 1/P._22, z = P._43, w = P._33
-	matrix PL_InvView; // Optimize out!
-	
+	matrix PL_InvView;
+
 	float3 PL_LightScreenPos;
 	float PL_Pad3;
+
+	// Rain wetness, frame-constant (see ApplyPointLightWetness / RainWetnessSample.h).
+	matrix PL_RainViewProj;
+	float PL_SceneWettness;
+	float3 PL_Pad4;
 };
 
 //--------------------------------------------------------------------------------------
@@ -36,6 +42,7 @@ Texture2D	TX_Nrm : register( t1 );
 Texture2D	TX_Depth : register( t2 );
 TextureCube	TX_ShadowCube : register( t3 );
 Texture2D	TX_SI_SP : register( t7 );
+Texture2D	TX_RainShadowmap : register( t4 );
 
 //--------------------------------------------------------------------------------------
 // Input / Output structures
@@ -77,7 +84,13 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float3 vsPosition = VSPositionFromDepth(expDepth, uv);
 	float3 wsPosition = mul(float4(vsPosition, 1), PL_InvView).xyz;
 	float3 wsNormal = normalize(mul(float4(normal, 0), PL_InvView).xyz);
-	
+
+	// Rain wetness: darken/dampen this light's contribution consistently with what
+	// PS_DS_AtmosphericScattering.hlsl already did for the sun/ambient term, instead of adding
+	// un-wetted brightness on top of it (see RainWetnessSample.h's header for the bug this fixes).
+	ApplyPointLightWetness(wsPosition, wsNormal, TX_RainShadowmap, SS_Comp, PL_RainViewProj, PL_SceneWettness,
+		diffuse.rgb, specIntensity, specPower);
+
 	//return float4(normalize(wsPosition - Pl_PositionWorld), 1.0f);
 	
 	// Compute flat normal

--- a/D3D11Engine/Shaders/include/RainWetnessSample.h
+++ b/D3D11Engine/Shaders/include/RainWetnessSample.h
@@ -1,0 +1,108 @@
+// Lightweight rain-wetness sampling for the legacy deferred point-light passes
+// (PS_DS_PointLight.hlsl / PS_DS_PointLightDynShadow.hlsl).
+//
+// BUG THIS FIXES: PS_DS_AtmosphericScattering.hlsl computes scene wetness (ApplySceneWettness) and
+// darkens/desaturates its own LOCAL copy of the G-buffer diffuse -- that darkening is never written
+// back to the G-buffer. The point-light passes below read the G-buffer's diffuse/specular directly and
+// additively blend into the same HDR target the atmospheric-scattering pass just wrote, so a pixel that
+// sits close to a torch/lantern gets its wet darkening overpowered by an un-wetted point-light
+// contribution added right on top -- wet ground reads as completely dry wherever a nearby point light
+// dominates the pixel's brightness (reported by the maintainer: "no rain wetness effect if light
+// touches the ground, only unlit areas get the rain effect").
+//
+// This header gives the point-light passes their own, cheaper wetness sample so their contribution is
+// darkened/dampened consistently with the atmospheric-scattering pass instead of ignoring wetness
+// entirely.
+#ifndef RAIN_WETNESS_SAMPLE_H
+#define RAIN_WETNESS_SAMPLE_H
+
+// Inner 8-tap ring of ShadowSampling.h's g_PoissonDisk32, duplicated rather than pulled in via
+// #include "ShadowSampling.h": that header also declares CSM-only globals (TX_ShadowmapArray /
+// TX_ShadowmapAtlas, SHADOW_ATLAS) the point-light shaders have no reason to bind. Same duplication
+// precedent as the D3D12 backend's Wetness.hlsl.
+static const float2 g_RainPoissonInner8[8] = {
+    float2( -0.94201624, -0.39906216 ), float2(  0.94558609, -0.76890725 ),
+    float2( -0.09418410, -0.92938870 ), float2(  0.34495938,  0.29387760 ),
+    float2( -0.91588581,  0.45771432 ), float2( -0.81544232, -0.87912464 ),
+    float2( -0.38277543,  0.27676845 ), float2(  0.97484398,  0.75648379 )
+};
+
+#ifndef RAIN_WET_BLUR_WORLD
+#define RAIN_WET_BLUR_WORLD 100.0f   // ~1m filter radius => ~2m wide wet/dry transition, matches ShadowSampling.h
+#endif
+
+// 1:1 with ShadowSampling.h's ComputeRainWetness, minus its optional 16-tap outer ring (SHD_FILTER_16TAP_PCF):
+// this runs once per pixel PER OVERLAPPING LIGHT rather than once per pixel, so it deliberately stays cheap.
+float ComputeRainWetnessLite( float3 wsPosition, Texture2D rainMap, SamplerComparisonState samplerState, matrix viewProj )
+{
+    float4 sp = mul( float4( wsPosition, 1 ), viewProj );
+    sp.xyz /= sp.www;   // orthographic rain camera, w == 1 -- kept for parity with ComputeRainWetness
+    float2 uv = sp.xy * float2( 0.5f, -0.5f ) + float2( 0.5f, 0.5f );
+
+    // Outside the rain camera there is no occluder information; the common case out there is open sky,
+    // so return "exposed" rather than drawing a dry ring at the map border.
+    if ( uv.x < 0.0f || uv.x > 1.0f || uv.y < 0.0f || uv.y > 1.0f )
+        return 1.0f;
+
+    float sx = length( float3( viewProj._11, viewProj._21, viewProj._31 ) );
+    float sy = length( float3( viewProj._12, viewProj._22, viewProj._32 ) );
+    float sz = length( float3( viewProj._13, viewProj._23, viewProj._33 ) );
+
+    float2 radiusUV = float2( sx, sy ) * ( 0.5f * RAIN_WET_BLUR_WORLD );
+    float bias = 0.0001f + RAIN_WET_BLUR_WORLD * sz;
+    float zReceiver = sp.z - bias;
+
+    const float wCenter = 1.0f;
+    const float rInner  = 0.45f;
+    const float wInner  = 0.66698f;   // exp(-0.45^2 * 2)
+
+    float sum = wCenter * rainMap.SampleCmpLevelZero( samplerState, uv, zReceiver );
+    float weight = wCenter;
+
+    [unroll]
+    for ( int i = 0; i < 8; ++i )
+    {
+        float2 offset = g_RainPoissonInner8[i] * ( rInner * radiusUV );
+        sum += wInner * rainMap.SampleCmpLevelZero( samplerState, uv + offset, zReceiver );
+        weight += wInner;
+    }
+
+    return saturate( sum / weight );
+}
+
+// Darkens/desaturates diffuse and dampens specular for a wet surface -- the point-light-pass analogue of
+// PS_DS_AtmosphericScattering.hlsl's ApplySceneWettness. Deliberately skips that function's tri-planar
+// ripple normal deformation and reflection-cube sheen (an extra texture + per-axis blend that would be
+// paid once per overlapping light instead of once per pixel); the diffuse darkening below is what
+// actually reads as "wet" and is the part this bug report is about.
+//
+// `wsNormal` must be the UNDEFORMED world-space surface normal (no ripple applied here, so nothing to
+// deform it with) and `sceneWetness` is GothicAPI::GetSceneWetness() (the sustained wetness level, same
+// split as AC_SceneWettness/AC_RainFXWeight elsewhere).
+void ApplyPointLightWetness( float3 wsPosition, float3 wsNormal, Texture2D rainMap,
+    SamplerComparisonState samplerState, matrix rainViewProj, float sceneWetness,
+    inout float3 diffuse, inout float specIntensity, inout float specPower )
+{
+    if ( sceneWetness <= 0.0f ) return;
+
+    float wetness = ComputeRainWetnessLite( wsPosition, rainMap, samplerState, rainViewProj ) * sceneWetness;
+    if ( wetness < 0.001f ) return;
+
+    // Rain mostly settles on upward-facing, unsheltered surfaces -- same exposure test as
+    // ApplySceneWettness (undeformed normal here, since there is no ripple to deform it with).
+    float wDot = saturate( dot( wsNormal, float3( 0, -1, 0 ) ) );
+    float wDot2 = wDot * wDot;
+    wetness *= 1.0f - ( wDot2 * wDot2 );
+    float exposure = saturate( wsNormal.y );
+    wetness *= exposure * exposure;
+    if ( wetness <= 0.0f ) return;
+
+    specIntensity = lerp( specIntensity, 0.0f, wetness );
+    specPower = lerp( specPower, 150.0f, wetness );
+
+    float diffuseLum = dot( diffuse, float3( 0.3333f, 0.3333f, 0.3333f ) );
+    float3 wetDiffuse = lerp( diffuseLum, diffuse, 0.75f ) * 0.75f;   // desaturate + darken, matches ApplySceneWettness's wetPixel
+    diffuse = lerp( diffuse, wetDiffuse, wetness );
+}
+
+#endif // RAIN_WETNESS_SAMPLE_H

--- a/D3D11Engine/SqliteBlobStore.cpp
+++ b/D3D11Engine/SqliteBlobStore.cpp
@@ -44,11 +44,12 @@ SqliteBlobStore::SqliteBlobStore( const std::string& path ) {
         return;
     }
 
-    // WAL: a reader on another thread (once it has m_mutex) never blocks behind a writer mid-transaction.
-    // NORMAL sync: this is a cache, not a ledger - losing the last few writes to a power cut is exactly
-    // as safe as never having cached them, and trading that away is the entire point of WAL+NORMAL.
+    // WAL+NORMAL: readers never block on an in-progress writer, and losing the last few writes to a
+    // power cut is fine for a cache. mmap_size=0: pin this explicitly - SQLITE_MAX_MMAP_SIZE is ~2GiB
+    // on Windows, too large to risk in a 32-bit process's address space.
     if ( !Exec( db, "PRAGMA journal_mode=WAL;" ) ||
         !Exec( db, "PRAGMA synchronous=NORMAL;" ) ||
+        !Exec( db, "PRAGMA mmap_size=0;" ) ||
         !Exec( db, "CREATE TABLE IF NOT EXISTS blobs (key INTEGER PRIMARY KEY, data BLOB NOT NULL);" ) ) {
         sqlite3_close( db );
         return;

--- a/D3D11Engine/Types.h
+++ b/D3D11Engine/Types.h
@@ -16,17 +16,34 @@ enum XRESULT : int {
 };
 
 struct INT2 {
-    INT2( int x, int y ) {
-        this->x = x;
-        this->y = y;
+    INT2( int x, int y ) :
+        x(x), y(y) { }
+
+    INT2( long x, long y ) :
+        x( x ), y( y ) {
+        static_assert(sizeof( long ) == sizeof( int ));
     }
 
-    INT2( const XMFLOAT2& v ) {
-        this->x = static_cast<int>(v.x + 0.5f);
-        this->y = static_cast<int>(v.y + 0.5f);
+    INT2( unsigned long x, unsigned long y ) :
+        x( x ), y( y ) {
+        static_assert(sizeof( long ) == sizeof( int ));
+
+        assert( x < INT_MAX );
+        assert( y < INT_MAX );
     }
 
-    INT2() { x = 0; y = 0; }
+    INT2( unsigned int x, unsigned int y ) :
+        x( x ), y( y ) {
+        assert( x < INT_MAX );
+        assert( y < INT_MAX );
+    }
+    
+    INT2( float x, float y )
+        : x(static_cast<int>(x + 0.5f)), y(static_cast<int>(y + 0.5f))  { }
+
+    INT2( const XMFLOAT2& v ) : INT2(v.x, v.y) { }
+
+    INT2() : x(0), y(0) { }
 
     INT2( const std::string& resolution ) {
         std::istringstream iss( resolution );

--- a/D3D11Engine/WorldConverter.cpp
+++ b/D3D11Engine/WorldConverter.cpp
@@ -80,7 +80,7 @@ namespace {
         std::vector<VERTEX_INDEX>* const wantShadow = s.EnableShadowIndexBuffers ? shadowIndices : nullptr;
 
         const uint64_t key = MeshOptimizeCache::Hash( indices, vertices, wantShadow != nullptr, lodIndices != nullptr );
-        if ( MeshOptimizeCache::TryGet( key, indices, vertices, wantShadow, lodIndices ) ) {
+        if ( MeshOptimizeCache::TryGet( key, indices, vertices, wantShadow, lodIndices, s.MeshOptimizeCacheFlags ) ) {
             return;
         }
 
@@ -89,7 +89,7 @@ namespace {
         vertexBuffer->OptimizeVertices( indices.data(), reinterpret_cast<byte*>(vertices.data()),
             indices.size(), vertices.size(), sizeof( ExVertexStruct ), wantShadow, lodIndices );
 
-        MeshOptimizeCache::Put( key, indices, vertices, wantShadow, lodIndices );
+        MeshOptimizeCache::Put( key, indices, vertices, wantShadow, lodIndices, s.MeshOptimizeCacheFlags );
     }
 
     /** ZENGIN's zPMINDEX_NONE: terminator of a WedgeMap collapse chain. */


### PR DESCRIPTION
- fix frame-incorrect sun light dir/pos
- Rain applied to point lights
- Mesh cache: disable in-memory cache after world load, cache settings flags. Limit im-memory world load cache to 512MiB (pruned after successfull load)
- misc: ListItem<T> combobox helper
- misc: type safety/auto conversions
- misc: remove NDEBUG in NoOpt
- misc: enforce sqlite not using MMAP (has not been using it, but now also added the pragma to ensure it in possible future updates)

dx12:
- SSR for rain wetness
- fix: PBR double-squared roughness
- artificial rain sheen removed
- misc: shader cleanup