### PR TITLE
fix(dx12): font scaling now also supports (if used) Union custom font…

### DIFF
--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -362,6 +362,15 @@ public:
 
     virtual void DrawString( std::string_view str, float x, float y, const zFont* font, zColor& fontColor ) {};
 
+    /** Union's font-scaling plugins set this through the ddraw export of the same name. Backend-neutral so
+        every renderer's DrawString scales its glyphs by it. Returns the previous value. */
+    float UpdateCustomFontMultiplierFontRendering( float multiplier ) {
+        float res = m_CustomFontMultiplier;
+        m_CustomFontMultiplier = multiplier;
+        return res;
+    }
+    float GetCustomFontMultiplier() const { return m_CustomFontMultiplier; }
+
     virtual XRESULT UpdateRenderStates() { return XR_SUCCESS; };
 
     virtual GraphicsEventRecord RecordGraphicsEvent( GraphicsEventName region ) { return GraphicsEventRecord{}; }
@@ -422,6 +431,9 @@ public:
 
 protected:
     GraphicsDeviceCapabilities m_DeviceCapabilities;
+
+    /** Glyph-scale multiplier set by Union's font plugins. 1 = untouched. */
+    float m_CustomFontMultiplier = 1.0f;
 
     HWND m_OutputWindow = nullptr;
     bool m_IsWindowActive = false;

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -291,7 +291,6 @@ D3D11GraphicsEngine::D3D11GraphicsEngine() :
     // Match the resolution with the current desktop resolution
     Resolution = m_scaledResolution =
         Engine::GAPI->GetRendererState().RendererSettings.LoadedResolution;
-    unionCurrentCustomFontMultiplier = 1.0;
 }
 
 D3D11GraphicsEngine::~D3D11GraphicsEngine() {
@@ -10064,12 +10063,6 @@ namespace UI::zFont {
 }
 
 
-float  D3D11GraphicsEngine::UpdateCustomFontMultiplierFontRendering( float multiplier ) {
-    float res = unionCurrentCustomFontMultiplier;
-    unionCurrentCustomFontMultiplier = multiplier;
-    return res; 
-}
-
 void D3D11GraphicsEngine::DrawString( std::string_view str, float x, float y, const zFont* font, zColor& fontColor ) {
     if ( !font ) return;
     if ( !font->tex ) return;
@@ -10101,7 +10094,7 @@ void D3D11GraphicsEngine::DrawString( std::string_view str, float x, float y, co
         return;
     }
     
-    UIScale *= unionCurrentCustomFontMultiplier;
+    UIScale *= GetCustomFontMultiplier();
 
     //
     // Set alpha blending

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -385,8 +385,6 @@ public:
 
     void EnsureTempVertexBufferSize( std::unique_ptr<D3D11VertexBuffer>& buffer, UINT size );
 
-    float UpdateCustomFontMultiplierFontRendering( float multiplier );
-
     // TODO: Remove from here, put into D3D11ShadowMaps
     D3D11PointLight* DebugPointlight;
 
@@ -796,7 +794,6 @@ private:
     bool m_HDR;
     int m_previousFpsLimit;
     bool m_FrameNeedsJitter;
-    float unionCurrentCustomFontMultiplier;
 
     std::unique_ptr<RenderToTextureBuffer> VelocityBuffer;
     XMFLOAT4X4 m_PrevViewProjMatrix;

--- a/D3D11Engine/D3D12Engine/D3D12Engine2D.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Engine2D.cpp
@@ -105,15 +105,18 @@ void D3D12GraphicsEngine::DrawString( std::string_view str, float x, float y, co
 	if ( tx->CacheIn( FONT_CACHE_PRIO ) != zRES_CACHED_IN )
 		return;
 
-	// UIScale mirrors D3D11 DrawString: swim-bar width / 180 (the custom-font multiplier defaults to 1).
+	// UIScale mirrors D3D11 DrawString: swim-bar width / 180, and only while that bar exists — the cached
+	// size must not keep scaling glyphs once it is gone, or D3D12 lays text out differently than D3D11.
 	float UIScale = 1.0f;
 	static int savedBarSize = -1;
-	if ( oCGame::GetGame() ) {
-		if ( savedBarSize == -1 && oCGame::GetGame()->swimBar )
-			savedBarSize = oCGame::GetGame()->swimBar->psizex;
-		if ( savedBarSize > 0 )
-			UIScale = static_cast<float>(savedBarSize) / 180.f;
+	if ( auto game = oCGame::GetGame(); game && game->swimBar ) {
+		if ( savedBarSize == -1 ) {
+			savedBarSize = game->swimBar->psizex;
+		}
+		UIScale = static_cast<float>(savedBarSize) / 180.f;
 	}
+
+	UIScale *= GetCustomFontMultiplier();
 
 	// Build glyph quads over the font atlas (screen-space xyzrhw ExVertexStruct triangle list).
 	static std::vector<ExVertexStruct> vertices;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -2071,21 +2071,28 @@ XRESULT D3D12GraphicsEngine::OnBeginFrame() {
     m_CurrentViewport = { 0.0f, 0.0f, static_cast<float>( m_BackbufferResolution.x ), static_cast<float>( m_BackbufferResolution.y ), 0.0f, 1.0f };
     m_CurrentScissor = { 0, 0, m_BackbufferResolution.x, m_BackbufferResolution.y };
 
-    // this seems to do nothing on its own - CURRENTLY. But who knows what will happen when we do 3d.
-    zCView::SetWindowMode(
-        m_BackbufferResolution.x,
-        m_BackbufferResolution.y,
-        32 );
+    // Only when the resolution actually changed, like D3D11 does from OnResize. SetVirtualMode ends in
+    // zCView::SetMode, which rewrites vid_xdim/ydim + screen->psizex and then RecalcChildsSize/Pos over every
+    // open view; running that per frame re-derives layouts that were set in pixels (oCViewDocument sizes the
+    // book that way) and ratchets them smaller each frame. First frame still applies it.
+    if ( m_AppliedZViewMode.x != m_BackbufferResolution.x || m_AppliedZViewMode.y != m_BackbufferResolution.y ) {
+        m_AppliedZViewMode = m_BackbufferResolution;
 
-    // This ensures any 2D UI is rendered with the proper resolution.
-    // needs to be per-frame or it won't do anything.
-    zCView::SetVirtualMode(
-        static_cast<int>(m_BackbufferResolution.x),
-        static_cast<int>(m_BackbufferResolution.y),
-        32 );
+        zCView::SetWindowMode(
+            m_BackbufferResolution.x,
+            m_BackbufferResolution.y,
+            32 );
 
-    //POINT virtualSize = { 8192, 8192 };
-    //zCViewDraw::GetScreen().SetVirtualSize( virtualSize );
+        zCView::SetVirtualMode(
+            static_cast<int>(m_BackbufferResolution.x),
+            static_cast<int>(m_BackbufferResolution.y),
+            32 );
+
+        // SetMode leaves the zCViewDraw screen's virtual size derived from pixels; restore the 8192 space the
+        // document/page views are authored in (D3D11 OnResize does the same right after its SetVirtualMode).
+        POINT virtualSize = { 8192, 8192 };
+        zCViewDraw::GetScreen().SetVirtualSize( virtualSize );
+    }
 
     m_FrameOpen = true;
     return XR_SUCCESS;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -616,6 +616,9 @@ private:
     INT2  m_Resolution = {};
     // NATIVE swapchain/window size: swapchain, HDR display target, every post-tonemap pass, 2D UI, ImGui.
     INT2  m_BackbufferResolution = {};
+    // Resolution zCView::SetMode was last handed. SetMode reflows Gothic's whole view hierarchy, so it may
+    // only run when this actually changes (see OnBeginFrame).
+    INT2  m_AppliedZViewMode = {};
     // Last ResolutionScalePercent the render targets were built for (D3D11's s_oldResolutionScalePercent).
     int   m_AppliedResolutionScalePercent = 100;
     int   m_PendingResolutionScalePercent = 0;   // value currently being waited out (0 = nothing pending)

--- a/D3D11Engine/DLLMain.cpp
+++ b/D3D11Engine/DLLMain.cpp
@@ -271,11 +271,7 @@ extern "C" void WINAPI HookedReleaseDDThreadLock() {
 }
 
 extern "C" float WINAPI UpdateCustomFontMultiplierFontRendering( float multiplier ) {
-    if (Engine::GraphicsEngine->GetBackendAPI() == EGraphicsEngineBackend::D3D11) {
-        D3D11GraphicsEngine* engine = AsD3D11Engine(Engine::GraphicsEngine);
-        return engine ? engine->UpdateCustomFontMultiplierFontRendering( multiplier ) : 1.0f;
-    }
-    return 1.0f;
+    return Engine::GraphicsEngine ? Engine::GraphicsEngine->UpdateCustomFontMultiplierFontRendering( multiplier ) : 1.0f;
 }
 
 extern "C" void WINAPI SetCustomCloudAndNightTexture( int idxTexture, bool isNightTexture ) {


### PR DESCRIPTION
… multiplier. Also call `zCViewDraw::GetScreen().SetVirtualSize( virtualSize );` after changing resolution