### PR TITLE
Make rain more prominent. ground puddles/ripples, sky/fog colored tint for visibility and more

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -287,6 +287,10 @@ struct DS_ScreenQuadConstantBuffer {
     // Packed into a float4 (x=cascade0 ... w=cascade3) to avoid cbuffer array padding.
     // Replaces per-fragment GetCascadeWorldTexelSize() matrix math in shaders.
     float4 SQ_CascadeTexelSize;
+
+    // Rain: rgb = sky tint wet ground reflects (the height-fog color), w = RainWetLightReflections.
+    // Only DrawWorldLights fills it; appended last so shorter HLSL declarations of this CB stay valid.
+    float4 SQ_WetSky;
 };
 
 struct CloudConstantBuffer {

--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -243,9 +243,13 @@ struct DS_PointLightConstantBuffer {
     XMFLOAT4X4 PL_RainViewProj;
     float PL_SceneWettness;
     float PL_WetLightReflections;
-    float2 PL_Pad4;
+    float PL_RainTime;       // AC_Time: rain ripples and puddle drop rings
+    float PL_RainFxWeight;
+
+    float PL_WetCoatScale;   // wet-ground reflection gate; PL_Color.w only gates material highlights
+    float3 PL_Pad5;
 };
-static_assert( sizeof( DS_PointLightConstantBuffer ) == 240,
+static_assert( sizeof( DS_PointLightConstantBuffer ) == 256,
     "DS_PointLightConstantBuffer (b0) layout must match PS_DS_PointLight.hlsl / PS_DS_PointLightDynShadow.hlsl" );
 
 constexpr int MAX_CSM_CASCADES = 4;
@@ -291,6 +295,8 @@ struct DS_ScreenQuadConstantBuffer {
     // Rain: rgb = sky tint wet ground reflects (the height-fog color), w = RainWetLightReflections.
     // Only DrawWorldLights fills it; appended last so shorter HLSL declarations of this CB stay valid.
     float4 SQ_WetSky;
+    // Rain: xyz = view-space moon direction for the night wet-ground glint, w = above-horizon fade.
+    float4 SQ_MoonDir;
 };
 
 struct CloudConstantBuffer {
@@ -533,7 +539,8 @@ struct TiledShadingConstantBuffer {
     XMFLOAT4X4 RainViewProj;
     float SceneWettness;
     float WetLightReflections;
-    float2 WetnessPad;
+    float RainTime;       // AC_Time: rain ripples and puddle drop rings
+    float RainFxWeight;
 };
 static_assert( sizeof( TiledShadingConstantBuffer ) == 192,
     "TiledShadingConstantBuffer (b0) layout must match CS_TiledShading.hlsl" );

--- a/D3D11Engine/D3D11LegacyDeferredShading.cpp
+++ b/D3D11Engine/D3D11LegacyDeferredShading.cpp
@@ -74,6 +74,8 @@ XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
         XMLoadFloat4x4( &graphicsEngine->Effects->GetRainShadowmapCameraRepl().ViewReplacement ) );
     plcb.PL_SceneWettness = Engine::GAPI->GetSceneWetness();
     plcb.PL_WetLightReflections = std::max( 0.0f, Engine::GAPI->GetRendererState().RendererSettings.RainWetLightReflections );
+    plcb.PL_RainTime = Engine::GAPI->GetTimeSeconds();
+    plcb.PL_RainFxWeight = Engine::GAPI->GetRainFXWeight();
 
     color.BindToPixelShader( context.Get(), 0 );
     normals.BindToPixelShader( context.Get(), 1 );
@@ -83,6 +85,7 @@ XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
     // slot); SS_Comp (s2) is already bound for the whole frame by that same earlier pass.
     if ( RenderToDepthStencilBuffer* rainShadowmap = graphicsEngine->Effects->GetRainShadowmap() )
         rainShadowmap->BindToPixelShader( context.Get(), TX_RainShadowmap );
+    graphicsEngine->GetDistortionTexture()->BindToPixelShader( TX_Distortion );   // rain ripples and puddle mask
 
     // Mirrors D3D12 BuildFrameLightBuffer's post-selection range clamp (D3D12Scene.cpp): a light that
     // ends up with no shadow cube shades unshadowed and bleeds through walls. Clamping its range to a
@@ -124,6 +127,7 @@ XRESULT D3D11LegacyDeferredShading::DrawPointlightLights(
 
         plcb.PL_Color = float4( vob->GetLightColor() );
         plcb.PL_Color.w = settings.PointLightSpecularScale( vob->IsStatic() );
+        plcb.PL_WetCoatScale = settings.PointLightWetReflectionScale( vob->IsStatic() );
         plcb.PL_Range = vob->GetLightRange();
         if ( !hasShadow && ( vob->IsStatic() || light->IsIndoorVob ) ) {
             const bool leakingOutdoors = light->IsIndoorVob && !cameraIndoors;

--- a/D3D11Engine/D3D11ShaderManager.cpp
+++ b/D3D11Engine/D3D11ShaderManager.cpp
@@ -285,9 +285,9 @@ XRESULT D3D11ShaderManager::Init() {
 }
 
 XRESULT D3D11ShaderManager::CompileShader( ShaderInfo& si ) {
-    // Compute hash (file timestamp + per-shader macros + global renderer macros).
+    // Hash (shader-tree timestamp + per-shader macros + global renderer macros).
     // Skip recompilation when the shader is already loaded and nothing has changed.
-    size_t newHash = ShaderRegistry::ComputeShaderHash( si );
+    size_t newHash = ShaderRegistry::ComputeShaderHash( si, m_SourceTreeStamp );
 
     auto IsKnown = [&]() -> bool {
         switch ( si.type ) {
@@ -448,6 +448,7 @@ XRESULT D3D11ShaderManager::LoadShaders( ShaderCategory categories ) {
     LogInfo() << "Compiling/Reloading shaders with " << compilationTP->getNumThreads() << " threads";
     */
     LogInfo() << "Compiling/Reloading shaders";
+    m_SourceTreeStamp = ShaderRegistry::ComputeSourceTreeStamp();
     for ( ShaderInfo& si : m_Registry.Shaders() ) {
         // Determine shader type category
         ShaderCategory shaderTypeCategory = ShaderCategory::None;

--- a/D3D11Engine/D3D11ShaderManager.h
+++ b/D3D11Engine/D3D11ShaderManager.h
@@ -81,4 +81,7 @@ private:
 
     /** Shader categories to reload next frame (OR-ed together from multiple calls) */
     ShaderCategory ShaderCategoriesToReloadNextFrame;
+
+    /** ShaderRegistry::ComputeSourceTreeStamp, taken once per LoadShaders pass */
+    uint64_t m_SourceTreeStamp = 0;
 };

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1591,6 +1591,17 @@ XRESULT D3D11ShadowMap::DrawWorldLights( ID3D11ShaderResourceView* aoMaskSRV )
             scb.SQ_LightColor = float4( 1, 1, 1, DEFAULT_INDOOR_VOB_AMBIENT.x );
         }
 
+    // Wet ground reflects the color the height fog fades distant geometry into (same formula as D3D11PfxRenderer).
+    {
+        XMVECTOR skyColor = XMLoadFloat3( &settings.FogColorMod );
+        if ( Engine::GAPI->GetFogOverride() > 0.0f )
+            skyColor = Engine::GAPI->GetFogColor();
+        skyColor = XMVectorLerp( skyColor, XMLoadFloat3( &settings.RainFogColor ), std::min( 1.0f, rain * 2.0f ) );
+        XMFLOAT3 sky;
+        XMStoreFloat3( &sky, skyColor );
+        scb.SQ_WetSky = float4( sky.x, sky.y, sky.z, std::max( 0.0f, settings.RainWetLightReflections ) );
+    }
+
     psAtmo->UpdateBuffer("DS_ScreenQuadConstantBuffer", &scb, sizeof(scb));
 
     // CSM: Bind the cascade array to a single slot (Texture2DArray)

--- a/D3D11Engine/D3D11ShadowMap.cpp
+++ b/D3D11Engine/D3D11ShadowMap.cpp
@@ -1597,9 +1597,20 @@ XRESULT D3D11ShadowMap::DrawWorldLights( ID3D11ShaderResourceView* aoMaskSRV )
         if ( Engine::GAPI->GetFogOverride() > 0.0f )
             skyColor = Engine::GAPI->GetFogColor();
         skyColor = XMVectorLerp( skyColor, XMLoadFloat3( &settings.RainFogColor ), std::min( 1.0f, rain * 2.0f ) );
-        XMFLOAT3 sky;
-        XMStoreFloat3( &sky, skyColor );
-        scb.SQ_WetSky = float4( sky.x, sky.y, sky.z, std::max( 0.0f, settings.RainWetLightReflections ) );
+        XMFLOAT3 skyRgb;
+        XMStoreFloat3( &skyRgb, skyColor );
+        scb.SQ_WetSky = float4( skyRgb.x, skyRgb.y, skyRgb.z, std::max( 0.0f, settings.RainWetLightReflections ) );
+
+        // Moon direction (view space) for the night glint on wet ground; w fades it out below the horizon.
+        zCSkyController_Outdoor* sc = ( oCGame::GetGame() && oCGame::GetGame()->_zCSession_world )
+            ? oCGame::GetGame()->_zCSession_world->GetSkyControllerOutdoor() : nullptr;
+        if ( sc ) {
+            const XMFLOAT3 moonWS = sc->GetMoonWorldPosition( sky->GetAtmoshpereSettings().SkyTimeScale );
+            const XMVECTOR moonDir = XMVector3Normalize( XMLoadFloat3( &moonWS ) );
+            XMFLOAT3 moonVS;
+            XMStoreFloat3( &moonVS, XMVector3TransformNormal( moonDir, view ) );
+            scb.SQ_MoonDir = float4( moonVS.x, moonVS.y, moonVS.z, std::clamp( XMVectorGetY( moonDir ) * 4.0f, 0.0f, 1.0f ) );
+        }
     }
 
     psAtmo->UpdateBuffer("DS_ScreenQuadConstantBuffer", &scb, sizeof(scb));

--- a/D3D11Engine/D3D11TiledDeferredShading.cpp
+++ b/D3D11Engine/D3D11TiledDeferredShading.cpp
@@ -444,6 +444,8 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
             XMLoadFloat4x4( &graphicsEngine->Effects->GetRainShadowmapCameraRepl().ViewReplacement ) );
         shadeCB.SceneWettness = Engine::GAPI->GetSceneWetness();
         shadeCB.WetLightReflections = std::max( 0.0f, settings.RainWetLightReflections );
+        shadeCB.RainTime = Engine::GAPI->GetTimeSeconds();
+        shadeCB.RainFxWeight = Engine::GAPI->GetRainFXWeight();
 
         csTiledShading->UpdateBuffer("TiledShadingConstantBuffer", &shadeCB, sizeof(shadeCB));
 
@@ -465,6 +467,10 @@ XRESULT D3D11TiledDeferredShading::DrawPointlightLights(
         // at D3D11ShadowMap.h's TX_RainShadowmap slot, here on the CS stage instead of PS.
         if ( RenderToDepthStencilBuffer* rainShadowmap = graphicsEngine->Effects->GetRainShadowmap() )
             context->CSSetShaderResources( TX_RainShadowmap, 1, rainShadowmap->GetShaderResView().GetAddressOf() );
+
+        // Rain ripples and puddle mask; s0 already holds the wrapping default sampler.
+        if ( D3D11Texture* distortion = graphicsEngine->GetDistortionTexture() )
+            context->CSSetShaderResources( TX_Distortion, 1, distortion->GetShaderResourceView().GetAddressOf() );
 
         // Bind comparison sampler unconditionally — the runtime validates at Dispatch
         // even if the shader branches around SampleCmpLevelZero
@@ -631,6 +637,7 @@ D3D11TiledDeferredShading::CullResult D3D11TiledDeferredShading::CullLights(
         tl.Range = lightRange;
         tl.Color = XMFLOAT4( lightColor.x, lightColor.y, lightColor.z,
             settings.PointLightSpecularScale( vob->IsStatic() ) );
+        tl.WetCoatScale = settings.PointLightWetReflectionScale( vob->IsStatic() );
         tl.PositionWorld = XMFLOAT3( posWorld.x, posWorld.y, posWorld.z );
         // The range the cube was actually baked with, so the depth compare normalizes by the same far plane
         // the bake used - neither the animated range read above nor its unshadowed clamp.

--- a/D3D11Engine/D3D11TiledDeferredShading.h
+++ b/D3D11Engine/D3D11TiledDeferredShading.h
@@ -49,7 +49,8 @@ struct TiledPointLight {
     // per-frame light animation plus the unshadowed clamp, and normalizing the depth compare by either of
     // those against a cube baked at neither is what makes the shadow detach from its caster.
     float ShadowRange;
-    float Pad[3];
+    float WetCoatScale;   // wet-ground reflection gate (PointLightWetReflectionScale); Color.w only gates material highlights
+    float Pad[2];
 };
 // StructuredBuffer stride - a mismatch with the HLSL copies (CS_LightCulling.hlsl, CS_TiledShading.hlsl,
 // ForwardPlusLighting.hlsl) silently misindexes every light.

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -268,8 +268,8 @@ struct MaterialInfo {
 
         void SetDefault() {
             // -- Defaults for NON Normalmapped, NON FX-Mapped materials
-            SpecularIntensity = 0.3f;
-            SpecularPower = 60.0f;
+            SpecularIntensity = 0.1f;
+            SpecularPower = 5.0f;
             // ---
             
             NormalmapStrength = 1.0f;

--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -268,8 +268,8 @@ struct MaterialInfo {
 
         void SetDefault() {
             // -- Defaults for NON Normalmapped, NON FX-Mapped materials
-            SpecularIntensity = 0.1f;
-            SpecularPower = 5.0f;
+            SpecularIntensity = 0.2f;
+            SpecularPower = 60.0f;
             // ---
             
             NormalmapStrength = 1.0f;

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -1472,6 +1472,12 @@ struct GothicRendererSettings {
         const int flag = isStatic ? SH_ATMOSPHERIC : SH_POINTLIGHTS;
         return ( SpecularHighlightsFlags & flag ) ? 1.0f : 0.0f;
     }
+
+    // Wet-ground reflection scale (0/1). Not tied to material highlights: real light sources always reflect in
+    // rain; static fill lights still follow SH_ATMOSPHERIC so they don't reflect as phantom lamps.
+    float PointLightWetReflectionScale( bool isStatic ) const {
+        return ( !isStatic || ( SpecularHighlightsFlags & SH_ATMOSPHERIC ) ) ? 1.0f : 0.0f;
+    }
 };
 
 /** Event rate over a SLIDING one-second window, as ten 100 ms buckets that PerSecond() sums - a tumbling

--- a/D3D11Engine/ShaderRegistry.cpp
+++ b/D3D11Engine/ShaderRegistry.cpp
@@ -558,16 +558,27 @@ static size_t HashCombine( size_t seed, size_t val ) noexcept {
     return seed ^ (val + 0x9e3779b9 + (seed << 6) + (seed >> 2));
 }
 
-size_t ShaderRegistry::ComputeShaderHash( const ShaderInfo& si ) {
+uint64_t ShaderRegistry::ComputeSourceTreeStamp() {
+    // Newest write time of any file under the shaders directory. #includes aren't tracked per shader, so a header
+    // edit has to invalidate every shader's skip; the D3D11 disk cache then recompiles only the real dependents.
+    const std::filesystem::path dir = Engine::GAPI->GetStartDirectory() + "\\system\\GD3D11\\shaders";
+    std::error_code ec;
+    int64_t newest = 0;
+    for ( std::filesystem::recursive_directory_iterator it( dir, ec ), end; !ec && it != end; it.increment( ec ) ) {
+        std::error_code fileEc;
+        if ( !it->is_regular_file( fileEc ) ) continue;
+        const auto lwt = it->last_write_time( fileEc );
+        if ( !fileEc && lwt.time_since_epoch().count() > newest ) newest = lwt.time_since_epoch().count();
+    }
+    return static_cast<uint64_t>( newest );
+}
+
+size_t ShaderRegistry::ComputeShaderHash( const ShaderInfo& si, uint64_t sourceTreeStamp ) {
     size_t h = 0;
 
-    // Hash file last-modified timestamp
-    std::string fullPath = Engine::GAPI->GetStartDirectory() + "\\system\\GD3D11\\shaders\\" + si.fileName;
-    std::error_code ec;
-    auto lwt = std::filesystem::last_write_time( std::filesystem::path( fullPath ), ec );
-    if ( !ec ) {
-        h = HashCombine( h, static_cast<size_t>(lwt.time_since_epoch().count()) );
-    }
+    // size_t is 32-bit in this process, so fold in both halves of the 64-bit timestamp.
+    h = HashCombine( h, static_cast<size_t>( sourceTreeStamp ) );
+    h = HashCombine( h, static_cast<size_t>( sourceTreeStamp >> 32 ) );
 
     // Hash per-shader macros
     for ( const auto& macro : si.shaderMakros ) {

--- a/D3D11Engine/ShaderRegistry.h
+++ b/D3D11Engine/ShaderRegistry.h
@@ -32,7 +32,7 @@ public:
     EVERTEX_INPUT_LAYOUT altLayout = VERTEX_INPUT_LAYOUT_NONE;
     std::vector<D3D_SHADER_MACRO> shaderMakros;
     ShaderCategory contentCategory;	//Content category for selective reloading
-    size_t compiledHash = 0;			//Hash of last successful compilation (file timestamp + macros)
+    size_t compiledHash = 0;			//Hash of last successful compilation (shader-tree timestamp + macros)
 
     // Optional: builds per-shader dynamic macros (renderer-settings-dependent) at compile/hash time.
     // Only macros this shader actually uses should be emitted — keeps hashing precise.
@@ -108,9 +108,12 @@ public:
     std::vector<ShaderInfo>& Shaders() noexcept { return m_Shaders; }
     const std::vector<ShaderInfo>& Shaders() const noexcept { return m_Shaders; }
 
-    /** Hash of a shader's compile inputs (source file timestamp + static + dynamic macros).
+    /** Hash of a shader's compile inputs (shader-tree timestamp + static + dynamic macros).
         Used by consumers to skip recompilation when nothing relevant changed. */
-    static size_t ComputeShaderHash( const ShaderInfo& si );
+    static size_t ComputeShaderHash( const ShaderInfo& si, uint64_t sourceTreeStamp );
+
+    /** Newest write time under system\GD3D11\shaders, so editing an #include also defeats the skip. */
+    static uint64_t ComputeSourceTreeStamp();
 
 private:
     std::vector<ShaderInfo> m_Shaders;   // Initial shader declaration list for loading

--- a/D3D11Engine/Shaders/CS_TiledShading.hlsl
+++ b/D3D11Engine/Shaders/CS_TiledShading.hlsl
@@ -12,7 +12,8 @@ struct TiledPointLight {
     float3 PositionWorld;
     int ShadowCubeIndex; // 0 = no shadow, else HI-LO slot pair (see PLS_SHADOW_SLOT_SHIFT)
     float ShadowRange;   // cube far-plane basis (far = ShadowRange*2); NOT Range - see TiledPointLight
-    float3 _pad;
+    float WetCoatScale;  // wet-ground reflection gate; Color.w only gates material highlights
+    float2 _pad;
 };
 
 // Clustered grid - layout-identical to CS_LightCulling.hlsl's and the C++ LightGrid.
@@ -38,15 +39,18 @@ cbuffer TiledShadingConstantBuffer : register( b0 ) {
     matrix RainViewProj;
     float SceneWettness;
     float WetLightReflections;
-    float2 WetnessPad;
+    float RainTime;
+    float RainFxWeight;
 };
 
+SamplerState SS_Linear : register( s0 );
 SamplerComparisonState SS_Comp : register( s2 );
 Texture2D TX_Diffuse : register( t0 );
 Texture2D TX_Nrm : register( t1 );
 Texture2D TX_Depth : register( t2 );
 Texture2D TX_SI_SP : register( t7 );
 Texture2D TX_RainShadowmap : register( t4 );
+Texture2D TX_Distortion : register( t6 );
 
 StructuredBuffer<TiledPointLight> SB_Lights : register( t8 );
 StructuredBuffer<LightGrid> SB_LightGrid : register( t9 );
@@ -61,6 +65,24 @@ float3 VSPositionFromDepth( float depth, uint2 pixelCoord ) {
     // Remove camera jitter (TAA/FSR) baked into the depth buffer's projection.
     float2 texcoord = (float2( pixelCoord ) + 0.5f) / ViewportSize - JitterOffset;
     return ReconstructVSPositionFromDepthReverseZInfinite( depth, texcoord, ProjParams.xy );
+}
+
+float3 LoadVSPosition( int2 p ) {
+    p = clamp( p, int2( 0, 0 ), int2( ViewportSize ) - 1 );
+    return VSPositionFromDepth( TX_Depth.Load( int3( p, 0 ) ).r, uint2( p ) );
+}
+
+// Geometric view-space normal from the depth neighbours, taking the smaller depth step per axis.
+float3 GeomNormalFromDepthVS( int2 p, float3 vsPosition, float3 N ) {
+    float3 r = LoadVSPosition( p + int2( 1, 0 ) ) - vsPosition;
+    float3 l = vsPosition - LoadVSPosition( p - int2( 1, 0 ) );
+    float3 d = LoadVSPosition( p + int2( 0, 1 ) ) - vsPosition;
+    float3 u = vsPosition - LoadVSPosition( p - int2( 0, 1 ) );
+    float3 dx = abs( r.z ) < abs( l.z ) ? r : l;
+    float3 dy = abs( d.z ) < abs( u.z ) ? d : u;
+    float3 n = cross( dx, dy );
+    n = normalize( n * sign( dot( n, N ) ) );
+    return dot( n, N ) >= 0.5f ? n : N;   // also catches NaN from sky neighbours
 }
 
 [numthreads( TILE_SIZE, TILE_SIZE, 1 )]
@@ -84,14 +106,16 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
     float3 wsPosition = mul( float4( vsPosition, 1 ), InvView ).xyz;
     float3 wsNormal = normalize( mul( float4( normal, 0 ), InvView ).xyz );
 
-    // Rain wetness: darken/dampen this pixel's diffuse/specular ONCE, before the light loop below, so
-    // every overlapping light shades against wet ground consistently with what
-    // PS_DS_AtmosphericScattering.hlsl already did for the sun/ambient term — instead of each light
-    // additively blending un-wetted brightness on top of it (see RainWetnessSample.h's header for the
-    // bug this fixes; this is the primary point-light path lights use, PS_DS_PointLight.hlsl only
-    // handles the shadow-cube-overflow fallback).
-    float wet = ApplyPointLightWetness( wsPosition, wsNormal, TX_RainShadowmap, SS_Comp, RainViewProj, SceneWettness,
+    // Rain wetness, once per pixel: the same wet surface (albedo, puddles, water film) the sun pass shaded.
+    float3 wsGeomNormal = wsNormal;
+    [branch]
+    if ( SceneWettness > 0.0f )
+        wsGeomNormal = normalize( mul( float4( GeomNormalFromDepthVS( int2( pixelCoord ), vsPosition, normal ), 0 ), InvView ).xyz );
+    WetSurface wet = ApplyPointLightWetness( wsPosition, wsNormal, wsGeomNormal, length( vsPosition ),
+        TX_RainShadowmap, SS_Comp, RainViewProj, SceneWettness, TX_Distortion, SS_Linear, RainTime, RainFxWeight,
         diffuse.rgb, specIntensity, specPower );
+    float3 litN = normalize( mul( (float3x3)InvView, wet.rippleN ) );   // G-buffer normal plus rain ripples/drop rings
+    float3 coatN = normalize( mul( (float3x3)InvView, wet.coatN ) );
 
     // Compute tile index
     uint tileX = pixelCoord.x / TILE_SIZE;
@@ -131,17 +155,18 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
 
             lightDir /= distance;
 
-            float ndl = max( 0, dot( lightDir, normal ) );
+            float ndl = max( 0, dot( lightDir, litN ) );
             float falloff = PLS_ComputeRangeFalloff( distance, light.Range );
 
             float3 H = normalize( lightDir + V );
-            float spec = PLS_CalcBlinnPhongLighting( normal, H ) * light.Color.w;
-            float3 lighting = PLS_ComputePointLightLighting( diffuse.rgb, light.Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod );
+            float spec = PLS_CalcBlinnPhongLighting( litN, H ) * light.Color.w;
+            float3 lighting = saturate( PLS_ComputePointLightLighting( diffuse.rgb, light.Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod ) );
 
-            // Wet ground: water-film reflection streak (see WetCoatSpecular in RainWetnessSample.h).
+            // Wet ground: water-film reflection, kept out of the clamp above so it can go HDR.
             [branch]
-            if ( wet > 0.0f && WetLightReflections > 0.0f )
-                lighting += light.Color.rgb * ( WetCoatSpecular( normal, V, lightDir, distance ) * falloff * wet * light.Color.w * WetLightReflections );
+            if ( wet.wetness > 0.0f && WetLightReflections > 0.0f )
+                lighting += light.Color.rgb * WetCoatRolloff( WetCoatSpecular( coatN, V, lightDir, distance, wet.roughness )
+                    * falloff * wet.wetness * light.WetCoatScale * WetLightReflections );
 
             // Apply shadow if this light has a shadow cubemap and contribution is non-negligible.
             // [branch]: guards a real cube-shadow sample, so force a branch instead of flattening.
@@ -151,8 +176,6 @@ void CSMain( uint3 groupID : SV_GroupID, uint3 threadID : SV_GroupThreadID, uint
                 float shadow = PLS_SampleShadowCubeArray( TX_ShadowStaticCubeArray, TX_ShadowDynCubeArray, SS_Comp, wsPosition, wsNormal, light.PositionWorld, light.ShadowRange, light.ShadowCubeIndex, taaActive );
                 lighting *= shadow;
             }
-
-            lighting = saturate( lighting );
 
             totalLighting += lighting;
             maxLighting = max( maxLighting, lighting );

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -42,6 +42,9 @@ cbuffer DS_ScreenQuadConstantBuffer : register(b0)
 
     // World-space units per texel, precomputed on CPU (x=cascade0 ... w=cascade3).
     float4 SQ_CascadeTexelSize;
+
+    // Rain: rgb = sky tint reflected by wet ground, w = RainWetLightReflections.
+    float4 SQ_WetSky;
 };
 
 //--------------------------------------------------------------------------------------
@@ -66,6 +69,10 @@ Texture2D TX_ShadowBlueNoise : register(t8);
 Texture2D TX_AO : register(t9);
 
 #include "ShadowSampling.h"
+#include "include/RainWetnessSample.h"
+
+static const float WET_SUN_DISTANCE = 1000.0f; // WetCoatSpecular source widening: sun disk softened by rain haze
+static const float WET_SUN_MAX      = 8.0f;    // caps the streak peak so rippled normals don't sparkle under TAA
 
 
 //--------------------------------------------------------------------------------------
@@ -196,7 +203,7 @@ void ApplySceneWettness(float3 wsPosition, inout float3 vsNormal, in out float3 
 	
     vsNormal = lerp(vsNormal, nrm, AC_RainFXWeight * pixelWettnes * 0.5f); // Only apply deformation if it's actually raining
 
-	// Scale specular intensity and power. No additive reflection-cube/fixed-direction sheen (removed, D3D12 parity).
+	// Blinn-Phong sun spec fades out; PSMain adds the water-film lobe and sky reflection instead.
     specIntensity = lerp(specIntensity, 0.0, pixelWettnes);
     specPower = lerp(specPower, 150.0f, pixelWettnes);
 
@@ -324,7 +331,27 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
 	float f8 = f4*f4; 
 	float fresnel = f8*f2;
     litPixel += lerp(fresnel * litPixel * 0.5f, 0.0f, sun);
-	
+
+#ifdef APPLY_RAIN_EFFECTS
+    // Water film on the rippled normal: sun streak plus the overcast sky reflected at grazing angles.
+    [branch]
+    if (localWettness > 0.0f && gb3.y > 0.0f) // grass writes spec power 0 and stays matte
+    {
+        float wetSun = WetCoatSpecular(normal, V, normalize(SQ_LightDirectionVS), WET_SUN_DISTANCE);
+        wetSun = min(wetSun * shadow * SQ_SunSpecularEnabled * SQ_WetSky.w, WET_SUN_MAX);
+
+        // PS_PFX_Heightfog's night blend and darkening, so the reflection matches the fog it fades into.
+        float3 wetSky = lerp(SQ_WetSky.rgb, float3(0.12f, 0.18f, 0.27f), saturate(-AC_LightPos.y * 4.0f))
+                      / (2.0f - 0.8f * saturate(AC_LightPos.y));
+        float wf = 1.0f - saturate(dot(normal, V));
+        float wf2 = wf * wf;
+        float skyFresnel = (0.02f + 0.98f * wf2 * wf2 * wf) * localWettness;
+
+        litPixel = lerp(litPixel, wetSky * worldAO * ssao, skyFresnel)
+                 + lightColor.rgb * (lightColor.a * wetSun * localWettness);
+    }
+#endif
+
 	// Run scattering
     litPixel = ApplyAtmosphericScatteringGround(wsPosition, litPixel.rgb);
 

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -45,6 +45,8 @@ cbuffer DS_ScreenQuadConstantBuffer : register(b0)
 
     // Rain: rgb = sky tint reflected by wet ground, w = RainWetLightReflections.
     float4 SQ_WetSky;
+    // xyz = view-space moon direction, w = above-horizon fade.
+    float4 SQ_MoonDir;
 };
 
 //--------------------------------------------------------------------------------------
@@ -71,8 +73,10 @@ Texture2D TX_AO : register(t9);
 #include "ShadowSampling.h"
 #include "include/RainWetnessSample.h"
 
-static const float WET_SUN_DISTANCE = 1000.0f; // WetCoatSpecular source widening: sun disk softened by rain haze
-static const float WET_SUN_MAX      = 8.0f;    // caps the streak peak so rippled normals don't sparkle under TAA
+static const float WET_SUN_DISTANCE     = 1000.0f;  // WetCoatSpecular source widening: sun disk softened by rain haze
+static const float WET_MOON_DISTANCE    = 60.0f;    // much wider: moonlight diffused by the rain clouds
+static const float3 WET_MOON_COLOR      = float3( 0.06f, 0.075f, 0.1f );
+static const float WET_NIGHT_SKY_DARKEN = 1.0f;     // the fog's day divisor is 2; at night the reflection skips it to stay readable
 
 
 //--------------------------------------------------------------------------------------
@@ -101,116 +105,26 @@ float CalcBlinnPhongLighting(float3 N, float3 H)
 }
 
 
-static const float WEIGHT_BIAS = -0.55;
-static const float WEIGHT_MUL = 0.7;
-
-/** Applys normal-deformation for the rain */
-void ApplyRainNormalDeformation(inout float3 vsNormal, float3 wsPosition, inout float3 diffuse, out float3 wsNormal)
+/** Rain wetness for the sun/ambient term: rippled normal, darker albedo, and the water-film surface for PSMain. */
+WetSurface ApplySceneWettness(float3 wsPosition, float3 vsPosition, inout float3 vsNormal, inout float3 diffuse, inout float specIntensity, inout float specPower)
 {
-	// Need worldspace normal for this
-    wsNormal = mul(vsNormal, (float3x3) SQ_InvView).xyz;
-	
-    float2 groundDir = normalize(float2(0.1f, 0.1f) + saturate(float3(-wsNormal.z, 0, wsNormal.x).xz));
-	
-    const float scale = 1000.0f;
-    float2 uv[4] =
+    float3 wsNormal = normalize(mul(vsNormal, (float3x3)SQ_InvView));
+    float3 wsGeomNormal = normalize(mul(GeomNormalFromDerivativesVS(vsPosition, vsNormal), (float3x3)SQ_InvView));
+
+    // Wide, world-sized soft filter so occluders fade the ground damp instead of stamping their outline.
+    float reach = ComputeRainWetness(wsPosition, TX_RainShadowmap, SS_Comp, SQ_RainViewProj) * AC_SceneWettness;
+    WetSurface wet = EvaluateWetSurface(reach, wsNormal, wsGeomNormal, wsPosition, length(vsPosition),
+        TX_Distortion, SS_Linear, AC_Time, AC_RainFXWeight);
+
+    if (wet.wetness > 0.0f)
     {
-        wsPosition.zy / scale,
-					wsPosition.xz / (scale * 2),
-					wsPosition.xz / (scale * 2),
-					wsPosition.xy / scale
-    };
-	
-    float groundSpeed = 0.1f * AC_RainFXWeight;
-    float downSpeed = 0.2f * AC_RainFXWeight;
-    uv[0] += float2(0, AC_Time * downSpeed);
-    uv[1] += float2(AC_Time * groundSpeed, AC_Time * groundSpeed);
-    uv[2] = uv[2] * float2(0.8f, 1.2f) + float2(-AC_Time * groundSpeed * 0.7f, AC_Time * groundSpeed * 0.4f);
-    uv[3] += float2(0, AC_Time * downSpeed);
-	
-	// Create weights for all 3 axis
-    float3 weights = float3(abs(wsNormal.x),
-							abs(wsNormal.y),
-							abs(wsNormal.z));
-							
-	// Tighten up the blending zone:
-    weights = (weights + WEIGHT_BIAS) * WEIGHT_MUL;
-    weights = max(weights, 0);
-							
-    weights /= (weights.x + weights.y +
-				weights.z).xxx;
-				
-    weights.xz *= 0.6f;
-    weights.y *= 0.7f;
-		
-    float3 dist[3] =
-    {
-        normalize((TX_Distortion.Sample(SS_Linear, uv[0]).zyx * 2 - 1)),
-					  normalize((TX_Distortion.Sample(SS_Linear, uv[1]).xzy * 2 - 1)) * 0.5f +
-					  normalize((TX_Distortion.Sample(SS_Linear, uv[2]).xzy * 2 - 1)) * 0.5f,
-					  normalize((TX_Distortion.Sample(SS_Linear, uv[3]).xyz * 2 - 1))
-    };
-		
-	// weights = pow(weights, 4.0f);
-	// inline "pow 4"
-	weights *= weights;
-	weights *= weights;
-		
-    const float distWeight = 0.9f;
-	
-	// Sample the distortion-texture for all 3 axis
-    [unroll]
-    for (int i = 0; i < 3; i++)
-    {
-		// Add to normal
-        wsNormal = lerp(wsNormal, dist[i], weights[i] * distWeight); //distWeight * weights[i]); 
+        vsNormal = normalize(mul(wet.rippleN, (float3x3)SQ_View));
+        // Blinn-Phong sun spec fades out; PSMain adds the water-film lobe and sky reflection instead.
+        specIntensity = lerp(specIntensity, 0.0f, wet.wetness);
+        specPower = lerp(specPower, 150.0f, wet.wetness);
+        ApplyWetAlbedo(diffuse, wet);
     }
-
-    wsNormal = normalize(wsNormal);
-	//diffuse.xyz = wsNormal;
-
-    vsNormal = normalize(mul(wsNormal, (float3x3) SQ_View).xyz);
-}
-
-/** Returns new diffusecolor (rgb)*/
-void ApplySceneWettness(float3 wsPosition, inout float3 vsNormal, in out float3 diffuse, in out float specIntensity, in out float specPower, out float localWettness)
-{
-	// Ask the rain-shadowmap if we can hit this pixel. Wide, world-sized soft filter (see
-	// ComputeRainWetness) so occluders fade the ground damp instead of stamping their outline.
-    float pixelWettnes = ComputeRainWetness(wsPosition, TX_RainShadowmap, SS_Comp, SQ_RainViewProj) * AC_SceneWettness;
-    pixelWettnes = pixelWettnes < 0.001f ? 0 : pixelWettnes;
-    
-    //IsWet(wsPosition, TX_RainShadowmap, SS_Comp) * AC_SceneWettness;
-
-    float3 vsNormalCpy = vsNormal;
-	
-	// Apply water-effects
-    float3 nrm = vsNormal;
-    float3 wsNormal;
-    ApplyRainNormalDeformation(nrm, wsPosition, diffuse.rgb, wsNormal);
-
-    // pixelWettnes *= 1 - pow(saturate(dot(wsNormal, float3(0, -1, 0))), 4.0f);
-	// simplify pow
-	float wDot = saturate(dot(wsNormal, float3(0, -1, 0))); 
-	float wDot2 = wDot * wDot;
-	pixelWettnes *= 1.0f - (wDot2 * wDot2);
-
-    // Rain mostly settles on upward-facing surfaces.
-    float surfaceExposure = saturate(wsNormal.y);
-    surfaceExposure *= surfaceExposure;
-    pixelWettnes *= surfaceExposure;
-    localWettness = pixelWettnes;
-	
-    vsNormal = lerp(vsNormal, nrm, AC_RainFXWeight * pixelWettnes * 0.5f); // Only apply deformation if it's actually raining
-
-	// Blinn-Phong sun spec fades out; PSMain adds the water-film lobe and sky reflection instead.
-    specIntensity = lerp(specIntensity, 0.0, pixelWettnes);
-    specPower = lerp(specPower, 150.0f, pixelWettnes);
-
-	// Compute wet pixel color
-    float diffuseLum = dot(diffuse, float3(0.3333f, 0.3333f, 0.3333f));
-    float3 wetPixel = lerp(diffuseLum, diffuse, 0.75f) * 0.75f; // Desaturate and darken the scene a bit
-    diffuse = lerp(diffuse, wetPixel, pixelWettnes);
+    return wet;
 }
 
 //--------------------------------------------------------------------------------------
@@ -285,7 +199,8 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
     float localWettness = 0.0f;
 
 #ifdef APPLY_RAIN_EFFECTS
-    ApplySceneWettness(wsPosition, normal, diffuse.rgb, specIntensity, specPower, localWettness);
+    WetSurface wet = ApplySceneWettness(wsPosition, vsPosition, normal, diffuse.rgb, specIntensity, specPower);
+    localWettness = wet.wetness;
 #endif
 	// Compute specular lighting
 	
@@ -333,22 +248,30 @@ float4 PSMain(PS_INPUT Input) : SV_TARGET
     litPixel += lerp(fresnel * litPixel * 0.5f, 0.0f, sun);
 
 #ifdef APPLY_RAIN_EFFECTS
-    // Water film on the rippled normal: sun streak plus the overcast sky reflected at grazing angles.
+    // Water film: sun and moon streaks plus the sky reflected at grazing angles.
     [branch]
     if (localWettness > 0.0f && gb3.y > 0.0f) // grass writes spec power 0 and stays matte
     {
-        float wetSun = WetCoatSpecular(normal, V, normalize(SQ_LightDirectionVS), WET_SUN_DISTANCE);
-        wetSun = min(wetSun * shadow * SQ_SunSpecularEnabled * SQ_WetSky.w, WET_SUN_MAX);
+        float3 coatN = normalize(mul(wet.coatN, (float3x3)SQ_View));
+        float nightBlend = saturate(-AC_LightPos.y * 4.0f);
+        float skyOcclusion = worldAO * ssao;
+
+        // Not gated by SQ_SunSpecularEnabled: that toggles material highlights, not rain reflections.
+        float wetSun = WetCoatSpecular(coatN, V, normalize(SQ_LightDirectionVS), WET_SUN_DISTANCE, wet.roughness) * shadow;
+        // Moonlight diffused by the clouds, so wet ground still reads at night without torches.
+        float wetMoon = WetCoatSpecular(coatN, V, SQ_MoonDir.xyz, WET_MOON_DISTANCE, wet.roughness)
+                      * SQ_MoonDir.w * nightBlend * skyOcclusion;
+        float3 wetLight = WetCoatRolloff((lightColor.rgb * (lightColor.a * wetSun) + WET_MOON_COLOR * wetMoon)
+                                         * (SQ_WetSky.w * localWettness));
 
         // PS_PFX_Heightfog's night blend and darkening, so the reflection matches the fog it fades into.
-        float3 wetSky = lerp(SQ_WetSky.rgb, float3(0.12f, 0.18f, 0.27f), saturate(-AC_LightPos.y * 4.0f))
-                      / (2.0f - 0.8f * saturate(AC_LightPos.y));
-        float wf = 1.0f - saturate(dot(normal, V));
+        float3 wetSky = lerp(SQ_WetSky.rgb, float3(0.12f, 0.18f, 0.27f), nightBlend)
+                      / lerp(2.0f - 0.8f * saturate(AC_LightPos.y), WET_NIGHT_SKY_DARKEN, nightBlend);
+        float wf = 1.0f - saturate(dot(coatN, V));
         float wf2 = wf * wf;
         float skyFresnel = (0.02f + 0.98f * wf2 * wf2 * wf) * localWettness;
 
-        litPixel = lerp(litPixel, wetSky * worldAO * ssao, skyFresnel)
-                 + lightColor.rgb * (lightColor.a * wetSun * localWettness);
+        litPixel = lerp(litPixel, wetSky * skyOcclusion, skyFresnel) + wetLight;
     }
 #endif
 

--- a/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLight.hlsl
@@ -29,7 +29,11 @@ cbuffer DS_PointLightConstantBuffer : register( b0 )
 	matrix PL_RainViewProj;
 	float PL_SceneWettness;
 	float PL_WetLightReflections;
-	float2 PL_Pad4;
+	float PL_RainTime;
+	float PL_RainFxWeight;
+
+	float PL_WetCoatScale;   // wet-ground reflection gate; PL_Color.w only gates material highlights
+	float3 PL_Pad5;
 };
 
 //--------------------------------------------------------------------------------------
@@ -43,6 +47,7 @@ Texture2D	TX_Nrm : register( t1 );
 Texture2D	TX_Depth : register( t2 );
 Texture2D	TX_SI_SP : register( t7 );
 Texture2D	TX_RainShadowmap : register( t4 );
+Texture2D	TX_Distortion : register( t6 );
 
 //--------------------------------------------------------------------------------------
 // Input / Output structures
@@ -71,28 +76,28 @@ float GetShadow(float2 uv)
 	float2 lightDir = PL_LightScreenPos.xy - uv;
 	float distance = length(lightDir);
 	lightDir /= distance; // Normalize the direction
-	
+
 	// Calculate ray steps size
 	const int numSteps = 100;
 	float stepSize = distance / numSteps;
-	
+
 	//float depthLight = TX_Depth.Sample(SS_Linear, PL_LightScreenPos).r;
 	float depthTarget = TX_Depth.Sample(SS_Linear, uv).r;
-	
+
 	float dx = ddx(uv.xy);
 	float dy = ddy(uv.xy);
-	
+
 	float2 ray = PL_LightScreenPos.xy;
 	for(int i=0;i<numSteps;i++)
 	{
 		ray += lightDir * stepSize;
-		
+
 		float depthRay = TX_Depth.SampleGrad(SS_Linear,ray, dx, dy);
-		
+
 		if(depthRay < PL_LightScreenPos.z)
 			return 0;
 	}
-	
+
 	return 1;
 }
 
@@ -103,32 +108,33 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 {
 	// Get screen UV
 	float2 uv = Input.vPosition.xy / PL_ViewportSize;
-	
+
 	// Look up the diffuse color
 	float4 diffuse = TX_Diffuse.Sample(SS_Linear, uv);
-	
+
 	// Get the second GBuffer
 	float2 gb2 = TX_Nrm.Sample(SS_Linear, uv).xy;
-	
+
 	// Decode the view-space normal from octahedral R16G16_SNORM
 	float3 normal = DecodeNormalGBuffer(gb2);
-	
+
 	// Get specular parameters
 	float4 gb3 = TX_SI_SP.Sample(SS_Linear, uv);
 	float specIntensity = gb3.x;
 	float specPower = gb3.y;
-	
+
 	// Reconstruct VS World Position from depth
 	float expDepth = TX_Depth.Sample(SS_Linear, uv).r;
 	float3 vsPosition = VSPositionFromDepth(expDepth, uv);
 	float3 wsPosition = mul(float4(vsPosition, 1), PL_InvView).xyz;
 	float3 wsNormal = normalize(mul(float4(normal, 0), PL_InvView).xyz);
+	float3 wsGeomNormal = normalize(mul(float4(GeomNormalFromDerivativesVS(vsPosition, normal), 0), PL_InvView).xyz);
 
-	// Rain wetness: darken/dampen this light's contribution consistently with what
-	// PS_DS_AtmosphericScattering.hlsl already did for the sun/ambient term, instead of adding
-	// un-wetted brightness on top of it (see RainWetnessSample.h's header for the bug this fixes).
-	float wet = ApplyPointLightWetness(wsPosition, wsNormal, TX_RainShadowmap, SS_Comp, PL_RainViewProj, PL_SceneWettness,
+	// Rain wetness: the same wet surface (albedo, puddles, water film) the sun pass shaded.
+	WetSurface wet = ApplyPointLightWetness(wsPosition, wsNormal, wsGeomNormal, length(vsPosition),
+		TX_RainShadowmap, SS_Comp, PL_RainViewProj, PL_SceneWettness, TX_Distortion, SS_Linear, PL_RainTime, PL_RainFxWeight,
 		diffuse.rgb, specIntensity, specPower);
+	float3 litN = normalize(mul((float3x3)PL_InvView, wet.rippleN));   // G-buffer normal plus rain ripples/drop rings
 
 	// Get direction and distance from the light to that position
 	float3 lightDir = Pl_PositionView - vsPosition;
@@ -136,7 +142,7 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	lightDir /= distance; // Normalize the direction
 
 	// Do some simple NdL-Lighting
-	float ndl = max(0, dot(lightDir, normal));
+	float ndl = max(0, dot(lightDir, litN));
 
 	// Compute range falloff
 	float falloff = PLS_ComputeRangeFalloff(distance, PL_Range);
@@ -145,17 +151,21 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	// Compute specular lighting
 	float3 V = normalize(-vsPosition);
 	float3 H = normalize(lightDir + V);
-	float spec = PLS_CalcBlinnPhongLighting(normal, H) * PL_Color.w;
+	float spec = PLS_CalcBlinnPhongLighting(litN, H) * PL_Color.w;
 	float specMod = PLS_ComputeSpecMod(diffuse.rgb);
 
 	// Blend this with the light color, world diffuse and specular term.
-	float3 lighting = PLS_ComputePointLightLighting(diffuse.rgb, PL_Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod);
+	float3 lighting = saturate(PLS_ComputePointLightLighting(diffuse.rgb, PL_Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod));
 
-	// Wet ground: water-film reflection streak (see WetCoatSpecular in RainWetnessSample.h).
+	// Wet ground: water-film reflection, kept out of the clamp above so it can go HDR.
 	[branch]
-	if (wet > 0.0f && PL_WetLightReflections > 0.0f)
-		lighting += PL_Color.rgb * (WetCoatSpecular(normal, V, lightDir, distance) * falloff * wet * PL_Color.w * PL_WetLightReflections);
+	if (wet.wetness > 0.0f && PL_WetLightReflections > 0.0f)
+	{
+		float3 coatN = normalize(mul((float3x3)PL_InvView, wet.coatN));
+		lighting += PL_Color.rgb * WetCoatRolloff(WetCoatSpecular(coatN, V, lightDir, distance, wet.roughness)
+			* falloff * wet.wetness * PL_WetCoatScale * PL_WetLightReflections);
+	}
 
-	return float4(saturate(lighting),1);
+	return float4(lighting, 1);
 }
 

--- a/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_PointLightDynShadow.hlsl
@@ -29,7 +29,11 @@ cbuffer DS_PointLightConstantBuffer : register( b0 )
 	matrix PL_RainViewProj;
 	float PL_SceneWettness;
 	float PL_WetLightReflections;
-	float2 PL_Pad4;
+	float PL_RainTime;
+	float PL_RainFxWeight;
+
+	float PL_WetCoatScale;   // wet-ground reflection gate; PL_Color.w only gates material highlights
+	float3 PL_Pad5;
 };
 
 //--------------------------------------------------------------------------------------
@@ -44,6 +48,7 @@ Texture2D	TX_Depth : register( t2 );
 TextureCube	TX_ShadowCube : register( t3 );
 Texture2D	TX_SI_SP : register( t7 );
 Texture2D	TX_RainShadowmap : register( t4 );
+Texture2D	TX_Distortion : register( t6 );
 
 //--------------------------------------------------------------------------------------
 // Input / Output structures
@@ -86,10 +91,10 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	float3 wsPosition = mul(float4(vsPosition, 1), PL_InvView).xyz;
 	float3 wsNormal = normalize(mul(float4(normal, 0), PL_InvView).xyz);
 
-	// Rain wetness: darken/dampen this light's contribution consistently with what
-	// PS_DS_AtmosphericScattering.hlsl already did for the sun/ambient term, instead of adding
-	// un-wetted brightness on top of it (see RainWetnessSample.h's header for the bug this fixes).
-	float wet = ApplyPointLightWetness(wsPosition, wsNormal, TX_RainShadowmap, SS_Comp, PL_RainViewProj, PL_SceneWettness,
+	// Rain wetness: the same wet surface (albedo, puddles, water film) the sun pass shaded.
+	float3 wsGeomNormal = normalize(mul(float4(GeomNormalFromDerivativesVS(vsPosition, normal), 0), PL_InvView).xyz);
+	WetSurface wet = ApplyPointLightWetness(wsPosition, wsNormal, wsGeomNormal, length(vsPosition),
+		TX_RainShadowmap, SS_Comp, PL_RainViewProj, PL_SceneWettness, TX_Distortion, SS_Linear, PL_RainTime, PL_RainFxWeight,
 		diffuse.rgb, specIntensity, specPower);
 
 	//return float4(normalize(wsPosition - Pl_PositionWorld), 1.0f);
@@ -108,7 +113,8 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	lightDir /= distance; // Normalize the direction
 	
 	// Do some simple NdL-Lighting
-	float ndl = max(0, dot(lightDir, normal));
+	float3 litN = normalize(mul((float3x3)PL_InvView, wet.rippleN));   // G-buffer normal plus rain ripples/drop rings
+	float ndl = max(0, dot(lightDir, litN));
 	
 	// Apply dynamic shadow
 	bool taaActive = PL_JitterOffset.x != 0.0f || PL_JitterOffset.y != 0.0f;
@@ -124,14 +130,18 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	// Compute specular lighting
 	float3 V = normalize(-vsPosition);
 	float3 H = normalize(lightDir + V);
-	float spec = PLS_CalcBlinnPhongLighting(normal, H) * PL_Color.w;
+	float spec = PLS_CalcBlinnPhongLighting(litN, H) * PL_Color.w;
 	float specMod = PLS_ComputeSpecMod(diffuse.rgb);
-	float3 lighting = PLS_ComputePointLightLighting(diffuse.rgb, PL_Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod);
+	float3 lighting = saturate(PLS_ComputePointLightLighting(diffuse.rgb, PL_Color.rgb, ndl, falloff, spec, specIntensity, specPower, specMod));
 
-	// Wet ground: water-film reflection streak (see WetCoatSpecular in RainWetnessSample.h).
+	// Wet ground: water-film reflection, kept out of the clamp above so it can go HDR.
 	[branch]
-	if (wet > 0.0f && PL_WetLightReflections > 0.0f)
-		lighting += PL_Color.rgb * (WetCoatSpecular(normal, V, lightDir, distance) * falloff * wet * PL_Color.w * PL_WetLightReflections);
+	if (wet.wetness > 0.0f && PL_WetLightReflections > 0.0f)
+	{
+		float3 coatN = normalize(mul((float3x3)PL_InvView, wet.coatN));
+		lighting += PL_Color.rgb * WetCoatRolloff(WetCoatSpecular(coatN, V, lightDir, distance, wet.roughness)
+			* falloff * wet.wetness * PL_WetCoatScale * PL_WetLightReflections);
+	}
 
 	lighting *= shadow;
 	
@@ -145,6 +155,6 @@ float4 PSMain( PS_INPUT Input ) : SV_TARGET
 	
 	//return float4(0.2f,0.2f,0.2f,1);
 	//return float4(ndl.rrr,1);
-	return float4(saturate(lighting),1);
+	return float4(lighting,1);
 }
 

--- a/D3D11Engine/Shaders/include/RainWetnessSample.h
+++ b/D3D11Engine/Shaders/include/RainWetnessSample.h
@@ -107,8 +107,8 @@ float ApplyPointLightWetness( float3 wsPosition, float3 wsNormal, Texture2D rain
     return wetness;
 }
 
-// Water-film specular under a point light: anisotropic GGX stretched toward the viewer (wet-street streaks),
-// widened by an assumed flame size. Mirrors D3D12 PBRLighting.hlsl; N/V/L must share one space.
+// Water-film specular (point lights and the sun): anisotropic GGX stretched toward the viewer (wet-street streaks),
+// widened by an assumed source size. Mirrors D3D12 PBRLighting.hlsl; N/V/L must share one space.
 static const float WET_COAT_ROUGHNESS      = 0.12f;
 static const float WET_COAT_STREAK         = 6.0f;
 static const float WET_LIGHT_SOURCE_RADIUS = 15.0f;   // world units (~15 cm flame)

--- a/D3D11Engine/Shaders/include/RainWetnessSample.h
+++ b/D3D11Engine/Shaders/include/RainWetnessSample.h
@@ -1,25 +1,9 @@
-// Lightweight rain-wetness sampling for the legacy deferred point-light passes
-// (PS_DS_PointLight.hlsl / PS_DS_PointLightDynShadow.hlsl).
-//
-// BUG THIS FIXES: PS_DS_AtmosphericScattering.hlsl computes scene wetness (ApplySceneWettness) and
-// darkens/desaturates its own LOCAL copy of the G-buffer diffuse -- that darkening is never written
-// back to the G-buffer. The point-light passes below read the G-buffer's diffuse/specular directly and
-// additively blend into the same HDR target the atmospheric-scattering pass just wrote, so a pixel that
-// sits close to a torch/lantern gets its wet darkening overpowered by an un-wetted point-light
-// contribution added right on top -- wet ground reads as completely dry wherever a nearby point light
-// dominates the pixel's brightness (reported by the maintainer: "no rain wetness effect if light
-// touches the ground, only unlit areas get the rain effect").
-//
-// This header gives the point-light passes their own, cheaper wetness sample so their contribution is
-// darkened/dampened consistently with the atmospheric-scattering pass instead of ignoring wetness
-// entirely.
+// Rain wetness shared by the D3D11 deferred passes (PS_DS_AtmosphericScattering, CS_TiledShading,
+// PS_DS_PointLight*), so the sun/ambient and point-light terms shade the same wet surface.
 #ifndef RAIN_WETNESS_SAMPLE_H
 #define RAIN_WETNESS_SAMPLE_H
 
-// Inner 8-tap ring of ShadowSampling.h's g_PoissonDisk32, duplicated rather than pulled in via
-// #include "ShadowSampling.h": that header also declares CSM-only globals (TX_ShadowmapArray /
-// TX_ShadowmapAtlas, SHADOW_ATLAS) the point-light shaders have no reason to bind. Same duplication
-// precedent as the D3D12 backend's Wetness.hlsl.
+// Inner 8-tap ring of ShadowSampling.h's g_PoissonDisk32 (that header also declares CSM-only resources).
 static const float2 g_RainPoissonInner8[8] = {
     float2( -0.94201624, -0.39906216 ), float2(  0.94558609, -0.76890725 ),
     float2( -0.09418410, -0.92938870 ), float2(  0.34495938,  0.29387760 ),
@@ -31,16 +15,16 @@ static const float2 g_RainPoissonInner8[8] = {
 #define RAIN_WET_BLUR_WORLD 100.0f   // ~1m filter radius => ~2m wide wet/dry transition, matches ShadowSampling.h
 #endif
 
-// 1:1 with ShadowSampling.h's ComputeRainWetness, minus its optional 16-tap outer ring (SHD_FILTER_16TAP_PCF):
-// this runs once per pixel PER OVERLAPPING LIGHT rather than once per pixel, so it deliberately stays cheap.
+static const float RAIN_PI = 3.14159265f;
+
+// ShadowSampling.h's ComputeRainWetness without the 16-tap outer ring.
 float ComputeRainWetnessLite( float3 wsPosition, Texture2D rainMap, SamplerComparisonState samplerState, matrix viewProj )
 {
     float4 sp = mul( float4( wsPosition, 1 ), viewProj );
     sp.xyz /= sp.www;   // orthographic rain camera, w == 1 -- kept for parity with ComputeRainWetness
     float2 uv = sp.xy * float2( 0.5f, -0.5f ) + float2( 0.5f, 0.5f );
 
-    // Outside the rain camera there is no occluder information; the common case out there is open sky,
-    // so return "exposed" rather than drawing a dry ring at the map border.
+    // Outside the rain camera there is no occluder information; assume open sky.
     if ( uv.x < 0.0f || uv.x > 1.0f || uv.y < 0.0f || uv.y > 1.0f )
         return 1.0f;
 
@@ -70,50 +54,208 @@ float ComputeRainWetnessLite( float3 wsPosition, Texture2D rainMap, SamplerCompa
     return saturate( sum / weight );
 }
 
-// Darkens/desaturates diffuse and dampens specular for a wet surface -- the point-light-pass analogue of
-// PS_DS_AtmosphericScattering.hlsl's ApplySceneWettness. Deliberately skips that function's tri-planar
-// ripple normal deformation (a per-axis blend that would be paid once per overlapping light instead of
-// once per pixel); the diffuse darkening below is what
-// actually reads as "wet" and is the part this bug report is about.
-//
-// `wsNormal` must be the UNDEFORMED world-space surface normal (no ripple applied here, so nothing to
-// deform it with) and `sceneWetness` is GothicAPI::GetSceneWetness() (the sustained wetness level, same
-// split as AC_SceneWettness/AC_RainFXWeight elsewhere).
-// Returns the pixel's wetness [0,1] for WetCoatSpecular below.
-float ApplyPointLightWetness( float3 wsPosition, float3 wsNormal, Texture2D rainMap,
-    SamplerComparisonState samplerState, matrix rainViewProj, float sceneWetness,
-    inout float3 diffuse, inout float specIntensity, inout float specPower )
+static const float WET_FILM_FLATTEN     = 0.7f;    // share of the normal-map relief the water film fills
+static const float WET_FILM_ROUGHNESS   = 0.40f;   // broad sheen pool around each light's reflection
+static const float WET_PUDDLE_ROUGHNESS = 0.22f;   // tighter, but still a pool rather than a thin beam
+
+static const float PUDDLE_FLATNESS_MIN       = 0.92f;    // dot(geometric normal, up); excludes pitched roofs
+static const float PUDDLE_NOISE_WORLD_SCALE  = 400.0f;   // ~4 m placement tile
+static const float PUDDLE_DETAIL_WORLD_SCALE = 120.0f;   // ~1.2 m perimeter breakup
+static const float PUDDLE_RIPPLE_CELL        = 70.0f;    // world units per drop cell
+static const float PUDDLE_RIPPLE_PERIOD      = 0.9f;     // seconds from impact to fade-out
+static const float PUDDLE_RIPPLE_STRENGTH    = 0.5f;
+static const float PUDDLE_RIPPLE_FADE_DIST   = 2500.0f;  // rings alias beyond this camera distance
+
+// Animated tri-planar rain ripple from the distortion texture. World space, N normalized.
+float3 RainRippleNormal( Texture2D distTex, SamplerState smp, float3 N, float3 wsPosition, float time, float rainFx )
 {
-    if ( sceneWetness <= 0.0f ) return 0.0f;
+    const float scale = 1000.0f;
+    float groundSpeed = 0.1f * rainFx;
+    float downSpeed = 0.2f * rainFx;
+    float2 uv0 = wsPosition.zy / scale + float2( 0.0f, time * downSpeed );
+    float2 uv1 = wsPosition.xz / ( scale * 2.0f ) + time * groundSpeed;
+    float2 uv2 = wsPosition.xz / ( scale * 2.0f ) * float2( 0.8f, 1.2f ) + float2( -time * groundSpeed * 0.7f, time * groundSpeed * 0.4f );
+    float2 uv3 = wsPosition.xy / scale + float2( 0.0f, time * downSpeed );
 
-    float wetness = ComputeRainWetnessLite( wsPosition, rainMap, samplerState, rainViewProj ) * sceneWetness;
-    if ( wetness < 0.001f ) return 0.0f;
+    // Tightened per-axis blend so each planar projection dominates near its own axis.
+    float3 weights = max( ( abs( N ) - 0.55f ) * 0.7f, 0.0f );
+    weights /= weights.x + weights.y + weights.z;
+    weights *= float3( 0.6f, 0.7f, 0.6f );
+    weights *= weights;
+    weights *= weights;
 
-    // Rain mostly settles on upward-facing, unsheltered surfaces -- same exposure test as
-    // ApplySceneWettness (undeformed normal here, since there is no ripple to deform it with).
-    float wDot = saturate( dot( wsNormal, float3( 0, -1, 0 ) ) );
-    float wDot2 = wDot * wDot;
-    wetness *= 1.0f - ( wDot2 * wDot2 );
-    float exposure = saturate( wsNormal.y );
-    wetness *= exposure * exposure;
-    if ( wetness <= 0.0f ) return 0.0f;
+    float3 d0 = normalize( distTex.SampleLevel( smp, uv0, 0 ).zyx * 2.0f - 1.0f );
+    float3 d1 = normalize( distTex.SampleLevel( smp, uv1, 0 ).xzy * 2.0f - 1.0f ) * 0.5f
+              + normalize( distTex.SampleLevel( smp, uv2, 0 ).xzy * 2.0f - 1.0f ) * 0.5f;
+    float3 d2 = normalize( distTex.SampleLevel( smp, uv3, 0 ).xyz * 2.0f - 1.0f );
 
-    specIntensity = lerp( specIntensity, 0.0f, wetness );
-    specPower = lerp( specPower, 150.0f, wetness );
-
-    float diffuseLum = dot( diffuse, float3( 0.3333f, 0.3333f, 0.3333f ) );
-    float3 wetDiffuse = lerp( diffuseLum, diffuse, 0.75f ) * 0.75f;   // desaturate + darken, matches ApplySceneWettness's wetPixel
-    diffuse = lerp( diffuse, wetDiffuse, wetness );
-    return wetness;
+    float3 n = lerp( N, d0, weights.x * 0.9f );
+    n = lerp( n, d1, weights.y * 0.9f );
+    n = lerp( n, d2, weights.z * 0.9f );
+    return normalize( n );
 }
 
-// Water-film specular (point lights and the sun): anisotropic GGX stretched toward the viewer (wet-street streaks),
-// widened by an assumed source size. Mirrors D3D12 PBRLighting.hlsl; N/V/L must share one space.
-static const float WET_COAT_ROUGHNESS      = 0.12f;
-static const float WET_COAT_STREAK         = 6.0f;
-static const float WET_LIGHT_SOURCE_RADIUS = 15.0f;   // world units (~15 cm flame)
+// Mip for a world-planar lookup from an approximate pixel footprint; capped so distant puddles keep contrast.
+float RainNoiseLod( Texture2D tex, float tileWorld, float viewDist )
+{
+    float w, h;
+    tex.GetDimensions( w, h );
+    return clamp( log2( max( viewDist, 1.0f ) * 0.0015f * w / tileWorld ), 0.0f, 2.0f );
+}
 
-float WetCoatSpecular( float3 N, float3 V, float3 L, float lightDist )
+// Pooled water [0,1] on flat ground, spreading as wetness rises. geomN must be the geometric world normal.
+float ComputePuddleMask( Texture2D distTex, SamplerState smp, float3 geomN, float3 wsPosition, float wetness, float viewDist )
+{
+    float flatness = saturate( ( geomN.y - PUDDLE_FLATNESS_MIN ) / ( 1.0f - PUDDLE_FLATNESS_MIN ) );
+    if ( flatness <= 0.0f ) return 0.0f;
+
+    float placement = distTex.SampleLevel( smp, wsPosition.xz / PUDDLE_NOISE_WORLD_SCALE,
+        RainNoiseLod( distTex, PUDDLE_NOISE_WORLD_SCALE, viewDist ) ).r;
+    float detail = distTex.SampleLevel( smp, wsPosition.xz / PUDDLE_DETAIL_WORLD_SCALE + 17.31f,
+        RainNoiseLod( distTex, PUDDLE_DETAIL_WORLD_SCALE, viewDist ) ).g;
+    float noise = placement * 0.7f + detail * 0.3f;
+
+    float threshold = lerp( 0.85f, 0.35f, saturate( wetness ) );
+    return smoothstep( threshold - 0.08f, threshold + 0.08f, noise ) * flatness;
+}
+
+uint PuddleHash( int2 c )
+{
+    uint h = ( uint( c.x ) * 0x8DA6B343u ) ^ ( uint( c.y ) * 0xD8163841u );
+    h ^= h >> 15; h *= 0x2C1B3C6Du; h ^= h >> 12; h *= 0x297A2D39u; h ^= h >> 15;
+    return h;
+}
+
+// World-XZ slope of the rain-drop rings: one expanding ring per cell on two offset grids, re-seeded every cycle.
+float2 PuddleRippleSlope( float2 p, float time, float rainFx )
+{
+    float2 slope = 0.0f;
+    [unroll] for ( int layer = 0; layer < 2; ++layer )
+    {
+        float2 q = p / PUDDLE_RIPPLE_CELL + float2( 0.5f, 0.37f ) * layer;
+        int2 cell = int2( floor( q ) );
+        float phase = float( PuddleHash( cell + int2( 0, 7919 * layer ) ) & 0xFFFFu ) / 65535.0f;
+        float cycle = time / PUDDLE_RIPPLE_PERIOD + phase;
+        uint h = PuddleHash( cell + int2( int( floor( cycle ) ) * 131, 7919 * layer + 17 ) );
+        if ( float( h >> 24 ) / 255.0f <= rainFx )   // lighter rain, fewer drops
+        {
+            float t = frac( cycle );
+            float2 center = 0.3f + 0.4f * float2( h & 0xFFu, ( h >> 8 ) & 0xFFu ) / 255.0f;
+            float2 d = frac( q ) - center;
+            float r = length( d );
+            // 1.5 wavelengths either side of the expanding front.
+            float x = clamp( ( r - t * 0.28f ) * 160.0f, -3.0f * RAIN_PI, 3.0f * RAIN_PI );
+            float wave = sin( x ) * ( 1.0f - abs( x ) / ( 3.0f * RAIN_PI ) );
+            slope += d / max( r, 1e-4f ) * ( wave * ( 1.0f - t ) * ( 1.0f - t ) );
+        }
+    }
+    return slope * PUDDLE_RIPPLE_STRENGTH;
+}
+
+struct WetSurface
+{
+    float wetness;    // 0 = dry; the other fields are then just the inputs
+    float puddle;
+    float roughness;  // water-film lobe roughness
+    float3 rippleN;   // world normal for diffuse lighting
+    float3 coatN;     // world normal of the water film: relief filled, flat in puddles, drop rings
+};
+
+// reach = rain-map exposure * scene wetness. N = G-buffer world normal, geomN = geometric world normal.
+WetSurface EvaluateWetSurface( float reach, float3 N, float3 geomN, float3 wsPosition, float viewDist,
+    Texture2D distTex, SamplerState smp, float time, float rainFx )
+{
+    WetSurface s = (WetSurface)0;
+    s.roughness = WET_FILM_ROUGHNESS;
+    s.rippleN = N;
+    s.coatN = N;
+    if ( reach < 0.001f ) return s;
+
+    float3 ripple = RainRippleNormal( distTex, smp, N, wsPosition, time, rainFx );
+
+    // Rain settles on upward-facing, unsheltered surfaces.
+    float wDot = saturate( -ripple.y );
+    float wDot2 = wDot * wDot;
+    float exposure = saturate( ripple.y );
+    float wetness = reach * ( 1.0f - wDot2 * wDot2 ) * exposure * exposure;
+    if ( wetness <= 0.0f ) return s;
+
+    float puddle = ComputePuddleMask( distTex, smp, geomN, wsPosition, wetness, viewDist );
+    // Ripples only while it rains; pooled water stays calmer.
+    float rippleAmount = rainFx * wetness * 0.5f * ( 1.0f - puddle * 0.8f );
+
+    s.wetness = wetness;
+    s.puddle = puddle;
+    s.roughness = lerp( WET_FILM_ROUGHNESS, WET_PUDDLE_ROUGHNESS, puddle );
+    s.rippleN = normalize( lerp( N, ripple, rippleAmount ) );
+
+    float3 filmN = normalize( lerp( N, geomN, wetness * lerp( WET_FILM_FLATTEN, 1.0f, puddle ) ) );
+    filmN = normalize( lerp( filmN, float3( 0.0f, 1.0f, 0.0f ), puddle ) );
+    filmN = normalize( lerp( filmN, ripple, rippleAmount ) );
+
+    // Drop rings go into the diffuse normal too, so puddles read even with every reflection off.
+    float rippleFade = saturate( 1.0f - viewDist / PUDDLE_RIPPLE_FADE_DIST );
+    [branch]
+    if ( puddle > 0.0f && rainFx > 0.0f && rippleFade > 0.0f )
+    {
+        float2 slope = PuddleRippleSlope( wsPosition.xz, time, rainFx ) * ( puddle * rippleFade );
+        float3 ring = float3( -slope.x, 0.0f, -slope.y );
+        filmN = normalize( filmN + ring );
+        s.rippleN = normalize( s.rippleN + ring * 0.5f );   // diffuse sees rings faintly; the reflection carries them
+    }
+    s.coatN = filmN;
+    return s;
+}
+
+// Darkens and desaturates wet albedo; pooled water reads darker still.
+void ApplyWetAlbedo( inout float3 diffuse, WetSurface s )
+{
+    float lum = dot( diffuse, float3( 0.3333f, 0.3333f, 0.3333f ) );
+    float k = lerp( 0.75f, 0.55f, s.puddle );
+    diffuse = lerp( diffuse, lerp( lum.xxx, diffuse, k ) * k, s.wetness );
+}
+
+// Point-light passes: evaluates the wet surface once per pixel and damps albedo/Blinn-Phong spec to match the sun pass.
+WetSurface ApplyPointLightWetness( float3 wsPosition, float3 wsNormal, float3 wsGeomNormal, float viewDist,
+    Texture2D rainMap, SamplerComparisonState cmp, matrix rainViewProj, float sceneWetness,
+    Texture2D distTex, SamplerState smp, float time, float rainFx,
+    inout float3 diffuse, inout float specIntensity, inout float specPower )
+{
+    float reach = 0.0f;
+    [branch]
+    if ( sceneWetness > 0.0f )
+        reach = ComputeRainWetnessLite( wsPosition, rainMap, cmp, rainViewProj ) * sceneWetness;
+
+    WetSurface s = EvaluateWetSurface( reach, wsNormal, wsGeomNormal, wsPosition, viewDist, distTex, smp, time, rainFx );
+    if ( s.wetness > 0.0f )
+    {
+        specIntensity = lerp( specIntensity, 0.0f, s.wetness );
+        specPower = lerp( specPower, 150.0f, s.wetness );
+        ApplyWetAlbedo( diffuse, s );
+    }
+    return s;
+}
+
+// Geometric view-space normal from screen derivatives (pixel shaders only); falls back to N at silhouettes.
+float3 GeomNormalFromDerivativesVS( float3 vsPosition, float3 N )
+{
+    float3 n = cross( ddx( vsPosition ), ddy( vsPosition ) );
+    n = normalize( n * sign( dot( n, N ) ) );
+    return dot( n, N ) >= 0.5f ? n : N;   // also catches NaN from sky neighbours
+}
+
+static const float WET_COAT_STREAK         = 2.5f;    // elongation toward the viewer at grazing view; higher = thinner beam
+static const float WET_LIGHT_SOURCE_RADIUS = 15.0f;   // world units (~15 cm flame)
+static const float WET_COAT_GAIN           = 5.0f;    // light colours are LDR-scaled; a physical 2% water reflection is invisible
+static const float WET_COAT_MAX            = 1.5f;    // asymptote of the per-light HDR shoulder below
+
+// Soft HDR shoulder instead of a hard clamp, so a hot highlight doesn't flatten into a blown-out plateau.
+float WetCoatRolloff( float x ) { return x / ( 1.0f + x / WET_COAT_MAX ); }
+float3 WetCoatRolloff( float3 x ) { return x / ( 1.0f + x / WET_COAT_MAX ); }
+
+// Water-film specular: anisotropic GGX stretched toward the viewer (wet-street streaks), widened by an assumed
+// source size. N/V/L must share one space. Brighter than the D3D12 twin in PBRLighting.hlsl (WET_COAT_GAIN).
+float WetCoatSpecular( float3 N, float3 V, float3 L, float lightDist, float roughness )
 {
     float NdotL = saturate( dot( N, L ) );
     if ( NdotL <= 0.0f ) return 0.0f;
@@ -121,7 +263,7 @@ float WetCoatSpecular( float3 N, float3 V, float3 L, float lightDist )
     float3 H = normalize( V + L );
 
     // Karis sphere-light widening.
-    float a = saturate( WET_COAT_ROUGHNESS * WET_COAT_ROUGHNESS + WET_LIGHT_SOURCE_RADIUS / ( 2.0f * max( lightDist, 1.0f ) ) );
+    float a = saturate( roughness * roughness + WET_LIGHT_SOURCE_RADIUS / ( 2.0f * max( lightDist, 1.0f ) ) );
 
     // Tangent = view projected onto the surface; the stretch fades out when looking straight down.
     float3 vt = V - N * dot( N, V );
@@ -135,7 +277,7 @@ float WetCoatSpecular( float3 N, float3 V, float3 L, float lightDist )
     float hb = dot( H, B ) / ab;
     float hn = dot( N, H );
     float s = ht * ht + hb * hb + hn * hn;
-    float D = 1.0f / ( 3.14159265f * at * ab * s * s );
+    float D = 1.0f / ( RAIN_PI * at * ab * s * s );
 
     // Height-correlated anisotropic Smith visibility.
     float lv = NdotL * length( float3( at * dot( T, V ), ab * dot( B, V ), NdotV ) );
@@ -145,7 +287,7 @@ float WetCoatSpecular( float3 N, float3 V, float3 L, float lightDist )
     float f = saturate( 1.0f - dot( V, H ) );
     float f2 = f * f;
     float F = 0.02f + 0.98f * f2 * f2 * f;   // water F0
-    return D * vis * F * NdotL;
+    return D * vis * F * NdotL * WET_COAT_GAIN;
 }
 
 #endif // RAIN_WETNESS_SAMPLE_H

--- a/D3D11Engine/Shaders/include/RainWetnessSample.h
+++ b/D3D11Engine/Shaders/include/RainWetnessSample.h
@@ -244,9 +244,9 @@ float3 GeomNormalFromDerivativesVS( float3 vsPosition, float3 N )
     return dot( n, N ) >= 0.5f ? n : N;   // also catches NaN from sky neighbours
 }
 
-static const float WET_COAT_STREAK         = 2.5f;    // elongation toward the viewer at grazing view; higher = thinner beam
+static const float WET_COAT_STREAK         = 1.0f;    // elongation toward the viewer at grazing view; higher = thinner beam
 static const float WET_LIGHT_SOURCE_RADIUS = 15.0f;   // world units (~15 cm flame)
-static const float WET_COAT_GAIN           = 5.0f;    // light colours are LDR-scaled; a physical 2% water reflection is invisible
+static const float WET_COAT_GAIN           = 3.0f;    // light colours are LDR-scaled; a physical 2% water reflection is invisible
 static const float WET_COAT_MAX            = 1.5f;    // asymptote of the per-light HDR shoulder below
 
 // Soft HDR shoulder instead of a hard clamp, so a hot highlight doesn't flatten into a blown-out plateau.


### PR DESCRIPTION
fixes #506 

Also fixes shader hot-reload not taking header files into account.

This is how it will look 

_With normalmaps_

<img width="2560" height="1440" alt="Image" src="https://github.com/user-attachments/assets/4999a0fa-c9fb-4cec-9360-4b7504ceeaa8" />

_without normalmaps_

<img width="2560" height="1440" alt="Image" src="https://github.com/user-attachments/assets/c5de5720-878d-48cd-bd7a-cc1dcb74a317" />