### PR TITLE
feat: introduce `Logging:Inf` c++20/23 std::format based logging. fix: unify dx11 and dx12 pointlight shadow tier-selection. Improve low-res tier usage, improve tier-spilling high->low

### DIFF
--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -338,6 +338,9 @@ public:
     /** Draws a VOB (used for inventory) */
     virtual void DrawVobSingle( VobInfo* vob, zCCamera& camera ) {};
 
+    /** Same, for an inventory item whose visual is a skeletal model (skinned meshes + node attachments) */
+    virtual void DrawVobSingle( SkeletalVobInfo* vob, zCCamera& camera ) {};
+
     /** Called when a vob was removed from the world */
     virtual XRESULT OnVobRemovedFromWorld( zCVob* vob ) { return XR_SUCCESS; }
 

--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -345,6 +345,12 @@ public:
         that bake it into a cached shadow (D3D12's static point-light cubes) must drop that cache. */
     virtual void OnVobBecameDynamic( zCVob* vob ) {}
 
+    /** A registered static-mesh vob's transform actually changed (GothicAPI::OnVobMoved, after the move has
+        been applied). A cached shadow that baked it at its old position is now wrong, and a light it has just
+        moved into range of has to pick it up - so a backend that caches must re-bake both. Fires per real
+        move, so anything acting on it should coalesce to at most once per frame. */
+    virtual void OnVobMoved( zCVob* vob ) {}
+
     /** Called from MeshInfo::~MeshInfo(), right before its buffers/CPU vectors are torn down. A MeshInfo can
         be freed independently of any world (re)load - e.g. a shared MeshVisualInfo's last VOB reference
         dropping via SharedVisualRegistry::Release() - so any backend that caches raw MeshInfo* pointers

--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -341,14 +341,13 @@ public:
     /** Called when a vob was removed from the world */
     virtual XRESULT OnVobRemovedFromWorld( zCVob* vob ) { return XR_SUCCESS; }
 
-    /** Gothic promoted this vob out of the BSP into its dynamic/animated list - it started moving. Backends
-        that bake it into a cached shadow (D3D12's static point-light cubes) must drop that cache. */
+    /** Gothic promoted this vob out of the BSP into its dynamic/animated list - it started moving. A
+        backend that baked it into a cached shadow must drop that cache. */
     virtual void OnVobBecameDynamic( zCVob* vob ) {}
 
-    /** A registered static-mesh vob's transform actually changed (GothicAPI::OnVobMoved, after the move has
-        been applied). A cached shadow that baked it at its old position is now wrong, and a light it has just
-        moved into range of has to pick it up - so a backend that caches must re-bake both. Fires per real
-        move, so anything acting on it should coalesce to at most once per frame. */
+    /** A registered static-mesh vob's transform changed, after the move has been applied. Both the cache
+        that baked it at its old position and any light it moved into range of need a re-bake. Fires per
+        real move, so anything acting on it should coalesce to at most once per frame. */
     virtual void OnVobMoved( zCVob* vob ) {}
 
     /** Called from MeshInfo::~MeshInfo(), right before its buffers/CPU vectors are torn down. A MeshInfo can

--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -341,6 +341,10 @@ public:
     /** Called when a vob was removed from the world */
     virtual XRESULT OnVobRemovedFromWorld( zCVob* vob ) { return XR_SUCCESS; }
 
+    /** Gothic promoted this vob out of the BSP into its dynamic/animated list - it started moving. Backends
+        that bake it into a cached shadow (D3D12's static point-light cubes) must drop that cache. */
+    virtual void OnVobBecameDynamic( zCVob* vob ) {}
+
     /** Called from MeshInfo::~MeshInfo(), right before its buffers/CPU vectors are torn down. A MeshInfo can
         be freed independently of any world (re)load - e.g. a shared MeshVisualInfo's last VOB reference
         dropping via SharedVisualRegistry::Release() - so any backend that caches raw MeshInfo* pointers

--- a/D3D11Engine/D3D11Effect.cpp
+++ b/D3D11Engine/D3D11Effect.cpp
@@ -600,7 +600,9 @@ XRESULT D3D11Effect::DrawRainShadowmap() {
     Microsoft::WRL::ComPtr<ID3D11DepthStencilView> oldDSV;
     e->GetContext()->OMGetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.GetAddressOf() );
 
-    e->RenderShadowmaps( p, RainShadowmap.get(), true, false );
+    // No vegetation: grass would cover the ground in the rain map and kill both the raindrops and the
+    // wetness on it (see VS_ParticlePointShaded's IsWet).
+    e->RenderShadowmaps( p, RainShadowmap.get(), true, false, nullptr, nullptr, false );
 
     // Restore old settings
     e->GetContext()->OMSetRenderTargets( 1, oldRTV.GetAddressOf(), oldDSV.Get() );

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1102,6 +1102,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="include\imgui\imstb_truetype.h" />
     <ClInclude Include="InstructionSet.h" />
     <ClInclude Include="Logger.h" />
+    <ClInclude Include="Logging.h" />
     <ClInclude Include="MemoryTracker.h" />
     <ClInclude Include="MeshManager.h" />
     <ClInclude Include="MeshOptimizeCache.h" />
@@ -1921,6 +1922,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClCompile Include="SMAA\D3D11SMAA.cpp" />
     <ClCompile Include="SteamOverlay.cpp" />
     <ClCompile Include="StackWalker.cpp" />
+    <ClCompile Include="Logging.cpp" />
     <ClCompile Include="Toolbox.cpp" />
     <ClCompile Include="VersionCheck.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release_NoOpt|Win32'">NotUsing</PrecompiledHeader>

--- a/D3D11Engine/D3D11Engine.vcxproj
+++ b/D3D11Engine/D3D11Engine.vcxproj
@@ -1120,6 +1120,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     <ClInclude Include="oCVisFX.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="BaseShadowedPointLight.h" />
+    <ClInclude Include="PointLightSlotSelector.h" />
     <ClInclude Include="RenderGraph.h" />
     <ClInclude Include="RenderPass.h" />
     <ClInclude Include="RenderQueue.h" />
@@ -1261,6 +1262,7 @@ copy "$(OutDir)$(TargetName).pdb" "$(G1_SYSTEM_PATH)\ddraw.pdb"</Command>
     </ClCompile>
     <ClCompile Include="D3D11PFX_TAA.cpp" />
     <ClCompile Include="D3D11PointLight.cpp" />
+    <ClCompile Include="PointLightSlotSelector.cpp" />
     <ClCompile Include="D3D11PShader.cpp" />
     <ClCompile Include="D3D11RenderQueue.cpp" />
     <ClCompile Include="D3D11ShaderManager.cpp" />

--- a/D3D11Engine/D3D11Engine.vcxproj.filters
+++ b/D3D11Engine/D3D11Engine.vcxproj.filters
@@ -109,6 +109,9 @@
     <ClInclude Include="Logger.h">
       <Filter>Tools</Filter>
     </ClInclude>
+    <ClInclude Include="Logging.h">
+      <Filter>Tools</Filter>
+    </ClInclude>
     <ClInclude Include="ZenGinTypes.h">
       <Filter>ZenGin</Filter>
     </ClInclude>
@@ -986,6 +989,9 @@
     </ClCompile>
     <ClCompile Include="D3D7\MyDirectDrawSurface7.cpp">
       <Filter>D3D7</Filter>
+    </ClCompile>
+    <ClCompile Include="Logging.cpp">
+      <Filter>Tools</Filter>
     </ClCompile>
     <ClCompile Include="Toolbox.cpp">
       <Filter>Tools</Filter>

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -8879,6 +8879,165 @@ void D3D11GraphicsEngine::DrawVobSingle( VobInfo* vob, zCCamera& camera ) {
     GetContext()->PSSetSamplers( 0, 1, ClampSamplerState.GetAddressOf() );
 }
 
+void D3D11GraphicsEngine::BindPreviewBoneTransforms( const std::vector<XMFLOAT4X4>& transforms ) {
+    const UINT boneCount = std::min<UINT>( static_cast<UINT>(transforms.size()), NUM_MAX_BONES );
+
+    if ( !FeatureLevel10Compatibility
+        && UploadStructuredMatrixBuffer( SkeletalBoneTransformsBufferTransient, transforms, "SkeletalBoneTransformsBufferTransient" )
+        && SkeletalBoneTransformsBufferTransient ) {
+        // Same buffer for both poses - the preview never moves, so a velocity of zero is correct.
+        ActiveVS->BindResource( "BoneTransforms", SkeletalBoneTransformsBufferTransient->GetShaderResourceView().Get() );
+        ActiveVS->BindResource( "PrevBoneTransforms", SkeletalBoneTransformsBufferTransient->GetShaderResourceView().Get() );
+
+        VS_ExConstantBuffer_SkeletalBoneRange range = {};
+        range.BoneCount = boneCount;
+        range.UseStructuredBones = 1u;
+        ActiveVS->UpdateBuffer( "BoneTransformRange", &range, sizeof( range ) );
+        return;
+    }
+
+    auto allocation = AllocateDynamicCB( transforms.data(), sizeof( XMFLOAT4X4 ) * boneCount );
+    BindDynamicCBToVertexShader( ActiveVS->GetInputIndex( "BoneTransforms" ), allocation );
+    BindDynamicCBToVertexShader( ActiveVS->GetInputIndex( "PrevBoneTransforms" ), allocation );
+}
+
+/** Draws a skeletal VOB (used for inventory) */
+void D3D11GraphicsEngine::DrawVobSingle( SkeletalVobInfo* vob, zCCamera& camera ) {
+    if ( !vob || !vob->Vob || !vob->VisualInfo ) return;
+
+    // Still being filled in on a worker thread (GothicAPI::LoadzCModelData) - skip until the meshes are
+    // safe to iterate. The item pops in a frame or two later instead.
+    SkeletalMeshVisualInfo* visualInfo = static_cast<SkeletalMeshVisualInfo*>(vob->VisualInfo);
+    if ( !visualInfo->GetIsReady() ) return;
+
+    zCModel* model = static_cast<zCModel*>(vob->Vob->GetVisual());
+    if ( !model ) return;
+
+    Engine::GAPI->SetViewTransformXM( XMLoadFloat4x4( &camera.GetTransformDX( zCCamera::ETransformType::TT_VIEW ) ) );
+
+    // Important: We NEED a swapchain-sized depth stencil buffer here, otherwise Advanced Inventory VOBs will be rendered without depth testing and thus look very bad.
+    GetContext()->OMSetRenderTargets( 1, Backbuffer->GetRenderTargetView().GetAddressOf(), m_SwapchainDepthStencilBuffer->GetDepthStencilView().Get() );
+
+    Engine::GAPI->GetRendererState().DepthState.SetDefault(); // defaul depth: buffer + write on.
+    Engine::GAPI->GetRendererState().DepthState.SetDirty();
+
+    // Set backface culling
+    Engine::GAPI->GetRendererState().RasterizerState.SetDefault(); // CULL_BACK is default.
+    Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+    GetContext()->PSSetSamplers( 0, 1, DefaultSamplerState.GetAddressOf() );
+    UpdateRenderStates();
+
+    // Into our own buffer, not GetBoneTransforms(): we are inside one of ZenGin's own render callbacks
+    // here, and that overload writes its result into zCModelNodeInst::TrafoObjToCam, which ZenGin keeps
+    // as the *world*-space node cache.
+    static std::vector<XMFLOAT4X4> boneTransforms; // Main thread only, keeps its capacity
+    boneTransforms.clear();
+    model->GetBoneTransformsTo( boneTransforms );
+    if ( boneTransforms.size() > NUM_MAX_BONES )
+        boneTransforms.resize( NUM_MAX_BONES );
+
+    const XMFLOAT4X4 world = *vob->Vob->GetWorldMatrixPtr();
+    const XMMATRIX worldXm = XMLoadFloat4x4( &world );
+
+    // Skinned base meshes - the part the static flatten used to drop entirely.
+    if ( !visualInfo->SkeletalMeshes.empty() && !boneTransforms.empty() ) {
+        SetActivePixelShader( PShaderID::PS_Preview_Textured );
+        SetActiveVertexShader( VShaderID::VS_ExSkeletal );
+
+        SetupVS_ExMeshDrawCall();
+        SetupVS_ExConstantBuffer();
+
+        VS_ExConstantBuffer_PerInstanceSkeletal cb = {};
+        cb.World = world;
+        cb.PrevWorld = world;
+        cb.PI_ModelColor = float4( 1.f, 1.f, 1.f, 1.f );
+        cb.PI_ModelFatness = 0.f;
+        ActiveVS->UpdateBuffer( "Matrices_PerInstances", &cb, sizeof( cb ) );
+
+        BindPreviewBoneTransforms( boneTransforms );
+        ActiveVS->Apply();
+
+        for ( auto const& itm : visualInfo->SkeletalMeshes ) {
+            zCTexture* texture;
+            if ( !itm.first || (texture = itm.first->GetAniTexture()) == nullptr ) continue;
+            if ( texture->CacheIn( 0.6f ) != zRES_CACHED_IN ) continue;
+            texture->Bind( 0 );
+
+            for ( auto const& mesh : itm.second ) {
+                UINT offset = 0;
+                UINT uStride = sizeof( ExSkelVertexStruct );
+                Context->IASetVertexBuffers( 0, 1, D3D11VertexBuffer::From( mesh->MeshVertexBuffer.get() )->GetVertexBuffer().GetAddressOf(), &uStride, &offset );
+                Context->IASetIndexBuffer( D3D11VertexBuffer::From( mesh->MeshIndexBuffer.get() )->GetVertexBuffer().Get(), VERTEX_INDEX_DXGI_FORMAT, 0 );
+                Context->DrawIndexed( static_cast<UINT>(mesh->Indices.size()), 0, 0 );
+
+                Engine::GAPI->GetRendererState().RendererInfo.FrameDrawnTriangles += mesh->Indices.size() / 3;
+            }
+        }
+    }
+
+    // Node attachments (a weapon in a hand, the lid of a chest, ...) - the same visuals the world path
+    // draws through VS_ExNode, just without the instancing.
+    zCArray<zCModelNodeInst*>* nodeList = model->GetNodeList();
+    const int numNodes = nodeList ? std::min<int>( nodeList->NumInArray, static_cast<int>(boneTransforms.size()) ) : 0;
+    if ( numNodes > 0 ) {
+        SetActivePixelShader( PShaderID::PS_Preview_Textured );
+        SetActiveVertexShader( VShaderID::VS_ExNode );
+
+        SetupVS_ExMeshDrawCall();
+        SetupVS_ExConstantBuffer();
+
+        auto& attachments = vob->NodeAttachments;
+        for ( int i = 0; i < numNodes; i++ ) {
+            zCModelNodeInst* node = nodeList->Array[i];
+            if ( !node->NodeVisual ) continue;
+
+            auto attachment = attachments.find( i );
+            // Extract on first sight, and re-extract when the node's visual changed. Gated on
+            // GetIsReady(): the worker writes Visual as it finishes, so comparing any earlier races it.
+            if ( attachment == attachments.end()
+                || (!attachment->second.empty() && attachment->second[0]->GetIsReady()
+                    && node->NodeVisual != attachment->second[0]->Visual) ) {
+                WorldConverter::ExtractNodeVisualAsync( i, node, attachments );
+                attachment = attachments.find( i );
+            }
+            if ( attachment == attachments.end() ) continue;
+
+            VS_ExConstantBuffer_PerInstanceNode cb = {};
+            XMStoreFloat4x4( &cb.World, worldXm * XMLoadFloat4x4( &boneTransforms[i] ) );
+            cb.PrevWorld = cb.World;
+            cb.Color = float4( 1.f, 1.f, 1.f, 1.f );
+            cb.Fatness = 0.f;
+            cb.Scaling = 1.f;
+
+            for ( MeshVisualInfo* mvi : attachment->second ) {
+                // Still being extracted on a worker thread - skip it for this frame rather than race it.
+                if ( !mvi->GetIsReady() || !mvi->Visual ) continue;
+
+                ActiveVS->UpdateBuffer( "Matrices_PerInstances", &cb, sizeof( cb ) );
+                ActiveVS->Apply();
+
+                for ( auto const& itm : mvi->Meshes ) {
+                    zCTexture* texture;
+                    if ( !itm.first || (texture = itm.first->GetAniTexture()) == nullptr ) continue;
+                    if ( texture->CacheIn( 0.6f ) != zRES_CACHED_IN ) continue;
+                    texture->Bind( 0 );
+
+                    for ( auto const& mesh : itm.second ) {
+                        DrawVertexBufferIndexed( mesh->GetMeshVertexBuffer(), mesh->GetMeshIndexBuffer(), mesh->Indices.size() );
+                    }
+                }
+            }
+        }
+    }
+
+    GetContext()->OMSetRenderTargets( 1, Backbuffer->GetRenderTargetView().GetAddressOf(), nullptr );
+
+    // Disable culling again
+    Engine::GAPI->GetRendererState().RasterizerState.CullMode = GothicRasterizerStateInfo::CM_CULL_NONE;
+    Engine::GAPI->GetRendererState().RasterizerState.SetDirty();
+    GetContext()->PSSetSamplers( 0, 1, ClampSamplerState.GetAddressOf() );
+}
+
 /** Returns the data of the backbuffer */
 void D3D11GraphicsEngine::GetBackbufferData( bool thumbnail, byte** data, INT2& buffersize, int& pixelsize ) {
     if ( thumbnail ) {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -7361,7 +7361,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
     }
 
     if ( renderState.RendererSettings.DrawVOBs
-        && isCloseCascade ) {
+        && isCloseCascade && params.DrawVegetation ) {
         ZoneScopedN( "Shadows::DrawVegetation" );
         auto _1 = RecordGraphicsEvent( GE_NAME( "Shadows::DrawVegetation" ) );
 
@@ -8780,9 +8780,11 @@ void XM_CALLCONV D3D11GraphicsEngine::RenderShadowmaps( FXMVECTOR cameraPosition
     RenderToDepthStencilBuffer* target,
     bool cullFront, bool dontCull,
     Microsoft::WRL::ComPtr<ID3D11DepthStencilView> dsvOverwrite,
-    Microsoft::WRL::ComPtr<ID3D11RenderTargetView> debugRTV ) {
+    Microsoft::WRL::ComPtr<ID3D11RenderTargetView> debugRTV,
+    bool drawVegetation ) {
 
     RenderShadowmapsParams renderParams = {};
+    renderParams.DrawVegetation = drawVegetation;
     XMStoreFloat3( &renderParams.CameraPosition, cameraPosition );
     renderParams.Target = target;
     renderParams.CullFront = cullFront;

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -9916,6 +9916,16 @@ void D3D11GraphicsEngine::DrawFrameParticles(
 XRESULT D3D11GraphicsEngine::OnVobRemovedFromWorld( zCVob* vob ) {
     if ( Engine::ImGuiHandle ) Engine::ImGuiHandle->OnVobRemovedFromWorld( vob );
 
+    if ( ShadowMaps ) {
+        // A vob leaving the world must stop casting into every cached static cube that baked it. Matched by
+        // POINTER against each slot's caster set - the object is on its way out, so nothing about its bbox or
+        // position can be trusted here any more.
+        ShadowMaps->GetPointSlots().InvalidateStaticForVobRemoved( vob );
+        // ...and if the vob IS a light, its slot goes back to the pool. Keyed on the pointer for the same
+        // reason: its VobLightInfo may already be half torn down.
+        ShadowMaps->ReleasePointLightSlotFor( vob );
+    }
+
     // Take out of shadowupdate queue
     for ( auto it = FrameShadowUpdateLights.begin(); it != FrameShadowUpdateLights.end(); ++it ) {
         if ( (*it)->Vob == vob ) {
@@ -9937,6 +9947,34 @@ XRESULT D3D11GraphicsEngine::OnVobRemovedFromWorld( zCVob* vob ) {
 
     return XR_SUCCESS;
 }
+
+void D3D11GraphicsEngine::OnAddVob( VobInfo* vi ) {
+    // A VOB added after a nearby point light already cached its static shadow cube would otherwise cast no
+    // point-light shadow at all: that cube is only re-rendered when the light is fresh / moved / resized, not
+    // when the world around it changes. PARKED rather than applied here - at this point Gothic has often not
+    // placed the vob yet (a dropped item is inserted where it came from and moved to where it lands
+    // afterwards) and its parent link can still be the NPC letting go of it, which are exactly the two things
+    // the decision reads. Resolved a frame later, once both have settled.
+    if ( ShadowMaps && vi && vi->Vob && vi->VisualInfo )
+        ShadowMaps->GetPointSlots().QueueVobChangedInvalidation( vi->Vob );
+}
+
+
+void D3D11GraphicsEngine::OnVobBecameDynamic( zCVob* vob ) {
+    // Gothic just promoted this vob out of the BSP into its dynamic/animated list, i.e. it started moving (a
+    // door swinging open, a chest lid). Anything baked into a cached static cube has to come back out - the
+    // animated pass draws it from now on.
+    if ( ShadowMaps ) ShadowMaps->GetPointSlots().InvalidateStaticForVobRemoved( vob );
+}
+
+
+void D3D11GraphicsEngine::OnVobMoved( zCVob* vob ) {
+    // A vob baked into a cached static cube at its old position leaves a shadow behind; one that just moved
+    // into a light's reach is missing from that light's cube. Queued rather than resolved here because a
+    // falling or thrown item moves several times per frame and its position is only final once it stops.
+    if ( ShadowMaps ) ShadowMaps->GetPointSlots().QueueVobChangedInvalidation( vob );
+}
+
 
 /** Updates the occlusion for the bsp-tree */
 void D3D11GraphicsEngine::UpdateOcclusion() {

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -5815,9 +5815,8 @@ void D3D11GraphicsEngine::DrawWaterSurfaces() {
 }
 
 namespace {
-    /** True if this vob rides an NPC's transform - a held item, a torch, an attached effect. Such a caster
-        moves with the animation every frame, so it must never enter a point light's cached static caster
-        set (D3D11PointLight::VobCache); the animated pass draws it instead. */
+    /** True if this vob rides an NPC's transform. It moves every frame, so it must never enter a point
+        light's cached caster set (D3D11PointLight::VobCache) - the animated pass draws it instead. */
     bool IsAttachedToNpc( const zCVob* vob ) {
         for ( const zCVob* v = vob; v; v = v->GetVobParent() ) {
             if ( v->GetVobType() == zVOB_TYPE_NSC ) return true;
@@ -5825,15 +5824,15 @@ namespace {
         return false;
     }
 
-    /** Same idea for MOB casters: anything ZenGin already promoted to the animated list moves, and the
-        animated pass redraws it anyway. Only ever called while (re)building a light's caster cache. */
+    /** Same idea for MOB casters: anything ZenGin promoted to the animated list moves, and the animated
+        pass redraws it anyway. */
     bool IsAnimatedShadowCaster( const SkeletalVobInfo* vob ) {
         if ( IsAttachedToNpc( vob->Vob ) ) return true;
         return std::ranges::contains( Engine::GAPI->GetAnimatedSkeletalMeshVobs(), vob );
     }
 
     /** True while this .MMS visual has a live morph channel, i.e. its vertex buffer is re-deformed every
-        frame (windmill sails, water wheels). Idle .MMS decoration answers false. */
+        frame. Idle .MMS decoration answers false. */
     bool IsMorphAnimating( MeshVisualInfo* visual ) {
         if ( !visual->MorphMeshVisual ) return false;
         return reinterpret_cast<zCMorphMesh*>(visual->MorphMeshVisual)->GetNumAniChannels() > 0;
@@ -6045,9 +6044,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                         continue;  // Seems to happen in Gothic 1
                     }
 
-                    // Rides an NPC (held item, torch, effect) - the animated pass owns it. Caching it here
-                    // is also what let a smoking/eating NPC's throwaway item invalidate every nearby light's
-                    // static cube the moment it despawned.
+                    // Rides an NPC - the animated pass owns it, and caching it here let a throwaway held
+                    // item invalidate every nearby light's static cube when it despawned.
                     if ( IsAttachedToNpc( it->Vob ) ) {
                         continue;
                     }
@@ -6416,9 +6414,8 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
                         continue;  // Seems to happen in Gothic 1
                     }
 
-                    // Rides an NPC (held item, torch, effect) - the animated pass owns it. Caching it here
-                    // is also what let a smoking/eating NPC's throwaway item invalidate every nearby light's
-                    // static cube the moment it despawned.
+                    // Rides an NPC - the animated pass owns it, and caching it here let a throwaway held
+                    // item invalidate every nearby light's static cube when it despawned.
                     if ( IsAttachedToNpc( it->Vob ) ) {
                         continue;
                     }
@@ -7113,8 +7110,7 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
         }
 
         // Morph-mesh casters are deformed per frame, so a cascade holding one can't be frozen by
-        // LazyCascadeUpdate, and the deform has to run even for a vob only the shadow pass sees (the main
-        // pass doesn't reach it, and UpdateMorphMeshVisual is frame-idempotent so doing it twice is free).
+        // LazyCascadeUpdate. UpdateMorphMeshVisual is frame-idempotent, so running it here too is free.
         bool hasAnimatedCaster = false;
         if ( renderState.RendererSettings.AnimateStaticVobs ) {
             for ( MeshVisualInfo* visual : activeVisuals ) {
@@ -9917,12 +9913,8 @@ XRESULT D3D11GraphicsEngine::OnVobRemovedFromWorld( zCVob* vob ) {
     if ( Engine::ImGuiHandle ) Engine::ImGuiHandle->OnVobRemovedFromWorld( vob );
 
     if ( ShadowMaps ) {
-        // A vob leaving the world must stop casting into every cached static cube that baked it. Matched by
-        // POINTER against each slot's caster set - the object is on its way out, so nothing about its bbox or
-        // position can be trusted here any more.
+        // Both are matched by POINTER: the object is on its way out, so nothing about it can be read here.
         ShadowMaps->GetPointSlots().InvalidateStaticForVobRemoved( vob );
-        // ...and if the vob IS a light, its slot goes back to the pool. Keyed on the pointer for the same
-        // reason: its VobLightInfo may already be half torn down.
         ShadowMaps->ReleasePointLightSlotFor( vob );
     }
 
@@ -9949,29 +9941,24 @@ XRESULT D3D11GraphicsEngine::OnVobRemovedFromWorld( zCVob* vob ) {
 }
 
 void D3D11GraphicsEngine::OnAddVob( VobInfo* vi ) {
-    // A VOB added after a nearby point light already cached its static shadow cube would otherwise cast no
-    // point-light shadow at all: that cube is only re-rendered when the light is fresh / moved / resized, not
-    // when the world around it changes. PARKED rather than applied here - at this point Gothic has often not
-    // placed the vob yet (a dropped item is inserted where it came from and moved to where it lands
-    // afterwards) and its parent link can still be the NPC letting go of it, which are exactly the two things
-    // the decision reads. Resolved a frame later, once both have settled.
+    // A cached static cube is only re-rendered when its light is fresh / moved / resized, so a new VOB in
+    // range has to say so. Parked rather than applied here: Gothic has often not placed the vob yet and its
+    // parent link can still be the NPC letting go of it, which are the two things the decision reads.
     if ( ShadowMaps && vi && vi->Vob && vi->VisualInfo )
         ShadowMaps->GetPointSlots().QueueVobChangedInvalidation( vi->Vob );
 }
 
 
 void D3D11GraphicsEngine::OnVobBecameDynamic( zCVob* vob ) {
-    // Gothic just promoted this vob out of the BSP into its dynamic/animated list, i.e. it started moving (a
-    // door swinging open, a chest lid). Anything baked into a cached static cube has to come back out - the
-    // animated pass draws it from now on.
+    // It started moving (a door swinging open, a chest lid), so anything that baked it into a static cube
+    // has to let go - the animated pass draws it from now on.
     if ( ShadowMaps ) ShadowMaps->GetPointSlots().InvalidateStaticForVobRemoved( vob );
 }
 
 
 void D3D11GraphicsEngine::OnVobMoved( zCVob* vob ) {
-    // A vob baked into a cached static cube at its old position leaves a shadow behind; one that just moved
-    // into a light's reach is missing from that light's cube. Queued rather than resolved here because a
-    // falling or thrown item moves several times per frame and its position is only final once it stops.
+    // A vob baked at its old position leaves a shadow behind, and one that moved into a light's reach is
+    // missing from its cube. Queued because a falling item moves several times before coming to rest.
     if ( ShadowMaps ) ShadowMaps->GetPointSlots().QueueVobChangedInvalidation( vob );
 }
 

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -5814,6 +5814,32 @@ void D3D11GraphicsEngine::DrawWaterSurfaces() {
         DepthStencilBuffer->GetDepthStencilView().Get() );
 }
 
+namespace {
+    /** True if this vob rides an NPC's transform - a held item, a torch, an attached effect. Such a caster
+        moves with the animation every frame, so it must never enter a point light's cached static caster
+        set (D3D11PointLight::VobCache); the animated pass draws it instead. */
+    bool IsAttachedToNpc( const zCVob* vob ) {
+        for ( const zCVob* v = vob; v; v = v->GetVobParent() ) {
+            if ( v->GetVobType() == zVOB_TYPE_NSC ) return true;
+        }
+        return false;
+    }
+
+    /** Same idea for MOB casters: anything ZenGin already promoted to the animated list moves, and the
+        animated pass redraws it anyway. Only ever called while (re)building a light's caster cache. */
+    bool IsAnimatedShadowCaster( const SkeletalVobInfo* vob ) {
+        if ( IsAttachedToNpc( vob->Vob ) ) return true;
+        return std::ranges::contains( Engine::GAPI->GetAnimatedSkeletalMeshVobs(), vob );
+    }
+
+    /** True while this .MMS visual has a live morph channel, i.e. its vertex buffer is re-deformed every
+        frame (windmill sails, water wheels). Idle .MMS decoration answers false. */
+    bool IsMorphAnimating( MeshVisualInfo* visual ) {
+        if ( !visual->MorphMeshVisual ) return false;
+        return reinterpret_cast<zCMorphMesh*>(visual->MorphMeshVisual)->GetNumAniChannels() > 0;
+    }
+}
+
 /** Draws everything around the given position */
 void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
     FXMVECTOR position, float range, bool cullFront, bool indoor,
@@ -6019,6 +6045,13 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
                         continue;  // Seems to happen in Gothic 1
                     }
 
+                    // Rides an NPC (held item, torch, effect) - the animated pass owns it. Caching it here
+                    // is also what let a smoking/eating NPC's throwaway item invalidate every nearby light's
+                    // static cube the moment it despawned.
+                    if ( IsAttachedToNpc( it->Vob ) ) {
+                        continue;
+                    }
+
                     if ( !it->Vob->GetShowVisual() ) {
                         continue;
                     }
@@ -6104,6 +6137,11 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround(
             for ( auto it : Engine::GAPI->GetSkeletalMeshVobs() ) {
                 if ( !it->VisualInfo ) {
                     continue;  // Seems to happen in Gothic 1
+                }
+
+                // Animated or NPC-attached MOBs belong to the animated pass - see IsAnimatedShadowCaster.
+                if ( IsAnimatedShadowCaster( it ) ) {
+                    continue;
                 }
 
                 if ( !it->Vob->GetShowVisual() ) {
@@ -6378,6 +6416,13 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
                         continue;  // Seems to happen in Gothic 1
                     }
 
+                    // Rides an NPC (held item, torch, effect) - the animated pass owns it. Caching it here
+                    // is also what let a smoking/eating NPC's throwaway item invalidate every nearby light's
+                    // static cube the moment it despawned.
+                    if ( IsAttachedToNpc( it->Vob ) ) {
+                        continue;
+                    }
+
                     if ( !it->Vob->GetShowVisual() ) {
                         continue;
                     }
@@ -6468,6 +6513,11 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAround_Layered(
             for ( auto it : Engine::GAPI->GetSkeletalMeshVobs() ) {
                 if ( !it->VisualInfo ) {
                     continue;  // Seems to happen in Gothic 1
+                }
+
+                // Animated or NPC-attached MOBs belong to the animated pass - see IsAnimatedShadowCaster.
+                if ( IsAnimatedShadowCaster( it ) ) {
+                    continue;
                 }
 
                 if ( !it->Vob->GetShowVisual() ) {
@@ -7061,6 +7111,19 @@ void XM_CALLCONV D3D11GraphicsEngine::DrawWorldAroundForWorldShadow( FXMVECTOR p
                 activeVisuals.push_back( pair.second );
             }
         }
+
+        // Morph-mesh casters are deformed per frame, so a cascade holding one can't be frozen by
+        // LazyCascadeUpdate, and the deform has to run even for a vob only the shadow pass sees (the main
+        // pass doesn't reach it, and UpdateMorphMeshVisual is frame-idempotent so doing it twice is free).
+        bool hasAnimatedCaster = false;
+        if ( renderState.RendererSettings.AnimateStaticVobs ) {
+            for ( MeshVisualInfo* visual : activeVisuals ) {
+                if ( !IsMorphAnimating( visual ) ) continue;
+                hasAnimatedCaster = true;
+                WorldConverter::UpdateMorphMeshVisual( visual->MorphMeshVisual, visual );
+            }
+        }
+        if ( ShadowMaps ) ShadowMaps->NoteCascadeAnimatedCasters( params.CascadeIndex, hasAnimatedCaster );
 
         // Apply instancing shader early so metadata indexing can be prepared before instance upload.
         SetActiveVertexShader( VShaderID::VS_ExInstancedObj );

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -312,7 +312,7 @@ public:
     bool IsVelocityBufferInUse() const;
 
     /** Renders the shadowmaps for the sun */
-    void XM_CALLCONV RenderShadowmaps( FXMVECTOR cameraPosition, RenderToDepthStencilBuffer* target = nullptr, bool cullFront = true, bool dontCull = false, Microsoft::WRL::ComPtr<ID3D11DepthStencilView> dsvOverwrite = nullptr, Microsoft::WRL::ComPtr<ID3D11RenderTargetView> debugRTV = nullptr );
+    void XM_CALLCONV RenderShadowmaps( FXMVECTOR cameraPosition, RenderToDepthStencilBuffer* target = nullptr, bool cullFront = true, bool dontCull = false, Microsoft::WRL::ComPtr<ID3D11DepthStencilView> dsvOverwrite = nullptr, Microsoft::WRL::ComPtr<ID3D11RenderTargetView> debugRTV = nullptr, bool drawVegetation = true );
 
     /** Renders the shadowmaps for a pointlight */
     void XM_CALLCONV RenderShadowCube( FXMVECTOR position,

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -186,6 +186,14 @@ public:
     /** Called when a vob was removed from the world */
     XRESULT OnVobRemovedFromWorld( zCVob* vob ) override;
 
+    // World changes that can invalidate a point light's CACHED static shadow cube. The cube is only
+    // re-rendered when the light itself is fresh / moved / resized, never when the geometry around it
+    // changes, so a vob appearing, moving, or starting to move has to say so. All three resolve through the
+    // shared PointLightSlotSelector, exactly as the D3D12 backend does.
+    void OnAddVob( VobInfo* vi ) override;
+    void OnVobBecameDynamic( zCVob* vob ) override;
+    void OnVobMoved( zCVob* vob ) override;
+
     /** Called when a key got pressed */
     XRESULT OnKeyDown( unsigned int key ) override;
 

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -263,6 +263,11 @@ public:
 
     /** Draws a VOB (used for inventory) */
     void DrawVobSingle( VobInfo* vob, zCCamera& camera ) override;
+    void DrawVobSingle( SkeletalVobInfo* vob, zCCamera& camera ) override;
+
+    /** Binds 'transforms' as both the current and the previous bone palette of the active skeletal VS.
+        Preview-only: an inventory item has no motion history to reproject against. */
+    void BindPreviewBoneTransforms( const std::vector<XMFLOAT4X4>& transforms );
 
     /** Draws everything around the given position */
     void ShadowPass_DrawWorldMesh_Indirect( const std::vector<WorldMeshSectionInfo*>& visibleSections, const Frustum* cullingFrustum = nullptr );

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -186,10 +186,8 @@ public:
     /** Called when a vob was removed from the world */
     XRESULT OnVobRemovedFromWorld( zCVob* vob ) override;
 
-    // World changes that can invalidate a point light's CACHED static shadow cube. The cube is only
-    // re-rendered when the light itself is fresh / moved / resized, never when the geometry around it
-    // changes, so a vob appearing, moving, or starting to move has to say so. All three resolve through the
-    // shared PointLightSlotSelector, exactly as the D3D12 backend does.
+    // World changes that can invalidate a point light's cached static shadow cube; all three resolve
+    // through the shared PointLightSlotSelector, exactly as the D3D12 backend does.
     void OnAddVob( VobInfo* vi ) override;
     void OnVobBecameDynamic( zCVob* vob ) override;
     void OnVobMoved( zCVob* vob ) override;

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -147,11 +147,31 @@ void D3D11PointLight::ReleaseShadowMap() {
 
 }
 
-void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner, bool lowRes ) {
+int D3D11PointLight::GetGlobalTiledSlot() const {
+    if ( m_TiledSlotIndex < 0 ) return -1;
+    return m_TiledSlotLowRes ? static_cast<int>(MAX_SHADOW_CUBEMAPS) + m_TiledSlotIndex : m_TiledSlotIndex;
+}
+
+void D3D11PointLight::CommitStaticBakeToSlot() {
+    const int global = GetGlobalTiledSlot();
+    if ( !m_SlotSel || global < 0 ) return;
+    m_SlotSel->CommitStatic( static_cast<uint32_t>(global) );
+    // The caster set this bake actually covered, so a vob later removed (or moved off its old spot) can be
+    // matched against it by pointer. VobCache/SkeletalVobCache are the same lists RenderShadowCube just
+    // filled/reused, so this is a copy of what went into the cube, not a second cull.
+    auto& baked = m_SlotSel->SlotAt( static_cast<uint32_t>(global) ).bakedVobs;
+    baked.clear();
+    for ( const VobInfo* v : VobCache ) if ( v && v->Vob ) baked.push_back( v->Vob );
+    for ( const SkeletalVobInfo* v : SkeletalVobCache ) if ( v && v->Vob ) baked.push_back( v->Vob );
+}
+
+void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner,
+    bool lowRes, PointLightSlotSelector* sel ) {
     m_TiledSlotIndex = slot;
     m_TiledSlotLowRes = lowRes;
     m_TiledDepthTarget = target;
     m_TiledOwner = owner;
+    m_SlotSel = sel;
 
     StartReInit();
     DrawnOnce = false;
@@ -161,20 +181,20 @@ void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target
 }
 
 void D3D11PointLight::ClearTiledSlot() {
-    if ( m_TiledSlotIndex >= 0 && m_TiledOwner ) {
-        if ( m_TiledSlotLowRes ) {
-            m_TiledOwner->FreeStaticSlot( m_TiledSlotIndex );
-        } else {
-            m_TiledOwner->FreeSlot( m_TiledSlotIndex );
-        }
-    }
+    // No free-list to give the slot back to: the shared PointLightSlotSelector owns who holds what, and this
+    // only lets go of the light's end of that (it is called BECAUSE the selector reassigned the slot).
+    m_SlotHasOwnDepth = false;
+    DropStaticBake();   // before dropping m_SlotSel, so the slot table stays the single invalidation counter
+    m_HasDynamicOverlay = false;
     m_TiledSlotIndex = -1;
     m_TiledSlotLowRes = false;
     m_TiledDepthTarget = nullptr;
     m_TiledOwner = nullptr;
-    m_SlotHasOwnDepth = false;
-    DropStaticBake();
-    m_HasDynamicOverlay = false;
+    m_SlotSel = nullptr;
+}
+
+bool D3D11PointLight::RestrictsCastersToWorld() const {
+    return !AllowsDynamicCasters( LightInfo );
 }
 
 int D3D11PointLight::GetCurrentShadowMode() const {
@@ -596,6 +616,7 @@ void D3D11PointLight::RenderFullCubemap() {
     if ( !m_StaticShadowReady && shadowMode == GothicRendererSettings::PLS_STATIC_ONLY ) {
         RenderStaticShadowPass( *activeTarget, true );
         m_StaticShadowReady = true;
+        CommitStaticBakeToSlot();
         return;
     }
 
@@ -617,6 +638,7 @@ void D3D11PointLight::RenderFullCubemap() {
                 if ( !m_StaticShadowReady ) {
                     RenderStaticShadowPass( *activeTarget, true );
                     m_StaticShadowReady = true;
+                    CommitStaticBakeToSlot();
                 }
 
                 // A world-mesh-only light (see RenderStaticShadowPass) has nothing animated to put in the
@@ -640,6 +662,7 @@ void D3D11PointLight::RenderFullCubemap() {
             if ( m_StaticDepthCubemap ) {
                 RenderStaticShadowPass( *m_StaticDepthCubemap, true );
                 m_StaticShadowReady = true;
+                CommitStaticBakeToSlot();
             } else {
                 // No aside buffer, we can't cache the static shadows.
                 RenderStaticShadowPass( *activeTarget, true );
@@ -699,7 +722,10 @@ bool D3D11PointLight::IsReady()
 }
 
 void D3D11PointLight::DropStaticBake() {
-    if ( m_StaticShadowReady ) {
+    // Counted only on the LEGACY path. In the tiled one the shared slot table is the single counter for every
+    // reason a bake dies (slot handover, retention, a world change), and every drop here is downstream of one
+    // it has already noted - counting both would simply double the number.
+    if ( m_StaticShadowReady && !m_SlotSel ) {
         Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
     }
     m_StaticShadowReady = false;

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -184,6 +184,7 @@ void D3D11PointLight::ClearTiledSlot() {
     // No free-list to give the slot back to: the shared PointLightSlotSelector owns who holds what, and this
     // only lets go of the light's end of that (it is called BECAUSE the selector reassigned the slot).
     m_SlotHasOwnDepth = false;
+    m_FallbackSlotIndex = -1;
     DropStaticBake();   // before dropping m_SlotSel, so the slot table stays the single invalidation counter
     m_HasDynamicOverlay = false;
     m_TiledSlotIndex = -1;
@@ -595,6 +596,7 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate ) {
     LightInfo->LastRenderedPosition = vobPos;
     DrawnOnce = true;
     m_SlotHasOwnDepth = true;   // the target now holds this light's depth - see HasOwnDepthInSlot()
+    m_FallbackSlotIndex = -1;   // handover complete: the new slot is the one to sample from here on
 }
 
 /** Renders all cubemap faces at once, using the geometry shader */

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -142,6 +142,7 @@ void D3D11PointLight::ReleaseShadowMap() {
     ReleaseStaticAsideShadowMap();
     m_CurrentResolution = 0;
     DrawnOnce = false;
+    m_SlotHasOwnDepth = false;
     m_HasDynamicOverlay = false;
 
 }
@@ -154,6 +155,7 @@ void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target
 
     StartReInit();
     DrawnOnce = false;
+    m_SlotHasOwnDepth = false;   // brand new slot: it holds the previous occupant's depth until we render
     DropStaticBake();
     m_HasDynamicOverlay = false;
 }
@@ -170,6 +172,7 @@ void D3D11PointLight::ClearTiledSlot() {
     m_TiledSlotLowRes = false;
     m_TiledDepthTarget = nullptr;
     m_TiledOwner = nullptr;
+    m_SlotHasOwnDepth = false;
     DropStaticBake();
     m_HasDynamicOverlay = false;
 }
@@ -571,6 +574,7 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate ) {
     // regardless of whether a render actually happened, so it was not trustworthy debug signal.
     LightInfo->LastRenderedPosition = vobPos;
     DrawnOnce = true;
+    m_SlotHasOwnDepth = true;   // the target now holds this light's depth - see HasOwnDepthInSlot()
 }
 
 /** Renders all cubemap faces at once, using the geometry shader */

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -156,9 +156,8 @@ void D3D11PointLight::CommitStaticBakeToSlot() {
     const int global = GetGlobalTiledSlot();
     if ( !m_SlotSel || global < 0 ) return;
     m_SlotSel->CommitStatic( static_cast<uint32_t>(global) );
-    // The caster set this bake actually covered, so a vob later removed (or moved off its old spot) can be
-    // matched against it by pointer. VobCache/SkeletalVobCache are the same lists RenderShadowCube just
-    // filled/reused, so this is a copy of what went into the cube, not a second cull.
+    // The caster set this bake covered, so a vob later removed or moved can be matched against it by
+    // pointer. These are the lists the render just used, so this is a copy rather than a second cull.
     auto& baked = m_SlotSel->SlotAt( static_cast<uint32_t>(global) ).bakedVobs;
     baked.clear();
     for ( const VobInfo* v : VobCache ) if ( v && v->Vob ) baked.push_back( v->Vob );
@@ -175,17 +174,17 @@ void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target
 
     StartReInit();
     DrawnOnce = false;
-    m_SlotHasOwnDepth = false;   // brand new slot: it holds the previous occupant's depth until we render
+    m_SlotHasOwnDepth = false;   // a new slot holds the previous occupant's depth until we render
     DropStaticBake();
     m_HasDynamicOverlay = false;
 }
 
 void D3D11PointLight::ClearTiledSlot() {
-    // No free-list to give the slot back to: the shared PointLightSlotSelector owns who holds what, and this
-    // only lets go of the light's end of that (it is called BECAUSE the selector reassigned the slot).
+    // No free list to give the slot back to: the selector owns who holds what, and this only lets go of
+    // the light's end of it (it is called BECAUSE the selector reassigned the slot).
     m_SlotHasOwnDepth = false;
     m_FallbackSlotIndex = -1;
-    DropStaticBake();   // before dropping m_SlotSel, so the slot table stays the single invalidation counter
+    DropStaticBake();   // before m_SlotSel goes, so the slot table stays the single invalidation counter
     m_HasDynamicOverlay = false;
     m_TiledSlotIndex = -1;
     m_TiledSlotLowRes = false;
@@ -199,10 +198,8 @@ bool D3D11PointLight::RestrictsCastersToWorld() const {
 }
 
 int D3D11PointLight::GetCurrentShadowMode() const {
-    // A light SPILLED into the low-res tier (the full-res pool was full - see DrawPointlightShadows) renders
-    // and samples as STATIC_ONLY whatever it would otherwise be: that array has no dynamic-overlay twin, so
-    // there is nowhere to put moving casters for it. It keeps asking for the full-res tier through
-    // GetPreferredShadowMode() and is promoted back the moment a slot can be had.
+    // A light spilled into the low-res tier renders and samples as STATIC_ONLY whatever it would otherwise
+    // be - that array has no dynamic-overlay twin. GetPreferredShadowMode() keeps asking for full-res.
     if ( m_TiledSlotLowRes ) {
         return GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY;
     }
@@ -224,10 +221,8 @@ int D3D11PointLight::GetPreferredShadowMode() const {
 }
 
 namespace {
-    /** True if this vob rides an NPC's transform - a held item, a torch, an attached effect. Such a light moves
-        with the animation, so it is never treated as a fixture however long it happens to stand still: an idle
-        NPC's torch would otherwise flip tier every time they set off walking again. Mirrors D3D12PointShadows::
-        IsNpcAttached and D3D11GraphicsEngine's IsAttachedToNpc. */
+    /** True if this vob rides an NPC's transform. Such a light is never treated as a fixture however long
+        it stands still, or an idle NPC's torch would flip tier every time they set off walking again. */
     bool LightRidesNpc( const zCVob* vob ) {
         for ( const zCVob* v = vob; v; v = v->GetVobParent() ) {
             if ( v->GetVobType() == zVOB_TYPE_NSC ) return true;
@@ -596,7 +591,7 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate ) {
     LightInfo->LastRenderedPosition = vobPos;
     DrawnOnce = true;
     m_SlotHasOwnDepth = true;   // the target now holds this light's depth - see HasOwnDepthInSlot()
-    m_FallbackSlotIndex = -1;   // handover complete: the new slot is the one to sample from here on
+    m_FallbackSlotIndex = -1;   // handover complete
 }
 
 /** Renders all cubemap faces at once, using the geometry shader */
@@ -724,9 +719,8 @@ bool D3D11PointLight::IsReady()
 }
 
 void D3D11PointLight::DropStaticBake() {
-    // Counted only on the LEGACY path. In the tiled one the shared slot table is the single counter for every
-    // reason a bake dies (slot handover, retention, a world change), and every drop here is downstream of one
-    // it has already noted - counting both would simply double the number.
+    // Counted only on the legacy path: in the tiled one the slot table is the single counter, and every
+    // drop here is downstream of one it has already noted.
     if ( m_StaticShadowReady && !m_SlotSel ) {
         Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
     }

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -175,6 +175,17 @@ void D3D11PointLight::ClearTiledSlot() {
 }
 
 int D3D11PointLight::GetCurrentShadowMode() const {
+    // A light SPILLED into the low-res tier (the full-res pool was full - see DrawPointlightShadows) renders
+    // and samples as STATIC_ONLY whatever it would otherwise be: that array has no dynamic-overlay twin, so
+    // there is nowhere to put moving casters for it. It keeps asking for the full-res tier through
+    // GetPreferredShadowMode() and is promoted back the moment a slot can be had.
+    if ( m_TiledSlotLowRes ) {
+        return GothicRendererSettings::EPointLightShadowMode::PLS_STATIC_ONLY;
+    }
+    return GetPreferredShadowMode();
+}
+
+int D3D11PointLight::GetPreferredShadowMode() const {
     auto mode = static_cast<int>(Engine::GAPI->GetRendererState().RendererSettings.EnablePointlightShadows);
     // Only PLS_UPDATE_DYNAMIC downgrades a static-flagged light to PLS_STATIC_ONLY; PLS_FULL must stay FULL
     // (it's the no-caching-shortcuts escape hatch, and downgrading it would make it never re-render). Skipped
@@ -186,6 +197,40 @@ int D3D11PointLight::GetCurrentShadowMode() const {
         }
     }
     return mode;
+}
+
+namespace {
+    /** True if this vob rides an NPC's transform - a held item, a torch, an attached effect. Such a light moves
+        with the animation, so it is never treated as a fixture however long it happens to stand still: an idle
+        NPC's torch would otherwise flip tier every time they set off walking again. Mirrors D3D12PointShadows::
+        IsNpcAttached and D3D11GraphicsEngine's IsAttachedToNpc. */
+    bool LightRidesNpc( const zCVob* vob ) {
+        for ( const zCVob* v = vob; v; v = v->GetVobParent() ) {
+            if ( v->GetVobType() == zVOB_TYPE_NSC ) return true;
+        }
+        return false;
+    }
+    constexpr float kStationaryEps = 1.0f;   // world units; below this a light is jittering, not moving
+    constexpr int   kStationaryFrames = 60;  // ~1 s of holding still before a light counts as a fixture
+}
+
+void D3D11PointLight::NoteStationary() {
+    if ( !LightInfo || !LightInfo->Vob ) return;
+    const XMFLOAT3 pos = LightInfo->Vob->GetPositionWorld();
+    if ( std::fabs( pos.x - m_StationaryPos.x ) > kStationaryEps
+        || std::fabs( pos.y - m_StationaryPos.y ) > kStationaryEps
+        || std::fabs( pos.z - m_StationaryPos.z ) > kStationaryEps ) {
+        m_StationaryPos = pos;
+        m_StationaryFrames = 0;
+    } else if ( m_StationaryFrames < kStationaryFrames ) {
+        ++m_StationaryFrames;
+    }
+}
+
+bool D3D11PointLight::IsSpatiallyStatic() const {
+    if ( LightInfo && LightInfo->IsStaticVobLight ) return true;
+    if ( !LightInfo || !LightInfo->Vob || LightRidesNpc( LightInfo->Vob ) ) return false;
+    return m_StationaryFrames >= kStationaryFrames;
 }
 
 void D3D11PointLight::HandleShadowModeChange( int shadowMode ) {

--- a/D3D11Engine/D3D11PointLight.cpp
+++ b/D3D11Engine/D3D11PointLight.cpp
@@ -154,7 +154,7 @@ void D3D11PointLight::SetTiledSlot( int slot, RenderToDepthStencilBuffer* target
 
     StartReInit();
     DrawnOnce = false;
-    m_StaticShadowReady = false;
+    DropStaticBake();
     m_HasDynamicOverlay = false;
 }
 
@@ -170,7 +170,7 @@ void D3D11PointLight::ClearTiledSlot() {
     m_TiledSlotLowRes = false;
     m_TiledDepthTarget = nullptr;
     m_TiledOwner = nullptr;
-    m_StaticShadowReady = false;
+    DropStaticBake();
     m_HasDynamicOverlay = false;
 }
 
@@ -194,7 +194,7 @@ void D3D11PointLight::HandleShadowModeChange( int shadowMode ) {
     }
 
     m_LastShadowMode = shadowMode;
-    m_StaticShadowReady = false;
+    DropStaticBake();
     DrawnOnce = false;
     m_HasDynamicOverlay = false;
 
@@ -235,12 +235,12 @@ void D3D11PointLight::AcquireStaticAsideShadowMap( DepthStencilPool* pool, int r
     desc.ArraySize = 6;
 
     m_StaticDepthCubemap = pool->Acquire( desc );
-    m_StaticShadowReady = false;
+    DropStaticBake();
 }
 
 void D3D11PointLight::ReleaseStaticAsideShadowMap() {
     m_StaticDepthCubemap.reset();
-    m_StaticShadowReady = false;
+    DropStaticBake();
 }
 
 void D3D11PointLight::CopyStaticAsideToActiveTarget() const {
@@ -438,7 +438,7 @@ void D3D11PointLight::RenderCubemap( bool forceUpdate ) {
         SkeletalVobCache.clear();
 
         // Invalidate worldcache
-        m_StaticShadowReady = false;
+        DropStaticBake();
         m_HasDynamicOverlay = false;
     }
 
@@ -610,7 +610,7 @@ void D3D11PointLight::RenderFullCubemap() {
 
     if ( shadowMode == GothicRendererSettings::PLS_FULL ) {
         ReleaseStaticAsideShadowMap();
-        m_StaticShadowReady = false;
+        DropStaticBake();
         m_HasDynamicOverlay = false;
 
         // FULL never reuses the world-mesh candidate cache - it always re-collects the whole scene fresh.
@@ -649,9 +649,16 @@ bool D3D11PointLight::IsReady()
         && LightInfo->Vob;
 }
 
+void D3D11PointLight::DropStaticBake() {
+    if ( m_StaticShadowReady ) {
+        Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+    }
+    m_StaticShadowReady = false;
+}
+
 void D3D11PointLight::Invalidate() {
     DrawnOnce = false;
-    m_StaticShadowReady = false;
+    DropStaticBake();
     m_HasDynamicOverlay = false;
     VobCache.clear();
     SkeletalVobCache.clear();
@@ -731,7 +738,7 @@ void D3D11PointLight::OnVobRemovedFromWorld( BaseVobInfo* vob ) {
         VobCache.clear();
         SkeletalVobCache.clear();
         DrawnOnce = false;
-        m_StaticShadowReady = false;
+        DropStaticBake();
         m_HasDynamicOverlay = false;
     }
 

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -57,14 +57,10 @@ public:
         return m_StaticShadowReady;
     }
 
-    /** True once this light has completed a cubemap render into the target it currently holds - i.e. that
-        target physically contains THIS light's depth. Deliberately NOT the same question as "is its bake up
-        to date" (IsStaticShadowReady) or "has it been drawn since the last invalidation" (NotYetDrawn): a
-        world change near the light drops those, but the depth in the slot is still the light's own and still
-        far better than nothing. Only a slot changing hands clears this. It is what gates advertising the cube
-        to the shader at all, because a slot that has NOT been rendered into holds the previous occupant's
-        depth and shades the light as fully occluded - black, not merely unshadowed. Mirrors D3D12's
-        Slot::staticPresent. */
+    /** True once the target this light holds physically contains THIS light's depth - not the same question
+        as whether the bake is up to date (IsStaticShadowReady), which a world change drops. Only a slot
+        changing hands clears it. Gates advertising the cube at all: an unrendered slot holds the previous
+        occupant's depth and shades the light black rather than merely unshadowed. */
     bool HasOwnDepthInSlot() const { return m_SlotHasOwnDepth; }
 
     bool IsShadowReady() const override {
@@ -88,29 +84,23 @@ public:
     int GetShadowMapResolution() const { return m_CurrentResolution; }
     ID3D11Texture2D* GetShadowCubeTexture() const { return m_DepthCubemap ? m_DepthCubemap->GetTexture().Get() : nullptr; }
 
-    /** Which tier this light would PREFER, independent of the one it currently sits in. Deliberately reads
-        the preferred mode and not GetCurrentShadowMode(): a light SPILLED into the low-res tier (see
-        DrawPointlightShadows) reports STATIC_ONLY as its effective mode, and asking that question here would
-        make the spill permanent - the light could never be promoted back once a full-res slot freed up. */
+    /** Which tier this light would PREFER, independent of the one it sits in. Reads the preferred mode, not
+        GetCurrentShadowMode(): a spilled light reports STATIC_ONLY, which would make the spill permanent. */
     bool WantsStaticOnlySlot() const {
         return GetPreferredShadowMode() == GothicRendererSettings::PLS_STATIC_ONLY;
     }
 
-    /** Fold this frame's position into the "has not moved recently" tracker. Called once per frame per
-        visible light from DrawPointlightShadows. Gothic's own IsStatic() bit does NOT answer the question
-        this does: a colour-animated candle or brazier reads as non-static there while never being
-        repositioned, and it is exactly those lights that fill the scarce full-res tier. */
+    /** Fold this frame's position into the "has not moved recently" tracker; called once per frame per
+        visible light. Gothic's IsStatic() bit does not answer this: a colour-animated brazier reads as
+        non-static there while never being repositioned. */
     void NoteStationary();
 
-    /** True when this light's category is NOT opted into VOB/NPC casters (see PointlightShadowCasterFlags):
-        its cube holds the world mesh alone. Handed to the shared slot selector as
-        PointLightSlotSelector::Candidate::restrictToWorld, where it decides whether the full-res tier would
-        buy this light anything at all - a world-mesh-only light can never receive a dynamic overlay. */
+    /** True when this light's category is not opted into VOB/NPC casters (PointlightShadowCasterFlags), so
+        its cube holds the world mesh alone and the full-res tier would buy it nothing. */
     bool RestrictsCastersToWorld() const;
 
     /** True once this light has held still long enough for its cube to be worth caching - the condition for
-        SPILLING it into the low-res static tier when the full-res one is full. A light that moves cannot go
-        there: that tier bakes a cube once and keeps it, and never runs the dynamic overlay. */
+        spilling it into the low-res tier, which bakes once and never runs the dynamic overlay. */
     bool IsSpatiallyStatic() const;
 
     void AcquireShadowMap( DepthStencilPool* pool, int resolution );
@@ -135,8 +125,7 @@ public:
     }
     int GetMissingFrames() const { return m_MissingFrames; }
 
-    /** How many consecutive frames this light has been in the low-res tier while preferring the full-res one.
-        Only used by the debug window. */
+    /** In the low-res tier while preferring the full-res one. Only used by the debug window. */
     bool IsSpilled() const { return m_TiledSlotLowRes && !WantsStaticOnlySlot(); }
 
     // Debug-visualization accessors (see ImGuiShim::RenderPointLightShadowDebugWindow).
@@ -147,38 +136,33 @@ public:
     float GetDebugZFar() const { return m_DebugLastZFar; }
 
     // Tiled deferred slot management (renders directly into a shared TextureCubeArray). `lowRes` selects
-    // which of the two independent slot pools this came from - see WantsStaticOnlySlot(). `sel` is the shared
-    // slot table that HANDED OUT this slot: the light reports its finished bakes back to it (the static-cache
-    // stamp and the caster set that bake covered), which is what lets the backend-neutral world-change
-    // invalidation reach a D3D11 light. Never owned, never held past ClearTiledSlot().
+    // which of the two independent slot pools this came from - see WantsStaticOnlySlot(). `sel` is the slot
+    // table that handed the slot out; the light reports its finished bakes back to it, which is what lets the
+    // backend-neutral world-change invalidation reach a D3D11 light. Never owned.
     void SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner, bool lowRes,
         PointLightSlotSelector* sel );
     void ClearTiledSlot();
-    /** Hands the slot this light is leaving OVER instead of dropping it: it still holds this light's depth, so
-        it stays what the lit pass samples until the new slot has been rendered. Called right after the
-        SetTiledSlot that moves the light, and only while the selector is holding that slot back for it.
-        Without it a tier change (low-res cache <-> full-res) shaded the light unshadowed for however long the
-        new bake took, which the range clamp in CullLights turns into the light visibly easing off. */
+    /** Hands the slot this light is leaving OVER instead of dropping it: it still holds this light's depth
+        and stays what the lit pass samples until the new slot is rendered. Without it a tier change shaded
+        the light unshadowed until the new bake landed, which the range clamp shows as it easing off. */
     void SetSlotFallback( int slot, bool lowRes ) { m_FallbackSlotIndex = slot; m_FallbackSlotLowRes = lowRes; }
     int GetTiledSlot() const { return m_TiledSlotIndex; }
     bool IsTiledSlotLowRes() const { return m_TiledSlotLowRes; }
-    /** Which slot the lit pass should actually sample: this light's own once it holds its depth, else the one
-        being handed over from. -1 when neither does, i.e. genuinely unshadowed. */
+    /** Which slot the lit pass samples: this light's own once it holds its depth, else the one being handed
+        over from. -1 when neither, i.e. genuinely unshadowed. */
     int GetSampleSlot() const { return m_SlotHasOwnDepth ? m_TiledSlotIndex : m_FallbackSlotIndex; }
     bool IsSampleSlotLowRes() const { return m_SlotHasOwnDepth ? m_TiledSlotLowRes : m_FallbackSlotLowRes; }
     bool HasSampleableDepth() const { return GetSampleSlot() >= 0; }
-    /** This light's slot in the selector's single GLOBAL index space (low-res slots sit above the full-res
-        pool), or -1. The two tiers keep separate local indices in D3D11 because they are separate arrays. */
+    /** This light's slot in the selector's single global index space (low-res slots sit above the full-res
+        pool), or -1. D3D11's two tiers keep separate local indices because they are separate arrays. */
     int GetGlobalTiledSlot() const;
     void SetCurrentResolution( int r ) { m_CurrentResolution = r; }
 
 protected:
-    /** The mode this light's CONTENT is rendered and sampled with. Equal to GetPreferredShadowMode(), except
-        that a light holding a low-res tier slot is forced to STATIC_ONLY: that array has no dynamic-overlay
-        twin, so a spilled light gives up its overlay in exchange for having a cube at all. */
+    /** The mode this light's content is rendered and sampled with: GetPreferredShadowMode(), except that a
+        low-res tier slot forces STATIC_ONLY - that array has no dynamic-overlay twin. */
     int GetCurrentShadowMode() const;
-    /** The mode the light would run at on its own merits - the global setting, with a static-flagged light
-        downgraded to STATIC_ONLY. Independent of which tier it currently occupies. */
+    /** The mode the light would run at on its own merits, independent of the tier it occupies. */
     int GetPreferredShadowMode() const;
     void HandleShadowModeChange( int shadowMode );
     RenderToDepthStencilBuffer* GetActiveShadowTarget() const;
@@ -186,10 +170,8 @@ protected:
     void ReleaseStaticAsideShadowMap();
     void CopyStaticAsideToActiveTarget() const;
 
-    /** Single funnel for "this light's baked static shadow is no longer valid". Counts the drop into
-        RendererInfo.PointLightStaticInvalidations, but only when there actually WAS a bake to lose - so
-        PLS_FULL, which never latches one, doesn't drown the stat in one event per light per frame - and only
-        on the legacy path, where no shared slot table has already counted it. */
+    /** Single funnel for "this light's baked static shadow is no longer valid". Counts the drop only when
+        there actually was a bake to lose, and only on the legacy path - see the note in the definition. */
     void DropStaticBake();
     void RenderStaticShadowPass( RenderToDepthStencilBuffer& target, bool clearDepth );
     void RenderAnimatedShadowPass( RenderToDepthStencilBuffer& target, bool clearDepth );
@@ -232,8 +214,7 @@ protected:
     std::atomic<bool> InitDone;
     bool DrawnOnce;
     bool m_StaticShadowReady = false;
-    // See HasOwnDepthInSlot(). Set when a render into the current target completes, cleared only when that
-    // target changes hands.
+    // See HasOwnDepthInSlot(). Set when a render completes, cleared when the target changes hands.
     bool m_SlotHasOwnDepth = false;
     /** Set once the animated pass has rendered into this light's slot of the dynamic-overlay array; cleared
         whenever the slot changes hands or the light's caches are invalidated, so we never advertise an
@@ -249,9 +230,8 @@ protected:
     XMFLOAT3 m_StationaryPos = {};
     int m_StationaryFrames = 0;
 
-    /** Reports a finished static bake back to the shared slot table: the cache stamp (so the selector stops
-        asking for a re-render) plus the caster identities it covered (so a vob later removed or moved can be
-        matched against it by pointer). No-op on the legacy per-light-cubemap path, which owns no slot. */
+    /** Reports a finished static bake back to the slot table: the cache stamp plus the caster identities it
+        covered. No-op on the legacy per-light-cubemap path, which owns no slot. */
     void CommitStaticBakeToSlot();
 
     // Tiled deferred slot (non-owning, owned by D3D11TiledDeferredShading)
@@ -259,9 +239,8 @@ protected:
     // The shared slot table this slot came from - see SetTiledSlot. Non-owning; null on the legacy path.
     PointLightSlotSelector* m_SlotSel = nullptr;
     bool m_TiledSlotLowRes = false; // which of the two independent slot pools m_TiledSlotIndex indexes into
-    // The slot a tier switch is handing over FROM - see SetTiledSlot's keepAsFallback. Still holds this
-    // light's depth and stays sampleable until m_TiledSlotIndex has been rendered. The selector holds the
-    // matching half and will not give this slot to anybody else meanwhile.
+    // The slot a tier switch is handing over FROM - see SetSlotFallback. Stays sampleable until
+    // m_TiledSlotIndex has been rendered; the selector holds the matching half.
     int m_FallbackSlotIndex = -1;
     bool m_FallbackSlotLowRes = false;
     RenderToDepthStencilBuffer* m_TiledDepthTarget = nullptr;

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -5,6 +5,7 @@
 #include <condition_variable>
 #include <atomic>
 #include "TexturePool.h"
+#include "PointLightSlotSelector.h"
 #include "ThreadPool.h"
 
 class D3D11PointLight;
@@ -101,6 +102,12 @@ public:
         repositioned, and it is exactly those lights that fill the scarce full-res tier. */
     void NoteStationary();
 
+    /** True when this light's category is NOT opted into VOB/NPC casters (see PointlightShadowCasterFlags):
+        its cube holds the world mesh alone. Handed to the shared slot selector as
+        PointLightSlotSelector::Candidate::restrictToWorld, where it decides whether the full-res tier would
+        buy this light anything at all - a world-mesh-only light can never receive a dynamic overlay. */
+    bool RestrictsCastersToWorld() const;
+
     /** True once this light has held still long enough for its cube to be worth caching - the condition for
         SPILLING it into the low-res static tier when the full-res one is full. A light that moves cannot go
         there: that tier bakes a cube once and keeps it, and never runs the dynamic overlay. */
@@ -140,11 +147,18 @@ public:
     float GetDebugZFar() const { return m_DebugLastZFar; }
 
     // Tiled deferred slot management (renders directly into a shared TextureCubeArray). `lowRes` selects
-    // which of the two independent slot pools this came from - see WantsStaticOnlySlot().
-    void SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner, bool lowRes );
+    // which of the two independent slot pools this came from - see WantsStaticOnlySlot(). `sel` is the shared
+    // slot table that HANDED OUT this slot: the light reports its finished bakes back to it (the static-cache
+    // stamp and the caster set that bake covered), which is what lets the backend-neutral world-change
+    // invalidation reach a D3D11 light. Never owned, never held past ClearTiledSlot().
+    void SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner, bool lowRes,
+        PointLightSlotSelector* sel );
     void ClearTiledSlot();
     int GetTiledSlot() const { return m_TiledSlotIndex; }
     bool IsTiledSlotLowRes() const { return m_TiledSlotLowRes; }
+    /** This light's slot in the selector's single GLOBAL index space (low-res slots sit above the full-res
+        pool), or -1. The two tiers keep separate local indices in D3D11 because they are separate arrays. */
+    int GetGlobalTiledSlot() const;
     void SetCurrentResolution( int r ) { m_CurrentResolution = r; }
 
 protected:
@@ -163,7 +177,8 @@ protected:
 
     /** Single funnel for "this light's baked static shadow is no longer valid". Counts the drop into
         RendererInfo.PointLightStaticInvalidations, but only when there actually WAS a bake to lose - so
-        PLS_FULL, which never latches one, doesn't drown the stat in one event per light per frame. */
+        PLS_FULL, which never latches one, doesn't drown the stat in one event per light per frame - and only
+        on the legacy path, where no shared slot table has already counted it. */
     void DropStaticBake();
     void RenderStaticShadowPass( RenderToDepthStencilBuffer& target, bool clearDepth );
     void RenderAnimatedShadowPass( RenderToDepthStencilBuffer& target, bool clearDepth );
@@ -223,8 +238,15 @@ protected:
     XMFLOAT3 m_StationaryPos = {};
     int m_StationaryFrames = 0;
 
+    /** Reports a finished static bake back to the shared slot table: the cache stamp (so the selector stops
+        asking for a re-render) plus the caster identities it covered (so a vob later removed or moved can be
+        matched against it by pointer). No-op on the legacy per-light-cubemap path, which owns no slot. */
+    void CommitStaticBakeToSlot();
+
     // Tiled deferred slot (non-owning, owned by D3D11TiledDeferredShading)
     int m_TiledSlotIndex = -1;
+    // The shared slot table this slot came from - see SetTiledSlot. Non-owning; null on the legacy path.
+    PointLightSlotSelector* m_SlotSel = nullptr;
     bool m_TiledSlotLowRes = false; // which of the two independent slot pools m_TiledSlotIndex indexes into
     RenderToDepthStencilBuffer* m_TiledDepthTarget = nullptr;
     D3D11TiledDeferredShading* m_TiledOwner = nullptr;

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -77,10 +77,24 @@ public:
     int GetShadowMapResolution() const { return m_CurrentResolution; }
     ID3D11Texture2D* GetShadowCubeTexture() const { return m_DepthCubemap ? m_DepthCubemap->GetTexture().Get() : nullptr; }
 
-    /** Whether this light belongs in the low-res static-only tiled tier rather than the full-res one. */
+    /** Which tier this light would PREFER, independent of the one it currently sits in. Deliberately reads
+        the preferred mode and not GetCurrentShadowMode(): a light SPILLED into the low-res tier (see
+        DrawPointlightShadows) reports STATIC_ONLY as its effective mode, and asking that question here would
+        make the spill permanent - the light could never be promoted back once a full-res slot freed up. */
     bool WantsStaticOnlySlot() const {
-        return GetCurrentShadowMode() == GothicRendererSettings::PLS_STATIC_ONLY;
+        return GetPreferredShadowMode() == GothicRendererSettings::PLS_STATIC_ONLY;
     }
+
+    /** Fold this frame's position into the "has not moved recently" tracker. Called once per frame per
+        visible light from DrawPointlightShadows. Gothic's own IsStatic() bit does NOT answer the question
+        this does: a colour-animated candle or brazier reads as non-static there while never being
+        repositioned, and it is exactly those lights that fill the scarce full-res tier. */
+    void NoteStationary();
+
+    /** True once this light has held still long enough for its cube to be worth caching - the condition for
+        SPILLING it into the low-res static tier when the full-res one is full. A light that moves cannot go
+        there: that tier bakes a cube once and keeps it, and never runs the dynamic overlay. */
+    bool IsSpatiallyStatic() const;
 
     void AcquireShadowMap( DepthStencilPool* pool, int resolution );
     void ReleaseShadowMap();
@@ -104,6 +118,10 @@ public:
     }
     int GetMissingFrames() const { return m_MissingFrames; }
 
+    /** How many consecutive frames this light has been in the low-res tier while preferring the full-res one.
+        Only used by the debug window. */
+    bool IsSpilled() const { return m_TiledSlotLowRes && !WantsStaticOnlySlot(); }
+
     // Debug-visualization accessors (see ImGuiShim::RenderPointLightShadowDebugWindow).
     VobLightInfo* GetLightInfo() const { return LightInfo; }
     ID3D11Texture2D* GetTiledShadowCubeTexture() const { return m_TiledDepthTarget ? m_TiledDepthTarget->GetTexture().Get() : nullptr; }
@@ -120,7 +138,13 @@ public:
     void SetCurrentResolution( int r ) { m_CurrentResolution = r; }
 
 protected:
+    /** The mode this light's CONTENT is rendered and sampled with. Equal to GetPreferredShadowMode(), except
+        that a light holding a low-res tier slot is forced to STATIC_ONLY: that array has no dynamic-overlay
+        twin, so a spilled light gives up its overlay in exchange for having a cube at all. */
     int GetCurrentShadowMode() const;
+    /** The mode the light would run at on its own merits - the global setting, with a static-flagged light
+        downgraded to STATIC_ONLY. Independent of which tier it currently occupies. */
+    int GetPreferredShadowMode() const;
     void HandleShadowModeChange( int shadowMode );
     RenderToDepthStencilBuffer* GetActiveShadowTarget() const;
     void AcquireStaticAsideShadowMap( DepthStencilPool* pool, int resolution );
@@ -181,6 +205,10 @@ protected:
     float m_DebugLastZFar = 0.0f;
     // Consecutive frames this light has been absent (disabled/out of VisibleInFrame) - see NoteAbsence().
     int m_MissingFrames = 0;
+
+    // "Has not moved recently" tracking - see NoteStationary()/IsSpatiallyStatic().
+    XMFLOAT3 m_StationaryPos = {};
+    int m_StationaryFrames = 0;
 
     // Tiled deferred slot (non-owning, owned by D3D11TiledDeferredShading)
     int m_TiledSlotIndex = -1;

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -154,8 +154,19 @@ public:
     void SetTiledSlot( int slot, RenderToDepthStencilBuffer* target, D3D11TiledDeferredShading* owner, bool lowRes,
         PointLightSlotSelector* sel );
     void ClearTiledSlot();
+    /** Hands the slot this light is leaving OVER instead of dropping it: it still holds this light's depth, so
+        it stays what the lit pass samples until the new slot has been rendered. Called right after the
+        SetTiledSlot that moves the light, and only while the selector is holding that slot back for it.
+        Without it a tier change (low-res cache <-> full-res) shaded the light unshadowed for however long the
+        new bake took, which the range clamp in CullLights turns into the light visibly easing off. */
+    void SetSlotFallback( int slot, bool lowRes ) { m_FallbackSlotIndex = slot; m_FallbackSlotLowRes = lowRes; }
     int GetTiledSlot() const { return m_TiledSlotIndex; }
     bool IsTiledSlotLowRes() const { return m_TiledSlotLowRes; }
+    /** Which slot the lit pass should actually sample: this light's own once it holds its depth, else the one
+        being handed over from. -1 when neither does, i.e. genuinely unshadowed. */
+    int GetSampleSlot() const { return m_SlotHasOwnDepth ? m_TiledSlotIndex : m_FallbackSlotIndex; }
+    bool IsSampleSlotLowRes() const { return m_SlotHasOwnDepth ? m_TiledSlotLowRes : m_FallbackSlotLowRes; }
+    bool HasSampleableDepth() const { return GetSampleSlot() >= 0; }
     /** This light's slot in the selector's single GLOBAL index space (low-res slots sit above the full-res
         pool), or -1. The two tiers keep separate local indices in D3D11 because they are separate arrays. */
     int GetGlobalTiledSlot() const;
@@ -248,6 +259,11 @@ protected:
     // The shared slot table this slot came from - see SetTiledSlot. Non-owning; null on the legacy path.
     PointLightSlotSelector* m_SlotSel = nullptr;
     bool m_TiledSlotLowRes = false; // which of the two independent slot pools m_TiledSlotIndex indexes into
+    // The slot a tier switch is handing over FROM - see SetTiledSlot's keepAsFallback. Still holds this
+    // light's depth and stays sampleable until m_TiledSlotIndex has been rendered. The selector holds the
+    // matching half and will not give this slot to anybody else meanwhile.
+    int m_FallbackSlotIndex = -1;
+    bool m_FallbackSlotLowRes = false;
     RenderToDepthStencilBuffer* m_TiledDepthTarget = nullptr;
     D3D11TiledDeferredShading* m_TiledOwner = nullptr;
 };

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -126,6 +126,11 @@ protected:
     void AcquireStaticAsideShadowMap( DepthStencilPool* pool, int resolution );
     void ReleaseStaticAsideShadowMap();
     void CopyStaticAsideToActiveTarget() const;
+
+    /** Single funnel for "this light's baked static shadow is no longer valid". Counts the drop into
+        RendererInfo.PointLightStaticInvalidations, but only when there actually WAS a bake to lose - so
+        PLS_FULL, which never latches one, doesn't drown the stat in one event per light per frame. */
+    void DropStaticBake();
     void RenderStaticShadowPass( RenderToDepthStencilBuffer& target, bool clearDepth );
     void RenderAnimatedShadowPass( RenderToDepthStencilBuffer& target, bool clearDepth );
 

--- a/D3D11Engine/D3D11PointLight.h
+++ b/D3D11Engine/D3D11PointLight.h
@@ -56,6 +56,16 @@ public:
         return m_StaticShadowReady;
     }
 
+    /** True once this light has completed a cubemap render into the target it currently holds - i.e. that
+        target physically contains THIS light's depth. Deliberately NOT the same question as "is its bake up
+        to date" (IsStaticShadowReady) or "has it been drawn since the last invalidation" (NotYetDrawn): a
+        world change near the light drops those, but the depth in the slot is still the light's own and still
+        far better than nothing. Only a slot changing hands clears this. It is what gates advertising the cube
+        to the shader at all, because a slot that has NOT been rendered into holds the previous occupant's
+        depth and shades the light as fully occluded - black, not merely unshadowed. Mirrors D3D12's
+        Slot::staticPresent. */
+    bool HasOwnDepthInSlot() const { return m_SlotHasOwnDepth; }
+
     bool IsShadowReady() const override {
         return m_StaticShadowReady;
     }
@@ -196,6 +206,9 @@ protected:
     std::atomic<bool> InitDone;
     bool DrawnOnce;
     bool m_StaticShadowReady = false;
+    // See HasOwnDepthInSlot(). Set when a render into the current target completes, cleared only when that
+    // target changes hands.
+    bool m_SlotHasOwnDepth = false;
     /** Set once the animated pass has rendered into this light's slot of the dynamic-overlay array; cleared
         whenever the slot changes hands or the light's caches are invalidated, so we never advertise an
         overlay that still holds another light's (or a stale) depth. */

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -914,32 +914,95 @@ std::vector<float> D3D11ShadowMap::ComputeCascadeSplits( float nearPlane, float 
     return splits;
 }
 
+void D3D11ShadowMap::ConfigurePointSlots() {
+    // Idempotent: the pool sizes are compile-time constants, so only the first call actually sizes the table.
+    PointLightSlotSelector::Config cfg;
+    cfg.MaxHiSlots = MAX_SHADOW_CUBEMAPS;
+    cfg.MaxLowSlots = MAX_STATIC_SHADOW_CUBEMAPS;
+    // The two tier bits are backend-specific - D3D11's live in D3D11TiledDeferredShading.h and are the other
+    // way round from D3D12's - so they are configuration rather than a shared constant.
+    cfg.TierLowBit = SHADOW_CUBE_TIER_LOW;
+    cfg.HasDynamicBit = SHADOW_CUBE_HAS_DYNAMIC;
+    m_PointSlots.Configure( cfg );
+}
+
+
+void D3D11ShadowMap::ReleasePointLightSlotFor( const zCVob* lightVob ) {
+    const int slot = m_PointSlots.FindSlotOf( reinterpret_cast<uint64_t>( lightVob ) );
+    if ( slot >= 0 ) m_PointSlots.ReleaseSlot( static_cast<uint32_t>( slot ) );
+}
+
+
+void D3D11ShadowMap::ReconcileTiledSlots() {
+    if ( !m_TiledDeferred ) return;
+    for ( auto& it : Engine::GAPI->VobLightMap ) {
+        VobLightInfo* light = it.second;
+        if ( !light->LightShadowBuffers ) continue;
+        D3D11PointLight* pl = dynamic_cast<D3D11PointLight*>(light->LightShadowBuffers.get());
+        if ( !pl ) continue;
+
+        const int global = m_PointSlots.FindSlotOf( reinterpret_cast<uint64_t>( light->Vob ) );
+        if ( global < 0 ) {
+            if ( pl->GetTiledSlot() >= 0 ) pl->ClearTiledSlot();
+            continue;
+        }
+
+        const bool low = m_PointSlots.IsLowSlot( static_cast<uint32_t>( global ) );
+        const int local = low ? static_cast<int>( m_PointSlots.LowIndex( static_cast<uint32_t>( global ) ) ) : global;
+        if ( pl->GetTiledSlot() == local && pl->IsTiledSlotLowRes() == low ) continue;
+
+        // Changing tier or slot means the depth this light held is gone: SetTiledSlot drops the bake and the
+        // has-own-depth flag, so it is shaded unshadowed (range-clamped) until its render lands rather than
+        // sampling whatever the previous occupant left in the new slot.
+        RenderToDepthStencilBuffer* target = low ? m_TiledDeferred->ClaimStaticSlot( local )
+                                                 : m_TiledDeferred->ClaimSlot( local );
+        if ( !target ) {
+            // The array could not be created - give the slot straight back so it is not held out of the pool.
+            m_PointSlots.ReleaseSlot( static_cast<uint32_t>( global ) );
+            if ( pl->GetTiledSlot() >= 0 ) pl->ClearTiledSlot();
+            continue;
+        }
+        pl->ClearTiledSlot();
+        pl->ReleaseShadowMap();
+        pl->SetTiledSlot( local, target, m_TiledDeferred.get(), low, &m_PointSlots );
+        pl->SetCurrentResolution( low ? STATIC_SHADOW_CUBE_SIZE : SHADOW_CUBE_SIZE );
+    }
+}
+
+
 XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& lights ) {
     ZoneScopedN( "DrawPointlightShadows" );
 
     auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
 
-    // Release resources of lights that have been out of view for a while now - NOT on the very first
-    // missing frame. A light that only blinks (zCVobLight::IsEnabled toggling for a flicker effect, or a
-    // one-frame frustum/visibility edge case) must keep its slot and baked depth across that blink: a
-    // PLS_STATIC_ONLY light's bake is meant to happen once and stick, but if every absent frame evicted it
-    // outright, a light that blinks even occasionally could never finish a bake that survives - it gets
-    // evicted mid-wait, wins a slot again on the next visible frame, and gets evicted again before that
-    // bake completes, so it lights unshadowed (bleeding through walls) forever instead of self-healing.
-    // Mirrors D3D12PointShadows' Slot::missingFrames retention in SelectShadowedLights.
+    // Release the LEGACY per-light cubemap of a light that has been out of view for a while - never on the
+    // first absent frame, or a light that merely blinks (zCVobLight::IsEnabled toggling for a flicker effect)
+    // could never finish a bake that sticks. Tiled slots are exempt: how long one is held for an absent light
+    // is the shared selector's business (PointLightSlotSelector::Slot::missingFrames), and it measures
+    // presence in the frame light SET rather than visibility, so a light that is still being shaded from past
+    // the candidacy horizon no longer has its own cube aged out from under it.
     constexpr int kPointLightSlotRetentionFrames = 120;
     for ( auto& it : Engine::GAPI->VobLightMap ) {
         if ( !it.second->LightShadowBuffers ) continue;
         if ( D3D11PointLight* pl = dynamic_cast<D3D11PointLight*>(it.second->LightShadowBuffers.get()) ) {
             const bool visible = it.second->Vob->IsEnabled() && it.second->VisibleInFrame;
-            if ( pl->NoteAbsence( visible, kPointLightSlotRetentionFrames ) ) {
-                pl->ClearTiledSlot();
+            if ( pl->NoteAbsence( visible, kPointLightSlotRetentionFrames ) && pl->GetTiledSlot() < 0 ) {
                 pl->ReleaseShadowMap();
             }
         }
     }
 
+    const bool isTiledShadingEnabled = m_TiledDeferred && settings.EnableTiledLighting;
+    if ( isTiledShadingEnabled ) ConfigurePointSlots();
+
     if (settings.EnablePointlightShadows <= 0) {
+        // Hand every cube back, so re-enabling mid-session re-renders from scratch instead of sampling depth
+        // that has been stale for however long the setting was off. ReconcileTiledSlots then makes each light
+        // let go of the slot it thought it held. Mirrors D3D12's PLS_DISABLED branch.
+        if ( isTiledShadingEnabled ) {
+            m_PointSlots.Select( {}, GothicRendererSettings::PLS_DISABLED );
+            ReconcileTiledSlots();
+        }
         return XR_SUCCESS;
     }
     
@@ -962,6 +1025,10 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
 
     bool partialShadowUpdate = settings.PartialDynamicShadowUpdates;
     const bool staticOnlyMode = settings.EnablePointlightShadows == GothicRendererSettings::PLS_STATIC_ONLY;
+    // See D3D11PointLight's AllowsDynamicCasters: on, a static light skips the cached low-res tier entirely and
+    // is routed through the same pipeline as a normal dynamic light.
+    const bool allowStaticDynamicShadows =
+        (settings.PointlightShadowCasterFlags & GothicRendererSettings::PLSC_STATIC_LIGHTS) != 0;
 
     // Draw pointlight shadows
     static std::vector<std::pair<float, VobLightInfo*>> importantUpdates;
@@ -969,59 +1036,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
 
     DepthStencilPool* dsPool = graphicsEngine->GetPfxRenderer()->GetDepthStencilPool();
 
-    const bool isTiledShadingEnabled = m_TiledDeferred && settings.EnableTiledLighting;
     const int requiredShadowMapKind = isTiledShadingEnabled ? 1 : 0;
-
-    // Tiled lights share small fixed-size cube-array pools (unlike legacy, where every light gets its own
-    // unbounded DepthStencilPool allocation), so requests are ranked closest-to-player and may evict the
-    // farthest current occupant under pressure - mirrors D3D12PointShadows' SelectShadowedLights. Two
-    // independent pools: WantsStaticOnlySlot() lights route to the low-res MAX_STATIC_SHADOW_CUBEMAPS pool
-    // instead of the full-res MAX_SHADOW_CUBEMAPS one.
-    struct PendingAcquire { VobLightInfo* light; D3D11PointLight* pl; float distSq; int desiredResolution;
-        bool wantsLowTier; bool spatiallyStatic; };
-    static std::vector<PendingAcquire> candidates;
-    candidates.clear();
-
-    // Lights that asked for a cube this frame and could not be given one in either tier. Surfaced in the
-    // ImGui point-light window: a starved static light is range-clamped by the tiled light fill below, which
-    // makes it look switched off, and that is otherwise indistinguishable from a bug in slot assignment.
-    unsigned int starvedThisFrame = 0;
-
-    static std::array<VobLightInfo*, MAX_SHADOW_CUBEMAPS> slotOwnerLightHigh;
-    slotOwnerLightHigh.fill( nullptr );
-    static std::array<VobLightInfo*, MAX_STATIC_SHADOW_CUBEMAPS> slotOwnerLightLow;
-    slotOwnerLightLow.fill( nullptr );
-
-    // A slot must be held by a light ~1.7x farther than a challenger to be evicted, to avoid thrashing
-    // between similarly-distant lights every frame (mirrors D3D12PointShadows' kIncumbentBias).
-    constexpr float kPointShadowIncumbentBias = 0.35f;
-
-    auto allocateOrEvictSlot = [&]( float requesterDistSq, auto& slotOwnerArray, uint32_t poolSize, auto&& allocate ) -> int {
-        int slot = allocate();
-        if ( slot >= 0 ) return slot;
-
-        int worstSlot = -1;
-        float worstDistSq = -1.0f;
-        for ( uint32_t s = 0; s < poolSize; s++ ) {
-            VobLightInfo* owner = slotOwnerArray[s];
-            if ( !owner ) continue;
-            const float ownerDistSq = XMVectorGetX( XMVector3LengthSq( owner->Vob->GetPositionWorldXM() - vPlayerPosition ) );
-            if ( ownerDistSq > worstDistSq ) {
-                worstDistSq = ownerDistSq;
-                worstSlot = static_cast<int>(s);
-            }
-        }
-        if ( worstSlot < 0 || requesterDistSq * kPointShadowIncumbentBias >= worstDistSq ) {
-            return -1;
-        }
-        VobLightInfo* worstOwner = slotOwnerArray[worstSlot];
-        D3D11PointLight* worstPl = dynamic_cast<D3D11PointLight*>(worstOwner->LightShadowBuffers.get());
-        if ( !worstPl ) return -1;
-
-        worstPl->ClearTiledSlot();
-        slotOwnerArray[worstSlot] = nullptr;
-        return allocate();
-    };
 
     auto classifyLight = [&]( VobLightInfo* light, D3D11PointLight* pl, float distSq ) {
         bool needsUpdate = pl->NeedsUpdate();
@@ -1046,6 +1061,32 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
         }
     };
 
+    // Drops a light out of both update paths - nothing is going to re-render its cube this frame.
+    auto dequeueLight = [&]( VobLightInfo* light ) {
+        auto it = std::find( graphicsEngine->FrameShadowUpdateLights.begin(), graphicsEngine->FrameShadowUpdateLights.end(), light );
+        if ( it != graphicsEngine->FrameShadowUpdateLights.end() ) {
+            graphicsEngine->FrameShadowUpdateLights.erase( it );
+        }
+        auto importantIt = std::find_if( importantUpdates.begin(), importantUpdates.end(),
+            [&]( const auto& entry ) { return entry.second == light; } );
+        if ( importantIt != importantUpdates.end() ) {
+            importantUpdates.erase( importantIt );
+        }
+    };
+
+    // Candidates for the shared slot selector: one entry per visible light, in whatever order the frame's
+    // light list is in. Which of them gets a cube, out of which tier, in which slot, and whether its cached
+    // static depth has to be re-rendered is decided entirely by PointLightSlotSelector::Select - the exact
+    // same code the D3D12 backend runs. Nothing below re-decides any of it.
+    static std::vector<PointLightSlotSelector::Candidate> slotCandidates;
+    slotCandidates.clear();
+
+    // Legacy (non-tiled) path only: every light owns an unbounded DepthStencilPool cubemap instead of a slot
+    // in a shared array, so there is no pool to select from and the old distance gating still applies.
+    struct LegacyAcquire { VobLightInfo* light; D3D11PointLight* pl; float distSq; int desiredResolution; };
+    static std::vector<LegacyAcquire> legacyAcquires;
+    legacyAcquires.clear();
+
     for ( auto const& light : lights ) {
         if ( !light->Vob->IsEnabled() || !light->VisibleInFrame ) {
             continue;
@@ -1058,194 +1099,111 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
             light->LightShadowBuffers.reset(bpl);
         }
 
-        if ( D3D11PointLight* pl = dynamic_cast<D3D11PointLight*>(light->LightShadowBuffers.get()) ) {
-            pl->NoteStationary();   // feeds IsSpatiallyStatic(), i.e. whether this light may spill (see below)
-            bool wantsLowTier = isTiledShadingEnabled && pl->WantsStaticOnlySlot();
+        D3D11PointLight* pl = dynamic_cast<D3D11PointLight*>(light->LightShadowBuffers.get());
+        if ( !pl ) continue;
 
-            if ( isTiledShadingEnabled ) {
-                int ownSlot = pl->GetTiledSlot();
-                if ( ownSlot >= 0 ) {
-                    if ( pl->IsTiledSlotLowRes() && static_cast<uint32_t>(ownSlot) < MAX_STATIC_SHADOW_CUBEMAPS ) {
-                        slotOwnerLightLow[ownSlot] = light;
-                    } else if ( !pl->IsTiledSlotLowRes() && static_cast<uint32_t>(ownSlot) < MAX_SHADOW_CUBEMAPS ) {
-                        slotOwnerLightHigh[ownSlot] = light;
-                    }
-                }
-            }
+        pl->NoteStationary();   // feeds IsSpatiallyStatic(), i.e. whether this light may spill into the low tier
 
-            const float d = XMVectorGetX( XMVector3LengthSq( light->Vob->GetPositionWorldXM() - vPlayerPosition ) );
-            float range = light->Vob->GetLightRange();
-            const float rangeSq = range * range;
+        const float d = XMVectorGetX( XMVector3LengthSq( light->Vob->GetPositionWorldXM() - vPlayerPosition ) );
+        const float range = light->Vob->GetLightRange();
 
-            float distVeryCloseSq = (range * 0.8f) * (range * 0.8f);
-            // Shadow-candidacy horizon. range*9 alone puts it at ~13 m for a candle (range ~150 units), and a
-            // light that falls outside it is shaded UNSHADOWED - which the tiled light fill then range-clamps
-            // to 0.35x/0.15x, collapsing the lit patch around the candle so it reads as switched OFF at a
-            // distance where it is still plainly visible. The horizon has to be about where the light stops
-            // being SEEN, not where its own falloff sphere stops reaching the camera, so it gets an absolute
-            // floor as well. Mirrors D3D12PointShadows::SelectShadowedLights' kMinShadowDist.
-            constexpr float kMinShadowDist = 3000.0f;   // Gothic world units (~100 = 1 m)
-            const float maxShadowDist = std::max( range * 9.0f, kMinShadowDist );
-            float distMaxShadowSq = maxShadowDist * maxShadowDist; // Fade out entirely after this
-
-            // Resolution also doubles as the tier-mismatch check below: a light whose tier flipped no longer
-            // matches its current GetShadowMapResolution(), so it re-acquires into the right tier automatically.
-            int desiredResolution = wantsLowTier ? STATIC_SHADOW_CUBE_SIZE : SHADOW_CUBE_SIZE;
-            if ( d < distVeryCloseSq && !staticOnlyMode ) {
-                light->UpdateShadows = true;
-                // for now, keep all lights/shadows the same size, otherwise they change their "volume"
-                // desiredResolution = 256; // High res for close lights
-            }
-
-            bool inShadowRange = d < distMaxShadowSq;
-            if ( inShadowRange ) {
-                if ( !pl->HasShadowMap( requiredShadowMapKind ) || pl->GetShadowMapResolution() != desiredResolution ) {
-                    candidates.push_back( { light, pl, d, desiredResolution, wantsLowTier, pl->IsSpatiallyStatic() } );
-                    continue;
-                }
-
-                classifyLight( light, pl, d );
-            } else {
-                if ( pl->HasAnyShadowMap() ) {
-                    // Past the horizon: stop UPDATING the cube, but in the tiled path do not throw it away.
-                    // The depth in a tiled slot is still perfectly good and still sampled, and dropping it
-                    // turned "too far to be worth re-rendering" into "unshadowed", i.e. into the range clamp
-                    // that makes a light look switched off. Slots are reclaimed under real pressure instead
-                    // (allocateOrEvictSlot takes the farthest owner) or by the absence retention above.
-                    // The legacy non-tiled path keeps releasing: there every light owns an unbounded
-                    // DepthStencilPool allocation, so holding one for a distant light is a real cost.
-                    if ( !isTiledShadingEnabled ) {
-                        pl->ClearTiledSlot();
-                        pl->ReleaseShadowMap();
-                    }
-
-                    auto it = std::find( graphicsEngine->FrameShadowUpdateLights.begin(), graphicsEngine->FrameShadowUpdateLights.end(), light );
-                    if ( it != graphicsEngine->FrameShadowUpdateLights.end() ) {
-                        graphicsEngine->FrameShadowUpdateLights.erase( it );
-                    }
-
-                    auto importantIt = std::find_if( importantUpdates.begin(), importantUpdates.end(),
-                        [&]( const auto& entry ) { return entry.second == light; } );
-                    if ( importantIt != importantUpdates.end() ) {
-                        importantUpdates.erase( importantIt );
-                    }
-                }
-            }
+        const float distVeryCloseSq = (range * 0.8f) * (range * 0.8f);
+        if ( d < distVeryCloseSq && !staticOnlyMode ) {
+            light->UpdateShadows = true;
         }
-    }
-
-    std::sort( candidates.begin(), candidates.end(), []( const PendingAcquire& a, const PendingAcquire& b ) {
-        return a.distSq < b.distSq;
-    } );
-
-    for ( auto& c : candidates ) {
-        D3D11PointLight* pl = c.pl;
-        VobLightInfo* light = c.light;
 
         if ( isTiledShadingEnabled ) {
-            // Find the new slot BEFORE giving up the one this light already holds. Releasing first and then
-            // failing to allocate left the light with no cube at all - and no cube is what the range clamp
-            // turns into a light that visibly switches off. This is also what makes PROMOTION safe: a light
-            // that spilled into the low-res tier asks for the full-res one again every frame (its preferred
-            // resolution no longer matches its current one, which is what put it in `candidates`), and it
-            // only lets go of the cube it has once the better slot is actually in hand.
-            bool useLowTier = c.wantsLowTier;
-            int slot = -1;
-            if ( useLowTier ) {
-                slot = allocateOrEvictSlot( c.distSq, slotOwnerLightLow, MAX_STATIC_SHADOW_CUBEMAPS,
-                    [&] { return m_TiledDeferred->AllocateStaticSlot(); } );
-            } else if ( c.desiredResolution != SHADOW_CUBE_SIZE ) {
-                // only one high-tier resolution is ever used; don't put a mismatched size into a tiled slot
-                light->UpdateShadows = false;
-                continue;
-            } else {
-                slot = allocateOrEvictSlot( c.distSq, slotOwnerLightHigh, MAX_SHADOW_CUBEMAPS,
-                    [&] { return m_TiledDeferred->AllocateSlot(); } );
-                // SPILL. The full-res pool is full of lights no farther away than this one, but a light that
-                // never moves has a cacheable cube, and a 32^2 cached cube is enormously better than none: it
-                // gives up its dynamic overlay (that tier has no overlay array - see GetCurrentShadowMode)
-                // and keeps its shadow. Without this a room full of fixed lights left everything past the
-                // pool size unshadowed while the static tier sat empty.
-                // `spatiallyStatic` is what makes a low-res slot a good LONG-TERM home (that tier bakes once
-                // and caches forever, so a mover would re-enter the per-frame bake budget every frame). A
-                // light that currently has NO cube at all is a different question: it is being shaded
-                // unshadowed and range-clamped right now, i.e. it looks switched off, and even a cube it will
-                // have to keep re-baking beats that. So it spills too, and is promoted out again as soon as
-                // the full-res tier has room.
-                const bool maySpill = c.spatiallyStatic || !pl->HasShadowMap( requiredShadowMapKind );
-                if ( slot < 0 && maySpill ) {
-                    if ( pl->GetTiledSlot() >= 0 && pl->IsTiledSlotLowRes() ) {
-                        // Already spilled, and still nothing in the full-res pool: keep the cube it has.
-                        // Taking a DIFFERENT low-res slot instead would drop the bake and re-render it, and
-                        // since this light asks to be promoted again every single frame, that is a re-bake
-                        // every frame for as long as the full-res tier stays full.
-                        light->UpdateShadows = false;
-                        classifyLight( light, pl, c.distSq );
-                        continue;
-                    }
-                    slot = allocateOrEvictSlot( c.distSq, slotOwnerLightLow, MAX_STATIC_SHADOW_CUBEMAPS,
-                        [&] { return m_TiledDeferred->AllocateStaticSlot(); } );
-                    if ( slot >= 0 ) useLowTier = true;
-                }
-            }
+            const bool spatiallyStatic = pl->IsSpatiallyStatic();
+            // Route to the cached low-res tier when the light will not move AND could not receive a dynamic
+            // overlay anyway - which at PLS_STATIC_ONLY is every light there is. Same formula D3D12 uses
+            // (D3D12Scene.cpp's routeStatic), so both backends put the same lights in the same tier: without
+            // it, every colour-animated room light queued for the scarce full-res cubes whose per-frame
+            // overlay that mode does not even run, and whichever ones lost the queue were range-clamped into
+            // looking switched off. `isStatic` and `preferLow` are the same answer - a light the selector must
+            // never hand an overlay to is exactly one that belongs in the cached tier.
+            const bool routeStatic = !allowStaticDynamicShadows
+                && ( light->IsStaticVobLight || ( spatiallyStatic && staticOnlyMode ) );
+            slotCandidates.push_back( { reinterpret_cast<uint64_t>( light->Vob ), light,
+                light->Vob->GetPositionWorld(), range,
+                routeStatic, routeStatic, spatiallyStatic, pl->RestrictsCastersToWorld() } );
+            continue;
+        }
 
-            if ( slot < 0 ) {
-                // Nothing to be had in either tier. Keep whatever this light already owns rather than
-                // dropping it - an older cube, even a stale one, beats going unshadowed.
-                light->UpdateShadows = false;
-                ++starvedThisFrame;
+        // Shadow-candidacy horizon, matching PointLightSlotSelector's: range*9 alone puts it at ~13 m for a
+        // candle (range ~150 units), and a light that falls outside it is shaded UNSHADOWED - which the light
+        // fill then range-clamps, collapsing the lit patch so the light reads as switched OFF at a distance
+        // where it is still plainly visible.
+        constexpr float kMinShadowDist = 3000.0f;   // Gothic world units (~100 = 1 m)
+        const float maxShadowDist = std::max( range * 9.0f, kMinShadowDist );
+        if ( d < maxShadowDist * maxShadowDist ) {
+            if ( !pl->HasShadowMap( requiredShadowMapKind ) || pl->GetShadowMapResolution() != SHADOW_CUBE_SIZE ) {
+                legacyAcquires.push_back( { light, pl, d, SHADOW_CUBE_SIZE } );
                 continue;
             }
-
-            // Read the previous slot only now: allocateOrEvictSlot may have evicted THIS light (it is a
-            // candidate for "farthest owner" like any other), in which case it has already been cleared.
-            const int prevSlot = pl->GetTiledSlot();
-            if ( prevSlot >= 0 ) {
-                if ( pl->IsTiledSlotLowRes() ) {
-                    if ( static_cast<uint32_t>(prevSlot) < MAX_STATIC_SHADOW_CUBEMAPS ) slotOwnerLightLow[prevSlot] = nullptr;
-                } else if ( static_cast<uint32_t>(prevSlot) < MAX_SHADOW_CUBEMAPS ) {
-                    slotOwnerLightHigh[prevSlot] = nullptr;
-                }
-                pl->ClearTiledSlot();
-            }
-            pl->ReleaseShadowMap();
-
-            if ( useLowTier ) {
-                pl->SetTiledSlot( slot, m_TiledDeferred->GetStaticSlotTarget( slot ), m_TiledDeferred.get(), true );
-                slotOwnerLightLow[slot] = light;
-                pl->SetCurrentResolution( STATIC_SHADOW_CUBE_SIZE );
-            } else {
-                pl->SetTiledSlot( slot, m_TiledDeferred->GetSlotTarget( slot ), m_TiledDeferred.get(), false );
-                slotOwnerLightHigh[slot] = light;
-                pl->SetCurrentResolution( SHADOW_CUBE_SIZE );
-            }
-        } else {
+            classifyLight( light, pl, d );
+        } else if ( pl->HasAnyShadowMap() ) {
+            // Here every light owns an unbounded DepthStencilPool allocation, so holding one for a distant
+            // light is a real cost - unlike a tiled slot, whose depth stays perfectly good where it is.
             pl->ClearTiledSlot();
             pl->ReleaseShadowMap();
-            pl->AcquireShadowMap( dsPool, c.desiredResolution );
+            dequeueLight( light );
         }
-
-        light->UpdateShadows = true;
-        classifyLight( light, pl, c.distSq );
     }
 
-    // Slot occupancy + starvation for the ImGui point-light window (DrawPointLightSlotStat). Occupancy comes
-    // from the pools themselves, not from the per-frame owner arrays: those only list slots held by lights
-    // VISIBLE this frame, while a slot stays allocated across the absence-retention window.
-    {
-        auto& info = Engine::GAPI->GetRendererState().RendererInfo;
-        if ( isTiledShadingEnabled ) {
-            info.PointLightSlotsUsed = m_TiledDeferred->GetUsedSlotCount();
-            info.PointLightSlotsMax = MAX_SHADOW_CUBEMAPS;
-            info.PointLightStaticSlotsUsed = m_TiledDeferred->GetUsedStaticSlotCount();
-            info.PointLightStaticSlotsMax = MAX_STATIC_SHADOW_CUBEMAPS;
-            info.PointLightSlotsStarved = starvedThisFrame;
-        } else {
-            // Legacy per-light cubemaps have no fixed pools to report on; zero Max hides the row entirely.
-            info.PointLightSlotsMax = 0;
-            info.PointLightStaticSlotsMax = 0;
-            info.PointLightSlotsStarved = 0;
+    if ( isTiledShadingEnabled ) {
+        m_PointSlots.Select( slotCandidates, settings.EnablePointlightShadows );
+        // Point every light at the slot the selector says it owns - and only then, because a light that just
+        // lost its slot must stop rendering into it before the new owner does.
+        ReconcileTiledSlots();
+
+        // Turn the selector's per-winner decisions into this frame's render schedule. renderStatic is the
+        // authoritative "this slot's cached static depth is out of date": fresh slot, light moved or resized,
+        // or a world change invalidated the bake (see PointLightSlotSelector::InvalidateStaticForVobAdded).
+        // The first two already drop the light's own bake elsewhere; the third is the reason ForceRebake has
+        // to be reachable from here at all.
+        for ( const PointLightSlotSelector::Assignment& a : m_PointSlots.GetAssignments() ) {
+            VobLightInfo* light = static_cast<VobLightInfo*>( a.owner );
+            if ( !light || !light->LightShadowBuffers ) continue;
+            D3D11PointLight* pl = static_cast<D3D11PointLight*>( light->LightShadowBuffers.get() );
+            if ( pl->GetTiledSlot() < 0 ) continue;   // ReconcileTiledSlots could not claim a target for it
+            if ( a.renderStatic ) {
+                if ( pl->IsStaticShadowReady() ) pl->ForceRebake();
+                light->UpdateShadows = true;
+            }
+            const float distSq = XMVectorGetX( XMVector3LengthSq( light->Vob->GetPositionWorldXM() - vPlayerPosition ) );
+            classifyLight( light, pl, distSq );
         }
+
+        // A light the selector did NOT pick this frame keeps whatever cube it holds - that is the whole point
+        // of stable slot ownership - but it must not sit in an update queue: re-rendering it would cost a full
+        // caster cull for a light the selector has already decided is not worth one this frame. Membership of
+        // the winner set, not of the slot table: a light past the candidacy horizon still owns its slot and
+        // still samples it, and it is exactly the one that must stop paying for re-renders.
+        static gtl::flat_hash_set<const zCVob*> winners;
+        winners.clear();
+        for ( const PointLightSlotSelector::Assignment& a : m_PointSlots.GetAssignments() )
+            if ( VobLightInfo* w = static_cast<VobLightInfo*>( a.owner ) ) winners.insert( w->Vob );
+        for ( auto const& light : lights ) {
+            if ( !light->LightShadowBuffers ) continue;
+            if ( winners.contains( light->Vob ) ) continue;
+            dequeueLight( light );
+        }
+    } else {
+        std::sort( legacyAcquires.begin(), legacyAcquires.end(), []( const LegacyAcquire& a, const LegacyAcquire& b ) {
+            return a.distSq < b.distSq;
+        } );
+        for ( auto& c : legacyAcquires ) {
+            c.pl->ClearTiledSlot();
+            c.pl->ReleaseShadowMap();
+            c.pl->AcquireShadowMap( dsPool, c.desiredResolution );
+            c.light->UpdateShadows = true;
+            classifyLight( c.light, c.pl, c.distSq );
+        }
+        // Legacy per-light cubemaps have no fixed pools to report on; zero Max hides the row entirely.
+        auto& info = Engine::GAPI->GetRendererState().RendererInfo;
+        info.PointLightSlotsMax = 0;
+        info.PointLightStaticSlotsMax = 0;
+        info.PointLightSlotsStarved = 0;
     }
 
     // Render the immediate priority lights - but never more than a handful in one frame.

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -636,7 +636,9 @@ XRESULT D3D11ShadowMap::PrepareRender()
             bool isLastCascade = (numCascades > 1 && cascadeIdx == numCascades - 1);
 
             bool shouldUpdateCascade = true;
-            if ( lazyCascadeUpdate && !m_ForceFullCascadeUpdate ) {
+            // A cascade holding a per-frame-deformed caster (spinning windmill sails and friends) must never
+            // be frozen - see NoteCascadeAnimatedCasters.
+            if ( lazyCascadeUpdate && !m_ForceFullCascadeUpdate && !m_CascadeHasAnimatedCaster[cascadeIdx] ) {
                 if ( cascadeIdx == 2 ) {
                     // pre-last cascade updates every 2nd frame which is 30 FPS = 15 updates per second
                     shouldUpdateCascade = (perFrameCascadeData.frameCount % 5) == 0;

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -977,9 +977,15 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
     // farthest current occupant under pressure - mirrors D3D12PointShadows' SelectShadowedLights. Two
     // independent pools: WantsStaticOnlySlot() lights route to the low-res MAX_STATIC_SHADOW_CUBEMAPS pool
     // instead of the full-res MAX_SHADOW_CUBEMAPS one.
-    struct PendingAcquire { VobLightInfo* light; D3D11PointLight* pl; float distSq; int desiredResolution; bool wantsLowTier; };
+    struct PendingAcquire { VobLightInfo* light; D3D11PointLight* pl; float distSq; int desiredResolution;
+        bool wantsLowTier; bool spatiallyStatic; };
     static std::vector<PendingAcquire> candidates;
     candidates.clear();
+
+    // Lights that asked for a cube this frame and could not be given one in either tier. Surfaced in the
+    // ImGui point-light window: a starved static light is range-clamped by the tiled light fill below, which
+    // makes it look switched off, and that is otherwise indistinguishable from a bug in slot assignment.
+    unsigned int starvedThisFrame = 0;
 
     static std::array<VobLightInfo*, MAX_SHADOW_CUBEMAPS> slotOwnerLightHigh;
     slotOwnerLightHigh.fill( nullptr );
@@ -1053,6 +1059,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
         }
 
         if ( D3D11PointLight* pl = dynamic_cast<D3D11PointLight*>(light->LightShadowBuffers.get()) ) {
+            pl->NoteStationary();   // feeds IsSpatiallyStatic(), i.e. whether this light may spill (see below)
             bool wantsLowTier = isTiledShadingEnabled && pl->WantsStaticOnlySlot();
 
             if ( isTiledShadingEnabled ) {
@@ -1071,7 +1078,15 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
             const float rangeSq = range * range;
 
             float distVeryCloseSq = (range * 0.8f) * (range * 0.8f);
-            float distMaxShadowSq = (range * 9.0f) * (range * 9.0f); // Fade out entirely after this
+            // Shadow-candidacy horizon. range*9 alone puts it at ~13 m for a candle (range ~150 units), and a
+            // light that falls outside it is shaded UNSHADOWED - which the tiled light fill then range-clamps
+            // to 0.35x/0.15x, collapsing the lit patch around the candle so it reads as switched OFF at a
+            // distance where it is still plainly visible. The horizon has to be about where the light stops
+            // being SEEN, not where its own falloff sphere stops reaching the camera, so it gets an absolute
+            // floor as well. Mirrors D3D12PointShadows::SelectShadowedLights' kMinShadowDist.
+            constexpr float kMinShadowDist = 3000.0f;   // Gothic world units (~100 = 1 m)
+            const float maxShadowDist = std::max( range * 9.0f, kMinShadowDist );
+            float distMaxShadowSq = maxShadowDist * maxShadowDist; // Fade out entirely after this
 
             // Resolution also doubles as the tier-mismatch check below: a light whose tier flipped no longer
             // matches its current GetShadowMapResolution(), so it re-acquires into the right tier automatically.
@@ -1085,15 +1100,24 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
             bool inShadowRange = d < distMaxShadowSq;
             if ( inShadowRange ) {
                 if ( !pl->HasShadowMap( requiredShadowMapKind ) || pl->GetShadowMapResolution() != desiredResolution ) {
-                    candidates.push_back( { light, pl, d, desiredResolution, wantsLowTier } );
+                    candidates.push_back( { light, pl, d, desiredResolution, wantsLowTier, pl->IsSpatiallyStatic() } );
                     continue;
                 }
 
                 classifyLight( light, pl, d );
             } else {
                 if ( pl->HasAnyShadowMap() ) {
-                    pl->ClearTiledSlot();
-                    pl->ReleaseShadowMap();
+                    // Past the horizon: stop UPDATING the cube, but in the tiled path do not throw it away.
+                    // The depth in a tiled slot is still perfectly good and still sampled, and dropping it
+                    // turned "too far to be worth re-rendering" into "unshadowed", i.e. into the range clamp
+                    // that makes a light look switched off. Slots are reclaimed under real pressure instead
+                    // (allocateOrEvictSlot takes the farthest owner) or by the absence retention above.
+                    // The legacy non-tiled path keeps releasing: there every light owns an unbounded
+                    // DepthStencilPool allocation, so holding one for a distant light is a real cost.
+                    if ( !isTiledShadingEnabled ) {
+                        pl->ClearTiledSlot();
+                        pl->ReleaseShadowMap();
+                    }
 
                     auto it = std::find( graphicsEngine->FrameShadowUpdateLights.begin(), graphicsEngine->FrameShadowUpdateLights.end(), light );
                     if ( it != graphicsEngine->FrameShadowUpdateLights.end() ) {
@@ -1118,43 +1142,103 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
         D3D11PointLight* pl = c.pl;
         VobLightInfo* light = c.light;
 
-        pl->ClearTiledSlot();
-        pl->ReleaseShadowMap();
-
         if ( isTiledShadingEnabled ) {
-            int slot;
-            if ( c.wantsLowTier ) {
+            // Find the new slot BEFORE giving up the one this light already holds. Releasing first and then
+            // failing to allocate left the light with no cube at all - and no cube is what the range clamp
+            // turns into a light that visibly switches off. This is also what makes PROMOTION safe: a light
+            // that spilled into the low-res tier asks for the full-res one again every frame (its preferred
+            // resolution no longer matches its current one, which is what put it in `candidates`), and it
+            // only lets go of the cube it has once the better slot is actually in hand.
+            bool useLowTier = c.wantsLowTier;
+            int slot = -1;
+            if ( useLowTier ) {
                 slot = allocateOrEvictSlot( c.distSq, slotOwnerLightLow, MAX_STATIC_SHADOW_CUBEMAPS,
                     [&] { return m_TiledDeferred->AllocateStaticSlot(); } );
+            } else if ( c.desiredResolution != SHADOW_CUBE_SIZE ) {
+                // only one high-tier resolution is ever used; don't put a mismatched size into a tiled slot
+                light->UpdateShadows = false;
+                continue;
             } else {
-                if ( c.desiredResolution != SHADOW_CUBE_SIZE ) {
-                    // only one high-tier resolution is ever used; don't put a mismatched size into a tiled slot
-                    light->UpdateShadows = false;
-                    continue;
-                }
                 slot = allocateOrEvictSlot( c.distSq, slotOwnerLightHigh, MAX_SHADOW_CUBEMAPS,
                     [&] { return m_TiledDeferred->AllocateSlot(); } );
+                // SPILL. The full-res pool is full of lights no farther away than this one, but a light that
+                // never moves has a cacheable cube, and a 32^2 cached cube is enormously better than none: it
+                // gives up its dynamic overlay (that tier has no overlay array - see GetCurrentShadowMode)
+                // and keeps its shadow. Without this a room full of fixed lights left everything past the
+                // pool size unshadowed while the static tier sat empty.
+                if ( slot < 0 && c.spatiallyStatic ) {
+                    if ( pl->GetTiledSlot() >= 0 && pl->IsTiledSlotLowRes() ) {
+                        // Already spilled, and still nothing in the full-res pool: keep the cube it has.
+                        // Taking a DIFFERENT low-res slot instead would drop the bake and re-render it, and
+                        // since this light asks to be promoted again every single frame, that is a re-bake
+                        // every frame for as long as the full-res tier stays full.
+                        light->UpdateShadows = false;
+                        classifyLight( light, pl, c.distSq );
+                        continue;
+                    }
+                    slot = allocateOrEvictSlot( c.distSq, slotOwnerLightLow, MAX_STATIC_SHADOW_CUBEMAPS,
+                        [&] { return m_TiledDeferred->AllocateStaticSlot(); } );
+                    if ( slot >= 0 ) useLowTier = true;
+                }
             }
 
             if ( slot < 0 ) {
+                // Nothing to be had in either tier. Keep whatever this light already owns rather than
+                // dropping it - an older cube, even a stale one, beats going unshadowed.
                 light->UpdateShadows = false;
+                ++starvedThisFrame;
                 continue;
             }
 
-            if ( c.wantsLowTier ) {
+            // Read the previous slot only now: allocateOrEvictSlot may have evicted THIS light (it is a
+            // candidate for "farthest owner" like any other), in which case it has already been cleared.
+            const int prevSlot = pl->GetTiledSlot();
+            if ( prevSlot >= 0 ) {
+                if ( pl->IsTiledSlotLowRes() ) {
+                    if ( static_cast<uint32_t>(prevSlot) < MAX_STATIC_SHADOW_CUBEMAPS ) slotOwnerLightLow[prevSlot] = nullptr;
+                } else if ( static_cast<uint32_t>(prevSlot) < MAX_SHADOW_CUBEMAPS ) {
+                    slotOwnerLightHigh[prevSlot] = nullptr;
+                }
+                pl->ClearTiledSlot();
+            }
+            pl->ReleaseShadowMap();
+
+            if ( useLowTier ) {
                 pl->SetTiledSlot( slot, m_TiledDeferred->GetStaticSlotTarget( slot ), m_TiledDeferred.get(), true );
                 slotOwnerLightLow[slot] = light;
+                pl->SetCurrentResolution( STATIC_SHADOW_CUBE_SIZE );
             } else {
                 pl->SetTiledSlot( slot, m_TiledDeferred->GetSlotTarget( slot ), m_TiledDeferred.get(), false );
                 slotOwnerLightHigh[slot] = light;
+                pl->SetCurrentResolution( SHADOW_CUBE_SIZE );
             }
-            pl->SetCurrentResolution( c.desiredResolution );
         } else {
+            pl->ClearTiledSlot();
+            pl->ReleaseShadowMap();
             pl->AcquireShadowMap( dsPool, c.desiredResolution );
         }
 
         light->UpdateShadows = true;
         classifyLight( light, pl, c.distSq );
+    }
+
+    // Slot occupancy + starvation for the ImGui point-light window (DrawPointLightSlotStat). Occupancy comes
+    // from the pools themselves, not from the per-frame owner arrays: those only list slots held by lights
+    // VISIBLE this frame, while a slot stays allocated across the absence-retention window.
+    {
+        auto& info = Engine::GAPI->GetRendererState().RendererInfo;
+        if ( isTiledShadingEnabled ) {
+            info.PointLightSlotsUsed = m_TiledDeferred->GetUsedSlotCount();
+            info.PointLightSlotsMax = MAX_SHADOW_CUBEMAPS;
+            info.PointLightStaticSlotsUsed = m_TiledDeferred->GetUsedStaticSlotCount();
+            info.PointLightStaticSlotsMax = MAX_STATIC_SHADOW_CUBEMAPS;
+            info.PointLightSlotsStarved = starvedThisFrame;
+        } else {
+            // Legacy per-light cubemaps have no fixed pools to report on; zero Max hides the row entirely.
+            info.PointLightSlotsMax = 0;
+            info.PointLightStaticSlotsMax = 0;
+            info.PointLightSlotsStarved = 0;
+        }
     }
 
     // Render the immediate priority lights - but never more than a handful in one frame.

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -919,8 +919,8 @@ void D3D11ShadowMap::ConfigurePointSlots() {
     PointLightSlotSelector::Config cfg;
     cfg.MaxHiSlots = MAX_SHADOW_CUBEMAPS;
     cfg.MaxLowSlots = MAX_STATIC_SHADOW_CUBEMAPS;
-    // The two tier bits are backend-specific - D3D11's live in D3D11TiledDeferredShading.h and are the other
-    // way round from D3D12's - so they are configuration rather than a shared constant.
+    // The tier bits are backend-specific (D3D11's are the other way round from D3D12's), so they are
+    // configuration rather than a shared constant.
     cfg.TierLowBit = SHADOW_CUBE_TIER_LOW;
     cfg.HasDynamicBit = SHADOW_CUBE_HAS_DYNAMIC;
     m_PointSlots.Configure( cfg );
@@ -947,9 +947,8 @@ void D3D11ShadowMap::ReconcileTiledSlots() {
             continue;
         }
 
-        // A handover the selector has retired (its target got baked, or the wait timed out) must stop being
-        // sampled here too: that slot is back in the pool and the next light to take it would be shading
-        // against foreign depth, which reads as black rather than merely unshadowed.
+        // A handover the selector has retired must stop being sampled here too: that slot is back in the
+        // pool, and shading against the next owner's depth reads as black rather than merely unshadowed.
         if ( !pl->HasOwnDepthInSlot() && pl->GetSampleSlot() >= 0
             && m_PointSlots.FindFallbackSlotOf( reinterpret_cast<uint64_t>( light->Vob ) ) < 0 ) {
             pl->SetSlotFallback( -1, false );
@@ -959,20 +958,18 @@ void D3D11ShadowMap::ReconcileTiledSlots() {
         const int local = low ? static_cast<int>( m_PointSlots.LowIndex( static_cast<uint32_t>( global ) ) ) : global;
         if ( pl->GetTiledSlot() == local && pl->IsTiledSlotLowRes() == low ) continue;
 
-        // Changing tier or slot means the new target holds nothing of this light's: SetTiledSlot drops the bake
-        // and the has-own-depth flag, so it would be shaded unshadowed (range-clamped) until its render lands.
-        // Unless the selector kept the OLD slot back for it - a tier handover - in which case that slot still
-        // holds this light's depth and is what the lit pass keeps sampling meanwhile.
+        // Changing tier or slot means the new target holds nothing of this light's, so it is range-clamped
+        // until its render lands - unless the selector kept the OLD slot back for it as a handover.
         RenderToDepthStencilBuffer* target = low ? m_TiledDeferred->ClaimStaticSlot( local )
                                                  : m_TiledDeferred->ClaimSlot( local );
         if ( !target ) {
-            // The array could not be created - give the slot straight back so it is not held out of the pool.
+            // The array could not be created - give the slot back rather than hold it out of the pool.
             m_PointSlots.ReleaseSlot( static_cast<uint32_t>( global ) );
             if ( pl->GetTiledSlot() >= 0 ) pl->ClearTiledSlot();
             continue;
         }
-        // Captured before ClearTiledSlot wipes both, and only honoured when the selector really is holding that
-        // exact slot back for this light: anything else and the depth there is about to belong to someone else.
+        // Captured before ClearTiledSlot wipes them, and only honoured when the selector really is holding
+        // that exact slot back for this light.
         const int prevSlot = pl->GetTiledSlot();
         const bool prevLow = pl->IsTiledSlotLowRes();
         const bool prevHadDepth = pl->HasOwnDepthInSlot();
@@ -999,11 +996,8 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
     auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
 
     // Release the LEGACY per-light cubemap of a light that has been out of view for a while - never on the
-    // first absent frame, or a light that merely blinks (zCVobLight::IsEnabled toggling for a flicker effect)
-    // could never finish a bake that sticks. Tiled slots are exempt: how long one is held for an absent light
-    // is the shared selector's business (PointLightSlotSelector::Slot::missingFrames), and it measures
-    // presence in the frame light SET rather than visibility, so a light that is still being shaded from past
-    // the candidacy horizon no longer has its own cube aged out from under it.
+    // first absent frame, or a blinking light could never finish a bake that sticks. Tiled slots are exempt:
+    // their retention is the selector's business (PointLightSlotSelector::Slot::missingFrames).
     constexpr int kPointLightSlotRetentionFrames = 120;
     for ( auto& it : Engine::GAPI->VobLightMap ) {
         if ( !it.second->LightShadowBuffers ) continue;
@@ -1019,9 +1013,8 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
     if ( isTiledShadingEnabled ) ConfigurePointSlots();
 
     if (settings.EnablePointlightShadows <= 0) {
-        // Hand every cube back, so re-enabling mid-session re-renders from scratch instead of sampling depth
-        // that has been stale for however long the setting was off. ReconcileTiledSlots then makes each light
-        // let go of the slot it thought it held. Mirrors D3D12's PLS_DISABLED branch.
+        // Re-enabling mid-session must re-render from scratch; ReconcileTiledSlots then makes each light let
+        // go of the slot it thought it held. Mirrors D3D12's PLS_DISABLED branch.
         if ( isTiledShadingEnabled ) {
             m_PointSlots.Select( {}, GothicRendererSettings::PLS_DISABLED );
             ReconcileTiledSlots();
@@ -1048,8 +1041,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
 
     bool partialShadowUpdate = settings.PartialDynamicShadowUpdates;
     const bool staticOnlyMode = settings.EnablePointlightShadows == GothicRendererSettings::PLS_STATIC_ONLY;
-    // See D3D11PointLight's AllowsDynamicCasters: on, a static light skips the cached low-res tier entirely and
-    // is routed through the same pipeline as a normal dynamic light.
+    // See D3D11PointLight::AllowsDynamicCasters: on, a static light skips the cached low-res tier entirely.
     const bool allowStaticDynamicShadows =
         (settings.PointlightShadowCasterFlags & GothicRendererSettings::PLSC_STATIC_LIGHTS) != 0;
 
@@ -1097,15 +1089,13 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
         }
     };
 
-    // Candidates for the shared slot selector: one entry per visible light, in whatever order the frame's
-    // light list is in. Which of them gets a cube, out of which tier, in which slot, and whether its cached
-    // static depth has to be re-rendered is decided entirely by PointLightSlotSelector::Select - the exact
-    // same code the D3D12 backend runs. Nothing below re-decides any of it.
+    // Candidates for the shared slot selector, one per visible light. Which get a cube, out of which tier,
+    // in which slot, and whether the cached depth is re-rendered is decided entirely by Select().
     static std::vector<PointLightSlotSelector::Candidate> slotCandidates;
     slotCandidates.clear();
 
-    // Legacy (non-tiled) path only: every light owns an unbounded DepthStencilPool cubemap instead of a slot
-    // in a shared array, so there is no pool to select from and the old distance gating still applies.
+    // Legacy (non-tiled) path only: every light owns an unbounded DepthStencilPool cubemap, so there is no
+    // pool to select from and the old distance gating still applies.
     struct LegacyAcquire { VobLightInfo* light; D3D11PointLight* pl; float distSq; int desiredResolution; };
     static std::vector<LegacyAcquire> legacyAcquires;
     legacyAcquires.clear();
@@ -1125,7 +1115,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
         D3D11PointLight* pl = dynamic_cast<D3D11PointLight*>(light->LightShadowBuffers.get());
         if ( !pl ) continue;
 
-        pl->NoteStationary();   // feeds IsSpatiallyStatic(), i.e. whether this light may spill into the low tier
+        pl->NoteStationary();   // feeds IsSpatiallyStatic(), i.e. whether this light may spill low
 
         const float d = XMVectorGetX( XMVector3LengthSq( light->Vob->GetPositionWorldXM() - vPlayerPosition ) );
         const float range = light->Vob->GetLightRange();
@@ -1138,12 +1128,8 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
         if ( isTiledShadingEnabled ) {
             const bool spatiallyStatic = pl->IsSpatiallyStatic();
             // Route to the cached low-res tier when the light will not move AND could not receive a dynamic
-            // overlay anyway - which at PLS_STATIC_ONLY is every light there is. Same formula D3D12 uses
-            // (D3D12Scene.cpp's routeStatic), so both backends put the same lights in the same tier: without
-            // it, every colour-animated room light queued for the scarce full-res cubes whose per-frame
-            // overlay that mode does not even run, and whichever ones lost the queue were range-clamped into
-            // looking switched off. `isStatic` and `preferLow` are the same answer - a light the selector must
-            // never hand an overlay to is exactly one that belongs in the cached tier.
+            // overlay anyway. Same formula as D3D12Scene.cpp's routeStatic, so both backends put the same
+            // lights in the same tier; `isStatic` and `preferLow` are deliberately the same answer.
             const bool routeStatic = !allowStaticDynamicShadows
                 && ( light->IsStaticVobLight || ( spatiallyStatic && staticOnlyMode ) );
             slotCandidates.push_back( { reinterpret_cast<uint64_t>( light->Vob ), light,
@@ -1152,10 +1138,8 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
             continue;
         }
 
-        // Shadow-candidacy horizon, matching PointLightSlotSelector's: range*9 alone puts it at ~13 m for a
-        // candle (range ~150 units), and a light that falls outside it is shaded UNSHADOWED - which the light
-        // fill then range-clamps, collapsing the lit patch so the light reads as switched OFF at a distance
-        // where it is still plainly visible.
+        // Shadow-candidacy horizon, matching PointLightSlotSelector's: range*9 alone puts a candle at ~13 m,
+        // and a light outside it is shaded unshadowed, which the range clamp reads as switched OFF.
         constexpr float kMinShadowDist = 3000.0f;   // Gothic world units (~100 = 1 m)
         const float maxShadowDist = std::max( range * 9.0f, kMinShadowDist );
         if ( d < maxShadowDist * maxShadowDist ) {
@@ -1165,8 +1149,8 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
             }
             classifyLight( light, pl, d );
         } else if ( pl->HasAnyShadowMap() ) {
-            // Here every light owns an unbounded DepthStencilPool allocation, so holding one for a distant
-            // light is a real cost - unlike a tiled slot, whose depth stays perfectly good where it is.
+            // An unbounded DepthStencilPool allocation is a real cost to hold for a distant light, unlike a
+            // tiled slot whose depth stays perfectly good where it is.
             pl->ClearTiledSlot();
             pl->ReleaseShadowMap();
             dequeueLight( light );
@@ -1175,20 +1159,16 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
 
     if ( isTiledShadingEnabled ) {
         m_PointSlots.Select( slotCandidates, settings.EnablePointlightShadows );
-        // Point every light at the slot the selector says it owns - and only then, because a light that just
-        // lost its slot must stop rendering into it before the new owner does.
+        // A light that just lost its slot must stop rendering into it before the new owner does.
         ReconcileTiledSlots();
 
-        // Turn the selector's per-winner decisions into this frame's render schedule. renderStatic is the
-        // authoritative "this slot's cached static depth is out of date": fresh slot, light moved or resized,
-        // or a world change invalidated the bake (see PointLightSlotSelector::InvalidateStaticForVobAdded).
-        // The first two already drop the light's own bake elsewhere; the third is the reason ForceRebake has
-        // to be reachable from here at all.
+        // renderStatic is the authoritative "this slot's cached depth is out of date": fresh slot, light
+        // moved or resized, or a world change invalidated the bake - only the last needs ForceRebake here.
         for ( const PointLightSlotSelector::Assignment& a : m_PointSlots.GetAssignments() ) {
             VobLightInfo* light = static_cast<VobLightInfo*>( a.owner );
             if ( !light || !light->LightShadowBuffers ) continue;
             D3D11PointLight* pl = static_cast<D3D11PointLight*>( light->LightShadowBuffers.get() );
-            if ( pl->GetTiledSlot() < 0 ) continue;   // ReconcileTiledSlots could not claim a target for it
+            if ( pl->GetTiledSlot() < 0 ) continue;   // ReconcileTiledSlots claimed no target for it
             if ( a.renderStatic ) {
                 if ( pl->IsStaticShadowReady() ) pl->ForceRebake();
                 light->UpdateShadows = true;
@@ -1197,11 +1177,9 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
             classifyLight( light, pl, distSq );
         }
 
-        // A light the selector did NOT pick this frame keeps whatever cube it holds - that is the whole point
-        // of stable slot ownership - but it must not sit in an update queue: re-rendering it would cost a full
-        // caster cull for a light the selector has already decided is not worth one this frame. Membership of
-        // the winner set, not of the slot table: a light past the candidacy horizon still owns its slot and
-        // still samples it, and it is exactly the one that must stop paying for re-renders.
+        // A light the selector did not pick keeps whatever cube it holds, but must not sit in an update
+        // queue: re-rendering costs a full caster cull. Keyed on the winner set, not the slot table - a light
+        // past the candidacy horizon still owns and samples its slot, and is exactly the one to drop.
         static gtl::flat_hash_set<const zCVob*> winners;
         winners.clear();
         for ( const PointLightSlotSelector::Assignment& a : m_PointSlots.GetAssignments() )
@@ -1222,7 +1200,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
             c.light->UpdateShadows = true;
             classifyLight( c.light, c.pl, c.distSq );
         }
-        // Legacy per-light cubemaps have no fixed pools to report on; zero Max hides the row entirely.
+        // No fixed pools to report on here; zero Max hides the row entirely.
         auto& info = Engine::GAPI->GetRendererState().RendererInfo;
         info.PointLightSlotsMax = 0;
         info.PointLightStaticSlotsMax = 0;
@@ -1259,12 +1237,8 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
     }
 
     // Process Background Queue (Round-Robin)
-    // Set a strict, safe limit to prevent FPS drops - but priced per cube rather than counted, because the
-    // two tiers are not the same job: a low-res static cube is 32^2 against 128^2, a sixteenth of the raster
-    // work, though it still pays the same CPU caster cull. Half price, so the full-res rate is unchanged at
-    // 2 per frame while a wave of spilled/static lights (which is what a room full of fixed lights produces
-    // the moment they all need their one-time bake) drains twice as fast. They are shaded unshadowed until
-    // their turn comes, so this is how long they spend looking range-clamped.
+    // Priced per cube rather than counted: a low-res cube is a sixteenth of the raster work but pays the
+    // same CPU caster cull, so it goes at half price and a wave of one-time bakes drains twice as fast.
     constexpr int kBackgroundUpdateBudget = 4;   // 2 full-res cubes, or 4 low-res ones
     int updateBudget = kBackgroundUpdateBudget;
 

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -947,13 +947,22 @@ void D3D11ShadowMap::ReconcileTiledSlots() {
             continue;
         }
 
+        // A handover the selector has retired (its target got baked, or the wait timed out) must stop being
+        // sampled here too: that slot is back in the pool and the next light to take it would be shading
+        // against foreign depth, which reads as black rather than merely unshadowed.
+        if ( !pl->HasOwnDepthInSlot() && pl->GetSampleSlot() >= 0
+            && m_PointSlots.FindFallbackSlotOf( reinterpret_cast<uint64_t>( light->Vob ) ) < 0 ) {
+            pl->SetSlotFallback( -1, false );
+        }
+
         const bool low = m_PointSlots.IsLowSlot( static_cast<uint32_t>( global ) );
         const int local = low ? static_cast<int>( m_PointSlots.LowIndex( static_cast<uint32_t>( global ) ) ) : global;
         if ( pl->GetTiledSlot() == local && pl->IsTiledSlotLowRes() == low ) continue;
 
-        // Changing tier or slot means the depth this light held is gone: SetTiledSlot drops the bake and the
-        // has-own-depth flag, so it is shaded unshadowed (range-clamped) until its render lands rather than
-        // sampling whatever the previous occupant left in the new slot.
+        // Changing tier or slot means the new target holds nothing of this light's: SetTiledSlot drops the bake
+        // and the has-own-depth flag, so it would be shaded unshadowed (range-clamped) until its render lands.
+        // Unless the selector kept the OLD slot back for it - a tier handover - in which case that slot still
+        // holds this light's depth and is what the lit pass keeps sampling meanwhile.
         RenderToDepthStencilBuffer* target = low ? m_TiledDeferred->ClaimStaticSlot( local )
                                                  : m_TiledDeferred->ClaimSlot( local );
         if ( !target ) {
@@ -962,10 +971,24 @@ void D3D11ShadowMap::ReconcileTiledSlots() {
             if ( pl->GetTiledSlot() >= 0 ) pl->ClearTiledSlot();
             continue;
         }
+        // Captured before ClearTiledSlot wipes both, and only honoured when the selector really is holding that
+        // exact slot back for this light: anything else and the depth there is about to belong to someone else.
+        const int prevSlot = pl->GetTiledSlot();
+        const bool prevLow = pl->IsTiledSlotLowRes();
+        const bool prevHadDepth = pl->HasOwnDepthInSlot();
+        const int fbGlobal = m_PointSlots.FindFallbackSlotOf( reinterpret_cast<uint64_t>( light->Vob ) );
+
         pl->ClearTiledSlot();
         pl->ReleaseShadowMap();
         pl->SetTiledSlot( local, target, m_TiledDeferred.get(), low, &m_PointSlots );
         pl->SetCurrentResolution( low ? STATIC_SHADOW_CUBE_SIZE : SHADOW_CUBE_SIZE );
+
+        if ( prevHadDepth && prevSlot >= 0 && fbGlobal >= 0 ) {
+            const bool fbLow = m_PointSlots.IsLowSlot( static_cast<uint32_t>( fbGlobal ) );
+            const int fbLocal = fbLow ? static_cast<int>( m_PointSlots.LowIndex( static_cast<uint32_t>( fbGlobal ) ) )
+                                      : fbGlobal;
+            if ( fbLocal == prevSlot && fbLow == prevLow ) pl->SetSlotFallback( prevSlot, prevLow );
+        }
     }
 }
 

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1166,7 +1166,14 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
                 // gives up its dynamic overlay (that tier has no overlay array - see GetCurrentShadowMode)
                 // and keeps its shadow. Without this a room full of fixed lights left everything past the
                 // pool size unshadowed while the static tier sat empty.
-                if ( slot < 0 && c.spatiallyStatic ) {
+                // `spatiallyStatic` is what makes a low-res slot a good LONG-TERM home (that tier bakes once
+                // and caches forever, so a mover would re-enter the per-frame bake budget every frame). A
+                // light that currently has NO cube at all is a different question: it is being shaded
+                // unshadowed and range-clamped right now, i.e. it looks switched off, and even a cube it will
+                // have to keep re-baking beats that. So it spills too, and is promoted out again as soon as
+                // the full-res tier has room.
+                const bool maySpill = c.spatiallyStatic || !pl->HasShadowMap( requiredShadowMapKind );
+                if ( slot < 0 && maySpill ) {
                     if ( pl->GetTiledSlot() >= 0 && pl->IsTiledSlotLowRes() ) {
                         // Already spilled, and still nothing in the full-res pool: keep the cube it has.
                         // Taking a DIFFERENT low-res slot instead would drop the bake and re-render it, and
@@ -1271,12 +1278,16 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
     }
 
     // Process Background Queue (Round-Robin)
-    // Set a strict, safe limit to prevent FPS drops. 
-    // 2 per frame is 120 updates per second at 60fps.
-    int maxBackgroundUpdates = 2;
-    int updatesDone = 0;
+    // Set a strict, safe limit to prevent FPS drops - but priced per cube rather than counted, because the
+    // two tiers are not the same job: a low-res static cube is 32^2 against 128^2, a sixteenth of the raster
+    // work, though it still pays the same CPU caster cull. Half price, so the full-res rate is unchanged at
+    // 2 per frame while a wave of spilled/static lights (which is what a room full of fixed lights produces
+    // the moment they all need their one-time bake) drains twice as fast. They are shaded unshadowed until
+    // their turn comes, so this is how long they spend looking range-clamped.
+    constexpr int kBackgroundUpdateBudget = 4;   // 2 full-res cubes, or 4 low-res ones
+    int updateBudget = kBackgroundUpdateBudget;
 
-    while ( !graphicsEngine->FrameShadowUpdateLights.empty() && updatesDone < maxBackgroundUpdates ) {
+    while ( !graphicsEngine->FrameShadowUpdateLights.empty() && updateBudget > 0 ) {
         auto light = graphicsEngine->FrameShadowUpdateLights.front();
         graphicsEngine->FrameShadowUpdateLights.pop_front();
 
@@ -1296,7 +1307,7 @@ XRESULT D3D11ShadowMap::DrawPointlightShadows( std::vector<VobLightInfo*>& light
         l->RenderCubemap( force );
         graphicsEngine->DebugPointlight = l;
 
-        updatesDone++;
+        updateBudget -= l->IsTiledSlotLowRes() ? 1 : 2;
     }
 
     return XR_SUCCESS;

--- a/D3D11Engine/D3D11ShadowMap.h
+++ b/D3D11Engine/D3D11ShadowMap.h
@@ -176,34 +176,28 @@ public:
 
     D3D11RenderQueue* GetRenderQueue( int cascadeIndex ) { return m_RenderQueues[cascadeIndex].get(); }
 
-    /** Reported back by the cascade's VOB pass: whether it drew a caster whose geometry is deformed every
-        frame (an .MMS morph mesh with a live ani channel - windmill sails, water wheels). Such a cascade
-        can't be frozen by LazyCascadeUpdate or its depth stops matching the mesh the main view draws, which
-        is what made big spinning props cast a detached, garbled shadow. Latched one frame late by design:
-        the flag is re-evaluated every time the cascade actually renders. */
+    /** Reported back by the cascade's VOB pass: whether it drew a per-frame-deformed caster (an .MMS with a
+        live ani channel). Such a cascade can't be frozen by LazyCascadeUpdate or its depth stops matching
+        the mesh the main view draws. Latched one frame late - re-evaluated whenever the cascade renders. */
     void NoteCascadeAnimatedCasters( int cascadeIndex, bool hasAnimated ) {
         if ( cascadeIndex >= 0 && cascadeIndex < MAX_CSM_CASCADES )
             m_CascadeHasAnimatedCaster[cascadeIndex] = hasAnimated;
     }
 
-    /** The shared point-light shadow-cube slot table - see PointLightSlotSelector.h. Public because the world
-        change hooks on D3D11GraphicsEngine (a vob added, moved, or promoted to dynamic) resolve against it,
-        exactly as the D3D12 backend does through D3D12PointShadows. */
+    /** The shared point-light shadow-cube slot table. Public because D3D11GraphicsEngine's world-change
+        hooks resolve against it, exactly as D3D12 does through D3D12PointShadows. */
     PointLightSlotSelector& GetPointSlots() { return m_PointSlots; }
 
-    /** Hands a point-light slot back when its owning light vob leaves the world. Keyed on the vob POINTER, so
-        nothing about the dying light has to be read - by the time this fires its VobLightInfo may already be
-        on its way out. */
+    /** Hands a point-light slot back when its light vob leaves the world. Keyed on the vob POINTER: the
+        VobLightInfo may already be on its way out by the time this fires. */
     void ReleasePointLightSlotFor( const zCVob* lightVob );
 
 private:
     /** Sizes the shared slot table for this backend on first use. Idempotent. */
     void ConfigurePointSlots();
 
-    /** Makes every light's tiled slot agree with the selector, which is the sole owner of the slot table.
-        Walks the whole light map rather than this frame's visible set on purpose: a light that has gone out
-        of view still holds a slot index, and a queued background update would otherwise render into a slot
-        the selector has since handed to somebody else. */
+    /** Makes every light's tiled slot agree with the selector. Walks the whole light map, not this frame's
+        visible set: a queued background update must not render into a slot that changed hands. */
     void ReconcileTiledSlots();
 
     // Per-cascade size cap for the multi-cascade atlas, which packs all cascades into one

--- a/D3D11Engine/D3D11ShadowMap.h
+++ b/D3D11Engine/D3D11ShadowMap.h
@@ -74,6 +74,9 @@ struct RenderShadowmapsParams {
     D3D11_VIEWPORT ViewportOverride = {};
     bool UseViewportOverride = false;
     bool SkipClear = false;
+
+    // Grass is not a rain blocker - the rain shadowmap must not see it (see D3D11Effect::DrawRainShadowmap)
+    bool DrawVegetation = true;
 };
 
 class D3D11ShadowMap {

--- a/D3D11Engine/D3D11ShadowMap.h
+++ b/D3D11Engine/D3D11ShadowMap.h
@@ -186,7 +186,26 @@ public:
             m_CascadeHasAnimatedCaster[cascadeIndex] = hasAnimated;
     }
 
+    /** The shared point-light shadow-cube slot table - see PointLightSlotSelector.h. Public because the world
+        change hooks on D3D11GraphicsEngine (a vob added, moved, or promoted to dynamic) resolve against it,
+        exactly as the D3D12 backend does through D3D12PointShadows. */
+    PointLightSlotSelector& GetPointSlots() { return m_PointSlots; }
+
+    /** Hands a point-light slot back when its owning light vob leaves the world. Keyed on the vob POINTER, so
+        nothing about the dying light has to be read - by the time this fires its VobLightInfo may already be
+        on its way out. */
+    void ReleasePointLightSlotFor( const zCVob* lightVob );
+
 private:
+    /** Sizes the shared slot table for this backend on first use. Idempotent. */
+    void ConfigurePointSlots();
+
+    /** Makes every light's tiled slot agree with the selector, which is the sole owner of the slot table.
+        Walks the whole light map rather than this frame's visible set on purpose: a light that has gone out
+        of view still holds a slot index, and a queued background update would otherwise render into a slot
+        the selector has since handed to somebody else. */
+    void ReconcileTiledSlots();
+
     // Per-cascade size cap for the multi-cascade atlas, which packs all cascades into one
     // (2*S) x (1.5*S) texture. 2048 keeps the biggest atlas at 4096x3072.
     static const int MAX_ATLAS_CASCADE_SIZE = 2048;
@@ -228,6 +247,10 @@ private:
     XMFLOAT3 m_WorldShadowPos;
 
     std::unique_ptr<D3D11TiledDeferredShading> m_TiledDeferred;
+
+    // Which point light owns which shadow cube, and when each one's cached static depth is re-rendered.
+    // Shared verbatim with the D3D12 backend - see PointLightSlotSelector.h.
+    PointLightSlotSelector m_PointSlots;
     D3D11LegacyDeferredShading m_LegacyDeferred;
 
     TracyLockable(std::mutex, m_CullingJobsMutex);

--- a/D3D11Engine/D3D11ShadowMap.h
+++ b/D3D11Engine/D3D11ShadowMap.h
@@ -176,6 +176,16 @@ public:
 
     D3D11RenderQueue* GetRenderQueue( int cascadeIndex ) { return m_RenderQueues[cascadeIndex].get(); }
 
+    /** Reported back by the cascade's VOB pass: whether it drew a caster whose geometry is deformed every
+        frame (an .MMS morph mesh with a live ani channel - windmill sails, water wheels). Such a cascade
+        can't be frozen by LazyCascadeUpdate or its depth stops matching the mesh the main view draws, which
+        is what made big spinning props cast a detached, garbled shadow. Latched one frame late by design:
+        the flag is re-evaluated every time the cascade actually renders. */
+    void NoteCascadeAnimatedCasters( int cascadeIndex, bool hasAnimated ) {
+        if ( cascadeIndex >= 0 && cascadeIndex < MAX_CSM_CASCADES )
+            m_CascadeHasAnimatedCaster[cascadeIndex] = hasAnimated;
+    }
+
 private:
     // Per-cascade size cap for the multi-cascade atlas, which packs all cascades into one
     // (2*S) x (1.5*S) texture. 2048 keeps the biggest atlas at 4096x3072.
@@ -212,6 +222,9 @@ private:
     std::array<std::unique_ptr<D3D11RenderQueue>, MAX_CSM_CASCADES> m_RenderQueues;
     std::vector<float> m_CascadeSplits;
     std::array<bool, MAX_CSM_CASCADES> m_ShouldUpdateCascade = { true, true, true, true };
+    // See NoteCascadeAnimatedCasters - keeps a cascade out of the lazy-update skip while it holds a
+    // per-frame-deformed caster.
+    std::array<bool, MAX_CSM_CASCADES> m_CascadeHasAnimatedCaster = {};
     XMFLOAT3 m_WorldShadowPos;
 
     std::unique_ptr<D3D11TiledDeferredShading> m_TiledDeferred;

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -504,13 +504,15 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
             // Mirrors D3D12's "publish the cube index only once the slot holds this owner's depth" - and,
             // like that rule, it deliberately keeps advertising a slot whose bake has merely been
             // INVALIDATED: stale depth is a small artefact, no depth at all is a light that switches off.
-            if ( pl && pl->IsInited() && pl->HasShadowMap( 1 ) && pl->HasOwnDepthInSlot() ) {
+            // HasSampleableDepth, not HasOwnDepthInSlot: a light mid-tier-handover has no depth in its NEW
+            // slot yet but its old one is being held back for exactly this - see SetSlotFallback.
+            if ( pl && pl->IsInited() && pl->HasShadowMap( 1 ) && pl->HasSampleableDepth() ) {
                 hasShadow = true;
             }
         }
 
         // Shadowed lights need a tiled slot (assigned earlier in DrawPointlightShadows).
-        if ( hasShadow && pl->GetTiledSlot() < 0 ) {
+        if ( hasShadow && pl->GetSampleSlot() < 0 ) {
             continue;
         }
 
@@ -563,9 +565,11 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
         tl.PositionWorld = XMFLOAT3( posWorld.x, posWorld.y, posWorld.z );
 
         if ( hasShadow ) {
-            tl.ShadowCubeIndex = pl->GetTiledSlot()
-                | ( pl->IsTiledSlotLowRes() ? SHADOW_CUBE_TIER_LOW : 0 )
-                | ( pl->HasDynamicShadowOverlay() ? SHADOW_CUBE_HAS_DYNAMIC : 0 );
+            // The overlay bit belongs to the light's OWN slot only - the one it is handing over from was
+            // never refreshed for this frame and its dynamic twin holds somebody else's casters.
+            tl.ShadowCubeIndex = pl->GetSampleSlot()
+                | ( pl->IsSampleSlotLowRes() ? SHADOW_CUBE_TIER_LOW : 0 )
+                | ( pl->HasOwnDepthInSlot() && pl->HasDynamicShadowOverlay() ? SHADOW_CUBE_HAS_DYNAMIC : 0 );
             hasShadowedTiledLights = true;
         } else {
             tl.ShadowCubeIndex = -1;

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -516,7 +516,16 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
         bool hasShadow = false;
         if ( settings.EnablePointlightShadows > 0 ) {
             pl = light->LightShadowBuffers ? static_cast<D3D11PointLight*>(light->LightShadowBuffers.get()) : nullptr;
-            if ( pl && pl->IsInited() && pl->HasShadowMap( 1 ) ) {
+            // HasOwnDepthInSlot() is load-bearing, not a formality: owning a slot is not the same as that
+            // slot holding THIS light's depth. A freshly assigned (or re-assigned) slot still contains
+            // whatever the previous occupant rendered there, or nothing at all, and the render that fills it
+            // is rationed to a handful of lights per frame in DrawPointlightShadows. Advertising the slot in
+            // the meantime samples that foreign depth and shades the light as fully occluded - it goes BLACK,
+            // which is far worse than the range-clamped unshadowed look it gets by waiting for its turn.
+            // Mirrors D3D12's "publish the cube index only once the slot holds this owner's depth" - and,
+            // like that rule, it deliberately keeps advertising a slot whose bake has merely been
+            // INVALIDATED: stale depth is a small artefact, no depth at all is a light that switches off.
+            if ( pl && pl->IsInited() && pl->HasShadowMap( 1 ) && pl->HasOwnDepthInSlot() ) {
                 hasShadow = true;
             }
         }

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -500,6 +500,11 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
     constexpr float kIndoorSeenFromOutsideScale = 0.15f; // worst bleed case - clamp it much harder
     const zCVob* playerVob = Engine::GAPI->GetPlayerVob();
     const bool cameraIndoors = playerVob && playerVob->IsIndoorVob();
+    // The clamp is applied THROUGH a per-light eased scale rather than switched on and off - see
+    // VobLightInfo::UnshadowedRangeScale. Framerate-independent exponential approach, ~0.3 s.
+    constexpr float kClampEaseSeconds = 0.3f;
+    const float clampDt = std::clamp( Engine::GAPI->GetFrameTimeSec(), 0.0f, 0.1f );
+    const float clampEase = 1.0f - std::exp( -clampDt / kClampEaseSeconds );
 
     for ( auto const& light : lights ) {
         zCVobLight* vob = light->Vob;
@@ -528,9 +533,13 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
 
         float4 lightColor = float4( vob->GetLightColor() );
         float lightRange = vob->GetLightRange();
-        if ( !hasShadow && ( vob->IsStatic() || light->IsIndoorVob ) ) {
+        if ( vob->IsStatic() || light->IsIndoorVob ) {
             const bool leakingOutdoors = light->IsIndoorVob && !cameraIndoors;
-            lightRange *= leakingOutdoors ? kIndoorSeenFromOutsideScale : kUnshadowedStaticScale;
+            const float target = hasShadow ? 1.0f
+                : ( leakingOutdoors ? kIndoorSeenFromOutsideScale : kUnshadowedStaticScale );
+            if ( light->UnshadowedRangeScale < 0.0f ) light->UnshadowedRangeScale = target;   // first sight
+            else light->UnshadowedRangeScale += ( target - light->UnshadowedRangeScale ) * clampEase;
+            if ( light->UnshadowedRangeScale < 0.999f ) lightRange *= light->UnshadowedRangeScale;
         }
         float3 posWorld = vob->GetPositionWorld();
 

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -47,7 +47,7 @@ void D3D11TiledDeferredShading::Init(
     // The clustered cull writes a bitmask straight into the grid, so it needs no flat index list and no
     // atomic allocation counter - both are gone with the old per-tile cull.
 
-    // Shadow cube array is lazy-created on first AllocateSlot() to save memory when shadows are off
+    // Shadow cube array is lazy-created on the first ClaimSlot() to save memory when shadows are off
 }
 
 void D3D11TiledDeferredShading::EnsureShadowArray() {
@@ -240,21 +240,10 @@ void D3D11TiledDeferredShading::EnsureStaticShadowArray() {
     }
 }
 
-int D3D11TiledDeferredShading::AllocateStaticSlot() {
+RenderToDepthStencilBuffer* D3D11TiledDeferredShading::ClaimStaticSlot( int slot ) {
+    if ( slot < 0 || static_cast<uint32_t>(slot) >= MAX_STATIC_SHADOW_CUBEMAPS ) return nullptr;
     EnsureStaticShadowArray();
-    if ( !m_ShadowStaticCubeArray ) return -1;
-    for ( uint32_t i = 0; i < MAX_STATIC_SHADOW_CUBEMAPS; i++ ) {
-        if ( !m_StaticSlotInUse[i] ) {
-            m_StaticSlotInUse[i] = true;
-            return static_cast<int>(i);
-        }
-    }
-    return -1;
-}
-
-void D3D11TiledDeferredShading::FreeStaticSlot( int slot ) {
-    if ( slot >= 0 && static_cast<uint32_t>(slot) < MAX_STATIC_SHADOW_CUBEMAPS )
-        m_StaticSlotInUse[slot] = false;
+    return GetStaticSlotTarget( slot );
 }
 
 RenderToDepthStencilBuffer* D3D11TiledDeferredShading::GetStaticSlotTarget( int slot ) {
@@ -263,20 +252,10 @@ RenderToDepthStencilBuffer* D3D11TiledDeferredShading::GetStaticSlotTarget( int 
     return nullptr;
 }
 
-int D3D11TiledDeferredShading::AllocateSlot() {
+RenderToDepthStencilBuffer* D3D11TiledDeferredShading::ClaimSlot( int slot ) {
+    if ( slot < 0 || static_cast<uint32_t>(slot) >= MAX_SHADOW_CUBEMAPS ) return nullptr;
     EnsureShadowArray();
-    for ( uint32_t i = 0; i < MAX_SHADOW_CUBEMAPS; i++ ) {
-        if ( !m_SlotInUse[i] ) {
-            m_SlotInUse[i] = true;
-            return static_cast<int>(i);
-        }
-    }
-    return -1;
-}
-
-void D3D11TiledDeferredShading::FreeSlot( int slot ) {
-    if ( slot >= 0 && static_cast<uint32_t>(slot) < MAX_SHADOW_CUBEMAPS )
-        m_SlotInUse[slot] = false;
+    return GetSlotTarget( slot );
 }
 
 RenderToDepthStencilBuffer* D3D11TiledDeferredShading::GetSlotTarget( int slot ) {

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -479,8 +479,8 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
     constexpr float kIndoorSeenFromOutsideScale = 0.15f; // worst bleed case - clamp it much harder
     const zCVob* playerVob = Engine::GAPI->GetPlayerVob();
     const bool cameraIndoors = playerVob && playerVob->IsIndoorVob();
-    // The clamp is applied THROUGH a per-light eased scale rather than switched on and off - see
-    // VobLightInfo::UnshadowedRangeScale. Framerate-independent exponential approach, ~0.3 s.
+    // Applied through a per-light eased scale rather than switched on and off - see
+    // VobLightInfo::UnshadowedRangeScale. Framerate-independent exponential approach.
     constexpr float kClampEaseSeconds = 0.3f;
     const float clampDt = std::clamp( Engine::GAPI->GetFrameTimeSec(), 0.0f, 0.1f );
     const float clampEase = 1.0f - std::exp( -clampDt / kClampEaseSeconds );
@@ -495,17 +495,11 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
         bool hasShadow = false;
         if ( settings.EnablePointlightShadows > 0 ) {
             pl = light->LightShadowBuffers ? static_cast<D3D11PointLight*>(light->LightShadowBuffers.get()) : nullptr;
-            // HasOwnDepthInSlot() is load-bearing, not a formality: owning a slot is not the same as that
-            // slot holding THIS light's depth. A freshly assigned (or re-assigned) slot still contains
-            // whatever the previous occupant rendered there, or nothing at all, and the render that fills it
-            // is rationed to a handful of lights per frame in DrawPointlightShadows. Advertising the slot in
-            // the meantime samples that foreign depth and shades the light as fully occluded - it goes BLACK,
-            // which is far worse than the range-clamped unshadowed look it gets by waiting for its turn.
-            // Mirrors D3D12's "publish the cube index only once the slot holds this owner's depth" - and,
-            // like that rule, it deliberately keeps advertising a slot whose bake has merely been
-            // INVALIDATED: stale depth is a small artefact, no depth at all is a light that switches off.
-            // HasSampleableDepth, not HasOwnDepthInSlot: a light mid-tier-handover has no depth in its NEW
-            // slot yet but its old one is being held back for exactly this - see SetSlotFallback.
+            // Owning a slot is not the same as that slot holding THIS light's depth: a freshly assigned
+            // one still holds the previous occupant's, and sampling that shades the light BLACK rather than
+            // merely unshadowed. A slot whose bake was only INVALIDATED keeps being advertised, though -
+            // stale depth beats none. HasSampleableDepth covers a light mid-handover, whose old slot is
+            // being held back for exactly this - see SetSlotFallback.
             if ( pl && pl->IsInited() && pl->HasShadowMap( 1 ) && pl->HasSampleableDepth() ) {
                 hasShadow = true;
             }
@@ -565,8 +559,8 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
         tl.PositionWorld = XMFLOAT3( posWorld.x, posWorld.y, posWorld.z );
 
         if ( hasShadow ) {
-            // The overlay bit belongs to the light's OWN slot only - the one it is handing over from was
-            // never refreshed for this frame and its dynamic twin holds somebody else's casters.
+            // The overlay bit belongs to the light's OWN slot only: the one it is handing over from was
+            // never refreshed this frame.
             tl.ShadowCubeIndex = pl->GetSampleSlot()
                 | ( pl->IsSampleSlotLowRes() ? SHADOW_CUBE_TIER_LOW : 0 )
                 | ( pl->HasOwnDepthInSlot() && pl->HasDynamicShadowOverlay() ? SHADOW_CUBE_HAS_DYNAMIC : 0 );

--- a/D3D11Engine/D3D11TiledDeferredShading.h
+++ b/D3D11Engine/D3D11TiledDeferredShading.h
@@ -114,6 +114,12 @@ public:
     void FreeStaticSlot( int slot );
     RenderToDepthStencilBuffer* GetStaticSlotTarget( int slot );
 
+    // Real occupancy, for the ImGui point-light window. Not derivable from DrawPointlightShadows' per-frame
+    // owner arrays: those only list slots held by lights VISIBLE this frame, while a slot stays allocated
+    // across the absence-retention window.
+    uint32_t GetUsedSlotCount() const { return static_cast<uint32_t>( m_SlotInUse.count() ); }
+    uint32_t GetUsedStaticSlotCount() const { return static_cast<uint32_t>( m_StaticSlotInUse.count() ); }
+
 private:
     void EnsureBuffers( uint32_t numTilesX, uint32_t numTilesY );
     void EnsureShadowArray();

--- a/D3D11Engine/D3D11TiledDeferredShading.h
+++ b/D3D11Engine/D3D11TiledDeferredShading.h
@@ -101,24 +101,19 @@ public:
     ID3D11ShaderResourceView* GetShadowStaticCubeArraySRV() const { return m_ShadowStaticCubeArraySRV.Get(); }
     bool IsStaticShadowArrayCreated() const { return m_StaticShadowArrayCreated; }
 
-    // Shadow cubemap array slot management
-    int AllocateSlot();
-    void FreeSlot( int slot );
+    // Shadow cubemap array slot access. There is no allocator here any more: which light owns which slot is
+    // decided entirely by the shared PointLightSlotSelector (see D3D11ShadowMap::ReconcileTiledSlots), so
+    // these only hand out the view for a slot the selector already assigned, creating the array on first use.
+    // A second, independently-owned free list here could only ever disagree with that one.
+    RenderToDepthStencilBuffer* ClaimSlot( int slot );
     RenderToDepthStencilBuffer* GetSlotTarget( int slot );
     /** Same slot index as GetSlotTarget, but into the dynamic-overlay array. Creates that array on first use,
         so worlds that never render a moving caster into a point-light cube never pay for it. */
     RenderToDepthStencilBuffer* GetDynSlotTarget( int slot );
 
     // Low-res static-only tier - see WantsStaticOnlySlot()/SHADOW_CUBE_TIER_LOW.
-    int AllocateStaticSlot();
-    void FreeStaticSlot( int slot );
+    RenderToDepthStencilBuffer* ClaimStaticSlot( int slot );
     RenderToDepthStencilBuffer* GetStaticSlotTarget( int slot );
-
-    // Real occupancy, for the ImGui point-light window. Not derivable from DrawPointlightShadows' per-frame
-    // owner arrays: those only list slots held by lights VISIBLE this frame, while a slot stays allocated
-    // across the absence-retention window.
-    uint32_t GetUsedSlotCount() const { return static_cast<uint32_t>( m_SlotInUse.count() ); }
-    uint32_t GetUsedStaticSlotCount() const { return static_cast<uint32_t>( m_StaticSlotInUse.count() ); }
 
 private:
     void EnsureBuffers( uint32_t numTilesX, uint32_t numTilesY );
@@ -141,7 +136,6 @@ private:
     // Shadow cubemap array for tiled shadowed lights (lazy-created)
     Microsoft::WRL::ComPtr<ID3D11Texture2D> m_ShadowCubeArray;
     Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_ShadowCubeArraySRV;
-    std::bitset<MAX_SHADOW_CUBEMAPS> m_SlotInUse;
     std::array<Microsoft::WRL::ComPtr<ID3D11DepthStencilView>, MAX_SHADOW_CUBEMAPS> m_SlotDSVs;
     std::array<std::unique_ptr<RenderToDepthStencilBuffer>, MAX_SHADOW_CUBEMAPS> m_SlotViews;
     bool m_ShadowArrayCreated = false;
@@ -159,7 +153,6 @@ private:
     // Low-res static-only cube array (see WantsStaticOnlySlot()). Lazy-created like the arrays above.
     Microsoft::WRL::ComPtr<ID3D11Texture2D> m_ShadowStaticCubeArray;
     Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_ShadowStaticCubeArraySRV;
-    std::bitset<MAX_STATIC_SHADOW_CUBEMAPS> m_StaticSlotInUse;
     std::array<Microsoft::WRL::ComPtr<ID3D11DepthStencilView>, MAX_STATIC_SHADOW_CUBEMAPS> m_StaticSlotDSVs;
     std::array<std::unique_ptr<RenderToDepthStencilBuffer>, MAX_STATIC_SHADOW_CUBEMAPS> m_StaticSlotViews;
     bool m_StaticShadowArrayCreated = false;

--- a/D3D11Engine/D3D11TiledDeferredShading.h
+++ b/D3D11Engine/D3D11TiledDeferredShading.h
@@ -101,10 +101,8 @@ public:
     ID3D11ShaderResourceView* GetShadowStaticCubeArraySRV() const { return m_ShadowStaticCubeArraySRV.Get(); }
     bool IsStaticShadowArrayCreated() const { return m_StaticShadowArrayCreated; }
 
-    // Shadow cubemap array slot access. There is no allocator here any more: which light owns which slot is
-    // decided entirely by the shared PointLightSlotSelector (see D3D11ShadowMap::ReconcileTiledSlots), so
-    // these only hand out the view for a slot the selector already assigned, creating the array on first use.
-    // A second, independently-owned free list here could only ever disagree with that one.
+    // Shadow cubemap array slot access. There is no allocator here: PointLightSlotSelector decides who owns
+    // which slot, so these only hand out the view for one it already assigned, creating the array on demand.
     RenderToDepthStencilBuffer* ClaimSlot( int slot );
     RenderToDepthStencilBuffer* GetSlotTarget( int slot );
     /** Same slot index as GetSlotTarget, but into the dynamic-overlay array. Creates that array on first use,

--- a/D3D11Engine/D3D12Engine/D3D12Device.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Device.cpp
@@ -58,9 +58,9 @@ namespace {
                     if ( SUCCEEDED( hr ) && sdkConfig ) {
                         hr = sdkConfig->CreateDeviceFactory( agilitySdkVersion, agilitySdkDeployPath, IID_PPV_ARGS(&agilityDeviceFactory));
                         if ( !SUCCEEDED( hr ) ) {
-                            LogWarn() << "Failed to initialize agility SDK (version " << agilitySdkVersion << ", result: " << hr << " ); using system D3D12.";
+                            Logging::Wrn( "D3D12: failed to initialize the Agility SDK (version {}, result 0x{:08X}); using the system D3D12.", agilitySdkVersion, static_cast<uint32_t>( hr ) );
                         } else {
-                            LogInfo() << "D3D12 Agility SDK " << agilitySdkVersion << " activated from " << agilitySdkDeployPath;
+                            Logging::Inf( "D3D12 Agility SDK {} activated from {}", agilitySdkVersion, agilitySdkDeployPath );
 
                             // CreateDeviceFactory only redirects devices made through the factory — the
                             // process-global runtime (and with it every exported free function) stays on
@@ -75,16 +75,16 @@ namespace {
                             // runs once, from the first IsAvailable()/Init() call.
                             HRESULT applyHr = agilityDeviceFactory->ApplyToGlobalState();
                             if ( FAILED( applyHr ) ) {
-                                LogWarn() << "D3D12: ID3D12DeviceFactory::ApplyToGlobalState failed (0x" << std::hex
-                                          << applyHr << std::dec << "); the exported root signature serializer stays on "
-                                          "the OS runtime, which may reject SM6.6 bindless root signatures.";
+                                Logging::Wrn( "D3D12: ID3D12DeviceFactory::ApplyToGlobalState failed (0x{:08X}); the exported "
+                                    "root signature serializer stays on the OS runtime, which may reject SM6.6 bindless "
+                                    "root signatures.", static_cast<uint32_t>( applyHr ) );
                             }
                         }
                     }
                 }
             }
         } else {
-            LogInfo() << "D3D12 Agility SDK core not deployed; using the system D3D12 runtime.";
+            Logging::Inf( "D3D12 Agility SDK core not deployed; using the system D3D12 runtime." );
         }
     }
 
@@ -231,6 +231,7 @@ namespace {
                 adapter->GetDesc1( &desc );
                 if ( desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE ) continue;
                 if ( AdapterSupportsD3D12( createDevice, adapter.Get(), outReason ) ) {
+                    Logging::Dbg( "D3D12: adapter {} ({}) accepted by GPU preference.", i, DescriptionToNarrow( desc ) );
                     outAdapter = adapter;
                     outDescription = DescriptionToNarrow( desc );
                     if ( outReason ) outReason->clear();   // drop any earlier candidate's rejection reason
@@ -246,11 +247,17 @@ namespace {
             DXGI_ADAPTER_DESC1 desc;
             adapter->GetDesc1( &desc );
             if ( desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE ) continue;
-            if ( !AdapterSupportsD3D12( createDevice, adapter.Get(), outReason ) ) continue;
+            if ( !AdapterSupportsD3D12( createDevice, adapter.Get(), outReason ) ) {
+                Logging::Dbg( "D3D12: adapter {} ({}) rejected: {}.", i, DescriptionToNarrow( desc ),
+                    outReason ? outReason->c_str() : "unsupported" );
+                continue;
+            }
 
             uint64_t rating = static_cast<uint64_t>( desc.DedicatedVideoMemory );
             if ( desc.VendorId == 0x10DE ) rating += 0x200000000; // NVIDIA
             else if ( desc.VendorId == 0x1002 ) rating += 0x100000000; // AMD > Intel IGPU
+            Logging::Dbg( "D3D12: adapter {} ({}) rated 0x{:X}, {} MiB dedicated VRAM.", i, DescriptionToNarrow( desc ),
+                rating, desc.DedicatedVideoMemory / (1024ull * 1024ull) );
             candidates.emplace( rating, adapter );
             descriptions.emplace( rating, DescriptionToNarrow( desc ) );
         }
@@ -301,7 +308,7 @@ bool D3D12Device::Init() {
     
     PFN_D3D12_CREATE_DEVICE createDevice = LoadD3D12CreateDevice();
     if ( !createDevice ) {
-        LogWarn() << "D3D12Device::Init: d3d12.dll / D3D12CreateDevice unavailable.";
+        Logging::Wrn( "D3D12Device::Init: d3d12.dll / D3D12CreateDevice unavailable." );
         return false;
     }
 
@@ -317,7 +324,7 @@ bool D3D12Device::Init() {
         ComPtr<ID3D12Debug> debug;
         if ( DEBUG_D3D11_ENABLED && getDebug && SUCCEEDED( getDebug( IID_PPV_ARGS( debug.ReleaseAndGetAddressOf() ) ) ) ) {
             debug->EnableDebugLayer();
-            LogInfo() << "D3D12 debug layer enabled.";
+            Logging::Inf( "D3D12 debug layer enabled." );
         }
 
         ComPtr<ID3D12Debug1> debug1;
@@ -341,23 +348,23 @@ bool D3D12Device::Init() {
     }
 
     if ( !CreateFactory( m_Factory ) ) {
-        LogWarn() << "D3D12Device::Init: failed to create DXGI factory.";
+        Logging::Wrn( "D3D12Device::Init: failed to create the DXGI factory." );
         return false;
     }
 
     std::string rejectReason;
     if ( !SelectAdapter( m_Factory.Get(), createDevice, m_Adapter, m_DeviceDescription, &rejectReason ) ) {
-        LogWarn() << "D3D12Device::Init: no usable GPU found ("
-                  << ( rejectReason.empty() ? "no Feature-Level-12_0-capable GPU" : rejectReason.c_str() ) << ").";
+        Logging::Wrn( "D3D12Device::Init: no usable GPU found ({}).",
+            rejectReason.empty() ? "no Feature-Level-12_0-capable GPU" : rejectReason.c_str() );
         return false;
     }
 
     HRESULT hr = createDevice( m_Adapter.Get(), D3D_FEATURE_LEVEL_12_0, IID_PPV_ARGS( m_Device.ReleaseAndGetAddressOf() ) );
     if ( FAILED( hr ) ) {
-        LogWarn() << "D3D12Device::Init: D3D12CreateDevice failed with code 0x" << std::hex << hr << ".";
+        Logging::Wrn( "D3D12Device::Init: D3D12CreateDevice failed with code 0x{:08X}.", static_cast<uint32_t>( hr ) );
         return false;
     }
-    LogInfo() << "D3D12 device created on: " << m_DeviceDescription.c_str();
+    Logging::Inf( "D3D12 device created on: {}", m_DeviceDescription );
 
     m_LayeredRenderingSupported = DeviceSupportsLayeredRendering( m_Device.Get() );
 
@@ -369,9 +376,9 @@ bool D3D12Device::Init() {
     std::string barrierReason;
     m_EnhancedBarriersSupported = DeviceSupportsEnhancedBarriers( m_Device.Get(), &barrierReason );
     if ( m_EnhancedBarriersSupported ) {
-        LogInfo() << "D3D12: enhanced barriers supported.";
+        Logging::Inf( "D3D12: enhanced barriers supported." );
     } else {
-        LogInfo() << "D3D12: enhanced barriers unavailable (" << barrierReason.c_str() << "); using legacy transitions.";
+        Logging::Inf( "D3D12: enhanced barriers unavailable ({}); using legacy transitions.", barrierReason );
     }
 
     // Direct (graphics) queue
@@ -380,7 +387,7 @@ bool D3D12Device::Init() {
     directDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
     hr = m_Device->CreateCommandQueue( &directDesc, IID_PPV_ARGS( m_DirectQueue.ReleaseAndGetAddressOf() ) );
     if ( FAILED( hr ) ) {
-        LogWarn() << "D3D12Device::Init: failed to create the direct command queue (0x" << std::hex << hr << ").";
+        Logging::Wrn( "D3D12Device::Init: failed to create the direct command queue (0x{:08X}).", static_cast<uint32_t>( hr ) );
         return false;
     }
 
@@ -390,7 +397,7 @@ bool D3D12Device::Init() {
     copyDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
     hr = m_Device->CreateCommandQueue( &copyDesc, IID_PPV_ARGS( m_CopyQueue.ReleaseAndGetAddressOf() ) );
     if ( FAILED( hr ) ) {
-        LogWarn() << "D3D12Device::Init: failed to create the copy command queue (0x" << std::hex << hr << ").";
+        Logging::Wrn( "D3D12Device::Init: failed to create the copy command queue (0x{:08X}).", static_cast<uint32_t>( hr ) );
         return false;
     }
 

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.cpp
@@ -79,7 +79,7 @@ D3D12GraphicsEngine::~D3D12GraphicsEngine() {
 
 XRESULT D3D12GraphicsEngine::Init() {
     if ( !m_Device.Init() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: device creation failed.";
+        Logging::Err( "D3D12GraphicsEngine::Init: device creation failed." );
         return XR_FAILED;
     }
     D3D12CmdList::SetEnhancedBarriersDeviceSupport( m_Device.EnhancedBarriersSupported() );
@@ -102,32 +102,32 @@ XRESULT D3D12GraphicsEngine::Init() {
     Engine::GAPI->GetRendererState().RendererSettings.ApplyDeviceCapabilities( m_DeviceCapabilities );
 
     if ( !CreateAllocators() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create allocators.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create allocators." );
         return XR_FAILED;
     }
     if ( !CreateUploadObjects() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create upload objects.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create upload objects." );
         return XR_FAILED;
     }
     if ( !InitCopyQueue() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to initialize the copy queue.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to initialize the copy queue." );
         return XR_FAILED;
     }
     if ( !CreateSrvHeap() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create SRV heap.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create SRV heap." );
         return XR_FAILED;
     }
     if ( !m_TexturePool.Attach( *this ) ) {
         // Non-fatal: nothing consumes the pool yet (see D3D12RenderGraph.h), so a failure here just means
         // that infrastructure stays unavailable until the next Init(). Nothing in today's frame depends on it.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the pooled-render-target RTV heap.";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the pooled-render-target RTV heap." );
     }
     if ( !m_AliasArena.Attach( *this ) ) {
         // Non-fatal for the same reason: no pass constructs a D3D12RenderGraph yet (see D3D12RenderGraph.h).
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the render-graph aliasing arena.";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the render-graph aliasing arena." );
     }
     if ( !m_Pipelines.Init( &m_Device, &m_ShaderBackend ) ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to init the pipeline-state module.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to init the pipeline-state module." );
         return XR_FAILED;
     }
     // Must run BEFORE any Create*() too: every scene PSO bakes kSceneColorFormat into RTVFormats[0].
@@ -138,10 +138,10 @@ XRESULT D3D12GraphicsEngine::Init() {
         if ( rs.CompressBackBuffer ) {
             if ( m_DeviceCapabilities.TypedUAVLoadAdditionalFormats ) {
                 kSceneColorFormat = DXGI_FORMAT_R11G11B10_FLOAT;
-                LogInfo() << "D3D12: compressed scene colour (R11G11B10_FLOAT).";
+                Logging::Inf( "D3D12: compressed scene colour (R11G11B10_FLOAT)." );
             } else {
-                LogWarn() << "D3D12: CompressBackBuffer requested but the device lacks "
-                             "TypedUAVLoadAdditionalFormats; keeping R16G16B16A16_FLOAT.";
+                Logging::Wrn( "D3D12: CompressBackBuffer requested but the device lacks "
+                    "TypedUAVLoadAdditionalFormats; keeping R16G16B16A16_FLOAT." );
                 rs.CompressBackBuffer = false;
             }
         }
@@ -155,49 +155,49 @@ XRESULT D3D12GraphicsEngine::Init() {
         // Without the encode pass nothing in the FP16 display buffer would ever reach the swapchain, so give
         // up on HDR here — while it is still free to do so, i.e. before any display-space PSO has baked
         // DisplayFormat. Everything downstream then builds exactly as it does in SDR.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the HDR scanout encode pipeline; falling back to SDR output.";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the HDR scanout encode pipeline; falling back to SDR output." );
         m_HdrOutputActive = false;
         m_HdrEncodePQ = false;
         m_Pipelines.DisplayFormat = kBackBufferFormat;
     }
     if ( !m_Pipelines.CreateUI() || !CreateUIVertexBuffers() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the 2D/UI pipeline.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the 2D/UI pipeline." );
         return XR_FAILED;
     }
     if ( !CreateWhiteTexture() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the white fallback texture.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the white fallback texture." );
         return XR_FAILED;
     }
     LoadDistortionTexture();   // non-fatal: wet ground just skips the no-normalmap fallback if this is missing
     if ( !m_Pipelines.CreateWorld() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the world-mesh pipeline.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the world-mesh pipeline." );
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreateDepthPrepass() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the depth prepass pipeline.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the depth prepass pipeline." );
         return XR_FAILED;
     }
     if ( !CreateWorldIndirect() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the world ExecuteIndirect resources.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the world ExecuteIndirect resources." );
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreateWorldTransparency() ) {
         // Non-fatal: DrawWorldTransparencyRun early-outs on a missing root sig, which leaves the peeled
         // alpha-blended world surfaces (ice/glass) simply undrawn — the same as before this pass existed,
         // minus their opaque stand-in. Everything else keeps rendering.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the alpha-blended world-mesh pipeline "
-                     "(ice/glass surfaces will not be drawn).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the alpha-blended world-mesh pipeline "
+            "(ice/glass surfaces will not be drawn)." );
     }
     if ( !m_Pipelines.CreateLightCull() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the light-culling compute pipeline.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the light-culling compute pipeline." );
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreateVob() || !CreateVobInstanceBuffers() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the VOB pipeline.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the VOB pipeline." );
         return XR_FAILED;
     }
     if ( !CreateVobIndirect() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the VOB ExecuteIndirect resources.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the VOB ExecuteIndirect resources." );
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreateCull() || !CreateVobCullResources() ) {
@@ -206,212 +206,212 @@ XRESULT D3D12GraphicsEngine::Init() {
         // frustum cull in charge (RndCullContext::drawFlags.SkipVobFrustumCull stays clear) — the exact
         // behavior the backend had before. Must run AFTER CreateVobInstanceBuffers (it sizes the compacted
         // instance buffer from m_VobInstanceBufferCapacity) and after CreateVobIndirect.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the GPU VOB-culling resources (falling back to CPU frustum culling).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the GPU VOB-culling resources (falling back to CPU frustum culling)." );
     }
     if ( !m_Pipelines.CreateMorphFold() || !CreateMorphFoldResources() ) {
         // Non-fatal, but it MUST be attempted here — before the first world/attachment conversion. Whether
         // the fold is available is what decides how a morph submesh's vertex buffer is created (DEFAULT+UAV
         // for the GPU fold vs DYNAMIC+CA_WRITE for ZENGIN's CPU deform), and MorphGpu::IsActive() freezes
         // that answer for the session. Failing here simply leaves the CPU deform as the path.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the GPU morph-fold resources (morph meshes will deform on the CPU).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the GPU morph-fold resources (morph meshes will deform on the CPU)." );
     }
     if ( !CreateLightBuffer() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the point-light buffer.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the point-light buffer." );
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreateSkeletal() || !CreateSkeletalConstantBuffers() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the skeletal pipeline.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the skeletal pipeline." );
         return XR_FAILED;
     }
     if ( !CreateSkeletalIndirect() ) {
         // Fatal: both skeletal passes submit exclusively through these (T9), so a missing signature/ring would
         // silently drop every NPC/monster and every node attachment. Must run after CreateSkeletal (it needs
         // Skeletal.RootSig) and after CreateVobIndirect (the attachment rings ride the VOB command signature).
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the skeletal ExecuteIndirect resources.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the skeletal ExecuteIndirect resources." );
         return XR_FAILED;
     }
     if ( !CreateShadowConstantBuffer() || !m_ShadowMap.Init() ) {
         // Fatal: the lit world PSO samples the shadow map (t4) + CB (b3) unconditionally, so a missing map would
         // leave those root slots unbound. Failing here cleanly falls back to D3D11 (D3D12 is dev-forced/opt-in).
         // Runs after the depth-prepass + VOB + skeletal pipelines so the caster PSOs can reuse all three depth VS blobs.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the sun shadow map.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the sun shadow map." );
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreatePointShadow() || !m_PointShadows.Init() ) {
         // Fatal: the lit PSOs sample the cube array (t5) unconditionally once P2.10d lands, so a missing resource
         // would leave that root slot unbound. Failing here cleanly falls back to D3D11 (D3D12 is dev-forced).
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create point-light shadow cubes.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create point-light shadow cubes." );
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreateWater() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the water pipeline.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the water pipeline." );
         return XR_FAILED;
     }
     if ( !CreateWaterConstantBuffers() ) {
         // Fatal-ish for water only: DrawWaterSurfaces skips its color pass without the CB (the Z-prepass
         // still runs so height fog stays correct), leaving water surfaces unshaded. Not worth failing the
         // whole backend over — but it should never happen, so log it loudly.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the water constant buffers (water will not be shaded).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the water constant buffers (water will not be shaded)." );
     }
     LoadReflectionCube();   // non-fatal: water then reflects only on-screen geometry via SSR
     if ( !m_Pipelines.CreateParticle() || !CreateParticleInstanceBuffers() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the particle pipeline.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the particle pipeline." );
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreateDecal() || !CreateDecalQuadVB() || !CreateDecalInstanceBuffers() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the decal pipeline.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the decal pipeline." );
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreateTonemap() ) {
         // Fatal: the 3D scene PSOs now target the HDR scene-color RT (kSceneColorFormat), so without the tonemap
         // resolve nothing reaches the swapchain. Failing here cleanly falls back to D3D11 (D3D12 is dev-forced).
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the tonemap pipeline.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the tonemap pipeline." );
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreateLumAdapt() || !CreateLumAdaptedBuffer() ) {
         // Fatal: Tonemap.hlsl's PS now reads m_LumAdaptedBuffer (t1) unconditionally every frame — a missing
         // buffer would leave that root SRV unbound. Same reasoning as the tonemap PSO itself just above.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the dynamic-exposure (auto-exposure) pipeline.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the dynamic-exposure (auto-exposure) pipeline." );
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreatePreview() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the inventory-item preview pipeline.";
+        Logging::Err( "D3D12GraphicsEngine::Init: failed to create the inventory-item preview pipeline." );
         return XR_FAILED;
     }
     if ( !m_Pipelines.CreateBloom() ) {
         // Non-fatal: bloom is an opt-in visual enhancement (RendererSettings.EnableBloom, default off), not a
         // required resource any other PSO samples unconditionally — unlike tonemap/shadow/point-shadow above.
         // RenderBloom() guards on the PSOs existing and just skips the effect if this failed.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the bloom pipeline (bloom will be unavailable).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the bloom pipeline (bloom will be unavailable)." );
     }
     if ( !m_Pipelines.CreateGhost() ) {
         // Non-fatal: ghost/transparency VOBs are a niche effect (invisible-potion/fade items). DrawGhostVobs()
         // guards on Ghost.PSO existing and, if this failed, simply drains+discards Engine::GAPI->TransparencyVobs
         // every frame instead of drawing it — GothicAPI still needs that drain to avoid an unbounded per-frame leak.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the ghost pipeline (ghost VOBs will be invisible).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the ghost pipeline (ghost VOBs will be invisible)." );
     }
     if ( !m_Pipelines.CreateGhostSkeletal() ) {
         // Non-fatal: skeletal ghosts (invisible/fading NPCs) are rarer still. DrawGhostVobs() guards on
         // GhostSkeletal.PSO existing and just skips those entries (still drained, no leak) if this failed.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the skeletal ghost pipeline (invisible NPCs will not render).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the skeletal ghost pipeline (invisible NPCs will not render)." );
     }
     if ( !m_Pipelines.CreateGrass() ) {
         // Non-fatal: vegetation boxes are an optional decoration layer. DrawVegetation() guards on
         // Grass.PSO existing and just skips the pass (grass simply doesn't render) if this failed.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the grass pipeline (vegetation boxes will not render).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the grass pipeline (vegetation boxes will not render)." );
     } else if ( !m_ShadowMap.CreateGrassCaster() ) {
         // Non-fatal: the CSM pass guards on the grass caster PSO and just skips grass's shadow
         // contribution (it still renders lit, just casts no shadow) if this failed.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the grass shadow-caster pipeline (grass will not cast shadows).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the grass shadow-caster pipeline (grass will not cast shadows)." );
     }
     if ( !CreateShadowRecordCommandLists() ) {
         // Non-fatal: BeginShadowRecording() checks m_ShadowCmdListsReady and falls back to recording every shadow
         // pass serially into m_CmdList (exactly what it did before) — slower, identical output.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the shadow command lists (shadow passes will be recorded single-threaded).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the shadow command lists (shadow passes will be recorded single-threaded)." );
     }
     if ( !m_Pipelines.CreateVideo() ) {
         // Non-fatal: Bink cutscene playback (zBinkPlayer.cpp) is a niche path. DrawVertexArray's PS_Video branch
         // guards on Video.PSO existing and falls back to the normal FF/UI draw (a black/untextured quad) if not.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the video (Bink) pipeline (cutscenes will not render).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the video (Bink) pipeline (cutscenes will not render)." );
     }
     if ( !m_Pipelines.CreateSmaa() ) {
         // Non-fatal: SMAA is an opt-in AA mode (RendererSettings.AntiAliasingMode == AA_SMAA). RenderSMAA()
         // guards on the PSOs existing and just skips the effect (no AA) if this failed.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the SMAA pipeline (SMAA anti-aliasing will be unavailable).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the SMAA pipeline (SMAA anti-aliasing will be unavailable)." );
     } else {
         LoadSmaaTextures();   // non-fatal; RenderSMAA also guards on the LUTs being present
     }
     if ( !m_Pipelines.CreateSharpen() ) {
         // Non-fatal: RenderSharpen() guards on the PSO for the selected mode and just leaves the frame
         // unsharpened. Note this one IS on by default (RendererSettings.SharpeningMode == SHARPEN_CAS).
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the sharpen pipeline (the image will not be sharpened).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the sharpen pipeline (the image will not be sharpened)." );
     }
     if ( !m_Pipelines.CreateGammaCorrect() ) {
         // Non-fatal: ApplyDisplayGammaCorrection() guards on the PSO, so the frame just shows at the
         // uncorrected 1.0/1.0 brightness and contrast.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the gamma-correct pipeline (the brightness/contrast sliders will do nothing).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the gamma-correct pipeline (the brightness/contrast sliders will do nothing)." );
     }
     if ( !m_Pipelines.CreateUnderwater() ) {
         // Non-fatal: DrawUnderwaterEffects() guards on the PSOs, so a failure here just leaves the frame
         // untinted and undistorted while swimming — everything else renders as before.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the underwater pipeline (no underwater screen effect).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the underwater pipeline (no underwater screen effect)." );
     }
     if ( !m_Pipelines.CreateAO() ) {
         // Non-fatal: SSAO is an opt-in visual enhancement (RendererSettings.AoMode, defaults to a real AO mode
         // but nothing else depends on it unconditionally). RenderSSAO() guards on the PSOs existing and just
         // leaves the AO mask at white (no occlusion) if this failed.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the SSAO pipeline (screen-space AO will be unavailable).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the SSAO pipeline (screen-space AO will be unavailable)." );
     }
     // Intel XeGTAO — AoMode::AO_ASSAO on this backend. Non-fatal: IsGtaoEnabled() reports false and RenderSSAO
     // falls back to the simple SSAO path above, so a failure here costs AO quality, never AO.
     if ( !m_Pipelines.CreateGtao() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the XeGTAO pipeline "
-                     "(AO mode 'ASSAO' will fall back to the simple SSAO).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the XeGTAO pipeline "
+            "(AO mode 'ASSAO' will fall back to the simple SSAO)." );
     }
     // Motion-vector G-buffer support (camera-velocity fill + debug overlay). Non-fatal: nothing consumes the
     // velocity/normal targets yet (TAA consumes velocity; FSR3 is still to come, and XeGTAO deliberately derives
     // its own normals from the depth snapshot instead), so a failure here costs TAA, never the frame. CreateMotionConstantBuffers must succeed too — without
     // the CB the *GBuf prepass PSOs would have an unbound root CBV, so failure disables the whole feature.
     if ( !m_Pipelines.CreateMotion() || !CreateMotionConstantBuffers() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the motion-vector pipeline "
-                     "(no motion vectors / normal buffer — TAA and FSR3 will have no input).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the motion-vector pipeline "
+            "(no motion vectors / normal buffer — TAA and FSR3 will have no input)." );
         m_MotionResourcesReady = false;
     }
     // Temporal AA (Intel's TAA resolve). Non-fatal: RenderTAA and AdvanceJitter both guard through
     // IsTaaEnabled(), so a failure here leaves the frame un-jittered and un-resolved exactly as before.
     if ( !m_Pipelines.CreateTaa() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the TAA pipeline (temporal AA unavailable).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the TAA pipeline (temporal AA unavailable)." );
     }
     // Depth of field. Non-fatal and opt-in (RendererSettings.EnableDoF, off by default): RenderDepthOfField
     // guards on the PSOs and leaves the whole scene in focus if this failed. Its textures are built lazily the
     // first time DoF is switched on, not here — see CreateDoFResources.
     if ( !m_Pipelines.CreateDoF() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the depth-of-field pipeline (DoF unavailable).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the depth-of-field pipeline (DoF unavailable)." );
     }
     if ( !m_Pipelines.CreateSkyIbl() ) {
         // Non-fatal: the lit shaders test the sky-IBL cube indices for 0xFFFFFFFF and fall back to the flat
         // ambient term they used before this existed, so a failure here costs indirect specular, not lighting.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the sky-IBL pipeline (falling back to flat ambient).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the sky-IBL pipeline (falling back to flat ambient)." );
     } else if ( !CreateSkyIblResources() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the sky-IBL cubemaps (falling back to flat ambient).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the sky-IBL cubemaps (falling back to flat ambient)." );
     }
     if ( !m_Pipelines.CreateSky() ) {
         // Non-fatal: DrawSky() falls back to Gothic's fixed-function sky (zCSkyController_Outdoor::RenderSkyPre)
         // whenever DrawAtmosphereSkyDome() can't draw, so a failure here costs the per-frame draw-call saving,
         // never the sky itself.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the sky-dome pipeline (falling back to Gothic's fixed-function sky).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the sky-dome pipeline (falling back to Gothic's fixed-function sky)." );
     } else if ( !CreateSkyConstantBuffers() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the sky-dome constant buffers (falling back to Gothic's fixed-function sky).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the sky-dome constant buffers (falling back to Gothic's fixed-function sky)." );
     }
     if ( !m_Pipelines.CreateFog() ) {
         // Non-fatal: the height-fog/god-ray composition is opt-in (RendererSettings.DrawFog / EnableGodRays)
         // and outdoor-only. RenderFogAndGodRays() guards on the PSOs; EvaluateHeightFogActive() additionally
         // keeps the geometry shaders' cheap linear distance fog switched ON when this failed, so a broken
         // composition pipeline degrades to the pre-existing D3D12 fog instead of no fog at all.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the height-fog/god-ray pipeline (falling back to the shaders' linear distance fog).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the height-fog/god-ray pipeline (falling back to the shaders' linear distance fog)." );
     } else if ( !CreateFogConstantBuffers() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the height-fog constant buffers (falling back to the shaders' linear distance fog).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the height-fog constant buffers (falling back to the shaders' linear distance fog)." );
     }
     if ( !m_Pipelines.CreateAdvanceRain() ) {
         // Non-fatal: rain/snow is an opt-in weather effect (RendererSettings.EnableRain). AdvanceRain() guards
         // on the PSO existing and just skips advancing/drawing particles if this failed.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the rain-advance compute pipeline (rain/snow particles will be unavailable).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the rain-advance compute pipeline (rain/snow particles will be unavailable)." );
     }
     if ( !m_Pipelines.CreateRainDraw() ) {
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the rain-draw pipeline (rain/snow particles will be unavailable).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the rain-draw pipeline (rain/snow particles will be unavailable)." );
     }
     if ( !m_Pipelines.CreateLines() || !CreateLineVertexBuffers() ) {
         // Non-fatal: debug/editor lines are a diagnostic overlay. DrawLines() guards on the PSOs + ring
         // existing; D3D12LineRenderer still drains its caches every frame either way (no unbounded growth).
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the debug-line pipeline (debug lines will not render).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the debug-line pipeline (debug lines will not render)." );
     }
     if ( !m_Pipelines.CreateFx() || !CreateFxVertexBuffers() ) {
         // Non-fatal: the three FX passes guard on the root sig / ring existing. Without them blood splatter,
         // spell ground marks and weapon/spell trails simply don't draw — the same as before they were ported.
-        LogWarn() << "D3D12GraphicsEngine::Init: failed to create the FX pipeline (quad marks and poly strips will not render).";
+        Logging::Wrn( "D3D12GraphicsEngine::Init: failed to create the FX pipeline (quad marks and poly strips will not render)." );
     }
     D3D12ShaderBackend::LogAndResetCacheStats( "startup" );
-    LogInfo() << "D3D12GraphicsEngine initialized (device + 2D + world + VOB + skeletal + water + particle + decal + HDR tonemap pipelines up). Swapchain is created once the game window is set.";
+    Logging::Inf( "D3D12GraphicsEngine initialized (device + 2D + world + VOB + skeletal + water + particle + decal + HDR tonemap pipelines up). Swapchain is created once the game window is set." );
     return XR_SUCCESS;
 }
 
@@ -1115,7 +1115,7 @@ bool D3D12GraphicsEngine::CreateDepthBuffer( INT2 size ) {
 	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), allocDesc, dd,
 		D3D12_RESOURCE_STATE_DEPTH_WRITE, &clear, m_DepthBufferAlloc.ReleaseAndGetAddressOf(),
 		IID_PPV_ARGS( m_DepthBuffer.ReleaseAndGetAddressOf() ) ) ) ) {
-		LogWarn() << "D3D12: failed to create the depth buffer (" << size.x << "x" << size.y << ").";
+		Logging::Err( "D3D12: failed to create the depth buffer ({}x{}).", size.x, size.y );
 		return false;
 	}
 	m_DepthBuffer->SetName( L"DepthBuffer(D32)" );
@@ -1194,8 +1194,8 @@ D3D12_CPU_DESCRIPTOR_HANDLE D3D12GraphicsEngine::GetPreviewDsv() {
 
 	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), allocDesc, dd, D3D12_RESOURCE_STATE_DEPTH_WRITE, &clear,
 		m_PreviewDepthAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( m_PreviewDepthBuffer.ReleaseAndGetAddressOf() ) ) ) ) {
-		LogWarn() << "D3D12: failed to create the inventory-preview depth buffer ("
-			<< m_BackbufferResolution.x << "x" << m_BackbufferResolution.y << ") — item previews will not render.";
+		Logging::Wrn( "D3D12: failed to create the inventory-preview depth buffer ({}x{}) — item previews will not render.",
+			m_BackbufferResolution.x, m_BackbufferResolution.y );
 		m_PreviewDepthBuffer.Reset();
 		m_PreviewDepthAlloc.Reset();
 		m_PreviewDepthFailed = true;
@@ -1243,7 +1243,7 @@ bool D3D12GraphicsEngine::CreateSceneColorTarget( INT2 size ) {
 	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), allocDesc, dd,
 		D3D12_RESOURCE_STATE_RENDER_TARGET, nullptr, m_SceneColorAlloc.ReleaseAndGetAddressOf(),
 		IID_PPV_ARGS( m_SceneColor.ReleaseAndGetAddressOf() ) ) ) ) {
-		LogWarn() << "D3D12: failed to create the HDR scene-color target (" << size.x << "x" << size.y << ").";
+		Logging::Err( "D3D12: failed to create the HDR scene-color target ({}x{}).", size.x, size.y );
 		return false;
 	}
 	m_SceneColor->SetName( kSceneColorFormat == DXGI_FORMAT_R11G11B10_FLOAT
@@ -1417,13 +1417,13 @@ void D3D12GraphicsEngine::DetectHdrOutputCapability() {
 	}
 
 	if ( !m_HdrOutputActive ) {
-		LogInfo() << "D3D12: HDR output requested but no HDR-enabled display was found on this adapter; using SDR.";
+		Logging::Inf( "D3D12: HDR output requested but no HDR-enabled display was found on this adapter; using SDR." );
 		return;
 	}
 
 	m_Pipelines.DisplayFormat = kHdrDisplayFormat;
-	LogInfo() << "D3D12: HDR output enabled. Monitor reports " << m_HdrMonitorMaxNits << " nits peak, "
-		<< m_HdrMonitorMaxFullFrameNits << " nits full-frame, " << m_HdrMonitorMinNits << " nits black.";
+	Logging::Inf( "D3D12: HDR output enabled. Monitor reports {} nits peak, {} nits full-frame, {} nits black.",
+		m_HdrMonitorMaxNits, m_HdrMonitorMaxFullFrameNits, m_HdrMonitorMinNits );
 }
 
 
@@ -1456,7 +1456,7 @@ void D3D12GraphicsEngine::ApplySwapChainColorSpace() {
 	if ( FAILED( m_SwapChain->CheckColorSpaceSupport( kHdr10, &support ) )
 		|| !( support & DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT )
 		|| FAILED( m_SwapChain->SetColorSpace1( kHdr10 ) ) ) {
-		LogWarn() << "D3D12: the swapchain refused the HDR10 colour space; presenting SDR from the HDR display buffer.";
+		Logging::Wrn( "D3D12: the swapchain refused the HDR10 colour space; presenting SDR from the HDR display buffer." );
 		return;
 	}
 	m_HdrEncodePQ = true;
@@ -1515,7 +1515,7 @@ bool D3D12GraphicsEngine::CreateHdrDisplayTarget( INT2 size ) {
 
 	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_Allocator.Get(), heapDefault, dd, D3D12_RESOURCE_STATE_RENDER_TARGET, &clearValue,
 		m_HdrDisplayAlloc.ReleaseAndGetAddressOf(), IID_PPV_ARGS( m_HdrDisplay.ReleaseAndGetAddressOf() ) ) ) ) {
-		LogWarn() << "D3D12: failed to create the HDR display composite target (" << size.x << "x" << size.y << ").";
+		Logging::Err( "D3D12: failed to create the HDR display composite target ({}x{}).", size.x, size.y );
 		return false;
 	}
 	m_HdrDisplay->SetName( L"HdrDisplayComposite" );
@@ -1582,7 +1582,7 @@ void D3D12GraphicsEngine::EncodeHdrDisplayToBackBuffer() {
 
 
 XRESULT D3D12GraphicsEngine::SetWindow( HWND hWnd ) {
-    LogInfo() << "D3D12: Creating swapchain";
+    Logging::Inf( "D3D12: creating the swapchain." );
     CommonSetWindow( hWnd ); // stores m_OutputWindow, force-activates, clips cursor, hides mouse cursor
 
     // Use the configured target resolution (NOT the current client rect — Gothic creates its window
@@ -1788,7 +1788,7 @@ bool D3D12GraphicsEngine::CreateRenderResolutionTargets( INT2 renderSize ) {
     if ( !CreateLumPartialBuffer( renderSize ) ) {
         // Non-fatal: RenderLuminanceAdapt() guards on this and skips the update, leaving m_LumAdaptedBuffer
         // at its last valid value.
-        LogWarn() << "D3D12GraphicsEngine: failed to create the dynamic-exposure partial-sum buffer.";
+        Logging::Wrn( "D3D12GraphicsEngine: failed to create the dynamic-exposure partial-sum buffer." );
     }
     m_AppliedResolutionScalePercent = Engine::GAPI->GetRendererState().RendererSettings.ResolutionScalePercent;
     return true;
@@ -1829,7 +1829,7 @@ bool D3D12GraphicsEngine::CreateSwapChain( INT2 size ) {
     HRESULT hr = m_Device.GetFactory()->CreateSwapChainForHwnd(
         m_Device.GetDirectQueue(), m_OutputWindow, &scd, nullptr, nullptr, swapChain1.GetAddressOf() );
     if ( FAILED( hr ) ) {
-        LogWarn() << "CreateSwapChainForHwnd failed (0x" << std::hex << hr << ").";
+        Logging::Err( "D3D12: CreateSwapChainForHwnd failed (0x{:08X}).", static_cast<uint32_t>( hr ) );
         return false;
     }
 
@@ -1837,7 +1837,7 @@ bool D3D12GraphicsEngine::CreateSwapChain( INT2 size ) {
     m_Device.GetFactory()->MakeWindowAssociation( m_OutputWindow, DXGI_MWA_NO_ALT_ENTER );
 
     if ( FAILED( swapChain1.As( &m_SwapChain ) ) ) {
-        LogWarn() << "Swapchain does not support IDXGISwapChain3.";
+        Logging::Err( "D3D12: the swapchain does not support IDXGISwapChain3." );
         return false;
     }
     m_FrameIndex = m_SwapChain->GetCurrentBackBufferIndex();
@@ -1862,7 +1862,7 @@ bool D3D12GraphicsEngine::CreateSwapChain( INT2 size ) {
         // would leave those draws unbound. Degrade to the SDR passthrough encode rather than showing nothing:
         // GetDisplayRtv() falls back to the swapchain, whose format no longer matches those PSOs, so the honest
         // move is to give up on the swapchain entirely and let Init's caller fall back to D3D11.
-        LogWarn() << "D3D12GraphicsEngine::CreateSwapChain: failed to create the HDR display target.";
+        Logging::Err( "D3D12GraphicsEngine::CreateSwapChain: failed to create the HDR display target." );
         return false;
     }
     CreateDisplayResolutionTargets( size );   // post-tonemap passes, native size
@@ -2510,13 +2510,13 @@ bool D3D12GraphicsEngine::CreateShadowRecordCommandLists() {
         for ( UINT i = 0; i < kBackBufferCount; ++i ) {
             if ( FAILED( device->CreateCommandAllocator( D3D12_COMMAND_LIST_TYPE_DIRECT,
                 IID_PPV_ARGS( m_ShadowCmdAllocators[c][i].ReleaseAndGetAddressOf() ) ) ) ) {
-                LogWarn() << "D3D12: failed to create a shadow command allocator — deferred shadow recording disabled.";
+                Logging::Wrn( "D3D12: failed to create a shadow command allocator — deferred shadow recording disabled." );
                 return false;
             }
             if ( FAILED( device->CreateCommandList( 0, D3D12_COMMAND_LIST_TYPE_DIRECT,
                 m_ShadowCmdAllocators[c][i].Get(), nullptr,
                 IID_PPV_ARGS( m_ShadowCmdLists[c][i].ReleaseAndGetAddressOf() ) ) ) ) {
-                LogWarn() << "D3D12: failed to create a shadow command list — deferred shadow recording disabled.";
+                Logging::Wrn( "D3D12: failed to create a shadow command list — deferred shadow recording disabled." );
                 return false;
             }
             // CreateCommandList returns the list already open; close it so BeginShadowRecording's Reset is symmetric.
@@ -2896,8 +2896,8 @@ XRESULT D3D12GraphicsEngine::OnResize( INT2 newSize ) {
     const int maxWidth = GetSystemMetrics( SM_CXSCREEN );
     const int maxHeight = GetSystemMetrics( SM_CYSCREEN );
     if ( maxWidth > 0 && maxHeight > 0 && ( newSize.x > maxWidth || newSize.y > maxHeight ) ) {
-        LogWarn() << "D3D12GraphicsEngine::OnResize: requested " << newSize.x << "x" << newSize.y
-            << " exceeds the desktop resolution (" << maxWidth << "x" << maxHeight << ") — clamping.";
+        Logging::Wrn( "D3D12GraphicsEngine::OnResize: requested {}x{} exceeds the desktop resolution ({}x{}) — clamping.",
+            newSize.x, newSize.y, maxWidth, maxHeight );
         newSize.x = std::min( newSize.x, maxWidth );
         newSize.y = std::min( newSize.y, maxHeight );
         m_NewResolution = newSize;   // keep in sync so OnBeginFrame doesn't re-trigger this every frame
@@ -2910,17 +2910,17 @@ XRESULT D3D12GraphicsEngine::OnResize( INT2 newSize ) {
 
     if ( !m_SwapChainReady ) {
         if ( !CreateSwapChain( newSize ) ) {
-            LogWarn() << "D3D12GraphicsEngine::OnResize: swapchain creation failed.";
+            Logging::Err( "D3D12GraphicsEngine::OnResize: swapchain creation failed." );
             return XR_FAILED;
         }
-        LogInfo() << "D3D12 swapchain created (" << newSize.x << "x" << newSize.y << ").";
+        Logging::Inf( "D3D12 swapchain created ({}x{}).", newSize.x, newSize.y );
     } else {
         if ( !ResizeSwapChain( newSize ) ) {
             // Depth/scene-color/light-cull targets may now be a mix of old- and new-resolution (or null, if
             // resource creation itself failed). Don't retry every frame — leave m_Resolution at whatever
             // ResizeSwapChain last got to and let the render path's existing null checks (haveDepth, etc.)
             // keep the frame from touching a mismatched/null DSV until the user tries again.
-            LogWarn() << "D3D12GraphicsEngine::OnResize: ResizeSwapChain failed (" << newSize.x << "x" << newSize.y << ").";
+            Logging::Err( "D3D12GraphicsEngine::OnResize: ResizeSwapChain failed ({}x{}).", newSize.x, newSize.y );
             m_NewResolution = m_BackbufferResolution;
             return XR_FAILED;
         }

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -222,6 +222,7 @@ public:
 
     void OnAddVob(VobInfo* vi) override;
     XRESULT OnVobRemovedFromWorld( zCVob* vob ) override;
+    void OnVobBecameDynamic( zCVob* vob ) override;
     // Purges the VOB arena's cache of this MeshInfo* before it's freed - see BaseGraphicsEngine's doc comment.
     void OnMeshInfoDestroyed( MeshInfo* mesh ) override { m_VobArena.Forget( mesh ); }
     void OnLoadWorld() override;

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -228,6 +228,7 @@ public:
     void OnMeshInfoDestroyed( MeshInfo* mesh ) override { m_VobArena.Forget( mesh ); }
     void OnLoadWorld() override;
     void DrawVobSingle( VobInfo* vob, zCCamera& camera ) override;  // inventory item preview (GInventory), drawn straight onto the backbuffer
+    void DrawVobSingle( SkeletalVobInfo* vob, zCCamera& camera ) override;  // same, for a skinned item visual
     D3D12MA::Allocator* GetAllocator() const { return m_Allocator.Get(); }
 
     /** Savegame-thumbnail / screenshot readback (MyDirectDrawSurface7::Lock's DDLOCK_READONLY hack).

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -223,6 +223,7 @@ public:
     void OnAddVob(VobInfo* vi) override;
     XRESULT OnVobRemovedFromWorld( zCVob* vob ) override;
     void OnVobBecameDynamic( zCVob* vob ) override;
+    void OnVobMoved( zCVob* vob ) override;
     // Purges the VOB arena's cache of this MeshInfo* before it's freed - see BaseGraphicsEngine's doc comment.
     void OnMeshInfoDestroyed( MeshInfo* mesh ) override { m_VobArena.Forget( mesh ); }
     void OnLoadWorld() override;

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.cpp
@@ -504,6 +504,80 @@ bool D3D12PipelineState::CreatePreview() {
     return true;
 }
 
+bool D3D12PipelineState::CreatePreviewSkeletal() {
+    // Skinned inventory-item preview (D3D12GraphicsEngine::DrawVobSingle(SkeletalVobInfo*)): same target,
+    // depth and alpha-clip as Preview above, but skins the vertex against the model's node palette. Its own
+    // root sig because Preview's has no b2 — everything else matches, and it reuses Preview.hlsl's PSMain.
+    ID3D12Device* device = m_Device->GetDevice();
+
+    D3D12RootLayout& rs = Layout( "PreviewSkeletal" );
+    rs.AddConstants( 0, 16, D3D12_SHADER_VISIBILITY_VERTEX );  // 0: b0 ViewProj
+    rs.AddConstants( 1, 16, D3D12_SHADER_VISIBILITY_VERTEX );  // 1: b1 World
+    // 2: b2 bone palette. Points into the per-frame skeletal ring, whose cursor only ADVANCES within a
+    // frame, so the handed-out address stays valid until Present — same promise as Skeletal.RootSig's b2.
+    rs.AddCBV( 2, D3D12_SHADER_VISIBILITY_VERTEX, 0, D3D12RootLayout::RootDataStatic );
+    rs.AddTable( D3D12RootLayout::SRVRange( 0 ), D3D12_SHADER_VISIBILITY_PIXEL );   // 3: t0 diffuse
+    rs.AddStaticSampler( D3D12RootLayout::SamplerAniso( 0, D3D12_SHADER_VISIBILITY_PIXEL ) );
+
+    if ( !rs.Build( device, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT ) )
+        return false;
+    PreviewSkeletal.RootSig = rs.RootSig();
+
+    if ( !m_Shaders->CompileFromFile( "Preview.hlsl", "VSSkeletal", Shadermodel_VS, PreviewSkeletal.VsBlob.ReleaseAndGetAddressOf() ) ) {
+        return false;
+    }
+    if ( !m_Shaders->CompileFromFile( "Preview.hlsl", "PSMain", Shadermodel_PS, PreviewSkeletal.PsBlob.ReleaseAndGetAddressOf() ) ) {
+        return false;
+    }
+
+    rs.ValidateShaders( {
+        { PreviewSkeletal.VsBlob.Get(), "Preview.hlsl:VSSkeletal", D3D12_SHADER_VISIBILITY_VERTEX },
+        { PreviewSkeletal.PsBlob.Get(), "Preview.hlsl:PSMain",     D3D12_SHADER_VISIBILITY_PIXEL  },
+    } );
+
+    // 76-byte ExSkelVertexStruct — same layout as Skeletal's PSOs, see CreateSkeletal.
+    const D3D12_INPUT_ELEMENT_DESC layout[] = {
+        { "POSITION", 0, DXGI_FORMAT_R16G16B16A16_FLOAT, 0,  0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "POSITION", 1, DXGI_FORMAT_R16G16B16A16_FLOAT, 0,  8, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "POSITION", 2, DXGI_FORMAT_R16G16B16A16_FLOAT, 0, 16, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "POSITION", 3, DXGI_FORMAT_R16G16B16A16_FLOAT, 0, 24, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "NORMAL",   0, DXGI_FORMAT_R32G32B32_FLOAT,    0, 32, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT,    0, 44, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT,       0, 56, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "BONEIDS",  0, DXGI_FORMAT_R8G8B8A8_UINT,      0, 64, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+        { "WEIGHTS",  0, DXGI_FORMAT_R16G16B16A16_FLOAT, 0, 68, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+    };
+
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC pso = {};
+    pso.pRootSignature = PreviewSkeletal.RootSig.Get();
+    pso.VS = { PreviewSkeletal.VsBlob->GetBufferPointer(), PreviewSkeletal.VsBlob->GetBufferSize() };
+    pso.PS = { PreviewSkeletal.PsBlob->GetBufferPointer(), PreviewSkeletal.PsBlob->GetBufferSize() };
+    pso.InputLayout = { layout, _countof( layout ) };
+    pso.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    pso.NumRenderTargets = 1;
+    pso.RTVFormats[0] = DisplayFormat;
+    pso.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+    pso.SampleDesc.Count = 1;
+    pso.SampleMask = UINT_MAX;
+
+    pso.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;
+    pso.RasterizerState.CullMode = D3D12_CULL_MODE_BACK;
+    pso.RasterizerState.DepthClipEnable = TRUE;
+
+    pso.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+
+    pso.DepthStencilState.DepthEnable = TRUE;
+    pso.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+    pso.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_GREATER_EQUAL;
+    pso.DepthStencilState.StencilEnable = FALSE;
+
+    if ( FAILED( device->CreateGraphicsPipelineState( &pso, IID_PPV_ARGS( PreviewSkeletal.PSO.ReleaseAndGetAddressOf() ) ) ) ) {
+        LogWarn() << "D3D12: CreateGraphicsPipelineState failed (skinned preview).";
+        return false;
+    }
+    return true;
+}
+
 bool D3D12PipelineState::CreateGhost() {
     // Ghost/transparency VOBs (GothicAPI::TransparencyVobs — invisible-potion/fade-out items, GetVisualAlpha()):
     // single-object, non-instanced, alpha-blended draw. Mirrors D3D11's PS_Transparency (unlit: sample diffuse,
@@ -3875,6 +3949,7 @@ bool D3D12PipelineState::ReloadAll( bool hdrEncodeActive, std::vector<std::strin
     runFatal( "Tonemap", &D3D12PipelineState::CreateTonemap );
     runFatal( "LumAdapt", &D3D12PipelineState::CreateLumAdapt );
     runFatal( "Preview", &D3D12PipelineState::CreatePreview );
+    runOptional( "PreviewSkeletal", &D3D12PipelineState::CreatePreviewSkeletal );
     runOptional( "Bloom", &D3D12PipelineState::CreateBloom );
     runOptional( "Ghost", &D3D12PipelineState::CreateGhost );
     runOptional( "GhostSkeletal", &D3D12PipelineState::CreateGhostSkeletal );

--- a/D3D11Engine/D3D12Engine/D3D12PipelineState.h
+++ b/D3D11Engine/D3D12Engine/D3D12PipelineState.h
@@ -564,6 +564,7 @@ public:
     bool CreateWater();       // alpha-blended water (own root sig: b0 ViewProj, t0, b1 fog, b2 water)
     bool CreateLightCull();   // Forward+ tiled light-cull compute (global compute root sig)
     bool CreatePreview();     // single-VOB inventory-item preview (own root sig: b0 ViewProj, b1 World, t0 diffuse)
+    bool CreatePreviewSkeletal();   // same, for a skinned item visual (adds b2 bone palette)
     bool CreateBloom();       // prefilter/downsample/upsample compute + additive composite graphics pipeline
     bool CreateGhost();       // ghost/transparency VOBs (own root sig: b0 ViewProj, b1 World, b2 GhostAlpha, t0 diffuse)
     bool CreateGhostSkeletal(); // skeletal ghost VOBs (invisible NPCs): own root sig (b0 ViewProj, b1 inst CBV,
@@ -636,6 +637,7 @@ public:
     ComputePipeline  LumReduce;   // dynamic exposure, level 1: scene color -> per-group partial luminance sums
     ComputePipeline  LumAdapt;    // dynamic exposure, level 2: reduce partials + temporal-adapt -> Tonemap's exposure
     GraphicsPipeline Preview;
+    GraphicsPipeline PreviewSkeletal;   // skinned inventory-item preview (Preview.hlsl:VSSkeletal)
     BloomPipeline    Bloom;
     GraphicsPipeline Ghost;
     GraphicsPipeline GhostSkeletal;

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -309,8 +309,10 @@ void D3D12PointShadows::InvalidateStaticForVobAdded( const XMFLOAT3& posWS, floa
 		if ( !ss.ownerKey || !ss.staticValid ) continue;
 		const float r = ss.range + extent;
 		const float dx = posWS.x - ss.pos.x, dy = posWS.y - ss.pos.y, dz = posWS.z - ss.pos.z;
-		if ( dx * dx + dy * dy + dz * dz < r * r )
+		if ( dx * dx + dy * dy + dz * dz < r * r ) {
 			ss.staticValid = false;   // re-render this slot's static depth next frame to include the new VOB
+			Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+		}
 	}
 }
 
@@ -325,8 +327,10 @@ void D3D12PointShadows::InvalidateStaticForVobRemoved( const zCVob* vob ) {
 	if ( !vob ) return;
 	for ( Slot& ss : m_Slots ) {
 		if ( !ss.ownerKey || !ss.staticValid || ss.bakedVobs.empty() ) continue;
-		if ( std::ranges::contains( ss.bakedVobs, vob ) )
+		if ( std::ranges::contains( ss.bakedVobs, vob ) ) {
 			ss.staticValid = false;   // this slot's cube holds the removed vob -- re-cache without it
+			Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+		}
 	}
 }
 
@@ -427,7 +431,12 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 		bool stillWinner = false;
 		for ( const Cand& c : cands ) if ( c.key == ss.ownerKey ) { stillWinner = true; break; }
 		if ( stillWinner ) { ss.missingFrames = 0; continue; }
-		if ( ++ss.missingFrames > kSlotRetentionFrames ) ss = Slot{};
+		if ( ++ss.missingFrames > kSlotRetentionFrames ) {
+			// Retention expired - the cached depth goes with the slot. Counted like any other invalidation
+			// (D3D11 counts its equivalent tiled-slot handover), so slot churn shows up in the stat too.
+			if ( ss.staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+			ss = Slot{};
+		}
 	}
 
 	static std::unordered_map<uint64_t, int32_t> encodedByKey;   // key -> tier-encoded ShadowCubeIndex
@@ -457,6 +466,7 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 					if ( m_Slots[s].missingFrames > worst ) { worst = m_Slots[s].missingFrames; slot = static_cast<int>( s ); }
 				if ( slot < 0 ) continue;   // whole tier held by present winners — this light goes unshadowed
 			}
+			if ( m_Slots[slot].staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
 			m_Slots[slot] = Slot{};
 			m_Slots[slot].ownerKey = c.key;
 			m_Slots[slot].owner = c.vob;          // nullptr for a cluster — see the Slot::owner comment

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -29,10 +29,9 @@ void D3D12PointShadows::Attach( D3D12GraphicsEngine& engine ) {
     m_E = &engine;
     kBackBufferCount = engine.kBackBufferCount;
 
-    // Size the shared slot table and hand it this backend's constants. The two tiers keep sharing ONE index
-    // space (global slot >= kMaxCubes is the low-res array), which is what the barrier-state arrays below and
-    // every DSV lookup in Prepare()/Record() index by. The two tier bits differ between backends - D3D12's
-    // live in Shaders/D3D12/include/GPULightShared.h - so they are configuration, not a shared constant.
+    // Size the shared slot table and hand it this backend's constants. The two tiers share ONE index space
+    // (global slot >= kMaxCubes is the low-res array), which the barrier arrays and every DSV lookup index
+    // by. The tier bits differ between backends, so they are configuration rather than shared constants.
     PointLightSlotSelector::Config cfg;
     cfg.MaxHiSlots = kMaxCubes;
     cfg.MaxLowSlots = kMaxStaticCubes;
@@ -211,9 +210,9 @@ bool D3D12PointShadows::Init() {
 
 	// --- Low-res STATIC cube array (see the kStaticCubeSize block in the header): kMaxStaticCubes slots at
 	// kStaticCubeSize^2, with its own per-slot 6-slice DSV heap and a bindless SRV. No aside twin: nothing
-	// routed here can receive a dynamic overlay, so its static depth renders straight in and persists. Born in
-	// PIXEL_SHADER_RESOURCE for the same reason the active cube is: barriers here are per-slot, so a slot the
-	// pass never touches is never transitioned and has to be born sampleable.
+	// routed here gets a dynamic overlay, so its static depth renders straight in and persists. Born in
+	// PIXEL_SHADER_RESOURCE because barriers are per-slot, so a slot the pass never touches is never
+	// transitioned.
 	D3D12_RESOURCE_DESC ld = dd;
 	ld.Width = kStaticCubeSize;
 	ld.Height = kStaticCubeSize;
@@ -326,10 +325,8 @@ void D3D12PointShadows::InvalidateStaticForVobRemoved( const zCVob* vob ) {
 
 
 void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const std::vector<LightShadowKey>& keys ) {
-	// Thin adapter onto the shared PointLightSlotSelector, which owns every decision this used to make inline
-	// (candidacy horizon, per-tier trim + spill, stable slot ownership, retention/eviction, promotion, the
-	// low-tier render budget, the publish gate and the dynamic round-robin). D3D11 runs the exact same code -
-	// see PointLightSlotSelector.h.
+	// Thin adapter onto the shared PointLightSlotSelector, which owns every decision this used to make
+	// inline. D3D11 runs the exact same code - see PointLightSlotSelector.h.
 	const GothicRendererSettings::EPointLightShadowMode shadowMode =
 		Engine::GAPI->GetRendererState().RendererSettings.EnablePointlightShadows;
 
@@ -342,7 +339,7 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 	}
 
 	// `m_Cube` is the resources gate: with no cube array there is nothing to own, so the selector only ticks
-	// its PLS_DISABLED wipe and leaves every slot alone (matching what this function did before the extraction).
+	// its PLS_DISABLED wipe and leaves every slot alone.
 	m_Sel.Select( cands, shadowMode, m_Cube != nullptr );
 
 	// Fan the result out to EVERY light, so all members of a clustered key sample the one cube their cluster won.
@@ -566,12 +563,9 @@ void D3D12PointShadows::Prepare() {
 			rec.staticWorldEnd = static_cast<UINT>( g_PsStaticWorldDraws.size() );
 
 			// --- Instanced VOBs (static decoration AND loose items): range-cull instances, pack 64B world
-			// matrices into the tight ring, draw count*6. Items used to be kept out of an isStatic() slot via
-			// GP_Slot bit 30 (ZENGIN's StaticVob flag, which oCItem always clears), which meant a torch-lit
-			// room cast no shadow at all from anything lying on its floor. They are baked now; what must stay
-			// out is only what MOVES with an animation, i.e. anything hanging off an NPC — that one is drawn
-			// by the dynamic overlay (Phase C) instead, and a vob leaving the world takes the cube with it
-			// (InvalidateStaticForVobRemoved). ---
+			// matrices into the tight ring, draw count*6. Loose items are baked too - excluding them by
+			// ZENGIN's StaticVob flag meant a torch-lit room cast no shadow from anything on its floor. Only
+			// what MOVES with an animation stays out; the dynamic overlay (Phase C) draws that. ---
 			// restrictToWorld: mirrors D3D11's world-mesh-only PFX gate — skip instanced-VOB casters too.
 			if ( haveVobs && !ps.restrictToWorld ) {
 				for ( const FrameVobUpload& up : g_FrameVobUploads ) {
@@ -587,8 +581,8 @@ void D3D12PointShadows::Prepare() {
 					UINT count = 0;
 					bool overflow = false;
 					const size_t numInst = visual->Instances.size();
-					// InstanceVobs is filled in lockstep with Instances (CollectVisibleVobs), but only trust the
-					// pairing while the two are actually the same length.
+					// InstanceVobs is filled in lockstep with Instances, but only trust the pairing while the
+					// two are actually the same length.
 					const bool haveInstanceVobs = visual->InstanceVobs.size() == numInst;
 					for ( size_t ii = 0; ii < numInst; ++ii ) {
 						const VobInstanceInfo& inst = visual->Instances[ii];
@@ -640,16 +634,12 @@ void D3D12PointShadows::Prepare() {
 			}
 			rec.staticVobEnd = static_cast<UINT>( g_PsStaticVobDraws.size() );
 
-			// --- MOB casters (chests, beds, chairs, doors, benches): skeletal vobs that are NOT NPCs. They are
-			// world furniture that happens to be built as a zCModel, so they belong in the cached static cube
-			// exactly like the instanced decoration above - without this a static/low-tier light saw them as
-			// nothing at all, since Phase C (the only place skeletals were drawn) never runs for such a slot.
-			// NPCs and anything parented under one are excluded: they animate, and Phase C already owns them.
-			// A MOB that later starts moving is promoted to Gothic's animated list, which invalidates every
-			// static cube it was baked into (GothicAPI::MoveVobFromBspToDynamic -> OnVobBecameDynamic).
-			// !overlayEligible: on a slot that DOES get the overlay, Phase C already sphere-culls the same
-			// full skeletal list every frame and draws MOBs along with the NPCs, so baking them here as well
-			// would only duplicate the draws and freeze a copy of them in the static cube.
+			// --- MOB casters (chests, beds, doors, benches): skeletal vobs that are NOT NPCs. World furniture
+			// that happens to be a zCModel, so it belongs in the cached cube like the decoration above -
+			// without this a low-tier light saw it as nothing at all, Phase C never running for such a slot.
+			// A MOB that starts moving is promoted to Gothic's animated list, which invalidates the cubes it
+			// was baked into. !overlayEligible because Phase C already draws MOBs on a slot that gets the
+			// overlay, so baking them would duplicate the draws and freeze a copy of them. ---
 			if ( haveSkel && !ps.restrictToWorld && !ps.overlayEligible ) {
 				SkelScratch.clear();
 				AttachScratch.clear();
@@ -695,9 +685,8 @@ void D3D12PointShadows::Prepare() {
 					if ( baked ) bakedVobs.push_back( sd.vobInfo->Vob );
 				}
 
-				// Most MOBs carry no soft-skin geometry at all: a chest, door or bench is a zCModel whose only
-				// renderable content hangs off its nodes, so the body loop above finds nothing for them. Bake
-				// those attachments too, through the VOB caster PSO like a node attachment in Phase C.
+				// Most MOBs carry no soft-skin geometry: a chest or door is a zCModel whose renderable content
+				// hangs off its nodes, so the body loop above finds nothing. Bake those attachments too.
 				if ( psPipe.CasterVobPSO ) {
 					const zCVob* lastOwner = nullptr;
 					for ( const FrameAttachDraw& a : AttachScratch ) {

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -65,6 +65,7 @@ namespace {
 		D3D12_GPU_VIRTUAL_ADDRESS faceCb = 0;
 		UINT staticWorldBegin = 0, staticWorldEnd = 0;
 		UINT staticVobBegin = 0,   staticVobEnd = 0;
+		UINT staticSkelBegin = 0,  staticSkelEnd = 0;
 		UINT dynSkelBegin = 0,     dynSkelEnd = 0;
 		UINT dynAttachBegin = 0,   dynAttachEnd = 0;
 		bool lowRes = false;         // slot lives in the low-res STATIC cube array (D3D12PointShadows::LowIndex(slot)).
@@ -77,6 +78,7 @@ namespace {
 	};
 	std::vector<PointShadowDraw>        g_PsStaticWorldDraws;
 	std::vector<PointShadowDraw>        g_PsStaticVobDraws;
+	std::vector<PointShadowDraw>        g_PsStaticSkelDraws;   // MOB bodies baked into the static cube
 	std::vector<PointShadowDraw>        g_PsDynSkelDraws;
 	std::vector<PointShadowDraw>        g_PsDynAttachDraws;
 	std::vector<PointShadowLightRecord> g_PsLights;   // only slots TOUCHED this frame (static and/or dynamic)
@@ -85,6 +87,14 @@ namespace {
 	// point-shadow pass is single-consumer (one recorder list) and the project's standing rule is no per-frame
 	// (re)allocations on the frame path.
 	std::vector<D3D12ResourceTransition> g_PsBarriers;
+}
+
+
+bool D3D12PointShadows::IsNpcAttached( const zCVob* vob ) {
+	for ( const zCVob* v = vob; v; v = v->GetVobParent() ) {
+		if ( v->GetVobType() == zVOB_TYPE_NSC ) return true;
+	}
+	return false;
 }
 
 
@@ -305,19 +315,18 @@ void D3D12PointShadows::InvalidateStaticForVobAdded( const XMFLOAT3& posWS, floa
 }
 
 
-void D3D12PointShadows::InvalidateStaticForVobRemoved( const zTBBox3D& bb ) {
-	// Symmetric to the add case: a VOB removed from the world must stop casting into any light's cached static
-	// cube. D3D11 keys this off each light's per-vob VobCache (D3D11PointLight::OnVobRemovedFromWorld); D3D12
-	// keeps no per-slot vob list, so test the removed vob's world AABB against each active slot's light sphere
-	// (the same closest-point AABB test the static world-section cull uses).
+void D3D12PointShadows::InvalidateStaticForVobRemoved( const zCVob* vob ) {
+	// Symmetric to the add case: a VOB removed from the world (an item picked up, a container emptied) must
+	// stop casting into any light's cached static cube. Matched against the exact caster set Phase A baked,
+	// by POINTER - the vob is being torn down, so its bbox and position can no longer be read, and identity is
+	// the only thing left that is still meaningful. D3D11 does the same thing against each light's VobCache
+	// (D3D11PointLight::OnVobRemovedFromWorld). Nothing was baked => nothing to invalidate, which is what keeps
+	// an NPC's throwaway held item (never baked, see IsNpcAttached) from re-rendering every cube nearby.
+	if ( !vob ) return;
 	for ( Slot& ss : m_Slots ) {
-		if ( !ss.ownerKey || !ss.staticValid ) continue;
-		const float cx = std::min( std::max( ss.pos.x, bb.Min.x ), bb.Max.x );
-		const float cy = std::min( std::max( ss.pos.y, bb.Min.y ), bb.Max.y );
-		const float cz = std::min( std::max( ss.pos.z, bb.Min.z ), bb.Max.z );
-		const float dx = ss.pos.x - cx, dy = ss.pos.y - cy, dz = ss.pos.z - cz;
-		if ( dx * dx + dy * dy + dz * dz < ss.range * ss.range )
-			ss.staticValid = false;   // removed vob was within this light's static coverage -- re-cache
+		if ( !ss.ownerKey || !ss.staticValid || ss.bakedVobs.empty() ) continue;
+		if ( std::ranges::contains( ss.bakedVobs, vob ) )
+			ss.staticValid = false;   // this slot's cube holds the removed vob -- re-cache without it
 	}
 }
 
@@ -516,7 +525,10 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 		// whose render got deferred by the budget above must NOT be sampled yet: it still holds the previous
 		// occupant's depth, which would read as a wrong shadow. Leaving it -1 makes the light unshadowed for a
 		// few frames instead, and BuildFrameLightBuffer's range clamp keeps it from bleeding meanwhile.
-		if ( ss.staticValid || renderStatic ) {
+		// staticPresent, not just staticValid: a slot that was invalidated by a world change still holds this
+		// owner's depth and stays sampleable until the re-render lands. Only a FRESH slot (holding the previous
+		// occupant's depth) is withheld.
+		if ( ss.staticValid || ss.staticPresent || renderStatic ) {
 			// What the shader sees is the TIER-ENCODED index (local slot | kShadowTierLow), not the global slot.
 			// kShadowHasDynamic additionally tells the lit pass to sample the dynamic-overlay array for this light
 			// and min it with the static one. Only full-res slots can carry it (the low tier has no dynamic twin),
@@ -656,6 +668,7 @@ void D3D12PointShadows::Prepare() {
 	g_PsLights.clear();
 	g_PsStaticWorldDraws.clear();
 	g_PsStaticVobDraws.clear();
+	g_PsStaticSkelDraws.clear();
 	g_PsDynSkelDraws.clear();
 	g_PsDynAttachDraws.clear();
 	g_PsAnyStatic = false;
@@ -766,8 +779,12 @@ void D3D12PointShadows::Prepare() {
 		// ==================== Phase A resolve — STATIC casters (world mesh + instanced VOBs) ====================
 		rec.staticWorldBegin = rec.staticWorldEnd = static_cast<UINT>( g_PsStaticWorldDraws.size() );
 		rec.staticVobBegin   = rec.staticVobEnd   = static_cast<UINT>( g_PsStaticVobDraws.size() );
+		rec.staticSkelBegin  = rec.staticSkelEnd  = static_cast<UINT>( g_PsStaticSkelDraws.size() );
 		if ( rec.renderStatic ) {
 			g_PsAnyStatic = true;
+			// Rebuilt below alongside the draws it describes - see InvalidateStaticForVobRemoved.
+			std::vector<const zCVob*>& bakedVobs = m_Slots[ps.slot].bakedVobs;
+			bakedVobs.clear();
 			// The slot's CURRENT static target (aside cube if eligible, else the active cube itself) is about to
 			// be cleared and redrawn — but it does not HOLD that depth until the pass has actually been recorded
 			// and submitted, so the cache stamp is queued for CommitStaticCache instead of applied here.
@@ -807,13 +824,15 @@ void D3D12PointShadows::Prepare() {
 			}
 			rec.staticWorldEnd = static_cast<UINT>( g_PsStaticWorldDraws.size() );
 
-			// --- Instanced VOBs (static decoration): range-cull instances, pack 64B world matrices into the
-			// tight ring, draw count*6. An isStatic() slot additionally requires GP_Slot bit 30 (ZENGIN's own
-			// StaticVob flag) per instance — items are always StaticVob==false and would otherwise get baked
-			// into a cube that never re-renders. Items cast via the dynamic overlay (Phase C) instead. ---
+			// --- Instanced VOBs (static decoration AND loose items): range-cull instances, pack 64B world
+			// matrices into the tight ring, draw count*6. Items used to be kept out of an isStatic() slot via
+			// GP_Slot bit 30 (ZENGIN's StaticVob flag, which oCItem always clears), which meant a torch-lit
+			// room cast no shadow at all from anything lying on its floor. They are baked now; what must stay
+			// out is only what MOVES with an animation, i.e. anything hanging off an NPC — that one is drawn
+			// by the dynamic overlay (Phase C) instead, and a vob leaving the world takes the cube with it
+			// (InvalidateStaticForVobRemoved). ---
 			// restrictToWorld: mirrors D3D11's world-mesh-only PFX gate — skip instanced-VOB casters too.
 			if ( haveVobs && !ps.restrictToWorld ) {
-				const bool staticTier = m_Slots[ps.slot].isStatic;
 				for ( const FrameVobUpload& up : g_FrameVobUploads ) {
 					MeshVisualInfo* visual = up.visual;
 					if ( !visual || visual->Instances.empty() ) continue;
@@ -826,8 +845,14 @@ void D3D12PointShadows::Prepare() {
 					const UINT gatherStart = m_VobInstOffset;
 					UINT count = 0;
 					bool overflow = false;
-					for ( const VobInstanceInfo& inst : visual->Instances ) {
-						if ( staticTier && !( inst.GP_Slot & ( 1u << 30 ) ) ) continue;   // not a StaticVob — see above
+					const size_t numInst = visual->Instances.size();
+					// InstanceVobs is filled in lockstep with Instances (CollectVisibleVobs), but only trust the
+					// pairing while the two are actually the same length.
+					const bool haveInstanceVobs = visual->InstanceVobs.size() == numInst;
+					for ( size_t ii = 0; ii < numInst; ++ii ) {
+						const VobInstanceInfo& inst = visual->Instances[ii];
+						const zCVob* srcVob = haveInstanceVobs ? visual->InstanceVobs[ii] : nullptr;
+						if ( srcVob && IsNpcAttached( srcVob ) ) continue;   // animated — see above
 						float dx = inst.world._14 - ps.posWS.x, dy = inst.world._24 - ps.posWS.y, dz = inst.world._34 - ps.posWS.z;
 						if ( dx * dx + dy * dy + dz * dz >= cullRSq ) continue;
 						if ( m_VobInstOffset + sizeof( XMFLOAT4X4 ) > m_VobInstCapacity ) {
@@ -841,6 +866,7 @@ void D3D12PointShadows::Prepare() {
 						}
 						memcpy( viBase + m_VobInstOffset, &inst.world, sizeof( XMFLOAT4X4 ) );
 						m_VobInstOffset += sizeof( XMFLOAT4X4 );
+						if ( srcVob ) bakedVobs.push_back( srcVob );
 						++count;
 					}
 					if ( count == 0 ) { if ( overflow ) break; continue; }
@@ -872,6 +898,63 @@ void D3D12PointShadows::Prepare() {
 				}
 			}
 			rec.staticVobEnd = static_cast<UINT>( g_PsStaticVobDraws.size() );
+
+			// --- MOB casters (chests, beds, chairs, doors, benches): skeletal vobs that are NOT NPCs. They are
+			// world furniture that happens to be built as a zCModel, so they belong in the cached static cube
+			// exactly like the instanced decoration above - without this a static/low-tier light saw them as
+			// nothing at all, since Phase C (the only place skeletals were drawn) never runs for such a slot.
+			// NPCs and anything parented under one are excluded: they animate, and Phase C already owns them.
+			// A MOB that later starts moving is promoted to Gothic's animated list, which invalidates every
+			// static cube it was baked into (GothicAPI::MoveVobFromBspToDynamic -> OnVobBecameDynamic).
+			// !overlayEligible: on a slot that DOES get the overlay, Phase C already sphere-culls the same
+			// full skeletal list every frame and draws MOBs along with the NPCs, so baking them here as well
+			// would only duplicate the draws and freeze a copy of them in the static cube.
+			if ( haveSkel && !ps.restrictToWorld && !ps.overlayEligible ) {
+				SkelScratch.clear();
+				AttachScratch.clear();
+				m_E->PrepareFrameSkeletals( Engine::GAPI->GetSkeletalMeshVobs(), nullptr, -2, &ps.posWS, ps.range + kSkeletalCullPad );
+
+				for ( const FrameSkelDraw& sd : SkelScratch ) {
+					if ( !sd.visual || !sd.vobInfo || !sd.vobInfo->Vob ) continue;
+					if ( sd.vobInfo->Vob->GetVobType() == zVOB_TYPE_NSC || IsNpcAttached( sd.vobInfo->Vob ) ) continue;
+					const XMFLOAT3 pos = sd.vobInfo->Vob->GetPositionWorld();
+					const float cullR = ps.range + sd.visual->MeshSize * 0.5f;
+					float dx = pos.x - ps.posWS.x, dy = pos.y - ps.posWS.y, dz = pos.z - ps.posWS.z;
+					if ( dx * dx + dy * dy + dz * dz >= cullR * cullR ) continue;
+
+					// Shared per-MODEL texture slots - see the identical note in the Phase C gather.
+					zCModel* model = static_cast<zCModel*>(sd.vobInfo->Vob->GetVisual());
+					model->UpdateMeshLibTexAniState();
+
+					bool baked = false;
+					for ( auto const& [mat, meshList] : sd.visual->SkeletalMeshes ) {
+						zCTexture* const matTex = mat ? mat->GetAniTexture() : nullptr;
+						const D3D12_GPU_DESCRIPTOR_HANDLE srv = resolveDiffuse( matTex );
+						const bool matAlphaTested = ( matTex && matTex->HasAlphaChannel() )
+							|| ( mat && mat->HasAlphaTest() );
+						for ( auto const& mesh : meshList ) {
+							if ( !mesh || mesh->Indices.empty() || !mesh->MeshVertexBuffer || !mesh->MeshIndexBuffer ) continue;
+							D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( mesh->MeshVertexBuffer.get() );
+							D3D12VertexBuffer* mib = D3D12VertexBuffer::From( mesh->MeshIndexBuffer.get() );
+							if ( !mvb->GetResource() || !mib->GetResource() ) continue;
+
+							PointShadowDraw d;
+							d.vb = mvb; d.ib = mib;
+							d.stride = sizeof( ExSkelVertexStruct );
+							d.indexCount = static_cast<UINT>( mesh->Indices.size() );
+							d.instanceCount = 6;
+							d.srv = srv;
+							d.instCb = sd.instCb;
+							d.boneCb = sd.boneCb;
+							d.alphaTested = matAlphaTested;
+							g_PsStaticSkelDraws.push_back( d );
+							baked = true;
+						}
+					}
+					if ( baked ) bakedVobs.push_back( sd.vobInfo->Vob );
+				}
+			}
+			rec.staticSkelEnd = static_cast<UINT>( g_PsStaticSkelDraws.size() );
 		}
 
 		// ==================== Phase C resolve — DYNAMIC casters (skeletal NPCs + their attachments) ============
@@ -1057,6 +1140,7 @@ void D3D12PointShadows::CommitStaticCache() {
 		Slot& ss = m_Slots[p.slot];
 		if ( !ss.ownerKey ) continue;   // slot released between Prepare() and here — nothing to validate
 		ss.staticValid = true;
+		ss.staticPresent = true;
 	}
 	m_PendingStatic.clear();
 
@@ -1222,6 +1306,23 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 					const PointShadowDraw& d = g_PsStaticVobDraws[i];
 					bindCasterPso( psPipe.CasterVobPSO.Get(), psPipe.CasterVobNoAlphaPSO.Get(), d.alphaTested );
 					if ( d.srv.ptr != lastSrv ) { cmdList->SetGraphicsRootDescriptorTable( 1, d.srv ); lastSrv = d.srv.ptr; }
+					emitGeometry( d );
+				}
+			}
+
+			if ( L.staticSkelEnd > L.staticSkelBegin ) {
+				DX_ZONE( cmdList.Get(), "MOBs" );
+				TracyD3D12ZoneCGX( cmdList.Get(), "MOBs" );
+				// Its own (smaller) root signature - re-bound per light for the same reason Phase C does it.
+				cmdList->SetGraphicsRootSignature( psPipe.SkeletalRootSig.Get() );
+				cmdList->SetGraphicsRootConstantBufferView( 0, L.faceCb );
+				resetBindCache();
+				for ( UINT i = L.staticSkelBegin; i < L.staticSkelEnd; ++i ) {
+					const PointShadowDraw& d = g_PsStaticSkelDraws[i];
+					bindCasterPso( psPipe.CasterSkeletalPSO.Get(), psPipe.CasterSkeletalNoAlphaPSO.Get(), d.alphaTested );
+					if ( d.instCb != lastInstCb ) { cmdList->SetGraphicsRootConstantBufferView( 1, d.instCb ); lastInstCb = d.instCb; }
+					if ( d.boneCb != lastBoneCb ) { cmdList->SetGraphicsRootConstantBufferView( 2, d.boneCb ); lastBoneCb = d.boneCb; }
+					if ( d.srv.ptr != lastSrv )   { cmdList->SetGraphicsRootDescriptorTable( 3, d.srv ); lastSrv = d.srv.ptr; }
 					emitGeometry( d );
 				}
 			}

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -547,15 +547,73 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 	for ( const Cand& c : cands ) {
 		const UINT poolBegin = c.lowRes ? kMaxCubes : 0u;
 		const UINT poolEnd   = c.lowRes ? kMaxSlots : kMaxCubes;
+
+		// PFX-spawned lights (candles/torches/spell effects) mirror D3D11's RenderStaticShadowPass/RenderFullCubemap
+		// gate: unless PLSC_PARTICLE_FX is enabled, restrict them to world-mesh-only casters — BuildExcludeList
+		// never excludes a PFX light's own carrier (see its comment), so without this a PFX light attached to an
+		// NPC/the player could throw a large self-shadow from its own carrier. Checked even when c.isStatic is
+		// already false only because PLSC_STATIC_LIGHTS opted it in (BuildFrameLightBuffer's shadowRoutingStatic):
+		// a light can be both IsStatic() and IsPFXVobLight (e.g. a fixed PFX-spawned torch), and PFX takes
+		// precedence — mirrors D3D11's AllowsDynamicCasters category order.
+		bool restrictToWorld = false;
+		if ( c.vob && !c.isStatic ) {
+			auto li = Engine::GAPI->VobLightMap.find( c.vob );
+			if ( li != Engine::GAPI->VobLightMap.end() && li->second->IsPFXVobLight ) {
+				restrictToWorld = !(Engine::GAPI->GetRendererState().RendererSettings.PointlightShadowCasterFlags
+					& GothicRendererSettings::PLSC_PARTICLE_FX);
+			}
+		}
+		// Would this light actually USE the full-res tier? Only one that receives the per-frame skeletal overlay
+		// there has anything to gain from it. Computed before slot assignment because it is what decides whether
+		// a light sitting in the low-res tier gets promoted back out of it.
+		const bool wantsOverlay = !c.isStatic && !restrictToWorld
+			&& shadowMode >= GothicRendererSettings::PLS_UPDATE_DYNAMIC;
+
+		// Pick a slot in [b,e): a free one; else the longest-absent owner (an absent light's cache is worth
+		// keeping, but not at the cost of a light on screen now); else the FARTHEST present owner, and only if
+		// this candidate is substantially closer than it — kEvictDistanceRatio is the anti-oscillation margin,
+		// so two lights at similar distances can never trade a slot back and forth. -1 when every owner is
+		// about as close as this light, i.e. genuine oversubscription rather than arrival order.
+		auto pickSlot = [&]( UINT b, UINT e ) -> int {
+			for ( UINT s = b; s < e; ++s ) if ( !m_Slots[s].ownerKey ) return static_cast<int>( s );
+			int best = -1;
+			UINT32 worst = 0;
+			for ( UINT s = b; s < e; ++s )
+				if ( m_Slots[s].missingFrames > worst ) { worst = m_Slots[s].missingFrames; best = static_cast<int>( s ); }
+			if ( best >= 0 ) return best;
+			float bar = c.distSq * kEvictDistanceRatio;
+			for ( UINT s = b; s < e; ++s ) {
+				const Slot& os = m_Slots[s];
+				if ( !os.ownerKey ) continue;
+				const XMVECTOR d = XMVectorSubtract( XMLoadFloat3( &os.pos ), camPos );
+				const float dsq = XMVectorGetX( XMVector3LengthSq( d ) );
+				if ( dsq > bar ) { bar = dsq; best = static_cast<int>( s ); }
+			}
+			return best;
+			};
+
 		int slot = -1;
 		// A light keeps whatever slot it already owns, in EITHER tier. Tier preference decides where a light
 		// LOOKS for a slot, not where it is allowed to keep one: re-homing a spilled light the moment pressure
-		// eased would make it ping-pong between tiers, and every flip is a fresh cube render.
-		// The one thing that forces a hand-back is a light that has STARTED MOVING while holding a low-res
-		// slot - that tier bakes a cube once and never runs the dynamic overlay, so a mover cannot stay in it.
+		// eased would make it ping-pong between tiers, and every flip is a fresh cube render. Two things do
+		// force a low-res holder out, both of them one-directional:
 		if ( auto it = slotByKey.find( c.key ); it != slotByKey.end() ) {
 			const UINT owned = it->second;
-			if ( IsLowSlot( owned ) && !c.spatiallyStatic ) {
+			const bool ownedLow = IsLowSlot( owned );
+			// 1. It STARTED MOVING. That tier bakes a cube once and caches it forever, and never runs the
+			//    dynamic overlay, so a mover cannot stay in it.
+			bool handBack = ownedLow && !c.spatiallyStatic;
+			// 2. It now ranks into the full-res tier (the trim left c.lowRes false) AND would get a dynamic
+			//    overlay there. Without this a light that spilled while far away stayed in the cached tier for
+			//    good: walk right up to it under UPDATE DYNAMIC and it still drew static-only shadows, because
+			//    ownership alone kept it there. Promotion is attempted only when a full-res slot can ACTUALLY
+			//    be had — giving up the cube it holds for nothing would leave it unshadowed, and unshadowed is
+			//    what the range clamp turns into a light that looks switched off.
+			if ( !handBack && ownedLow && !c.lowRes && wantsOverlay ) {
+				const int hi = pickSlot( 0, kMaxCubes );
+				if ( hi >= 0 ) { handBack = true; slot = hi; }
+			}
+			if ( handBack ) {
 				if ( m_Slots[owned].staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
 				m_Slots[owned] = Slot{};
 				slotByKey.erase( c.key );
@@ -563,36 +621,9 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 				slot = static_cast<int>( owned );
 			}
 		}
-		if ( slot < 0 ) {
-			for ( UINT s = poolBegin; s < poolEnd; ++s )
-				if ( !m_Slots[s].ownerKey ) { slot = static_cast<int>( s ); break; }
-			if ( slot < 0 ) {
-				// Every slot in this tier is spoken for. Retained-but-absent owners are the ones to give up
-				// first, longest-absent first — an absent light's cache is worth keeping, but not at the cost
-				// of a light on screen now.
-				UINT32 worst = 0;
-				for ( UINT s = poolBegin; s < poolEnd; ++s )
-					if ( m_Slots[s].missingFrames > worst ) { worst = m_Slots[s].missingFrames; slot = static_cast<int>( s ); }
-				if ( slot < 0 ) {
-					// Every slot is held by a light that is on screen RIGHT NOW. This used to give up here, which
-					// made slot ownership first-come-first-served for the rest of the session: whoever filled the
-					// tier kept it, however far away they drifted, and a light you walked right up to never got
-					// one. Take the FARTHEST owner's slot instead, and only if this candidate is substantially
-					// closer than it — that margin is the anti-oscillation hysteresis (two lights at similar
-					// distances can never trade the slot back and forth).
-					float bar = c.distSq * kEvictDistanceRatio;   // the owner must be beyond this to be worth taking
-					for ( UINT s = poolBegin; s < poolEnd; ++s ) {
-						const Slot& ss = m_Slots[s];
-						if ( !ss.ownerKey ) continue;
-						const XMVECTOR d = XMVectorSubtract( XMLoadFloat3( &ss.pos ), camPos );
-						const float dsq = XMVectorGetX( XMVector3LengthSq( d ) );
-						if ( dsq > bar ) { bar = dsq; slot = static_cast<int>( s ); }
-					}
-					// Still nothing: every owner is about as close as this light. It goes unshadowed — but it is
-					// genuinely one of the farthest in a fully-subscribed tier, not a victim of arrival order.
-					if ( slot < 0 ) { ++starvedThisFrame; continue; }
-				}
-			}
+		if ( slot < 0 ) slot = pickSlot( poolBegin, poolEnd );
+		if ( slot < 0 ) { ++starvedThisFrame; continue; }
+		if ( m_Slots[slot].ownerKey != c.key ) {
 			if ( m_Slots[slot].staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
 			if ( m_Slots[slot].ownerKey ) slotByKey.erase( m_Slots[slot].ownerKey );
 			slotByKey[c.key] = static_cast<UINT>( slot );
@@ -620,24 +651,7 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 		// `!slotLow` is load-bearing, not belt-and-braces: the low-res array has no dynamic twin, so a low slot
 		// becoming overlay-eligible would point Phase C at a DSV that does not exist for it. Since the SPILL,
 		// a non-static light can end up in that tier too - it gives up its overlay in exchange for a cube.
-		// PFX-spawned lights (candles/torches/spell effects) mirror D3D11's RenderStaticShadowPass/RenderFullCubemap
-		// gate: unless PLSC_PARTICLE_FX is enabled, restrict them to world-mesh-only casters — BuildExcludeList
-		// never excludes a PFX light's own carrier (see its comment), so without this a PFX light attached to an
-		// NPC/the player could throw a large self-shadow from its own carrier. Checked even when c.isStatic is
-		// already false only because PLSC_STATIC_LIGHTS opted it in (BuildFrameLightBuffer's shadowRoutingStatic):
-		// a light can be both IsStatic() and IsPFXVobLight (e.g. a fixed PFX-spawned torch), and PFX takes
-		// precedence — mirrors D3D11's AllowsDynamicCasters category order.
-		bool restrictToWorld = false;
-		if ( c.vob && !c.isStatic ) {
-			auto li = Engine::GAPI->VobLightMap.find( c.vob );
-			if ( li != Engine::GAPI->VobLightMap.end() && li->second->IsPFXVobLight ) {
-				restrictToWorld = !(Engine::GAPI->GetRendererState().RendererSettings.PointlightShadowCasterFlags
-					& GothicRendererSettings::PLSC_PARTICLE_FX);
-			}
-		}
-
-		const bool overlayEligible = !c.isStatic && !slotLow && shadowMode >= GothicRendererSettings::PLS_UPDATE_DYNAMIC
-			&& !restrictToWorld;
+		const bool overlayEligible = wantsOverlay && !slotLow;
 		// An ineligible slot must not keep advertising a stale overlay: drop the bit so the lit pass stops
 		// sampling the dynamic array for it the moment the setting (or the light's IsStatic) changes.
 		if ( !overlayEligible ) ss.dynamicValid = false;

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -200,25 +200,21 @@ bool D3D12PointShadows::Init() {
 	if ( m_DynSrvSlot == UINT_MAX ) return false;
 	device->CreateShaderResourceView( m_DynCube.Get(), &srv, m_E->GetSrvCpuHandle( m_DynSrvSlot ) );
 
-	// --- Low-res STATIC cube tier (see the kStaticCubeSize block in the header): kMaxStaticCubes slots at
-	// kStaticCubeSize^2, split over kStaticCubePages arrays because 341 cubes is the hard per-array ceiling. One
-	// shared per-slot 6-slice DSV heap across all pages, plus one bindless SRV PER PAGE, allocated contiguously so
-	// the shader can reach page p as PointShadowLowIndex + p. No aside twin: nothing routed here can receive a
-	// dynamic overlay, so its static depth renders straight in and persists. Born in PIXEL_SHADER_RESOURCE for the
-	// same reason the active cube is: barriers here are per-slot, so a slot the pass never touches is never
-	// transitioned and has to be born sampleable.
+	// --- Low-res STATIC cube array (see the kStaticCubeSize block in the header): kMaxStaticCubes slots at
+	// kStaticCubeSize^2, with its own per-slot 6-slice DSV heap and a bindless SRV. No aside twin: nothing
+	// routed here can receive a dynamic overlay, so its static depth renders straight in and persists. Born in
+	// PIXEL_SHADER_RESOURCE for the same reason the active cube is: barriers here are per-slot, so a slot the
+	// pass never touches is never transitioned and has to be born sampleable.
 	D3D12_RESOURCE_DESC ld = dd;
 	ld.Width = kStaticCubeSize;
 	ld.Height = kStaticCubeSize;
-	ld.DepthOrArraySize = static_cast<UINT16>(kStaticCubesPerPage * 6);
-	for ( UINT page = 0; page < kStaticCubePages; ++page ) {
-		if ( FAILED( D3D12ResourceCreate::CreateTexture( m_E->m_Allocator.Get(), defaultAlloc, ld,
-			D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &clear, m_LowCubeAlloc[page].ReleaseAndGetAddressOf(),
-			IID_PPV_ARGS( m_LowCube[page].ReleaseAndGetAddressOf() ) ) ) )
-			return false;
-		m_LowCube[page]->SetName( L"PointShadowStaticLowCubeArray(D16)" );
-		m_LowCubeAlloc[page]->SetName( L"AllocPointShadowStaticLowCubeArray" );
-	}
+	ld.DepthOrArraySize = static_cast<UINT16>(kMaxStaticCubes * 6);
+	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_E->m_Allocator.Get(), defaultAlloc, ld,
+		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &clear, m_LowCubeAlloc.ReleaseAndGetAddressOf(),
+		IID_PPV_ARGS( m_LowCube.ReleaseAndGetAddressOf() ) ) ) )
+		return false;
+	m_LowCube->SetName( L"PointShadowStaticLowCubeArray(D16)" );
+	m_LowCubeAlloc->SetName( L"AllocPointShadowStaticLowCubeArray" );
 	for ( D3D12_RESOURCE_STATES& s : m_LowSlotState ) s = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 
 	D3D12_DESCRIPTOR_HEAP_DESC lowDsvHeapDesc = {};
@@ -231,30 +227,20 @@ bool D3D12PointShadows::Init() {
 		D3D12_DEPTH_STENCIL_VIEW_DESC dsv = {};
 		dsv.Format = DXGI_FORMAT_D16_UNORM;
 		dsv.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DARRAY;
-		dsv.Texture2DArray.FirstArraySlice = LowIndexInPage( s ) * 6;
+		dsv.Texture2DArray.FirstArraySlice = s * 6;
 		dsv.Texture2DArray.ArraySize = 6;
-		device->CreateDepthStencilView( m_LowCube[LowPage( s )].Get(), &dsv, ldsvH );
+		device->CreateDepthStencilView( m_LowCube.Get(), &dsv, ldsvH );
 		ldsvH.ptr += m_DsvSize;
 	}
 
-	// Bindless (SM6.6 ResourceDescriptorHeap) — the forward shaders reach this tier through LightCB's
-	// PointShadowLowIndex root constant rather than a declared t-register, so it cost no root signature changes.
-	// The pages MUST land on consecutive heap slots: the shader indexes PointShadowLowIndex + page and only that
-	// base is passed. AllocateSrvSlot recycles freed slots, so contiguity is checked rather than assumed (same
-	// pattern as D3D12AO's blur pairs). See PBRLighting.hlsl SamplePointShadow.
+	// Bindless (SM6.6 ResourceDescriptorHeap) - the forward shaders reach this array through LightCB's
+	// PointShadowLowIndex root constant rather than a declared t-register, so the second tier cost no root
+	// signature changes. See PBRLighting.hlsl SamplePointShadow.
+	m_LowSrvSlot = m_E->AllocateSrvSlot();
+	if ( m_LowSrvSlot == UINT_MAX ) return false;
 	D3D12_SHADER_RESOURCE_VIEW_DESC lowSrv = srv;
-	lowSrv.TextureCubeArray.NumCubes = kStaticCubesPerPage;
-	for ( UINT page = 0; page < kStaticCubePages; ++page ) {
-		const UINT slot = m_E->AllocateSrvSlot();
-		if ( slot == UINT_MAX ) return false;
-		if ( page == 0 ) m_LowSrvSlot = slot;
-		else if ( slot != m_LowSrvSlot + page ) {
-			LogWarn() << "D3D12: point-shadow low-res cube SRVs not contiguous - static point-light shadows disabled.";
-			m_LowSrvSlot = UINT_MAX;
-			return false;
-		}
-		device->CreateShaderResourceView( m_LowCube[page].Get(), &lowSrv, m_E->GetSrvCpuHandle( slot ) );
-	}
+	lowSrv.TextureCubeArray.NumCubes = kMaxStaticCubes;
+	device->CreateShaderResourceView( m_LowCube.Get(), &lowSrv, m_E->GetSrvCpuHandle( m_LowSrvSlot ) );
 
 	// Per-frame ring for the face-matrix CB: one 512-byte (256-aligned; 6 matrices = 384B) slot per shadowed
 	// light, so each light's cube draw binds its own root CBV without clobbering earlier same-frame draws.
@@ -694,12 +680,8 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 			// kShadowHasDynamic additionally tells the lit pass to sample the dynamic-overlay array for this light
 			// and min it with the static one. Only full-res slots can carry it (the low tier has no dynamic twin),
 			// and it reflects the last SUBMITTED overlay — see Slot::dynamicValid on the one-frame lag.
-			// The low tier's slot is encoded as (page << kShadowLowPageShift) | slot-within-page: it spans
-			// kStaticCubePages separate arrays, and the shader picks the array by adding the page to
-			// PointShadowLowIndex. See GPULightShared.h.
-			const UINT lowIdx = slotLow ? LowIndex( static_cast<UINT>( slot ) ) : 0u;
 			encodedByKey[c.key] = slotLow
-				? static_cast<int32_t>( LowIndexInPage( lowIdx ) | ( LowPage( lowIdx ) << kShadowLowPageShift ) ) | kShadowTierLow
+				? static_cast<int32_t>( LowIndex( static_cast<UINT>( slot ) ) ) | kShadowTierLow
 				: ( static_cast<int32_t>( slot ) | ( ss.dynamicValid ? kShadowHasDynamic : 0 ) );
 		}
 		m_FrameLights.push_back( { np, L.ShadowRange, static_cast<UINT>(slot), renderStatic, false, overlayEligible, restrictToWorld } );
@@ -731,13 +713,9 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 		if ( std::fabs( np.x - ss.pos.x ) > 0.5f || std::fabs( np.y - ss.pos.y ) > 0.5f
 			|| std::fabs( np.z - ss.pos.z ) > 0.5f || std::fabs( dst[i].ShadowRange - ss.range ) > 1.0f )
 			continue;
-		if ( IsLowSlot( it->second ) ) {
-			const UINT lowIdx = LowIndex( it->second );
-			encodedByKey[key] = static_cast<int32_t>( LowIndexInPage( lowIdx ) | ( LowPage( lowIdx ) << kShadowLowPageShift ) )
-				| kShadowTierLow;
-		} else {
-			encodedByKey[key] = static_cast<int32_t>( it->second );
-		}
+		encodedByKey[key] = IsLowSlot( it->second )
+			? static_cast<int32_t>( LowIndex( it->second ) ) | kShadowTierLow
+			: static_cast<int32_t>( it->second );
 	}
 
 	// Occupancy + starvation, for the ImGui point-light window (see DrawPointLightSlotStat). Counted here rather
@@ -889,7 +867,7 @@ void D3D12PointShadows::Prepare() {
 
 
 	const auto& psPipe = m_E->m_Pipelines.PointShadow;
-	if ( !m_E->m_FrameOpen || !m_Cube || !m_DynCube || !m_LowCube[0] || !psPipe.CasterWorldPSO
+	if ( !m_E->m_FrameOpen || !m_Cube || !m_DynCube || !m_LowCube || !psPipe.CasterWorldPSO
 		|| !m_DsvHeap || !m_DynDsvHeap || !m_LowDsvHeap || !psPipe.RootSig )
 		return;
 	if ( m_FrameLights.empty() ) return;
@@ -1437,18 +1415,12 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 	// ---- Per-slot (6-subresource) barriers. Never transition these two cubes with ALL_SUBRESOURCES — see the
 	// m_ActiveSlotState comment in the header. Transitions are batched into g_PsBarriers and issued in one call
 	// per phase so the GPU pays one pipeline flush per phase rather than one per slot.
-	// `slot` indexes the state array (the tier-local slot), `resSlot` the SUBRESOURCE inside `res` — the two
-	// differ for the paged low-res tier, where the state array spans all pages but each page is its own resource.
-	auto pushSlot = [&]( ID3D12Resource* res, D3D12_RESOURCE_STATES* slotStates, UINT slot, UINT resSlot, D3D12_RESOURCE_STATES after ) {
+	auto pushSlot = [&]( ID3D12Resource* res, D3D12_RESOURCE_STATES* slotStates, UINT slot, D3D12_RESOURCE_STATES after ) {
 		if ( slotStates[slot] == after ) return;   // already there — no redundant barrier
 		for ( UINT face = 0; face < 6; ++face ) {
-			g_PsBarriers.push_back( { res, slotStates[slot], after, resSlot * 6 + face } );
+			g_PsBarriers.push_back( { res, slotStates[slot], after, slot * 6 + face } );
 		}
 		slotStates[slot] = after;
-		};
-	// The paged low tier's two coordinates in one place: which page resource, and the slot within it.
-	auto pushLowSlot = [&]( UINT lowIndex, D3D12_RESOURCE_STATES after ) {
-		pushSlot( m_LowCube[LowPage( lowIndex )].Get(), m_LowSlotState, lowIndex, LowIndexInPage( lowIndex ), after );
 		};
 	auto flushBarriers = [&]() {
 		if ( g_PsBarriers.empty() ) return;
@@ -1513,8 +1485,8 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 		TracyD3D12ZoneCGX( cmdList.Get(), "Static Pass" );
 		for ( const PointShadowLightRecord& L : g_PsLights ) {
 			if ( !L.renderStatic ) continue;
-			if ( L.lowRes ) pushLowSlot( LowIndex( L.slot ), D3D12_RESOURCE_STATE_DEPTH_WRITE );
-			else            pushSlot( m_Cube.Get(), m_ActiveSlotState, L.slot, L.slot, D3D12_RESOURCE_STATE_DEPTH_WRITE );
+			if ( L.lowRes ) pushSlot( m_LowCube.Get(), m_LowSlotState,    LowIndex( L.slot ), D3D12_RESOURCE_STATE_DEPTH_WRITE );
+			else            pushSlot( m_Cube.Get(),    m_ActiveSlotState, L.slot,             D3D12_RESOURCE_STATE_DEPTH_WRITE );
 		}
 		flushBarriers();
 
@@ -1622,7 +1594,7 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 		// its dynamicValid below and the shader stops reading the array for it.
 		for ( const PointShadowLightRecord& L : g_PsLights )
 			if ( L.dynSkelEnd > L.dynSkelBegin || L.dynAttachEnd > L.dynAttachBegin )
-				pushSlot( m_DynCube.Get(), m_DynSlotState, L.slot, L.slot, D3D12_RESOURCE_STATE_DEPTH_WRITE );
+				pushSlot( m_DynCube.Get(), m_DynSlotState, L.slot, D3D12_RESOURCE_STATE_DEPTH_WRITE );
 		flushBarriers();
 
 		for ( const PointShadowLightRecord& L : g_PsLights ) {
@@ -1678,11 +1650,11 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 	// already sampleable and are never named in a barrier. Slots in g_PsLights that ended up doing no work at all
 	// never left PSR either, and pushSlot drops those as redundant.
 	for ( const PointShadowLightRecord& L : g_PsLights ) {
-		if ( L.lowRes ) pushLowSlot( LowIndex( L.slot ), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-		else            pushSlot( m_Cube.Get(), m_ActiveSlotState, L.slot, L.slot, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
+		if ( L.lowRes ) pushSlot( m_LowCube.Get(), m_LowSlotState, LowIndex( L.slot ), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
+		else            pushSlot( m_Cube.Get(),    m_ActiveSlotState, L.slot, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
 		// ...and the dynamic array, which is now sampled as well. pushSlot drops this as redundant for every slot
 		// Phase C did not actually draw into, so it costs nothing for lights with no casters in range.
-		if ( !L.lowRes ) pushSlot( m_DynCube.Get(), m_DynSlotState, L.slot, L.slot, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
+		if ( !L.lowRes ) pushSlot( m_DynCube.Get(), m_DynSlotState, L.slot, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
 	}
 	flushBarriers();
 	// Leave nothing bound: the cube DSVs this list used have just left DEPTH_WRITE, and a DSV that is still the

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -299,6 +299,26 @@ bool D3D12PointShadows::Init() {
 }
 
 
+void D3D12PointShadows::QueueVobAddedInvalidation( zCVob* vob ) {
+	if ( !vob || !m_HaveCachedStatic ) return;
+	m_PendingVobAdds.push_back( vob );
+}
+
+
+void D3D12PointShadows::DrainPendingVobAdds() {
+	for ( zCVob* vob : m_PendingVobAdds ) {
+		// OnRemovedVob erases the entry (and deletes the VobInfo), so a hit means the vob is still alive.
+		VobInfo* vi = Engine::GAPI->GetVobByVob( vob );
+		if ( !vi || !vi->Vob || !vi->VisualInfo ) continue;
+		// Settled in an NPC's hand rather than on the ground: it animates, so it is never baked and must not
+		// invalidate anything. This is the read that is unreliable at AddVob time - see the header.
+		if ( IsNpcAttached( vi->Vob ) ) continue;
+		InvalidateStaticForVobAdded( vi->Vob->GetPositionWorld(), vi->VisualInfo->MeshSize * 0.5f );
+	}
+	m_PendingVobAdds.clear();
+}
+
+
 void D3D12PointShadows::InvalidateStaticForVobAdded( const XMFLOAT3& posWS, float extent ) {
 	// A VOB added after a nearby point light already cached its static shadow cube would otherwise cast no
 	// point-light shadow: the static cube is only re-rendered when the light is fresh / moved / resized, not when
@@ -325,6 +345,8 @@ void D3D12PointShadows::InvalidateStaticForVobRemoved( const zCVob* vob ) {
 	// (D3D11PointLight::OnVobRemovedFromWorld). Nothing was baked => nothing to invalidate, which is what keeps
 	// an NPC's throwaway held item (never baked, see IsNpcAttached) from re-rendering every cube nearby.
 	if ( !vob ) return;
+	// It may still be parked for a deferred add-invalidation - drop it, the drain must never look it up.
+	std::erase( m_PendingVobAdds, const_cast<zCVob*>( vob ) );
 	for ( Slot& ss : m_Slots ) {
 		if ( !ss.ownerKey || !ss.staticValid || ss.bakedVobs.empty() ) continue;
 		if ( std::ranges::contains( ss.bakedVobs, vob ) ) {
@@ -336,6 +358,10 @@ void D3D12PointShadows::InvalidateStaticForVobRemoved( const zCVob* vob ) {
 
 
 void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const std::vector<LightShadowKey>& keys ) {
+	// Before anything decides renderStatic below: apply the world changes that were parked last frame, so a
+	// vob added since then lands in this frame's re-bake rather than the next one.
+	DrainPendingVobAdds();
+
 	// Point-light shadow selection (P2.10c + static-aside/round-robin P2.10f). Pick the closest-to-camera
 	// in-range lights (up to kMaxCubes) as this frame's "winners", but assign each winner a STABLE cube slot
 	// keyed by its light Vob identity (kept across frames, not reassigned by proximity every frame). A slot's
@@ -1151,6 +1177,7 @@ void D3D12PointShadows::CommitStaticCache() {
 		if ( !ss.ownerKey ) continue;   // slot released between Prepare() and here — nothing to validate
 		ss.staticValid = true;
 		ss.staticPresent = true;
+		m_HaveCachedStatic = true;
 	}
 	m_PendingStatic.clear();
 

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -321,11 +321,20 @@ void D3D12PointShadows::DrainPendingVobChanges() {
 		// Riding an NPC rather than lying on the ground: it animates, so it is never baked and must not
 		// invalidate anything. This is the read that is unreliable at report time - see the header.
 		if ( IsNpcAttached( vi->Vob ) ) continue;
+		// Below the movement threshold this is jitter, not a move - see kVobMoveEpsSq. The stored reference is
+		// only advanced when an invalidation actually happens, so repeated sub-eps steps still add up to one.
+		const XMFLOAT3 pos = vi->Vob->GetPositionWorld();
+		if ( auto posIt = m_LastInvalidationPos.find( vi->Vob ); posIt != m_LastInvalidationPos.end() ) {
+			const float dx = pos.x - posIt->second.x, dy = pos.y - posIt->second.y, dz = pos.z - posIt->second.z;
+			if ( dx * dx + dy * dy + dz * dz < kVobMoveEpsSq ) continue;
+		}
 		// Two halves, and a move needs both: every cube that baked it is now showing a shadow where the vob
 		// no longer is, and every cube reaching where it is NOW is missing it. A fresh add matches nothing in
 		// the first half, a vob that moved within one light's reach matches in both.
 		InvalidateStaticForVobRemoved( vi->Vob );
-		InvalidateStaticForVobAdded( vi->Vob->GetPositionWorld(), vi->VisualInfo->MeshSize * 0.5f );
+		InvalidateStaticForVobAdded( pos, vi->VisualInfo->MeshSize * 0.5f );
+		// After the removal half, which drops this vob's entry along with the caster records it matched.
+		m_LastInvalidationPos.insert_or_assign( vi->Vob, pos );
 	}
 	m_DrainScratch.clear();
 }
@@ -359,6 +368,7 @@ void D3D12PointShadows::InvalidateStaticForVobRemoved( const zCVob* vob ) {
 	if ( !vob ) return;
 	// It may still be parked for a deferred resolve - drop it, the drain must never look it up.
 	std::erase( m_PendingVobChanges, const_cast<zCVob*>( vob ) );
+	m_LastInvalidationPos.erase( vob );   // the address may be reused by a different vob later
 	for ( Slot& ss : m_Slots ) {
 		if ( !ss.ownerKey || !ss.staticValid || ss.bakedVobs.empty() ) continue;
 		if ( std::ranges::contains( ss.bakedVobs, vob ) ) {

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -299,23 +299,33 @@ bool D3D12PointShadows::Init() {
 }
 
 
-void D3D12PointShadows::QueueVobAddedInvalidation( zCVob* vob ) {
+void D3D12PointShadows::QueueVobChangedInvalidation( zCVob* vob ) {
 	if ( !vob || !m_HaveCachedStatic ) return;
-	m_PendingVobAdds.push_back( vob );
+	// A falling or thrown vob reports several transform changes per frame; they would all resolve to the same
+	// answer, so only the first is kept. Scanning is fine - the list holds one frame of world changes.
+	if ( std::ranges::contains( m_PendingVobChanges, vob ) ) return;
+	m_PendingVobChanges.push_back( vob );
 }
 
 
-void D3D12PointShadows::DrainPendingVobAdds() {
-	for ( zCVob* vob : m_PendingVobAdds ) {
+void D3D12PointShadows::DrainPendingVobChanges() {
+	if ( m_PendingVobChanges.empty() ) return;
+	// Swapped out, not iterated in place: InvalidateStaticForVobRemoved below scrubs the pending list.
+	m_DrainScratch.swap( m_PendingVobChanges );
+	for ( zCVob* vob : m_DrainScratch ) {
 		// OnRemovedVob erases the entry (and deletes the VobInfo), so a hit means the vob is still alive.
 		VobInfo* vi = Engine::GAPI->GetVobByVob( vob );
 		if ( !vi || !vi->Vob || !vi->VisualInfo ) continue;
-		// Settled in an NPC's hand rather than on the ground: it animates, so it is never baked and must not
-		// invalidate anything. This is the read that is unreliable at AddVob time - see the header.
+		// Riding an NPC rather than lying on the ground: it animates, so it is never baked and must not
+		// invalidate anything. This is the read that is unreliable at report time - see the header.
 		if ( IsNpcAttached( vi->Vob ) ) continue;
+		// Two halves, and a move needs both: every cube that baked it is now showing a shadow where the vob
+		// no longer is, and every cube reaching where it is NOW is missing it. A fresh add matches nothing in
+		// the first half, a vob that moved within one light's reach matches in both.
+		InvalidateStaticForVobRemoved( vi->Vob );
 		InvalidateStaticForVobAdded( vi->Vob->GetPositionWorld(), vi->VisualInfo->MeshSize * 0.5f );
 	}
-	m_PendingVobAdds.clear();
+	m_DrainScratch.clear();
 }
 
 
@@ -345,8 +355,8 @@ void D3D12PointShadows::InvalidateStaticForVobRemoved( const zCVob* vob ) {
 	// (D3D11PointLight::OnVobRemovedFromWorld). Nothing was baked => nothing to invalidate, which is what keeps
 	// an NPC's throwaway held item (never baked, see IsNpcAttached) from re-rendering every cube nearby.
 	if ( !vob ) return;
-	// It may still be parked for a deferred add-invalidation - drop it, the drain must never look it up.
-	std::erase( m_PendingVobAdds, const_cast<zCVob*>( vob ) );
+	// It may still be parked for a deferred resolve - drop it, the drain must never look it up.
+	std::erase( m_PendingVobChanges, const_cast<zCVob*>( vob ) );
 	for ( Slot& ss : m_Slots ) {
 		if ( !ss.ownerKey || !ss.staticValid || ss.bakedVobs.empty() ) continue;
 		if ( std::ranges::contains( ss.bakedVobs, vob ) ) {
@@ -359,8 +369,8 @@ void D3D12PointShadows::InvalidateStaticForVobRemoved( const zCVob* vob ) {
 
 void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const std::vector<LightShadowKey>& keys ) {
 	// Before anything decides renderStatic below: apply the world changes that were parked last frame, so a
-	// vob added since then lands in this frame's re-bake rather than the next one.
-	DrainPendingVobAdds();
+	// vob added or moved since then lands in this frame's re-bake rather than the next one.
+	DrainPendingVobChanges();
 
 	// Point-light shadow selection (P2.10c + static-aside/round-robin P2.10f). Pick the closest-to-camera
 	// in-range lights (up to kMaxCubes) as this frame's "winners", but assign each winner a STABLE cube slot

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -28,6 +28,18 @@ static_assert( D3D12PointShadows::kBackBufferMax == D3D12GraphicsEngine::kBackBu
 void D3D12PointShadows::Attach( D3D12GraphicsEngine& engine ) {
     m_E = &engine;
     kBackBufferCount = engine.kBackBufferCount;
+
+    // Size the shared slot table and hand it this backend's constants. The two tiers keep sharing ONE index
+    // space (global slot >= kMaxCubes is the low-res array), which is what the barrier-state arrays below and
+    // every DSV lookup in Prepare()/Record() index by. The two tier bits differ between backends - D3D12's
+    // live in Shaders/D3D12/include/GPULightShared.h - so they are configuration, not a shared constant.
+    PointLightSlotSelector::Config cfg;
+    cfg.MaxHiSlots = kMaxCubes;
+    cfg.MaxLowSlots = kMaxStaticCubes;
+    cfg.RetentionFrames = 600;   // ~10 s at 60 fps; see PointLightSlotSelector::Slot::missingFrames
+    cfg.TierLowBit = kShadowTierLow;
+    cfg.HasDynamicBit = kShadowHasDynamic;
+    m_Sel.Configure( cfg );
 }
 
 using namespace DirectX;
@@ -93,10 +105,7 @@ namespace {
 
 
 bool D3D12PointShadows::IsNpcAttached( const zCVob* vob ) {
-	for ( const zCVob* v = vob; v; v = v->GetVobParent() ) {
-		if ( v->GetVobType() == zVOB_TYPE_NSC ) return true;
-	}
-	return false;
+	return PointLightSlotSelector::IsNpcAttached( vob );
 }
 
 
@@ -302,518 +311,43 @@ bool D3D12PointShadows::Init() {
 
 
 void D3D12PointShadows::QueueVobChangedInvalidation( zCVob* vob ) {
-	if ( !vob || !m_HaveCachedStatic ) return;
-	// A falling or thrown vob reports several transform changes per frame; they would all resolve to the same
-	// answer, so only the first is kept. Scanning is fine - the list holds one frame of world changes.
-	if ( std::ranges::contains( m_PendingVobChanges, vob ) ) return;
-	m_PendingVobChanges.push_back( vob );
-}
-
-
-void D3D12PointShadows::DrainPendingVobChanges() {
-	if ( m_PendingVobChanges.empty() ) return;
-	// Swapped out, not iterated in place: InvalidateStaticForVobRemoved below scrubs the pending list.
-	m_DrainScratch.swap( m_PendingVobChanges );
-	for ( zCVob* vob : m_DrainScratch ) {
-		// OnRemovedVob erases the entry (and deletes the VobInfo), so a hit means the vob is still alive.
-		VobInfo* vi = Engine::GAPI->GetVobByVob( vob );
-		if ( !vi || !vi->Vob || !vi->VisualInfo ) continue;
-		// Riding an NPC rather than lying on the ground: it animates, so it is never baked and must not
-		// invalidate anything. This is the read that is unreliable at report time - see the header.
-		if ( IsNpcAttached( vi->Vob ) ) continue;
-		// Below the movement threshold this is jitter, not a move - see kVobMoveEpsSq. The stored reference is
-		// only advanced when an invalidation actually happens, so repeated sub-eps steps still add up to one.
-		const XMFLOAT3 pos = vi->Vob->GetPositionWorld();
-		if ( auto posIt = m_LastInvalidationPos.find( vi->Vob ); posIt != m_LastInvalidationPos.end() ) {
-			const float dx = pos.x - posIt->second.x, dy = pos.y - posIt->second.y, dz = pos.z - posIt->second.z;
-			if ( dx * dx + dy * dy + dz * dz < kVobMoveEpsSq ) continue;
-		}
-		// Two halves, and a move needs both: every cube that baked it is now showing a shadow where the vob
-		// no longer is, and every cube reaching where it is NOW is missing it. A fresh add matches nothing in
-		// the first half, a vob that moved within one light's reach matches in both.
-		InvalidateStaticForVobRemoved( vi->Vob );
-		InvalidateStaticForVobAdded( pos, vi->VisualInfo->MeshSize * 0.5f );
-		// After the removal half, which drops this vob's entry along with the caster records it matched.
-		m_LastInvalidationPos.insert_or_assign( vi->Vob, pos );
-	}
-	m_DrainScratch.clear();
+	m_Sel.QueueVobChangedInvalidation( vob );
 }
 
 
 void D3D12PointShadows::InvalidateStaticForVobAdded( const XMFLOAT3& posWS, float extent ) {
-	// A VOB added after a nearby point light already cached its static shadow cube would otherwise cast no
-	// point-light shadow: the static cube is only re-rendered when the light is fresh / moved / resized, not when
-	// world geometry around it changes. Walk the active slots and invalidate any whose light range the new VOB
-	// reaches. Slots are empty during world load (owner==nullptr) so this is a no-op then; the margin mirrors the
-	// static-VOB gather's cull (ps.range + visual->MeshSize * 0.5f).
-	for ( Slot& ss : m_Slots ) {
-		if ( !ss.ownerKey || !ss.staticValid ) continue;
-		const float r = ss.range + extent;
-		const float dx = posWS.x - ss.pos.x, dy = posWS.y - ss.pos.y, dz = posWS.z - ss.pos.z;
-		if ( dx * dx + dy * dy + dz * dz < r * r ) {
-			ss.staticValid = false;   // re-render this slot's static depth next frame to include the new VOB
-			Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
-		}
-	}
+	m_Sel.InvalidateStaticForVobAdded( posWS, extent );
 }
 
 
 void D3D12PointShadows::InvalidateStaticForVobRemoved( const zCVob* vob ) {
-	// Symmetric to the add case: a VOB removed from the world (an item picked up, a container emptied) must
-	// stop casting into any light's cached static cube. Matched against the exact caster set Phase A baked,
-	// by POINTER - the vob is being torn down, so its bbox and position can no longer be read, and identity is
-	// the only thing left that is still meaningful. D3D11 does the same thing against each light's VobCache
-	// (D3D11PointLight::OnVobRemovedFromWorld). Nothing was baked => nothing to invalidate, which is what keeps
-	// an NPC's throwaway held item (never baked, see IsNpcAttached) from re-rendering every cube nearby.
-	if ( !vob ) return;
-	// It may still be parked for a deferred resolve - drop it, the drain must never look it up.
-	std::erase( m_PendingVobChanges, const_cast<zCVob*>( vob ) );
-	m_LastInvalidationPos.erase( vob );   // the address may be reused by a different vob later
-	for ( Slot& ss : m_Slots ) {
-		if ( !ss.ownerKey || !ss.staticValid || ss.bakedVobs.empty() ) continue;
-		if ( std::ranges::contains( ss.bakedVobs, vob ) ) {
-			ss.staticValid = false;   // this slot's cube holds the removed vob -- re-cache without it
-			Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
-		}
-	}
+	m_Sel.InvalidateStaticForVobRemoved( vob );
 }
 
 
 void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const std::vector<LightShadowKey>& keys ) {
-	// Before anything decides renderStatic below: apply the world changes that were parked last frame, so a
-	// vob added or moved since then lands in this frame's re-bake rather than the next one.
-	DrainPendingVobChanges();
-
-	// Point-light shadow selection (P2.10c + static-aside/round-robin P2.10f). Pick the closest-to-camera
-	// in-range lights (up to kMaxCubes) as this frame's "winners", but assign each winner a STABLE cube slot
-	// keyed by its light Vob identity (kept across frames, not reassigned by proximity every frame). A slot's
-	// rendered content persists in the cube array, so a STATIC winner whose light didn't move can reuse its
-	// cached cube (renderStatic=false) instead of re-culling + re-rendering all world/VOB/skeletal casters each
-	// frame. Dynamic (moving) lights, newly-assigned slots, and moved/range-changed lights render.
-	// Mirrors D3D11 DrawPointlightShadows' distance/range gating (it keys off the player; camera is close enough).
-	//
-	// The global PointlightShadows setting (ini [Shadows] PointlightShadows / the ImGui combo) gates the whole
-	// thing:
-	//   PLS_DISABLED       — no winners at all; every ShadowCubeIndex stays -1 and the pass never arms.
-	//   PLS_STATIC_ONLY    — winners get their static cube (rendered direct-to-active, no aside/copy) but never a
-	//                        dynamic overlay.
-	//   PLS_UPDATE_DYNAMIC — overlay for the near winners + a round-robin budget for the rest.
-	//   PLS_FULL           — overlay for every winner, every frame (no round-robin).
+	// Thin adapter onto the shared PointLightSlotSelector, which owns every decision this used to make inline
+	// (candidacy horizon, per-tier trim + spill, stable slot ownership, retention/eviction, promotion, the
+	// low-tier render budget, the publish gate and the dynamic round-robin). D3D11 runs the exact same code -
+	// see PointLightSlotSelector.h.
 	const GothicRendererSettings::EPointLightShadowMode shadowMode =
 		Engine::GAPI->GetRendererState().RendererSettings.EnablePointlightShadows;
-	m_FrameLights.clear();
-	if ( shadowMode == GothicRendererSettings::PLS_DISABLED ) {
-		// Release every slot so re-enabling mid-session re-renders from scratch instead of sampling depth that has
-		// been stale for however long the setting was off. Slot resource states are indexed by slot, not by owner,
-		// and every touched slot is returned to PIXEL_SHADER_RESOURCE before the frame ends, so dropping ownership
-		// here cannot desync the barrier tracking.
-		for ( Slot& ss : m_Slots )
-			if ( ss.ownerKey ) ss = Slot{};
-		for ( UINT i = 0; i < count; ++i ) dst[i].ShadowCubeIndex = -1;
-		return;
-	}
-	// NOT gated on count>0: with zero visible lights every slot's owner is absent, and the retention/eviction
-	// bookkeeping below still has to tick for them.
-	if ( !m_Cube ) return;
 
-	// Absolute shadow-candidacy horizon, in Gothic world units (~100 = 1 m). Not a quality knob: below this
-	// distance a light MUST be allowed to compete for a cube, because a static light without one is range-clamped
-	// down to nothing and reads as switched off. Applies to BOTH tiers — a static light routed to the full-res
-	// tier by PLSC_STATIC_LIGHTS is clamped by exactly the same rule and switches off exactly the same way.
-	constexpr float kMinShadowDist = 3000.0f;
-	// How much closer (squared) a candidate must be than a present slot owner before it may take that slot.
-	// 2.0 squared = ~1.41x in linear distance.
-	constexpr float kEvictDistanceRatio = 2.0f;
-	// Candidates that wanted a cube and could not get one because their tier was fully subscribed by lights at
-	// comparable distance. Surfaced in the ImGui point-light window: a steady non-zero value is the signal that
-	// the tier is genuinely too small for the scene, which is otherwise indistinguishable from a bug.
-	UINT starvedThisFrame = 0;
-
-	const XMVECTOR camPos = Engine::GAPI->GetCameraPositionXM();
-	// One candidate per distinct ownership KEY, not per light: a cluster of co-located static lights shares a key
-	// (and a ShadowOrigin/ShadowRange), so it competes for — and wins — exactly ONE cube between all its members.
-	// `dstIdx` is just the first member found; the write-back at the end fans the result out to all of them.
-	struct Cand { UINT dstIdx; uint64_t key; zCVobLight* vob; float distSq; bool isStatic; bool lowRes; bool spatiallyStatic; };
-	static std::vector<Cand> cands;
-	static std::unordered_map<uint64_t, UINT> candByKey;   // key -> index into cands; capacity reused across frames
+	static std::vector<PointLightSlotSelector::Candidate> cands;   // frame path: capacity reused, no realloc
 	cands.clear();
-	candByKey.clear();
-	// key -> slot, for every OCCUPIED slot. Built once because the three lookups below (incumbency, ageing,
-	// "does this winner already own a slot") each used to walk all kMaxSlots per light — fine at 192 slots,
-	// but the static tier is now paged into four figures and that product is a per-frame O(slots*lights) scan.
-	// Kept in sync by hand at the two points a slot changes hands.
-	static std::unordered_map<uint64_t, UINT> slotByKey;
-	slotByKey.clear();
-	for ( UINT s = 0; s < kMaxSlots; ++s )
-		if ( m_Slots[s].ownerKey ) slotByKey.emplace( m_Slots[s].ownerKey, s );
-	// Every ownership key the frame's light buffer carries, winner or not. Slot ageing keys off THIS, not off
-	// the winner set: a light that is on screen and being shaded still wants the cube it already paid for, even
-	// on frames it is too far away to compete for a new one.
-	static std::unordered_set<uint64_t> frameKeys;
-	frameKeys.clear();
 	for ( UINT i = 0; i < count; ++i ) {
-		const GPULight& L = dst[i];
-		if ( keys[i].key == 0 ) continue;                     // caller marked this light as never-shadowed
-		frameKeys.insert( keys[i].key );
-		if ( candByKey.contains( keys[i].key ) ) continue;    // another member of this cluster already stands for it
-		// Ranked on the CUBE's placement (ShadowOrigin/ShadowRange), which for a clustered light is its cluster's.
-		const float range = L.ShadowRange;
-		if ( range <= 0.0f ) continue;
-		XMVECTOR d = XMVectorSubtract( XMLoadFloat3( &L.ShadowOrigin ), camPos );
-		float distSq = XMVectorGetX( XMVector3LengthSq( d ) );
-		// D3D11's distMaxShadowSq is range*9, which for a CANDLE (range ~150 units) puts the horizon at ~13 m —
-		// and a light that falls off this list is shaded unshadowed, which BuildFrameLightBuffer then range-clamps
-		// to 0.35x/0.15x. The lit patch around the candle collapses and the light reads as switched OFF, at a
-		// distance where it is still plainly visible. The horizon has to be about where the light stops being
-		// *seen*, not where its own falloff sphere stops reaching the camera, so the low tier gets an absolute
-		// floor as well. It can afford one: its cubes are 32^2, rendered once and cached forever.
-		const float maxDist = std::max( range * 9.0f, kMinShadowDist );
-		if ( distSq >= maxDist * maxDist ) continue;
-		// Ranked on RAW distance. This used to discount an incumbent's distance by 0.35 before ranking, as
-		// hysteresis against a newcomer bumping an established light out on a marginal difference — but the
-		// ranking is also what the per-tier TRIM cuts at, so with more candidate keys than slots the discount
-		// let far-away incumbents outrank a light right in front of the camera and push it off the list
-		// entirely. Since a light that is off the list cannot take a slot back (eviction only ever considered
-		// ABSENT owners), that was permanent: the candle stayed unshadowed, hence range-clamped, hence dark,
-		// until something flushed the light set. Nearest-first here; the hysteresis now lives where it belongs,
-		// in the eviction rule below, which demands a newcomer be substantially closer than the owner it takes
-		// a slot from.
-		candByKey.emplace( keys[i].key, static_cast<UINT>( cands.size() ) );
-		cands.push_back( { i, keys[i].key, keys[i].vob, distSq, keys[i].isStatic, keys[i].lowRes, keys[i].spatiallyStatic } );
-	}
-	std::sort( cands.begin(), cands.end(), []( const Cand& a, const Cand& b ) {
-		if ( a.distSq != b.distSq ) return a.distSq < b.distSq;
-		return a.key < b.key;   // total order: equal distances must not permute between frames
-		} );
-
-	// Trim PER TIER: the two pools are independent budgets, so a room full of static clusters can never crowd a
-	// dynamic torch out of the full-res pool (and vice versa). Nearest-first within each tier; the losers simply
-	// go unshadowed here — BuildFrameLightBuffer has already range-clamped the statics so they cannot bleed far.
-	{
-		UINT keptHi = 0, keptLow = 0;
-		size_t out = 0;
-		for ( size_t idx = 0; idx < cands.size(); ++idx ) {
-			Cand& c = cands[idx];
-			if ( !c.lowRes ) {
-				// SPILL. A light whose preferred tier is full does not go dark while the other tier sits empty:
-				// if it never moves, its cube is cacheable, and a 32^2 cached cube is enormously better than no
-				// cube at all (no cube means the range clamp, which reads as the light being switched off). This
-				// is what makes "64/64 dynamic, 0/1020 static, N starved" impossible for a light that holds still.
-				if ( keptHi >= kMaxCubes && c.spatiallyStatic ) c.lowRes = true;
-			}
-			UINT& kept = c.lowRes ? keptLow : keptHi;
-			const UINT budget = c.lowRes ? kMaxStaticCubes : kMaxCubes;
-			if ( kept >= budget ) { ++starvedThisFrame; continue; }   // more candidate keys than either tier holds
-			++kept;
-			cands[out++] = c;
-		}
-		cands.resize( out );
-		// candByKey stood for "already has a candidate" during the build above; from here on it is the winner
-		// set, which the ageing loop below tests every occupied slot against.
-		candByKey.clear();
-		for ( size_t idx = 0; idx < cands.size(); ++idx ) candByKey.emplace( cands[idx].key, static_cast<UINT>( idx ) );
+		const LightShadowKey& k = keys[i];
+		cands.push_back( { k.key, k.vob, dst[i].ShadowOrigin, dst[i].ShadowRange,
+			k.isStatic, k.lowRes, k.spatiallyStatic, k.restrictToWorld } );
 	}
 
-	// Age slots whose owner is not in this frame's light buffer at all — but do NOT release them. That buffer is
-	// frustum-culled upstream (CollectVisibleVobs), so a light drops out merely because the camera turned away;
-	// its cached static depth is still valid and is exactly what should be reused the moment it comes back.
-	// Releasing on absence made every frustum blink a fresh occupant, i.e. a full static re-cull + re-render of
-	// the world sections and VOB instances around that light. Slots are surrendered only under real pressure
-	// (below) or once the absence outlives kSlotRetentionFrames.
-	// Presence, NOT winning: a light past the candidacy horizon keeps being SHADED every frame, so it keeps
-	// sampling the cube it owns (see the cached-cube publish below) and must not have it aged out from under it.
-	for ( UINT s = 0; s < kMaxSlots; ++s ) {
-		Slot& ss = m_Slots[s];
-		if ( !ss.ownerKey ) continue;
-		if ( frameKeys.contains( ss.ownerKey ) ) { ss.missingFrames = 0; continue; }
-		if ( ++ss.missingFrames > kSlotRetentionFrames ) {
-			// Retention expired - the cached depth goes with the slot. Counted like any other invalidation
-			// (D3D11 counts its equivalent tiled-slot handover), so slot churn shows up in the stat too.
-			if ( ss.staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
-			slotByKey.erase( ss.ownerKey );
-			ss = Slot{};
-		}
-	}
-
-	static std::unordered_map<uint64_t, int32_t> encodedByKey;   // key -> tier-encoded ShadowCubeIndex
-	encodedByKey.clear();
-	// Per-frame ceiling on low-tier static (re)renders — see the deferral in the assignment loop below.
-	constexpr UINT kLowStaticRendersPerFrame = 8;
-	UINT lowStaticBudget = kLowStaticRendersPerFrame;
-
-	// Assign each winner a stable slot (keep its existing one, else grab a free one) and decide render vs cache.
-	// The search is confined to the winner's TIER — [0,kMaxCubes) for dynamic lights, [kMaxCubes,kMaxSlots) for
-	// static/clustered ones — so the two budgets stay genuinely independent.
-	for ( const Cand& c : cands ) {
-		const UINT poolBegin = c.lowRes ? kMaxCubes : 0u;
-		const UINT poolEnd   = c.lowRes ? kMaxSlots : kMaxCubes;
-
-		// PFX-spawned lights (candles/torches/spell effects) mirror D3D11's RenderStaticShadowPass/RenderFullCubemap
-		// gate: unless PLSC_PARTICLE_FX is enabled, restrict them to world-mesh-only casters — BuildExcludeList
-		// never excludes a PFX light's own carrier (see its comment), so without this a PFX light attached to an
-		// NPC/the player could throw a large self-shadow from its own carrier. Checked even when c.isStatic is
-		// already false only because PLSC_STATIC_LIGHTS opted it in (BuildFrameLightBuffer's shadowRoutingStatic):
-		// a light can be both IsStatic() and IsPFXVobLight (e.g. a fixed PFX-spawned torch), and PFX takes
-		// precedence — mirrors D3D11's AllowsDynamicCasters category order.
-		bool restrictToWorld = false;
-		if ( c.vob && !c.isStatic ) {
-			auto li = Engine::GAPI->VobLightMap.find( c.vob );
-			if ( li != Engine::GAPI->VobLightMap.end() && li->second->IsPFXVobLight ) {
-				restrictToWorld = !(Engine::GAPI->GetRendererState().RendererSettings.PointlightShadowCasterFlags
-					& GothicRendererSettings::PLSC_PARTICLE_FX);
-			}
-		}
-		// Would this light actually USE the full-res tier? Only one that receives the per-frame skeletal overlay
-		// there has anything to gain from it. Computed before slot assignment because it is what decides whether
-		// a light sitting in the low-res tier gets promoted back out of it.
-		const bool wantsOverlay = !c.isStatic && !restrictToWorld
-			&& shadowMode >= GothicRendererSettings::PLS_UPDATE_DYNAMIC;
-
-		// Pick a slot in [b,e): a free one; else the longest-absent owner (an absent light's cache is worth
-		// keeping, but not at the cost of a light on screen now); else the FARTHEST present owner, and only if
-		// this candidate is substantially closer than it — kEvictDistanceRatio is the anti-oscillation margin,
-		// so two lights at similar distances can never trade a slot back and forth. -1 when every owner is
-		// about as close as this light, i.e. genuine oversubscription rather than arrival order.
-		auto pickSlot = [&]( UINT b, UINT e ) -> int {
-			for ( UINT s = b; s < e; ++s ) if ( !m_Slots[s].ownerKey ) return static_cast<int>( s );
-			int best = -1;
-			UINT32 worst = 0;
-			for ( UINT s = b; s < e; ++s )
-				if ( m_Slots[s].missingFrames > worst ) { worst = m_Slots[s].missingFrames; best = static_cast<int>( s ); }
-			if ( best >= 0 ) return best;
-			float bar = c.distSq * kEvictDistanceRatio;
-			for ( UINT s = b; s < e; ++s ) {
-				const Slot& os = m_Slots[s];
-				if ( !os.ownerKey ) continue;
-				const XMVECTOR d = XMVectorSubtract( XMLoadFloat3( &os.pos ), camPos );
-				const float dsq = XMVectorGetX( XMVector3LengthSq( d ) );
-				if ( dsq > bar ) { bar = dsq; best = static_cast<int>( s ); }
-			}
-			return best;
-			};
-
-		int slot = -1;
-		// A light keeps whatever slot it already owns, in EITHER tier. Tier preference decides where a light
-		// LOOKS for a slot, not where it is allowed to keep one: re-homing a spilled light the moment pressure
-		// eased would make it ping-pong between tiers, and every flip is a fresh cube render. Two things do
-		// force a low-res holder out, both of them one-directional:
-		if ( auto it = slotByKey.find( c.key ); it != slotByKey.end() ) {
-			const UINT owned = it->second;
-			const bool ownedLow = IsLowSlot( owned );
-			// 1. It STARTED MOVING. That tier bakes a cube once and caches it forever, and never runs the
-			//    dynamic overlay, so a mover cannot stay in it.
-			bool handBack = ownedLow && !c.spatiallyStatic;
-			// 2. It now ranks into the full-res tier (the trim left c.lowRes false) AND would get a dynamic
-			//    overlay there. Without this a light that spilled while far away stayed in the cached tier for
-			//    good: walk right up to it under UPDATE DYNAMIC and it still drew static-only shadows, because
-			//    ownership alone kept it there. Promotion is attempted only when a full-res slot can ACTUALLY
-			//    be had — giving up the cube it holds for nothing would leave it unshadowed, and unshadowed is
-			//    what the range clamp turns into a light that looks switched off.
-			if ( !handBack && ownedLow && !c.lowRes && wantsOverlay ) {
-				const int hi = pickSlot( 0, kMaxCubes );
-				if ( hi >= 0 ) { handBack = true; slot = hi; }
-			}
-			if ( handBack ) {
-				if ( m_Slots[owned].staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
-				m_Slots[owned] = Slot{};
-				slotByKey.erase( c.key );
-			} else {
-				slot = static_cast<int>( owned );
-			}
-		}
-		if ( slot < 0 ) slot = pickSlot( poolBegin, poolEnd );
-		if ( slot < 0 ) { ++starvedThisFrame; continue; }
-		if ( m_Slots[slot].ownerKey != c.key ) {
-			if ( m_Slots[slot].staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
-			if ( m_Slots[slot].ownerKey ) slotByKey.erase( m_Slots[slot].ownerKey );
-			slotByKey[c.key] = static_cast<UINT>( slot );
-			m_Slots[slot] = Slot{};
-			m_Slots[slot].ownerKey = c.key;
-			m_Slots[slot].owner = c.vob;          // nullptr for a cluster — see the Slot::owner comment
-			m_Slots[slot].staticValid = false;   // fresh occupant → must render static (the slot changed hands)
-			// Stamp the intended cube origin NOW, not when the static render finally happens: an acquisition
-			// whose render the per-frame budget defers would otherwise sit at pos {0,0,0}, read as infinitely
-			// far to the eviction scan above, and be taken straight back off the light that just got it.
-			m_Slots[slot].pos = dst[c.dstIdx].ShadowOrigin;
-			m_Slots[slot].range = dst[c.dstIdx].ShadowRange;
-		}
-		Slot& ss = m_Slots[slot];
-		ss.isStatic = c.isStatic;
-		// Everything below follows the slot this light ACTUALLY holds, not the tier it asked for - a spilled
-		// light sits in the low-res array and must be encoded, budgeted and overlay-gated as such.
-		const bool slotLow = IsLowSlot( static_cast<UINT>( slot ) );
-
-		// Can this slot EVER receive the skeletal overlay? Static lights never do (D3D11's GetCurrentShadowMode
-		// forces them to PLS_STATIC_ONLY), and neither does anything below PLS_UPDATE_DYNAMIC.
-		// This NO LONGER decides which cube the static pass targets — static always goes to m_Cube, the overlay
-		// always to m_DynCube — so there is no routing flip to invalidate staticValid over any more. It only
-		// gates whether the overlay runs at all.
-		// `!slotLow` is load-bearing, not belt-and-braces: the low-res array has no dynamic twin, so a low slot
-		// becoming overlay-eligible would point Phase C at a DSV that does not exist for it. Since the SPILL,
-		// a non-static light can end up in that tier too - it gives up its overlay in exchange for a cube.
-		const bool overlayEligible = wantsOverlay && !slotLow;
-		// An ineligible slot must not keep advertising a stale overlay: drop the bit so the lit pass stops
-		// sampling the dynamic array for it the moment the setting (or the light's IsStatic) changes.
-		if ( !overlayEligible ) ss.dynamicValid = false;
-
-		GPULight& L = dst[c.dstIdx];
-		// Move/resize detection tracks the CUBE, not the light: a clustered light wandering inside its cluster
-		// does not move the shared cube, and must not invalidate its cached static depth.
-		const XMFLOAT3& np = L.ShadowOrigin;
-		const float moveEps = 0.5f;   // Gothic world units; below this the light hasn't meaningfully moved
-		bool moved = std::fabs( np.x - ss.pos.x ) > moveEps
-			|| std::fabs( np.y - ss.pos.y ) > moveEps
-			|| std::fabs( np.z - ss.pos.z ) > moveEps;
-		bool rangeChanged = std::fabs( L.ShadowRange - ss.range ) > 1.0f;
-		// The static cube is re-rendered only when fresh / the light moved / range changed / the routing
-		// flipped; otherwise reused. For overlay-eligible slots the DYNAMIC overlay + the static->active copy
-		// still run every frame regardless (see Prepare()).
-		bool renderStatic = !ss.staticValid || moved || rangeChanged;
-
-		// Amortize LOW-TIER static renders across frames. A static cube is rendered once and then cached forever,
-		// but "once" still costs a full world-section cull plus its draws — and acquisitions arrive in BURSTS
-		// (world load, a teleport, rounding a corner into a lit district), which without a budget means up to
-		// kMaxStaticCubes full static renders in a single frame and a very visible hitch. Nearest-first, because
-		// `cands` is already sorted by distance. The dynamic tier is deliberately NOT budgeted: it holds few
-		// lights, they are the ones the player is looking at, and its behaviour here is unchanged.
-		if ( renderStatic && slotLow ) {
-			if ( lowStaticBudget == 0 ) renderStatic = false;   // deferred; staticValid stays false so it retries
-			else --lowStaticBudget;
-		}
-
-		// Publish the cube index ONLY once the slot actually holds this owner's depth — either it was already
-		// cached, or it is being rendered this very frame (the cube pass runs before the lit pass). A fresh slot
-		// whose render got deferred by the budget above must NOT be sampled yet: it still holds the previous
-		// occupant's depth, which would read as a wrong shadow. Leaving it -1 makes the light unshadowed for a
-		// few frames instead, and BuildFrameLightBuffer's range clamp keeps it from bleeding meanwhile.
-		// staticPresent, not just staticValid: a slot that was invalidated by a world change still holds this
-		// owner's depth and stays sampleable until the re-render lands. Only a FRESH slot (holding the previous
-		// occupant's depth) is withheld.
-		if ( ss.staticValid || ss.staticPresent || renderStatic ) {
-			// What the shader sees is the TIER-ENCODED index (local slot | kShadowTierLow), not the global slot.
-			// kShadowHasDynamic additionally tells the lit pass to sample the dynamic-overlay array for this light
-			// and min it with the static one. Only full-res slots can carry it (the low tier has no dynamic twin),
-			// and it reflects the last SUBMITTED overlay — see Slot::dynamicValid on the one-frame lag.
-			encodedByKey[c.key] = slotLow
-				? static_cast<int32_t>( LowIndex( static_cast<UINT>( slot ) ) ) | kShadowTierLow
-				: ( static_cast<int32_t>( slot ) | ( ss.dynamicValid ? kShadowHasDynamic : 0 ) );
-		}
-		m_FrameLights.push_back( { np, L.ShadowRange, static_cast<UINT>(slot), renderStatic, false, overlayEligible, restrictToWorld } );
-		if ( renderStatic ) { ss.pos = np; ss.range = L.ShadowRange; }   // staticValid stamped once actually drawn
-	}
-
-	// ---- Non-winners that STILL OWN a valid cube keep sampling it -------------------------------------------
-	// Winning is about who may SPEND slots and render passes this frame; it is not what makes a cube sampleable.
-	// A static light that fell off the candidate list (past the horizon above, or beaten to the last free slot)
-	// used to drop to ShadowCubeIndex -1 while its own depth sat there in a slot it still owns, cached and
-	// resting in PIXEL_SHADER_RESOURCE — and going unshadowed is what triggers BuildFrameLightBuffer's range
-	// clamp, i.e. the light visibly switching off. Publishing the cube it already owns costs nothing: no
-	// re-render, no barrier, no entry in m_FrameLights, just one shadow sample the light was worth anyway.
-	//
-	// BOTH tiers, but only while the light still sits where the cube was rendered from: a cube is valid for the
-	// ORIGIN it was baked at, and the shader looks it up from the light's CURRENT ShadowOrigin, so a light that
-	// moved away from its bake would sample a cube centred somewhere else. That check is what makes this safe
-	// for the full-res tier too, whose lights can move. What a full-res non-winner does NOT get is
-	// kShadowHasDynamic: nothing refreshed its skeletal overlay this frame, and a stale one would leave an NPC's
-	// shadow standing where the NPC no longer is. Its static depth is still exactly right.
-	for ( UINT i = 0; i < count; ++i ) {
-		const uint64_t key = keys[i].key;
-		if ( !key || encodedByKey.contains( key ) ) continue;
-		const auto it = slotByKey.find( key );
-		if ( it == slotByKey.end() ) continue;
-		const Slot& ss = m_Slots[it->second];
-		if ( !ss.staticPresent ) continue;   // slot holds no depth for this owner yet
-		const XMFLOAT3& np = dst[i].ShadowOrigin;
-		if ( std::fabs( np.x - ss.pos.x ) > 0.5f || std::fabs( np.y - ss.pos.y ) > 0.5f
-			|| std::fabs( np.z - ss.pos.z ) > 0.5f || std::fabs( dst[i].ShadowRange - ss.range ) > 1.0f )
-			continue;
-		encodedByKey[key] = IsLowSlot( it->second )
-			? static_cast<int32_t>( LowIndex( it->second ) ) | kShadowTierLow
-			: static_cast<int32_t>( it->second );
-	}
-
-	// Occupancy + starvation, for the ImGui point-light window (see DrawPointLightSlotStat). Counted here rather
-	// than derived later: `starvedThisFrame` is only knowable inside the assignment loop.
-	{
-		auto& info = Engine::GAPI->GetRendererState().RendererInfo;
-		UINT usedHi = 0, usedLow = 0;
-		for ( UINT s = 0; s < kMaxSlots; ++s )
-			if ( m_Slots[s].ownerKey ) ( IsLowSlot( s ) ? usedLow : usedHi )++;
-		info.PointLightSlotsUsed = usedHi;
-		info.PointLightSlotsMax = kMaxCubes;
-		info.PointLightStaticSlotsUsed = usedLow;
-		info.PointLightStaticSlotsMax = kMaxStaticCubes;
-		info.PointLightSlotsStarved = starvedThisFrame;
-	}
+	// `m_Cube` is the resources gate: with no cube array there is nothing to own, so the selector only ticks
+	// its PLS_DISABLED wipe and leaves every slot alone (matching what this function did before the extraction).
+	m_Sel.Select( cands, shadowMode, m_Cube != nullptr );
 
 	// Fan the result out to EVERY light, so all members of a clustered key sample the one cube their cluster won.
-	for ( UINT i = 0; i < count; ++i ) {
-		dst[i].ShadowCubeIndex = -1;
-		if ( !keys[i].key ) continue;
-		if ( auto it = encodedByKey.find( keys[i].key ); it != encodedByKey.end() )
-			dst[i].ShadowCubeIndex = it->second;
-	}
-
-	// Round-robin the per-frame skeletal DYNAMIC overlay across overlay-eligible winners (P2.10h). With
-	// kMaxCubes persisting many lights, running the full sphere-cull-against-registered-skeletal-vobs pass for
-	// every single winner every frame would multiply CPU cost with light count. The nearest kAlwaysDynamicCount
-	// winners (where a moving caster's shadow lag would be most visible) always get it; the rest take turns via
-	// a stale-frames counter so every dynamic light's overlay still refreshes periodically instead of never.
-	// Static geometry shadows (walls, VOBs) are unaffected — those persist via the static cache regardless.
-	// Skipped wholesale below PLS_UPDATE_DYNAMIC (nothing is eligible), and un-budgeted at PLS_FULL.
-	if ( shadowMode < GothicRendererSettings::PLS_UPDATE_DYNAMIC ) return;
-
-	constexpr UINT kAlwaysDynamicCount = 8;   // NPCs barely move frame-to-frame; only the player (camera) moves a lot,
-	// and it won't be this close to more than a handful of lights at once, nor perceive the lag on distant ones.
-	constexpr UINT kDynamicRoundRobinBudget = 6;
-
-	static std::vector<FrameLight*> eligible;   // frame path: keep the capacity, don't realloc per frame
-	eligible.clear();
-	for ( FrameLight& ps : m_FrameLights ) if ( ps.overlayEligible ) eligible.push_back( &ps );
-
-	if ( shadowMode >= GothicRendererSettings::PLS_FULL ) {
-		// "Very expensive. Don't use unless you encounter visual bugs." — every eligible winner overlays
-		// every frame, no distance ranking and no budget.
-		for ( FrameLight* ps : eligible ) {
-			ps->renderDynamic = true;
-			m_Slots[ps->slot].dynamicStaleFrames = 0;
-		}
-	} else {
-		std::sort( eligible.begin(), eligible.end(), [&]( const FrameLight* a, const FrameLight* b ) {
-			XMVECTOR da = XMVectorSubtract( XMLoadFloat3( &a->posWS ), camPos );
-			XMVECTOR db = XMVectorSubtract( XMLoadFloat3( &b->posWS ), camPos );
-			return XMVectorGetX( XMVector3LengthSq( da ) ) < XMVectorGetX( XMVector3LengthSq( db ) );
-		} );
-
-		const size_t closeCount = std::min<size_t>( kAlwaysDynamicCount, eligible.size() );
-		for ( size_t idx = 0; idx < closeCount; ++idx ) {
-			eligible[idx]->renderDynamic = true;
-			m_Slots[eligible[idx]->slot].dynamicStaleFrames = 0;
-		}
-		for ( size_t idx = closeCount; idx < eligible.size(); ++idx ) ++m_Slots[eligible[idx]->slot].dynamicStaleFrames;
-
-		// Among the "far" set, service the most-stale slots first, up to this frame's round-robin budget.
-		std::sort( eligible.begin() + closeCount, eligible.end(), [&]( const FrameLight* a, const FrameLight* b ) {
-			return m_Slots[a->slot].dynamicStaleFrames > m_Slots[b->slot].dynamicStaleFrames;
-		} );
-		for ( size_t idx = closeCount, serviced = 0; idx < eligible.size() && serviced < kDynamicRoundRobinBudget; ++idx, ++serviced ) {
-			eligible[idx]->renderDynamic = true;
-			m_Slots[eligible[idx]->slot].dynamicStaleFrames = 0;
-		}
-	}
-
-	// An ELIGIBLE slot whose STATIC base is (re)rendered this frame must also refresh its dynamic overlay,
-	// round-robin turn or not: the previous active cube's dynamic content was composited against the OLD
-	// static depth — invalid once the static geometry/position changes. Not forcing this would either ghost
-	// stale skeletal shadows onto a new depth base, or (since Phase B still copies the new static in)
-	// silently drop the overlay for a light that's actually due for a refresh. Ineligible slots have no
-	// overlay to reconcile — their static render lands straight in the active cube and stands alone.
-	for ( FrameLight& ps : m_FrameLights ) {
-		if ( ps.overlayEligible && ps.renderStatic && !ps.renderDynamic ) {
-			ps.renderDynamic = true;
-			m_Slots[ps.slot].dynamicStaleFrames = 0;
-		}
-	}
+	for ( UINT i = 0; i < count; ++i )
+		dst[i].ShadowCubeIndex = m_Sel.GetEncodedIndex( keys[i].key );
 }
 
 
@@ -884,7 +418,7 @@ void D3D12PointShadows::Prepare() {
 	if ( !m_E->m_FrameOpen || !m_Cube || !m_DynCube || !m_LowCube || !psPipe.CasterWorldPSO
 		|| !m_DsvHeap || !m_DynDsvHeap || !m_LowDsvHeap || !psPipe.RootSig )
 		return;
-	if ( m_FrameLights.empty() ) return;
+	if ( m_Sel.GetAssignments().empty() ) return;
 
 	ZoneScopedN( "Prepare point shadows" );
 
@@ -929,7 +463,7 @@ void D3D12PointShadows::Prepare() {
 
 	// Precompute each winner's 6 face view-projs into its per-frame CB slot (transpose(view*proj) — same
 	// column-major convention the world/CSM shaders read back). Both the static and dynamic passes bind this.
-	for ( const FrameLight& ps : m_FrameLights ) {
+	for ( const FrameLight& ps : m_Sel.GetAssignments() ) {
 		if ( ps.slot >= kMaxSlots ) continue;
 		const XMVECTOR eye = XMLoadFloat3( &ps.posWS );
 		const XMMATRIX proj = XMMatrixPerspectiveFovLH( XM_PIDIV2, 1.0f, 15.0f, ps.range * 2.0f );
@@ -962,7 +496,7 @@ void D3D12PointShadows::Prepare() {
 	// avoid. Loop-invariant, so it is decided once here rather than per light.
 	const bool staticResolvable = haveWorld && !worldSections.empty();
 
-	for ( const FrameLight& ps : m_FrameLights ) {
+	for ( const FrameLight& ps : m_Sel.GetAssignments() ) {
 		if ( ps.slot >= kMaxSlots ) continue;
 		// Only the slots being (re)drawn THIS frame (static change and/or scheduled dynamic overlay, see the
 		// round-robin scheduling in SelectShadowedLights). A far light skipped this frame keeps EXACTLY what its
@@ -990,7 +524,7 @@ void D3D12PointShadows::Prepare() {
 		if ( rec.renderStatic ) {
 			g_PsAnyStatic = true;
 			// Rebuilt below alongside the draws it describes - see InvalidateStaticForVobRemoved.
-			std::vector<const zCVob*>& bakedVobs = m_Slots[ps.slot].bakedVobs;
+			std::vector<const zCVob*>& bakedVobs = m_Sel.SlotAt( ps.slot ).bakedVobs;
 			bakedVobs.clear();
 			// The slot's CURRENT static target (aside cube if eligible, else the active cube itself) is about to
 			// be cleared and redrawn — but it does not HOLD that depth until the pass has actually been recorded
@@ -1204,7 +738,7 @@ void D3D12PointShadows::Prepare() {
 		if ( ps.renderDynamic && ps.overlayEligible ) {
 			// Self-shadow exclusion (see BuildExcludeList) — shared by the skeletal/attachment gather and the
 			// dynamic-mesh-vob gather below.
-			const bool hasExclusions = BuildExcludeList( m_Slots[ps.slot].owner, excludeVobs );
+			const bool hasExclusions = BuildExcludeList( static_cast<zCVobLight*>( m_Sel.SlotAt( ps.slot ).owner ), excludeVobs );
 
 		if ( haveSkel ) {
 			// Sphere-cull the FULL registered skeletal-vob list against THIS light (parity with the CSM cascade
@@ -1372,11 +906,7 @@ void D3D12PointShadows::CommitStaticCache() {
 		// point is that this happens once. That also kept Phase A issuing low-res records every frame, which is
 		// what left the 32^2 viewport bound underneath the dynamic overlay (see Phase C).
 		if ( p.slot >= kMaxSlots ) continue;
-		Slot& ss = m_Slots[p.slot];
-		if ( !ss.ownerKey ) continue;   // slot released between Prepare() and here — nothing to validate
-		ss.staticValid = true;
-		ss.staticPresent = true;
-		m_HaveCachedStatic = true;
+		m_Sel.CommitStatic( p.slot );   // no-op if the slot was released between Prepare() and here
 	}
 	m_PendingStatic.clear();
 
@@ -1384,9 +914,7 @@ void D3D12PointShadows::CommitStaticCache() {
 	// unscheduled round-robin slot keeps its previous bit and its cube contents untouched.
 	for ( const PendingDynamic& p : m_PendingDynamic ) {
 		if ( p.slot >= kMaxSlots ) continue;
-		Slot& ss = m_Slots[p.slot];
-		if ( !ss.ownerKey ) continue;   // slot released between Prepare() and here — nothing to validate
-		ss.dynamicValid = p.has;
+		m_Sel.CommitDynamic( p.slot, p.has );
 	}
 	m_PendingDynamic.clear();
 }

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -66,6 +66,7 @@ namespace {
 		UINT staticWorldBegin = 0, staticWorldEnd = 0;
 		UINT staticVobBegin = 0,   staticVobEnd = 0;
 		UINT staticSkelBegin = 0,  staticSkelEnd = 0;
+		UINT staticAttachBegin = 0, staticAttachEnd = 0;
 		UINT dynSkelBegin = 0,     dynSkelEnd = 0;
 		UINT dynAttachBegin = 0,   dynAttachEnd = 0;
 		bool lowRes = false;         // slot lives in the low-res STATIC cube array (D3D12PointShadows::LowIndex(slot)).
@@ -79,6 +80,7 @@ namespace {
 	std::vector<PointShadowDraw>        g_PsStaticWorldDraws;
 	std::vector<PointShadowDraw>        g_PsStaticVobDraws;
 	std::vector<PointShadowDraw>        g_PsStaticSkelDraws;   // MOB bodies baked into the static cube
+	std::vector<PointShadowDraw>        g_PsStaticAttachDraws; // MOB node attachments baked into the static cube
 	std::vector<PointShadowDraw>        g_PsDynSkelDraws;
 	std::vector<PointShadowDraw>        g_PsDynAttachDraws;
 	std::vector<PointShadowLightRecord> g_PsLights;   // only slots TOUCHED this frame (static and/or dynamic)
@@ -715,6 +717,7 @@ void D3D12PointShadows::Prepare() {
 	g_PsStaticWorldDraws.clear();
 	g_PsStaticVobDraws.clear();
 	g_PsStaticSkelDraws.clear();
+	g_PsStaticAttachDraws.clear();
 	g_PsDynSkelDraws.clear();
 	g_PsDynAttachDraws.clear();
 	g_PsAnyStatic = false;
@@ -826,6 +829,7 @@ void D3D12PointShadows::Prepare() {
 		rec.staticWorldBegin = rec.staticWorldEnd = static_cast<UINT>( g_PsStaticWorldDraws.size() );
 		rec.staticVobBegin   = rec.staticVobEnd   = static_cast<UINT>( g_PsStaticVobDraws.size() );
 		rec.staticSkelBegin  = rec.staticSkelEnd  = static_cast<UINT>( g_PsStaticSkelDraws.size() );
+		rec.staticAttachBegin = rec.staticAttachEnd = static_cast<UINT>( g_PsStaticAttachDraws.size() );
 		if ( rec.renderStatic ) {
 			g_PsAnyStatic = true;
 			// Rebuilt below alongside the draws it describes - see InvalidateStaticForVobRemoved.
@@ -999,8 +1003,36 @@ void D3D12PointShadows::Prepare() {
 					}
 					if ( baked ) bakedVobs.push_back( sd.vobInfo->Vob );
 				}
+
+				// Most MOBs carry no soft-skin geometry at all: a chest, door or bench is a zCModel whose only
+				// renderable content hangs off its nodes, so the body loop above finds nothing for them. Bake
+				// those attachments too, through the VOB caster PSO like a node attachment in Phase C.
+				if ( psPipe.CasterVobPSO ) {
+					const zCVob* lastOwner = nullptr;
+					for ( const FrameAttachDraw& a : AttachScratch ) {
+						if ( !a.mesh || !a.owner || a.mesh->Indices.empty() ) continue;
+						if ( !a.mesh->GetMeshVertexBuffer() || !a.mesh->GetMeshIndexBuffer() ) continue;
+						if ( a.owner->GetVobType() == zVOB_TYPE_NSC || IsNpcAttached( a.owner ) ) continue;
+						D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( a.mesh->GetMeshVertexBuffer() );
+						D3D12VertexBuffer* mib = D3D12VertexBuffer::From( a.mesh->GetMeshIndexBuffer() );
+						if ( !mvb->GetResource() || !mib->GetResource() ) continue;
+
+						PointShadowDraw d;
+						d.vb = mvb; d.ib = mib;
+						d.stride = sizeof( ExVertexStruct );
+						d.indexCount = static_cast<UINT>( a.mesh->Indices.size() );
+						d.instanceCount = 6;
+						d.srv = resolveDiffuse( a.tex );
+						d.instView = a.instView;
+						d.alphaTested = a.alphaTested;
+						g_PsStaticAttachDraws.push_back( d );
+						// AttachScratch is grouped by owner, so this dedupes the whole run in one compare.
+						if ( a.owner != lastOwner ) { bakedVobs.push_back( a.owner ); lastOwner = a.owner; }
+					}
+				}
 			}
 			rec.staticSkelEnd = static_cast<UINT>( g_PsStaticSkelDraws.size() );
+			rec.staticAttachEnd = static_cast<UINT>( g_PsStaticAttachDraws.size() );
 		}
 
 		// ==================== Phase C resolve — DYNAMIC casters (skeletal NPCs + their attachments) ============
@@ -1370,6 +1402,21 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 					if ( d.instCb != lastInstCb ) { cmdList->SetGraphicsRootConstantBufferView( 1, d.instCb ); lastInstCb = d.instCb; }
 					if ( d.boneCb != lastBoneCb ) { cmdList->SetGraphicsRootConstantBufferView( 2, d.boneCb ); lastBoneCb = d.boneCb; }
 					if ( d.srv.ptr != lastSrv )   { cmdList->SetGraphicsRootDescriptorTable( 3, d.srv ); lastSrv = d.srv.ptr; }
+					emitGeometry( d );
+				}
+			}
+
+			if ( L.staticAttachEnd > L.staticAttachBegin ) {
+				DX_ZONE( cmdList.Get(), "MOB Nodes" );
+				TracyD3D12ZoneCGX( cmdList.Get(), "MOB Nodes" );
+				// Back to the VOB signature the block above switched away from - see Phase C's identical note.
+				cmdList->SetGraphicsRootSignature( psPipe.RootSig.Get() );
+				cmdList->SetGraphicsRootConstantBufferView( 0, L.faceCb );
+				resetBindCache();
+				for ( UINT i = L.staticAttachBegin; i < L.staticAttachEnd; ++i ) {
+					const PointShadowDraw& d = g_PsStaticAttachDraws[i];
+					bindCasterPso( psPipe.CasterVobPSO.Get(), psPipe.CasterVobNoAlphaPSO.Get(), d.alphaTested );
+					if ( d.srv.ptr != lastSrv ) { cmdList->SetGraphicsRootDescriptorTable( 1, d.srv ); lastSrv = d.srv.ptr; }
 					emitGeometry( d );
 				}
 			}

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.cpp
@@ -200,21 +200,25 @@ bool D3D12PointShadows::Init() {
 	if ( m_DynSrvSlot == UINT_MAX ) return false;
 	device->CreateShaderResourceView( m_DynCube.Get(), &srv, m_E->GetSrvCpuHandle( m_DynSrvSlot ) );
 
-	// --- Low-res STATIC cube array (see the kStaticCubeSize block in the header): kMaxStaticCubes slots at
-	// kStaticCubeSize^2, with its own per-slot 6-slice DSV heap and a bindless SRV. No aside twin — nothing routed
-	// here can receive a dynamic overlay, so its static depth renders straight in and persists. Born in
-	// PIXEL_SHADER_RESOURCE for the same reason the active cube is: barriers here are per-slot, so a slot the pass
-	// never touches is never transitioned and has to be born sampleable.
+	// --- Low-res STATIC cube tier (see the kStaticCubeSize block in the header): kMaxStaticCubes slots at
+	// kStaticCubeSize^2, split over kStaticCubePages arrays because 341 cubes is the hard per-array ceiling. One
+	// shared per-slot 6-slice DSV heap across all pages, plus one bindless SRV PER PAGE, allocated contiguously so
+	// the shader can reach page p as PointShadowLowIndex + p. No aside twin: nothing routed here can receive a
+	// dynamic overlay, so its static depth renders straight in and persists. Born in PIXEL_SHADER_RESOURCE for the
+	// same reason the active cube is: barriers here are per-slot, so a slot the pass never touches is never
+	// transitioned and has to be born sampleable.
 	D3D12_RESOURCE_DESC ld = dd;
 	ld.Width = kStaticCubeSize;
 	ld.Height = kStaticCubeSize;
-	ld.DepthOrArraySize = static_cast<UINT16>(kMaxStaticCubes * 6);
-	if ( FAILED( D3D12ResourceCreate::CreateTexture( m_E->m_Allocator.Get(), defaultAlloc, ld,
-		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &clear, m_LowCubeAlloc.ReleaseAndGetAddressOf(),
-		IID_PPV_ARGS( m_LowCube.ReleaseAndGetAddressOf() ) ) ) )
-		return false;
-	m_LowCube->SetName( L"PointShadowStaticLowCubeArray(D16)" );
-	m_LowCubeAlloc->SetName( L"AllocPointShadowStaticLowCubeArray" );
+	ld.DepthOrArraySize = static_cast<UINT16>(kStaticCubesPerPage * 6);
+	for ( UINT page = 0; page < kStaticCubePages; ++page ) {
+		if ( FAILED( D3D12ResourceCreate::CreateTexture( m_E->m_Allocator.Get(), defaultAlloc, ld,
+			D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &clear, m_LowCubeAlloc[page].ReleaseAndGetAddressOf(),
+			IID_PPV_ARGS( m_LowCube[page].ReleaseAndGetAddressOf() ) ) ) )
+			return false;
+		m_LowCube[page]->SetName( L"PointShadowStaticLowCubeArray(D16)" );
+		m_LowCubeAlloc[page]->SetName( L"AllocPointShadowStaticLowCubeArray" );
+	}
 	for ( D3D12_RESOURCE_STATES& s : m_LowSlotState ) s = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 
 	D3D12_DESCRIPTOR_HEAP_DESC lowDsvHeapDesc = {};
@@ -227,20 +231,30 @@ bool D3D12PointShadows::Init() {
 		D3D12_DEPTH_STENCIL_VIEW_DESC dsv = {};
 		dsv.Format = DXGI_FORMAT_D16_UNORM;
 		dsv.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DARRAY;
-		dsv.Texture2DArray.FirstArraySlice = s * 6;
+		dsv.Texture2DArray.FirstArraySlice = LowIndexInPage( s ) * 6;
 		dsv.Texture2DArray.ArraySize = 6;
-		device->CreateDepthStencilView( m_LowCube.Get(), &dsv, ldsvH );
+		device->CreateDepthStencilView( m_LowCube[LowPage( s )].Get(), &dsv, ldsvH );
 		ldsvH.ptr += m_DsvSize;
 	}
 
-	// Bindless (SM6.6 ResourceDescriptorHeap) — the forward shaders reach this array through LightCB's
-	// PointShadowLowIndex root constant rather than a declared t-register, so the second tier cost no root
-	// signature changes. See PBRLighting.hlsl SamplePointShadow.
-	m_LowSrvSlot = m_E->AllocateSrvSlot();
-	if ( m_LowSrvSlot == UINT_MAX ) return false;
+	// Bindless (SM6.6 ResourceDescriptorHeap) — the forward shaders reach this tier through LightCB's
+	// PointShadowLowIndex root constant rather than a declared t-register, so it cost no root signature changes.
+	// The pages MUST land on consecutive heap slots: the shader indexes PointShadowLowIndex + page and only that
+	// base is passed. AllocateSrvSlot recycles freed slots, so contiguity is checked rather than assumed (same
+	// pattern as D3D12AO's blur pairs). See PBRLighting.hlsl SamplePointShadow.
 	D3D12_SHADER_RESOURCE_VIEW_DESC lowSrv = srv;
-	lowSrv.TextureCubeArray.NumCubes = kMaxStaticCubes;
-	device->CreateShaderResourceView( m_LowCube.Get(), &lowSrv, m_E->GetSrvCpuHandle( m_LowSrvSlot ) );
+	lowSrv.TextureCubeArray.NumCubes = kStaticCubesPerPage;
+	for ( UINT page = 0; page < kStaticCubePages; ++page ) {
+		const UINT slot = m_E->AllocateSrvSlot();
+		if ( slot == UINT_MAX ) return false;
+		if ( page == 0 ) m_LowSrvSlot = slot;
+		else if ( slot != m_LowSrvSlot + page ) {
+			LogWarn() << "D3D12: point-shadow low-res cube SRVs not contiguous - static point-light shadows disabled.";
+			m_LowSrvSlot = UINT_MAX;
+			return false;
+		}
+		device->CreateShaderResourceView( m_LowCube[page].Get(), &lowSrv, m_E->GetSrvCpuHandle( slot ) );
+	}
 
 	// Per-frame ring for the face-matrix CB: one 512-byte (256-aligned; 6 matrices = 384B) slot per shadowed
 	// light, so each light's cube draw binds its own root CBV without clobbering earlier same-frame draws.
@@ -416,40 +430,75 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 	// bookkeeping below still has to tick for them.
 	if ( !m_Cube ) return;
 
+	// Absolute shadow-candidacy horizon, in Gothic world units (~100 = 1 m). Not a quality knob: below this
+	// distance a light MUST be allowed to compete for a cube, because a static light without one is range-clamped
+	// down to nothing and reads as switched off. Applies to BOTH tiers — a static light routed to the full-res
+	// tier by PLSC_STATIC_LIGHTS is clamped by exactly the same rule and switches off exactly the same way.
+	constexpr float kMinShadowDist = 3000.0f;
+	// How much closer (squared) a candidate must be than a present slot owner before it may take that slot.
+	// 2.0 squared = ~1.41x in linear distance.
+	constexpr float kEvictDistanceRatio = 2.0f;
+	// Candidates that wanted a cube and could not get one because their tier was fully subscribed by lights at
+	// comparable distance. Surfaced in the ImGui point-light window: a steady non-zero value is the signal that
+	// the tier is genuinely too small for the scene, which is otherwise indistinguishable from a bug.
+	UINT starvedThisFrame = 0;
+
 	const XMVECTOR camPos = Engine::GAPI->GetCameraPositionXM();
 	// One candidate per distinct ownership KEY, not per light: a cluster of co-located static lights shares a key
 	// (and a ShadowOrigin/ShadowRange), so it competes for — and wins — exactly ONE cube between all its members.
 	// `dstIdx` is just the first member found; the write-back at the end fans the result out to all of them.
-	struct Cand { UINT dstIdx; uint64_t key; zCVobLight* vob; float distSq; float sortKey; bool isStatic; bool lowRes; };
+	struct Cand { UINT dstIdx; uint64_t key; zCVobLight* vob; float distSq; bool isStatic; bool lowRes; bool spatiallyStatic; };
 	static std::vector<Cand> cands;
 	static std::unordered_map<uint64_t, UINT> candByKey;   // key -> index into cands; capacity reused across frames
 	cands.clear();
 	candByKey.clear();
+	// key -> slot, for every OCCUPIED slot. Built once because the three lookups below (incumbency, ageing,
+	// "does this winner already own a slot") each used to walk all kMaxSlots per light — fine at 192 slots,
+	// but the static tier is now paged into four figures and that product is a per-frame O(slots*lights) scan.
+	// Kept in sync by hand at the two points a slot changes hands.
+	static std::unordered_map<uint64_t, UINT> slotByKey;
+	slotByKey.clear();
+	for ( UINT s = 0; s < kMaxSlots; ++s )
+		if ( m_Slots[s].ownerKey ) slotByKey.emplace( m_Slots[s].ownerKey, s );
+	// Every ownership key the frame's light buffer carries, winner or not. Slot ageing keys off THIS, not off
+	// the winner set: a light that is on screen and being shaded still wants the cube it already paid for, even
+	// on frames it is too far away to compete for a new one.
+	static std::unordered_set<uint64_t> frameKeys;
+	frameKeys.clear();
 	for ( UINT i = 0; i < count; ++i ) {
 		const GPULight& L = dst[i];
 		if ( keys[i].key == 0 ) continue;                     // caller marked this light as never-shadowed
+		frameKeys.insert( keys[i].key );
 		if ( candByKey.contains( keys[i].key ) ) continue;    // another member of this cluster already stands for it
 		// Ranked on the CUBE's placement (ShadowOrigin/ShadowRange), which for a clustered light is its cluster's.
 		const float range = L.ShadowRange;
 		if ( range <= 0.0f ) continue;
 		XMVECTOR d = XMVectorSubtract( XMLoadFloat3( &L.ShadowOrigin ), camPos );
 		float distSq = XMVectorGetX( XMVector3LengthSq( d ) );
-		const float maxSq = (range * 9.0f) * (range * 9.0f);   // D3D11 distMaxShadowSq
-		if ( distSq >= maxSq ) continue;
-		// Sticky/hysteresis: a light that already owns a slot gets its distance discounted before ranking,
-		// so it takes a meaningfully closer newcomer to evict it rather than a marginal distance difference.
-		// Without this, a burst of newly-frustum-visible lights (e.g. rotating to face an outdoor cluster)
-		// could bump an already-shadowed indoor light out of the winner set on a single frame, snapping its
-		// shadow off (and letting its light bleed through walls unshadowed) until it re-wins a slot later —
-		// the exact "shadows pop on/off when turning a few degrees" artifact this guards against.
-		bool isIncumbent = false;
-		for ( UINT s = 0; s < kMaxSlots; ++s ) if ( m_Slots[s].ownerKey == keys[i].key ) { isIncumbent = true; break; }
-		constexpr float kIncumbentBias = 0.35f;   // incumbent must be ~1.7x farther than a challenger to lose its slot
-		float sortKey = isIncumbent ? distSq * kIncumbentBias : distSq;
+		// D3D11's distMaxShadowSq is range*9, which for a CANDLE (range ~150 units) puts the horizon at ~13 m —
+		// and a light that falls off this list is shaded unshadowed, which BuildFrameLightBuffer then range-clamps
+		// to 0.35x/0.15x. The lit patch around the candle collapses and the light reads as switched OFF, at a
+		// distance where it is still plainly visible. The horizon has to be about where the light stops being
+		// *seen*, not where its own falloff sphere stops reaching the camera, so the low tier gets an absolute
+		// floor as well. It can afford one: its cubes are 32^2, rendered once and cached forever.
+		const float maxDist = std::max( range * 9.0f, kMinShadowDist );
+		if ( distSq >= maxDist * maxDist ) continue;
+		// Ranked on RAW distance. This used to discount an incumbent's distance by 0.35 before ranking, as
+		// hysteresis against a newcomer bumping an established light out on a marginal difference — but the
+		// ranking is also what the per-tier TRIM cuts at, so with more candidate keys than slots the discount
+		// let far-away incumbents outrank a light right in front of the camera and push it off the list
+		// entirely. Since a light that is off the list cannot take a slot back (eviction only ever considered
+		// ABSENT owners), that was permanent: the candle stayed unshadowed, hence range-clamped, hence dark,
+		// until something flushed the light set. Nearest-first here; the hysteresis now lives where it belongs,
+		// in the eviction rule below, which demands a newcomer be substantially closer than the owner it takes
+		// a slot from.
 		candByKey.emplace( keys[i].key, static_cast<UINT>( cands.size() ) );
-		cands.push_back( { i, keys[i].key, keys[i].vob, distSq, sortKey, keys[i].isStatic, keys[i].lowRes } );
+		cands.push_back( { i, keys[i].key, keys[i].vob, distSq, keys[i].isStatic, keys[i].lowRes, keys[i].spatiallyStatic } );
 	}
-	std::sort( cands.begin(), cands.end(), []( const Cand& a, const Cand& b ) { return a.sortKey < b.sortKey; } );
+	std::sort( cands.begin(), cands.end(), []( const Cand& a, const Cand& b ) {
+		if ( a.distSq != b.distSq ) return a.distSq < b.distSq;
+		return a.key < b.key;   // total order: equal distances must not permute between frames
+		} );
 
 	// Trim PER TIER: the two pools are independent budgets, so a room full of static clusters can never crowd a
 	// dynamic torch out of the full-res pool (and vice versa). Nearest-first within each tier; the losers simply
@@ -458,31 +507,44 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 		UINT keptHi = 0, keptLow = 0;
 		size_t out = 0;
 		for ( size_t idx = 0; idx < cands.size(); ++idx ) {
-			UINT& kept = cands[idx].lowRes ? keptLow : keptHi;
-			const UINT budget = cands[idx].lowRes ? kMaxStaticCubes : kMaxCubes;
-			if ( kept >= budget ) continue;
+			Cand& c = cands[idx];
+			if ( !c.lowRes ) {
+				// SPILL. A light whose preferred tier is full does not go dark while the other tier sits empty:
+				// if it never moves, its cube is cacheable, and a 32^2 cached cube is enormously better than no
+				// cube at all (no cube means the range clamp, which reads as the light being switched off). This
+				// is what makes "64/64 dynamic, 0/1020 static, N starved" impossible for a light that holds still.
+				if ( keptHi >= kMaxCubes && c.spatiallyStatic ) c.lowRes = true;
+			}
+			UINT& kept = c.lowRes ? keptLow : keptHi;
+			const UINT budget = c.lowRes ? kMaxStaticCubes : kMaxCubes;
+			if ( kept >= budget ) { ++starvedThisFrame; continue; }   // more candidate keys than either tier holds
 			++kept;
-			cands[out++] = cands[idx];
+			cands[out++] = c;
 		}
 		cands.resize( out );
+		// candByKey stood for "already has a candidate" during the build above; from here on it is the winner
+		// set, which the ageing loop below tests every occupied slot against.
+		candByKey.clear();
+		for ( size_t idx = 0; idx < cands.size(); ++idx ) candByKey.emplace( cands[idx].key, static_cast<UINT>( idx ) );
 	}
 
-	// Age slots whose owner is not a winner this frame — but do NOT release them. The light buffer these
-	// candidates come from is frustum-culled upstream (CollectVisibleVobs), so a light drops out merely because
-	// the camera turned away; its cached static depth is still valid and is exactly what should be reused the
-	// moment it comes back. Releasing on absence made every frustum blink a fresh occupant, i.e. a full static
-	// re-cull + re-render of the world sections and VOB instances around that light. Slots are surrendered only
-	// under real pressure (below) or once the absence outlives kSlotRetentionFrames.
+	// Age slots whose owner is not in this frame's light buffer at all — but do NOT release them. That buffer is
+	// frustum-culled upstream (CollectVisibleVobs), so a light drops out merely because the camera turned away;
+	// its cached static depth is still valid and is exactly what should be reused the moment it comes back.
+	// Releasing on absence made every frustum blink a fresh occupant, i.e. a full static re-cull + re-render of
+	// the world sections and VOB instances around that light. Slots are surrendered only under real pressure
+	// (below) or once the absence outlives kSlotRetentionFrames.
+	// Presence, NOT winning: a light past the candidacy horizon keeps being SHADED every frame, so it keeps
+	// sampling the cube it owns (see the cached-cube publish below) and must not have it aged out from under it.
 	for ( UINT s = 0; s < kMaxSlots; ++s ) {
 		Slot& ss = m_Slots[s];
 		if ( !ss.ownerKey ) continue;
-		bool stillWinner = false;
-		for ( const Cand& c : cands ) if ( c.key == ss.ownerKey ) { stillWinner = true; break; }
-		if ( stillWinner ) { ss.missingFrames = 0; continue; }
+		if ( frameKeys.contains( ss.ownerKey ) ) { ss.missingFrames = 0; continue; }
 		if ( ++ss.missingFrames > kSlotRetentionFrames ) {
 			// Retention expired - the cached depth goes with the slot. Counted like any other invalidation
 			// (D3D11 counts its equivalent tiled-slot handover), so slot churn shows up in the stat too.
 			if ( ss.staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+			slotByKey.erase( ss.ownerKey );
 			ss = Slot{};
 		}
 	}
@@ -490,7 +552,7 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 	static std::unordered_map<uint64_t, int32_t> encodedByKey;   // key -> tier-encoded ShadowCubeIndex
 	encodedByKey.clear();
 	// Per-frame ceiling on low-tier static (re)renders — see the deferral in the assignment loop below.
-	constexpr UINT kLowStaticRendersPerFrame = 4;
+	constexpr UINT kLowStaticRendersPerFrame = 8;
 	UINT lowStaticBudget = kLowStaticRendersPerFrame;
 
 	// Assign each winner a stable slot (keep its existing one, else grab a free one) and decide render vs cache.
@@ -500,37 +562,78 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 		const UINT poolBegin = c.lowRes ? kMaxCubes : 0u;
 		const UINT poolEnd   = c.lowRes ? kMaxSlots : kMaxCubes;
 		int slot = -1;
-		for ( UINT s = poolBegin; s < poolEnd; ++s )
-			if ( m_Slots[s].ownerKey == c.key ) { slot = static_cast<int>( s ); break; }
+		// A light keeps whatever slot it already owns, in EITHER tier. Tier preference decides where a light
+		// LOOKS for a slot, not where it is allowed to keep one: re-homing a spilled light the moment pressure
+		// eased would make it ping-pong between tiers, and every flip is a fresh cube render.
+		// The one thing that forces a hand-back is a light that has STARTED MOVING while holding a low-res
+		// slot - that tier bakes a cube once and never runs the dynamic overlay, so a mover cannot stay in it.
+		if ( auto it = slotByKey.find( c.key ); it != slotByKey.end() ) {
+			const UINT owned = it->second;
+			if ( IsLowSlot( owned ) && !c.spatiallyStatic ) {
+				if ( m_Slots[owned].staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+				m_Slots[owned] = Slot{};
+				slotByKey.erase( c.key );
+			} else {
+				slot = static_cast<int>( owned );
+			}
+		}
 		if ( slot < 0 ) {
 			for ( UINT s = poolBegin; s < poolEnd; ++s )
 				if ( !m_Slots[s].ownerKey ) { slot = static_cast<int>( s ); break; }
 			if ( slot < 0 ) {
-				// Every slot in this tier is spoken for. Retained-but-absent owners are the ones to give up,
-				// longest-absent first — an absent light's cache is worth keeping, but not at the cost of a
-				// light on screen now.
+				// Every slot in this tier is spoken for. Retained-but-absent owners are the ones to give up
+				// first, longest-absent first — an absent light's cache is worth keeping, but not at the cost
+				// of a light on screen now.
 				UINT32 worst = 0;
 				for ( UINT s = poolBegin; s < poolEnd; ++s )
 					if ( m_Slots[s].missingFrames > worst ) { worst = m_Slots[s].missingFrames; slot = static_cast<int>( s ); }
-				if ( slot < 0 ) continue;   // whole tier held by present winners — this light goes unshadowed
+				if ( slot < 0 ) {
+					// Every slot is held by a light that is on screen RIGHT NOW. This used to give up here, which
+					// made slot ownership first-come-first-served for the rest of the session: whoever filled the
+					// tier kept it, however far away they drifted, and a light you walked right up to never got
+					// one. Take the FARTHEST owner's slot instead, and only if this candidate is substantially
+					// closer than it — that margin is the anti-oscillation hysteresis (two lights at similar
+					// distances can never trade the slot back and forth).
+					float bar = c.distSq * kEvictDistanceRatio;   // the owner must be beyond this to be worth taking
+					for ( UINT s = poolBegin; s < poolEnd; ++s ) {
+						const Slot& ss = m_Slots[s];
+						if ( !ss.ownerKey ) continue;
+						const XMVECTOR d = XMVectorSubtract( XMLoadFloat3( &ss.pos ), camPos );
+						const float dsq = XMVectorGetX( XMVector3LengthSq( d ) );
+						if ( dsq > bar ) { bar = dsq; slot = static_cast<int>( s ); }
+					}
+					// Still nothing: every owner is about as close as this light. It goes unshadowed — but it is
+					// genuinely one of the farthest in a fully-subscribed tier, not a victim of arrival order.
+					if ( slot < 0 ) { ++starvedThisFrame; continue; }
+				}
 			}
 			if ( m_Slots[slot].staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+			if ( m_Slots[slot].ownerKey ) slotByKey.erase( m_Slots[slot].ownerKey );
+			slotByKey[c.key] = static_cast<UINT>( slot );
 			m_Slots[slot] = Slot{};
 			m_Slots[slot].ownerKey = c.key;
 			m_Slots[slot].owner = c.vob;          // nullptr for a cluster — see the Slot::owner comment
 			m_Slots[slot].staticValid = false;   // fresh occupant → must render static (the slot changed hands)
+			// Stamp the intended cube origin NOW, not when the static render finally happens: an acquisition
+			// whose render the per-frame budget defers would otherwise sit at pos {0,0,0}, read as infinitely
+			// far to the eviction scan above, and be taken straight back off the light that just got it.
+			m_Slots[slot].pos = dst[c.dstIdx].ShadowOrigin;
+			m_Slots[slot].range = dst[c.dstIdx].ShadowRange;
 		}
 		Slot& ss = m_Slots[slot];
 		ss.isStatic = c.isStatic;
+		// Everything below follows the slot this light ACTUALLY holds, not the tier it asked for - a spilled
+		// light sits in the low-res array and must be encoded, budgeted and overlay-gated as such.
+		const bool slotLow = IsLowSlot( static_cast<UINT>( slot ) );
 
 		// Can this slot EVER receive the skeletal overlay? Static lights never do (D3D11's GetCurrentShadowMode
 		// forces them to PLS_STATIC_ONLY), and neither does anything below PLS_UPDATE_DYNAMIC.
 		// This NO LONGER decides which cube the static pass targets — static always goes to m_Cube, the overlay
 		// always to m_DynCube — so there is no routing flip to invalidate staticValid over any more. It only
 		// gates whether the overlay runs at all.
-		// `!c.lowRes` is redundant with `!c.isStatic` today (only static lights are routed low) but is stated
-		// explicitly: the low-res array has no dynamic twin, so a low slot becoming overlay-eligible would point
-		// Phase C at a DSV that does not exist for it.
+		// `!slotLow` is load-bearing, not belt-and-braces: the low-res array has no dynamic twin, so a low slot
+		// becoming overlay-eligible would point Phase C at a DSV that does not exist for it. Since the SPILL,
+		// a non-static light can end up in that tier too - it gives up its overlay in exchange for a cube.
 		// PFX-spawned lights (candles/torches/spell effects) mirror D3D11's RenderStaticShadowPass/RenderFullCubemap
 		// gate: unless PLSC_PARTICLE_FX is enabled, restrict them to world-mesh-only casters — BuildExcludeList
 		// never excludes a PFX light's own carrier (see its comment), so without this a PFX light attached to an
@@ -547,7 +650,7 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 			}
 		}
 
-		const bool overlayEligible = !c.isStatic && !c.lowRes && shadowMode >= GothicRendererSettings::PLS_UPDATE_DYNAMIC
+		const bool overlayEligible = !c.isStatic && !slotLow && shadowMode >= GothicRendererSettings::PLS_UPDATE_DYNAMIC
 			&& !restrictToWorld;
 		// An ineligible slot must not keep advertising a stale overlay: drop the bit so the lit pass stops
 		// sampling the dynamic array for it the moment the setting (or the light's IsStatic) changes.
@@ -573,7 +676,7 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 		// kMaxStaticCubes full static renders in a single frame and a very visible hitch. Nearest-first, because
 		// `cands` is already sorted by distance. The dynamic tier is deliberately NOT budgeted: it holds few
 		// lights, they are the ones the player is looking at, and its behaviour here is unchanged.
-		if ( renderStatic && c.lowRes ) {
+		if ( renderStatic && slotLow ) {
 			if ( lowStaticBudget == 0 ) renderStatic = false;   // deferred; staticValid stays false so it retries
 			else --lowStaticBudget;
 		}
@@ -591,12 +694,64 @@ void D3D12PointShadows::SelectShadowedLights( GPULight* dst, UINT count, const s
 			// kShadowHasDynamic additionally tells the lit pass to sample the dynamic-overlay array for this light
 			// and min it with the static one. Only full-res slots can carry it (the low tier has no dynamic twin),
 			// and it reflects the last SUBMITTED overlay — see Slot::dynamicValid on the one-frame lag.
-			encodedByKey[c.key] = c.lowRes
-				? static_cast<int32_t>( LowIndex( static_cast<UINT>( slot ) ) ) | kShadowTierLow
+			// The low tier's slot is encoded as (page << kShadowLowPageShift) | slot-within-page: it spans
+			// kStaticCubePages separate arrays, and the shader picks the array by adding the page to
+			// PointShadowLowIndex. See GPULightShared.h.
+			const UINT lowIdx = slotLow ? LowIndex( static_cast<UINT>( slot ) ) : 0u;
+			encodedByKey[c.key] = slotLow
+				? static_cast<int32_t>( LowIndexInPage( lowIdx ) | ( LowPage( lowIdx ) << kShadowLowPageShift ) ) | kShadowTierLow
 				: ( static_cast<int32_t>( slot ) | ( ss.dynamicValid ? kShadowHasDynamic : 0 ) );
 		}
 		m_FrameLights.push_back( { np, L.ShadowRange, static_cast<UINT>(slot), renderStatic, false, overlayEligible, restrictToWorld } );
 		if ( renderStatic ) { ss.pos = np; ss.range = L.ShadowRange; }   // staticValid stamped once actually drawn
+	}
+
+	// ---- Non-winners that STILL OWN a valid cube keep sampling it -------------------------------------------
+	// Winning is about who may SPEND slots and render passes this frame; it is not what makes a cube sampleable.
+	// A static light that fell off the candidate list (past the horizon above, or beaten to the last free slot)
+	// used to drop to ShadowCubeIndex -1 while its own depth sat there in a slot it still owns, cached and
+	// resting in PIXEL_SHADER_RESOURCE — and going unshadowed is what triggers BuildFrameLightBuffer's range
+	// clamp, i.e. the light visibly switching off. Publishing the cube it already owns costs nothing: no
+	// re-render, no barrier, no entry in m_FrameLights, just one shadow sample the light was worth anyway.
+	//
+	// BOTH tiers, but only while the light still sits where the cube was rendered from: a cube is valid for the
+	// ORIGIN it was baked at, and the shader looks it up from the light's CURRENT ShadowOrigin, so a light that
+	// moved away from its bake would sample a cube centred somewhere else. That check is what makes this safe
+	// for the full-res tier too, whose lights can move. What a full-res non-winner does NOT get is
+	// kShadowHasDynamic: nothing refreshed its skeletal overlay this frame, and a stale one would leave an NPC's
+	// shadow standing where the NPC no longer is. Its static depth is still exactly right.
+	for ( UINT i = 0; i < count; ++i ) {
+		const uint64_t key = keys[i].key;
+		if ( !key || encodedByKey.contains( key ) ) continue;
+		const auto it = slotByKey.find( key );
+		if ( it == slotByKey.end() ) continue;
+		const Slot& ss = m_Slots[it->second];
+		if ( !ss.staticPresent ) continue;   // slot holds no depth for this owner yet
+		const XMFLOAT3& np = dst[i].ShadowOrigin;
+		if ( std::fabs( np.x - ss.pos.x ) > 0.5f || std::fabs( np.y - ss.pos.y ) > 0.5f
+			|| std::fabs( np.z - ss.pos.z ) > 0.5f || std::fabs( dst[i].ShadowRange - ss.range ) > 1.0f )
+			continue;
+		if ( IsLowSlot( it->second ) ) {
+			const UINT lowIdx = LowIndex( it->second );
+			encodedByKey[key] = static_cast<int32_t>( LowIndexInPage( lowIdx ) | ( LowPage( lowIdx ) << kShadowLowPageShift ) )
+				| kShadowTierLow;
+		} else {
+			encodedByKey[key] = static_cast<int32_t>( it->second );
+		}
+	}
+
+	// Occupancy + starvation, for the ImGui point-light window (see DrawPointLightSlotStat). Counted here rather
+	// than derived later: `starvedThisFrame` is only knowable inside the assignment loop.
+	{
+		auto& info = Engine::GAPI->GetRendererState().RendererInfo;
+		UINT usedHi = 0, usedLow = 0;
+		for ( UINT s = 0; s < kMaxSlots; ++s )
+			if ( m_Slots[s].ownerKey ) ( IsLowSlot( s ) ? usedLow : usedHi )++;
+		info.PointLightSlotsUsed = usedHi;
+		info.PointLightSlotsMax = kMaxCubes;
+		info.PointLightStaticSlotsUsed = usedLow;
+		info.PointLightStaticSlotsMax = kMaxStaticCubes;
+		info.PointLightSlotsStarved = starvedThisFrame;
 	}
 
 	// Fan the result out to EVERY light, so all members of a clustered key sample the one cube their cluster won.
@@ -734,7 +889,7 @@ void D3D12PointShadows::Prepare() {
 
 
 	const auto& psPipe = m_E->m_Pipelines.PointShadow;
-	if ( !m_E->m_FrameOpen || !m_Cube || !m_DynCube || !m_LowCube || !psPipe.CasterWorldPSO
+	if ( !m_E->m_FrameOpen || !m_Cube || !m_DynCube || !m_LowCube[0] || !psPipe.CasterWorldPSO
 		|| !m_DsvHeap || !m_DynDsvHeap || !m_LowDsvHeap || !psPipe.RootSig )
 		return;
 	if ( m_FrameLights.empty() ) return;
@@ -1282,12 +1437,18 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 	// ---- Per-slot (6-subresource) barriers. Never transition these two cubes with ALL_SUBRESOURCES — see the
 	// m_ActiveSlotState comment in the header. Transitions are batched into g_PsBarriers and issued in one call
 	// per phase so the GPU pays one pipeline flush per phase rather than one per slot.
-	auto pushSlot = [&]( ID3D12Resource* res, D3D12_RESOURCE_STATES* slotStates, UINT slot, D3D12_RESOURCE_STATES after ) {
+	// `slot` indexes the state array (the tier-local slot), `resSlot` the SUBRESOURCE inside `res` — the two
+	// differ for the paged low-res tier, where the state array spans all pages but each page is its own resource.
+	auto pushSlot = [&]( ID3D12Resource* res, D3D12_RESOURCE_STATES* slotStates, UINT slot, UINT resSlot, D3D12_RESOURCE_STATES after ) {
 		if ( slotStates[slot] == after ) return;   // already there — no redundant barrier
 		for ( UINT face = 0; face < 6; ++face ) {
-			g_PsBarriers.push_back( { res, slotStates[slot], after, slot * 6 + face } );
+			g_PsBarriers.push_back( { res, slotStates[slot], after, resSlot * 6 + face } );
 		}
 		slotStates[slot] = after;
+		};
+	// The paged low tier's two coordinates in one place: which page resource, and the slot within it.
+	auto pushLowSlot = [&]( UINT lowIndex, D3D12_RESOURCE_STATES after ) {
+		pushSlot( m_LowCube[LowPage( lowIndex )].Get(), m_LowSlotState, lowIndex, LowIndexInPage( lowIndex ), after );
 		};
 	auto flushBarriers = [&]() {
 		if ( g_PsBarriers.empty() ) return;
@@ -1352,8 +1513,8 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 		TracyD3D12ZoneCGX( cmdList.Get(), "Static Pass" );
 		for ( const PointShadowLightRecord& L : g_PsLights ) {
 			if ( !L.renderStatic ) continue;
-			if ( L.lowRes ) pushSlot( m_LowCube.Get(), m_LowSlotState,    LowIndex( L.slot ), D3D12_RESOURCE_STATE_DEPTH_WRITE );
-			else            pushSlot( m_Cube.Get(),    m_ActiveSlotState, L.slot,             D3D12_RESOURCE_STATE_DEPTH_WRITE );
+			if ( L.lowRes ) pushLowSlot( LowIndex( L.slot ), D3D12_RESOURCE_STATE_DEPTH_WRITE );
+			else            pushSlot( m_Cube.Get(), m_ActiveSlotState, L.slot, L.slot, D3D12_RESOURCE_STATE_DEPTH_WRITE );
 		}
 		flushBarriers();
 
@@ -1461,7 +1622,7 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 		// its dynamicValid below and the shader stops reading the array for it.
 		for ( const PointShadowLightRecord& L : g_PsLights )
 			if ( L.dynSkelEnd > L.dynSkelBegin || L.dynAttachEnd > L.dynAttachBegin )
-				pushSlot( m_DynCube.Get(), m_DynSlotState, L.slot, D3D12_RESOURCE_STATE_DEPTH_WRITE );
+				pushSlot( m_DynCube.Get(), m_DynSlotState, L.slot, L.slot, D3D12_RESOURCE_STATE_DEPTH_WRITE );
 		flushBarriers();
 
 		for ( const PointShadowLightRecord& L : g_PsLights ) {
@@ -1517,11 +1678,11 @@ void D3D12PointShadows::Record( D3D12CmdList& cmdList ) {
 	// already sampleable and are never named in a barrier. Slots in g_PsLights that ended up doing no work at all
 	// never left PSR either, and pushSlot drops those as redundant.
 	for ( const PointShadowLightRecord& L : g_PsLights ) {
-		if ( L.lowRes ) pushSlot( m_LowCube.Get(), m_LowSlotState, LowIndex( L.slot ), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
-		else            pushSlot( m_Cube.Get(),    m_ActiveSlotState, L.slot, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
+		if ( L.lowRes ) pushLowSlot( LowIndex( L.slot ), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
+		else            pushSlot( m_Cube.Get(), m_ActiveSlotState, L.slot, L.slot, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
 		// ...and the dynamic array, which is now sampled as well. pushSlot drops this as redundant for every slot
 		// Phase C did not actually draw into, so it costs nothing for lights with no casters in range.
-		if ( !L.lowRes ) pushSlot( m_DynCube.Get(), m_DynSlotState, L.slot, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
+		if ( !L.lowRes ) pushSlot( m_DynCube.Get(), m_DynSlotState, L.slot, L.slot, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE );
 	}
 	flushBarriers();
 	// Leave nothing bound: the cube DSVs this list used have just left DEPTH_WRITE, and a DSV that is still the

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.h
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.h
@@ -10,7 +10,7 @@
 // m_Cube (cached static-only depth) and m_DynCube (this frame's moving casters). Hundreds of shadowed lights
 // can therefore update their MOVING casters every frame without re-rendering static geometry. Three phases:
 //   A) STATIC   — for slots whose light is fresh / moved / resized, (re)render the static casters
-//                 (world mesh + instanced VOBs) into m_Cube. Amortized: usually a no-op.
+//                 (world mesh + instanced VOBs + MOB bodies/node attachments) into m_Cube. Amortized: usually a no-op.
 //   C) DYNAMIC  — clear this slot's m_DynCube face-set and draw the moving casters (skeletal NPCs + their node
 //                 attachments) into it. Only for slots that actually HAVE casters in range this frame.
 //   D) hand the touched slots back to PIXEL_SHADER_RESOURCE for the lit pass.

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.h
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.h
@@ -170,6 +170,15 @@ private:
     /** Resolves everything QueueVobChangedInvalidation parked since the last frame - see there. */
     void DrainPendingVobChanges();
     std::vector<zCVob*> m_PendingVobChanges;
+    // Movement threshold for the resolve, mirroring D3D11's PositionEqualEps (D3D11PointLight.cpp). Gothic
+    // reports a transform change for ANY delta, and a settling/jittering vob produces a sub-unit one every
+    // single frame - each of which would re-bake the static cube of every light around it, forever.
+    static constexpr float kVobMoveEpsSq = 1.0f;
+    // Where each vob was when it last actually invalidated something. The reference is that position, NOT the
+    // previous frame's, so a slow drift keeps accumulating until it crosses the threshold instead of being
+    // filtered out one sub-eps step at a time. Entries are dropped in InvalidateStaticForVobRemoved, i.e. when
+    // the vob leaves the world.
+    gtl::flat_hash_map<const zCVob*, DirectX::XMFLOAT3> m_LastInvalidationPos;
     // Swapped with the above for the duration of a drain, so the invalidation helpers it calls can scrub the
     // pending list without the loop iterating a vector that is being erased from. Capacity is retained.
     std::vector<zCVob*> m_DrainScratch;

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.h
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.h
@@ -133,14 +133,17 @@ public:
         and goings must not invalidate one either. Mirrors D3D11's IsAttachedToNpc. */
     static bool IsNpcAttached( const zCVob* vob );
 
-    /** Park a vob that just entered the world; the actual invalidation happens at the top of the next
-        SelectShadowedLights. It cannot be decided at AddVob time: ZenGin has not necessarily given the vob
-        its final transform yet (an item is inserted at the hand/waypoint it came from and moved to where it
-        lands afterwards) and its parent link may still be the NPC that is in the middle of letting go of it
-        - and the position and that parent are exactly the two things the decision reads. One frame later
-        both have settled. Entries whose vob left the world again are dropped; still being in
-        GothicAPI::VobMap is the liveness test that also makes the deferred read safe. */
-    void QueueVobAddedInvalidation( zCVob* vob );
+    /** Park a vob that just entered the world or just moved; the invalidation itself happens at the top of
+        the next SelectShadowedLights. Deferred rather than decided on the spot because the two things the
+        decision reads - the vob's position and whether it hangs off an NPC - are not settled when Gothic
+        reports the change. An item is inserted at the hand/waypoint it came from and placed afterwards, its
+        parent link can still be the NPC that is letting go of it, and it then FALLS: several transform
+        changes across several frames before it comes to rest. So this coalesces to one resolve per frame
+        reading the position as it is by then, and a still-moving vob simply queues again next frame until it
+        stops - the last resolve is the one that sticks. Entries whose vob left the world meanwhile are
+        dropped; still being in GothicAPI::VobMap is the liveness test that also makes the deferred read
+        safe. */
+    void QueueVobChangedInvalidation( zCVob* vob );
 
     void InvalidateStaticForVobAdded( const DirectX::XMFLOAT3& posWS, float extent );
     // Removal is matched by POINTER against what each slot actually baked (Slot::bakedVobs), never by reading
@@ -164,9 +167,12 @@ private:
     // or it's a PFX-spawned light (those aren't excluded, matching D3D11's GetHasOriginVob gate).
     bool BuildExcludeList( zCVobLight* lightVob, std::vector<const zCVob*>& excludeOut );
 
-    /** Resolves everything QueueVobAddedInvalidation parked since the last frame - see there. */
-    void DrainPendingVobAdds();
-    std::vector<zCVob*> m_PendingVobAdds;
+    /** Resolves everything QueueVobChangedInvalidation parked since the last frame - see there. */
+    void DrainPendingVobChanges();
+    std::vector<zCVob*> m_PendingVobChanges;
+    // Swapped with the above for the duration of a drain, so the invalidation helpers it calls can scrub the
+    // pending list without the loop iterating a vector that is being erased from. Capacity is retained.
+    std::vector<zCVob*> m_DrainScratch;
     // Has any slot ever finished a static bake? Until one has there is no cache to invalidate, which is what
     // keeps world load (tens of thousands of AddVob calls before the first frame) from parking any of them.
     bool m_HaveCachedStatic = false;

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.h
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.h
@@ -34,6 +34,7 @@
 
 #include "D3D12EngineCommon.h"
 #include "D3D12StateCache.h"
+#include "../PointLightSlotSelector.h"
 
 class D3D12GraphicsEngine;
 class zCVobLight;
@@ -110,6 +111,11 @@ public:
                                        // holds - the low tier renders a cube once and caches it forever, so a
                                        // light that moves would re-enter its per-frame render budget every single
                                        // frame and starve everything else in it.
+        bool        restrictToWorld;   // world-mesh-only casters. Mirrors D3D11's RenderStaticShadowPass /
+                                       // AllowsDynamicCasters PFX gate: a PFX-spawned light with PLSC_PARTICLE_FX
+                                       // off casts from the world mesh alone, because BuildExcludeList never
+                                       // excludes such a light's own carrier and it would otherwise throw a large
+                                       // self-shadow from whatever is holding it.
     };
 
     // Picks this frame's shadowed lights out of the filled GPU light buffer and writes each winner's
@@ -175,24 +181,6 @@ private:
     // or it's a PFX-spawned light (those aren't excluded, matching D3D11's GetHasOriginVob gate).
     bool BuildExcludeList( zCVobLight* lightVob, std::vector<const zCVob*>& excludeOut );
 
-    /** Resolves everything QueueVobChangedInvalidation parked since the last frame - see there. */
-    void DrainPendingVobChanges();
-    std::vector<zCVob*> m_PendingVobChanges;
-    // Movement threshold for the resolve, mirroring D3D11's PositionEqualEps (D3D11PointLight.cpp). Gothic
-    // reports a transform change for ANY delta, and a settling/jittering vob produces a sub-unit one every
-    // single frame - each of which would re-bake the static cube of every light around it, forever.
-    static constexpr float kVobMoveEpsSq = 1.0f;
-    // Where each vob was when it last actually invalidated something. The reference is that position, NOT the
-    // previous frame's, so a slow drift keeps accumulating until it crosses the threshold instead of being
-    // filtered out one sub-eps step at a time. Entries are dropped in InvalidateStaticForVobRemoved, i.e. when
-    // the vob leaves the world.
-    gtl::flat_hash_map<const zCVob*, DirectX::XMFLOAT3> m_LastInvalidationPos;
-    // Swapped with the above for the duration of a drain, so the invalidation helpers it calls can scrub the
-    // pending list without the loop iterating a vector that is being erased from. Capacity is retained.
-    std::vector<zCVob*> m_DrainScratch;
-    // Has any slot ever finished a static bake? Until one has there is no cache to invalidate, which is what
-    // keeps world load (tens of thousands of AddVob calls before the first frame) from parking any of them.
-    bool m_HaveCachedStatic = false;
 
     D3D12GraphicsEngine* m_E = nullptr;
 
@@ -254,61 +242,12 @@ private:
     UINT m_VobInstOffset = 0;     // reset each frame at the top of Prepare()
     bool m_VobInstOverflowLogged = false;
 
-    // Slots are owned by light Vob identity and kept stable across frames (not reassigned by proximity), so a
-    // static winner whose light didn't move reuses its cached cube instead of re-culling + re-rendering.
-    struct Slot {
-        uint64_t          ownerKey = 0;      // identity owning this slot (0 = free). A light's own vob pointer, or
-                                             // a tagged cluster-cell id when several co-located static lights share
-                                             // this cube. Compared for identity only; never dereferenced.
-        zCVobLight*       owner = nullptr;   // the owning vob when ownerKey is a single light, else nullptr. Read
-                                             // ONLY by the dynamic-overlay exclude list, which no clustered or
-                                             // low-tier slot ever reaches — so a cluster leaving it null is safe.
-        DirectX::XMFLOAT3 pos = {};          // last static-rendered cube origin (move detection)
-        float             range = 0.0f;      // last static-rendered range (range-change detection)
-        bool              isStatic = false;  // Vob->IsStatic(): gates Prepare() — static lights cache world mesh
-                                             // plus StaticVob-flagged decoration once, forever; never receive the
-                                             // per-frame dynamic overlay (mirrors D3D11's PLS_STATIC_ONLY).
-        bool              staticPresent = false; // this slot's static target physically holds depth rendered for THIS
-                                             // owner, even if a later world change has since marked it out of date.
-                                             // Kept apart from staticValid so an INVALIDATED slot keeps being sampled
-                                             // (slightly stale) while it waits its turn in the low-tier render budget,
-                                             // instead of dropping to unshadowed - a stale shadow is a far smaller
-                                             // artifact than a light that briefly bleeds through walls, and it is what
-                                             // makes over-invalidation genuinely cheap rather than visible.
-        bool              staticValid = false; // the slot's CURRENT static target (aside if usesAside, else the active
-                                             // cube itself) holds valid static-only depth; false => must re-render static
-        bool              dynamicValid = false; // this slot's DYNAMIC cube holds a valid skeletal overlay, as of the
-                                             // last Record that was actually submitted (committed in CommitStaticCache,
-                                             // symmetric with staticValid). Drives kShadowHasDynamic in the encoded
-                                             // index, i.e. whether the lit pass samples the dynamic cube for this
-                                             // light at all. Set on a frame whose overlay produced draws, cleared on a
-                                             // SCHEDULED frame that produced none (the NPC left) — deliberately left
-                                             // alone on an unscheduled frame, so a round-robin light keeps its last
-                                             // overlay between turns instead of flickering.
-                                             // Read one frame late by design: SelectShadowedLights builds the encoded
-                                             // index from BuildFrameLightBuffer, before Prepare() has resolved this
-                                             // frame's overlay. Same class of latency the round-robin already has.
-        UINT32            dynamicStaleFrames = 0; // frames since this slot's skeletal dynamic overlay last ran (round-robin, P2.10h)
-        // Every caster identity Phase A baked into this slot's static cube, in the order it gathered them.
-        // Rebuilt from scratch on each static (re)render and consulted ONLY by InvalidateStaticForVobRemoved,
-        // which compares pointers - see there for why the removed vob can't be read instead. Capacity is kept
-        // across rebuilds; a slot handing over to a new owner drops it with the rest of the Slot.
-        std::vector<const zCVob*> bakedVobs;
-        UINT32            missingFrames = 0;   // consecutive frames this slot's owner was NOT a winner; 0 while it is.
-                                             // A slot is NOT released the moment its light drops out of the winner
-                                             // set (the light buffer is frustum-culled upstream, so merely turning
-                                             // away drops it): its cached static depth is still perfectly good and
-                                             // is exactly what should be reused when the light comes back. Slots
-                                             // are given up only under pressure (a new winner needs one — the
-                                             // longest-absent goes first) or after kSlotRetentionFrames, so a
-                                             // static re-cull happens on FIRST acquisition, on invalidation, or
-                                             // after actually losing the slot — not on every frustum blink.
-    };
-    // Absent-owner retention cap. Also bounds how long a released-but-remembered zCVobLight* can linger: `owner`
-    // is only ever compared for identity while absent (never dereferenced — BuildExcludeList only ever sees a
-    // current winner), but a vob freed and its address reused would otherwise inherit the slot's stale cache.
-    static constexpr UINT32 kSlotRetentionFrames = 600;   // ~10 s at 60 fps
-    Slot m_Slots[kMaxSlots];   // [0,kMaxCubes) = full-res dynamic pool, [kMaxCubes,kMaxSlots) = low-res static pool
+    // Every decision about slots - ownership, retention, eviction, tier spill/promotion, the static-cache
+    // stamps and the dynamic round-robin - lives in the backend-neutral PointLightSlotSelector, shared
+    // verbatim with D3D11. See PointLightSlotSelector.h; this class only owns the resources and the draws.
+    PointLightSlotSelector m_Sel;
+    using Slot = PointLightSlotSelector::Slot;
+    using FrameLight = PointLightSlotSelector::Assignment;
 
     // Slots whose static target was (re)rendered by THIS frame's records, pending the CommitStaticCache() that
     // turns them into cache hits. Kept out of Slot so an uncommitted frame simply leaves staticValid false and
@@ -321,24 +260,6 @@ private:
     struct PendingDynamic { UINT slot; bool has; };
     std::vector<PendingDynamic> m_PendingDynamic;
 
-    // The shadowed lights chosen this frame — filled by SelectShadowedLights, consumed by Prepare().
-    // renderStatic: also (re)render the STATIC casters into this slot's static target (fresh slot / light moved
-    // / range changed / routing flipped); otherwise the cached static depth is reused.
-    // renderDynamic (round-robin, P2.10h): whether the per-frame skeletal overlay runs THIS frame for this
-    // winner — always for the closest kAlwaysDynamicCount, round-robined (oldest-serviced-first) for the rest,
-    // so a large persisted-light count doesn't multiply the CPU cost of sphere-culling the full skeletal-vob
-    // list against every shadowed light every frame.
-    // overlayEligible: whether this light can EVER receive a dynamic overlay (not a static-tier light — see
-    // shadowRoutingStatic in D3D12Scene.cpp's BuildFrameLightBuffer — and the global PointlightShadows setting
-    // is >= PLS_UPDATE_DYNAMIC).
-    // `slot` is the GLOBAL slot index (see kMaxSlots); IsLowSlot(slot) picks the array/DSV heap/viewport.
-    // restrictToWorld: mirrors D3D11's RenderStaticShadowPass/RenderFullCubemap PFX gate (see D3D11PointLight.cpp
-    // AllowsDynamicCasters) — true when this winner is a PFX-spawned light and RendererSettings.
-    // PointlightShadowCasterFlags doesn't have PLSC_PARTICLE_FX set. Strips instanced-VOB casters from Phase A
-    // (see Prepare()) on top of overlayEligible already excluding it from the skeletal Phase C overlay, so an
-    // unopted-in PFX light casts world-mesh-only shadows like D3D11.
-    struct FrameLight { DirectX::XMFLOAT3 posWS; float range; UINT slot; bool renderStatic; bool renderDynamic; bool overlayEligible; bool restrictToWorld; };
-    std::vector<FrameLight> m_FrameLights;
 
     bool m_PassReady = false;
 };

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.h
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.h
@@ -53,36 +53,29 @@ public:
     // atmospheric fill lights look right at all. But a static light's cube is rendered ONCE and cached forever
     // (the light and the world it occludes both never move), and it exists only to stop room-to-room bleed, not
     // to resolve shadow detail. So it does not need 128^2:
-    //     dynamic tier: 64 slots @128^2 = 12.6 MB (x2: static + overlay)   static tier: 1020 slots @32^2 = 12.5 MB
+    //     dynamic tier: 64 slots @128^2 = 12.6 MB (x2: static + overlay)   static tier: 340 slots @32^2 = 4.2 MB
     //
-    // 340 is the per-ARRAY hard ceiling, not a tuning choice: a cube array is a Texture2DArray of slot*6 slices,
-    // and D3D12 caps a Texture2D array at D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION (2048) slices regardless of
-    // how small the faces are — 2048/6 = 341. Going past it fails resource creation outright
-    // (CREATERESOURCE_INVALIDDIMENSIONS, which is exactly how the first 512-slot attempt died). More static
-    // cubes than that therefore need MORE ARRAYS, not a bigger one — hence the PAGES below: kStaticCubePages
-    // separate arrays whose SRVs are allocated CONTIGUOUSLY in the bindless heap, so the shader reaches page p
-    // as ResourceDescriptorHeap[PointShadowLowIndex + p] and the extra tier still costs no root parameter.
-    // The page rides in the encoded ShadowCubeIndex (kShadowLowPageShift in GPULightShared.h).
+    // 340 slots is the hard ceiling of ONE array, and it is also more than any Gothic scene has been measured to
+    // need (~200 static, ~64 moving): a cube array is a Texture2DArray of slot*6 slices, and D3D12 caps a
+    // Texture2D array at D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION (2048) slices regardless of how small the faces
+    // are - 2048/6 = 341. Going past it fails resource creation outright (CREATERESOURCE_INVALIDDIMENSIONS, which
+    // is exactly how the first 512-slot attempt died), so more cubes than this would need MORE ARRAYS, not a
+    // bigger one. That was built once - paged arrays, contiguous bindless SRVs, a page index in the encoded
+    // ShadowCubeIndex - and removed again as unused complexity once the real occupancy was measured. Raise this
+    // only with that measurement in hand.
     //
     // The two pools share ONE slot index space so all the ownership/retention bookkeeping below stays single-pool:
-    // global slot < kMaxCubes is the dynamic array, >= kMaxCubes is the static tier at (slot - kMaxCubes). What
-    // reaches the SHADER is the re-encoded GPULight::ShadowCubeIndex (kShadowTierLow | page | localIndex), not this.
+    // global slot < kMaxCubes is the dynamic array, >= kMaxCubes is the static array at (slot - kMaxCubes). What
+    // reaches the SHADER is the re-encoded GPULight::ShadowCubeIndex (kShadowTierLow | localIndex), not this.
     static constexpr UINT kStaticCubeSize = 32;
-    static constexpr UINT kStaticCubesPerPage = 340;   // 340*6 = 2040 slices, just under the 2048 array-axis cap
-    static constexpr UINT kStaticCubePages = 3;        // 1020 cubes total >= kMaxFrameLights, i.e. never the constraint
-    static constexpr UINT kMaxStaticCubes = kStaticCubesPerPage * kStaticCubePages;
+    static constexpr UINT kMaxStaticCubes = 340;
     static constexpr UINT kMaxSlots = kMaxCubes + kMaxStaticCubes;
-    // Both tiers are Texture2DArrays of slot*6 slices — see the ceiling note above. Asserted for BOTH so raising
+    // Both tiers are Texture2DArrays of slot*6 slices - see the ceiling note above. Asserted for BOTH so raising
     // either one can never silently produce an undersized/failed resource again.
     static_assert( kMaxCubes * 6 <= 2048, "dynamic cube array exceeds D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION" );
-    static_assert( kStaticCubesPerPage * 6 <= 2048, "static cube page exceeds D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION" );
-    // The page index has kShadowLowPageBits in the encoded ShadowCubeIndex, the in-page slot kShadowLowSlotBits.
-    static_assert( kStaticCubePages <= 8 && kStaticCubesPerPage <= 1024, "static tier exceeds the ShadowCubeIndex encoding" );
+    static_assert( kMaxStaticCubes * 6 <= 2048, "static cube array exceeds D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION" );
     static bool IsLowSlot( UINT globalSlot ) { return globalSlot >= kMaxCubes; }
     static UINT LowIndex( UINT globalSlot ) { return globalSlot - kMaxCubes; }
-    // Which of the kStaticCubePages arrays a low-tier index lives in, and where inside that array's own slices.
-    static UINT LowPage( UINT lowIndex ) { return lowIndex / kStaticCubesPerPage; }
-    static UINT LowIndexInPage( UINT lowIndex ) { return lowIndex % kStaticCubesPerPage; }
 
     static constexpr UINT kBackBufferMax = 3;   // must match D3D12GraphicsEngine::kBackBufferMax (asserted in the .cpp)
     UINT kBackBufferCount = 2;   // synced from the engine in Attach() below
@@ -98,8 +91,7 @@ public:
     bool Init();
 
     UINT GetSrvSlot() const { return m_SrvSlot; }
-    UINT GetLowSrvSlot() const { return m_LowSrvSlot; }   // first of the low-res static tier's kStaticCubePages
-                                                          // CONTIGUOUS bindless slots (page p = this + p)
+    UINT GetLowSrvSlot() const { return m_LowSrvSlot; }   // bindless heap slot of the low-res static cube array
     UINT GetDynSrvSlot() const { return m_DynSrvSlot; }   // bindless heap slot of the dynamic-overlay cube array
     bool IsPassReady() const { return m_PassReady; }
 
@@ -226,16 +218,10 @@ private:
     // overlay-eligible (D3D11's GetCurrentShadowMode forces static lights to PLS_STATIC_ONLY). Their static depth
     // therefore renders straight into this array and stays there — no per-frame copy, no dynamic overlay. Phases
     // B and C skip these slots entirely; only Phase A (on a cache miss) and Phase D ever touch them.
-    // kStaticCubePages separate arrays, not one: 341 cubes is the hard per-array slice ceiling (see above).
-    // Everything else about the tier stays single-pool — one DSV heap and one per-slot state array span all
-    // pages, indexed by the GLOBAL low index, while the RESOURCE and the subresource number come from
-    // LowPage()/LowIndexInPage().
-    Microsoft::WRL::ComPtr<ID3D12Resource>       m_LowCube[kStaticCubePages];
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation>  m_LowCubeAlloc[kStaticCubePages];
-    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_LowDsvHeap;   // one D16 6-slice DSV per low-res slot, all pages
-    UINT m_LowSrvSlot = UINT_MAX;                                // FIRST of kStaticCubePages CONTIGUOUS R16_UNORM
-                                                                 // TextureCubeArray SRVs, fetched bindlessly as
-                                                                 // PointShadowLowIndex + page
+    Microsoft::WRL::ComPtr<ID3D12Resource>       m_LowCube;
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation>  m_LowCubeAlloc;
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_LowDsvHeap;   // one D16 6-slice DSV per low-res slot
+    UINT m_LowSrvSlot = UINT_MAX;                                // R16_UNORM TextureCubeArray SRV, fetched bindlessly
     D3D12_RESOURCE_STATES m_LowSlotState[kMaxStaticCubes] = {};  // PIXEL_SHADER_RESOURCE at rest, per-slot like above
 
     // Dynamic-overlay cube: second persistent full-res cube array holding ONLY this frame's skeletal overlay

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.h
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.h
@@ -133,6 +133,15 @@ public:
         and goings must not invalidate one either. Mirrors D3D11's IsAttachedToNpc. */
     static bool IsNpcAttached( const zCVob* vob );
 
+    /** Park a vob that just entered the world; the actual invalidation happens at the top of the next
+        SelectShadowedLights. It cannot be decided at AddVob time: ZenGin has not necessarily given the vob
+        its final transform yet (an item is inserted at the hand/waypoint it came from and moved to where it
+        lands afterwards) and its parent link may still be the NPC that is in the middle of letting go of it
+        - and the position and that parent are exactly the two things the decision reads. One frame later
+        both have settled. Entries whose vob left the world again are dropped; still being in
+        GothicAPI::VobMap is the liveness test that also makes the deferred read safe. */
+    void QueueVobAddedInvalidation( zCVob* vob );
+
     void InvalidateStaticForVobAdded( const DirectX::XMFLOAT3& posWS, float extent );
     // Removal is matched by POINTER against what each slot actually baked (Slot::bakedVobs), never by reading
     // the vob: by the time this fires the object may already be half torn down, and its bbox/position are no
@@ -154,6 +163,13 @@ private:
     // false (excludeOut left empty) when self-shadowing is allowed, the light isn't attached to a carried item,
     // or it's a PFX-spawned light (those aren't excluded, matching D3D11's GetHasOriginVob gate).
     bool BuildExcludeList( zCVobLight* lightVob, std::vector<const zCVob*>& excludeOut );
+
+    /** Resolves everything QueueVobAddedInvalidation parked since the last frame - see there. */
+    void DrainPendingVobAdds();
+    std::vector<zCVob*> m_PendingVobAdds;
+    // Has any slot ever finished a static bake? Until one has there is no cache to invalidate, which is what
+    // keeps world load (tens of thousands of AddVob calls before the first frame) from parking any of them.
+    bool m_HaveCachedStatic = false;
 
     D3D12GraphicsEngine* m_E = nullptr;
 

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.h
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.h
@@ -10,7 +10,7 @@
 // m_Cube (cached static-only depth) and m_DynCube (this frame's moving casters). Hundreds of shadowed lights
 // can therefore update their MOVING casters every frame without re-rendering static geometry. Three phases:
 //   A) STATIC   — for slots whose light is fresh / moved / resized, (re)render the static casters
-//                 (world mesh + instanced VOBs + MOB bodies/node attachments) into m_Cube. Amortized: usually a no-op.
+//                 (world mesh + instanced VOBs + MOB bodies/attachments) into m_Cube. Usually a no-op.
 //   C) DYNAMIC  — clear this slot's m_DynCube face-set and draw the moving casters (skeletal NPCs + their node
 //                 attachments) into it. Only for slots that actually HAVE casters in range this frame.
 //   D) hand the touched slots back to PIXEL_SHADER_RESOURCE for the lit pass.
@@ -48,22 +48,18 @@ public:
 
     // ---- Low-resolution STATIC tier -------------------------------------------------------------------------
     // Static lights (and the clusters they are merged into) get their own, much coarser cube array. A cube-less
-    // point light is shaded UNSHADOWED — and BuildFrameLightBuffer then clamps its range hard so it cannot bleed
-    // through walls, which is what makes losing a slot visible as a light POPPING between its full and its
-    // clamped radius. So the slot count is not a quality knob, it is what decides how many of a Gothic room's
-    // atmospheric fill lights look right at all. But a static light's cube is rendered ONCE and cached forever
-    // (the light and the world it occludes both never move), and it exists only to stop room-to-room bleed, not
-    // to resolve shadow detail. So it does not need 128^2:
+    // point light is shaded UNSHADOWED, and BuildFrameLightBuffer then clamps its range hard so it cannot bleed
+    // through walls - which makes losing a slot visible as the light popping between its full and its clamped
+    // radius. So the slot count decides how many of a room's fill lights look right at all. But a static
+    // light's cube is rendered ONCE and cached forever, and only exists to stop room-to-room bleed, so it does
+    // not need 128^2:
     //     dynamic tier: 64 slots @128^2 = 12.6 MB (x2: static + overlay)   static tier: 340 slots @32^2 = 4.2 MB
     //
-    // 340 slots is the hard ceiling of ONE array, and it is also more than any Gothic scene has been measured to
-    // need (~200 static, ~64 moving): a cube array is a Texture2DArray of slot*6 slices, and D3D12 caps a
-    // Texture2D array at D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION (2048) slices regardless of how small the faces
-    // are - 2048/6 = 341. Going past it fails resource creation outright (CREATERESOURCE_INVALIDDIMENSIONS, which
-    // is exactly how the first 512-slot attempt died), so more cubes than this would need MORE ARRAYS, not a
-    // bigger one. That was built once - paged arrays, contiguous bindless SRVs, a page index in the encoded
-    // ShadowCubeIndex - and removed again as unused complexity once the real occupancy was measured. Raise this
-    // only with that measurement in hand.
+    // 340 slots is the hard ceiling of ONE array, and more than any Gothic scene has been measured to need
+    // (~200 static, ~64 moving): a cube array is a Texture2DArray of slot*6 slices, and D3D12 caps that at
+    // D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION (2048) slices - 2048/6 = 341. Going past it fails resource
+    // creation outright, so more cubes would need MORE ARRAYS, not a bigger one. Paging was built once and
+    // removed again as unused complexity; raise this only with an occupancy measurement in hand.
     //
     // The two pools share ONE slot index space so all the ownership/retention bookkeeping below stays single-pool:
     // global slot < kMaxCubes is the dynamic array, >= kMaxCubes is the static array at (slot - kMaxCubes). What
@@ -106,16 +102,12 @@ public:
                               // list, which a static/clustered (low-tier) slot never reaches.
         bool        lowRes;   // PREFERRED tier: take the slot from the low-res static pool
         bool        isStatic;
-        bool        spatiallyStatic;   // never moves, whatever tier it was routed to. A full-res candidate that
-                                       // cannot be given a full-res cube SPILLS into the low-res tier when this
-                                       // holds - the low tier renders a cube once and caches it forever, so a
-                                       // light that moves would re-enter its per-frame render budget every single
-                                       // frame and starve everything else in it.
-        bool        restrictToWorld;   // world-mesh-only casters. Mirrors D3D11's RenderStaticShadowPass /
-                                       // AllowsDynamicCasters PFX gate: a PFX-spawned light with PLSC_PARTICLE_FX
-                                       // off casts from the world mesh alone, because BuildExcludeList never
-                                       // excludes such a light's own carrier and it would otherwise throw a large
-                                       // self-shadow from whatever is holding it.
+        bool        spatiallyStatic;   // never moves; only such a candidate may SPILL into the low-res tier,
+                                       // which bakes once and would be starved by a mover re-entering its
+                                       // per-frame render budget every frame.
+        bool        restrictToWorld;   // world-mesh-only casters, mirroring D3D11's AllowsDynamicCasters PFX
+                                       // gate: BuildExcludeList never excludes such a light's own carrier, so
+                                       // it would otherwise throw a large self-shadow from whatever holds it.
     };
 
     // Picks this frame's shadowed lights out of the filled GPU light buffer and writes each winner's
@@ -142,27 +134,19 @@ public:
     // fresh / moved / resized — not when geometry around it changes — so a VOB appearing or disappearing inside
     // a cached slot's light sphere must force a one-time static re-render next frame. Over-invalidation is
     // harmless (one extra static pass); under-invalidation freezes a stale shadow in the cache.
-    /** True if this vob rides an NPC's transform - a held item, a torch, an attached effect. Such a caster
-        moves with the animation every frame, so it is never baked into a cached static cube and its comings
-        and goings must not invalidate one either. Mirrors D3D11's IsAttachedToNpc. */
+    /** True if this vob rides an NPC's transform. Such a caster is never baked into a cached static cube,
+        so its comings and goings must not invalidate one. Mirrors D3D11's IsAttachedToNpc. */
     static bool IsNpcAttached( const zCVob* vob );
 
-    /** Park a vob that just entered the world or just moved; the invalidation itself happens at the top of
-        the next SelectShadowedLights. Deferred rather than decided on the spot because the two things the
-        decision reads - the vob's position and whether it hangs off an NPC - are not settled when Gothic
-        reports the change. An item is inserted at the hand/waypoint it came from and placed afterwards, its
-        parent link can still be the NPC that is letting go of it, and it then FALLS: several transform
-        changes across several frames before it comes to rest. So this coalesces to one resolve per frame
-        reading the position as it is by then, and a still-moving vob simply queues again next frame until it
-        stops - the last resolve is the one that sticks. Entries whose vob left the world meanwhile are
-        dropped; still being in GothicAPI::VobMap is the liveness test that also makes the deferred read
-        safe. */
+    /** Park a vob that entered the world or moved; the invalidation happens at the top of the next
+        SelectShadowedLights. Deferred because neither the position nor the NPC parent link is settled when
+        Gothic reports the change - a dropped item is inserted, re-parented and then falls for several
+        frames. Entries whose vob left the world meanwhile are dropped. */
     void QueueVobChangedInvalidation( zCVob* vob );
 
     void InvalidateStaticForVobAdded( const DirectX::XMFLOAT3& posWS, float extent );
-    // Removal is matched by POINTER against what each slot actually baked (Slot::bakedVobs), never by reading
-    // the vob: by the time this fires the object may already be half torn down, and its bbox/position are no
-    // longer trustworthy. Identity comparison only - `vob` is never dereferenced.
+    // Matched by POINTER against Slot::bakedVobs - the vob may already be half torn down here, so it is
+    // never dereferenced.
     void InvalidateStaticForVobRemoved( const zCVob* vob );
 
     // Skeletal-caster scratch lists for the per-light sphere cull. PrepareFrameSkeletals(..., shadowCascade=-2)
@@ -180,7 +164,6 @@ private:
     // false (excludeOut left empty) when self-shadowing is allowed, the light isn't attached to a carried item,
     // or it's a PFX-spawned light (those aren't excluded, matching D3D11's GetHasOriginVob gate).
     bool BuildExcludeList( zCVobLight* lightVob, std::vector<const zCVob*>& excludeOut );
-
 
     D3D12GraphicsEngine* m_E = nullptr;
 
@@ -242,9 +225,9 @@ private:
     UINT m_VobInstOffset = 0;     // reset each frame at the top of Prepare()
     bool m_VobInstOverflowLogged = false;
 
-    // Every decision about slots - ownership, retention, eviction, tier spill/promotion, the static-cache
-    // stamps and the dynamic round-robin - lives in the backend-neutral PointLightSlotSelector, shared
-    // verbatim with D3D11. See PointLightSlotSelector.h; this class only owns the resources and the draws.
+    // Every slot decision - ownership, retention, eviction, tier spill/promotion, cache stamps, the dynamic
+    // round-robin - lives in PointLightSlotSelector, shared verbatim with D3D11. This class owns only the
+    // resources and the draws.
     PointLightSlotSelector m_Sel;
     using Slot = PointLightSlotSelector::Slot;
     using FrameLight = PointLightSlotSelector::Assignment;
@@ -259,7 +242,6 @@ private:
     // unscheduled round-robin slot keeps whatever it had.
     struct PendingDynamic { UINT slot; bool has; };
     std::vector<PendingDynamic> m_PendingDynamic;
-
 
     bool m_PassReady = false;
 };

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.h
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.h
@@ -128,8 +128,16 @@ public:
     // fresh / moved / resized — not when geometry around it changes — so a VOB appearing or disappearing inside
     // a cached slot's light sphere must force a one-time static re-render next frame. Over-invalidation is
     // harmless (one extra static pass); under-invalidation freezes a stale shadow in the cache.
+    /** True if this vob rides an NPC's transform - a held item, a torch, an attached effect. Such a caster
+        moves with the animation every frame, so it is never baked into a cached static cube and its comings
+        and goings must not invalidate one either. Mirrors D3D11's IsAttachedToNpc. */
+    static bool IsNpcAttached( const zCVob* vob );
+
     void InvalidateStaticForVobAdded( const DirectX::XMFLOAT3& posWS, float extent );
-    void InvalidateStaticForVobRemoved( const zTBBox3D& bbox );
+    // Removal is matched by POINTER against what each slot actually baked (Slot::bakedVobs), never by reading
+    // the vob: by the time this fires the object may already be half torn down, and its bbox/position are no
+    // longer trustworthy. Identity comparison only - `vob` is never dereferenced.
+    void InvalidateStaticForVobRemoved( const zCVob* vob );
 
     // Skeletal-caster scratch lists for the per-light sphere cull. PrepareFrameSkeletals(..., shadowCascade=-2)
     // routes into these: each shadowed light sphere-culls the FULL registered skeletal-vob list against itself
@@ -221,6 +229,13 @@ private:
         bool              isStatic = false;  // Vob->IsStatic(): gates Prepare() — static lights cache world mesh
                                              // plus StaticVob-flagged decoration once, forever; never receive the
                                              // per-frame dynamic overlay (mirrors D3D11's PLS_STATIC_ONLY).
+        bool              staticPresent = false; // this slot's static target physically holds depth rendered for THIS
+                                             // owner, even if a later world change has since marked it out of date.
+                                             // Kept apart from staticValid so an INVALIDATED slot keeps being sampled
+                                             // (slightly stale) while it waits its turn in the low-tier render budget,
+                                             // instead of dropping to unshadowed - a stale shadow is a far smaller
+                                             // artifact than a light that briefly bleeds through walls, and it is what
+                                             // makes over-invalidation genuinely cheap rather than visible.
         bool              staticValid = false; // the slot's CURRENT static target (aside if usesAside, else the active
                                              // cube itself) holds valid static-only depth; false => must re-render static
         bool              dynamicValid = false; // this slot's DYNAMIC cube holds a valid skeletal overlay, as of the
@@ -235,6 +250,11 @@ private:
                                              // index from BuildFrameLightBuffer, before Prepare() has resolved this
                                              // frame's overlay. Same class of latency the round-robin already has.
         UINT32            dynamicStaleFrames = 0; // frames since this slot's skeletal dynamic overlay last ran (round-robin, P2.10h)
+        // Every caster identity Phase A baked into this slot's static cube, in the order it gathered them.
+        // Rebuilt from scratch on each static (re)render and consulted ONLY by InvalidateStaticForVobRemoved,
+        // which compares pointers - see there for why the removed vob can't be read instead. Capacity is kept
+        // across rebuilds; a slot handing over to a new owner drops it with the rest of the Slot.
+        std::vector<const zCVob*> bakedVobs;
         UINT32            missingFrames = 0;   // consecutive frames this slot's owner was NOT a winner; 0 while it is.
                                              // A slot is NOT released the moment its light drops out of the winner
                                              // set (the light buffer is frustum-culled upstream, so merely turning

--- a/D3D11Engine/D3D12Engine/D3D12PointShadows.h
+++ b/D3D11Engine/D3D12Engine/D3D12PointShadows.h
@@ -47,32 +47,42 @@ public:
 
     // ---- Low-resolution STATIC tier -------------------------------------------------------------------------
     // Static lights (and the clusters they are merged into) get their own, much coarser cube array. A cube-less
-    // point light is shaded UNSHADOWED, so it bleeds through walls and fights the tiled cull — which made the
-    // 128-cube ceiling the binding constraint on how many lights a room could have. But a static light's cube is
-    // rendered ONCE and cached forever (the light and the world it occludes both never move), and it exists only
-    // to stop room-to-room bleed, not to resolve shadow detail. So it does not need 128^2:
-    //     dynamic tier: 128 slots @128^2 = 25 MB      static tier: 340 slots @32^2 = 4 MB
-    // i.e. ~2.7x the shadowed-light budget for a sixth of the memory. See SamplePointShadow in PBRLighting.hlsl
-    // for the matching bias/PCF widening the coarser texels need.
+    // point light is shaded UNSHADOWED — and BuildFrameLightBuffer then clamps its range hard so it cannot bleed
+    // through walls, which is what makes losing a slot visible as a light POPPING between its full and its
+    // clamped radius. So the slot count is not a quality knob, it is what decides how many of a Gothic room's
+    // atmospheric fill lights look right at all. But a static light's cube is rendered ONCE and cached forever
+    // (the light and the world it occludes both never move), and it exists only to stop room-to-room bleed, not
+    // to resolve shadow detail. So it does not need 128^2:
+    //     dynamic tier: 64 slots @128^2 = 12.6 MB (x2: static + overlay)   static tier: 1020 slots @32^2 = 12.5 MB
     //
-    // 340 is a HARD CEILING, not a tuning choice: a cube array is a Texture2DArray of slot*6 slices, and D3D12
-    // caps a Texture2D array at D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION (2048) slices regardless of how small
-    // the faces are — 2048/6 = 341. Going past it fails resource creation outright (CREATERESOURCE_INVALIDDIMENSIONS,
-    // which is exactly how the first 512-slot attempt died), and since Init() is fail-closed that takes the whole
-    // point-shadow system down with it. More static cubes than this would need a SECOND array, not a bigger one.
+    // 340 is the per-ARRAY hard ceiling, not a tuning choice: a cube array is a Texture2DArray of slot*6 slices,
+    // and D3D12 caps a Texture2D array at D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION (2048) slices regardless of
+    // how small the faces are — 2048/6 = 341. Going past it fails resource creation outright
+    // (CREATERESOURCE_INVALIDDIMENSIONS, which is exactly how the first 512-slot attempt died). More static
+    // cubes than that therefore need MORE ARRAYS, not a bigger one — hence the PAGES below: kStaticCubePages
+    // separate arrays whose SRVs are allocated CONTIGUOUSLY in the bindless heap, so the shader reaches page p
+    // as ResourceDescriptorHeap[PointShadowLowIndex + p] and the extra tier still costs no root parameter.
+    // The page rides in the encoded ShadowCubeIndex (kShadowLowPageShift in GPULightShared.h).
     //
     // The two pools share ONE slot index space so all the ownership/retention bookkeeping below stays single-pool:
-    // global slot < kMaxCubes is the dynamic array, >= kMaxCubes is the static array at (slot - kMaxCubes). What
-    // reaches the SHADER is the re-encoded GPULight::ShadowCubeIndex (kShadowTierLow | localIndex), not this.
+    // global slot < kMaxCubes is the dynamic array, >= kMaxCubes is the static tier at (slot - kMaxCubes). What
+    // reaches the SHADER is the re-encoded GPULight::ShadowCubeIndex (kShadowTierLow | page | localIndex), not this.
     static constexpr UINT kStaticCubeSize = 32;
-    static constexpr UINT kMaxStaticCubes = 128;
+    static constexpr UINT kStaticCubesPerPage = 340;   // 340*6 = 2040 slices, just under the 2048 array-axis cap
+    static constexpr UINT kStaticCubePages = 3;        // 1020 cubes total >= kMaxFrameLights, i.e. never the constraint
+    static constexpr UINT kMaxStaticCubes = kStaticCubesPerPage * kStaticCubePages;
     static constexpr UINT kMaxSlots = kMaxCubes + kMaxStaticCubes;
-    // Both arrays are Texture2DArrays of slot*6 slices — see the ceiling note above. Asserted for BOTH tiers so
-    // raising either one can never silently produce an undersized/failed resource again.
+    // Both tiers are Texture2DArrays of slot*6 slices — see the ceiling note above. Asserted for BOTH so raising
+    // either one can never silently produce an undersized/failed resource again.
     static_assert( kMaxCubes * 6 <= 2048, "dynamic cube array exceeds D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION" );
-    static_assert( kMaxStaticCubes * 6 <= 2048, "static cube array exceeds D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION" );
+    static_assert( kStaticCubesPerPage * 6 <= 2048, "static cube page exceeds D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION" );
+    // The page index has kShadowLowPageBits in the encoded ShadowCubeIndex, the in-page slot kShadowLowSlotBits.
+    static_assert( kStaticCubePages <= 8 && kStaticCubesPerPage <= 1024, "static tier exceeds the ShadowCubeIndex encoding" );
     static bool IsLowSlot( UINT globalSlot ) { return globalSlot >= kMaxCubes; }
     static UINT LowIndex( UINT globalSlot ) { return globalSlot - kMaxCubes; }
+    // Which of the kStaticCubePages arrays a low-tier index lives in, and where inside that array's own slices.
+    static UINT LowPage( UINT lowIndex ) { return lowIndex / kStaticCubesPerPage; }
+    static UINT LowIndexInPage( UINT lowIndex ) { return lowIndex % kStaticCubesPerPage; }
 
     static constexpr UINT kBackBufferMax = 3;   // must match D3D12GraphicsEngine::kBackBufferMax (asserted in the .cpp)
     UINT kBackBufferCount = 2;   // synced from the engine in Attach() below
@@ -88,7 +98,8 @@ public:
     bool Init();
 
     UINT GetSrvSlot() const { return m_SrvSlot; }
-    UINT GetLowSrvSlot() const { return m_LowSrvSlot; }   // bindless heap slot of the low-res static cube array
+    UINT GetLowSrvSlot() const { return m_LowSrvSlot; }   // first of the low-res static tier's kStaticCubePages
+                                                          // CONTIGUOUS bindless slots (page p = this + p)
     UINT GetDynSrvSlot() const { return m_DynSrvSlot; }   // bindless heap slot of the dynamic-overlay cube array
     bool IsPassReady() const { return m_PassReady; }
 
@@ -100,8 +111,13 @@ public:
         uint64_t    key;      // 0 = never shadowed. Else the light's own vob pointer, or a tagged cluster cell id.
         zCVobLight* vob;      // nullptr for clusters — only ever dereferenced for the dynamic overlay's exclude
                               // list, which a static/clustered (low-tier) slot never reaches.
-        bool        lowRes;   // take the slot from the low-res static pool
+        bool        lowRes;   // PREFERRED tier: take the slot from the low-res static pool
         bool        isStatic;
+        bool        spatiallyStatic;   // never moves, whatever tier it was routed to. A full-res candidate that
+                                       // cannot be given a full-res cube SPILLS into the low-res tier when this
+                                       // holds - the low tier renders a cube once and caches it forever, so a
+                                       // light that moves would re-enter its per-frame render budget every single
+                                       // frame and starve everything else in it.
     };
 
     // Picks this frame's shadowed lights out of the filled GPU light buffer and writes each winner's
@@ -210,10 +226,16 @@ private:
     // overlay-eligible (D3D11's GetCurrentShadowMode forces static lights to PLS_STATIC_ONLY). Their static depth
     // therefore renders straight into this array and stays there — no per-frame copy, no dynamic overlay. Phases
     // B and C skip these slots entirely; only Phase A (on a cache miss) and Phase D ever touch them.
-    Microsoft::WRL::ComPtr<ID3D12Resource>       m_LowCube;
-    Microsoft::WRL::ComPtr<D3D12MA::Allocation>  m_LowCubeAlloc;
-    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_LowDsvHeap;   // one D16 6-slice DSV per low-res slot
-    UINT m_LowSrvSlot = UINT_MAX;                                // R16_UNORM TextureCubeArray SRV, fetched bindlessly
+    // kStaticCubePages separate arrays, not one: 341 cubes is the hard per-array slice ceiling (see above).
+    // Everything else about the tier stays single-pool — one DSV heap and one per-slot state array span all
+    // pages, indexed by the GLOBAL low index, while the RESOURCE and the subresource number come from
+    // LowPage()/LowIndexInPage().
+    Microsoft::WRL::ComPtr<ID3D12Resource>       m_LowCube[kStaticCubePages];
+    Microsoft::WRL::ComPtr<D3D12MA::Allocation>  m_LowCubeAlloc[kStaticCubePages];
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_LowDsvHeap;   // one D16 6-slice DSV per low-res slot, all pages
+    UINT m_LowSrvSlot = UINT_MAX;                                // FIRST of kStaticCubePages CONTIGUOUS R16_UNORM
+                                                                 // TextureCubeArray SRVs, fetched bindlessly as
+                                                                 // PointShadowLowIndex + page
     D3D12_RESOURCE_STATES m_LowSlotState[kMaxStaticCubes] = {};  // PIXEL_SHADER_RESOURCE at rest, per-slot like above
 
     // Dynamic-overlay cube: second persistent full-res cube array holding ONLY this frame's skeletal overlay

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -345,12 +345,17 @@ void D3D12GraphicsEngine::OnAddVob(VobInfo* vi) {
     // shadow slots and invalidate any whose light range the new VOB reaches, forcing a one-time static re-render
     // next frame (staticValid=false → renderStatic). Slots are empty during world load (owner==nullptr) so this is
     // a no-op then; the margin mirrors the static-VOB gather's cull (ps.range + visual->MeshSize * 0.5f).
-    // Gated on "not riding an NPC" rather than on the StaticVob flag: items always clear StaticVob (oItem does
-    // it unconditionally), so that gate also kept a dropped item from ever appearing in a nearby cube. What it
-    // was really there to stop is the item an NPC eating/drinking/smoking spawns and despawns constantly, which
-    // forced a full re-render of every cached slot around it -- and that one is identified by its NPC parent.
-    if ( vi->Vob && vi->VisualInfo && !D3D12PointShadows::IsNpcAttached( vi->Vob ) )
-        m_PointShadows.InvalidateStaticForVobAdded( vi->Vob->GetPositionWorld(), vi->VisualInfo->MeshSize * 0.5f );
+    // PARKED, not applied here: at this point Gothic has often not placed the vob yet (a dropped item is
+    // inserted where it came from and moved to where it lands afterwards) and its parent link may still be the
+    // NPC that is letting go of it -- and the position and that parent are precisely what the decision reads,
+    // so doing it now either misses every light or writes off a genuine drop as an NPC attachment. Resolved a
+    // frame later, once both have settled (D3D12PointShadows::QueueVobAddedInvalidation).
+    // The "not riding an NPC" test that lives there replaces the old StaticVob gate: items always clear
+    // StaticVob (oItem does it unconditionally), so that gate kept a dropped item from ever appearing in a
+    // nearby cube at all. What it was really there to stop is the item an NPC eating/drinking/smoking spawns
+    // and despawns constantly -- and that one is identified by its NPC parent.
+    if ( vi->Vob && vi->VisualInfo )
+        m_PointShadows.QueueVobAddedInvalidation( vi->Vob );
 }
 
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -345,25 +345,31 @@ void D3D12GraphicsEngine::OnAddVob(VobInfo* vi) {
     // shadow slots and invalidate any whose light range the new VOB reaches, forcing a one-time static re-render
     // next frame (staticValid=false → renderStatic). Slots are empty during world load (owner==nullptr) so this is
     // a no-op then; the margin mirrors the static-VOB gather's cull (ps.range + visual->MeshSize * 0.5f).
-    // Gated on StaticVob: items are always StaticVob==false (even ones just lying around, since oItem clears it
-    // unconditionally), and an NPC eating/drinking spawns/despawns one constantly -- without this gate that
-    // forced a full re-render of every nearby cached slot, causing a visible one-frame shadow blackout.
-    if ( vi->Vob && vi->VisualInfo && vi->Vob->GetFlags().StaticVob )
+    // Gated on "not riding an NPC" rather than on the StaticVob flag: items always clear StaticVob (oItem does
+    // it unconditionally), so that gate also kept a dropped item from ever appearing in a nearby cube. What it
+    // was really there to stop is the item an NPC eating/drinking/smoking spawns and despawns constantly, which
+    // forced a full re-render of every cached slot around it -- and that one is identified by its NPC parent.
+    if ( vi->Vob && vi->VisualInfo && !D3D12PointShadows::IsNpcAttached( vi->Vob ) )
         m_PointShadows.InvalidateStaticForVobAdded( vi->Vob->GetPositionWorld(), vi->VisualInfo->MeshSize * 0.5f );
 }
 
 
 XRESULT D3D12GraphicsEngine::OnVobRemovedFromWorld( zCVob* vob ) {
-    // Symmetric to OnAddVob's static-cube invalidation: a VOB removed from the world must stop casting into any
-    // point light's cached static-aside shadow cube. D3D11 keys this off each light's per-vob VobCache
-    // (D3D11PointLight::OnVobRemovedFromWorld); D3D12 keeps no per-slot vob list, so test the removed vob's world
-    // AABB against each active slot's light sphere (the same closest-point AABB test the static world-section cull
-    // uses) and force a one-time static re-render (staticValid=false) for any slot it intersects. Over-invalidation
-    // is harmless (one extra static pass); under-invalidation would leave the removed vob's shadow frozen in the
-    // cache. Slots are empty during world load (owner==nullptr) so this is a no-op then.
-    // Gated on StaticVob -- see OnAddVob.
-    if ( vob && vob->GetFlags().StaticVob ) m_PointShadows.InvalidateStaticForVobRemoved( vob->GetBBox() );
+    // Symmetric to OnAddVob's static-cube invalidation: a VOB removed from the world (an item picked up, a
+    // container emptied) must stop casting into any point light's cached static shadow cube. Matched by POINTER
+    // against the caster set each slot actually baked -- the vob is on its way out and nothing about its contents
+    // (bbox, position, flags) can be trusted here any more, which is also why there is no StaticVob gate left:
+    // a slot that never baked this vob simply doesn't match. Slots are empty during world load, no-op then.
+    m_PointShadows.InvalidateStaticForVobRemoved( vob );
     return XR_SUCCESS;
+}
+
+
+void D3D12GraphicsEngine::OnVobBecameDynamic( zCVob* vob ) {
+    // Gothic just promoted this vob out of the BSP into its dynamic/animated list, i.e. it started moving (a
+    // door swinging open, a chest lid). Anything baked into a cached static cube has to come back out -- same
+    // pointer match as the removal case, and equally cheap when nothing baked it.
+    m_PointShadows.InvalidateStaticForVobRemoved( vob );
 }
 
 
@@ -4206,10 +4212,18 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
         ? reinterpret_cast<VobCullVisual*>( m_VobCullVisualsPtr[frame] ) : nullptr;
 
     for ( auto const& [visualPtr, visual] : Engine::GAPI->GetStaticMeshVisuals() ) {
-        if ( !visual || visual->Instances.empty() ) continue;
+        if ( !visual ) continue;
 
-        if ( animateStaticVobs && visual->MorphMeshVisual )
+        // The second condition is what keeps a spinning windmill's SHADOW attached to it: the cascades cull
+        // against their own frustum, so a caster the player can't see still casts, and a morph visual left at
+        // whatever deformation it had when it was last on screen makes that shadow drift off the mesh. Gated
+        // on a live ani channel so idle .MMS decoration costs one read and nothing else.
+        if ( animateStaticVobs && visual->MorphMeshVisual
+            && ( !visual->Instances.empty()
+                || reinterpret_cast<zCMorphMesh*>( visual->MorphMeshVisual )->GetNumAniChannels() > 0 ) )
             WorldConverter::UpdateMorphMeshVisual( visual->MorphMeshVisual, visual );
+
+        if ( visual->Instances.empty() ) continue;
 
         const UINT numInstances = static_cast<UINT>( visual->Instances.size() );
         constexpr UINT kInstStride = static_cast<UINT>( sizeof( VobInstanceInfo ) );

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -355,7 +355,7 @@ void D3D12GraphicsEngine::OnAddVob(VobInfo* vi) {
     // nearby cube at all. What it was really there to stop is the item an NPC eating/drinking/smoking spawns
     // and despawns constantly -- and that one is identified by its NPC parent.
     if ( vi->Vob && vi->VisualInfo )
-        m_PointShadows.QueueVobAddedInvalidation( vi->Vob );
+        m_PointShadows.QueueVobChangedInvalidation( vi->Vob );
 }
 
 
@@ -367,6 +367,14 @@ XRESULT D3D12GraphicsEngine::OnVobRemovedFromWorld( zCVob* vob ) {
     // a slot that never baked this vob simply doesn't match. Slots are empty during world load, no-op then.
     m_PointShadows.InvalidateStaticForVobRemoved( vob );
     return XR_SUCCESS;
+}
+
+
+void D3D12GraphicsEngine::OnVobMoved( zCVob* vob ) {
+    // A vob baked into a cached static cube at its old position leaves a shadow behind; one that just moved
+    // into a light's reach is missing from that light's cube. Queued rather than resolved here because a
+    // falling/thrown item moves several times per frame and its position is only final once it stops.
+    m_PointShadows.QueueVobChangedInvalidation( vob );
 }
 
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -499,6 +499,192 @@ void D3D12GraphicsEngine::DrawVobSingle( VobInfo* vob, zCCamera& camera ) {
     m_CmdList->OMSetRenderTargets( 1, &rtv, FALSE, nullptr );
 }
 
+// Same, for an inventory item whose visual is a skeletal model: skinned base meshes through the
+// PreviewSkeletal pipeline, node attachments through the plain Preview one (world = modelWorld *
+// bone[node], exactly as the scene path builds them). Mirrors D3D11GraphicsEngine's overload.
+void D3D12GraphicsEngine::DrawVobSingle( SkeletalVobInfo* vob, zCCamera& camera ) {
+    if ( !vob || !vob->VisualInfo || !vob->Vob || !m_FrameOpen
+        || !m_Pipelines.Preview.PSO || !m_Pipelines.Preview.RootSig || !m_DepthBuffer || !m_DsvHeap )
+        return;
+
+    // Still being filled in on a worker thread (GothicAPI::LoadzCModelData) - skip until the meshes are
+    // safe to iterate. The item pops in a frame or two later instead.
+    SkeletalMeshVisualInfo* visualInfo = static_cast<SkeletalMeshVisualInfo*>( vob->VisualInfo );
+    if ( !visualInfo->GetIsReady() ) return;
+
+    zCModel* model = static_cast<zCModel*>( vob->Vob->GetVisual() );
+    if ( !model ) return;
+
+    Engine::GAPI->SetViewTransformXM( XMLoadFloat4x4( &camera.GetTransformDX( zCCamera::ETransformType::TT_VIEW ) ) );
+
+    GothicRendererState& rs = Engine::GAPI->GetRendererState();
+    const XMFLOAT4X4& viewM = rs.TransformState.TransformView;
+    // By VALUE, with the TAA jitter stripped - see DrawVobSingle(VobInfo*) above.
+    XMFLOAT4X4 projM = Engine::GAPI->GetProjectionMatrix();
+    projM._13 = 0.0f;
+    projM._23 = 0.0f;
+    XMFLOAT4X4 viewProj;
+    XMStoreFloat4x4( &viewProj, XMMatrixMultiply( XMLoadFloat4x4( &projM ), XMLoadFloat4x4( &viewM ) ) );
+
+    D3D12_CPU_DESCRIPTOR_HANDLE rtv = GetDisplayRtv();
+    D3D12_CPU_DESCRIPTOR_HANDLE dsv = GetPreviewDsv();
+    if ( !dsv.ptr ) return;
+
+    D3D12_VIEWPORT vp = m_CurrentViewport;
+    D3D12_RECT     sc = m_CurrentScissor;
+    // The scene's own depth is still in there at these pixels - clear this slot's rect back to reversed-Z
+    // far (0.0) first, same as the static preview.
+    const D3D12_RECT clearRect = {
+        static_cast<LONG>( vp.TopLeftX ), static_cast<LONG>( vp.TopLeftY ),
+        static_cast<LONG>( vp.TopLeftX + vp.Width ), static_cast<LONG>( vp.TopLeftY + vp.Height ) };
+    m_CmdList->ClearDepthStencilView( dsv, D3D12_CLEAR_FLAG_DEPTH, 0.0f, 0, 1, &clearRect );
+
+    m_CmdList->OMSetRenderTargets( 1, &rtv, FALSE, &dsv );
+    m_CmdList->RSSetViewports( 1, &vp );
+    m_CmdList->RSSetScissorRects( 1, &sc );
+    m_CmdList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
+
+    // Into our own buffer, not GetBoneTransforms(): we are inside one of ZenGin's own render callbacks
+    // here, and that overload writes its result into zCModelNodeInst::TrafoObjToCam, which ZenGin keeps
+    // as the *world*-space node cache.
+    static std::vector<XMFLOAT4X4> boneTransforms; // Main thread only, keeps its capacity
+    boneTransforms.clear();
+    model->GetBoneTransformsTo( boneTransforms );
+    if ( boneTransforms.size() > kSkeletalMaxBones )
+        boneTransforms.resize( kSkeletalMaxBones );
+
+    const XMFLOAT4X4 world = *vob->Vob->GetWorldMatrixPtr();
+    const XMMATRIX worldXm = XMLoadFloat4x4( &world );
+
+    const D3D12_GPU_DESCRIPTOR_HANDLE fallbackSrv = GetSrvGpuHandle( m_BlackTexture->GetSrvSlot() );
+    auto bindDiffuse = [&]( zCMaterial* material, UINT rootParam ) -> bool {
+        zCTexture* texture = material ? material->GetAniTexture() : nullptr;
+        if ( !texture || texture->CacheIn( 0.6f ) != zRES_CACHED_IN ) return false;
+
+        D3D12_GPU_DESCRIPTOR_HANDLE srv = fallbackSrv;
+        if ( MyDirectDrawSurface7* surface = texture->GetSurface() ) {
+            if ( GfxTexture* gfx = surface->GetEngineTexture() ) {
+                D3D12Texture* d12 = D3D12Texture::From( gfx );
+                if ( d12->HasSRV() ) srv = d12->GetSrvGpuHandle();
+            }
+        }
+        m_CmdList->SetGraphicsRootDescriptorTable( rootParam, srv );
+        return true;
+    };
+
+    // Skinned base meshes - the part a static flatten of the model would drop entirely.
+    if ( m_Pipelines.PreviewSkeletal.PSO && m_Pipelines.PreviewSkeletal.RootSig
+        && !visualInfo->SkeletalMeshes.empty() && !boneTransforms.empty() ) {
+        // Bone palette out of the per-frame skeletal ring (advance-only cursor, so the address stays
+        // valid until Present - the same promise PreviewSkeletal.RootSig's b2 is declared with).
+        const UINT frame = m_FrameIndex;
+        const UINT boneSize = static_cast<UINT>( boneTransforms.size() * sizeof( XMFLOAT4X4 ) );
+        // Reserve the full palette the shader declares, not just the poses we write: a root CBV is not
+        // bounds-checked, so a stray bone index must still land inside the ring resource.
+        const UINT boneReserve = kSkeletalMaxBones * static_cast<UINT>( sizeof( XMFLOAT4X4 ) );
+        const UINT boneOff = AlignCB( m_SkeletalCBBufferOffset );
+        if ( m_SkeletalCBBuffer[frame] && m_SkeletalCBBufferPtr[frame]
+            && boneOff + boneReserve <= m_SkeletalCBBufferCapacity ) {
+            memcpy( m_SkeletalCBBufferPtr[frame] + boneOff, boneTransforms.data(), boneSize );
+            memset( m_SkeletalCBBufferPtr[frame] + boneOff + boneSize, 0, boneReserve - boneSize );
+            m_SkeletalCBBufferOffset = boneOff + boneReserve;
+
+            m_CmdList->SetPipelineState( m_Pipelines.PreviewSkeletal.PSO.Get() );
+            m_CmdList->SetGraphicsRootSignature( m_Pipelines.PreviewSkeletal.RootSig.Get() );
+            m_CmdList->SetGraphicsRoot32BitConstants( 0, 16, &viewProj, 0 );   // b0 ViewProj
+            m_CmdList->SetGraphicsRoot32BitConstants( 1, 16, &world, 0 );      // b1 World
+            m_CmdList->SetGraphicsRootConstantBufferView( 2,
+                m_SkeletalCBBuffer[frame]->GetGPUVirtualAddress() + boneOff ); // b2 bone palette
+
+            for ( auto const& [material, meshes] : visualInfo->SkeletalMeshes ) {
+                if ( !bindDiffuse( material, 3 ) ) continue;
+
+                for ( auto const& mesh : meshes ) {
+                    if ( !mesh || mesh->Indices.empty() || !mesh->MeshVertexBuffer || !mesh->MeshIndexBuffer ) continue;
+                    D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( mesh->MeshVertexBuffer.get() );
+                    D3D12VertexBuffer* mib = D3D12VertexBuffer::From( mesh->MeshIndexBuffer.get() );
+                    if ( !mvb->GetResource() || !mib->GetResource() ) continue;
+
+                    const D3D12_VERTEX_BUFFER_VIEW vbv = { mvb->GetGpuVirtualAddress(), mvb->GetSizeInBytes(), sizeof( ExSkelVertexStruct ) };
+                    m_CmdList->IASetVertexBuffers( 0, 1, &vbv );
+                    const D3D12_INDEX_BUFFER_VIEW ibv = { mib->GetGpuVirtualAddress(), mib->GetSizeInBytes(), DXGI_FORMAT_R16_UINT };
+                    m_CmdList->IASetIndexBuffer( &ibv );
+
+                    m_CmdList->DrawIndexedInstanced( static_cast<UINT>( mesh->Indices.size() ), 1, 0, 0, 0 );
+                    rs.RendererInfo.FrameDrawnTriangles += static_cast<unsigned int>( mesh->Indices.size() ) / 3;
+                }
+            }
+        } else if ( !m_SkeletalCBOverflowLogged ) {
+            LogWarn() << "D3D12: skeletal CB ring overflow (" << m_SkeletalCBBufferCapacity
+                      << " bytes/frame). Skinned inventory preview dropped this frame.";
+            m_SkeletalCBOverflowLogged = true;
+        }
+    }
+
+    // Node attachments (a weapon in a hand, the lid of a chest, ...) - plain ExVertexStruct meshes, so the
+    // non-skinned Preview pipeline draws them, one root-constant world matrix per node.
+    zCArray<zCModelNodeInst*>* nodeList = model->GetNodeList();
+    const int numNodes = nodeList ? std::min<int>( nodeList->NumInArray, static_cast<int>( boneTransforms.size() ) ) : 0;
+    if ( numNodes > 0 ) {
+        m_CmdList->SetPipelineState( m_Pipelines.Preview.PSO.Get() );
+        m_CmdList->SetGraphicsRootSignature( m_Pipelines.Preview.RootSig.Get() );
+        m_CmdList->SetGraphicsRoot32BitConstants( 0, 16, &viewProj, 0 );   // b0 ViewProj
+
+        auto& attachments = vob->NodeAttachments;
+        for ( int n = 0; n < numNodes; ++n ) {
+            zCModelNodeInst* node = nodeList->Array[n];
+            if ( !node || !node->NodeVisual ) continue;
+
+            // Extract on first sight, and re-extract when the node's visual changed. The visual-changed
+            // comparison is gated on Ready because the worker writes MeshVisualInfo::Visual as it finishes.
+            auto it = attachments.find( n );
+            if ( it == attachments.end() ) {
+                WorldConverter::ExtractNodeVisualAsync( n, node, attachments );
+                it = attachments.find( n );
+            } else if ( !it->second.empty() && it->second[0]
+                && it->second[0]->GetIsReady()
+                && it->second[0]->Visual != node->NodeVisual ) {
+                WorldConverter::ExtractNodeVisualAsync( n, node, attachments );
+                it = attachments.find( n );
+            }
+            if ( it == attachments.end() ) continue;
+
+            XMFLOAT4X4 attWorld;
+            XMStoreFloat4x4( &attWorld, worldXm * XMLoadFloat4x4( &boneTransforms[n] ) );
+
+            for ( MeshVisualInfo* mvi : it->second ) {
+                // Still being extracted on a worker thread - skip it for this frame rather than race it.
+                if ( !mvi || !mvi->GetIsReady() || !mvi->Visual ) continue;
+
+                m_CmdList->SetGraphicsRoot32BitConstants( 1, 16, &attWorld, 0 );   // b1 World
+
+                for ( auto const& [material, meshes] : mvi->Meshes ) {
+                    if ( !bindDiffuse( material, 2 ) ) continue;
+
+                    for ( auto const& mesh : meshes ) {
+                        if ( !mesh || mesh->Indices.empty() || !mesh->GetMeshVertexBuffer() || !mesh->GetMeshIndexBuffer() ) continue;
+                        D3D12VertexBuffer* mvb = D3D12VertexBuffer::From( mesh->GetMeshVertexBuffer() );
+                        D3D12VertexBuffer* mib = D3D12VertexBuffer::From( mesh->GetMeshIndexBuffer() );
+                        if ( !mvb->GetResource() || !mib->GetResource() ) continue;
+
+                        const D3D12_VERTEX_BUFFER_VIEW vbv = { mvb->GetGpuVirtualAddress(), mvb->GetSizeInBytes(), sizeof( ExVertexStruct ) };
+                        m_CmdList->IASetVertexBuffers( 0, 1, &vbv );
+                        const D3D12_INDEX_BUFFER_VIEW ibv = { mib->GetGpuVirtualAddress(), mib->GetSizeInBytes(), DXGI_FORMAT_R16_UINT };
+                        m_CmdList->IASetIndexBuffer( &ibv );
+
+                        m_CmdList->DrawIndexedInstanced( static_cast<UINT>( mesh->Indices.size() ), 1, 0, 0, 0 );
+                        rs.RendererInfo.FrameDrawnTriangles += static_cast<unsigned int>( mesh->Indices.size() ) / 3;
+                    }
+                }
+            }
+        }
+    }
+
+    // Rebind the backbuffer alone (no depth) so the following 2D UI draws aren't depth-tested.
+    m_CmdList->OMSetRenderTargets( 1, &rtv, FALSE, nullptr );
+}
+
+
 
 
 

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -339,49 +339,36 @@ void D3D12GraphicsEngine::OnAddVob(VobInfo* vi) {
     // headroom. Queueing is cheap and idempotent, the upload happens at the next frame's flush.
     m_VobArena.QueueVisual( static_cast<MeshVisualInfo*>( vi->VisualInfo ) );
 
-    // A VOB added after a nearby point light already cached its static-aside shadow cube would otherwise cast no
-    // point-light shadow: the static cube is only re-rendered when the light is fresh / moved / resized (the
-    // renderStatic gate in BuildFramePointShadows), not when world geometry around it changes. Walk the active
-    // shadow slots and invalidate any whose light range the new VOB reaches, forcing a one-time static re-render
-    // next frame (staticValid=false → renderStatic). Slots are empty during world load (owner==nullptr) so this is
-    // a no-op then; the margin mirrors the static-VOB gather's cull (ps.range + visual->MeshSize * 0.5f).
-    // PARKED, not applied here: at this point Gothic has often not placed the vob yet (a dropped item is
-    // inserted where it came from and moved to where it lands afterwards) and its parent link may still be the
-    // NPC that is letting go of it -- and the position and that parent are precisely what the decision reads,
-    // so doing it now either misses every light or writes off a genuine drop as an NPC attachment. Resolved a
-    // frame later, once both have settled (D3D12PointShadows::QueueVobAddedInvalidation).
-    // The "not riding an NPC" test that lives there replaces the old StaticVob gate: items always clear
-    // StaticVob (oItem does it unconditionally), so that gate kept a dropped item from ever appearing in a
-    // nearby cube at all. What it was really there to stop is the item an NPC eating/drinking/smoking spawns
-    // and despawns constantly -- and that one is identified by its NPC parent.
+    // A cached static cube is only re-rendered when its light is fresh / moved / resized, never when the
+    // geometry around it changes, so a new VOB in range has to say so.
+    // Parked, not applied here: Gothic has often not placed the vob yet and its parent link may still be the
+    // NPC letting go of it, which are the two things the decision reads. The "not riding an NPC" test that
+    // resolves it replaces the old StaticVob gate, which kept a dropped item out of every nearby cube (oItem
+    // clears StaticVob unconditionally) while only meaning to exclude an NPC's throwaway item.
     if ( vi->Vob && vi->VisualInfo )
         m_PointShadows.QueueVobChangedInvalidation( vi->Vob );
 }
 
 
 XRESULT D3D12GraphicsEngine::OnVobRemovedFromWorld( zCVob* vob ) {
-    // Symmetric to OnAddVob's static-cube invalidation: a VOB removed from the world (an item picked up, a
-    // container emptied) must stop casting into any point light's cached static shadow cube. Matched by POINTER
-    // against the caster set each slot actually baked -- the vob is on its way out and nothing about its contents
-    // (bbox, position, flags) can be trusted here any more, which is also why there is no StaticVob gate left:
-    // a slot that never baked this vob simply doesn't match. Slots are empty during world load, no-op then.
+    // Symmetric to OnAddVob: a VOB leaving the world must stop casting into any cached static cube. Matched
+    // by POINTER against what each slot baked -- nothing about the dying vob can be read here, which is also
+    // why no StaticVob gate is left: a slot that never baked it simply doesn't match.
     m_PointShadows.InvalidateStaticForVobRemoved( vob );
     return XR_SUCCESS;
 }
 
 
 void D3D12GraphicsEngine::OnVobMoved( zCVob* vob ) {
-    // A vob baked into a cached static cube at its old position leaves a shadow behind; one that just moved
-    // into a light's reach is missing from that light's cube. Queued rather than resolved here because a
-    // falling/thrown item moves several times per frame and its position is only final once it stops.
+    // A vob baked at its old position leaves a shadow behind, and one that moved into a light's reach is
+    // missing from its cube. Queued because a falling item moves several times before coming to rest.
     m_PointShadows.QueueVobChangedInvalidation( vob );
 }
 
 
 void D3D12GraphicsEngine::OnVobBecameDynamic( zCVob* vob ) {
-    // Gothic just promoted this vob out of the BSP into its dynamic/animated list, i.e. it started moving (a
-    // door swinging open, a chest lid). Anything baked into a cached static cube has to come back out -- same
-    // pointer match as the removal case, and equally cheap when nothing baked it.
+    // It started moving (a door swinging open, a chest lid), so anything that baked it has to let go --
+    // same pointer match as the removal case, and equally cheap when nothing baked it.
     m_PointShadows.InvalidateStaticForVobRemoved( vob );
 }
 
@@ -871,10 +858,8 @@ namespace {
 		                              // unaffected by PointlightShadowCasterFlags
 		bool        isIndoor;
 		bool        spatiallyStatic;  // has not MOVED for a while and does not ride a moving transform.
-		                              // Gothic's own IsStatic() is NOT this: a colour-animated candle or
-		                              // brazier reads as non-static there while never being repositioned,
-		                              // which is why so many fixed room lights were competing for the
-		                              // 64-slot moving-light tier. Also gates the SPILL in SelectShadowedLights.
+		                              // Gothic's IsStatic() is NOT this: a colour-animated brazier reads as
+		                              // non-static there while never being repositioned. Gates the SPILL.
 		bool        isPFX;            // oCVisualFX-spawned (candle/torch/spell). Gates the world-mesh-only
 		                              // caster restriction below - see LightShadowKey::restrictToWorld.
 		bool        shadowRoutingStatic; // isStatic, UNLESS PLSC_STATIC_LIGHTS opted static lights into full
@@ -1049,12 +1034,11 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 	const zCVob* playerVob = Engine::GAPI->GetPlayerVob();
 	const bool cameraIndoors = playerVob && playerVob->IsIndoorVob();
 
-	// At PLS_STATIC_ONLY nothing receives a dynamic overlay at all, so the full-res tier buys resolution and
-	// nothing else - and it is 16x scarcer. See the routing decision in the collect loop below.
+	// At PLS_STATIC_ONLY nothing receives a dynamic overlay, so the 16x scarcer full-res tier buys only
+	// resolution. See the routing decision in the collect loop below.
 	const bool staticOnlyMode = lightSettings.EnablePointlightShadows == GothicRendererSettings::PLS_STATIC_ONLY;
 
-	// Per-light "has not moved recently" tracking, keyed by vob. Frame-path map: capacity is reused, and it
-	// is swept only every 1024 frames.
+	// Per-light "has not moved recently" tracking, keyed by vob. Capacity is reused; swept every 1024 frames.
 	struct StationaryState { XMFLOAT3 pos{}; UINT32 frames = 0; UINT32 lastSeen = 0; };
 	static std::unordered_map<const zCVob*, StationaryState> s_stationary;
 	static UINT32 s_stationaryFrame = 0;
@@ -1076,11 +1060,9 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 		const XMFLOAT3 pw = vob->GetPositionWorld();
 		const float range = vob->GetLightRange();
 		const float distSq = XMVectorGetX( XMVector3LengthSq( XMVectorSubtract( XMLoadFloat3( &pw ), camPos ) ) );
-		// Has this light held still long enough to count as a fixture? A light that never moves has a shadow
-		// cube that can be rendered once and cached forever, which is the entire basis of the low-res static
-		// tier - and Gothic's IsStatic() bit does not answer that question. NPC-attached lights are excluded
-		// outright rather than timed out: a torch in an idle NPC's hand stands still for seconds at a time and
-		// would flip tier every time they set off walking again.
+		// Has this light held still long enough to count as a fixture? Only such a light's cube can be baked
+		// once and cached, which is the whole basis of the low-res tier. NPC-attached lights are excluded
+		// outright: an idle NPC's torch stands still for seconds and would flip tier every time they walk.
 		bool spatiallyStatic = isStatic;
 		if ( !spatiallyStatic && !D3D12PointShadows::IsNpcAttached( vob ) ) {
 			auto& st = s_stationary[vob];
@@ -1092,18 +1074,16 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 			st.lastSeen = s_stationaryFrame;
 			spatiallyStatic = st.frames >= kStationaryFrames;
 		}
-		// Route to the cached low-res tier when the light will not move AND could not receive a dynamic overlay
-		// anyway - which at PLS_STATIC_ONLY is every light there is. Without this, every colour-animated room
-		// light in Gothic queued for the 64 full-res cubes (whose per-frame skeletal overlay that mode does not
-		// even run) while a thousand static slots sat empty, and whichever ones lost the queue were
-		// range-clamped into looking switched off.
+		// Route to the cached low-res tier when the light will not move AND could not receive a dynamic
+		// overlay anyway - which at PLS_STATIC_ONLY is every light there is. Without it, colour-animated room
+		// lights queued for the 64 full-res cubes while hundreds of static slots sat empty.
 		const bool routeStatic = !allowStaticDynamicShadows && ( isStatic || ( spatiallyStatic && staticOnlyMode ) );
 		// shadowOrigin/shadowRange start as the light's own and are redirected to a cluster's below; `key`
 		// likewise starts as the light's own identity.
 		s_cands.push_back( { vob, pw, range, distSq, isStatic, li->IsIndoorVob, spatiallyStatic,
 			li->IsPFXVobLight, routeStatic, pw, range, reinterpret_cast<uint64_t>( vob ) } );
 	}
-	// Drop stationary-tracking entries for lights long out of the light set. Swept rarely; walks the map.
+	// Drop tracking entries for lights long out of the light set. Swept rarely; walks the whole map.
 	if ( ( s_stationaryFrame % 1024 ) == 0 )
 		std::erase_if( s_stationary, []( const auto& e ) { return s_stationaryFrame - e.second.lastSeen > 600; } );
 	// Total order, not just "by distance": the cluster cull keeps the first MAX_ACTIVE_LIGHTS candidates in BUFFER
@@ -1156,7 +1136,7 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 		// passed for an UNclustered light: a cluster has no single owning vob, and the field exists purely for
 		// the dynamic-overlay exclude list, which no static/clustered slot reaches.
 		// World-mesh-only casters for an un-opted-in PFX light, mirroring D3D11's AllowsDynamicCasters. Asked
-		// of the light's OWN identity only: a clustered light is routing-static, so the question never applies.
+		// of the light's OWN identity only - a clustered light is routing-static anyway.
 		const bool unclustered = cand.key == reinterpret_cast<uint64_t>( vob );
 		const bool restrictToWorld = unclustered && !cand.shadowRoutingStatic && cand.isPFX
 			&& !( lightSettings.PointlightShadowCasterFlags & GothicRendererSettings::PLSC_PARTICLE_FX );
@@ -1166,9 +1146,8 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 		++count;
 	}
 	m_FrameLightCount = count;
-	// Lights the per-frame buffer could not hold at all (the farthest ones, since s_cands is distance-sorted).
-	// Not the same failure as being starved of a shadow cube - these are not shaded at all - but it looks
-	// identical in game, so it is reported next to it.
+	// Lights the per-frame buffer could not hold at all (the farthest, s_cands being distance-sorted). Not
+	// the same failure as being starved of a cube, but it looks identical in game.
 	Engine::GAPI->GetRendererState().RendererInfo.PointLightsDropped =
 		static_cast<unsigned int>( s_cands.size() - count );
 
@@ -1190,11 +1169,9 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 	constexpr float kUnshadowedStaticScale = 0.35f;        // still lights its own alcove; can't reach the next room
 	constexpr float kIndoorSeenFromOutsideScale = 0.15f;   // the worst bleed case — clamp it much harder
 
-	// The clamp is applied THROUGH a per-light eased scale rather than switched on and off. Gaining or losing a
-	// cube changes a light's radius by 3-7x, and snapping that in one frame reads as the light being switched
-	// off (or flashing on) — which is exactly what a static light does the moment it drops out of the shadow
-	// system. Easing it over ~0.3 s turns the switch into a dimmer. A light seen for the FIRST time starts at
-	// its target, so world load and every fresh room light in are unaffected.
+	// The clamp is applied through a per-light eased scale rather than switched on and off: gaining or losing
+	// a cube changes a light's radius by 3-7x, and snapping that reads as the light switching off. A light
+	// seen for the first time starts at its target, so world load does not fade every light in.
 	constexpr float kClampEaseSeconds = 0.3f;
 	struct ClampState { float scale; UINT32 lastFrame; };
 	static std::unordered_map<uint64_t, ClampState> s_clampScale;
@@ -1210,8 +1187,7 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 		const bool leakingOutdoors = s_cands[i].isIndoor && !cameraIndoors;
 		const float target = dst[i].ShadowCubeIndex >= 0 ? 1.0f
 			: ( leakingOutdoors ? kIndoorSeenFromOutsideScale : kUnshadowedStaticScale );
-		// key 0 is "this light can never be shadowed" (point shadows off): its target never changes, so there
-		// is nothing to ease and no identity to ease it under. Clamp it outright, as before.
+		// key 0 is "this light can never be shadowed": no identity to ease under, and nothing to ease to.
 		const uint64_t key = s_lightKeys[i].key;
 		if ( !key ) {
 			dst[i].Range *= target;
@@ -1219,19 +1195,17 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 			continue;
 		}
 		const auto [it, fresh] = s_clampScale.try_emplace( key, ClampState{ target, s_clampFrame } );
-		if ( !fresh && it->second.lastFrame != s_clampFrame ) {   // once per frame, however many members share the key
+		if ( !fresh && it->second.lastFrame != s_clampFrame ) {   // once per frame, however many share the key
 			it->second.scale += ( target - it->second.scale ) * ease;
 			it->second.lastFrame = s_clampFrame;
 		}
-		if ( it->second.scale >= 0.999f ) continue;    // fully unclamped — leave the light exactly as it was
+		if ( it->second.scale >= 0.999f ) continue;    // fully unclamped
 		dst[i].Range *= it->second.scale;
-		// ShadowRange follows Range only while the light is UNSHADOWED. It is the cube's far-plane basis, and the
-		// shader rebuilds the caster's depth from it: shrinking it under a light that HAS a cube (one easing back
-		// up after re-acquiring one) would compare against a projection the cube was never rendered with.
+		// ShadowRange follows Range only while the light is UNSHADOWED: it is the cube's far-plane basis, so
+		// shrinking it under a light that has a cube compares against a projection it was never rendered with.
 		if ( dst[i].ShadowCubeIndex < 0 ) dst[i].ShadowRange = dst[i].Range;
 	}
-	// Drop lights that have been out of the buffer long enough that their eased scale is meaningless anyway;
-	// without this the map keeps every light the session has ever seen. Swept rarely — it walks the whole map.
+	// Without this the map keeps every light the session has ever seen. Swept rarely; walks the whole map.
 	if ( ( s_clampFrame % 1024 ) == 0 )
 		std::erase_if( s_clampScale, [&]( const auto& e ) { return s_clampFrame - e.second.lastFrame > 600; } );
 }
@@ -4318,10 +4292,9 @@ void D3D12GraphicsEngine::UploadFrameVobInstances() {
     for ( auto const& [visualPtr, visual] : Engine::GAPI->GetStaticMeshVisuals() ) {
         if ( !visual ) continue;
 
-        // The second condition is what keeps a spinning windmill's SHADOW attached to it: the cascades cull
-        // against their own frustum, so a caster the player can't see still casts, and a morph visual left at
-        // whatever deformation it had when it was last on screen makes that shadow drift off the mesh. Gated
-        // on a live ani channel so idle .MMS decoration costs one read and nothing else.
+        // The second condition keeps a spinning windmill's SHADOW attached to it: cascades cull against their
+        // own frustum, so a caster the player can't see still casts, and a morph visual left at its last
+        // on-screen deformation drifts off the mesh. Gated on a live ani channel, so idle .MMS costs one read.
         if ( animateStaticVobs && visual->MorphMeshVisual
             && ( !visual->Instances.empty()
                 || reinterpret_cast<zCMorphMesh*>( visual->MorphMeshVisual )->GetNumAniChannels() > 0 ) )

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -870,6 +870,11 @@ namespace {
 		bool        isStatic;         // Gothic's true IsStatic() — governs specular scale / DisableStaticPointlights,
 		                              // unaffected by PointlightShadowCasterFlags
 		bool        isIndoor;
+		bool        spatiallyStatic;  // has not MOVED for a while and does not ride a moving transform.
+		                              // Gothic's own IsStatic() is NOT this: a colour-animated candle or
+		                              // brazier reads as non-static there while never being repositioned,
+		                              // which is why so many fixed room lights were competing for the
+		                              // 64-slot moving-light tier. Also gates the SPILL in SelectShadowedLights.
 		bool        shadowRoutingStatic; // isStatic, UNLESS PLSC_STATIC_LIGHTS opted static lights into full
 		                              // dynamic-tier shadow treatment — see the PointlightShadowCasterFlags read below.
 		                              // Governs clustering eligibility and LightShadowKey::isStatic/lowRes.
@@ -1042,6 +1047,19 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 	const zCVob* playerVob = Engine::GAPI->GetPlayerVob();
 	const bool cameraIndoors = playerVob && playerVob->IsIndoorVob();
 
+	// At PLS_STATIC_ONLY nothing receives a dynamic overlay at all, so the full-res tier buys resolution and
+	// nothing else - and it is 16x scarcer. See the routing decision in the collect loop below.
+	const bool staticOnlyMode = lightSettings.EnablePointlightShadows == GothicRendererSettings::PLS_STATIC_ONLY;
+
+	// Per-light "has not moved recently" tracking, keyed by vob. Frame-path map: capacity is reused, and it
+	// is swept only every 1024 frames.
+	struct StationaryState { XMFLOAT3 pos{}; UINT32 frames = 0; UINT32 lastSeen = 0; };
+	static std::unordered_map<const zCVob*, StationaryState> s_stationary;
+	static UINT32 s_stationaryFrame = 0;
+	++s_stationaryFrame;
+	constexpr float  kStationaryEps = 1.0f;     // world units; below this a light is jittering, not moving
+	constexpr UINT32 kStationaryFrames = 60;    // ~1 s of holding still before a light counts as a fixture
+
 	static std::vector<FrameLightCand> s_cands;   // static: capacity is reused, no per-frame allocation
 	s_cands.clear();
 
@@ -1056,11 +1074,36 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 		const XMFLOAT3 pw = vob->GetPositionWorld();
 		const float range = vob->GetLightRange();
 		const float distSq = XMVectorGetX( XMVector3LengthSq( XMVectorSubtract( XMLoadFloat3( &pw ), camPos ) ) );
+		// Has this light held still long enough to count as a fixture? A light that never moves has a shadow
+		// cube that can be rendered once and cached forever, which is the entire basis of the low-res static
+		// tier - and Gothic's IsStatic() bit does not answer that question. NPC-attached lights are excluded
+		// outright rather than timed out: a torch in an idle NPC's hand stands still for seconds at a time and
+		// would flip tier every time they set off walking again.
+		bool spatiallyStatic = isStatic;
+		if ( !spatiallyStatic && !D3D12PointShadows::IsNpcAttached( vob ) ) {
+			auto& st = s_stationary[vob];
+			const bool moved = std::fabs( pw.x - st.pos.x ) > kStationaryEps
+				|| std::fabs( pw.y - st.pos.y ) > kStationaryEps
+				|| std::fabs( pw.z - st.pos.z ) > kStationaryEps;
+			if ( moved ) { st.pos = pw; st.frames = 0; }
+			else if ( st.frames < kStationaryFrames ) ++st.frames;
+			st.lastSeen = s_stationaryFrame;
+			spatiallyStatic = st.frames >= kStationaryFrames;
+		}
+		// Route to the cached low-res tier when the light will not move AND could not receive a dynamic overlay
+		// anyway - which at PLS_STATIC_ONLY is every light there is. Without this, every colour-animated room
+		// light in Gothic queued for the 64 full-res cubes (whose per-frame skeletal overlay that mode does not
+		// even run) while a thousand static slots sat empty, and whichever ones lost the queue were
+		// range-clamped into looking switched off.
+		const bool routeStatic = !allowStaticDynamicShadows && ( isStatic || ( spatiallyStatic && staticOnlyMode ) );
 		// shadowOrigin/shadowRange start as the light's own and are redirected to a cluster's below; `key`
 		// likewise starts as the light's own identity.
-		s_cands.push_back( { vob, pw, range, distSq, isStatic, li->IsIndoorVob,
-			isStatic && !allowStaticDynamicShadows, pw, range, reinterpret_cast<uint64_t>( vob ) } );
+		s_cands.push_back( { vob, pw, range, distSq, isStatic, li->IsIndoorVob, spatiallyStatic,
+			routeStatic, pw, range, reinterpret_cast<uint64_t>( vob ) } );
 	}
+	// Drop stationary-tracking entries for lights long out of the light set. Swept rarely; walks the map.
+	if ( ( s_stationaryFrame % 1024 ) == 0 )
+		std::erase_if( s_stationary, []( const auto& e ) { return s_stationaryFrame - e.second.lastSeen > 600; } );
 	// Total order, not just "by distance": the cluster cull keeps the first MAX_ACTIVE_LIGHTS candidates in BUFFER
 	// order, so the buffer order has to be a pure function of the visible light SET. std::sort is unstable, so
 	// equal distances (co-located atmospheric lights are common) would otherwise permute between frames and make
@@ -1112,10 +1155,15 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 		// the dynamic-overlay exclude list, which no static/clustered slot reaches.
 		s_lightKeys.push_back( { pointShadowsOn ? cand.key : 0ull,
 			cand.key == reinterpret_cast<uint64_t>( vob ) ? vob : nullptr,
-			cand.shadowRoutingStatic, cand.shadowRoutingStatic } );
+			cand.shadowRoutingStatic, cand.shadowRoutingStatic, cand.spatiallyStatic } );
 		++count;
 	}
 	m_FrameLightCount = count;
+	// Lights the per-frame buffer could not hold at all (the farthest ones, since s_cands is distance-sorted).
+	// Not the same failure as being starved of a shadow cube - these are not shaded at all - but it looks
+	// identical in game, so it is reported next to it.
+	Engine::GAPI->GetRendererState().RendererInfo.PointLightsDropped =
+		static_cast<unsigned int>( s_cands.size() - count );
 
 	// Point-light shadow selection: hand the filled buffer to the point-shadow module, which picks this
 	// frame's shadowed lights (stable per-light cube slots, static-cache + round-robin scheduling) and writes
@@ -1134,15 +1182,51 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 	// s_cands is parallel to dst[] for i < count (the fill loop walks it in order and only ever breaks).
 	constexpr float kUnshadowedStaticScale = 0.35f;        // still lights its own alcove; can't reach the next room
 	constexpr float kIndoorSeenFromOutsideScale = 0.15f;   // the worst bleed case — clamp it much harder
+
+	// The clamp is applied THROUGH a per-light eased scale rather than switched on and off. Gaining or losing a
+	// cube changes a light's radius by 3-7x, and snapping that in one frame reads as the light being switched
+	// off (or flashing on) — which is exactly what a static light does the moment it drops out of the shadow
+	// system. Easing it over ~0.3 s turns the switch into a dimmer. A light seen for the FIRST time starts at
+	// its target, so world load and every fresh room light in are unaffected.
+	constexpr float kClampEaseSeconds = 0.3f;
+	struct ClampState { float scale; UINT32 lastFrame; };
+	static std::unordered_map<uint64_t, ClampState> s_clampScale;
+	static UINT32 s_clampFrame = 0;
+	++s_clampFrame;
+	const float dt = std::clamp( Engine::GAPI->GetFrameTimeSec(), 0.0f, 0.1f );
+	const float ease = 1.0f - std::exp( -dt / kClampEaseSeconds );   // framerate-independent exponential approach
+
 	for ( UINT i = 0; i < count; ++i ) {
-		if ( dst[i].ShadowCubeIndex >= 0 ) continue;   // shadowed: correctly occluded, leave it alone
 		if ( !s_cands[i].isStatic && !s_cands[i].isIndoor ) continue;
 		// An INDOOR light with no cube, seen from outdoors, looks worst: it washes over the outside of the
 		// building it is sealed inside, and nothing can occlude it. Cut it to almost nothing.
 		const bool leakingOutdoors = s_cands[i].isIndoor && !cameraIndoors;
-		dst[i].Range *= leakingOutdoors ? kIndoorSeenFromOutsideScale : kUnshadowedStaticScale;
-		dst[i].ShadowRange = dst[i].Range;
+		const float target = dst[i].ShadowCubeIndex >= 0 ? 1.0f
+			: ( leakingOutdoors ? kIndoorSeenFromOutsideScale : kUnshadowedStaticScale );
+		// key 0 is "this light can never be shadowed" (point shadows off): its target never changes, so there
+		// is nothing to ease and no identity to ease it under. Clamp it outright, as before.
+		const uint64_t key = s_lightKeys[i].key;
+		if ( !key ) {
+			dst[i].Range *= target;
+			dst[i].ShadowRange = dst[i].Range;
+			continue;
+		}
+		const auto [it, fresh] = s_clampScale.try_emplace( key, ClampState{ target, s_clampFrame } );
+		if ( !fresh && it->second.lastFrame != s_clampFrame ) {   // once per frame, however many members share the key
+			it->second.scale += ( target - it->second.scale ) * ease;
+			it->second.lastFrame = s_clampFrame;
+		}
+		if ( it->second.scale >= 0.999f ) continue;    // fully unclamped — leave the light exactly as it was
+		dst[i].Range *= it->second.scale;
+		// ShadowRange follows Range only while the light is UNSHADOWED. It is the cube's far-plane basis, and the
+		// shader rebuilds the caster's depth from it: shrinking it under a light that HAS a cube (one easing back
+		// up after re-acquiring one) would compare against a projection the cube was never rendered with.
+		if ( dst[i].ShadowCubeIndex < 0 ) dst[i].ShadowRange = dst[i].Range;
 	}
+	// Drop lights that have been out of the buffer long enough that their eased scale is meaningless anyway;
+	// without this the map keeps every light the session has ever seen. Swept rarely — it walks the whole map.
+	if ( ( s_clampFrame % 1024 ) == 0 )
+		std::erase_if( s_clampScale, [&]( const auto& e ) { return s_clampFrame - e.second.lastFrame > 600; } );
 }
 
 
@@ -1157,7 +1241,8 @@ void D3D12GraphicsEngine::BindFrameLights( UINT srvParam, UINT countParam, UINT 
 	// every overlapping point light" for "brightest single light" to avoid overexposure).
 	const UINT limitLightIntensity = Engine::GAPI->GetRendererState().RendererSettings.LimitLightIntesity ? 1u : 0u;
 	m_CmdList->SetGraphicsRoot32BitConstant( countParam, limitLightIntensity, 2 );
-	// PointShadowLowIndex @ b*.w — the BINDLESS heap slot of the low-res static shadow-cube array. The full-res
+	// PointShadowLowIndex @ b*.w — the BINDLESS heap slot of the low-res static shadow-cube tier's FIRST page;
+	// the encoded ShadowCubeIndex carries the page, which the shader adds to this (the pages are contiguous). The full-res
 	// array is a declared t-register in each shader, but the second tier rides in this spare 4th root constant
 	// instead (SM6.6 ResourceDescriptorHeap), which is why adding it needed no root signature changes. Only ever
 	// read by a light whose ShadowCubeIndex carries kShadowTierLow, so the 0 fallback is never dereferenced.

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -1241,8 +1241,7 @@ void D3D12GraphicsEngine::BindFrameLights( UINT srvParam, UINT countParam, UINT 
 	// every overlapping point light" for "brightest single light" to avoid overexposure).
 	const UINT limitLightIntensity = Engine::GAPI->GetRendererState().RendererSettings.LimitLightIntesity ? 1u : 0u;
 	m_CmdList->SetGraphicsRoot32BitConstant( countParam, limitLightIntensity, 2 );
-	// PointShadowLowIndex @ b*.w — the BINDLESS heap slot of the low-res static shadow-cube tier's FIRST page;
-	// the encoded ShadowCubeIndex carries the page, which the shader adds to this (the pages are contiguous). The full-res
+	// PointShadowLowIndex @ b*.w — the BINDLESS heap slot of the low-res static shadow-cube array. The full-res
 	// array is a declared t-register in each shader, but the second tier rides in this spare 4th root constant
 	// instead (SM6.6 ResourceDescriptorHeap), which is why adding it needed no root signature changes. Only ever
 	// read by a light whose ShadowCubeIndex carries kShadowTierLow, so the 0 fallback is never dereferenced.

--- a/D3D11Engine/D3D12Engine/D3D12Scene.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Scene.cpp
@@ -875,6 +875,8 @@ namespace {
 		                              // brazier reads as non-static there while never being repositioned,
 		                              // which is why so many fixed room lights were competing for the
 		                              // 64-slot moving-light tier. Also gates the SPILL in SelectShadowedLights.
+		bool        isPFX;            // oCVisualFX-spawned (candle/torch/spell). Gates the world-mesh-only
+		                              // caster restriction below - see LightShadowKey::restrictToWorld.
 		bool        shadowRoutingStatic; // isStatic, UNLESS PLSC_STATIC_LIGHTS opted static lights into full
 		                              // dynamic-tier shadow treatment — see the PointlightShadowCasterFlags read below.
 		                              // Governs clustering eligibility and LightShadowKey::isStatic/lowRes.
@@ -1099,7 +1101,7 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 		// shadowOrigin/shadowRange start as the light's own and are redirected to a cluster's below; `key`
 		// likewise starts as the light's own identity.
 		s_cands.push_back( { vob, pw, range, distSq, isStatic, li->IsIndoorVob, spatiallyStatic,
-			routeStatic, pw, range, reinterpret_cast<uint64_t>( vob ) } );
+			li->IsPFXVobLight, routeStatic, pw, range, reinterpret_cast<uint64_t>( vob ) } );
 	}
 	// Drop stationary-tracking entries for lights long out of the light set. Swept rarely; walks the map.
 	if ( ( s_stationaryFrame % 1024 ) == 0 )
@@ -1153,9 +1155,14 @@ void D3D12GraphicsEngine::BuildFrameLightBuffer() {
 		// key 0 = "never give this light a cube" — what point-shadows-off means for every light. `vob` is only
 		// passed for an UNclustered light: a cluster has no single owning vob, and the field exists purely for
 		// the dynamic-overlay exclude list, which no static/clustered slot reaches.
+		// World-mesh-only casters for an un-opted-in PFX light, mirroring D3D11's AllowsDynamicCasters. Asked
+		// of the light's OWN identity only: a clustered light is routing-static, so the question never applies.
+		const bool unclustered = cand.key == reinterpret_cast<uint64_t>( vob );
+		const bool restrictToWorld = unclustered && !cand.shadowRoutingStatic && cand.isPFX
+			&& !( lightSettings.PointlightShadowCasterFlags & GothicRendererSettings::PLSC_PARTICLE_FX );
 		s_lightKeys.push_back( { pointShadowsOn ? cand.key : 0ull,
-			cand.key == reinterpret_cast<uint64_t>( vob ) ? vob : nullptr,
-			cand.shadowRoutingStatic, cand.shadowRoutingStatic, cand.spatiallyStatic } );
+			unclustered ? vob : nullptr,
+			cand.shadowRoutingStatic, cand.shadowRoutingStatic, cand.spatiallyStatic, restrictToWorld } );
 		++count;
 	}
 	m_FrameLightCount = count;

--- a/D3D11Engine/D3D12Engine/D3D12ShaderBackend.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShaderBackend.cpp
@@ -44,20 +44,20 @@ namespace {
         s_attempted = true;
 
         if ( !LoadLibraryA( "dxil.dll" ) ) {
-            LogWarn() << "D3D12: dxil.dll not found; DXIL shaders would fail validation outside "
-                          "developer mode. D3D12 shader compilation is unavailable.";
+            Logging::Err( "D3D12: dxil.dll not found; DXIL shaders would fail validation outside "
+                "developer mode. D3D12 shader compilation is unavailable." );
             return nullptr;
         }
 
         HMODULE hDxCompiler = LoadLibraryA( "dxcompiler.dll" );
         if ( !hDxCompiler ) {
-            LogWarn() << "D3D12: dxcompiler.dll not found. D3D12 shader compilation is unavailable.";
+            Logging::Err( "D3D12: dxcompiler.dll not found. D3D12 shader compilation is unavailable." );
             return nullptr;
         }
 
         s_pfn = reinterpret_cast<PFN_DXC_CREATE_INSTANCE>( GetProcAddress( hDxCompiler, "DxcCreateInstance" ) );
         if ( !s_pfn ) {
-            LogWarn() << "D3D12: dxcompiler.dll is missing the DxcCreateInstance export. D3D12 shader compilation is unavailable.";
+            Logging::Err( "D3D12: dxcompiler.dll is missing the DxcCreateInstance export. D3D12 shader compilation is unavailable." );
         }
         return s_pfn;
     }
@@ -304,7 +304,7 @@ namespace {
 
         if ( FAILED( dxcCreateInstance( kClsidDxcCompiler, IID_PPV_ARGS( compiler.GetAddressOf() ) ) ) ||
             FAILED( dxcCreateInstance( kClsidDxcUtils, IID_PPV_ARGS( dxcUtils.GetAddressOf() ) ) ) ) {
-            LogWarn() << "D3D12: Failed to create DXC compiler instances.";
+            Logging::Err( "D3D12: failed to create the DXC compiler instances." );
             return false;
         }
 
@@ -502,9 +502,9 @@ bool D3D12ShaderBackend::CompileFromFile( const std::string& fileName, const cha
 
 void D3D12ShaderBackend::LogAndResetCacheStats( const char* context ) {
     if ( g_CacheHits == 0 && g_CacheMisses == 0 ) return;
-    LogInfo() << "D3D12 shader cache (" << ( context ? context : "" ) << "): " << g_CacheHits
-        << " reused from disk, " << g_CacheMisses << " compiled."
-        << ( g_CacheHits == 0 ? " (first run for these shaders, or dxcompiler.dll changed)" : "" );
+    Logging::Inf( "D3D12 shader cache ({}): {} reused from disk, {} compiled.{}", context ? context : "",
+        g_CacheHits, g_CacheMisses,
+        g_CacheHits == 0 ? " (first run for these shaders, or dxcompiler.dll changed)" : "" );
     g_CacheHits = 0;
     g_CacheMisses = 0;
 }

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -14,6 +14,7 @@
 #include "../zCMaterial.h"
 #include "../zCTexture.h"
 #include "../zCVob.h"
+#include "../zCMorphMesh.h"
 #include "../zCWorld.h"
 #include "../zCBspTree.h"
 #include "../GSky.h"
@@ -579,7 +580,7 @@ void D3D12ShadowMap::ComputeCascadeMatrices() {
 	++m_LazyFrameCounter;
 	const bool lazyUpdate = shadowDirSettings.DebugSettings.ShadowCascades.LazyCascadeUpdate && m_CascadeMatricesValid;
 	for ( UINT c = 0; c < kShadowCascades; ++c ) m_ShouldUpdateCascade[c] = true;
-	if ( lazyUpdate && kShadowCascades > 1 )
+	if ( lazyUpdate && kShadowCascades > 1 && !m_CascadeHasAnimatedCaster[kShadowCascades - 1] )
 		m_ShouldUpdateCascade[kShadowCascades - 1] = (m_LazyFrameCounter % kLazyLastCascadeInterval) == 0;
 	m_CascadeMatricesValid = true;
 
@@ -992,6 +993,7 @@ void D3D12ShadowMap::BuildCascade( UINT cascade ) {
 	const UINT c = cascade;
 	const UINT frame = m_E->m_FrameIndex;
 	m_VobDrawCount[c] = 0;
+	m_CascadeHasAnimatedCaster[c] = false;
 	if ( !m_SunUp ) return;
 
 	// thread_local, not static: one of these exists per worker now that cascades build concurrently. Cleared
@@ -999,6 +1001,15 @@ void D3D12ShadowMap::BuildCascade( UINT cascade ) {
 	thread_local std::vector<FrameVobUpload> cascadeUploads;
 	cascadeUploads.clear();
 	if ( !m_E->UploadVobs( PassVobs[c].buckets, cascadeUploads, c ) ) return;
+	// Does this cascade hold a per-frame-deformed caster? If so it must not be lazily frozen next frame - see
+	// m_CascadeHasAnimatedCaster. Read-only on Gothic state, which is what makes it safe from a pool thread.
+	for ( const FrameVobUpload& up : cascadeUploads ) {
+		if ( !up.visual || !up.visual->MorphMeshVisual ) continue;
+		if ( reinterpret_cast<zCMorphMesh*>( up.visual->MorphMeshVisual )->GetNumAniChannels() > 0 ) {
+			m_CascadeHasAnimatedCaster[c] = true;
+			break;
+		}
+	}
 	// GPU-driven VOB casters (P2.12): build this cascade's command set from the uploads (diffuse-only
 	// material resolution — the void PSShadowClipBindless just alpha-clips), submitted as ONE
 	// ExecuteIndirect by RecordCascade. Same command signature/PSO family as the main-view VOB pass;

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.cpp
@@ -1001,8 +1001,8 @@ void D3D12ShadowMap::BuildCascade( UINT cascade ) {
 	thread_local std::vector<FrameVobUpload> cascadeUploads;
 	cascadeUploads.clear();
 	if ( !m_E->UploadVobs( PassVobs[c].buckets, cascadeUploads, c ) ) return;
-	// Does this cascade hold a per-frame-deformed caster? If so it must not be lazily frozen next frame - see
-	// m_CascadeHasAnimatedCaster. Read-only on Gothic state, which is what makes it safe from a pool thread.
+	// A per-frame-deformed caster must keep this cascade out of the lazy freeze - see
+	// m_CascadeHasAnimatedCaster. Read-only on Gothic state, so it is safe from a pool thread.
 	for ( const FrameVobUpload& up : cascadeUploads ) {
 		if ( !up.visual || !up.visual->MorphMeshVisual ) continue;
 		if ( reinterpret_cast<zCMorphMesh*>( up.visual->MorphMeshVisual )->GetNumAniChannels() > 0 ) {

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
@@ -217,12 +217,9 @@ private:
     static constexpr size_t kLazyLastCascadeInterval = 3;
     size_t m_LazyFrameCounter = 0;
     bool m_ShouldUpdateCascade[kShadowCascades] = {};   // resolved in ComputeCascadeMatrices, read everywhere else
-    // Set by BuildCascade when the cascade's caster set contains an .MMS with a live morph channel - a
-    // windmill sail, a water wheel. Such a caster's vertex buffer is re-deformed every frame, so freezing the
-    // cascade leaves its depth describing a shape the main view no longer draws (a shadow visibly detached
-    // from the mesh). Latched one frame late by design: written by the cascade's own job (nothing else touches
-    // the entry) and read here after WaitCascadeJobs, and a cascade that stays unfrozen re-evaluates it every
-    // frame, so it clears itself once the caster leaves.
+    // Set by BuildCascade when the cascade holds an .MMS with a live morph channel. Such a caster is
+    // re-deformed every frame, so freezing the cascade leaves its depth describing a shape the main view no
+    // longer draws. Latched one frame late: written by the cascade's own job, read after WaitCascadeJobs.
     bool m_CascadeHasAnimatedCaster[kShadowCascades] = {};
     bool m_CascadeMatricesValid = false;                // first frame (and after a Resize) nothing may be frozen
 

--- a/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
+++ b/D3D11Engine/D3D12Engine/D3D12ShadowMap.h
@@ -217,6 +217,13 @@ private:
     static constexpr size_t kLazyLastCascadeInterval = 3;
     size_t m_LazyFrameCounter = 0;
     bool m_ShouldUpdateCascade[kShadowCascades] = {};   // resolved in ComputeCascadeMatrices, read everywhere else
+    // Set by BuildCascade when the cascade's caster set contains an .MMS with a live morph channel - a
+    // windmill sail, a water wheel. Such a caster's vertex buffer is re-deformed every frame, so freezing the
+    // cascade leaves its depth describing a shape the main view no longer draws (a shadow visibly detached
+    // from the mesh). Latched one frame late by design: written by the cascade's own job (nothing else touches
+    // the entry) and read here after WaitCascadeJobs, and a cascade that stays unfrozen re-evaluates it every
+    // frame, so it clears itself once the caster leaves.
+    bool m_CascadeHasAnimatedCaster[kShadowCascades] = {};
     bool m_CascadeMatricesValid = false;                // first frame (and after a Resize) nothing may be frozen
 
     bool m_CullingPending = false;   // cascade jobs are in flight and must be joined before the results are read

--- a/D3D11Engine/Engine.cpp
+++ b/D3D11Engine/Engine.cpp
@@ -66,12 +66,12 @@ namespace Engine {
             } else {
                 SAFE_DELETE( GraphicsEngine );
                 
-                LogWarn() << "The Direct3D 12 backend failed to initialize. Falling back to Direct3D 11.";
+                Logging::Wrn( "The Direct3D 12 backend failed to initialize. Falling back to Direct3D 11." );
                 
                 std::string deviceDesc, reason;
                 if (!D3D12Device::IsAvailable( &deviceDesc, &reason ))
                 {
-                    LogWarn() << "Direct3D 12 was requested but is unavailable: " << reason << ". Using Direct3D 11. GPU: " << deviceDesc;
+                    Logging::Wrn( "Direct3D 12 was requested but is unavailable: {}. Using Direct3D 11. GPU: {}", reason, deviceDesc );
                 }
             }
         }
@@ -122,6 +122,9 @@ namespace Engine {
         // from DllMain(DLL_PROCESS_DETACH) under the loader lock - not a place to bet that outcome on
         // function-local statics' destructors still running cleanly. See SqliteBlobStore::CloseAll().
         SqliteBlobStore::CloseAll();
+        
+        // Drains the async log queue on this thread; never joins the worker (we are under the loader lock).
+        Logging::Shutdown();
 
         // TODO: remove this hack in the future, just a temporary workaround to fix crash on shutdown with the need to kill process via TaskManager
         // Just killing before GraphicsEngine is not enough.

--- a/D3D11Engine/GInventory.cpp
+++ b/D3D11Engine/GInventory.cpp
@@ -10,29 +10,84 @@ GInventory::~GInventory() {}
 
 /** Called when a VOB got added to the BSP-Tree or the world */
 void GInventory::OnAddVob( VobInfo* vob, zCWorld* world ) {
-    auto it = InventoryVobs.find( world );
-    if ( it != InventoryVobs.end() ) {
-        it->second.reset( vob );
-    } else {
-        InventoryVobs.emplace( world, vob );
-    }
+    StaticVobs[world].reset( vob );
+    CurrentVobs[world] = { vob, false };
+}
+
+void GInventory::OnAddVob( SkeletalVobInfo* vob, zCWorld* world ) {
+    SkeletalEntry& entry = SkeletalVobs[vob->Vob];
+    entry.Info.reset( vob );
+    entry.Visual = vob->Vob->GetVisual();
+    entry.LastUsed = ++UseCounter;
+
+    CurrentVobs[world] = { vob, true };
+    TrimSkeletalCache();
+}
+
+SkeletalVobInfo* GInventory::FindSkeletal( zCVob* vob, zCWorld* world ) {
+    auto it = SkeletalVobs.find( vob );
+    // The visual check is what makes a recycled zCVob* address safe to key on.
+    if ( it == SkeletalVobs.end() || !it->second.Info || it->second.Visual != vob->GetVisual() )
+        return nullptr;
+
+    it->second.LastUsed = ++UseCounter;
+    CurrentVobs[world] = { it->second.Info.get(), true };
+    return it->second.Info.get();
 }
 
 /** Called when a VOB got removed from the world */
 bool GInventory::OnRemovedVob( zCVob* vob, zCWorld* world ) {
-    auto it = InventoryVobs.find( world );
-    if ( it != InventoryVobs.end() ) {
-        InventoryVobs.erase( it );
-        return true;
-    }
+    auto it = CurrentVobs.find( world );
+    if ( it == CurrentVobs.end() )
+        return false;
 
-    return false;
+    // The skeletal info itself stays in the cache for the next add (see FindSkeletal); only its
+    // "this slot is showing an item" state goes away.
+    CurrentVobs.erase( it );
+    StaticVobs.erase( world );
+    return true;
+}
+
+/** Drops every entry built from this visual - Gothic frees it once we return */
+void GInventory::OnVisualDeleted( zCVisual* visual ) {
+    for ( auto it = SkeletalVobs.begin(); it != SkeletalVobs.end(); ) {
+        if ( it->second.Visual != visual ) { ++it; continue; }
+
+        for ( auto cur = CurrentVobs.begin(); cur != CurrentVobs.end(); ) {
+            cur = (cur->second.Info == it->second.Info.get()) ? CurrentVobs.erase( cur ) : std::next( cur );
+        }
+        it = SkeletalVobs.erase( it );
+    }
+}
+
+void GInventory::TrimSkeletalCache() {
+    while ( SkeletalVobs.size() > MaxCachedSkeletals ) {
+        auto oldest = SkeletalVobs.end();
+        for ( auto it = SkeletalVobs.begin(); it != SkeletalVobs.end(); ++it ) {
+            // Never evict what a slot is currently showing - CurrentVobs borrows the pointer.
+            const bool live = std::ranges::any_of( CurrentVobs,
+                [&]( const auto& cur ) { return cur.second.Info == it->second.Info.get(); } );
+            if ( live ) continue;
+
+            if ( oldest == SkeletalVobs.end() || it->second.LastUsed < oldest->second.LastUsed )
+                oldest = it;
+        }
+        if ( oldest == SkeletalVobs.end() )
+            break; // Everything in there is live
+
+        SkeletalVobs.erase( oldest );
+    }
 }
 
 /** Draws the inventory for the given world */
 void GInventory::DrawInventory( zCWorld* world, zCCamera& camera ) {
-    auto it = InventoryVobs.find( world );
-    if ( it != InventoryVobs.end() ) {
-        Engine::GraphicsEngine->DrawVobSingle( it->second.get(), camera);
+    auto it = CurrentVobs.find( world );
+    if ( it == CurrentVobs.end() || !it->second.Info )
+        return;
+
+    if ( it->second.Skeletal ) {
+        Engine::GraphicsEngine->DrawVobSingle( static_cast<SkeletalVobInfo*>(it->second.Info), camera );
+    } else {
+        Engine::GraphicsEngine->DrawVobSingle( static_cast<VobInfo*>(it->second.Info), camera );
     }
 }

--- a/D3D11Engine/GInventory.h
+++ b/D3D11Engine/GInventory.h
@@ -8,16 +8,50 @@ public:
     GInventory();
     ~GInventory();
 
-    /** Called when a VOB got added to the BSP-Tree or the world */
+    /** Called when a VOB got added to the BSP-Tree or the world. Takes ownership of the info. */
     void OnAddVob( VobInfo* vob, zCWorld* world );
+    void OnAddVob( SkeletalVobInfo* vob, zCWorld* world );
+
+    /** Returns the skeletal info already built for this vob, or null. ZenGin adds and removes the preview
+        vob once per slot per frame, and node attachments are extracted on a worker thread - rebuilding the
+        info every frame would mean they never get to finish (and would re-create their buffers every frame). */
+    SkeletalVobInfo* FindSkeletal( zCVob* vob, zCWorld* world );
 
     /** Called when a VOB got removed from the world */
     bool OnRemovedVob( zCVob* vob, zCWorld* world );
+
+    /** Drops every entry built from this visual - Gothic frees it once we return */
+    void OnVisualDeleted( zCVisual* visual );
 
     /** Draws the inventory for the given world */
     void DrawInventory( zCWorld* world, zCCamera& camera );
 
 private:
-    std::map<zCWorld*, std::unique_ptr<VobInfo>> InventoryVobs;
-};
+    /** Skeletal previews we hold on to past their removal (see FindSkeletal). Bounded, because the info
+        keeps its attachments' GPU buffers alive and address space is the scarce resource here. */
+    static constexpr size_t MaxCachedSkeletals = 64;
 
+    struct SkeletalEntry {
+        std::unique_ptr<SkeletalVobInfo> Info;
+        zCVisual* Visual = nullptr;     // what the vob had when we built this - a recycled zCVob* is not a hit
+        size_t LastUsed = 0;
+    };
+
+    struct Current {
+        BaseVobInfo* Info = nullptr;    // borrowed from StaticVobs/SkeletalVobs
+        bool Skeletal = false;
+    };
+
+    /** Drops the least recently used non-live entries until the cache is back within its bound. */
+    void TrimSkeletalCache();
+
+    /** Static (flattened) previews, rebuilt on every add - one per pseudo-world, as before. */
+    std::map<zCWorld*, std::unique_ptr<VobInfo>> StaticVobs;
+    std::map<zCVob*, SkeletalEntry> SkeletalVobs;
+
+    /** What each pseudo-world currently holds. Only set between AddVob and RemoveVobSubtree: a retained
+        skeletal entry must not be drawn into a slot that holds no item any more. */
+    std::map<zCWorld*, Current> CurrentVobs;
+
+    size_t UseCounter = 0;
+};

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -6663,6 +6663,11 @@ SkeletalVobInfo* GothicAPI::GetSkeletalVobByVob( zCVob* vob ) {
     return nullptr;
 }
 
+VobInfo* GothicAPI::GetVobByVob( zCVob* vob ) {
+    auto it = VobMap.find( vob );
+    return it != VobMap.end() ? it->second : nullptr;
+}
+
 /** Returns true if the given string can be found in the commandline */
 bool GothicAPI::HasCommandlineParameter( const std::string& param ) {
     return zCOption::GetOptions()->IsParameter( param );

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5044,6 +5044,10 @@ void GothicAPI::MoveVobFromBspToDynamic( SkeletalVobInfo* vob ) {
     parentBspNodes.clear();
 
     AnimatedSkeletalVobs.push_back( vob );
+
+    // It moves from here on, so anything that baked it as static geometry has to let go - see
+    // D3D12PointShadows' static cube cache.
+    Engine::GraphicsEngine->OnVobBecameDynamic( vob->Vob );
 }
 
 /** Moves the given vob from a BSP-Node to the dynamic vob list */
@@ -5061,6 +5065,9 @@ void GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob ) {
 
     // Add to dynamic vob list
     DynamicallyAddedVobs.push_back( vob );
+
+    // See the SkeletalVobInfo overload - it moves now, so cached static shadows holding it must be dropped.
+    Engine::GraphicsEngine->OnVobBecameDynamic( vob->Vob );
 }
 
 std::vector<LeafVobEntry>::iterator GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob, std::vector<LeafVobEntry>* source ) {
@@ -5105,6 +5112,7 @@ std::vector<LeafVobEntry>::iterator GothicAPI::MoveVobFromBspToDynamic( VobInfo*
 
     // Add to dynamic vob list
     DynamicallyAddedVobs.push_back( vob );
+    Engine::GraphicsEngine->OnVobBecameDynamic( vob->Vob );
 
     return itn;
 }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1961,6 +1961,10 @@ void GothicAPI::OnVisualDeleted( zCVisual* visual ) {
     // Attachments still holding the entry keep it alive until their "visual changed" check retires them.
     s_SharedVisualRegistry->Unregister( visual );
 
+    // An inventory preview info outlives its vob (see GInventory::OnRemovedVob), so it has to be
+    // dropped here rather than waiting for the next add to replace it.
+    Inventory->OnVisualDeleted( visual );
+
     std::vector<std::string> extv;
 
     zCClassDef* classDef = reinterpret_cast<zCObject*>(visual)->_GetClassDef();
@@ -2473,8 +2477,13 @@ void GothicAPI::OnAddVob( zCVob* vob, zCWorld* world ) {
 
             break;
         } else if ( ext == ".MDS" || ext == ".ASC" ) {
-            // Some mods use MDS/ASC models for inventory
-            if ( world != oCGame::GetGame()->_zCSession_world ) {
+            const bool isInventory = world != oCGame::GetGame()->_zCSession_world;
+
+            // Some mods use MDS/ASC models for inventory. A model without a skinned mesh is flattened
+            // into one static mesh (node attachments baked at their bind transform); one that has a
+            // skinned mesh must go through the skeletal path below, which is what the flatten drops -
+            // hence those items looking wrong in the inventory but right once dropped into the world.
+            if ( isInventory && static_cast<zCModel*>(vob->GetVisual())->GetMeshSoftSkinList()->NumInArray == 0 ) {
                 // Cast to zCProgMeshProto only to make it work with StaticMeshVisuals
                 zCProgMeshProto* pm = static_cast<zCProgMeshProto*>(vob->GetVisual());
 
@@ -2495,6 +2504,16 @@ void GothicAPI::OnAddVob( zCVob* vob, zCWorld* world ) {
                 // Must be inventory
                 Inventory->OnAddVob( vi, world );
                 break;
+            }
+
+            // ZenGin adds and removes the preview vob once per slot per frame - reuse the info we
+            // already built for it instead of dropping its (asynchronously extracted) attachments.
+            if ( isInventory ) {
+                if ( SkeletalVobInfo* known = Inventory->FindSkeletal( vob, world ) ) {
+                    VobsByVisual[vob->GetVisual()].push_back( known );
+                    XMStoreFloat4x4( &known->WorldMatrix, vob->GetWorldMatrixXM() );
+                    break;
+                }
             }
 
             // Add vob to the skeletal list
@@ -2520,6 +2539,9 @@ void GothicAPI::OnAddVob( zCVob* vob, zCWorld* world ) {
                 {
                     AnimatedSkeletalVobs.push_back( vi );
                 }
+            } else {
+                // Must be inventory
+                Inventory->OnAddVob( vi, world );
             }
             break;
         } else if ( ext == ".PFX" ) {

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1934,6 +1934,7 @@ void GothicAPI::OnVobMoved( zCVob* vob ) {
         }
 
         vi->UpdateState();
+        Engine::GraphicsEngine->OnVobMoved( vob );
         Engine::GAPI->GetRendererState().RendererInfo.FrameVobUpdates++;
     } else {
         auto sit = SkeletalVobMap.find( vob );
@@ -5065,9 +5066,8 @@ void GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob ) {
 
     // Add to dynamic vob list
     DynamicallyAddedVobs.push_back( vob );
-
-    // See the SkeletalVobInfo overload - it moves now, so cached static shadows holding it must be dropped.
-    Engine::GraphicsEngine->OnVobBecameDynamic( vob->Vob );
+    // No OnVobBecameDynamic here: the only caller is OnVobMoved, which fires OnVobMoved( vob ) right after
+    // this and covers the same ground with the transform already applied.
 }
 
 std::vector<LeafVobEntry>::iterator GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob, std::vector<LeafVobEntry>* source ) {
@@ -5112,7 +5112,6 @@ std::vector<LeafVobEntry>::iterator GothicAPI::MoveVobFromBspToDynamic( VobInfo*
 
     // Add to dynamic vob list
     DynamicallyAddedVobs.push_back( vob );
-    Engine::GraphicsEngine->OnVobBecameDynamic( vob->Vob );
 
     return itn;
 }

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -5046,8 +5046,7 @@ void GothicAPI::MoveVobFromBspToDynamic( SkeletalVobInfo* vob ) {
 
     AnimatedSkeletalVobs.push_back( vob );
 
-    // It moves from here on, so anything that baked it as static geometry has to let go - see
-    // D3D12PointShadows' static cube cache.
+    // It moves from here on, so anything that baked it as static geometry has to let go.
     Engine::GraphicsEngine->OnVobBecameDynamic( vob->Vob );
 }
 
@@ -5066,8 +5065,8 @@ void GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob ) {
 
     // Add to dynamic vob list
     DynamicallyAddedVobs.push_back( vob );
-    // No OnVobBecameDynamic here: the only caller is OnVobMoved, which fires OnVobMoved( vob ) right after
-    // this and covers the same ground with the transform already applied.
+    // No OnVobBecameDynamic here: the only caller is OnVobMoved, which fires its own hook right after this
+    // with the transform already applied.
 }
 
 std::vector<LeafVobEntry>::iterator GothicAPI::MoveVobFromBspToDynamic( VobInfo* vob, std::vector<LeafVobEntry>* source ) {

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -993,6 +993,11 @@ public:
     /** Returns if the given vob is registered in the world */
     SkeletalVobInfo* GetSkeletalVobByVob( zCVob* vob );
 
+    /** Static-mesh counterpart of the above. Also the cheapest liveness test there is for a zCVob* that was
+        stashed for later: OnRemovedVob erases the entry and deletes the VobInfo, so a hit means the vob is
+        still in the world and safe to read. */
+    VobInfo* GetVobByVob( zCVob* vob );
+
     /** Returns the frame particle info collected from all DrawParticleFX-Calls */
     std::map<zCTexture*, ParticleRenderInfo>& GetFrameParticleInfo();
 

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -993,9 +993,8 @@ public:
     /** Returns if the given vob is registered in the world */
     SkeletalVobInfo* GetSkeletalVobByVob( zCVob* vob );
 
-    /** Static-mesh counterpart of the above. Also the cheapest liveness test there is for a zCVob* that was
-        stashed for later: OnRemovedVob erases the entry and deletes the VobInfo, so a hit means the vob is
-        still in the world and safe to read. */
+    /** Static-mesh counterpart of the above. Also the cheapest liveness test for a stashed zCVob*:
+        OnRemovedVob erases the entry, so a hit means the vob is still in the world and safe to read. */
     VobInfo* GetVobByVob( zCVob* vob );
 
     /** Returns the frame particle info collected from all DrawParticleFX-Calls */

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -1468,6 +1468,35 @@ struct GothicRendererSettings {
     }
 };
 
+/** Event rate over a sliding ~1 second window. Self-sampling: the window rolls inside both Note() and
+    PerSecond(), so a metric nothing has reported in a while decays to 0 on its own without needing a
+    per-frame tick, and reading it from a debug window that is only sometimes open changes nothing. */
+class RollingSecondCounter {
+public:
+    void Note( unsigned int n = 1 ) {
+        Roll();
+        m_Count.fetch_add( n, std::memory_order_relaxed );
+    }
+
+    /** Events counted in the last completed window. */
+    unsigned int PerSecond() {
+        Roll();
+        return m_Last.load( std::memory_order_relaxed );
+    }
+
+private:
+    void Roll() {
+        const auto now = std::chrono::steady_clock::now();
+        if ( now - m_WindowStart < std::chrono::seconds( 1 ) ) return;
+        m_WindowStart = now;
+        m_Last.store( m_Count.exchange( 0, std::memory_order_relaxed ), std::memory_order_relaxed );
+    }
+
+    std::chrono::steady_clock::time_point m_WindowStart = std::chrono::steady_clock::now();
+    std::atomic<unsigned int> m_Count = 0;
+    std::atomic<unsigned int> m_Last = 0;
+};
+
 struct GothicRendererInfo {
     GothicRendererInfo() {
         VOBVerticesDataSize = 0;
@@ -1525,6 +1554,13 @@ struct GothicRendererInfo {
     float NearPlane;
     int FrameDrawnLights;
     int WorldMeshDrawCalls;
+
+    // Cached static point-light shadows dropped per second - a caster appearing, vanishing or starting to
+    // move inside a light's range, or the light itself moving. Deliberately NOT reset per frame (it owns its
+    // own window). A steady non-zero rate means point-light cubes are being re-baked continuously instead of
+    // cached, which is the expensive failure mode this cache exists to avoid; see ImGuiShim's Point Light
+    // Shadow Debug window.
+    RollingSecondCounter PointLightStaticInvalidations;
 
     unsigned int VOBVerticesDataSize;
     // Skeletal meshes can be extracted (and their SkeletalMeshInfo destroyed) from background

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -1468,18 +1468,11 @@ struct GothicRendererSettings {
     }
 };
 
-/** Event rate over a SLIDING one-second window, kept as ten 100 ms buckets that PerSecond() sums.
-    Deliberately not a single tumbling window: that only publishes a count once the second it was counting
-    in has ended, so a stat you watch while provoking the thing you are measuring reads 0 for the entire
-    time the events are happening and then reports them after the fact - which makes it look broken and,
-    worse, easy to miss. Summing the buckets (the one in progress included) surfaces an event within
-    100 ms and lets it decay out again over the following second.
+/** Event rate over a SLIDING one-second window, as ten 100 ms buckets that PerSecond() sums - a tumbling
+    window would read 0 for the whole time the events are happening and report them afterwards. The buckets
+    advance inside both Note() and PerSecond(), so nothing needs a per-frame tick.
 
-    Self-sampling: the buckets advance inside both Note() and PerSecond(), so nothing needs a per-frame
-    tick and a metric no one has reported in a while falls back to 0 on its own.
-
-    MAIN THREAD ONLY - the bucket rotation is not synchronized. Every current caller is on Gothic's own
-    thread; anything reporting from the worker pool needs its own accumulation. */
+    MAIN THREAD ONLY - the bucket rotation is not synchronized. */
 class RollingSecondCounter {
 public:
     void Note( unsigned int n = 1 ) {
@@ -1497,7 +1490,7 @@ public:
     }
 
     /** Every event since startup. Unwindowed, so it separates "nothing is happening" from "the window
-        already let it go" - which is the question a rate alone cannot answer. */
+        already let it go". */
     unsigned long long Total() const { return m_Total; }
 
 private:
@@ -1589,24 +1582,20 @@ struct GothicRendererInfo {
     int FrameDrawnLights;
     int WorldMeshDrawCalls;
 
-    // Cached static point-light shadows dropped per second - a caster appearing, vanishing or starting to
-    // move inside a light's range, or the light itself moving. Deliberately NOT reset per frame (it owns its
-    // own window). A steady non-zero rate means point-light cubes are being re-baked continuously instead of
-    // cached, which is the expensive failure mode this cache exists to avoid; see ImGuiShim's Point Light
-    // Shadow Debug window.
+    // Cached static point-light shadows dropped per second. Owns its own window, so it is not reset per
+    // frame. A steady non-zero rate means cubes are being re-baked continuously instead of cached.
     RollingSecondCounter PointLightStaticInvalidations;
 
-    // Point-light shadow-cube slot occupancy, per tier, as of the last frame's selection (D3D12 only; D3D11
-    // leaves them 0). `Starved` counts lights that wanted a cube and could not be given one because their tier
-    // was full of lights at comparable distance - the one number that separates "the tier is too small for this
-    // scene" from "something is wrong with slot assignment", which look identical from inside the game.
+    // Point-light shadow-cube slot occupancy per tier, as of the last frame's selection. `Starved` counts
+    // lights that wanted a cube and could not be given one because their tier was full at comparable
+    // distance - which is what separates "the tier is too small" from "slot assignment is broken".
     unsigned int PointLightSlotsUsed = 0;
     unsigned int PointLightSlotsMax = 0;
     unsigned int PointLightStaticSlotsUsed = 0;
     unsigned int PointLightStaticSlotsMax = 0;
     unsigned int PointLightSlotsStarved = 0;
-    // Visible point lights that did not fit in the per-frame light buffer at all (kMaxFrameLights). These are
-    // not shaded at all, not merely unshadowed - a different failure that looks the same from inside the game.
+    // Visible point lights that did not fit in the per-frame light buffer (kMaxFrameLights). Not shaded at
+    // all rather than merely unshadowed, though it looks the same in game.
     unsigned int PointLightsDropped = 0;
 
     unsigned int VOBVerticesDataSize;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -1596,6 +1596,19 @@ struct GothicRendererInfo {
     // Shadow Debug window.
     RollingSecondCounter PointLightStaticInvalidations;
 
+    // Point-light shadow-cube slot occupancy, per tier, as of the last frame's selection (D3D12 only; D3D11
+    // leaves them 0). `Starved` counts lights that wanted a cube and could not be given one because their tier
+    // was full of lights at comparable distance - the one number that separates "the tier is too small for this
+    // scene" from "something is wrong with slot assignment", which look identical from inside the game.
+    unsigned int PointLightSlotsUsed = 0;
+    unsigned int PointLightSlotsMax = 0;
+    unsigned int PointLightStaticSlotsUsed = 0;
+    unsigned int PointLightStaticSlotsMax = 0;
+    unsigned int PointLightSlotsStarved = 0;
+    // Visible point lights that did not fit in the per-frame light buffer at all (kMaxFrameLights). These are
+    // not shaded at all, not merely unshadowed - a different failure that looks the same from inside the game.
+    unsigned int PointLightsDropped = 0;
+
     unsigned int VOBVerticesDataSize;
     // Skeletal meshes can be extracted (and their SkeletalMeshInfo destroyed) from background
     // worker threads (see GothicAPI::LoadzCModelData), so this counter needs to be atomic.

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -1468,33 +1468,67 @@ struct GothicRendererSettings {
     }
 };
 
-/** Event rate over a sliding ~1 second window. Self-sampling: the window rolls inside both Note() and
-    PerSecond(), so a metric nothing has reported in a while decays to 0 on its own without needing a
-    per-frame tick, and reading it from a debug window that is only sometimes open changes nothing. */
+/** Event rate over a SLIDING one-second window, kept as ten 100 ms buckets that PerSecond() sums.
+    Deliberately not a single tumbling window: that only publishes a count once the second it was counting
+    in has ended, so a stat you watch while provoking the thing you are measuring reads 0 for the entire
+    time the events are happening and then reports them after the fact - which makes it look broken and,
+    worse, easy to miss. Summing the buckets (the one in progress included) surfaces an event within
+    100 ms and lets it decay out again over the following second.
+
+    Self-sampling: the buckets advance inside both Note() and PerSecond(), so nothing needs a per-frame
+    tick and a metric no one has reported in a while falls back to 0 on its own.
+
+    MAIN THREAD ONLY - the bucket rotation is not synchronized. Every current caller is on Gothic's own
+    thread; anything reporting from the worker pool needs its own accumulation. */
 class RollingSecondCounter {
 public:
     void Note( unsigned int n = 1 ) {
-        Roll();
-        m_Count.fetch_add( n, std::memory_order_relaxed );
+        Advance();
+        m_Buckets[m_Head] += n;
+        m_Total += n;
     }
 
-    /** Events counted in the last completed window. */
+    /** Events in the last second, including the bucket still being filled. */
     unsigned int PerSecond() {
-        Roll();
-        return m_Last.load( std::memory_order_relaxed );
+        Advance();
+        unsigned int sum = 0;
+        for ( unsigned int b : m_Buckets ) sum += b;
+        return sum;
     }
+
+    /** Every event since startup. Unwindowed, so it separates "nothing is happening" from "the window
+        already let it go" - which is the question a rate alone cannot answer. */
+    unsigned long long Total() const { return m_Total; }
 
 private:
-    void Roll() {
+    static const size_t NUM_BUCKETS = 10;
+    static const long long BUCKET_MS = 100;   // NUM_BUCKETS * BUCKET_MS = the window length
+
+    void Advance() {
         const auto now = std::chrono::steady_clock::now();
-        if ( now - m_WindowStart < std::chrono::seconds( 1 ) ) return;
-        m_WindowStart = now;
-        m_Last.store( m_Count.exchange( 0, std::memory_order_relaxed ), std::memory_order_relaxed );
+        const long long elapsed = std::chrono::duration_cast<std::chrono::milliseconds>( now - m_BucketStart ).count();
+        if ( elapsed < BUCKET_MS ) return;
+
+        const long long steps = elapsed / BUCKET_MS;
+        if ( steps >= static_cast<long long>( NUM_BUCKETS ) ) {
+            // Idle (or paused) for longer than the whole window - everything in it has expired.
+            m_Buckets.fill( 0 );
+            m_Head = 0;
+            m_BucketStart = now;
+            return;
+        }
+        // Keep the phase rather than restarting from `now`, so buckets stay on a fixed 100 ms grid.
+        m_BucketStart += std::chrono::milliseconds( BUCKET_MS * steps );
+        for ( long long i = 0; i < steps; ++i ) {
+            m_Head = ( m_Head + 1 ) % NUM_BUCKETS;
+            m_Buckets[m_Head] = 0;
+        }
     }
 
-    std::chrono::steady_clock::time_point m_WindowStart = std::chrono::steady_clock::now();
-    std::atomic<unsigned int> m_Count = 0;
-    std::atomic<unsigned int> m_Last = 0;
+    std::chrono::steady_clock::time_point m_BucketStart = std::chrono::steady_clock::now();
+    std::array<unsigned int, NUM_BUCKETS> m_Buckets = {};
+    size_t m_Head = 0;
+    unsigned long long m_Total = 0;
 };
 
 struct GothicRendererInfo {

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -663,7 +663,8 @@ struct GothicMemoryLocations {
         // { T* array; int numAlloc; int numInArray; } - the COUNT is the third dword, not the second.
         // zCArrayAdapt reads the second, which is fine for file-loaded arrays (numAlloc == numInArray)
         // but wrong here: this array grows and shrinks as anis start and finish.
-        static const unsigned int Offset_AniChannels = 0x6C;
+        // G1 lacks G2's zCMorphMesh::m_bUsesAlphaTesting at 0x68, so the array sits 4 bytes earlier here.
+        static const unsigned int Offset_AniChannels = 0x68;
         static const unsigned int ArraySort_Offset_Array = 0x00;
         static const unsigned int ArraySort_Offset_NumInArray = 0x08;
         // zTMorphAniEntry (sizeof 0x2C)

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -592,7 +592,8 @@ struct GothicMemoryLocations {
         // { T* array; int numAlloc; int numInArray; } - the COUNT is the third dword, not the second.
         // zCArrayAdapt reads the second, which is fine for file-loaded arrays (numAlloc == numInArray)
         // but wrong here: this array grows and shrinks as anis start and finish.
-        static const unsigned int Offset_AniChannels = 0x6C;
+        // G1 lacks G2's zCMorphMesh::m_bUsesAlphaTesting at 0x68, so the array sits 4 bytes earlier here.
+        static const unsigned int Offset_AniChannels = 0x68;
         static const unsigned int ArraySort_Offset_Array = 0x00;
         static const unsigned int ArraySort_Offset_NumInArray = 0x08;
         // zTMorphAniEntry (sizeof 0x2C)

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -383,7 +383,7 @@ static void DrawPointLightInvalidationStat() {
 // hard to tell apart from a bug in slot assignment.
 static void DrawPointLightSlotStat() {
     const auto& info = Engine::GAPI->GetRendererState().RendererInfo;
-    if ( info.PointLightSlotsMax == 0 ) return;   // D3D11 doesn't fill these
+    if ( info.PointLightSlotsMax == 0 ) return;   // legacy per-light cubemaps: no fixed pools to report on
     ImGui::Text( "Shadow cubes: %u/%u dynamic, %u/%u static",
         info.PointLightSlotsUsed, info.PointLightSlotsMax,
         info.PointLightStaticSlotsUsed, info.PointLightStaticSlotsMax );

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -473,6 +473,7 @@ void ImGuiShim::RenderPointLightShadowDebugWindow() {
     }
 
     DrawPointLightInvalidationStat();
+    DrawPointLightSlotStat();
     ImGui::Separator();
 
     if ( !nearest || !nearestInfo ) {

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -355,16 +355,41 @@ namespace {
     }
 }
 
+// Rate at which cached static point-light shadows are being thrown away. Shown on both backends, since the
+// number is the point: a cached cube costs nothing to keep and a full re-bake to replace, so anything but a
+// brief spike after a teleport/world change means something nearby is churning the cache every frame.
+static void DrawPointLightInvalidationStat() {
+    const unsigned int perSec = Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.PerSecond();
+    const ImVec4 color = perSec == 0 ? ImVec4( 0.6f, 0.6f, 0.6f, 1.0f )
+        : perSec < 10 ? ImVec4( 1.0f, 1.0f, 0.2f, 1.0f )
+                      : ImVec4( 1.0f, 0.3f, 0.3f, 1.0f );
+    ImGui::TextColored( color, "Static shadow invalidations: %u / s", perSec );
+    ImGui::SetItemTooltip( "Baked static point-light shadows dropped in the last one-second window, across all\n"
+        "lights: a caster appearing, vanishing or starting to move inside a light's range, the light\n"
+        "itself moving or changing shadow mode, or a shadow slot changing hands. Steady zero is the\n"
+        "healthy state - every light is reusing its cached cube. A sustained non-zero rate means those\n"
+        "cubes are being re-rendered instead, which is the exact cost the cache exists to avoid; the\n"
+        "usual culprit is a caster that keeps entering and leaving the static caster set." );
+}
+
 /** Debug-only visualization to help diagnose point-light shadow bugs (light bleed/self-occlusion) without
     guessing blind: draws every active light's range as a wireframe sphere (color-coded by shadow state) and
     shows the raw shadow-cube depth faces for whichever light is nearest the camera, unfolded as a cross. */
 void ImGuiShim::RenderPointLightShadowDebugWindow() {
-    if ( Engine::GraphicsEngine->GetBackendAPI() != EGraphicsEngineBackend::D3D11 ) {
-        return; // Point-light cube visualization only implemented for the D3D11 backend so far.
-    }
-
     auto& settings = Engine::GAPI->GetRendererState().RendererSettings;
     if ( !settings.DebugSettings.PointLightDebug.Enabled ) {
+        return;
+    }
+
+    // The cube visualization below is D3D11-only, but the invalidation rate is backend-neutral and is just as
+    // useful on D3D12 - so open the window either way and show what applies.
+    if ( Engine::GraphicsEngine->GetBackendAPI() != EGraphicsEngineBackend::D3D11 ) {
+        ImGui::SetNextWindowSize( ImVec2( 620, 120 ), ImGuiCond_FirstUseEver );
+        if ( ImGui::Begin( "Point Light Shadow Debug" ) ) {
+            DrawPointLightInvalidationStat();
+            ImGui::TextUnformatted( "Cube visualization is only implemented for the D3D11 backend." );
+        }
+        ImGui::End();
         return;
     }
 
@@ -411,6 +436,9 @@ void ImGuiShim::RenderPointLightShadowDebugWindow() {
         ImGui::End();
         return;
     }
+
+    DrawPointLightInvalidationStat();
+    ImGui::Separator();
 
     if ( !nearest || !nearestInfo ) {
         ImGui::TextUnformatted( "No point light with an allocated shadow map found nearby." );

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -359,17 +359,22 @@ namespace {
 // number is the point: a cached cube costs nothing to keep and a full re-bake to replace, so anything but a
 // brief spike after a teleport/world change means something nearby is churning the cache every frame.
 static void DrawPointLightInvalidationStat() {
-    const unsigned int perSec = Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.PerSecond();
+    auto& counter = Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations;
+    const unsigned int perSec = counter.PerSecond();
     const ImVec4 color = perSec == 0 ? ImVec4( 0.6f, 0.6f, 0.6f, 1.0f )
         : perSec < 10 ? ImVec4( 1.0f, 1.0f, 0.2f, 1.0f )
                       : ImVec4( 1.0f, 0.3f, 0.3f, 1.0f );
-    ImGui::TextColored( color, "Static shadow invalidations: %u / s", perSec );
+    // The total is shown next to the rate because the rate alone cannot distinguish "nothing is invalidating"
+    // from "it happened and the window has already let it go".
+    ImGui::TextColored( color, "Static shadow invalidations: %u / s   (%llu total)", perSec, counter.Total() );
     ImGui::SetItemTooltip( "Baked static point-light shadows dropped in the last one-second window, across all\n"
         "lights: a caster appearing, vanishing or starting to move inside a light's range, the light\n"
         "itself moving or changing shadow mode, or a shadow slot changing hands. Steady zero is the\n"
         "healthy state - every light is reusing its cached cube. A sustained non-zero rate means those\n"
         "cubes are being re-rendered instead, which is the exact cost the cache exists to avoid; the\n"
-        "usual culprit is a caster that keeps entering and leaving the static caster set." );
+        "usual culprit is a caster that keeps entering and leaving the static caster set.\n"
+        "The rate is a sliding one-second window, so it reacts within ~100ms of an event and decays\n"
+        "back to 0 over the following second; the total only ever climbs." );
 }
 
 /** Debug-only visualization to help diagnose point-light shadow bugs (light bleed/self-occlusion) without

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -355,17 +355,16 @@ namespace {
     }
 }
 
-// Rate at which cached static point-light shadows are being thrown away. Shown on both backends, since the
-// number is the point: a cached cube costs nothing to keep and a full re-bake to replace, so anything but a
-// brief spike after a teleport/world change means something nearby is churning the cache every frame.
+// Rate at which cached static point-light shadows are being thrown away: a cached cube costs nothing to keep
+// and a full re-bake to replace, so anything but a brief spike means something nearby is churning the cache.
 static void DrawPointLightInvalidationStat() {
     auto& counter = Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations;
     const unsigned int perSec = counter.PerSecond();
     const ImVec4 color = perSec == 0 ? ImVec4( 0.6f, 0.6f, 0.6f, 1.0f )
         : perSec < 10 ? ImVec4( 1.0f, 1.0f, 0.2f, 1.0f )
                       : ImVec4( 1.0f, 0.3f, 0.3f, 1.0f );
-    // The total is shown next to the rate because the rate alone cannot distinguish "nothing is invalidating"
-    // from "it happened and the window has already let it go".
+    // The total sits next to the rate because the rate alone cannot tell "nothing is invalidating" from
+    // "it happened and the window has already let it go".
     ImGui::TextColored( color, "Static shadow invalidations: %u / s   (%llu total)", perSec, counter.Total() );
     ImGui::SetItemTooltip( "Baked static point-light shadows dropped in the last one-second window, across all\n"
         "lights: a caster appearing, vanishing or starting to move inside a light's range, the light\n"
@@ -377,10 +376,8 @@ static void DrawPointLightInvalidationStat() {
         "back to 0 over the following second; the total only ever climbs." );
 }
 
-// Shadow-cube slot occupancy per tier, plus the number of lights that asked for a cube and got none. Zero
-// starved is the healthy state; a steady non-zero value means the tier is genuinely too small for the scene,
-// and the lights missing out are being range-clamped (i.e. they look switched off), which is otherwise very
-// hard to tell apart from a bug in slot assignment.
+// Shadow-cube slot occupancy per tier, plus the lights that asked for a cube and got none. Zero starved is
+// the healthy state; a steady non-zero value means the tier is genuinely too small for the scene.
 static void DrawPointLightSlotStat() {
     const auto& info = Engine::GAPI->GetRendererState().RendererInfo;
     if ( info.PointLightSlotsMax == 0 ) return;   // legacy per-light cubemaps: no fixed pools to report on
@@ -415,8 +412,8 @@ void ImGuiShim::RenderPointLightShadowDebugWindow() {
         return;
     }
 
-    // The cube visualization below is D3D11-only, but the invalidation rate is backend-neutral and is just as
-    // useful on D3D12 - so open the window either way and show what applies.
+    // The cube visualization below is D3D11-only, but the invalidation rate is backend-neutral - so open the
+    // window either way and show what applies.
     if ( Engine::GraphicsEngine->GetBackendAPI() != EGraphicsEngineBackend::D3D11 ) {
         ImGui::SetNextWindowSize( ImVec2( 620, 170 ), ImGuiCond_FirstUseEver );
         if ( ImGui::Begin( "Point Light Shadow Debug" ) ) {

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -377,6 +377,35 @@ static void DrawPointLightInvalidationStat() {
         "back to 0 over the following second; the total only ever climbs." );
 }
 
+// Shadow-cube slot occupancy per tier, plus the number of lights that asked for a cube and got none. Zero
+// starved is the healthy state; a steady non-zero value means the tier is genuinely too small for the scene,
+// and the lights missing out are being range-clamped (i.e. they look switched off), which is otherwise very
+// hard to tell apart from a bug in slot assignment.
+static void DrawPointLightSlotStat() {
+    const auto& info = Engine::GAPI->GetRendererState().RendererInfo;
+    if ( info.PointLightSlotsMax == 0 ) return;   // D3D11 doesn't fill these
+    ImGui::Text( "Shadow cubes: %u/%u dynamic, %u/%u static",
+        info.PointLightSlotsUsed, info.PointLightSlotsMax,
+        info.PointLightStaticSlotsUsed, info.PointLightStaticSlotsMax );
+    const ImVec4 color = info.PointLightSlotsStarved == 0 ? ImVec4( 0.6f, 0.6f, 0.6f, 1.0f )
+                                                         : ImVec4( 1.0f, 0.3f, 0.3f, 1.0f );
+    ImGui::TextColored( color, "Lights starved of a cube: %u", info.PointLightSlotsStarved );
+    ImGui::SetItemTooltip(
+        "Lights that wanted a shadow cube this frame and could not be given one because their tier was\n"
+        "already full of lights at a comparable distance. A starved static light is range-clamped so it\n"
+        "cannot bleed through walls, which makes it look switched off - so a sustained non-zero number\n"
+        "here is the direct explanation for lights that go dark. Slots are taken from the farthest owner\n"
+        "when a much closer light needs one, so this counts genuine oversubscription, not lights waiting." );
+    if ( info.PointLightsDropped ) {
+        ImGui::TextColored( ImVec4( 1.0f, 0.3f, 0.3f, 1.0f ),
+            "Lights dropped from the frame buffer: %u", info.PointLightsDropped );
+        ImGui::SetItemTooltip(
+            "Visible point lights that did not fit in the per-frame light buffer and are not shaded at all\n"
+            "this frame. The buffer keeps the nearest ones, so this is the far end of the light set - but\n"
+            "it is a hard cap, and raising the effects draw distance is what pushes a scene into it." );
+    }
+}
+
 /** Debug-only visualization to help diagnose point-light shadow bugs (light bleed/self-occlusion) without
     guessing blind: draws every active light's range as a wireframe sphere (color-coded by shadow state) and
     shows the raw shadow-cube depth faces for whichever light is nearest the camera, unfolded as a cross. */
@@ -389,9 +418,10 @@ void ImGuiShim::RenderPointLightShadowDebugWindow() {
     // The cube visualization below is D3D11-only, but the invalidation rate is backend-neutral and is just as
     // useful on D3D12 - so open the window either way and show what applies.
     if ( Engine::GraphicsEngine->GetBackendAPI() != EGraphicsEngineBackend::D3D11 ) {
-        ImGui::SetNextWindowSize( ImVec2( 620, 120 ), ImGuiCond_FirstUseEver );
+        ImGui::SetNextWindowSize( ImVec2( 620, 170 ), ImGuiCond_FirstUseEver );
         if ( ImGui::Begin( "Point Light Shadow Debug" ) ) {
             DrawPointLightInvalidationStat();
+            DrawPointLightSlotStat();
             ImGui::TextUnformatted( "Cube visualization is only implemented for the D3D11 backend." );
         }
         ImGui::End();

--- a/D3D11Engine/Logging.cpp
+++ b/D3D11Engine/Logging.cpp
@@ -227,10 +227,9 @@ namespace Logging {
     void Shutdown() {
         State& state = Get();
 
-        // Drains here rather than joining the worker: this runs from DllMain, where a join would
-        // deadlock on the loader lock. For the same reason every lock is a try_lock - at process
-        // teardown the worker may already have been killed holding one, and blocking the loader on an
-        // abandoned mutex would hang the game on exit. Losing the last second of records beats that.
+        // Drains here rather than joining the worker: this runs from DllMain, where a join would deadlock
+        // on the loader lock. Every lock is a try_lock for the same reason - the worker may already have
+        // been killed holding one. Losing the last second of records beats hanging the game on exit.
         std::unique_lock fileLock( state.FileMutex, std::try_to_lock );
         std::unique_lock lock( state.QueueMutex, std::try_to_lock );
         if ( !lock.owns_lock() ) return;

--- a/D3D11Engine/Logging.cpp
+++ b/D3D11Engine/Logging.cpp
@@ -1,0 +1,248 @@
+#include "pch.h"
+#include "Logging.h"
+
+#include <condition_variable>
+#include <cstdio>
+#include <mutex>
+#include <print>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace Logging {
+
+    namespace {
+
+        constexpr size_t MessageStackBytes = 1024;          // one record; longer ones take the heap fallback
+        constexpr size_t FlushThresholdBytes = 64 * 1024;   // wake the worker early once a buffer holds this much
+        constexpr size_t MaxBufferBytes = 1024 * 1024;      // hard cap per buffer; past it records are dropped and counted
+        constexpr size_t RetainedBytes = 128 * 1024;        // capacity kept across flushes; a burst's excess is given back
+        constexpr auto FlushInterval = std::chrono::seconds( 1 );
+
+        struct State {
+            std::mutex QueueMutex;
+            std::condition_variable Wake;
+
+            std::vector<char> Buffers[2];
+            int Active = 0;
+            uint32_t Dropped = 0;
+            bool Stopping = false;
+            bool FlushRequested = false;
+
+            std::mutex FileMutex; // serialises the file write: worker vs. a Shutdown() drain
+        };
+
+        /** Deliberately leaked: the worker is detached and must never touch a destroyed global
+            during CRT teardown. */
+        State& Get() {
+            static State* state = [] {
+                auto* s = new State();
+                s->Buffers[0].reserve( RetainedBytes );
+                s->Buffers[1].reserve( RetainedBytes );
+                return s;
+            }();
+            return *state;
+        }
+
+        const std::string& LogFilePath() {
+            static std::string path = [] {
+                if ( !LOGFILE.empty() ) return LOGFILE; // set by Log::Clear(); share the one Log.txt
+                std::string p;
+                p.resize( MAX_PATH );
+                p.resize( GetModuleFileNameA( nullptr, p.data(), MAX_PATH ) );
+                p.erase( p.find_last_of( '\\' ) + 1 );
+                p += "Log.txt";
+                return p;
+            }();
+            return path;
+        }
+
+        constexpr char LevelTag( Level level ) {
+            switch ( level ) {
+            case Level::Debug: return 'D';
+            case Level::Warn:  return 'W';
+            case Level::Error: return 'E';
+            default:           return 'I';
+            }
+        }
+
+        constexpr std::string_view FileName( const char* path ) {
+            std::string_view v( path );
+            if ( auto slash = v.find_last_of( "\\/" ); slash != std::string_view::npos ) v.remove_prefix( slash + 1 );
+            return v;
+        }
+
+        /** Output iterator over a fixed buffer that drops - and remembers - anything past the end. */
+        struct BoundedOutput {
+            using difference_type = std::ptrdiff_t;
+
+            char* Cursor = nullptr;
+            char* End = nullptr;
+            bool Overflowed = false;
+
+            BoundedOutput& operator*() { return *this; }
+            BoundedOutput& operator++() { return *this; }
+            // Returns a reference on purpose: a copy would make "*it++ = c" write through a temporary.
+            BoundedOutput& operator++( int ) { return *this; }
+            BoundedOutput& operator=( char c ) {
+                if ( Cursor < End ) *Cursor++ = c; else Overflowed = true;
+                return *this;
+            }
+        };
+
+        template<class Out>
+        Out EmitRecord( Out out, Level level, const std::source_location& where,
+            std::string_view fmt, std::format_args args ) {
+            SYSTEMTIME t;
+            GetLocalTime( &t );
+            out = std::format_to( out, "[{:02}:{:02}:{:02}.{:03}] {} {:<5} | ",
+                t.wHour, t.wMinute, t.wSecond, t.wMilliseconds, LevelTag( level ), GetCurrentThreadId() );
+            out = std::vformat_to( out, fmt, args );
+            if ( level >= Level::Warn ) {
+                out = std::format_to( out, "  ({}:{})", FileName( where.file_name() ), where.line() );
+            }
+            *out++ = '\n';
+            return out;
+        }
+
+        void Enqueue( State& state, const char* data, size_t size ) {
+            bool wake = false;
+            {
+                std::lock_guard lock( state.QueueMutex );
+                auto& buffer = state.Buffers[state.Active];
+                if ( buffer.size() + size > MaxBufferBytes ) {
+                    ++state.Dropped;
+                    return;
+                }
+                buffer.insert( buffer.end(), data, data + size );
+                wake = buffer.size() >= FlushThresholdBytes;
+            }
+            if ( wake ) state.Wake.notify_one();
+        }
+
+        /** Hands the active buffer over to the flusher and starts producers on the other one.
+            Returns nullptr when there is nothing to write. Caller holds QueueMutex. */
+        std::vector<char>* RetireActive( State& state, uint32_t& outDropped ) {
+            if ( state.Buffers[state.Active].empty() && state.Dropped == 0 ) return nullptr;
+            std::vector<char>* retired = &state.Buffers[state.Active];
+            state.Active ^= 1;
+            outDropped = std::exchange( state.Dropped, 0u );
+            return retired;
+        }
+
+        /** Caller holds FileMutex, which is what makes the retired buffer exclusively ours: producers
+            only ever touch Buffers[Active], and the next swap needs FileMutex too. */
+        void WriteRetired( State& state, std::vector<char>* retired, uint32_t dropped ) {
+            if ( FILE* f = fopen( LogFilePath().c_str(), "a" ) ) {
+                if ( dropped ) std::print( f, "[logging] dropped {} message(s): in-memory queue full\n", dropped );
+                // The bulk is already formatted; fwrite it instead of letting std::print copy a megabyte.
+                if ( !retired->empty() ) fwrite( retired->data(), 1, retired->size(), f );
+                fclose( f );
+            }
+
+            retired->clear();
+            if ( retired->capacity() > RetainedBytes ) {
+                retired->shrink_to_fit();
+                retired->reserve( RetainedBytes );
+            }
+        }
+
+        void FlushOnce( State& state ) {
+            std::lock_guard fileLock( state.FileMutex );
+
+            std::vector<char>* retired = nullptr;
+            uint32_t dropped = 0;
+            {
+                std::lock_guard lock( state.QueueMutex );
+                retired = RetireActive( state, dropped );
+            }
+            if ( retired ) WriteRetired( state, retired, dropped );
+        }
+
+        void WorkerMain( State& state ) {
+            for ( ;; ) {
+                {
+                    std::unique_lock lock( state.QueueMutex );
+                    state.Wake.wait_for( lock, FlushInterval, [&state] {
+                        return state.Stopping || state.FlushRequested
+                            || state.Buffers[state.Active].size() >= FlushThresholdBytes;
+                    } );
+                    state.FlushRequested = false;
+                    if ( state.Stopping ) return;
+                }
+                FlushOnce( state );
+            }
+        }
+
+        /** Started from the first record. std::thread's constructor doesn't wait on the new thread,
+            so this stays safe under the loader lock - the worker just idles until DllMain returns. */
+        void EnsureWorker( State& state ) {
+            static std::once_flag once;
+            std::call_once( once, [&state] { std::thread( WorkerMain, std::ref( state ) ).detach(); } );
+        }
+
+    } // namespace
+
+    namespace Detail {
+#if PUBLIC_RELEASE
+        std::atomic<Level> MinLevel = Level::Info;
+#else
+        std::atomic<Level> MinLevel = Level::Debug;
+#endif
+
+        void Write( Level level, const std::source_location& where, std::string_view fmt, std::format_args args ) {
+            char stack[MessageStackBytes];
+            BoundedOutput out{ stack, stack + sizeof( stack ) };
+            out = EmitRecord( out, level, where, fmt, args );
+
+            State& state = Get();
+            EnsureWorker( state );
+
+            if ( !out.Overflowed ) {
+                Enqueue( state, stack, static_cast<size_t>( out.Cursor - stack ) );
+                return;
+            }
+
+            // Rare: the record outgrew the stack buffer, so build it once on the heap.
+            std::string big;
+            big.reserve( MessageStackBytes * 2 );
+            EmitRecord( std::back_inserter( big ), level, where, fmt, args );
+            Enqueue( state, big.data(), big.size() );
+        }
+    }
+
+    void SetMinLevel( Level level ) noexcept {
+        Detail::MinLevel.store( level, std::memory_order_relaxed );
+    }
+
+    void Flush() {
+        State& state = Get();
+        {
+            std::lock_guard lock( state.QueueMutex );
+            state.FlushRequested = true;
+        }
+        state.Wake.notify_one();
+    }
+
+    void Shutdown() {
+        State& state = Get();
+
+        // Drains here rather than joining the worker: this runs from DllMain, where a join would
+        // deadlock on the loader lock. For the same reason every lock is a try_lock - at process
+        // teardown the worker may already have been killed holding one, and blocking the loader on an
+        // abandoned mutex would hang the game on exit. Losing the last second of records beats that.
+        std::unique_lock fileLock( state.FileMutex, std::try_to_lock );
+        std::unique_lock lock( state.QueueMutex, std::try_to_lock );
+        if ( !lock.owns_lock() ) return;
+
+        state.Stopping = true;
+        std::vector<char>* retired = nullptr;
+        uint32_t dropped = 0;
+        if ( fileLock.owns_lock() ) retired = RetireActive( state, dropped );
+        lock.unlock();
+
+        state.Wake.notify_all();
+        if ( retired ) WriteRetired( state, retired, dropped );
+    }
+
+} // namespace Logging

--- a/D3D11Engine/Logging.h
+++ b/D3D11Engine/Logging.h
@@ -1,0 +1,78 @@
+#pragma once
+
+/** Asynchronous logging. Callers only format into a stack buffer and memcpy the bytes into a
+    double-buffered in-memory queue; a background worker swaps the queue and writes it to Log.txt
+    once a second, or earlier once enough bytes piled up. */
+
+#include <atomic>
+#include <concepts>
+#include <cstdint>
+#include <format>
+#include <source_location>
+#include <string_view>
+#include <type_traits>
+
+namespace Logging {
+
+    enum class Level : uint8_t { Debug = 0, Info, Warn, Error, Off };
+
+    namespace Detail {
+        extern std::atomic<Level> MinLevel;
+
+        /** Carries the call site alongside the format string, so I/D/W/E can stay variadic
+            function templates instead of macros. */
+        template<class... Args>
+        struct FormatSite {
+            std::format_string<Args...> Fmt;
+            std::source_location Where;
+
+            template<class T> requires std::convertible_to<const T&, std::string_view>
+            consteval FormatSite( const T& fmt, std::source_location where = std::source_location::current() )
+                : Fmt( fmt ), Where( where ) {}
+        };
+
+        /** Type-erased sink. Defined in Logging.cpp so <format>'s codegen isn't duplicated per call site. */
+        void Write( Level level, const std::source_location& where, std::string_view fmt, std::format_args args );
+    }
+
+    template<class... Args>
+    using Site = Detail::FormatSite<std::type_identity_t<Args>...>;
+
+    [[nodiscard]] inline bool IsEnabled( Level level ) noexcept {
+        return level >= Detail::MinLevel.load( std::memory_order_relaxed );
+    }
+
+    /** Messages below this are discarded before they are formatted. */
+    void SetMinLevel( Level level ) noexcept;
+
+    /** Asks the worker to write out what is queued; returns without waiting for it. */
+    void Flush();
+
+    /** Final synchronous drain. Safe to call from DllMain: it never waits on the worker thread. */
+    void Shutdown();
+
+    template<class... Args>
+    void Dbg( Site<Args...> site, Args&&... args ) {
+        if ( !IsEnabled( Level::Debug ) ) return;
+        Detail::Write( Level::Debug, site.Where, site.Fmt.get(), std::make_format_args( args... ) );
+    }
+
+    template<class... Args>
+    void Inf( Site<Args...> site, Args&&... args ) {
+        if ( !IsEnabled( Level::Info ) ) return;
+        Detail::Write( Level::Info, site.Where, site.Fmt.get(), std::make_format_args( args... ) );
+    }
+
+    template<class... Args>
+    void Wrn( Site<Args...> site, Args&&... args ) {
+        if ( !IsEnabled( Level::Warn ) ) return;
+        Detail::Write( Level::Warn, site.Where, site.Fmt.get(), std::make_format_args( args... ) );
+    }
+
+    template<class... Args>
+    void Err( Site<Args...> site, Args&&... args ) {
+        if ( !IsEnabled( Level::Error ) ) return;
+        Detail::Write( Level::Error, site.Where, site.Fmt.get(), std::make_format_args( args... ) );
+    }
+
+} // namespace Logging

--- a/D3D11Engine/PointLightSlotSelector.cpp
+++ b/D3D11Engine/PointLightSlotSelector.cpp
@@ -30,9 +30,18 @@ int PointLightSlotSelector::FindSlotOf( uint64_t key ) const {
 }
 
 
+int PointLightSlotSelector::FindFallbackSlotOf( uint64_t key ) const {
+    if ( !key ) return -1;
+    const auto it = m_FallbackByKey.find( key );
+    return it == m_FallbackByKey.end() ? -1 : static_cast<int>( it->second );
+}
+
+
 void PointLightSlotSelector::ReleaseSlot( uint32_t slot ) {
     if ( slot >= m_Slots.size() ) return;
-    if ( m_Slots[slot].ownerKey ) m_SlotByKey.erase( m_Slots[slot].ownerKey );
+    // A fallback slot's key belongs to the slot it is handing over TO; only its own side of the pair goes.
+    if ( m_Slots[slot].handoverFallback ) m_FallbackByKey.erase( m_Slots[slot].ownerKey );
+    else if ( m_Slots[slot].ownerKey ) m_SlotByKey.erase( m_Slots[slot].ownerKey );
     m_Slots[slot] = Slot{};
 }
 
@@ -41,6 +50,7 @@ void PointLightSlotSelector::ReleaseAllSlots() {
     for ( Slot& ss : m_Slots )
         if ( ss.ownerKey ) ss = Slot{};
     m_SlotByKey.clear();
+    m_FallbackByKey.clear();
     m_Assignments.clear();
     m_EncodedByKey.clear();
 }
@@ -203,9 +213,15 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
     // top of every Select anyway, so a desync could only ever last one frame. Without it the incumbency, ageing
     // and "does this winner already own a slot" lookups each walked all slots per light - fine at 192 slots, but
     // the static tier runs into the hundreds and that product is a per-frame O(slots*lights) scan.
+    // A slot mid-handover is excluded: its key belongs to the NEW slot, and the old one is only a fallback to
+    // sample from meanwhile.
     m_SlotByKey.clear();
-    for ( uint32_t s = 0; s < maxSlots; ++s )
-        if ( m_Slots[s].ownerKey ) m_SlotByKey.emplace( m_Slots[s].ownerKey, s );
+    m_FallbackByKey.clear();
+    for ( uint32_t s = 0; s < maxSlots; ++s ) {
+        if ( !m_Slots[s].ownerKey ) continue;
+        if ( m_Slots[s].handoverFallback ) m_FallbackByKey.emplace( m_Slots[s].ownerKey, s );
+        else m_SlotByKey.emplace( m_Slots[s].ownerKey, s );
+    }
     // Every ownership key the frame's light set carries, winner or not. Slot ageing keys off THIS, not off the
     // winner set: a light that is on screen and being shaded still wants the cube it already paid for, even on
     // frames it is too far away to compete for a new one.
@@ -284,12 +300,31 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
     for ( uint32_t s = 0; s < maxSlots; ++s ) {
         Slot& ss = m_Slots[s];
         if ( !ss.ownerKey ) continue;
+        if ( ss.handoverFallback ) continue;   // bounded by the handover loop below, and not in m_SlotByKey
         if ( m_FrameKeys.contains( ss.ownerKey ) ) { ss.missingFrames = 0; continue; }
         if ( ++ss.missingFrames > m_Cfg.RetentionFrames ) {
             // Retention expired - the cached depth goes with the slot. Counted like any other invalidation, so
             // slot churn shows up in the stat too.
             if ( ss.staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
             m_SlotByKey.erase( ss.ownerKey );
+            ss = Slot{};
+        }
+    }
+
+    // Retire tier handovers whose new slot has arrived. Changing tier means a new, empty cube, and the bake that
+    // fills it lands a frame or more later (the low tier is budgeted, and D3D11 renders through its own queue).
+    // Dropping the old cube at the moment of the switch left the light unshadowed until then - which the caller's
+    // range clamp shows as the light easing off and its shadow disappearing, on a light that never stopped
+    // deserving one. So the old slot lives on until the new one demonstrably holds this owner's depth.
+    for ( uint32_t s = 0; s < maxSlots; ++s ) {
+        Slot& ss = m_Slots[s];
+        if ( !ss.handoverFallback ) continue;
+        const Slot& tgt = m_Slots[ss.handoverTarget];
+        // Target baked (the switch is complete), or it was taken off us again, or the wait ran out of patience.
+        const bool done = tgt.ownerKey != ss.ownerKey || tgt.staticPresent
+            || ++ss.handoverFrames > m_Cfg.HandoverMaxFrames;
+        if ( done ) {
+            m_FallbackByKey.erase( ss.ownerKey );
             ss = Slot{};
         }
     }
@@ -316,15 +351,30 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
         // close as this light, i.e. genuine oversubscription rather than arrival order.
         auto pickSlot = [&]( uint32_t b, uint32_t e ) -> int {
             for ( uint32_t s = b; s < e; ++s ) if ( !m_Slots[s].ownerKey ) return static_cast<int>( s );
+            // Longest-absent owner - but only one that has been gone long enough to have stopped being about
+            // to come back, and only in favour of a light that is genuinely CLOSER than it. Both conditions
+            // are what stops a camera pan from strip-mining the pool. A light leaves the frustum the instant
+            // you turn past it, so with no grace EVERY occupied slot is a donor on EVERY frame, the distance
+            // rule below never runs at all, and turning in a circle hands each light's cube to whatever came
+            // into view next - however far away. Every light you then turn back to has lost its bake and has
+            // to fade in from the unshadowed range clamp, which is what the whole stable-ownership design
+            // exists to prevent.
             int best = -1;
-            uint32_t worst = 0;
-            for ( uint32_t s = b; s < e; ++s )
-                if ( m_Slots[s].missingFrames > worst ) { worst = m_Slots[s].missingFrames; best = static_cast<int>( s ); }
+            uint32_t worst = m_Cfg.SlotStealGraceFrames;
+            for ( uint32_t s = b; s < e; ++s ) {
+                const Slot& os = m_Slots[s];
+                if ( os.handoverFallback ) continue;         // someone is mid-switch and sampling this right now
+                if ( os.missingFrames <= worst ) continue;   // free (0), or not absent long enough yet
+                const XMVECTOR od = XMVectorSubtract( XMLoadFloat3( &os.pos ), camPos );
+                if ( XMVectorGetX( XMVector3LengthSq( od ) ) <= c.distSq ) continue;   // nearer than us: leave it be
+                worst = os.missingFrames;
+                best = static_cast<int>( s );
+            }
             if ( best >= 0 ) return best;
             float bar = c.distSq * m_Cfg.EvictDistanceRatio;
             for ( uint32_t s = b; s < e; ++s ) {
                 const Slot& os = m_Slots[s];
-                if ( !os.ownerKey ) continue;
+                if ( !os.ownerKey || os.handoverFallback ) continue;
                 const XMVECTOR d = XMVectorSubtract( XMLoadFloat3( &os.pos ), camPos );
                 const float dsq = XMVectorGetX( XMVector3LengthSq( d ) );
                 if ( dsq > bar ) { bar = dsq; best = static_cast<int>( s ); }
@@ -342,26 +392,47 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
             const bool ownedLow = IsLowSlot( owned );
             // 1. It STARTED MOVING. That tier bakes a cube once and caches it forever, and never runs the
             //    dynamic overlay, so a mover cannot stay in it.
-            bool handBack = ownedLow && !c.spatiallyStatic;
             // 2. It now ranks into the full-res tier (the trim left c.lowRes false) AND would get a dynamic
             //    overlay there. Without this a light that spilled while far away stayed in the cached tier for
             //    good: walk right up to it under UPDATE DYNAMIC and it still drew static-only shadows, because
-            //    ownership alone kept it there. Promotion is attempted only when a full-res slot can ACTUALLY
-            //    be had - giving up the cube it holds for nothing would leave it unshadowed, and unshadowed is
-            //    what the range clamp turns into a light that looks switched off.
-            if ( !handBack && ownedLow && !c.lowRes && wantsOverlay ) {
+            //    ownership alone kept it there.
+            const bool leaveLow = ownedLow && ( !c.spatiallyStatic || ( !c.lowRes && wantsOverlay ) );
+            // Either way the full-res slot is taken FIRST and the low one is only then handed over. A switch
+            // that gives up the cube it holds before it has a replacement leaves the light unshadowed, and
+            // unshadowed is what the range clamp turns into a light that looks switched off - so when the
+            // full-res tier has nothing to give, the light simply stays where it is and asks again next frame.
+            slot = static_cast<int>( owned );
+            if ( leaveLow ) {
                 const int hi = pickSlot( 0, maxHi );
-                if ( hi >= 0 ) { handBack = true; slot = hi; }
-            }
-            if ( handBack ) {
-                if ( m_Slots[owned].staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
-                m_Slots[owned] = Slot{};
-                m_SlotByKey.erase( c.key );
-            } else {
-                slot = static_cast<int>( owned );
+                if ( hi >= 0 ) {
+                    slot = hi;
+                    // Not released: it keeps this light's baked depth, and keeps being what the shader samples
+                    // until `hi` has been baked too. See the handover retirement above.
+                    Slot& old = m_Slots[owned];
+                    old.handoverFallback = old.staticPresent;
+                    old.handoverTarget = static_cast<uint32_t>( hi );
+                    old.handoverFrames = 0;
+                    if ( old.handoverFallback ) {
+                        m_FallbackByKey[c.key] = owned;
+                    } else {
+                        // Nothing worth keeping in it - it never held this owner's depth in the first place.
+                        if ( old.staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+                        old = Slot{};
+                    }
+                    m_SlotByKey.erase( c.key );
+                }
             }
         }
         if ( slot < 0 ) slot = pickSlot( poolBegin, poolEnd );
+        // SPILL, second half. The trim above cuts the full-res tier at a RANK - it admits maxHi candidates and
+        // spills only what ranks past that - but ranking into the tier is not the same as there being a slot in
+        // it. Ownership is stable and eviction demands a real distance margin, so an admitted newcomer routinely
+        // finds nothing free and nothing takeable. It used to starve there, with the low tier sitting almost
+        // empty: hundreds of free static slots and dozens of lights waiting indefinitely for a full-res one that
+        // was never going to come free. Availability is only knowable here, so the same spill rule is applied
+        // again now that it is - a tiny cached cube beats no cube, and everything downstream already follows the
+        // slot actually held rather than the tier asked for.
+        if ( slot < 0 && !c.lowRes && c.spatiallyStatic ) slot = pickSlot( maxHi, maxSlots );
         if ( slot < 0 ) { ++m_StarvedThisFrame; continue; }
         if ( m_Slots[slot].ownerKey != c.key ) {
             if ( m_Slots[slot].staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
@@ -423,7 +494,24 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
         // staticPresent, not just staticValid: a slot that was invalidated by a world change still holds this
         // owner's depth and stays sampleable until the re-render lands. Only a FRESH slot (holding the previous
         // occupant's depth) is withheld.
-        if ( ss.staticValid || ss.staticPresent || renderStatic ) {
+        // A handover in flight advertises the OLD cube instead: it holds this owner's depth right now, where the
+        // new slot only will once its bake lands. Gated on the light still standing where that cube was baked
+        // from - the shader looks a cube up from the light's CURRENT origin - which is why this covers a
+        // promotion (the light did not move, only its tier did) but declines to help a light that left the low
+        // tier because it started moving. That one has no valid cached cube anywhere by definition.
+        const auto fbIt = m_FallbackByKey.find( c.key );
+        const bool useFallback = fbIt != m_FallbackByKey.end() && !ss.staticPresent
+            && std::fabs( np.x - m_Slots[fbIt->second].pos.x ) <= m_Cfg.MoveEps
+            && std::fabs( np.y - m_Slots[fbIt->second].pos.y ) <= m_Cfg.MoveEps
+            && std::fabs( np.z - m_Slots[fbIt->second].pos.z ) <= m_Cfg.MoveEps
+            && std::fabs( src.shadowRange - m_Slots[fbIt->second].range ) <= m_Cfg.RangeEps;
+        if ( useFallback ) {
+            // Its own tier, and never the has-dynamic bit: nothing refreshed an overlay into a slot the light
+            // is on its way out of.
+            m_EncodedByKey[c.key] = IsLowSlot( fbIt->second )
+                ? static_cast<int32_t>( LowIndex( fbIt->second ) ) | m_Cfg.TierLowBit
+                : static_cast<int32_t>( fbIt->second );
+        } else if ( ss.staticValid || ss.staticPresent || renderStatic ) {
             // What the shader sees is the TIER-ENCODED index (local slot | tier bit), not the global slot. The
             // has-dynamic bit additionally tells the lit pass to sample the dynamic-overlay array for this light
             // and min it with the static one. Only full-res slots can carry it (the low tier has no dynamic

--- a/D3D11Engine/PointLightSlotSelector.cpp
+++ b/D3D11Engine/PointLightSlotSelector.cpp
@@ -91,8 +91,7 @@ bool PointLightSlotSelector::IsNpcAttached( const zCVob* vob ) {
 
 void PointLightSlotSelector::QueueVobChangedInvalidation( zCVob* vob ) {
     if ( !vob || !m_HaveCachedStatic ) return;
-    // A falling or thrown vob reports several transform changes per frame; they would all resolve to the same
-    // answer, so only the first is kept. Scanning is fine - the list holds one frame of world changes.
+    // A falling vob reports several transform changes per frame, all resolving to the same answer.
     if ( std::ranges::contains( m_PendingVobChanges, vob ) ) return;
     m_PendingVobChanges.push_back( vob );
 }
@@ -106,22 +105,20 @@ void PointLightSlotSelector::DrainPendingVobChanges() {
         // OnRemovedVob erases the entry (and deletes the VobInfo), so a hit means the vob is still alive.
         VobInfo* vi = Engine::GAPI->GetVobByVob( vob );
         if ( !vi || !vi->Vob || !vi->VisualInfo ) continue;
-        // Riding an NPC rather than lying on the ground: it animates, so it is never baked and must not
-        // invalidate anything. This is the read that is unreliable at report time - see the header.
+        // Animates, so it is never baked - and this is the read that is unreliable at report time.
         if ( IsNpcAttached( vi->Vob ) ) continue;
-        // Below the movement threshold this is jitter, not a move. The stored reference is only advanced when
-        // an invalidation actually happens, so repeated sub-eps steps still add up to one.
+        // Below the threshold this is jitter. The reference only advances on an actual invalidation, so
+        // repeated sub-eps steps still add up to one.
         const XMFLOAT3 pos = vi->Vob->GetPositionWorld();
         if ( auto posIt = m_LastInvalidationPos.find( vi->Vob ); posIt != m_LastInvalidationPos.end() ) {
             const float dx = pos.x - posIt->second.x, dy = pos.y - posIt->second.y, dz = pos.z - posIt->second.z;
             if ( dx * dx + dy * dy + dz * dz < m_Cfg.VobMoveEpsSq ) continue;
         }
-        // Two halves, and a move needs both: every cube that baked it is now showing a shadow where the vob
-        // no longer is, and every cube reaching where it is NOW is missing it. A fresh add matches nothing in
-        // the first half, a vob that moved within one light's reach matches in both.
+        // A move needs both halves: cubes that baked it show a shadow where it no longer is, and cubes
+        // reaching where it is now are missing it.
         InvalidateStaticForVobRemoved( vi->Vob );
         InvalidateStaticForVobAdded( pos, vi->VisualInfo->MeshSize * 0.5f );
-        // After the removal half, which drops this vob's entry along with the caster records it matched.
+        // After the removal half, which drops this vob's entry.
         m_LastInvalidationPos.insert_or_assign( vi->Vob, pos );
     }
     m_DrainScratch.clear();
@@ -129,17 +126,15 @@ void PointLightSlotSelector::DrainPendingVobChanges() {
 
 
 void PointLightSlotSelector::InvalidateStaticForVobAdded( const XMFLOAT3& posWS, float extent ) {
-    // A VOB added after a nearby point light already cached its static shadow cube would otherwise cast no
-    // point-light shadow: the static cube is only re-rendered when the light is fresh / moved / resized, not when
-    // world geometry around it changes. Walk the active slots and invalidate any whose light range the new VOB
-    // reaches. Slots are empty during world load (ownerKey==0) so this is a no-op then; the margin mirrors the
-    // static-VOB gather's cull (range + visual->MeshSize * 0.5f).
+    // A cached static cube is only re-rendered when its light is fresh / moved / resized, never when the
+    // geometry around it changes - so a new VOB in range has to say so. The margin mirrors the static-VOB
+    // gather's cull (range + visual->MeshSize * 0.5f).
     for ( Slot& ss : m_Slots ) {
         if ( !ss.ownerKey || !ss.staticValid ) continue;
         const float r = ss.range + extent;
         const float dx = posWS.x - ss.pos.x, dy = posWS.y - ss.pos.y, dz = posWS.z - ss.pos.z;
         if ( dx * dx + dy * dy + dz * dz < r * r ) {
-            ss.staticValid = false;   // re-render this slot's static depth next frame to include the new VOB
+            ss.staticValid = false;
             Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
         }
     }
@@ -147,19 +142,17 @@ void PointLightSlotSelector::InvalidateStaticForVobAdded( const XMFLOAT3& posWS,
 
 
 void PointLightSlotSelector::InvalidateStaticForVobRemoved( const zCVob* vob ) {
-    // Symmetric to the add case: a VOB removed from the world (an item picked up, a container emptied) must
-    // stop casting into any light's cached static cube. Matched against the exact caster set the bake gathered,
-    // by POINTER - the vob is being torn down, so its bbox and position can no longer be read, and identity is
-    // the only thing left that is still meaningful. Nothing was baked => nothing to invalidate, which is what
-    // keeps an NPC's throwaway held item (never baked, see IsNpcAttached) from re-rendering every cube nearby.
+    // Symmetric to the add case, but matched by POINTER against what each bake actually gathered: the vob is
+    // being torn down, so its bbox and position can no longer be read. Never baked => nothing to invalidate,
+    // which is what keeps an NPC's throwaway held item from re-rendering every cube nearby.
     if ( !vob ) return;
-    // It may still be parked for a deferred resolve - drop it, the drain must never look it up.
+    // It may still be parked for a deferred resolve - the drain must never look it up.
     std::erase( m_PendingVobChanges, const_cast<zCVob*>( vob ) );
     m_LastInvalidationPos.erase( vob );   // the address may be reused by a different vob later
     for ( Slot& ss : m_Slots ) {
         if ( !ss.ownerKey || !ss.staticValid || ss.bakedVobs.empty() ) continue;
         if ( std::ranges::contains( ss.bakedVobs, vob ) ) {
-            ss.staticValid = false;   // this slot's cube holds the removed vob - re-cache without it
+            ss.staticValid = false;
             Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
         }
     }
@@ -168,19 +161,12 @@ void PointLightSlotSelector::InvalidateStaticForVobRemoved( const zCVob* vob ) {
 
 void PointLightSlotSelector::Select( std::span<const Candidate> cands,
     GothicRendererSettings::EPointLightShadowMode shadowMode, bool resourcesReady ) {
-    // Before anything decides renderStatic below: apply the world changes that were parked last frame, so a
-    // vob added or moved since then lands in this frame's re-bake rather than the next one.
+    // Before anything decides renderStatic below, so a vob parked last frame lands in this frame's re-bake.
     DrainPendingVobChanges();
 
-    // Pick the closest-to-camera in-range lights (up to the tier budget) as this frame's "winners", but assign
-    // each winner a STABLE slot keyed by its light identity (kept across frames, not reassigned by proximity
-    // every frame). A slot's rendered content persists in the cube array, so a STATIC winner whose light didn't
-    // move can reuse its cached cube (renderStatic=false) instead of re-culling + re-rendering all world/VOB/
-    // skeletal casters each frame. Dynamic (moving) lights, newly-assigned slots, and moved/range-changed
-    // lights render.
-    //
-    // The global PointlightShadows setting (ini [Shadows] PointlightShadows / the ImGui combo) gates the whole
-    // thing:
+    // The closest in-range lights (up to the tier budget) win, but each gets a STABLE slot keyed by light
+    // identity, so a static winner that didn't move reuses its cached cube (renderStatic=false) instead of
+    // re-culling and re-rendering every caster. The global PointlightShadows setting gates the whole thing:
     //   PLS_DISABLED       - no winners at all; every index stays -1 and the pass never arms.
     //   PLS_STATIC_ONLY    - winners get their static cube but never a dynamic overlay.
     //   PLS_UPDATE_DYNAMIC - overlay for the near winners + a round-robin budget for the rest.
@@ -189,13 +175,11 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
     m_EncodedByKey.clear();
     m_StarvedThisFrame = 0;
     if ( shadowMode == GothicRendererSettings::PLS_DISABLED ) {
-        // Release every slot so re-enabling mid-session re-renders from scratch instead of sampling depth that
-        // has been stale for however long the setting was off.
+        // Re-enabling mid-session must re-render from scratch, not sample however stale depth is left.
         ReleaseAllSlots();
         return;
     }
-    // NOT gated on cands being non-empty: with zero visible lights every slot's owner is absent, and the
-    // retention/eviction bookkeeping below still has to tick for them.
+    // NOT gated on cands being non-empty: retention/eviction still has to tick with zero visible lights.
     if ( !resourcesReady || m_Slots.empty() ) return;
 
     const uint32_t maxHi = m_Cfg.MaxHiSlots;
@@ -203,18 +187,13 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
     const uint32_t count = static_cast<uint32_t>( cands.size() );
 
     const XMVECTOR camPos = Engine::GAPI->GetCameraPositionXM();
-    // One candidate per distinct ownership KEY, not per light: a cluster of co-located static lights shares a
-    // key (and a shadowOrigin/shadowRange), so it competes for - and wins - exactly ONE cube between all its
-    // members. `srcIdx` is just the first member found; the write-back at the end fans the result out to all.
+    // One candidate per ownership KEY, not per light: a cluster shares a key and wins one cube between all
+    // its members. `srcIdx` is the first member found; the write-back at the end fans the result out.
     m_Cands.clear();
     m_CandByKey.clear();
-    // key -> slot, for every OCCUPIED slot. It is what FindSlotOf answers from, so it outlives this call and is
-    // maintained by hand wherever a slot changes hands (here and in ReleaseSlot). Rebuilt from the table at the
-    // top of every Select anyway, so a desync could only ever last one frame. Without it the incumbency, ageing
-    // and "does this winner already own a slot" lookups each walked all slots per light - fine at 192 slots, but
-    // the static tier runs into the hundreds and that product is a per-frame O(slots*lights) scan.
-    // A slot mid-handover is excluded: its key belongs to the NEW slot, and the old one is only a fallback to
-    // sample from meanwhile.
+    // key -> slot for every occupied slot; rebuilt here, then maintained by hand wherever a slot changes
+    // hands. Without it the incumbency/ageing lookups are a per-frame O(slots*lights) scan. A slot
+    // mid-handover goes in m_FallbackByKey instead: its key belongs to the NEW slot.
     m_SlotByKey.clear();
     m_FallbackByKey.clear();
     for ( uint32_t s = 0; s < maxSlots; ++s ) {
@@ -222,9 +201,8 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
         if ( m_Slots[s].handoverFallback ) m_FallbackByKey.emplace( m_Slots[s].ownerKey, s );
         else m_SlotByKey.emplace( m_Slots[s].ownerKey, s );
     }
-    // Every ownership key the frame's light set carries, winner or not. Slot ageing keys off THIS, not off the
-    // winner set: a light that is on screen and being shaded still wants the cube it already paid for, even on
-    // frames it is too far away to compete for a new one.
+    // Every key the frame's light set carries, winner or not. Ageing keys off THIS: a light being shaded
+    // still wants the cube it paid for, even on frames it is too far to compete for a new one.
     m_FrameKeys.clear();
     for ( uint32_t i = 0; i < count; ++i ) {
         const Candidate& c = cands[i];
@@ -236,22 +214,14 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
         if ( range <= 0.0f ) continue;
         XMVECTOR d = XMVectorSubtract( XMLoadFloat3( &c.shadowOrigin ), camPos );
         const float distSq = XMVectorGetX( XMVector3LengthSq( d ) );
-        // D3D11's historical distMaxShadowSq is range*9, which for a CANDLE (range ~150 units) puts the horizon
-        // at ~13 m - and a light that falls off this list is shaded unshadowed, which the caller then range-
-        // clamps to 0.35x/0.15x. The lit patch around the candle collapses and the light reads as switched OFF,
-        // at a distance where it is still plainly visible. The horizon has to be about where the light stops
-        // being *seen*, not where its own falloff sphere stops reaching the camera, so it gets an absolute
-        // floor as well. The low tier can afford one: its cubes are tiny, rendered once and cached forever.
+        // range*9 alone puts a candle's horizon at ~13 m, and a light off this list is shaded unshadowed,
+        // which the caller's range clamp then reads as switched OFF while it is still plainly visible. Hence
+        // the absolute floor; the low tier can afford it, its cubes are tiny and cached forever.
         const float maxDist = std::max( range * 9.0f, m_Cfg.MinShadowDist );
         if ( distSq >= maxDist * maxDist ) continue;
-        // Ranked on RAW distance. This used to discount an incumbent's distance before ranking, as hysteresis
-        // against a newcomer bumping an established light out on a marginal difference - but the ranking is also
-        // what the per-tier TRIM cuts at, so with more candidate keys than slots the discount let far-away
-        // incumbents outrank a light right in front of the camera and push it off the list entirely. Since a
-        // light that is off the list cannot take a slot back (eviction only ever considered ABSENT owners), that
-        // was permanent: the candle stayed unshadowed, hence range-clamped, hence dark, until something flushed
-        // the light set. Nearest-first here; the hysteresis now lives where it belongs, in the eviction rule
-        // below, which demands a newcomer be substantially closer than the owner it takes a slot from.
+        // Ranked on RAW distance, with no incumbency discount: the trim below cuts at this ranking, so a
+        // discount let distant incumbents push a light in front of the camera off the list for good. The
+        // hysteresis lives in the eviction rule instead.
         m_CandByKey.emplace( c.key, static_cast<uint32_t>( m_Cands.size() ) );
         m_Cands.push_back( { i, c.key, c.owner, distSq, c.isStatic, c.preferLow, c.spatiallyStatic,
             c.restrictToWorld } );
@@ -261,66 +231,54 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
         return a.key < b.key;   // total order: equal distances must not permute between frames
         } );
 
-    // Trim PER TIER: the two pools are independent budgets, so a room full of static clusters can never crowd a
-    // dynamic torch out of the full-res pool (and vice versa). Nearest-first within each tier; the losers simply
-    // go unshadowed here - the caller has already range-clamped the statics so they cannot bleed far.
+    // Trim PER TIER, so a room full of static clusters can never crowd a dynamic torch out of the full-res
+    // pool. Nearest-first within each tier; the losers go unshadowed.
     {
         uint32_t keptHi = 0, keptLow = 0;
         size_t out = 0;
         for ( size_t idx = 0; idx < m_Cands.size(); ++idx ) {
             Cand& c = m_Cands[idx];
             if ( !c.lowRes ) {
-                // SPILL. A light whose preferred tier is full does not go dark while the other tier sits empty:
-                // if it never moves, its cube is cacheable, and a tiny cached cube is enormously better than no
-                // cube at all (no cube means the range clamp, which reads as the light being switched off).
+                // SPILL: a light that never moves has a cacheable cube, and a tiny cached cube beats no cube
+                // at all (no cube means the range clamp, which reads as the light being switched off).
                 if ( keptHi >= maxHi && c.spatiallyStatic ) c.lowRes = true;
             }
             uint32_t& kept = c.lowRes ? keptLow : keptHi;
             const uint32_t budget = c.lowRes ? m_Cfg.MaxLowSlots : maxHi;
-            if ( kept >= budget ) { ++m_StarvedThisFrame; continue; }   // more candidate keys than either tier holds
+            if ( kept >= budget ) { ++m_StarvedThisFrame; continue; }
             ++kept;
             m_Cands[out++] = c;
         }
         m_Cands.resize( out );
-        // m_CandByKey stood for "already has a candidate" during the build above; from here on it is the winner
-        // set, which the ageing loop below tests every occupied slot against.
+        // m_CandByKey meant "already has a candidate" above; from here on it is the winner set.
         m_CandByKey.clear();
         for ( size_t idx = 0; idx < m_Cands.size(); ++idx )
             m_CandByKey.emplace( m_Cands[idx].key, static_cast<uint32_t>( idx ) );
     }
 
-    // Age slots whose owner is not in this frame's light set at all - but do NOT release them. That set is
-    // frustum-culled upstream, so a light drops out merely because the camera turned away; its cached static
-    // depth is still valid and is exactly what should be reused the moment it comes back. Releasing on absence
-    // made every frustum blink a fresh occupant, i.e. a full static re-cull + re-render of the world sections
-    // and VOB instances around that light. Slots are surrendered only under real pressure (below) or once the
-    // absence outlives RetentionFrames.
-    // Presence, NOT winning: a light past the candidacy horizon keeps being SHADED every frame, so it keeps
-    // sampling the cube it owns (see the cached-cube publish below) and must not have it aged out from under it.
+    // Age slots whose owner is absent from the light set, but do NOT release them: that set is frustum-culled
+    // upstream, so releasing on absence made every camera pan a fresh occupant and a full static re-render.
+    // Presence, not winning - a light past the candidacy horizon still samples the cube it owns.
     for ( uint32_t s = 0; s < maxSlots; ++s ) {
         Slot& ss = m_Slots[s];
         if ( !ss.ownerKey ) continue;
-        if ( ss.handoverFallback ) continue;   // bounded by the handover loop below, and not in m_SlotByKey
+        if ( ss.handoverFallback ) continue;   // bounded by the handover loop below
         if ( m_FrameKeys.contains( ss.ownerKey ) ) { ss.missingFrames = 0; continue; }
         if ( ++ss.missingFrames > m_Cfg.RetentionFrames ) {
-            // Retention expired - the cached depth goes with the slot. Counted like any other invalidation, so
-            // slot churn shows up in the stat too.
+            // Counted like any other invalidation, so slot churn shows up in the stat too.
             if ( ss.staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
             m_SlotByKey.erase( ss.ownerKey );
             ss = Slot{};
         }
     }
 
-    // Retire tier handovers whose new slot has arrived. Changing tier means a new, empty cube, and the bake that
-    // fills it lands a frame or more later (the low tier is budgeted, and D3D11 renders through its own queue).
-    // Dropping the old cube at the moment of the switch left the light unshadowed until then - which the caller's
-    // range clamp shows as the light easing off and its shadow disappearing, on a light that never stopped
-    // deserving one. So the old slot lives on until the new one demonstrably holds this owner's depth.
+    // Retire tier handovers whose new slot has arrived. The bake that fills a new cube lands a frame or more
+    // later, and dropping the old one at the moment of the switch left the light range-clamped until then.
     for ( uint32_t s = 0; s < maxSlots; ++s ) {
         Slot& ss = m_Slots[s];
         if ( !ss.handoverFallback ) continue;
         const Slot& tgt = m_Slots[ss.handoverTarget];
-        // Target baked (the switch is complete), or it was taken off us again, or the wait ran out of patience.
+        // Target baked, taken off us again, or the wait ran out of patience.
         const bool done = tgt.ownerKey != ss.ownerKey || tgt.staticPresent
             || ++ss.handoverFrames > m_Cfg.HandoverMaxFrames;
         if ( done ) {
@@ -338,32 +296,24 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
         const uint32_t poolBegin = c.lowRes ? maxHi : 0u;
         const uint32_t poolEnd = c.lowRes ? maxSlots : maxHi;
 
-        // Would this light actually USE the full-res tier? Only one that receives the per-frame skeletal overlay
-        // there has anything to gain from it. Computed before slot assignment because it is what decides whether
-        // a light sitting in the low-res tier gets promoted back out of it.
+        // Would this light actually USE the full-res tier? Only the per-frame overlay makes it worth anything,
+        // and this is what decides whether a light in the low-res tier is promoted back out of it.
         const bool wantsOverlay = !c.isStatic && !c.restrictToWorld
             && shadowMode >= GothicRendererSettings::PLS_UPDATE_DYNAMIC;
 
-        // Pick a slot in [b,e): a free one; else the longest-absent owner (an absent light's cache is worth
-        // keeping, but not at the cost of a light on screen now); else the FARTHEST present owner, and only if
-        // this candidate is substantially closer than it - EvictDistanceRatio is the anti-oscillation margin, so
-        // two lights at similar distances can never trade a slot back and forth. -1 when every owner is about as
-        // close as this light, i.e. genuine oversubscription rather than arrival order.
+        // Pick a slot in [b,e): a free one, else the longest-absent owner, else the farthest present owner and
+        // only if this candidate beats it by EvictDistanceRatio - the anti-oscillation margin. -1 when every
+        // owner is about as close as this light, i.e. genuine oversubscription.
         auto pickSlot = [&]( uint32_t b, uint32_t e ) -> int {
             for ( uint32_t s = b; s < e; ++s ) if ( !m_Slots[s].ownerKey ) return static_cast<int>( s );
-            // Longest-absent owner - but only one that has been gone long enough to have stopped being about
-            // to come back, and only in favour of a light that is genuinely CLOSER than it. Both conditions
-            // are what stops a camera pan from strip-mining the pool. A light leaves the frustum the instant
-            // you turn past it, so with no grace EVERY occupied slot is a donor on EVERY frame, the distance
-            // rule below never runs at all, and turning in a circle hands each light's cube to whatever came
-            // into view next - however far away. Every light you then turn back to has lost its bake and has
-            // to fade in from the unshadowed range clamp, which is what the whole stable-ownership design
-            // exists to prevent.
+            // Both the grace period and the distance test are what stop a camera pan from strip-mining the
+            // pool: a light leaves the frustum the instant you turn past it, so without them every occupied
+            // slot is a donor on every frame and turning in a circle loses every bake.
             int best = -1;
             uint32_t worst = m_Cfg.SlotStealGraceFrames;
             for ( uint32_t s = b; s < e; ++s ) {
                 const Slot& os = m_Slots[s];
-                if ( os.handoverFallback ) continue;         // someone is mid-switch and sampling this right now
+                if ( os.handoverFallback ) continue;         // mid-switch, and being sampled right now
                 if ( os.missingFrames <= worst ) continue;   // free (0), or not absent long enough yet
                 const XMVECTOR od = XMVectorSubtract( XMLoadFloat3( &os.pos ), camPos );
                 if ( XMVectorGetX( XMVector3LengthSq( od ) ) <= c.distSq ) continue;   // nearer than us: leave it be
@@ -383,31 +333,25 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
             };
 
         int slot = -1;
-        // A light keeps whatever slot it already owns, in EITHER tier. Tier preference decides where a light
-        // LOOKS for a slot, not where it is allowed to keep one: re-homing a spilled light the moment pressure
-        // eased would make it ping-pong between tiers, and every flip is a fresh cube render. Two things do
-        // force a low-res holder out, both of them one-directional:
+        // A light keeps whatever slot it owns, in either tier: tier preference decides where it LOOKS for a
+        // slot, not where it may keep one, or a spilled light would ping-pong (and re-render) on every flip.
+        // Two things force a low-res holder out, both one-directional:
         if ( auto it = m_SlotByKey.find( c.key ); it != m_SlotByKey.end() ) {
             const uint32_t owned = it->second;
             const bool ownedLow = IsLowSlot( owned );
             // 1. It STARTED MOVING. That tier bakes a cube once and caches it forever, and never runs the
             //    dynamic overlay, so a mover cannot stay in it.
-            // 2. It now ranks into the full-res tier (the trim left c.lowRes false) AND would get a dynamic
-            //    overlay there. Without this a light that spilled while far away stayed in the cached tier for
-            //    good: walk right up to it under UPDATE DYNAMIC and it still drew static-only shadows, because
-            //    ownership alone kept it there.
+            // 2. It now ranks into the full-res tier AND would get an overlay there - without this, a light
+            //    that spilled while far away stayed static-only however close you walked up to it.
             const bool leaveLow = ownedLow && ( !c.spatiallyStatic || ( !c.lowRes && wantsOverlay ) );
-            // Either way the full-res slot is taken FIRST and the low one is only then handed over. A switch
-            // that gives up the cube it holds before it has a replacement leaves the light unshadowed, and
-            // unshadowed is what the range clamp turns into a light that looks switched off - so when the
-            // full-res tier has nothing to give, the light simply stays where it is and asks again next frame.
+            // The full-res slot is taken FIRST and the low one only then handed over: giving up a cube before
+            // there is a replacement range-clamps the light. With nothing to give it stays put and asks again.
             slot = static_cast<int>( owned );
             if ( leaveLow ) {
                 const int hi = pickSlot( 0, maxHi );
                 if ( hi >= 0 ) {
                     slot = hi;
-                    // Not released: it keeps this light's baked depth, and keeps being what the shader samples
-                    // until `hi` has been baked too. See the handover retirement above.
+                    // Not released: it keeps this light's depth and stays sampled until `hi` is baked too.
                     Slot& old = m_Slots[owned];
                     old.handoverFallback = old.staticPresent;
                     old.handoverTarget = static_cast<uint32_t>( hi );
@@ -415,7 +359,7 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
                     if ( old.handoverFallback ) {
                         m_FallbackByKey[c.key] = owned;
                     } else {
-                        // Nothing worth keeping in it - it never held this owner's depth in the first place.
+                        // It never held this owner's depth, so there is nothing to hand over.
                         if ( old.staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
                         old = Slot{};
                     }
@@ -424,14 +368,9 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
             }
         }
         if ( slot < 0 ) slot = pickSlot( poolBegin, poolEnd );
-        // SPILL, second half. The trim above cuts the full-res tier at a RANK - it admits maxHi candidates and
-        // spills only what ranks past that - but ranking into the tier is not the same as there being a slot in
-        // it. Ownership is stable and eviction demands a real distance margin, so an admitted newcomer routinely
-        // finds nothing free and nothing takeable. It used to starve there, with the low tier sitting almost
-        // empty: hundreds of free static slots and dozens of lights waiting indefinitely for a full-res one that
-        // was never going to come free. Availability is only knowable here, so the same spill rule is applied
-        // again now that it is - a tiny cached cube beats no cube, and everything downstream already follows the
-        // slot actually held rather than the tier asked for.
+        // SPILL, second half. The trim above cuts at a RANK, but ranking into the tier is not the same as
+        // finding a slot in it - with stable ownership an admitted newcomer routinely finds nothing takeable
+        // and would starve while the low tier sits empty. Availability is only knowable here.
         if ( slot < 0 && !c.lowRes && c.spatiallyStatic ) slot = pickSlot( maxHi, maxSlots );
         if ( slot < 0 ) { ++m_StarvedThisFrame; continue; }
         if ( m_Slots[slot].ownerKey != c.key ) {
@@ -440,65 +379,48 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
             m_SlotByKey[c.key] = static_cast<uint32_t>( slot );
             m_Slots[slot] = Slot{};
             m_Slots[slot].ownerKey = c.key;
-            m_Slots[slot].owner = c.owner;        // nullptr for a cluster - see the Slot::owner comment
-            m_Slots[slot].staticValid = false;    // fresh occupant -> must render static (the slot changed hands)
-            // Stamp the intended cube origin NOW, not when the static render finally happens: an acquisition
-            // whose render the per-frame budget defers would otherwise sit at pos {0,0,0}, read as infinitely
-            // far to the eviction scan above, and be taken straight back off the light that just got it.
+            m_Slots[slot].owner = c.owner;        // nullptr for a cluster
+            m_Slots[slot].staticValid = false;    // fresh occupant -> must render static
+            // Stamped now, not when the render happens: a budget-deferred acquisition would otherwise sit at
+            // {0,0,0}, read as infinitely far to the eviction scan, and be taken straight back off the light.
             m_Slots[slot].pos = cands[c.srcIdx].shadowOrigin;
             m_Slots[slot].range = cands[c.srcIdx].shadowRange;
         }
         Slot& ss = m_Slots[slot];
         ss.isStatic = c.isStatic;
-        // Everything below follows the slot this light ACTUALLY holds, not the tier it asked for - a spilled
-        // light sits in the low-res array and must be encoded, budgeted and overlay-gated as such.
+        // Everything below follows the slot actually held, not the tier asked for.
         const bool slotLow = IsLowSlot( static_cast<uint32_t>( slot ) );
 
-        // Can this slot EVER receive the skeletal overlay? Static lights never do, and neither does anything
-        // below PLS_UPDATE_DYNAMIC. `!slotLow` is load-bearing, not belt-and-braces: the low-res array has no
-        // dynamic twin, so a low slot becoming overlay-eligible would point the overlay pass at a target that
-        // does not exist for it. Since the SPILL, a non-static light can end up in that tier too - it gives up
-        // its overlay in exchange for a cube.
+        // `!slotLow` is load-bearing: the low-res array has no dynamic twin, so an eligible low slot would
+        // point the overlay pass at a target that does not exist. A spilled light gives its overlay up.
         const bool overlayEligible = wantsOverlay && !slotLow;
-        // An ineligible slot must not keep advertising a stale overlay: drop the bit so the lit pass stops
-        // sampling the dynamic array for it the moment the setting (or the light's IsStatic) changes.
+        // An ineligible slot must not keep advertising a stale overlay.
         if ( !overlayEligible ) ss.dynamicValid = false;
 
         const Candidate& src = cands[c.srcIdx];
-        // Move/resize detection tracks the CUBE, not the light: a clustered light wandering inside its cluster
-        // does not move the shared cube, and must not invalidate its cached static depth.
+        // Move/resize detection tracks the CUBE, not the light: a clustered light wandering inside its
+        // cluster does not move the shared cube.
         const XMFLOAT3& np = src.shadowOrigin;
         const bool moved = std::fabs( np.x - ss.pos.x ) > m_Cfg.MoveEps
             || std::fabs( np.y - ss.pos.y ) > m_Cfg.MoveEps
             || std::fabs( np.z - ss.pos.z ) > m_Cfg.MoveEps;
         const bool rangeChanged = std::fabs( src.shadowRange - ss.range ) > m_Cfg.RangeEps;
-        // The static cube is re-rendered only when fresh / the light moved / the range changed; otherwise reused.
         bool renderStatic = !ss.staticValid || moved || rangeChanged;
 
-        // Amortize LOW-TIER static renders across frames. A static cube is rendered once and then cached forever,
-        // but "once" still costs a full world-section cull plus its draws - and acquisitions arrive in BURSTS
-        // (world load, a teleport, rounding a corner into a lit district), which without a budget means up to
-        // MaxLowSlots full static renders in a single frame and a very visible hitch. Nearest-first, because
-        // m_Cands is already sorted by distance. The dynamic tier is deliberately NOT budgeted: it holds few
-        // lights, they are the ones the player is looking at.
+        // Amortize LOW-TIER static renders: acquisitions arrive in bursts (world load, a teleport, rounding a
+        // corner), and a cube costs a full cull plus draws even though it is only rendered once. Nearest-first,
+        // m_Cands already being sorted. The dynamic tier is deliberately un-budgeted - it holds few lights.
         if ( renderStatic && slotLow ) {
             if ( lowStaticBudget == 0 ) renderStatic = false;   // deferred; staticValid stays false so it retries
             else --lowStaticBudget;
         }
 
-        // Publish the cube index ONLY once the slot actually holds this owner's depth - either it was already
-        // cached, or it is being rendered this very frame (the cube pass runs before the lit pass). A fresh slot
-        // whose render got deferred by the budget above must NOT be sampled yet: it still holds the previous
-        // occupant's depth, which would read as a wrong shadow. Leaving it -1 makes the light unshadowed for a
-        // few frames instead, and the caller's range clamp keeps it from bleeding meanwhile.
-        // staticPresent, not just staticValid: a slot that was invalidated by a world change still holds this
-        // owner's depth and stays sampleable until the re-render lands. Only a FRESH slot (holding the previous
-        // occupant's depth) is withheld.
-        // A handover in flight advertises the OLD cube instead: it holds this owner's depth right now, where the
-        // new slot only will once its bake lands. Gated on the light still standing where that cube was baked
-        // from - the shader looks a cube up from the light's CURRENT origin - which is why this covers a
-        // promotion (the light did not move, only its tier did) but declines to help a light that left the low
-        // tier because it started moving. That one has no valid cached cube anywhere by definition.
+        // Publish the cube index only once the slot holds this owner's depth: a fresh slot whose render the
+        // budget deferred still holds the PREVIOUS occupant's, which reads as a wrong shadow. staticPresent,
+        // not staticValid - a slot invalidated by a world change is merely stale, and stale beats unshadowed.
+        // A handover in flight advertises the OLD cube, which holds that depth right now. Gated on the light
+        // still standing where it was baked from, since the shader looks a cube up from the current origin -
+        // so this covers a promotion but not a light that left the low tier because it started moving.
         const auto fbIt = m_FallbackByKey.find( c.key );
         const bool useFallback = fbIt != m_FallbackByKey.end() && !ss.staticPresent
             && std::fabs( np.x - m_Slots[fbIt->second].pos.x ) <= m_Cfg.MoveEps
@@ -506,46 +428,34 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
             && std::fabs( np.z - m_Slots[fbIt->second].pos.z ) <= m_Cfg.MoveEps
             && std::fabs( src.shadowRange - m_Slots[fbIt->second].range ) <= m_Cfg.RangeEps;
         if ( useFallback ) {
-            // Its own tier, and never the has-dynamic bit: nothing refreshed an overlay into a slot the light
-            // is on its way out of.
+            // Never the has-dynamic bit: nothing refreshed an overlay into a slot being left behind.
             m_EncodedByKey[c.key] = IsLowSlot( fbIt->second )
                 ? static_cast<int32_t>( LowIndex( fbIt->second ) ) | m_Cfg.TierLowBit
                 : static_cast<int32_t>( fbIt->second );
         } else if ( ss.staticValid || ss.staticPresent || renderStatic ) {
-            // What the shader sees is the TIER-ENCODED index (local slot | tier bit), not the global slot. The
-            // has-dynamic bit additionally tells the lit pass to sample the dynamic-overlay array for this light
-            // and min it with the static one. Only full-res slots can carry it (the low tier has no dynamic
-            // twin), and it reflects the last SUBMITTED overlay - see Slot::dynamicValid on the one-frame lag.
+            // Tier-encoded (local slot | tier bit), not the global slot. The has-dynamic bit tells the lit
+            // pass to also sample the overlay array; only full-res slots can carry it.
             m_EncodedByKey[c.key] = slotLow
                 ? static_cast<int32_t>( LowIndex( static_cast<uint32_t>( slot ) ) ) | m_Cfg.TierLowBit
                 : ( static_cast<int32_t>( slot ) | ( ss.dynamicValid ? m_Cfg.HasDynamicBit : 0 ) );
         }
         m_Assignments.push_back( { np, src.shadowRange, static_cast<uint32_t>( slot ), c.key, c.owner,
             slotLow, renderStatic, false, overlayEligible, c.restrictToWorld } );
-        if ( renderStatic ) { ss.pos = np; ss.range = src.shadowRange; }   // staticValid stamped once actually drawn
+        if ( renderStatic ) { ss.pos = np; ss.range = src.shadowRange; }   // staticValid stamped once drawn
     }
 
     // ---- Non-winners that STILL OWN a valid cube keep sampling it -------------------------------------------
-    // Winning is about who may SPEND slots and render passes this frame; it is not what makes a cube sampleable.
-    // A static light that fell off the candidate list (past the horizon above, or beaten to the last free slot)
-    // used to drop to index -1 while its own depth sat there in a slot it still owns, cached and resting - and
-    // going unshadowed is what triggers the caller's range clamp, i.e. the light visibly switching off.
-    // Publishing the cube it already owns costs nothing: no re-render, no barrier, no entry in the assignments,
-    // just one shadow sample the light was worth anyway.
-    //
-    // BOTH tiers, but only while the light still sits where the cube was rendered from: a cube is valid for the
-    // ORIGIN it was baked at, and the shader looks it up from the light's CURRENT origin, so a light that moved
-    // away from its bake would sample a cube centred somewhere else. That check is what makes this safe for the
-    // full-res tier too, whose lights can move. What a full-res non-winner does NOT get is the has-dynamic bit:
-    // nothing refreshed its skeletal overlay this frame, and a stale one would leave an NPC's shadow standing
-    // where the NPC no longer is. Its static depth is still exactly right.
+    // Winning decides who may spend slots and render passes, not what is sampleable: a light that fell off the
+    // candidate list still owns cached depth, and dropping it to -1 range-clamps the light for free.
+    // Both tiers, but only while the light still sits where the cube was baked from, since the shader looks it
+    // up from the current origin. No has-dynamic bit - nothing refreshed the overlay this frame.
     for ( uint32_t i = 0; i < count; ++i ) {
         const uint64_t key = cands[i].key;
         if ( !key || m_EncodedByKey.contains( key ) ) continue;
         const auto it = m_SlotByKey.find( key );
         if ( it == m_SlotByKey.end() ) continue;
         const Slot& ss = m_Slots[it->second];
-        if ( !ss.staticPresent ) continue;   // slot holds no depth for this owner yet
+        if ( !ss.staticPresent ) continue;
         const XMFLOAT3& np = cands[i].shadowOrigin;
         if ( std::fabs( np.x - ss.pos.x ) > m_Cfg.MoveEps || std::fabs( np.y - ss.pos.y ) > m_Cfg.MoveEps
             || std::fabs( np.z - ss.pos.z ) > m_Cfg.MoveEps
@@ -556,8 +466,7 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
             : static_cast<int32_t>( it->second );
     }
 
-    // Occupancy + starvation, for the ImGui point-light window. Counted here rather than derived later:
-    // m_StarvedThisFrame is only knowable inside the trim and assignment loops.
+    // Occupancy + starvation for the ImGui point-light window; m_StarvedThisFrame is only knowable here.
     {
         auto& info = Engine::GAPI->GetRendererState().RendererInfo;
         unsigned int usedHi = 0, usedLow = 0;
@@ -570,21 +479,16 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
         info.PointLightSlotsStarved = m_StarvedThisFrame;
     }
 
-    // Round-robin the per-frame skeletal DYNAMIC overlay across overlay-eligible winners. With many persisted
-    // lights, running the full sphere-cull-against-registered-skeletal-vobs pass for every single winner every
-    // frame would multiply CPU cost with light count. The nearest AlwaysDynamicCount winners (where a moving
-    // caster's shadow lag would be most visible) always get it; the rest take turns via a stale-frames counter
-    // so every dynamic light's overlay still refreshes periodically instead of never. Static geometry shadows
-    // are unaffected - those persist via the static cache regardless. Skipped wholesale below
-    // PLS_UPDATE_DYNAMIC (nothing is eligible), and un-budgeted at PLS_FULL.
+    // Round-robin the skeletal overlay across eligible winners: the full sphere cull for every winner every
+    // frame would multiply CPU cost with light count. The nearest AlwaysDynamicCount always get it, the rest
+    // take turns by stale-frames count. Un-budgeted at PLS_FULL, skipped entirely below UPDATE_DYNAMIC.
     if ( shadowMode < GothicRendererSettings::PLS_UPDATE_DYNAMIC ) return;
 
     m_Eligible.clear();
     for ( Assignment& ps : m_Assignments ) if ( ps.overlayEligible ) m_Eligible.push_back( &ps );
 
     if ( shadowMode >= GothicRendererSettings::PLS_FULL ) {
-        // "Very expensive. Don't use unless you encounter visual bugs." - every eligible winner overlays every
-        // frame, no distance ranking and no budget.
+        // "Very expensive. Don't use unless you encounter visual bugs." - no ranking and no budget.
         for ( Assignment* ps : m_Eligible ) {
             ps->renderDynamic = true;
             m_Slots[ps->slot].dynamicStaleFrames = 0;
@@ -614,11 +518,8 @@ void PointLightSlotSelector::Select( std::span<const Candidate> cands,
         }
     }
 
-    // An ELIGIBLE slot whose STATIC base is (re)rendered this frame must also refresh its dynamic overlay,
-    // round-robin turn or not: the overlay was resolved against the OLD static depth, which is invalid once the
-    // static geometry/position changes. Not forcing this would either ghost stale skeletal shadows onto a new
-    // depth base, or silently drop the overlay for a light that's actually due for a refresh. Ineligible slots
-    // have no overlay to reconcile.
+    // A slot whose static base is re-rendered must refresh its overlay too, turn or not: the overlay was
+    // resolved against the old depth, so keeping it ghosts stale skeletal shadows onto the new base.
     for ( Assignment& ps : m_Assignments ) {
         if ( ps.overlayEligible && ps.renderStatic && !ps.renderDynamic ) {
             ps.renderDynamic = true;

--- a/D3D11Engine/PointLightSlotSelector.cpp
+++ b/D3D11Engine/PointLightSlotSelector.cpp
@@ -1,0 +1,540 @@
+#include "pch.h"
+#include "PointLightSlotSelector.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "Engine.h"
+#include "GothicAPI.h"
+#include "zCVob.h"
+
+using namespace DirectX;
+
+
+void PointLightSlotSelector::Configure( const Config& cfg ) {
+    const size_t total = static_cast<size_t>( cfg.MaxHiSlots ) + cfg.MaxLowSlots;
+    const bool resized = m_Slots.size() != total || m_Cfg.MaxHiSlots != cfg.MaxHiSlots;
+    m_Cfg = cfg;
+    if ( resized ) {
+        m_Slots.clear();
+        m_Slots.resize( total );
+        m_SlotByKey.clear();
+    }
+}
+
+
+int PointLightSlotSelector::FindSlotOf( uint64_t key ) const {
+    if ( !key ) return -1;
+    const auto it = m_SlotByKey.find( key );
+    return it == m_SlotByKey.end() ? -1 : static_cast<int>( it->second );
+}
+
+
+void PointLightSlotSelector::ReleaseSlot( uint32_t slot ) {
+    if ( slot >= m_Slots.size() ) return;
+    if ( m_Slots[slot].ownerKey ) m_SlotByKey.erase( m_Slots[slot].ownerKey );
+    m_Slots[slot] = Slot{};
+}
+
+
+void PointLightSlotSelector::ReleaseAllSlots() {
+    for ( Slot& ss : m_Slots )
+        if ( ss.ownerKey ) ss = Slot{};
+    m_SlotByKey.clear();
+    m_Assignments.clear();
+    m_EncodedByKey.clear();
+}
+
+
+int32_t PointLightSlotSelector::GetEncodedIndex( uint64_t key ) const {
+    if ( !key ) return -1;
+    const auto it = m_EncodedByKey.find( key );
+    return it == m_EncodedByKey.end() ? -1 : it->second;
+}
+
+
+void PointLightSlotSelector::CommitStatic( uint32_t slot ) {
+    if ( slot >= m_Slots.size() ) return;
+    Slot& ss = m_Slots[slot];
+    if ( !ss.ownerKey ) return;   // slot released since the render was resolved - nothing to validate
+    ss.staticValid = true;
+    ss.staticPresent = true;
+    m_HaveCachedStatic = true;
+}
+
+
+void PointLightSlotSelector::CommitDynamic( uint32_t slot, bool has ) {
+    if ( slot >= m_Slots.size() ) return;
+    Slot& ss = m_Slots[slot];
+    if ( !ss.ownerKey ) return;
+    ss.dynamicValid = has;
+}
+
+
+bool PointLightSlotSelector::IsNpcAttached( const zCVob* vob ) {
+    for ( const zCVob* v = vob; v; v = v->GetVobParent() ) {
+        if ( v->GetVobType() == zVOB_TYPE_NSC ) return true;
+    }
+    return false;
+}
+
+
+void PointLightSlotSelector::QueueVobChangedInvalidation( zCVob* vob ) {
+    if ( !vob || !m_HaveCachedStatic ) return;
+    // A falling or thrown vob reports several transform changes per frame; they would all resolve to the same
+    // answer, so only the first is kept. Scanning is fine - the list holds one frame of world changes.
+    if ( std::ranges::contains( m_PendingVobChanges, vob ) ) return;
+    m_PendingVobChanges.push_back( vob );
+}
+
+
+void PointLightSlotSelector::DrainPendingVobChanges() {
+    if ( m_PendingVobChanges.empty() ) return;
+    // Swapped out, not iterated in place: InvalidateStaticForVobRemoved below scrubs the pending list.
+    m_DrainScratch.swap( m_PendingVobChanges );
+    for ( zCVob* vob : m_DrainScratch ) {
+        // OnRemovedVob erases the entry (and deletes the VobInfo), so a hit means the vob is still alive.
+        VobInfo* vi = Engine::GAPI->GetVobByVob( vob );
+        if ( !vi || !vi->Vob || !vi->VisualInfo ) continue;
+        // Riding an NPC rather than lying on the ground: it animates, so it is never baked and must not
+        // invalidate anything. This is the read that is unreliable at report time - see the header.
+        if ( IsNpcAttached( vi->Vob ) ) continue;
+        // Below the movement threshold this is jitter, not a move. The stored reference is only advanced when
+        // an invalidation actually happens, so repeated sub-eps steps still add up to one.
+        const XMFLOAT3 pos = vi->Vob->GetPositionWorld();
+        if ( auto posIt = m_LastInvalidationPos.find( vi->Vob ); posIt != m_LastInvalidationPos.end() ) {
+            const float dx = pos.x - posIt->second.x, dy = pos.y - posIt->second.y, dz = pos.z - posIt->second.z;
+            if ( dx * dx + dy * dy + dz * dz < m_Cfg.VobMoveEpsSq ) continue;
+        }
+        // Two halves, and a move needs both: every cube that baked it is now showing a shadow where the vob
+        // no longer is, and every cube reaching where it is NOW is missing it. A fresh add matches nothing in
+        // the first half, a vob that moved within one light's reach matches in both.
+        InvalidateStaticForVobRemoved( vi->Vob );
+        InvalidateStaticForVobAdded( pos, vi->VisualInfo->MeshSize * 0.5f );
+        // After the removal half, which drops this vob's entry along with the caster records it matched.
+        m_LastInvalidationPos.insert_or_assign( vi->Vob, pos );
+    }
+    m_DrainScratch.clear();
+}
+
+
+void PointLightSlotSelector::InvalidateStaticForVobAdded( const XMFLOAT3& posWS, float extent ) {
+    // A VOB added after a nearby point light already cached its static shadow cube would otherwise cast no
+    // point-light shadow: the static cube is only re-rendered when the light is fresh / moved / resized, not when
+    // world geometry around it changes. Walk the active slots and invalidate any whose light range the new VOB
+    // reaches. Slots are empty during world load (ownerKey==0) so this is a no-op then; the margin mirrors the
+    // static-VOB gather's cull (range + visual->MeshSize * 0.5f).
+    for ( Slot& ss : m_Slots ) {
+        if ( !ss.ownerKey || !ss.staticValid ) continue;
+        const float r = ss.range + extent;
+        const float dx = posWS.x - ss.pos.x, dy = posWS.y - ss.pos.y, dz = posWS.z - ss.pos.z;
+        if ( dx * dx + dy * dy + dz * dz < r * r ) {
+            ss.staticValid = false;   // re-render this slot's static depth next frame to include the new VOB
+            Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+        }
+    }
+}
+
+
+void PointLightSlotSelector::InvalidateStaticForVobRemoved( const zCVob* vob ) {
+    // Symmetric to the add case: a VOB removed from the world (an item picked up, a container emptied) must
+    // stop casting into any light's cached static cube. Matched against the exact caster set the bake gathered,
+    // by POINTER - the vob is being torn down, so its bbox and position can no longer be read, and identity is
+    // the only thing left that is still meaningful. Nothing was baked => nothing to invalidate, which is what
+    // keeps an NPC's throwaway held item (never baked, see IsNpcAttached) from re-rendering every cube nearby.
+    if ( !vob ) return;
+    // It may still be parked for a deferred resolve - drop it, the drain must never look it up.
+    std::erase( m_PendingVobChanges, const_cast<zCVob*>( vob ) );
+    m_LastInvalidationPos.erase( vob );   // the address may be reused by a different vob later
+    for ( Slot& ss : m_Slots ) {
+        if ( !ss.ownerKey || !ss.staticValid || ss.bakedVobs.empty() ) continue;
+        if ( std::ranges::contains( ss.bakedVobs, vob ) ) {
+            ss.staticValid = false;   // this slot's cube holds the removed vob - re-cache without it
+            Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+        }
+    }
+}
+
+
+void PointLightSlotSelector::Select( std::span<const Candidate> cands,
+    GothicRendererSettings::EPointLightShadowMode shadowMode, bool resourcesReady ) {
+    // Before anything decides renderStatic below: apply the world changes that were parked last frame, so a
+    // vob added or moved since then lands in this frame's re-bake rather than the next one.
+    DrainPendingVobChanges();
+
+    // Pick the closest-to-camera in-range lights (up to the tier budget) as this frame's "winners", but assign
+    // each winner a STABLE slot keyed by its light identity (kept across frames, not reassigned by proximity
+    // every frame). A slot's rendered content persists in the cube array, so a STATIC winner whose light didn't
+    // move can reuse its cached cube (renderStatic=false) instead of re-culling + re-rendering all world/VOB/
+    // skeletal casters each frame. Dynamic (moving) lights, newly-assigned slots, and moved/range-changed
+    // lights render.
+    //
+    // The global PointlightShadows setting (ini [Shadows] PointlightShadows / the ImGui combo) gates the whole
+    // thing:
+    //   PLS_DISABLED       - no winners at all; every index stays -1 and the pass never arms.
+    //   PLS_STATIC_ONLY    - winners get their static cube but never a dynamic overlay.
+    //   PLS_UPDATE_DYNAMIC - overlay for the near winners + a round-robin budget for the rest.
+    //   PLS_FULL           - overlay for every winner, every frame (no round-robin).
+    m_Assignments.clear();
+    m_EncodedByKey.clear();
+    m_StarvedThisFrame = 0;
+    if ( shadowMode == GothicRendererSettings::PLS_DISABLED ) {
+        // Release every slot so re-enabling mid-session re-renders from scratch instead of sampling depth that
+        // has been stale for however long the setting was off.
+        ReleaseAllSlots();
+        return;
+    }
+    // NOT gated on cands being non-empty: with zero visible lights every slot's owner is absent, and the
+    // retention/eviction bookkeeping below still has to tick for them.
+    if ( !resourcesReady || m_Slots.empty() ) return;
+
+    const uint32_t maxHi = m_Cfg.MaxHiSlots;
+    const uint32_t maxSlots = static_cast<uint32_t>( m_Slots.size() );
+    const uint32_t count = static_cast<uint32_t>( cands.size() );
+
+    const XMVECTOR camPos = Engine::GAPI->GetCameraPositionXM();
+    // One candidate per distinct ownership KEY, not per light: a cluster of co-located static lights shares a
+    // key (and a shadowOrigin/shadowRange), so it competes for - and wins - exactly ONE cube between all its
+    // members. `srcIdx` is just the first member found; the write-back at the end fans the result out to all.
+    m_Cands.clear();
+    m_CandByKey.clear();
+    // key -> slot, for every OCCUPIED slot. It is what FindSlotOf answers from, so it outlives this call and is
+    // maintained by hand wherever a slot changes hands (here and in ReleaseSlot). Rebuilt from the table at the
+    // top of every Select anyway, so a desync could only ever last one frame. Without it the incumbency, ageing
+    // and "does this winner already own a slot" lookups each walked all slots per light - fine at 192 slots, but
+    // the static tier runs into the hundreds and that product is a per-frame O(slots*lights) scan.
+    m_SlotByKey.clear();
+    for ( uint32_t s = 0; s < maxSlots; ++s )
+        if ( m_Slots[s].ownerKey ) m_SlotByKey.emplace( m_Slots[s].ownerKey, s );
+    // Every ownership key the frame's light set carries, winner or not. Slot ageing keys off THIS, not off the
+    // winner set: a light that is on screen and being shaded still wants the cube it already paid for, even on
+    // frames it is too far away to compete for a new one.
+    m_FrameKeys.clear();
+    for ( uint32_t i = 0; i < count; ++i ) {
+        const Candidate& c = cands[i];
+        if ( c.key == 0 ) continue;                     // caller marked this light as never-shadowed
+        m_FrameKeys.insert( c.key );
+        if ( m_CandByKey.contains( c.key ) ) continue;  // another member of this cluster already stands for it
+        // Ranked on the CUBE's placement, which for a clustered light is its cluster's.
+        const float range = c.shadowRange;
+        if ( range <= 0.0f ) continue;
+        XMVECTOR d = XMVectorSubtract( XMLoadFloat3( &c.shadowOrigin ), camPos );
+        const float distSq = XMVectorGetX( XMVector3LengthSq( d ) );
+        // D3D11's historical distMaxShadowSq is range*9, which for a CANDLE (range ~150 units) puts the horizon
+        // at ~13 m - and a light that falls off this list is shaded unshadowed, which the caller then range-
+        // clamps to 0.35x/0.15x. The lit patch around the candle collapses and the light reads as switched OFF,
+        // at a distance where it is still plainly visible. The horizon has to be about where the light stops
+        // being *seen*, not where its own falloff sphere stops reaching the camera, so it gets an absolute
+        // floor as well. The low tier can afford one: its cubes are tiny, rendered once and cached forever.
+        const float maxDist = std::max( range * 9.0f, m_Cfg.MinShadowDist );
+        if ( distSq >= maxDist * maxDist ) continue;
+        // Ranked on RAW distance. This used to discount an incumbent's distance before ranking, as hysteresis
+        // against a newcomer bumping an established light out on a marginal difference - but the ranking is also
+        // what the per-tier TRIM cuts at, so with more candidate keys than slots the discount let far-away
+        // incumbents outrank a light right in front of the camera and push it off the list entirely. Since a
+        // light that is off the list cannot take a slot back (eviction only ever considered ABSENT owners), that
+        // was permanent: the candle stayed unshadowed, hence range-clamped, hence dark, until something flushed
+        // the light set. Nearest-first here; the hysteresis now lives where it belongs, in the eviction rule
+        // below, which demands a newcomer be substantially closer than the owner it takes a slot from.
+        m_CandByKey.emplace( c.key, static_cast<uint32_t>( m_Cands.size() ) );
+        m_Cands.push_back( { i, c.key, c.owner, distSq, c.isStatic, c.preferLow, c.spatiallyStatic,
+            c.restrictToWorld } );
+    }
+    std::sort( m_Cands.begin(), m_Cands.end(), []( const Cand& a, const Cand& b ) {
+        if ( a.distSq != b.distSq ) return a.distSq < b.distSq;
+        return a.key < b.key;   // total order: equal distances must not permute between frames
+        } );
+
+    // Trim PER TIER: the two pools are independent budgets, so a room full of static clusters can never crowd a
+    // dynamic torch out of the full-res pool (and vice versa). Nearest-first within each tier; the losers simply
+    // go unshadowed here - the caller has already range-clamped the statics so they cannot bleed far.
+    {
+        uint32_t keptHi = 0, keptLow = 0;
+        size_t out = 0;
+        for ( size_t idx = 0; idx < m_Cands.size(); ++idx ) {
+            Cand& c = m_Cands[idx];
+            if ( !c.lowRes ) {
+                // SPILL. A light whose preferred tier is full does not go dark while the other tier sits empty:
+                // if it never moves, its cube is cacheable, and a tiny cached cube is enormously better than no
+                // cube at all (no cube means the range clamp, which reads as the light being switched off).
+                if ( keptHi >= maxHi && c.spatiallyStatic ) c.lowRes = true;
+            }
+            uint32_t& kept = c.lowRes ? keptLow : keptHi;
+            const uint32_t budget = c.lowRes ? m_Cfg.MaxLowSlots : maxHi;
+            if ( kept >= budget ) { ++m_StarvedThisFrame; continue; }   // more candidate keys than either tier holds
+            ++kept;
+            m_Cands[out++] = c;
+        }
+        m_Cands.resize( out );
+        // m_CandByKey stood for "already has a candidate" during the build above; from here on it is the winner
+        // set, which the ageing loop below tests every occupied slot against.
+        m_CandByKey.clear();
+        for ( size_t idx = 0; idx < m_Cands.size(); ++idx )
+            m_CandByKey.emplace( m_Cands[idx].key, static_cast<uint32_t>( idx ) );
+    }
+
+    // Age slots whose owner is not in this frame's light set at all - but do NOT release them. That set is
+    // frustum-culled upstream, so a light drops out merely because the camera turned away; its cached static
+    // depth is still valid and is exactly what should be reused the moment it comes back. Releasing on absence
+    // made every frustum blink a fresh occupant, i.e. a full static re-cull + re-render of the world sections
+    // and VOB instances around that light. Slots are surrendered only under real pressure (below) or once the
+    // absence outlives RetentionFrames.
+    // Presence, NOT winning: a light past the candidacy horizon keeps being SHADED every frame, so it keeps
+    // sampling the cube it owns (see the cached-cube publish below) and must not have it aged out from under it.
+    for ( uint32_t s = 0; s < maxSlots; ++s ) {
+        Slot& ss = m_Slots[s];
+        if ( !ss.ownerKey ) continue;
+        if ( m_FrameKeys.contains( ss.ownerKey ) ) { ss.missingFrames = 0; continue; }
+        if ( ++ss.missingFrames > m_Cfg.RetentionFrames ) {
+            // Retention expired - the cached depth goes with the slot. Counted like any other invalidation, so
+            // slot churn shows up in the stat too.
+            if ( ss.staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+            m_SlotByKey.erase( ss.ownerKey );
+            ss = Slot{};
+        }
+    }
+
+    // Per-frame ceiling on low-tier static (re)renders - see the deferral in the assignment loop below.
+    uint32_t lowStaticBudget = m_Cfg.LowStaticRendersPerFrame;
+
+    // Assign each winner a stable slot (keep its existing one, else grab a free one) and decide render vs cache.
+    // The search is confined to the winner's TIER so the two budgets stay genuinely independent.
+    for ( const Cand& c : m_Cands ) {
+        const uint32_t poolBegin = c.lowRes ? maxHi : 0u;
+        const uint32_t poolEnd = c.lowRes ? maxSlots : maxHi;
+
+        // Would this light actually USE the full-res tier? Only one that receives the per-frame skeletal overlay
+        // there has anything to gain from it. Computed before slot assignment because it is what decides whether
+        // a light sitting in the low-res tier gets promoted back out of it.
+        const bool wantsOverlay = !c.isStatic && !c.restrictToWorld
+            && shadowMode >= GothicRendererSettings::PLS_UPDATE_DYNAMIC;
+
+        // Pick a slot in [b,e): a free one; else the longest-absent owner (an absent light's cache is worth
+        // keeping, but not at the cost of a light on screen now); else the FARTHEST present owner, and only if
+        // this candidate is substantially closer than it - EvictDistanceRatio is the anti-oscillation margin, so
+        // two lights at similar distances can never trade a slot back and forth. -1 when every owner is about as
+        // close as this light, i.e. genuine oversubscription rather than arrival order.
+        auto pickSlot = [&]( uint32_t b, uint32_t e ) -> int {
+            for ( uint32_t s = b; s < e; ++s ) if ( !m_Slots[s].ownerKey ) return static_cast<int>( s );
+            int best = -1;
+            uint32_t worst = 0;
+            for ( uint32_t s = b; s < e; ++s )
+                if ( m_Slots[s].missingFrames > worst ) { worst = m_Slots[s].missingFrames; best = static_cast<int>( s ); }
+            if ( best >= 0 ) return best;
+            float bar = c.distSq * m_Cfg.EvictDistanceRatio;
+            for ( uint32_t s = b; s < e; ++s ) {
+                const Slot& os = m_Slots[s];
+                if ( !os.ownerKey ) continue;
+                const XMVECTOR d = XMVectorSubtract( XMLoadFloat3( &os.pos ), camPos );
+                const float dsq = XMVectorGetX( XMVector3LengthSq( d ) );
+                if ( dsq > bar ) { bar = dsq; best = static_cast<int>( s ); }
+            }
+            return best;
+            };
+
+        int slot = -1;
+        // A light keeps whatever slot it already owns, in EITHER tier. Tier preference decides where a light
+        // LOOKS for a slot, not where it is allowed to keep one: re-homing a spilled light the moment pressure
+        // eased would make it ping-pong between tiers, and every flip is a fresh cube render. Two things do
+        // force a low-res holder out, both of them one-directional:
+        if ( auto it = m_SlotByKey.find( c.key ); it != m_SlotByKey.end() ) {
+            const uint32_t owned = it->second;
+            const bool ownedLow = IsLowSlot( owned );
+            // 1. It STARTED MOVING. That tier bakes a cube once and caches it forever, and never runs the
+            //    dynamic overlay, so a mover cannot stay in it.
+            bool handBack = ownedLow && !c.spatiallyStatic;
+            // 2. It now ranks into the full-res tier (the trim left c.lowRes false) AND would get a dynamic
+            //    overlay there. Without this a light that spilled while far away stayed in the cached tier for
+            //    good: walk right up to it under UPDATE DYNAMIC and it still drew static-only shadows, because
+            //    ownership alone kept it there. Promotion is attempted only when a full-res slot can ACTUALLY
+            //    be had - giving up the cube it holds for nothing would leave it unshadowed, and unshadowed is
+            //    what the range clamp turns into a light that looks switched off.
+            if ( !handBack && ownedLow && !c.lowRes && wantsOverlay ) {
+                const int hi = pickSlot( 0, maxHi );
+                if ( hi >= 0 ) { handBack = true; slot = hi; }
+            }
+            if ( handBack ) {
+                if ( m_Slots[owned].staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+                m_Slots[owned] = Slot{};
+                m_SlotByKey.erase( c.key );
+            } else {
+                slot = static_cast<int>( owned );
+            }
+        }
+        if ( slot < 0 ) slot = pickSlot( poolBegin, poolEnd );
+        if ( slot < 0 ) { ++m_StarvedThisFrame; continue; }
+        if ( m_Slots[slot].ownerKey != c.key ) {
+            if ( m_Slots[slot].staticValid ) Engine::GAPI->GetRendererState().RendererInfo.PointLightStaticInvalidations.Note();
+            if ( m_Slots[slot].ownerKey ) m_SlotByKey.erase( m_Slots[slot].ownerKey );
+            m_SlotByKey[c.key] = static_cast<uint32_t>( slot );
+            m_Slots[slot] = Slot{};
+            m_Slots[slot].ownerKey = c.key;
+            m_Slots[slot].owner = c.owner;        // nullptr for a cluster - see the Slot::owner comment
+            m_Slots[slot].staticValid = false;    // fresh occupant -> must render static (the slot changed hands)
+            // Stamp the intended cube origin NOW, not when the static render finally happens: an acquisition
+            // whose render the per-frame budget defers would otherwise sit at pos {0,0,0}, read as infinitely
+            // far to the eviction scan above, and be taken straight back off the light that just got it.
+            m_Slots[slot].pos = cands[c.srcIdx].shadowOrigin;
+            m_Slots[slot].range = cands[c.srcIdx].shadowRange;
+        }
+        Slot& ss = m_Slots[slot];
+        ss.isStatic = c.isStatic;
+        // Everything below follows the slot this light ACTUALLY holds, not the tier it asked for - a spilled
+        // light sits in the low-res array and must be encoded, budgeted and overlay-gated as such.
+        const bool slotLow = IsLowSlot( static_cast<uint32_t>( slot ) );
+
+        // Can this slot EVER receive the skeletal overlay? Static lights never do, and neither does anything
+        // below PLS_UPDATE_DYNAMIC. `!slotLow` is load-bearing, not belt-and-braces: the low-res array has no
+        // dynamic twin, so a low slot becoming overlay-eligible would point the overlay pass at a target that
+        // does not exist for it. Since the SPILL, a non-static light can end up in that tier too - it gives up
+        // its overlay in exchange for a cube.
+        const bool overlayEligible = wantsOverlay && !slotLow;
+        // An ineligible slot must not keep advertising a stale overlay: drop the bit so the lit pass stops
+        // sampling the dynamic array for it the moment the setting (or the light's IsStatic) changes.
+        if ( !overlayEligible ) ss.dynamicValid = false;
+
+        const Candidate& src = cands[c.srcIdx];
+        // Move/resize detection tracks the CUBE, not the light: a clustered light wandering inside its cluster
+        // does not move the shared cube, and must not invalidate its cached static depth.
+        const XMFLOAT3& np = src.shadowOrigin;
+        const bool moved = std::fabs( np.x - ss.pos.x ) > m_Cfg.MoveEps
+            || std::fabs( np.y - ss.pos.y ) > m_Cfg.MoveEps
+            || std::fabs( np.z - ss.pos.z ) > m_Cfg.MoveEps;
+        const bool rangeChanged = std::fabs( src.shadowRange - ss.range ) > m_Cfg.RangeEps;
+        // The static cube is re-rendered only when fresh / the light moved / the range changed; otherwise reused.
+        bool renderStatic = !ss.staticValid || moved || rangeChanged;
+
+        // Amortize LOW-TIER static renders across frames. A static cube is rendered once and then cached forever,
+        // but "once" still costs a full world-section cull plus its draws - and acquisitions arrive in BURSTS
+        // (world load, a teleport, rounding a corner into a lit district), which without a budget means up to
+        // MaxLowSlots full static renders in a single frame and a very visible hitch. Nearest-first, because
+        // m_Cands is already sorted by distance. The dynamic tier is deliberately NOT budgeted: it holds few
+        // lights, they are the ones the player is looking at.
+        if ( renderStatic && slotLow ) {
+            if ( lowStaticBudget == 0 ) renderStatic = false;   // deferred; staticValid stays false so it retries
+            else --lowStaticBudget;
+        }
+
+        // Publish the cube index ONLY once the slot actually holds this owner's depth - either it was already
+        // cached, or it is being rendered this very frame (the cube pass runs before the lit pass). A fresh slot
+        // whose render got deferred by the budget above must NOT be sampled yet: it still holds the previous
+        // occupant's depth, which would read as a wrong shadow. Leaving it -1 makes the light unshadowed for a
+        // few frames instead, and the caller's range clamp keeps it from bleeding meanwhile.
+        // staticPresent, not just staticValid: a slot that was invalidated by a world change still holds this
+        // owner's depth and stays sampleable until the re-render lands. Only a FRESH slot (holding the previous
+        // occupant's depth) is withheld.
+        if ( ss.staticValid || ss.staticPresent || renderStatic ) {
+            // What the shader sees is the TIER-ENCODED index (local slot | tier bit), not the global slot. The
+            // has-dynamic bit additionally tells the lit pass to sample the dynamic-overlay array for this light
+            // and min it with the static one. Only full-res slots can carry it (the low tier has no dynamic
+            // twin), and it reflects the last SUBMITTED overlay - see Slot::dynamicValid on the one-frame lag.
+            m_EncodedByKey[c.key] = slotLow
+                ? static_cast<int32_t>( LowIndex( static_cast<uint32_t>( slot ) ) ) | m_Cfg.TierLowBit
+                : ( static_cast<int32_t>( slot ) | ( ss.dynamicValid ? m_Cfg.HasDynamicBit : 0 ) );
+        }
+        m_Assignments.push_back( { np, src.shadowRange, static_cast<uint32_t>( slot ), c.key, c.owner,
+            slotLow, renderStatic, false, overlayEligible, c.restrictToWorld } );
+        if ( renderStatic ) { ss.pos = np; ss.range = src.shadowRange; }   // staticValid stamped once actually drawn
+    }
+
+    // ---- Non-winners that STILL OWN a valid cube keep sampling it -------------------------------------------
+    // Winning is about who may SPEND slots and render passes this frame; it is not what makes a cube sampleable.
+    // A static light that fell off the candidate list (past the horizon above, or beaten to the last free slot)
+    // used to drop to index -1 while its own depth sat there in a slot it still owns, cached and resting - and
+    // going unshadowed is what triggers the caller's range clamp, i.e. the light visibly switching off.
+    // Publishing the cube it already owns costs nothing: no re-render, no barrier, no entry in the assignments,
+    // just one shadow sample the light was worth anyway.
+    //
+    // BOTH tiers, but only while the light still sits where the cube was rendered from: a cube is valid for the
+    // ORIGIN it was baked at, and the shader looks it up from the light's CURRENT origin, so a light that moved
+    // away from its bake would sample a cube centred somewhere else. That check is what makes this safe for the
+    // full-res tier too, whose lights can move. What a full-res non-winner does NOT get is the has-dynamic bit:
+    // nothing refreshed its skeletal overlay this frame, and a stale one would leave an NPC's shadow standing
+    // where the NPC no longer is. Its static depth is still exactly right.
+    for ( uint32_t i = 0; i < count; ++i ) {
+        const uint64_t key = cands[i].key;
+        if ( !key || m_EncodedByKey.contains( key ) ) continue;
+        const auto it = m_SlotByKey.find( key );
+        if ( it == m_SlotByKey.end() ) continue;
+        const Slot& ss = m_Slots[it->second];
+        if ( !ss.staticPresent ) continue;   // slot holds no depth for this owner yet
+        const XMFLOAT3& np = cands[i].shadowOrigin;
+        if ( std::fabs( np.x - ss.pos.x ) > m_Cfg.MoveEps || std::fabs( np.y - ss.pos.y ) > m_Cfg.MoveEps
+            || std::fabs( np.z - ss.pos.z ) > m_Cfg.MoveEps
+            || std::fabs( cands[i].shadowRange - ss.range ) > m_Cfg.RangeEps )
+            continue;
+        m_EncodedByKey[key] = IsLowSlot( it->second )
+            ? static_cast<int32_t>( LowIndex( it->second ) ) | m_Cfg.TierLowBit
+            : static_cast<int32_t>( it->second );
+    }
+
+    // Occupancy + starvation, for the ImGui point-light window. Counted here rather than derived later:
+    // m_StarvedThisFrame is only knowable inside the trim and assignment loops.
+    {
+        auto& info = Engine::GAPI->GetRendererState().RendererInfo;
+        unsigned int usedHi = 0, usedLow = 0;
+        for ( uint32_t s = 0; s < maxSlots; ++s )
+            if ( m_Slots[s].ownerKey ) ( IsLowSlot( s ) ? usedLow : usedHi )++;
+        info.PointLightSlotsUsed = usedHi;
+        info.PointLightSlotsMax = maxHi;
+        info.PointLightStaticSlotsUsed = usedLow;
+        info.PointLightStaticSlotsMax = m_Cfg.MaxLowSlots;
+        info.PointLightSlotsStarved = m_StarvedThisFrame;
+    }
+
+    // Round-robin the per-frame skeletal DYNAMIC overlay across overlay-eligible winners. With many persisted
+    // lights, running the full sphere-cull-against-registered-skeletal-vobs pass for every single winner every
+    // frame would multiply CPU cost with light count. The nearest AlwaysDynamicCount winners (where a moving
+    // caster's shadow lag would be most visible) always get it; the rest take turns via a stale-frames counter
+    // so every dynamic light's overlay still refreshes periodically instead of never. Static geometry shadows
+    // are unaffected - those persist via the static cache regardless. Skipped wholesale below
+    // PLS_UPDATE_DYNAMIC (nothing is eligible), and un-budgeted at PLS_FULL.
+    if ( shadowMode < GothicRendererSettings::PLS_UPDATE_DYNAMIC ) return;
+
+    m_Eligible.clear();
+    for ( Assignment& ps : m_Assignments ) if ( ps.overlayEligible ) m_Eligible.push_back( &ps );
+
+    if ( shadowMode >= GothicRendererSettings::PLS_FULL ) {
+        // "Very expensive. Don't use unless you encounter visual bugs." - every eligible winner overlays every
+        // frame, no distance ranking and no budget.
+        for ( Assignment* ps : m_Eligible ) {
+            ps->renderDynamic = true;
+            m_Slots[ps->slot].dynamicStaleFrames = 0;
+        }
+    } else {
+        std::sort( m_Eligible.begin(), m_Eligible.end(), [&]( const Assignment* a, const Assignment* b ) {
+            XMVECTOR da = XMVectorSubtract( XMLoadFloat3( &a->posWS ), camPos );
+            XMVECTOR db = XMVectorSubtract( XMLoadFloat3( &b->posWS ), camPos );
+            return XMVectorGetX( XMVector3LengthSq( da ) ) < XMVectorGetX( XMVector3LengthSq( db ) );
+            } );
+
+        const size_t closeCount = std::min<size_t>( m_Cfg.AlwaysDynamicCount, m_Eligible.size() );
+        for ( size_t idx = 0; idx < closeCount; ++idx ) {
+            m_Eligible[idx]->renderDynamic = true;
+            m_Slots[m_Eligible[idx]->slot].dynamicStaleFrames = 0;
+        }
+        for ( size_t idx = closeCount; idx < m_Eligible.size(); ++idx ) ++m_Slots[m_Eligible[idx]->slot].dynamicStaleFrames;
+
+        // Among the "far" set, service the most-stale slots first, up to this frame's round-robin budget.
+        std::sort( m_Eligible.begin() + closeCount, m_Eligible.end(), [&]( const Assignment* a, const Assignment* b ) {
+            return m_Slots[a->slot].dynamicStaleFrames > m_Slots[b->slot].dynamicStaleFrames;
+            } );
+        for ( size_t idx = closeCount, serviced = 0;
+            idx < m_Eligible.size() && serviced < m_Cfg.DynamicRoundRobinBudget; ++idx, ++serviced ) {
+            m_Eligible[idx]->renderDynamic = true;
+            m_Slots[m_Eligible[idx]->slot].dynamicStaleFrames = 0;
+        }
+    }
+
+    // An ELIGIBLE slot whose STATIC base is (re)rendered this frame must also refresh its dynamic overlay,
+    // round-robin turn or not: the overlay was resolved against the OLD static depth, which is invalid once the
+    // static geometry/position changes. Not forcing this would either ghost stale skeletal shadows onto a new
+    // depth base, or silently drop the overlay for a light that's actually due for a refresh. Ineligible slots
+    // have no overlay to reconcile.
+    for ( Assignment& ps : m_Assignments ) {
+        if ( ps.overlayEligible && ps.renderStatic && !ps.renderDynamic ) {
+            ps.renderDynamic = true;
+            m_Slots[ps.slot].dynamicStaleFrames = 0;
+        }
+    }
+}

--- a/D3D11Engine/PointLightSlotSelector.h
+++ b/D3D11Engine/PointLightSlotSelector.h
@@ -1,0 +1,208 @@
+#pragma once
+// Backend-neutral point-light shadow-cube SLOT SELECTION, shared by the D3D11 and D3D12 renderers.
+//
+// This is D3D12PointShadows::SelectShadowedLights lifted out verbatim - D3D12 is the reference
+// implementation and D3D11 was moved onto it, not the other way round. Everything here is a DECISION:
+// which lights get a cube, out of which of the two tiers, in which slot, when the cached static bake is
+// re-rendered, when the per-frame dynamic overlay runs, and when a slot may be advertised to the shader.
+// Nothing here touches a graphics API; the backends own their resources and draws and consume the
+// Assignments this produces.
+//
+// Two tiers, ONE slot index space so all the ownership bookkeeping stays single-pool:
+//   global slot <  MaxHiSlots  -> the full-res dynamic pool (a cube per moving/near light, per-frame overlay)
+//   global slot >= MaxHiSlots  -> the low-res static pool at (slot - MaxHiSlots), baked once and cached forever
+// What reaches the SHADER is the tier-ENCODED index (local index | tier bit), not the global slot - and the
+// two backends do not agree on which bit is which, so both masks come from Config.
+#include <cstdint>
+#include <span>
+#include <vector>
+#include <unordered_map>
+#include <DirectXMath.h>
+#include <gtl/phmap.hpp>
+
+#include "GothicGraphicsState.h"
+
+class zCVob;
+
+class PointLightSlotSelector {
+public:
+    struct Config {
+        uint32_t MaxHiSlots = 64;                  // full-res dynamic pool size (D3D11 128 / D3D12 64)
+        uint32_t MaxLowSlots = 340;                // low-res static pool size; 340 is one array's hard ceiling
+        uint32_t RetentionFrames = 600;            // ~10 s at 60 fps before an absent owner loses its slot
+        uint32_t LowStaticRendersPerFrame = 8;     // per-frame ceiling on low-tier static (re)bakes
+        uint32_t AlwaysDynamicCount = 8;           // nearest winners that always get the overlay
+        uint32_t DynamicRoundRobinBudget = 6;      // most-stale winners serviced per frame beyond those
+        float    MinShadowDist = 3000.0f;          // absolute candidacy horizon floor, Gothic units (~100 = 1 m)
+        float    EvictDistanceRatio = 2.0f;        // squared-distance margin a newcomer must beat an owner by
+        float    MoveEps = 0.5f;                   // below this the cube origin has not meaningfully moved
+        float    RangeEps = 1.0f;                  // below this the cube range has not meaningfully changed
+        float    VobMoveEpsSq = 1.0f;              // squared world units a vob must move to invalidate a bake
+        int32_t  TierLowBit = 0;                   // OR'd into the encoded index for a low-tier slot
+        int32_t  HasDynamicBit = 0;                // OR'd in when the lit pass should also sample the overlay
+    };
+
+    // One visible light on its way into the frame's light buffer, in the order the backend will shade them.
+    // Several entries may share a `key`: that is exactly how a CLUSTER of co-located static lights ends up
+    // sharing one cube - they are one candidate for selection and every member gets the winner's index.
+    struct Candidate {
+        uint64_t          key = 0;          // 0 = never shadowed. The light's vob pointer, or a cluster cell id.
+        void*             owner = nullptr;  // opaque to us: zCVobLight* (D3D12) / VobLightInfo* (D3D11).
+                                            // nullptr for clusters - only ever handed back for the dynamic
+                                            // overlay's exclude list, which no low-tier slot reaches.
+        DirectX::XMFLOAT3 shadowOrigin{};   // the CUBE's centre - the light's own, or its cluster's
+        float             shadowRange = 0;  // the CUBE's far-plane basis - likewise
+        bool              isStatic = false; // routing-static: never receives a dynamic overlay
+        bool              preferLow = false;// PREFERRED tier, not necessarily the one it ends up in
+        bool              spatiallyStatic = false;  // never moves, whatever tier it was routed to. A full-res
+                                            // candidate that cannot be given a full-res cube SPILLS into the
+                                            // low-res tier when this holds - that tier bakes once and caches
+                                            // forever, so a mover would re-enter its per-frame render budget
+                                            // every single frame and starve everything else in it.
+        bool              restrictToWorld = false;  // world-mesh-only casters (the PFX gate) - passed through
+    };
+
+    // One decision, per winning key. `slot` is the GLOBAL index; IsLowSlot(slot) picks the tier.
+    struct Assignment {
+        DirectX::XMFLOAT3 posWS{};
+        float             range = 0;
+        uint32_t          slot = 0;
+        uint64_t          key = 0;
+        void*             owner = nullptr;
+        bool              lowRes = false;
+        bool              renderStatic = false;
+        bool              renderDynamic = false;
+        bool              overlayEligible = false;
+        bool              restrictToWorld = false;
+    };
+
+    // Slots are owned by light identity and kept stable across frames (not reassigned by proximity), so a
+    // static winner whose light didn't move reuses its cached cube instead of re-culling + re-rendering.
+    struct Slot {
+        uint64_t          ownerKey = 0;      // identity owning this slot (0 = free). Compared for identity only;
+                                             // never dereferenced.
+        void*             owner = nullptr;   // the owning light when ownerKey is a single light, else nullptr.
+        DirectX::XMFLOAT3 pos{};             // last static-rendered cube origin (move detection)
+        float             range = 0.0f;      // last static-rendered range (range-change detection)
+        bool              isStatic = false;  // gates the overlay - a static light never receives one
+        bool              staticPresent = false; // this slot's static target physically holds depth rendered for
+                                             // THIS owner, even if a later world change has since marked it out
+                                             // of date. Kept apart from staticValid so an INVALIDATED slot keeps
+                                             // being sampled (slightly stale) while it waits its turn in the
+                                             // render budget, instead of dropping to unshadowed - a stale shadow
+                                             // is a far smaller artifact than a light that briefly bleeds through
+                                             // walls, and it is what makes over-invalidation genuinely cheap.
+        bool              staticValid = false;  // the static depth is up to date; false => must re-render
+        bool              dynamicValid = false; // the dynamic overlay holds a valid, already-rendered caster set.
+                                             // Set on a frame whose overlay produced draws, cleared on a
+                                             // SCHEDULED frame that produced none - deliberately left alone on an
+                                             // unscheduled frame, so a round-robin light keeps its last overlay
+                                             // between turns instead of flickering. Read one frame late by
+                                             // design: Select() runs before the pass resolves this frame.
+        uint32_t          dynamicStaleFrames = 0;  // frames since the overlay last ran (round-robin)
+        uint32_t          missingFrames = 0; // consecutive frames this slot's owner was absent from the light
+                                             // set; 0 while present. A slot is NOT released the moment its light
+                                             // drops out (the light set is frustum-culled upstream, so merely
+                                             // turning away drops it): its cached static depth is still good and
+                                             // is exactly what should be reused when the light comes back.
+        // Every caster identity the static bake put into this slot, in the order it gathered them. Rebuilt from
+        // scratch on each static (re)render and consulted ONLY by InvalidateStaticForVobRemoved, which compares
+        // pointers - by the time that fires the vob may be half torn down and unreadable.
+        std::vector<const zCVob*> bakedVobs;
+    };
+
+    /** Sizes the slot table. Safe to call again with the same config; a changed pool size wipes the table. */
+    void Configure( const Config& cfg );
+    const Config& GetConfig() const { return m_Cfg; }
+
+    bool IsLowSlot( uint32_t globalSlot ) const { return globalSlot >= m_Cfg.MaxHiSlots; }
+    uint32_t LowIndex( uint32_t globalSlot ) const { return globalSlot - m_Cfg.MaxHiSlots; }
+
+    /** The whole decision. `cands` is parallel to the backend's light list, one entry per light (cluster
+        members included); results are read back through GetAssignments()/GetEncodedIndex(). */
+    void Select( std::span<const Candidate> cands, GothicRendererSettings::EPointLightShadowMode mode,
+        bool resourcesReady = true );
+
+    std::span<Assignment> GetAssignments() { return m_Assignments; }
+    std::span<const Assignment> GetAssignments() const { return m_Assignments; }
+
+    /** The tier-encoded ShadowCubeIndex this key may advertise this frame, or -1 for none. Includes keys that
+        did NOT win a render slot this frame but still own a cube holding their own depth. */
+    int32_t GetEncodedIndex( uint64_t key ) const;
+
+    Slot& SlotAt( uint32_t slot ) { return m_Slots[slot]; }
+    const Slot& SlotAt( uint32_t slot ) const { return m_Slots[slot]; }
+
+    /** Slot index currently owned by `key`, or -1. */
+    int FindSlotOf( uint64_t key ) const;
+
+    /** Hand a slot back unconditionally (the light died, the backend tore its resources down). */
+    void ReleaseSlot( uint32_t slot );
+    /** Drop every slot, so whatever comes next re-renders from scratch instead of sampling stale depth. */
+    void ReleaseAllSlots();
+
+    // ---- static-bake cache bookkeeping ---------------------------------------------------------------------
+    /** True once a static (re)render into this slot is known to have reached the GPU. Split from the decision
+        so a frame that resolved a render but never issued it leaves the slot uncached and simply retries -
+        stamping at resolve time meant "we intended to draw it", and a slot marked cached while its target held
+        only the clear silently lost its static shadow FOREVER (nothing re-renders a slot that believes it is
+        cached). */
+    void CommitStatic( uint32_t slot );
+    void CommitDynamic( uint32_t slot, bool has );
+
+    // ---- world-change invalidation -------------------------------------------------------------------------
+    /** True if this vob rides an NPC's transform - a held item, a torch, an attached effect. Such a caster
+        moves with the animation every frame, so it is never baked into a cached static cube and its comings
+        and goings must not invalidate one either. */
+    static bool IsNpcAttached( const zCVob* vob );
+
+    /** Park a vob that just entered the world or just moved; the invalidation itself happens at the top of the
+        next Select(). Deferred rather than decided on the spot because the two things the decision reads - the
+        vob's position and whether it hangs off an NPC - are not settled when Gothic reports the change. An item
+        is inserted at the hand/waypoint it came from and placed afterwards, its parent link can still be the NPC
+        that is letting go of it, and it then FALLS: several transform changes across several frames before it
+        comes to rest. So this coalesces to one resolve per frame reading the position as it is by then, and a
+        still-moving vob simply queues again next frame until it stops. Entries whose vob left the world
+        meanwhile are dropped; still being in GothicAPI's vob map is the liveness test that makes the deferred
+        read safe. */
+    void QueueVobChangedInvalidation( zCVob* vob );
+
+    void InvalidateStaticForVobAdded( const DirectX::XMFLOAT3& posWS, float extent );
+    /** Removal is matched by POINTER against what each slot actually baked (Slot::bakedVobs), never by reading
+        the vob: by the time this fires the object may already be half torn down, and its bbox/position are no
+        longer trustworthy. Identity comparison only - `vob` is never dereferenced. */
+    void InvalidateStaticForVobRemoved( const zCVob* vob );
+
+private:
+    void DrainPendingVobChanges();
+
+    Config m_Cfg{};
+    std::vector<Slot> m_Slots;
+    std::vector<Assignment> m_Assignments;
+
+    // Frame scratch. All static-lifetime capacity, reused frame to frame (32-bit address space rule).
+    struct Cand { uint32_t srcIdx; uint64_t key; void* owner; float distSq; bool isStatic; bool lowRes;
+                  bool spatiallyStatic; bool restrictToWorld; };
+    std::vector<Cand> m_Cands;
+    std::unordered_map<uint64_t, uint32_t> m_CandByKey;
+    std::unordered_map<uint64_t, int32_t>  m_EncodedByKey;
+    // Not scratch: the persistent key -> occupied-slot index that FindSlotOf answers from. Maintained wherever
+    // a slot changes hands, and rebuilt from the table at the top of every Select.
+    std::unordered_map<uint64_t, uint32_t> m_SlotByKey;
+    gtl::flat_hash_set<uint64_t> m_FrameKeys;
+    std::vector<Assignment*> m_Eligible;
+
+    std::vector<zCVob*> m_PendingVobChanges;
+    // Swapped with the above for the duration of a drain, so the invalidation helpers it calls can scrub the
+    // pending list without the loop iterating a vector that is being erased from. Capacity is retained.
+    std::vector<zCVob*> m_DrainScratch;
+    // Where each vob was when it last actually invalidated something. The reference is that position, NOT the
+    // previous frame's, so a slow drift keeps accumulating until it crosses the threshold instead of being
+    // filtered out one sub-eps step at a time.
+    gtl::flat_hash_map<const zCVob*, DirectX::XMFLOAT3> m_LastInvalidationPos;
+    // Has any slot ever finished a static bake? Until one has there is no cache to invalidate, which is what
+    // keeps world load (tens of thousands of AddVob calls before the first frame) from parking any of them.
+    bool m_HaveCachedStatic = false;
+
+    uint32_t m_StarvedThisFrame = 0;
+};

--- a/D3D11Engine/PointLightSlotSelector.h
+++ b/D3D11Engine/PointLightSlotSelector.h
@@ -30,6 +30,8 @@ public:
         uint32_t MaxHiSlots = 64;                  // full-res dynamic pool size (D3D11 128 / D3D12 64)
         uint32_t MaxLowSlots = 340;                // low-res static pool size; 340 is one array's hard ceiling
         uint32_t RetentionFrames = 600;            // ~10 s at 60 fps before an absent owner loses its slot
+        uint32_t SlotStealGraceFrames = 300;       // ~5 s an absent owner's cube is off limits to newcomers
+        uint32_t HandoverMaxFrames = 120;          // ~2 s a tier switch may keep its old cube waiting on the new
         uint32_t LowStaticRendersPerFrame = 8;     // per-frame ceiling on low-tier static (re)bakes
         uint32_t AlwaysDynamicCount = 8;           // nearest winners that always get the overlay
         uint32_t DynamicRoundRobinBudget = 6;      // most-stale winners serviced per frame beyond those
@@ -104,7 +106,15 @@ public:
                                              // set; 0 while present. A slot is NOT released the moment its light
                                              // drops out (the light set is frustum-culled upstream, so merely
                                              // turning away drops it): its cached static depth is still good and
-                                             // is exactly what should be reused when the light comes back.
+                                             // is exactly what should be reused when the light comes back. Nor is
+                                             // it a donor to a newcomer until it has been gone longer than
+                                             // Config::SlotStealGraceFrames - see pickSlot.
+        // A tier switch HANDS OVER rather than hands back: until the new tier's slot has really been baked, the
+        // old one stays owned, keeps this light's depth and is what the shader samples. Such a slot is not in
+        // m_SlotByKey (the key points at its new slot) and is never a donor to anyone else.
+        bool              handoverFallback = false;
+        uint32_t          handoverTarget = 0;      // the slot being baked; the fallback dies once it holds depth
+        uint32_t          handoverFrames = 0;      // bounded, so a target that never bakes cannot pin a slot
         // Every caster identity the static bake put into this slot, in the order it gathered them. Rebuilt from
         // scratch on each static (re)render and consulted ONLY by InvalidateStaticForVobRemoved, which compares
         // pointers - by the time that fires the vob may be half torn down and unreadable.
@@ -135,6 +145,9 @@ public:
 
     /** Slot index currently owned by `key`, or -1. */
     int FindSlotOf( uint64_t key ) const;
+    /** The slot `key` is handing over FROM while its new slot bakes, or -1. It still holds that light's depth
+        and is what should be sampled meanwhile - see Slot::handoverFallback. */
+    int FindFallbackSlotOf( uint64_t key ) const;
 
     /** Hand a slot back unconditionally (the light died, the backend tore its resources down). */
     void ReleaseSlot( uint32_t slot );
@@ -189,6 +202,9 @@ private:
     // Not scratch: the persistent key -> occupied-slot index that FindSlotOf answers from. Maintained wherever
     // a slot changes hands, and rebuilt from the table at the top of every Select.
     std::unordered_map<uint64_t, uint32_t> m_SlotByKey;
+    // key -> the slot it is handing over FROM, for keys with a tier switch in flight. Rebuilt alongside
+    // m_SlotByKey, which deliberately holds the other half (the slot being handed over TO).
+    std::unordered_map<uint64_t, uint32_t> m_FallbackByKey;
     gtl::flat_hash_set<uint64_t> m_FrameKeys;
     std::vector<Assignment*> m_Eligible;
 

--- a/D3D11Engine/PointLightSlotSelector.h
+++ b/D3D11Engine/PointLightSlotSelector.h
@@ -1,18 +1,13 @@
 #pragma once
-// Backend-neutral point-light shadow-cube SLOT SELECTION, shared by the D3D11 and D3D12 renderers.
+// Backend-neutral point-light shadow-cube slot selection, shared by the D3D11 and D3D12 renderers.
+// Decisions only, no graphics API: which lights get a cube, out of which tier, in which slot, when the
+// cached static bake is re-rendered and when the dynamic overlay runs. Backends own the resources.
 //
-// This is D3D12PointShadows::SelectShadowedLights lifted out verbatim - D3D12 is the reference
-// implementation and D3D11 was moved onto it, not the other way round. Everything here is a DECISION:
-// which lights get a cube, out of which of the two tiers, in which slot, when the cached static bake is
-// re-rendered, when the per-frame dynamic overlay runs, and when a slot may be advertised to the shader.
-// Nothing here touches a graphics API; the backends own their resources and draws and consume the
-// Assignments this produces.
-//
-// Two tiers, ONE slot index space so all the ownership bookkeeping stays single-pool:
-//   global slot <  MaxHiSlots  -> the full-res dynamic pool (a cube per moving/near light, per-frame overlay)
-//   global slot >= MaxHiSlots  -> the low-res static pool at (slot - MaxHiSlots), baked once and cached forever
-// What reaches the SHADER is the tier-ENCODED index (local index | tier bit), not the global slot - and the
-// two backends do not agree on which bit is which, so both masks come from Config.
+// Two tiers, one slot index space:
+//   global slot <  MaxHiSlots  -> full-res dynamic pool (per-frame overlay)
+//   global slot >= MaxHiSlots  -> low-res static pool at (slot - MaxHiSlots), baked once and cached
+// The shader gets the tier-ENCODED index (local index | tier bit); the bits differ per backend, so both
+// masks come from Config.
 #include <cstdint>
 #include <span>
 #include <vector>
@@ -44,23 +39,18 @@ public:
         int32_t  HasDynamicBit = 0;                // OR'd in when the lit pass should also sample the overlay
     };
 
-    // One visible light on its way into the frame's light buffer, in the order the backend will shade them.
-    // Several entries may share a `key`: that is exactly how a CLUSTER of co-located static lights ends up
-    // sharing one cube - they are one candidate for selection and every member gets the winner's index.
+    // One visible light, in the backend's shading order. Entries sharing a `key` are a cluster of co-located
+    // static lights: one candidate for selection, and every member gets the winner's index.
     struct Candidate {
         uint64_t          key = 0;          // 0 = never shadowed. The light's vob pointer, or a cluster cell id.
-        void*             owner = nullptr;  // opaque to us: zCVobLight* (D3D12) / VobLightInfo* (D3D11).
-                                            // nullptr for clusters - only ever handed back for the dynamic
-                                            // overlay's exclude list, which no low-tier slot reaches.
+        void*             owner = nullptr;  // opaque: zCVobLight* (D3D12) / VobLightInfo* (D3D11). nullptr for
+                                            // clusters, which never reach the dynamic overlay's exclude list.
         DirectX::XMFLOAT3 shadowOrigin{};   // the CUBE's centre - the light's own, or its cluster's
         float             shadowRange = 0;  // the CUBE's far-plane basis - likewise
         bool              isStatic = false; // routing-static: never receives a dynamic overlay
         bool              preferLow = false;// PREFERRED tier, not necessarily the one it ends up in
-        bool              spatiallyStatic = false;  // never moves, whatever tier it was routed to. A full-res
-                                            // candidate that cannot be given a full-res cube SPILLS into the
-                                            // low-res tier when this holds - that tier bakes once and caches
-                                            // forever, so a mover would re-enter its per-frame render budget
-                                            // every single frame and starve everything else in it.
+        bool              spatiallyStatic = false;  // never moves; only such a candidate may SPILL into the
+                                            // low-res tier, which bakes once and would be starved by a mover
         bool              restrictToWorld = false;  // world-mesh-only casters (the PFX gate) - passed through
     };
 
@@ -78,46 +68,32 @@ public:
         bool              restrictToWorld = false;
     };
 
-    // Slots are owned by light identity and kept stable across frames (not reassigned by proximity), so a
-    // static winner whose light didn't move reuses its cached cube instead of re-culling + re-rendering.
+    // Slots are owned by light identity and stay stable across frames, so a static winner whose light didn't
+    // move reuses its cached cube instead of re-culling + re-rendering.
     struct Slot {
-        uint64_t          ownerKey = 0;      // identity owning this slot (0 = free). Compared for identity only;
-                                             // never dereferenced.
+        uint64_t          ownerKey = 0;      // identity owning this slot (0 = free). Never dereferenced.
         void*             owner = nullptr;   // the owning light when ownerKey is a single light, else nullptr.
         DirectX::XMFLOAT3 pos{};             // last static-rendered cube origin (move detection)
         float             range = 0.0f;      // last static-rendered range (range-change detection)
         bool              isStatic = false;  // gates the overlay - a static light never receives one
-        bool              staticPresent = false; // this slot's static target physically holds depth rendered for
-                                             // THIS owner, even if a later world change has since marked it out
-                                             // of date. Kept apart from staticValid so an INVALIDATED slot keeps
-                                             // being sampled (slightly stale) while it waits its turn in the
-                                             // render budget, instead of dropping to unshadowed - a stale shadow
-                                             // is a far smaller artifact than a light that briefly bleeds through
-                                             // walls, and it is what makes over-invalidation genuinely cheap.
+        bool              staticPresent = false; // the target holds depth rendered for THIS owner, however
+                                             // stale. Split from staticValid so an invalidated slot keeps
+                                             // being sampled while it waits its turn in the render budget.
         bool              staticValid = false;  // the static depth is up to date; false => must re-render
-        bool              dynamicValid = false; // the dynamic overlay holds a valid, already-rendered caster set.
-                                             // Set on a frame whose overlay produced draws, cleared on a
-                                             // SCHEDULED frame that produced none - deliberately left alone on an
-                                             // unscheduled frame, so a round-robin light keeps its last overlay
-                                             // between turns instead of flickering. Read one frame late by
-                                             // design: Select() runs before the pass resolves this frame.
+        bool              dynamicValid = false; // the overlay holds a rendered caster set. Cleared only on a
+                                             // SCHEDULED frame that produced no draws, so a round-robin light
+                                             // keeps its last overlay between turns. Read one frame late.
         uint32_t          dynamicStaleFrames = 0;  // frames since the overlay last ran (round-robin)
-        uint32_t          missingFrames = 0; // consecutive frames this slot's owner was absent from the light
-                                             // set; 0 while present. A slot is NOT released the moment its light
-                                             // drops out (the light set is frustum-culled upstream, so merely
-                                             // turning away drops it): its cached static depth is still good and
-                                             // is exactly what should be reused when the light comes back. Nor is
-                                             // it a donor to a newcomer until it has been gone longer than
-                                             // Config::SlotStealGraceFrames - see pickSlot.
-        // A tier switch HANDS OVER rather than hands back: until the new tier's slot has really been baked, the
-        // old one stays owned, keeps this light's depth and is what the shader samples. Such a slot is not in
-        // m_SlotByKey (the key points at its new slot) and is never a donor to anyone else.
+        uint32_t          missingFrames = 0; // consecutive frames the owner was absent from the light set. The
+                                             // set is frustum-culled upstream, so merely turning away drops a
+                                             // light; its cached depth is kept for its return.
+        // A tier switch hands over rather than back: the old slot stays owned and keeps being sampled until
+        // the new one is baked. Not in m_SlotByKey (the key points at the new slot) and never a donor.
         bool              handoverFallback = false;
         uint32_t          handoverTarget = 0;      // the slot being baked; the fallback dies once it holds depth
         uint32_t          handoverFrames = 0;      // bounded, so a target that never bakes cannot pin a slot
-        // Every caster identity the static bake put into this slot, in the order it gathered them. Rebuilt from
-        // scratch on each static (re)render and consulted ONLY by InvalidateStaticForVobRemoved, which compares
-        // pointers - by the time that fires the vob may be half torn down and unreadable.
+        // Casters this slot's static bake covered. Rebuilt on each static (re)render and compared by POINTER
+        // only - InvalidateStaticForVobRemoved fires when the vob may already be half torn down.
         std::vector<const zCVob*> bakedVobs;
     };
 
@@ -137,7 +113,7 @@ public:
     std::span<const Assignment> GetAssignments() const { return m_Assignments; }
 
     /** The tier-encoded ShadowCubeIndex this key may advertise this frame, or -1 for none. Includes keys that
-        did NOT win a render slot this frame but still own a cube holding their own depth. */
+        won no render this frame but still own a cube holding their own depth. */
     int32_t GetEncodedIndex( uint64_t key ) const;
 
     Slot& SlotAt( uint32_t slot ) { return m_Slots[slot]; }
@@ -155,35 +131,26 @@ public:
     void ReleaseAllSlots();
 
     // ---- static-bake cache bookkeeping ---------------------------------------------------------------------
-    /** True once a static (re)render into this slot is known to have reached the GPU. Split from the decision
-        so a frame that resolved a render but never issued it leaves the slot uncached and simply retries -
-        stamping at resolve time meant "we intended to draw it", and a slot marked cached while its target held
-        only the clear silently lost its static shadow FOREVER (nothing re-renders a slot that believes it is
-        cached). */
+    /** Stamps a static (re)render that actually reached the GPU. Split from the decision so a frame that
+        resolved a render but never issued it retries instead of caching an empty cube forever. */
     void CommitStatic( uint32_t slot );
     void CommitDynamic( uint32_t slot, bool has );
 
     // ---- world-change invalidation -------------------------------------------------------------------------
-    /** True if this vob rides an NPC's transform - a held item, a torch, an attached effect. Such a caster
-        moves with the animation every frame, so it is never baked into a cached static cube and its comings
-        and goings must not invalidate one either. */
+    /** True if this vob rides an NPC's transform - a held item, a torch, an attached effect. Such a caster is
+        never baked into a cached static cube, so its comings and goings must not invalidate one either. */
     static bool IsNpcAttached( const zCVob* vob );
 
-    /** Park a vob that just entered the world or just moved; the invalidation itself happens at the top of the
-        next Select(). Deferred rather than decided on the spot because the two things the decision reads - the
-        vob's position and whether it hangs off an NPC - are not settled when Gothic reports the change. An item
-        is inserted at the hand/waypoint it came from and placed afterwards, its parent link can still be the NPC
-        that is letting go of it, and it then FALLS: several transform changes across several frames before it
-        comes to rest. So this coalesces to one resolve per frame reading the position as it is by then, and a
-        still-moving vob simply queues again next frame until it stops. Entries whose vob left the world
-        meanwhile are dropped; still being in GothicAPI's vob map is the liveness test that makes the deferred
-        read safe. */
+    /** Park a vob that just entered the world or just moved; the invalidation happens at the top of the next
+        Select(). Deferred because neither of the two things it reads - the vob's position and whether it hangs
+        off an NPC - is settled when Gothic reports the change: a dropped item is inserted where it came from,
+        still parented to the NPC letting go of it, and then falls for several frames before coming to rest.
+        Entries whose vob left the world meanwhile are dropped. */
     void QueueVobChangedInvalidation( zCVob* vob );
 
     void InvalidateStaticForVobAdded( const DirectX::XMFLOAT3& posWS, float extent );
-    /** Removal is matched by POINTER against what each slot actually baked (Slot::bakedVobs), never by reading
-        the vob: by the time this fires the object may already be half torn down, and its bbox/position are no
-        longer trustworthy. Identity comparison only - `vob` is never dereferenced. */
+    /** Matched by POINTER against what each slot baked (Slot::bakedVobs): by the time this fires the object
+        may be half torn down, so `vob` is never dereferenced. */
     void InvalidateStaticForVobRemoved( const zCVob* vob );
 
 private:
@@ -193,31 +160,29 @@ private:
     std::vector<Slot> m_Slots;
     std::vector<Assignment> m_Assignments;
 
-    // Frame scratch. All static-lifetime capacity, reused frame to frame (32-bit address space rule).
+    // Frame scratch; capacity reused frame to frame (32-bit address space rule).
     struct Cand { uint32_t srcIdx; uint64_t key; void* owner; float distSq; bool isStatic; bool lowRes;
                   bool spatiallyStatic; bool restrictToWorld; };
     std::vector<Cand> m_Cands;
     std::unordered_map<uint64_t, uint32_t> m_CandByKey;
     std::unordered_map<uint64_t, int32_t>  m_EncodedByKey;
-    // Not scratch: the persistent key -> occupied-slot index that FindSlotOf answers from. Maintained wherever
-    // a slot changes hands, and rebuilt from the table at the top of every Select.
+    // Persistent key -> occupied-slot index that FindSlotOf answers from. Maintained wherever a slot changes
+    // hands, and rebuilt from the table at the top of every Select.
     std::unordered_map<uint64_t, uint32_t> m_SlotByKey;
-    // key -> the slot it is handing over FROM, for keys with a tier switch in flight. Rebuilt alongside
-    // m_SlotByKey, which deliberately holds the other half (the slot being handed over TO).
+    // key -> the slot it is handing over FROM; m_SlotByKey holds the other half.
     std::unordered_map<uint64_t, uint32_t> m_FallbackByKey;
     gtl::flat_hash_set<uint64_t> m_FrameKeys;
     std::vector<Assignment*> m_Eligible;
 
     std::vector<zCVob*> m_PendingVobChanges;
-    // Swapped with the above for the duration of a drain, so the invalidation helpers it calls can scrub the
-    // pending list without the loop iterating a vector that is being erased from. Capacity is retained.
+    // Swapped with the above during a drain, so the invalidation helpers can scrub the pending list without
+    // the loop iterating a vector that is being erased from. Capacity is retained.
     std::vector<zCVob*> m_DrainScratch;
-    // Where each vob was when it last actually invalidated something. The reference is that position, NOT the
-    // previous frame's, so a slow drift keeps accumulating until it crosses the threshold instead of being
-    // filtered out one sub-eps step at a time.
+    // Where each vob was when it last actually invalidated something - not last frame, so a slow drift keeps
+    // accumulating until it crosses the threshold instead of being filtered out one sub-eps step at a time.
     gtl::flat_hash_map<const zCVob*, DirectX::XMFLOAT3> m_LastInvalidationPos;
-    // Has any slot ever finished a static bake? Until one has there is no cache to invalidate, which is what
-    // keeps world load (tens of thousands of AddVob calls before the first frame) from parking any of them.
+    // Until some slot has finished a bake there is no cache to invalidate; this keeps world load (tens of
+    // thousands of AddVob calls before the first frame) from parking any of them.
     bool m_HaveCachedStatic = false;
 
     uint32_t m_StarvedThisFrame = 0;

--- a/D3D11Engine/Shaders/D3D12/Preview.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Preview.hlsl
@@ -47,3 +47,33 @@ float4 PSGhost( VS_OUT i ) : SV_TARGET
     // verbatim port reads far too bright here — the same reason Decal/Fx/Particle/World/Vob all linearize.
     return float4( SrgbToLinear( t.rgb ), t.a * GhostAlpha );
 }
+
+// Skinned variant of VSMain, for an inventory item whose visual is a skeletal model
+// (D3D12GraphicsEngine::DrawVobSingle(SkeletalVobInfo*)). Mirrors D3D11's VS_ExSkeletal + PS_Preview_Textured,
+// minus fatness and motion vectors — a preview item neither swells nor moves. Reuses PSMain above.
+static const int NUM_MAX_BONES = 96;
+cbuffer BonesCB : register(b2) { float4x4 Bones[NUM_MAX_BONES]; };
+
+struct VS_SKEL_IN
+{
+    float4 pos[4]     : POSITION;    // 4 per-bone-space positions (half4)
+    float3 normal     : NORMAL;
+    float3 bindNormal : TEXCOORD0;
+    float2 uv         : TEXCOORD1;
+    uint4  boneIds    : BONEIDS;
+    float4 weights    : WEIGHTS;
+};
+
+VS_OUT VSSkeletal( VS_SKEL_IN i )
+{
+    float3 skinned = float3( 0, 0, 0 );
+    [unroll]
+    for ( int b = 0; b < 4; ++b )
+        skinned += i.weights[b] * mul( float4( i.pos[b].xyz, 1.0 ), Bones[i.boneIds[b]] ).xyz;
+
+    VS_OUT o;
+    float3 worldPos = mul( float4( skinned, 1.0 ), World ).xyz;
+    o.clip = mul( float4( worldPos, 1.0 ), ViewProj );
+    o.uv = i.uv;
+    return o;
+}

--- a/D3D11Engine/Shaders/D3D12/include/GPULightShared.h
+++ b/D3D11Engine/Shaders/D3D12/include/GPULightShared.h
@@ -38,5 +38,12 @@ static const int kShadowTierLow = 0x40000000;
 // twin. Absent = pure static shadow, and no second sample is taken.
 static const int kShadowHasDynamic = 0x20000000;
 static const int kShadowSlotMask = 0x1FFFFFFF;
+// LOW-TIER slot layout inside those bits. The static tier is bigger than one Texture2DArray can hold
+// (341 cubes), so it is split into pages — separate arrays whose SRVs sit CONTIGUOUSLY in the bindless heap.
+// Bits 0..9 are the slot within its page, bits 10..12 the page: the shader reads
+// ResourceDescriptorHeap[PointShadowLowIndex + page]. Full-res slots keep using the whole kShadowSlotMask.
+static const int kShadowLowSlotMask = 0x3FF;
+static const int kShadowLowPageShift = 10;
+static const int kShadowLowPageMask = 0x7;
 
 #endif // GD3D12_GPULIGHT_SHARED_H

--- a/D3D11Engine/Shaders/D3D12/include/GPULightShared.h
+++ b/D3D11Engine/Shaders/D3D12/include/GPULightShared.h
@@ -38,12 +38,5 @@ static const int kShadowTierLow = 0x40000000;
 // twin. Absent = pure static shadow, and no second sample is taken.
 static const int kShadowHasDynamic = 0x20000000;
 static const int kShadowSlotMask = 0x1FFFFFFF;
-// LOW-TIER slot layout inside those bits. The static tier is bigger than one Texture2DArray can hold
-// (341 cubes), so it is split into pages — separate arrays whose SRVs sit CONTIGUOUSLY in the bindless heap.
-// Bits 0..9 are the slot within its page, bits 10..12 the page: the shader reads
-// ResourceDescriptorHeap[PointShadowLowIndex + page]. Full-res slots keep using the whole kShadowSlotMask.
-static const int kShadowLowSlotMask = 0x3FF;
-static const int kShadowLowPageShift = 10;
-static const int kShadowLowPageMask = 0x7;
 
 #endif // GD3D12_GPULIGHT_SHARED_H

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -44,8 +44,8 @@ float3 DelightDiffuse( float3 linearAlbedo )
 // apply the LH projection z-map. Most acne bias is the PSO's hardware slope bias; add a small normal offset +
 // constant. 4-tap rotated-disk PCF softens the edges; a camera-distance fade is applied at the call site.
 // `encodedIndex` is GPULight::ShadowCubeIndex: the low 30 bits are the cube slot, bit 30 (kShadowTierLow)
-// selects the LOW-RES static cube tier (kStaticCubeSize^2, fetched bindlessly via LightCB's
-// PointShadowLowIndex + the encoded page) over the full-res dynamic one (PointShadowCubes). `lightPos`/`range` are the CUBE's
+// selects the LOW-RES static cube array (kStaticCubeSize^2, fetched bindlessly via LightCB's
+// PointShadowLowIndex) over the full-res dynamic one (PointShadowCubes). `lightPos`/`range` are the CUBE's
 // origin and far-plane basis — GPULight::ShadowOrigin /
 // ShadowRange, NOT the light's own position/range, because co-located static lights share one clustered cube.
 //
@@ -55,11 +55,8 @@ float3 DelightDiffuse( float3 linearAlbedo )
 // to resolve shadow detail.
 float SamplePointShadow( int encodedIndex, float3 wpos, float3 N, float3 lightPos, float range )
 {
+    int   slot   = encodedIndex & kShadowSlotMask;
     bool  lowRes = ( encodedIndex & kShadowTierLow ) != 0;
-    // Low tier: the slot is per-PAGE (the tier spans several arrays — 341 cubes is the hard per-array ceiling),
-    // and the page selects which of the contiguous bindless SRVs at PointShadowLowIndex to read.
-    int   slot   = lowRes ? ( encodedIndex & kShadowLowSlotMask ) : ( encodedIndex & kShadowSlotMask );
-    uint  lowPage = ( encodedIndex >> kShadowLowPageShift ) & kShadowLowPageMask;
     float coarse = lowRes ? 4.0 : 1.0;
     // Full-res slots keep their STATIC depth in PointShadowCubes and this frame's moving (skeletal) casters in a
     // SEPARATE array; taking the min of the two comparisons is "occluded by either", which is exactly what the
@@ -100,7 +97,7 @@ float SamplePointShadow( int encodedIndex, float3 wpos, float3 N, float3 lightPo
         float3 o = normalize( L + ( kDisk[s * stride].x * t + kDisk[s * stride].y * bt ) * r );
         if ( lowRes )
         {
-            TextureCubeArray lowCubes = ResourceDescriptorHeap[NonUniformResourceIndex( PointShadowLowIndex + lowPage )];
+            TextureCubeArray lowCubes = ResourceDescriptorHeap[PointShadowLowIndex];
             sh += lowCubes.SampleCmpLevelZero( shadowCmp, float4( o, (float)slot ), compareDepth );
         }
         else

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -44,8 +44,8 @@ float3 DelightDiffuse( float3 linearAlbedo )
 // apply the LH projection z-map. Most acne bias is the PSO's hardware slope bias; add a small normal offset +
 // constant. 4-tap rotated-disk PCF softens the edges; a camera-distance fade is applied at the call site.
 // `encodedIndex` is GPULight::ShadowCubeIndex: the low 30 bits are the cube slot, bit 30 (kShadowTierLow)
-// selects the LOW-RES static cube array (kStaticCubeSize^2, fetched bindlessly via LightCB's
-// PointShadowLowIndex) over the full-res dynamic one (PointShadowCubes). `lightPos`/`range` are the CUBE's
+// selects the LOW-RES static cube tier (kStaticCubeSize^2, fetched bindlessly via LightCB's
+// PointShadowLowIndex + the encoded page) over the full-res dynamic one (PointShadowCubes). `lightPos`/`range` are the CUBE's
 // origin and far-plane basis — GPULight::ShadowOrigin /
 // ShadowRange, NOT the light's own position/range, because co-located static lights share one clustered cube.
 //
@@ -55,8 +55,11 @@ float3 DelightDiffuse( float3 linearAlbedo )
 // to resolve shadow detail.
 float SamplePointShadow( int encodedIndex, float3 wpos, float3 N, float3 lightPos, float range )
 {
-    int   slot   = encodedIndex & kShadowSlotMask;
     bool  lowRes = ( encodedIndex & kShadowTierLow ) != 0;
+    // Low tier: the slot is per-PAGE (the tier spans several arrays — 341 cubes is the hard per-array ceiling),
+    // and the page selects which of the contiguous bindless SRVs at PointShadowLowIndex to read.
+    int   slot   = lowRes ? ( encodedIndex & kShadowLowSlotMask ) : ( encodedIndex & kShadowSlotMask );
+    uint  lowPage = ( encodedIndex >> kShadowLowPageShift ) & kShadowLowPageMask;
     float coarse = lowRes ? 4.0 : 1.0;
     // Full-res slots keep their STATIC depth in PointShadowCubes and this frame's moving (skeletal) casters in a
     // SEPARATE array; taking the min of the two comparisons is "occluded by either", which is exactly what the
@@ -97,7 +100,7 @@ float SamplePointShadow( int encodedIndex, float3 wpos, float3 N, float3 lightPo
         float3 o = normalize( L + ( kDisk[s * stride].x * t + kDisk[s * stride].y * bt ) * r );
         if ( lowRes )
         {
-            TextureCubeArray lowCubes = ResourceDescriptorHeap[PointShadowLowIndex];
+            TextureCubeArray lowCubes = ResourceDescriptorHeap[NonUniformResourceIndex( PointShadowLowIndex + lowPage )];
             sh += lowCubes.SampleCmpLevelZero( shadowCmp, float4( o, (float)slot ), compareDepth );
         }
         else

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -488,6 +488,12 @@ struct VobLightInfo {
     std::atomic<size_t> VisibleInRenderPass;
     bool IsPFXVobLight;
     bool IsStaticVobLight;
+    /** Eased 0..1 multiplier the tiled light fill applies to this light's range while it has no shadow
+        cube (see D3D11TiledDeferredShading's unshadowed clamp). Gaining or losing a cube changes the
+        radius by 3-7x, and snapping that in one frame reads as the light being switched off, so the
+        clamp is approached over ~0.3 s instead. 1 = unclamped; a light seen for the first time starts
+        at its target, so world load does not fade every light in. */
+    float UnshadowedRangeScale = -1.0f;   // <0 = never evaluated, snap to the target on first sight
     /** True if this is an indoor-vob */
     bool IsIndoorVob;
 

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -489,10 +489,8 @@ struct VobLightInfo {
     bool IsPFXVobLight;
     bool IsStaticVobLight;
     /** Eased 0..1 multiplier the tiled light fill applies to this light's range while it has no shadow
-        cube (see D3D11TiledDeferredShading's unshadowed clamp). Gaining or losing a cube changes the
-        radius by 3-7x, and snapping that in one frame reads as the light being switched off, so the
-        clamp is approached over ~0.3 s instead. 1 = unclamped; a light seen for the first time starts
-        at its target, so world load does not fade every light in. */
+        cube. Gaining or losing a cube changes the radius by 3-7x, and snapping that in one frame reads as
+        the light switching off, so the clamp is approached over ~0.3 s instead. 1 = unclamped. */
     float UnshadowedRangeScale = -1.0f;   // <0 = never evaluated, snap to the target on first sight
     /** True if this is an indoor-vob */
     bool IsIndoorVob;

--- a/D3D11Engine/pch.h
+++ b/D3D11Engine/pch.h
@@ -39,6 +39,7 @@
 #include <gtl/phmap.hpp>
 
 #include "Logger.h"
+#include "Logging.h"
 #include "Types.h"
 #include "VertexTypes.h"
 


### PR DESCRIPTION
- C++20/23 std::format based logging
  - `Logging::(Inf|Wrn|Dbg|Err)`
- Improve and fix Pointlight shadows some more (fixes #503)
  - don't include vobs into static-only-tier if they are attached to a NPC
  - reduce static-tier re-rendering by making sure positions are properly epsilon-distance gated
  - unify the pointlight tier selection code by extracting the dx12 path and applying it to both dx11 and dx12
  - introduce a second-round spill, where any left-over shadow starved lights get another chance at getting a static-tier shadow slot.
  - Do not only count on having a tiled slot, but also take into account if that slot was actually rendered-into from our light.
- fix #494 by excluding vegetation in dx11 rain shadowmap
- #500 add unverified support for skeletal mesh inventory items