### PR TITLE
fix: crash due to stale pointlight cache. remove artificial sky-cube sheen on wet surfaces, which moved with camera movement and also looked horrible with d3d11 vegetation. Fix MaterialInfo being overridden on rain start if no Normalmaps were found on the material.

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -242,7 +242,8 @@ struct DS_PointLightConstantBuffer {
     // ApplyPointLightWetness (Shaders/include/RainWetnessSample.h).
     XMFLOAT4X4 PL_RainViewProj;
     float PL_SceneWettness;
-    float3 PL_Pad4;
+    float PL_WetLightReflections;
+    float2 PL_Pad4;
 };
 static_assert( sizeof( DS_PointLightConstantBuffer ) == 240,
     "DS_PointLightConstantBuffer (b0) layout must match PS_DS_PointLight.hlsl / PS_DS_PointLightDynShadow.hlsl" );
@@ -525,7 +526,8 @@ struct TiledShadingConstantBuffer {
     // ambient term. See ApplyPointLightWetness (Shaders/include/RainWetnessSample.h).
     XMFLOAT4X4 RainViewProj;
     float SceneWettness;
-    float3 WetnessPad;
+    float WetLightReflections;
+    float2 WetnessPad;
 };
 static_assert( sizeof( TiledShadingConstantBuffer ) == 192,
     "TiledShadingConstantBuffer (b0) layout must match CS_TiledShading.hlsl" );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -875,12 +875,6 @@ XRESULT D3D11GraphicsEngine::Init() {
         LogWarn()
         << "Failed to load file: system\\GD3D11\\Textures\\reflect_cube.dds";
 
-    if ( S_OK != CreateDDSTextureFromFile(
-        GetDevice().Get(), L"system\\GD3D11\\Textures\\SkyCubemap2.dds",
-        nullptr, ReflectionCube2.GetAddressOf() ) )
-        LogWarn()
-        << "Failed to load file: system\\GD3D11\\Textures\\SkyCubemap2.dds";
-
     // Init quad buffers
     ExVertexStruct vx[6];
     ZeroMemory( vx, sizeof( vx ) );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -292,6 +292,9 @@ D3D11GraphicsEngine::D3D11GraphicsEngine() :
     // Initialize previous view-proj matrix to identity for motion vectors
     XMStoreFloat4x4(&m_PrevViewProjMatrix, XMMatrixIdentity());
 
+    m_RainMaterialInfo.buffer.NormalmapStrength = DEFAULT_NOISE_NORMALMAP_STRENGTH;
+    m_RainMaterialInfo.buffer.SpecularIntensity = DEFAULT_NOISE_SPECULAR_STRENGTH;
+
     // Match the resolution with the current desktop resolution
     Resolution = m_scaledResolution =
         Engine::GAPI->GetRendererState().RendererSettings.LoadedResolution;
@@ -2474,12 +2477,7 @@ bool D3D11GraphicsEngine::BindTextureNRFX(zCMaterial* mat, zCTexture* tex, bool 
             srvs[1] = GetSrvFromGfx( nrm );
         } else if ( Engine::GAPI->GetSceneWetness() > 1e-6 ) {
             srvs[1] = DistortionTexture->GetShaderResourceView().Get();
-            if (!info) { info = Engine::GAPI->GetMaterialInfoFrom( mat ); }
-            if (info) {
-                // Value override for non-normalmapped textures in case of rain
-                info->buffer.NormalmapStrength = DEFAULT_NOISE_NORMALMAP_STRENGTH;
-                info->buffer.SpecularIntensity = DEFAULT_NOISE_SPECULAR_STRENGTH;
-            }
+            info = &m_RainMaterialInfo;
         }
     }
 
@@ -5654,11 +5652,8 @@ XRESULT D3D11GraphicsEngine::DrawWorldMesh( bool noTextures ) {
                     updatePSBuffers();
                 }
 
-                if ( info &&
-                    needDefaultNormalsStrength ) {
-                    // Value override for non-normalmapped textures in case of rain
-                    info->buffer.NormalmapStrength = DEFAULT_NOISE_NORMALMAP_STRENGTH;
-                    info->buffer.SpecularIntensity = DEFAULT_NOISE_SPECULAR_STRENGTH;
+                if ( needDefaultNormalsStrength ) {
+                    info = &m_RainMaterialInfo;
                 }
 
                 auto materialInfoBufferAllocation = lastMatCbAllocation;
@@ -7988,13 +7983,7 @@ XRESULT D3D11GraphicsEngine::DrawVOBsInstanced() {
                         // Bind a default normalmap in case the scene is wet and we
                         // currently have none
                         if ( !srv[1] && (wantShader && !isZPrepass) && sceneIsWet) {
-                            // Modify the strength of that default normalmap for the
-                            // material info
-                            if ( info ) {
-                                // update values for distortion texture
-                                info->buffer.NormalmapStrength = DEFAULT_NOISE_NORMALMAP_STRENGTH;
-                                info->buffer.SpecularIntensity = DEFAULT_NOISE_SPECULAR_STRENGTH;
-                            }
+                            info = &m_RainMaterialInfo;
                             srv[1] = GetSrvFromGfx(DistortionTexture);
                         }
                         if ( lastTex != tx

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -606,7 +606,6 @@ public:
     GMesh* InverseUnitSphereMesh;
     /** Reflection */
     Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> ReflectionCube;
-    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> ReflectionCube2;
 private:
     bool PrepareAndBindWindMetadata( const std::vector<MeshVisualInfo*>& activeVisuals );
     void UnbindWindMetadata();

--- a/D3D11Engine/D3D11GraphicsEngine.h
+++ b/D3D11Engine/D3D11GraphicsEngine.h
@@ -796,6 +796,9 @@ private:
         MaterialInfo::IsSame() to skip re-allocating/re-binding an identical buffer. */
     MaterialInfo* m_LastMaterialInfo = nullptr;
 
+    /** Shared stand-in bound for non-normalmapped materials while the scene is wet (distortion noise as normalmap). */
+    MaterialInfo m_RainMaterialInfo;
+
     /** Per-frame ring for small per-draw/per-object dynamic constant buffers
         (grass, and other buffers migrated off their own ID3D11Buffer). */
     std::unique_ptr<ConstantBufferPool> DynamicConstantBufferPool;

--- a/D3D11Engine/D3D11LegacyDeferredShading.cpp
+++ b/D3D11Engine/D3D11LegacyDeferredShading.cpp
@@ -73,6 +73,7 @@ XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
         XMLoadFloat4x4( &graphicsEngine->Effects->GetRainShadowmapCameraRepl().ProjectionReplacement ) *
         XMLoadFloat4x4( &graphicsEngine->Effects->GetRainShadowmapCameraRepl().ViewReplacement ) );
     plcb.PL_SceneWettness = Engine::GAPI->GetSceneWetness();
+    plcb.PL_WetLightReflections = std::max( 0.0f, Engine::GAPI->GetRendererState().RendererSettings.RainWetLightReflections );
 
     color.BindToPixelShader( context.Get(), 0 );
     normals.BindToPixelShader( context.Get(), 1 );

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1597,8 +1597,6 @@ XRESULT D3D11ShadowMap::DrawWorldLights( ID3D11ShaderResourceView* aoMaskSRV )
 
     this->BindSampler( m_context.Get(), 2 );
 
-    m_context->PSSetShaderResources( TX_ReflectionCube, 1, graphicsEngine->ReflectionCube2.GetAddressOf() );
-
     graphicsEngine->GetDistortionTexture()->BindToPixelShader( TX_Distortion );
     graphicsEngine->GetBlueNoiseTexture()->BindToPixelShader( TX_BlueNoise512 );
 

--- a/D3D11Engine/D3D11ShadowMap.h
+++ b/D3D11Engine/D3D11ShadowMap.h
@@ -35,7 +35,6 @@ class GSky;
 enum PS_DS_AtmosphericScatteringSlots {
     TX_ShadowmapArray = 3,
     TX_RainShadowmap = 4,
-    TX_ReflectionCube = 5,
     TX_Distortion = 6,
     TX_SI_SP = 7,
     TX_BlueNoise512 = 8,

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -443,6 +443,7 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
             XMLoadFloat4x4( &graphicsEngine->Effects->GetRainShadowmapCameraRepl().ProjectionReplacement ) *
             XMLoadFloat4x4( &graphicsEngine->Effects->GetRainShadowmapCameraRepl().ViewReplacement ) );
         shadeCB.SceneWettness = Engine::GAPI->GetSceneWetness();
+        shadeCB.WetLightReflections = std::max( 0.0f, settings.RainWetLightReflections );
 
         csTiledShading->UpdateBuffer("TiledShadingConstantBuffer", &shadeCB, sizeof(shadeCB));
 

--- a/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
+++ b/D3D11Engine/D3D12Engine/D3D12GraphicsEngine.h
@@ -1904,7 +1904,7 @@ private:
     struct WetnessCBData {
         XMFLOAT4X4 RainViewProj;
         float SceneWetness; float RainFxWeight; float RainTime; UINT RainShadowIndex;
-        UINT  DistortionIndex; float RainShadowMapSize; float _pad0; float _pad1;
+        UINT  DistortionIndex; float RainShadowMapSize; float WetLightReflections; float _pad1;
     };
     void UploadWetnessConstants();
 

--- a/D3D11Engine/D3D12Engine/D3D12Rain.cpp
+++ b/D3D11Engine/D3D12Engine/D3D12Rain.cpp
@@ -408,6 +408,7 @@ void D3D12GraphicsEngine::UploadWetnessConstants() {
     cb.RainFxWeight  = Engine::GAPI->GetRainFXWeight();
     cb.RainTime      = Engine::GAPI->GetTimeSeconds();   // same clock D3D11 feeds AC_Time (GSky.cpp)
     cb.RainShadowMapSize = static_cast<float>( kRainShadowMapSize );
+    cb.WetLightReflections = std::max( 0.0f, Engine::GAPI->GetRendererState().RendererSettings.RainWetLightReflections );
 
     // 0xFFFFFFFF on either index disables the effect in the shader. The rain map needs both its resources
     // AND a computed camera; the distortion texture is an optional asset (distortion2.dds).

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -2183,6 +2183,16 @@ void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world, bool tearDownLight ) {
     if ( !world || world == LoadedWorldInfo->MainWorld )
         Engine::GraphicsEngine->OnVobRemovedFromWorld( vob );
 
+    // Before the RegisteredVobs early-out: a zCVobLight has no visual, so OnAddVob never registers it.
+    if ( tearDownLight ) {
+        if ( auto lit = VobLightMap.find( static_cast<zCVobLight*>(vob) ); lit != VobLightMap.end() ) {
+            VobLightInfo* li = lit->second;
+            VobLightMap.erase( lit );
+            ++LightMirrorEpoch;   // BspInfo::Lights mirrors may still hold li
+            delete li;
+        }
+    }
+
     auto it = RegisteredVobs.find( vob );
     if ( it == RegisteredVobs.end() ) {
         // Not registered
@@ -2235,13 +2245,6 @@ void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world, bool tearDownLight ) {
             vlit.second->LightShadowBuffers->OnVobRemovedFromWorld( svi );
     }
 
-    // A disabled zCVobLight keeps its slot in the BSP leaf's LightVobList (that array mirrors the
-    // world's static light layout, not enabled state) and can be re-enabled with the same zCVob*.
-    // Tearing its VobLightInfo down here would delete state that CollectLeafVobs' mirror
-    // (base->Lights) and VobLightMap still expect to find, and that the vob's own IsEnabled() check
-    // is what's supposed to filter out of rendering - not us deleting and recreating it every toggle.
-    VobLightInfo* li = tearDownLight ? VobLightMap[static_cast<zCVobLight*>(vob)] : nullptr;
-
     // Erase it from the particle-effect list
     auto pit = std::ranges::find(ParticleEffectVobs, vob );
     if ( pit != ParticleEffectVobs.end() ) {
@@ -2255,17 +2258,10 @@ void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world, bool tearDownLight ) {
         DecalVobs.pop_back();
     }
 
-    // Erase it from the list of lights - only on a real removal (see tearDownLight comment above).
-    if ( tearDownLight ) {
-        VobLightMap.erase( static_cast<zCVobLight*>(vob) );
-    }
-
     // Remove from BSP-Cache
     std::vector<BspInfo*>* nodes = nullptr;
     if ( vi )
         nodes = &vi->ParentBSPNodes;
-    else if ( li )
-        nodes = &li->ParentBSPNodes;
     else if ( svi )
         nodes = &svi->ParentBSPNodes;
 
@@ -2276,24 +2272,6 @@ void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world, bool tearDownLight ) {
                 EraseVobFromLeafList( node->IndoorVobs, vi );
                 EraseVobFromLeafList( node->Vobs, vi );
                 EraseVobFromLeafList( node->SmallVobs, vi );
-            }
-
-            if ( li && nodes ) {
-                for ( auto bit = node->Lights.begin(); bit != node->Lights.end(); ++bit ) {
-                    if ( (*bit)->Vob == static_cast<zCVobLight*>(vob) ) {
-                        (*bit) = node->Lights.back();
-                        node->Lights.pop_back();
-                        break;
-                    }
-                }
-
-                for ( auto bit = node->IndoorLights.begin(); bit != node->IndoorLights.end(); ++bit ) {
-                    if ( (*bit)->Vob == static_cast<zCVobLight*>(vob) ) {
-                        (*bit) = node->IndoorLights.back();
-                        node->IndoorLights.pop_back();
-                        break;
-                    }
-                }
             }
 
             if ( svi && nodes ) {
@@ -2356,9 +2334,6 @@ void GothicAPI::OnRemovedVob( zCVob* vob, zCWorld* world, bool tearDownLight ) {
         delete (*svit).second;
         SkeletalVobMap.erase( svit );
     }
-
-    // delete light info, if valid
-    if ( li ) delete li;
 }
 
 /** Called on a SetVisual-Call of a vob */
@@ -5346,6 +5321,7 @@ void GothicAPI::BuildBspVobMapCacheHelper( zCBspBase* base ) {
         }
 
         bvi.NumStaticLights = leaf->LightVobList.NumInArray;
+        bvi.LightsEpoch = LightMirrorEpoch;
     } else {
         zCBspNode* node = static_cast<zCBspNode*>(base);
 
@@ -7100,10 +7076,13 @@ static void CollectLeafVobs(
         // before the range and frustum tests so a light pays for those exactly once per frame.
         const int numLights = leaf->LightVobList.NumInArray;
 
-        // base->Lights mirrors LightVobList index-for-index (filled in BuildBspVobMapCacheHelper).
-        // It can go stale when the game adds or removes a light at runtime, so each entry is checked
-        // with one pointer compare; a miss falls back to the map and repairs the slot.
+        // base->Lights mirrors LightVobList index-for-index; each entry is pointer-checked and repaired from the map.
+        // An older epoch means a VobLightInfo was deleted since, so the entries are dropped unread.
         const bool mirrorUsable = static_cast<int>(base->Lights.size()) == numLights;
+        if ( mirrorUsable && base->LightsEpoch != Engine::GAPI->LightMirrorEpoch ) {
+            std::ranges::fill( base->Lights, nullptr );
+            base->LightsEpoch = Engine::GAPI->LightMirrorEpoch;
+        }
 
         const bool dropStaticLights = Engine::GAPI->GetRendererState().RendererSettings.DisableStaticPointlights;
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -1201,6 +1201,7 @@ void GothicAPI::LoadRendererWorldSettings( GothicRendererSettings& s, const char
     s.RainNumParticles = GetPrivateProfileIntA( "Rain", "NumParticles", s.RainNumParticles, ini.c_str() );
     GetPrivateProfileArray( "Rain", "GlobalVelocity", &s.RainGlobalVelocity.x, 3, &s.RainGlobalVelocity.x, ini );
     s.RainSceneWettness = GetPrivateProfileFloatA( "Rain", "SceneWettness", s.RainSceneWettness, ini );
+    s.RainWetLightReflections = std::clamp( GetPrivateProfileFloatA( "Rain", "WetLightReflections", s.RainWetLightReflections, ini ), 0.0f, 4.0f );
     s.RainSunLightStrength = GetPrivateProfileFloatA( "Rain", "SunLightStrength", s.RainSunLightStrength, ini );
     GetPrivateProfileRGB( "Rain", "FogColor", s.RainFogColor, ini );
     s.RainFogDensity = GetPrivateProfileFloatA( "Rain", "FogDensity", s.RainFogDensity, ini );
@@ -1269,6 +1270,7 @@ void GothicAPI::SaveRendererWorldSettings( const GothicRendererSettings& s, cons
     WritePrivateProfileStringA( "Rain", "NumParticles", to_string_locale_independent( s.RainNumParticles ).c_str(), ini.c_str() );
     WritePrivateProfileArray( "Rain", "GlobalVelocity", &s.RainGlobalVelocity.x, 3, ini.c_str() );
     WritePrivateProfileStringA( "Rain", "SceneWettness", to_string_locale_independent( s.RainSceneWettness ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Rain", "WetLightReflections", to_string_locale_independent( s.RainWetLightReflections ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Rain", "SunLightStrength", to_string_locale_independent( s.RainSunLightStrength ).c_str(), ini.c_str() );
     WritePrivateProfileRGB( "Rain", "FogColor", s.RainFogColor, ini );
     WritePrivateProfileStringA( "Rain", "FogDensity", to_string_locale_independent( s.RainFogDensity ).c_str(), ini.c_str() );

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -266,8 +266,8 @@ struct MaterialInfo {
 
         void SetDefault() {
             // -- Defaults for NON Normalmapped, NON FX-Mapped materials
-            SpecularIntensity = 0.1f;
-            SpecularPower = 5.0f;
+            SpecularIntensity = 0.3f;
+            SpecularPower = 60.0f;
             // ---
             
             NormalmapStrength = 1.0f;

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -145,6 +145,7 @@ struct BspInfo {
         IndoorVobs = std::move( other.IndoorVobs );
         SmallVobs = std::move( other.SmallVobs );
         Lights = std::move( other.Lights );
+        LightsEpoch = other.LightsEpoch;
         IndoorLights = std::move( other.IndoorLights );
         Mobs = std::move( other.Mobs );
         NodePolygons = std::move( other.NodePolygons );
@@ -172,6 +173,7 @@ struct BspInfo {
     std::vector<LeafVobEntry> IndoorVobs;
     std::vector<LeafVobEntry> SmallVobs;
     std::vector<VobLightInfo*> Lights;
+    uint32_t LightsEpoch = 0;   // GothicAPI::LightMirrorEpoch the Lights entries were last valid for
     std::vector<VobLightInfo*> IndoorLights;
     std::vector<SkeletalVobInfo*> Mobs;
 
@@ -1209,6 +1211,8 @@ private:
 public:
     // temporarily, to allow CollectVisibleVobsHelper to be templated for inlining optimizations
     gtl::flat_hash_map<zCVobLight*, VobLightInfo*> VobLightMap;
+    // Bumped on every VobLightInfo delete; a BspInfo::Lights stamped with an older value may dangle.
+    uint32_t LightMirrorEpoch = 0;
     // Exposed for CollectLeafVobs/CollectVisibleVobsWithLeafCache (file-static helpers)
     BspLeafLinearCache LeafLinearCache;
 private:

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -872,6 +872,7 @@ struct GothicRendererSettings {
         RainGlobalVelocity = XMFLOAT3( 250, -1000, 0 );
         RainUseInitialSet = false;
         RainSceneWettness = 0.0f;
+        RainWetLightReflections = 1.0f;
         RainSunLightStrength = 0.50f;
         RainFogColor = XMFLOAT3( 0.28f, 0.28f, 0.28f );
         RainFogDensity = 0.00050f;
@@ -1294,6 +1295,8 @@ struct GothicRendererSettings {
     bool RainUseInitialSet;
     XMFLOAT3 RainGlobalVelocity;
     float RainSceneWettness;
+    // Strength of the point-light reflection streaks on wet ground (0 = off, the old dull look).
+    float RainWetLightReflections;
 
     float RainSunLightStrength;
     XMFLOAT3 RainFogColor;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -816,7 +816,7 @@ struct GothicRendererSettings {
         SkyIblIntensity = 0.0f; // D3D12 only: scales the sky image-based indirect light (0 = flat ambient only)
         SkyOcclusionStrength = 0.85f; // D3D12 only: how hard a roof cuts the sky ambient (0 = off, 1 = interiors get none)
         SkyIblNightFloor = 0.14f; // D3D12 only: minimum night sky radiance for the IBL (see D3D12SkyIbl.cpp)
-        DefaultMaterialRoughness = 0.80f; // D3D12 only: roughness for materials with no _FX/_ORM map
+        DefaultMaterialRoughness = 0.50f; // D3D12 only: roughness for materials with no _FX/_ORM map
 
         BloomStrength = 1.0f;
         EnableBloom = false;

--- a/D3D11Engine/ImGuiShim.cpp
+++ b/D3D11Engine/ImGuiShim.cpp
@@ -1867,6 +1867,8 @@ void ImGuiShim::RenderAdvancedColumn2( GothicRendererSettings& settings, GothicA
         ImGui::Checkbox( "RainUseInitialSet", &settings.RainUseInitialSet );
         ImGui::DragFloat3( "RainGlobalVelocity", &settings.RainGlobalVelocity.x, 1.0f, -5000.0f, 5000.0f, "%.0f" );
         ImGui::DragFloat( "RainSceneWettness", &settings.RainSceneWettness, 0.01f );
+        ImGui::SliderFloat( "RainWetLightReflections", &settings.RainWetLightReflections, 0.0f, 4.0f, "%.2f" );
+        ImGui::SetItemTooltip( "Strength of point-light reflection streaks on wet ground and puddles. 0 = off." );
         ImGui::DragFloat( "RainSunLightStrength", &settings.RainSunLightStrength, 0.01f, 0.0f, 0.0f, "%.2f" );
         ImGui::DragFloat( "RainFogDensity", &settings.RainFogDensity, 0.001f );
         ImGui::ColorEdit3( "RainFogColor", &settings.RainFogColor.x );

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -37,7 +37,8 @@ cbuffer TiledShadingConstantBuffer : register( b0 ) {
     // Rain wetness, frame-constant (see ApplyPointLightWetness / RainWetnessSample.h).
     matrix RainViewProj;
     float SceneWettness;
-    float3 WetnessPad;
+    float WetLightReflections;
+    float2 WetnessPad;
 };
 
 SamplerComparisonState SS_Comp : register( s2 );
@@ -89,7 +90,7 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
     // additively blending un-wetted brightness on top of it (see RainWetnessSample.h's header for the
     // bug this fixes; this is the primary point-light path lights use, PS_DS_PointLight.hlsl only
     // handles the shadow-cube-overflow fallback).
-    ApplyPointLightWetness( wsPosition, wsNormal, TX_RainShadowmap, SS_Comp, RainViewProj, SceneWettness,
+    float wet = ApplyPointLightWetness( wsPosition, wsNormal, TX_RainShadowmap, SS_Comp, RainViewProj, SceneWettness,
         diffuse.rgb, specIntensity, specPower );
 
     // Compute tile index
@@ -136,6 +137,11 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
             float3 H = normalize( lightDir + V );
             float spec = PLS_CalcBlinnPhongLighting( normal, H ) * light.Color.w;
             float3 lighting = PLS_ComputePointLightLighting( diffuse.rgb, light.Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod );
+
+            // Wet ground: water-film reflection streak (see WetCoatSpecular in RainWetnessSample.h).
+            [branch]
+            if ( wet > 0.0f && WetLightReflections > 0.0f )
+                lighting += light.Color.rgb * ( WetCoatSpecular( normal, V, lightDir, distance ) * falloff * wet * light.Color.w * WetLightReflections );
 
             // Apply shadow if this light has a shadow cubemap and contribution is non-negligible.
             // [branch]: guards a real cube-shadow sample, so force a branch instead of flattening.

--- a/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Skeletal.hlsl
@@ -131,7 +131,7 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= mad(wetness, 0.8 - 1.0, 1.0);
-    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );   // dynamic point lights on top (PBR)
+    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b, wetness );   // dynamic point lights on top (PBR)
     // No fixed-direction wet sheen here — see Wetness.hlsl's ApplySceneWetness header comment.
     // Opaque-surface SSR (temporal, D3D12 only) — see World.hlsl's PSMain for the full explanation. The
     // weight MUST be PBR_FresnelSchlick, not an ad hoc curve (see EvaluateOpaqueSSR's header comment).

--- a/D3D11Engine/Shaders/D3D12/Vob.hlsl
+++ b/D3D11Engine/Shaders/D3D12/Vob.hlsl
@@ -127,7 +127,7 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= mad(wetness, 0.8 - 1.0, 1.0);
-    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
+    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b, wetness );
     // No fixed-direction wet sheen here — see Wetness.hlsl's ApplySceneWetness header comment.
     // Opaque-surface SSR (temporal, D3D12 only) — see World.hlsl's PSMain for the full explanation. The
     // weight MUST be PBR_FresnelSchlick, not an ad hoc curve (see EvaluateOpaqueSSR's header comment).
@@ -236,7 +236,7 @@ float4 PSMainBindless( VS_OUT i ) : SV_TARGET
     float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= mad(wetness, 0.8 - 1.0, 1.0);
-    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
+    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b, wetness );
     // No fixed-direction wet sheen here — see Wetness.hlsl's ApplySceneWetness header comment.
     // Opaque-surface SSR (temporal, D3D12 only) — see World.hlsl's PSMain for the full explanation. The
     // weight MUST be PBR_FresnelSchlick, not an ad hoc curve (see EvaluateOpaqueSSR's header comment).

--- a/D3D11Engine/Shaders/D3D12/World.hlsl
+++ b/D3D11Engine/Shaders/D3D12/World.hlsl
@@ -148,7 +148,7 @@ float4 PSMain( VS_OUT i ) : SV_TARGET
     float ssao = SampleScreenSpaceAO( i.clip.xy );
     float3 rgb = ComputeSunLightingPBR( i.wpos, N, albedo, vertLighting, shadow, orm.g, orm.b, orm.r, ssao );
     rgb *= mad(wetness, 0.8 - 1.0, 1.0);   // D3D11 dims the SUN light color 20% where the surface is wet
-    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b );
+    rgb += AccumTiledPointLights( i.clip.xyz, i.wpos, N, albedo, orm.g, orm.b, wetness );
     // No fixed-direction wet sheen here — see ApplySceneWetness's header comment for why D3D12 drops that
     // D3D11 hack in favor of the real Cook-Torrance sun specular (already fed by the roughness dip above)
     // plus the opaque-surface SSR below.

--- a/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/PBRLighting.hlsl
@@ -583,9 +583,50 @@ uint ComputeZSlice( float hwDepth )
     return (uint)clamp( floor( t * (float)NUM_Z_SLICES ), 0.0, (float)( NUM_Z_SLICES - 1 ) );
 }
 
+// Water-film specular under a point light: anisotropic GGX stretched toward the viewer (wet-street streaks),
+// widened by an assumed flame size so the reflection isn't a sub-pixel dot. Mirrored in RainWetnessSample.h.
+static const float WET_COAT_STREAK         = 6.0;    // lobe width multiplier along the view direction at grazing view
+static const float WET_COAT_MIN_ROUGHNESS  = 0.06;
+static const float WET_LIGHT_SOURCE_RADIUS = 15.0;   // world units (~15 cm flame)
+
+float WetCoatSpecular( float3 N, float3 V, float3 L, float lightDist, float roughness )
+{
+    float NdotL = saturate( dot( N, L ) );
+    if ( NdotL <= 0.0 ) return 0.0;
+    float NdotV = saturate( dot( N, V ) );
+    float3 H = normalize( V + L );
+
+    // Karis sphere-light widening.
+    float r = max( roughness, WET_COAT_MIN_ROUGHNESS );
+    float a = saturate( r * r + WET_LIGHT_SOURCE_RADIUS / ( 2.0 * max( lightDist, 1.0 ) ) );
+
+    // Tangent = view projected onto the surface; the stretch fades out when looking straight down.
+    float3 vt = V - N * dot( N, V );
+    float vtLen = length( vt );
+    float3 T = vtLen > 1e-3 ? vt / vtLen : normalize( cross( N, abs( N.x ) < 0.9 ? float3( 1, 0, 0 ) : float3( 0, 0, 1 ) ) );
+    float3 B = cross( N, T );
+    float at = min( a * lerp( 1.0, WET_COAT_STREAK, vtLen ), 1.0 );
+    float ab = a;
+
+    float ht = dot( H, T ) / at, hb = dot( H, B ) / ab, hn = dot( N, H );
+    float s = ht * ht + hb * hb + hn * hn;
+    float D = 1.0 / ( PBR_PI * at * ab * s * s );
+
+    // Height-correlated anisotropic Smith visibility.
+    float lv = NdotL * length( float3( at * dot( T, V ), ab * dot( B, V ), NdotV ) );
+    float ll = NdotV * length( float3( at * dot( T, L ), ab * dot( B, L ), NdotL ) );
+    float vis = 0.5 / max( lv + ll, 1e-4 );
+
+    float f = saturate( 1.0 - dot( V, H ) );
+    float f2 = f * f;
+    float F = 0.02 + 0.98 * f2 * f2 * f;   // water F0
+    return D * vis * F * NdotL;
+}
+
 // Applies one light's contribution (direct BRDF + its shadow, if any) and folds it into `total`/`maxLit`.
+// `wet` is ApplySceneWetness's result; the water-film lobe replaces the base specular in proportion.
 void ApplyTiledLight( uint lightIndex, float3 wpos, float3 N, float3 V, float3 albedo, float roughness,
-                       float metallic, inout float3 total, inout float3 maxLit )
+                       float metallic, float wet, inout float3 total, inout float3 maxLit )
 {
     GPULight L = Lights[lightIndex];
     float3 dir = L.PositionWorld - wpos;
@@ -598,7 +639,11 @@ void ApplyTiledLight( uint lightIndex, float3 wpos, float3 N, float3 V, float3 a
     // specular scale: an isStatic() zCVobLight is one of the "atmospheric" fill lights Gothic pre-places to
     // brighten a room, not a physical source, so it must contribute diffuse only — a highlight from it reads as a
     // phantom lamp. Same suppression D3D11 does with light.Color.w.
-    float3 lit = PBR_DirectLighting( albedo, L.Color.rgb, N, V, dir, roughness, metallic, falloff, L.Color.w );
+    float coat = wet * saturate( WetLightReflections );
+    float3 lit = PBR_DirectLighting( albedo, L.Color.rgb, N, V, dir, roughness, metallic, falloff, L.Color.w * ( 1.0 - coat ) );
+    [branch]
+    if ( coat > 0.0 && L.Color.w > 0.0 )
+        lit += L.Color.rgb * ( WetCoatSpecular( N, V, dir, dist, roughness ) * falloff * wet * L.Color.w * WetLightReflections );
     // [branch]: guards a real cube-shadow sample, so force a branch instead of flattening.
     [branch]
     if ( L.ShadowCubeIndex != 0 )
@@ -623,7 +668,7 @@ void ApplyTiledLight( uint lightIndex, float3 wpos, float3 N, float3 V, float3 a
 // Cook-Torrance BRDF per light, additive. Bit-scanning a fixed-width mask (rather than looping an
 // {Offset,Count} index slice) can never spin away on a garbage grid entry — the loop bound is the popcount of
 // the mask, not an unclamped Count. Most words are 0 for a typical cluster, so the per-word while() is cheap.
-float3 AccumTiledPointLights( float3 svpos, float3 wpos, float3 N, float3 albedo, float roughness, float metallic )
+float3 AccumTiledPointLights( float3 svpos, float3 wpos, float3 N, float3 albedo, float roughness, float metallic, float wet = 0.0 )
 {
     uint2 tile = uint2( svpos.xy ) / TILE_SIZE;
     uint  tileIndex = tile.y * NumTilesX + tile.x;
@@ -648,7 +693,7 @@ float3 AccumTiledPointLights( float3 svpos, float3 wpos, float3 N, float3 albedo
         {
             uint bit = firstbitlow( m );
             m &= m - 1;   // clear the lowest set bit
-            ApplyTiledLight( w * 32u + bit, wpos, N, V, albedo, roughness, metallic, total, maxLit );
+            ApplyTiledLight( w * 32u + bit, wpos, N, V, albedo, roughness, metallic, wet, total, maxLit );
         }
     }
     // LimitLightIntensity: swap "sum of every light" for "brightest single light" (mirrors D3D11's

--- a/D3D11Engine/Shaders/D3D12/include/ShadowCB.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/ShadowCB.hlsl
@@ -33,7 +33,7 @@ cbuffer ShadowCB : register(SHADOWCB_REGISTER)
     // rain shadowmap / distortion2.dds isn't available, which disables the effect entirely.
     float4x4 RainViewProj;
     float    SceneWetness;      float RainFxWeight;     float RainTime;   uint RainShadowIndex;
-    uint     DistortionIndex;   float RainShadowMapSize; float2 _wetpad;
+    uint     DistortionIndex;   float RainShadowMapSize; float WetLightReflections; float _wetpad;
     // --- Screen-space AO / opaque-SSR-reprojection block, 80 bytes, written by UploadAoScreenConstants
     // (kAoReprojCbOffset). AoInvRes: 1/screen-size, which SampleScreenSpaceAO turns SV_Position into a mask
     // UV with. SsrPrevColorIndex/SsrPrevDepthIndex + SsrPrevViewProj: the previous-frame opaque scene

--- a/D3D11Engine/Shaders/D3D12/include/Wetness.hlsl
+++ b/D3D11Engine/Shaders/D3D12/include/Wetness.hlsl
@@ -199,6 +199,44 @@ float ComputePuddleMask( float3 geomN, float3 wsPosition, float wetness )
     return pooled * flatness;
 }
 
+// Rain-drop rings on puddles: one expanding ring per cell on two offset grids, re-seeded every cycle.
+static const float PUDDLE_RIPPLE_CELL      = 70.0;    // world units per drop cell
+static const float PUDDLE_RIPPLE_PERIOD    = 0.9;     // seconds from impact to fade-out
+static const float PUDDLE_RIPPLE_STRENGTH  = 0.5;
+static const float PUDDLE_RIPPLE_FADE_DIST = 2500.0;  // rings fade out by this camera distance (they alias beyond it)
+
+uint PuddleHash( int2 c )
+{
+    uint h = ( uint( c.x ) * 0x8DA6B343u ) ^ ( uint( c.y ) * 0xD8163841u );
+    h ^= h >> 15; h *= 0x2C1B3C6Du; h ^= h >> 12; h *= 0x297A2D39u; h ^= h >> 15;
+    return h;
+}
+
+// World-XZ surface slope of the ripple field at p.
+float2 PuddleRippleSlope( float2 p, float time )
+{
+    float2 slope = 0.0;
+    [unroll] for ( int layer = 0; layer < 2; ++layer )
+    {
+        float2 q = p / PUDDLE_RIPPLE_CELL + float2( 0.5, 0.37 ) * layer;
+        int2 cell = int2( floor( q ) );
+        float phase = float( PuddleHash( cell + int2( 0, 7919 * layer ) ) & 0xFFFFu ) / 65535.0;
+        float cycle = time / PUDDLE_RIPPLE_PERIOD + phase;
+        uint h = PuddleHash( cell + int2( int( floor( cycle ) ) * 131, 7919 * layer + 17 ) );
+        if ( float( h >> 24 ) / 255.0 > RainFxWeight ) continue;   // lighter rain, fewer drops
+
+        float t = frac( cycle );
+        float2 center = 0.3 + 0.4 * float2( h & 0xFFu, ( h >> 8 ) & 0xFFu ) / 255.0;
+        float2 d = frac( q ) - center;
+        float r = length( d );
+        // 1.5 wavelengths either side of the expanding front, calm inside and outside it.
+        float x = clamp( ( r - t * 0.28 ) * 160.0, -3.0 * PBR_PI, 3.0 * PBR_PI );
+        float wave = sin( x ) * ( 1.0 - abs( x ) / ( 3.0 * PBR_PI ) );
+        slope += d / max( r, 1e-4 ) * ( wave * ( 1.0 - t ) * ( 1.0 - t ) );
+    }
+    return slope * PUDDLE_RIPPLE_STRENGTH;
+}
+
 // Applies scene wetness at one fragment. N / albedo / roughness are modified in place. Returns
 // localWettness [0,1] — 0 means "nothing was changed", which callers use to skip the remaining wetness
 // work. Call with the UNPERTURBED-by-wetness normal and BEFORE the sun shadow lookup, matching D3D11 (it
@@ -244,6 +282,15 @@ float ApplySceneWetness( float3 wpos, inout float3 N, inout float3 albedo, inout
     // water stays closer to a flat mirror than a rippling wet wall, so puddle pixels get less of the
     // tri-planar ripple deformation blended in.
     N = normalize( lerp( N, wetNormal, RainFxWeight * wetness * 0.5 * ( 1.0 - puddle * 0.8 ) ) );
+
+    // Rain-drop rings on pooled water; they break up the light streaks and SSR like real puddles do.
+    float rippleFade = saturate( 1.0 - distance( wpos, CamPosWS ) / PUDDLE_RIPPLE_FADE_DIST );
+    [branch]
+    if ( puddle > 0.0 && RainFxWeight > 0.0 && rippleFade > 0.0 )
+    {
+        float2 slope = PuddleRippleSlope( wpos.xz, RainTime ) * ( puddle * rippleFade );
+        N = normalize( N + float3( -slope.x, 0.0, -slope.y ) );
+    }
 
     // PBR stand-in for D3D11's "specPower -> 150, specIntensity -> 0": water is smooth, so pull
     // roughness toward glossy and let Cook-Torrance tighten the existing highlights. Puddle pixels go all

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -59,7 +59,6 @@ Texture2D TX_ShadowmapAtlas : register(t3);
 Texture2DArray TX_ShadowmapArray : register(t3);
 #endif
 Texture2D TX_RainShadowmap : register(t4);
-TextureCube TX_ReflectionCube : register(t5);
 Texture2D TX_Distortion : register(t6);
 Texture2D TX_SI_SP : register(t7);
 Texture2D TX_ShadowBlueNoise : register(t8);
@@ -167,7 +166,7 @@ void ApplyRainNormalDeformation(inout float3 vsNormal, float3 wsPosition, inout 
 }
 
 /** Returns new diffusecolor (rgb)*/
-void ApplySceneWettness(float3 wsPosition, float3 vsPosition, float3 vsDir, inout float3 vsNormal, in out float3 diffuse, in out float specIntensity, in out float specPower, out float specAdd, out float localWettness)
+void ApplySceneWettness(float3 wsPosition, inout float3 vsNormal, in out float3 diffuse, in out float specIntensity, in out float specPower, out float localWettness)
 {
 	// Ask the rain-shadowmap if we can hit this pixel. Wide, world-sized soft filter (see
 	// ComputeRainWetness) so occluders fade the ground damp instead of stamping their outline.
@@ -196,50 +195,14 @@ void ApplySceneWettness(float3 wsPosition, float3 vsPosition, float3 vsDir, inou
     localWettness = pixelWettnes;
 	
     vsNormal = lerp(vsNormal, nrm, AC_RainFXWeight * pixelWettnes * 0.5f); // Only apply deformation if it's actually raining
-	
-	// Get fresnel-effect
-    // float fresnel = pow(1.0f - max(0.0f, dot(vsNormal, -vsDir)), 160.0f);
-    
-    	
-	//vsNormalCpy.z *= 0.3f;
-	//vsNormalCpy = normalize(vsNormalCpy);
-	
-	// Scale specular intensity and power
+
+	// Scale specular intensity and power. No additive reflection-cube/fixed-direction sheen (removed, D3D12 parity).
     specIntensity = lerp(specIntensity, 0.0, pixelWettnes);
     specPower = lerp(specPower, 150.0f, pixelWettnes);
-	
-	// Reflection
-    float3 reflect_vec = reflect(-vsDir.xyz, vsNormal.xyz);
-	
-	// sample reflection cube
-    float4 refCube = TX_ReflectionCube.Sample(SS_Linear, reflect_vec);
-    float3 reflection = refCube.rgb * refCube.a;
-	
-    float3 l1 = normalize(float3(0.0f, 0.5f, -1.0f));
-    float3 l2 = normalize(mul(normalize(float3(-0.333f, 0.533f, 0.333f)), (float3x3) SQ_View));
-    float3 l3 = normalize(mul(normalize(float3(0, 0.566f, -0.666f)), (float3x3) SQ_View));
-	
-    float3 H_1 = normalize(l1 + vsDir);
-    float3 H_2 = normalize(l2 + vsDir);
-    float3 H_3 = normalize(l3 + vsDir);
-    float spec1 = CalcBlinnPhongLighting(vsNormal, H_1);
-    float spec2 = CalcBlinnPhongLighting(vsNormal, H_2);
-    float spec3 = CalcBlinnPhongLighting(vsNormal, H_3);
-		
-	// power the reflection 
-    reflection = pow(reflection, 2.5f);
-    //reflection += fresnel * 0.1f;
-	
-    reflection += pow(spec1, specPower) * 0.7f + pow(spec2, specPower) * 0.7f + pow(spec3, specPower) * 0.6f;
-	
+
 	// Compute wet pixel color
     float diffuseLum = dot(diffuse, float3(0.3333f, 0.3333f, 0.3333f));
     float3 wetPixel = lerp(diffuseLum, diffuse, 0.75f) * 0.75f; // Desaturate and darken the scene a bit
-	
-	
-	
-		// Scale the total amount of spec-lighting by the wetness factor and whether the scene is currently drying out or it's still raining
-    specAdd = reflection * pixelWettnes * mad(AC_RainFXWeight, 0.10f - 0.08f, 0.08f);
     diffuse = lerp(diffuse, wetPixel, pixelWettnes);
 }
 
@@ -312,14 +275,10 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 #endif
 
 	// Compute wettness
-    float specWet = 0.0f;
     float localWettness = 0.0f;
-	
+
 #ifdef APPLY_RAIN_EFFECTS
-    ApplySceneWettness(wsPosition, vsPosition, V, normal, diffuse.rgb, specIntensity, specPower, specWet, localWettness);
-	
-	// Boost specWet when not in shadow
-	specWet += specWet * shadow;
+    ApplySceneWettness(wsPosition, normal, diffuse.rgb, specIntensity, specPower, localWettness);
 #endif
 	// Compute specular lighting
 	
@@ -347,7 +306,7 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
     float ssao = TX_AO.Sample(SS_Linear, uv).r;
 
     spec = pow(spec, specPower) * specIntensity * SQ_SunSpecularEnabled;
-    float3 specBare = spec * lightColor.rgb * sun + specWet * lightColor.rgb;
+    float3 specBare = spec * lightColor.rgb * sun;
     float3 specColored = saturate(lerp(specBare, specBare * diffuse.rgb, specMod));
 	
     float shadowAO = lerp(1.0f, vertLighting, SQ_ShadowAOStrength);

--- a/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
@@ -28,7 +28,8 @@ cbuffer DS_PointLightConstantBuffer : register( b0 )
 	// Rain wetness, frame-constant (see ApplyPointLightWetness / RainWetnessSample.h).
 	matrix PL_RainViewProj;
 	float PL_SceneWettness;
-	float3 PL_Pad4;
+	float PL_WetLightReflections;
+	float2 PL_Pad4;
 };
 
 //--------------------------------------------------------------------------------------
@@ -126,7 +127,7 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	// Rain wetness: darken/dampen this light's contribution consistently with what
 	// PS_DS_AtmosphericScattering.hlsl already did for the sun/ambient term, instead of adding
 	// un-wetted brightness on top of it (see RainWetnessSample.h's header for the bug this fixes).
-	ApplyPointLightWetness(wsPosition, wsNormal, TX_RainShadowmap, SS_Comp, PL_RainViewProj, PL_SceneWettness,
+	float wet = ApplyPointLightWetness(wsPosition, wsNormal, TX_RainShadowmap, SS_Comp, PL_RainViewProj, PL_SceneWettness,
 		diffuse.rgb, specIntensity, specPower);
 
 	// Get direction and distance from the light to that position
@@ -149,7 +150,12 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 
 	// Blend this with the light color, world diffuse and specular term.
 	float3 lighting = PLS_ComputePointLightLighting(diffuse.rgb, PL_Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod);
-	
+
+	// Wet ground: water-film reflection streak (see WetCoatSpecular in RainWetnessSample.h).
+	[branch]
+	if (wet > 0.0f && PL_WetLightReflections > 0.0f)
+		lighting += PL_Color.rgb * (WetCoatSpecular(normal, V, lightDir, distance) * falloff * wet * PL_Color.w * PL_WetLightReflections);
+
 	return float4(saturate(lighting),1);
 }
 

--- a/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
@@ -28,7 +28,8 @@ cbuffer DS_PointLightConstantBuffer : register( b0 )
 	// Rain wetness, frame-constant (see ApplyPointLightWetness / RainWetnessSample.h).
 	matrix PL_RainViewProj;
 	float PL_SceneWettness;
-	float3 PL_Pad4;
+	float PL_WetLightReflections;
+	float2 PL_Pad4;
 };
 
 //--------------------------------------------------------------------------------------
@@ -88,7 +89,7 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	// Rain wetness: darken/dampen this light's contribution consistently with what
 	// PS_DS_AtmosphericScattering.hlsl already did for the sun/ambient term, instead of adding
 	// un-wetted brightness on top of it (see RainWetnessSample.h's header for the bug this fixes).
-	ApplyPointLightWetness(wsPosition, wsNormal, TX_RainShadowmap, SS_Comp, PL_RainViewProj, PL_SceneWettness,
+	float wet = ApplyPointLightWetness(wsPosition, wsNormal, TX_RainShadowmap, SS_Comp, PL_RainViewProj, PL_SceneWettness,
 		diffuse.rgb, specIntensity, specPower);
 
 	//return float4(normalize(wsPosition - Pl_PositionWorld), 1.0f);
@@ -126,7 +127,12 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float spec = PLS_CalcBlinnPhongLighting(normal, H) * PL_Color.w;
 	float specMod = PLS_ComputeSpecMod(diffuse.rgb);
 	float3 lighting = PLS_ComputePointLightLighting(diffuse.rgb, PL_Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod);
-	
+
+	// Wet ground: water-film reflection streak (see WetCoatSpecular in RainWetnessSample.h).
+	[branch]
+	if (wet > 0.0f && PL_WetLightReflections > 0.0f)
+		lighting += PL_Color.rgb * (WetCoatSpecular(normal, V, lightDir, distance) * falloff * wet * PL_Color.w * PL_WetLightReflections);
+
 	lighting *= shadow;
 	
 	//lighting = GetShadow(uv);

--- a/D3D11Engine/Shaders/include/RainWetnessSample.h
+++ b/D3D11Engine/Shaders/include/RainWetnessSample.h
@@ -72,8 +72,8 @@ float ComputeRainWetnessLite( float3 wsPosition, Texture2D rainMap, SamplerCompa
 
 // Darkens/desaturates diffuse and dampens specular for a wet surface -- the point-light-pass analogue of
 // PS_DS_AtmosphericScattering.hlsl's ApplySceneWettness. Deliberately skips that function's tri-planar
-// ripple normal deformation and reflection-cube sheen (an extra texture + per-axis blend that would be
-// paid once per overlapping light instead of once per pixel); the diffuse darkening below is what
+// ripple normal deformation (a per-axis blend that would be paid once per overlapping light instead of
+// once per pixel); the diffuse darkening below is what
 // actually reads as "wet" and is the part this bug report is about.
 //
 // `wsNormal` must be the UNDEFORMED world-space surface normal (no ripple applied here, so nothing to

--- a/D3D11Engine/Shaders/include/RainWetnessSample.h
+++ b/D3D11Engine/Shaders/include/RainWetnessSample.h
@@ -79,14 +79,15 @@ float ComputeRainWetnessLite( float3 wsPosition, Texture2D rainMap, SamplerCompa
 // `wsNormal` must be the UNDEFORMED world-space surface normal (no ripple applied here, so nothing to
 // deform it with) and `sceneWetness` is GothicAPI::GetSceneWetness() (the sustained wetness level, same
 // split as AC_SceneWettness/AC_RainFXWeight elsewhere).
-void ApplyPointLightWetness( float3 wsPosition, float3 wsNormal, Texture2D rainMap,
+// Returns the pixel's wetness [0,1] for WetCoatSpecular below.
+float ApplyPointLightWetness( float3 wsPosition, float3 wsNormal, Texture2D rainMap,
     SamplerComparisonState samplerState, matrix rainViewProj, float sceneWetness,
     inout float3 diffuse, inout float specIntensity, inout float specPower )
 {
-    if ( sceneWetness <= 0.0f ) return;
+    if ( sceneWetness <= 0.0f ) return 0.0f;
 
     float wetness = ComputeRainWetnessLite( wsPosition, rainMap, samplerState, rainViewProj ) * sceneWetness;
-    if ( wetness < 0.001f ) return;
+    if ( wetness < 0.001f ) return 0.0f;
 
     // Rain mostly settles on upward-facing, unsheltered surfaces -- same exposure test as
     // ApplySceneWettness (undeformed normal here, since there is no ripple to deform it with).
@@ -95,7 +96,7 @@ void ApplyPointLightWetness( float3 wsPosition, float3 wsNormal, Texture2D rainM
     wetness *= 1.0f - ( wDot2 * wDot2 );
     float exposure = saturate( wsNormal.y );
     wetness *= exposure * exposure;
-    if ( wetness <= 0.0f ) return;
+    if ( wetness <= 0.0f ) return 0.0f;
 
     specIntensity = lerp( specIntensity, 0.0f, wetness );
     specPower = lerp( specPower, 150.0f, wetness );
@@ -103,6 +104,48 @@ void ApplyPointLightWetness( float3 wsPosition, float3 wsNormal, Texture2D rainM
     float diffuseLum = dot( diffuse, float3( 0.3333f, 0.3333f, 0.3333f ) );
     float3 wetDiffuse = lerp( diffuseLum, diffuse, 0.75f ) * 0.75f;   // desaturate + darken, matches ApplySceneWettness's wetPixel
     diffuse = lerp( diffuse, wetDiffuse, wetness );
+    return wetness;
+}
+
+// Water-film specular under a point light: anisotropic GGX stretched toward the viewer (wet-street streaks),
+// widened by an assumed flame size. Mirrors D3D12 PBRLighting.hlsl; N/V/L must share one space.
+static const float WET_COAT_ROUGHNESS      = 0.12f;
+static const float WET_COAT_STREAK         = 6.0f;
+static const float WET_LIGHT_SOURCE_RADIUS = 15.0f;   // world units (~15 cm flame)
+
+float WetCoatSpecular( float3 N, float3 V, float3 L, float lightDist )
+{
+    float NdotL = saturate( dot( N, L ) );
+    if ( NdotL <= 0.0f ) return 0.0f;
+    float NdotV = saturate( dot( N, V ) );
+    float3 H = normalize( V + L );
+
+    // Karis sphere-light widening.
+    float a = saturate( WET_COAT_ROUGHNESS * WET_COAT_ROUGHNESS + WET_LIGHT_SOURCE_RADIUS / ( 2.0f * max( lightDist, 1.0f ) ) );
+
+    // Tangent = view projected onto the surface; the stretch fades out when looking straight down.
+    float3 vt = V - N * dot( N, V );
+    float vtLen = length( vt );
+    float3 T = vtLen > 1e-3f ? vt / vtLen : normalize( cross( N, abs( N.x ) < 0.9f ? float3( 1, 0, 0 ) : float3( 0, 0, 1 ) ) );
+    float3 B = cross( N, T );
+    float at = min( a * lerp( 1.0f, WET_COAT_STREAK, vtLen ), 1.0f );
+    float ab = a;
+
+    float ht = dot( H, T ) / at;
+    float hb = dot( H, B ) / ab;
+    float hn = dot( N, H );
+    float s = ht * ht + hb * hb + hn * hn;
+    float D = 1.0f / ( 3.14159265f * at * ab * s * s );
+
+    // Height-correlated anisotropic Smith visibility.
+    float lv = NdotL * length( float3( at * dot( T, V ), ab * dot( B, V ), NdotV ) );
+    float ll = NdotV * length( float3( at * dot( T, L ), ab * dot( B, L ), NdotL ) );
+    float vis = 0.5f / max( lv + ll, 1e-4f );
+
+    float f = saturate( 1.0f - dot( V, H ) );
+    float f2 = f * f;
+    float F = 0.02f + 0.98f * f2 * f2 * f;   // water F0
+    return D * vis * F * NdotL;
 }
 
 #endif // RAIN_WETNESS_SAMPLE_H


### PR DESCRIPTION
fixes #506

Should also fix crash mentioned here https://github.com/kirides/GD3D11/issues/503#issuecomment-5569884737